### PR TITLE
[ISSUE ##516]✅Add test case for StoreType 🚧

### DIFF
--- a/rocketmq-store/src/base/store_enum.rs
+++ b/rocketmq-store/src/base/store_enum.rs
@@ -82,3 +82,43 @@ impl<'de> Deserialize<'de> for StoreType {
         deserializer.deserialize_str(StoreTypeVisitor)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn get_store_type_returns_correct_string() {
+        assert_eq!(StoreType::LocalFile.get_store_type(), "LocalFile");
+        assert_eq!(StoreType::RocksDB.get_store_type(), "RocksDB");
+    }
+
+    #[test]
+    fn serialize_returns_correct_json() {
+        let local_file = StoreType::LocalFile;
+        let rocks_db = StoreType::RocksDB;
+
+        assert_eq!(
+            serde_json::to_value(&local_file).unwrap(),
+            json!("LocalFile")
+        );
+        assert_eq!(serde_json::to_value(&rocks_db).unwrap(), json!("RocksDB"));
+    }
+
+    #[test]
+    fn deserialize_returns_correct_enum() {
+        let local_file: StoreType = serde_json::from_value(json!("LocalFile")).unwrap();
+        let rocks_db: StoreType = serde_json::from_value(json!("RocksDB")).unwrap();
+
+        assert_eq!(local_file, StoreType::LocalFile);
+        assert_eq!(rocks_db, StoreType::RocksDB);
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown variant `Unknown`, expected `SingleTag` or `MultiTag`")]
+    fn deserialize_panics_on_unknown_variant() {
+        let _: StoreType = serde_json::from_value(json!("Unknown")).unwrap();
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #516 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added test functions to ensure `get_store_type`, `serialize`, `deserialize`, and panic handling for unknown variants in `StoreType` enum are functioning correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->