### PR TITLE
[ISSUE #201]🐛Fix Use RequestHeaderCodec macro cannot find type HashMap in this scope

### DIFF
--- a/rocketmq-macros/src/request_header_custom.rs
+++ b/rocketmq-macros/src/request_header_custom.rs
@@ -112,7 +112,7 @@ pub(super) fn request_header_codec_inner(
         impl crate::protocol::command_custom_header::FromMap for #struct_name {
             type Target = Self;
 
-            fn from(map: &HashMap<String, String>) -> Option<Self::Target> {
+            fn from(map: &std::collections::HashMap<String, String>) -> Option<Self::Target> {
                 Some(#struct_name {
                     #(#from_map)*
                 })


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #201 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
