### PR TITLE
[ISSUE #542]🔨Add auto add label for pr approval

### DIFF
--- a/.github/workflows/label-on-approval.yml
+++ b/.github/workflows/label-on-approval.yml
@@ -18,7 +18,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         with:
           script: |
-            const github = require('@actions/github');
             const context = github.context;
             const approved = context.payload.review.state === 'approved';
             const owner = context.repo.owner;

--- a/.github/workflows/label-on-approval.yml
+++ b/.github/workflows/label-on-approval.yml
@@ -1,0 +1,39 @@
+name: Label on Approval
+
+on:
+  pull_request_review:
+    types: [ submitted ]
+
+jobs:
+  add-label-on-approval:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for approval and add label
+        uses: actions/github-script@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        with:
+          script: |
+            const approved = context.payload.review.state === 'approved';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            if (approved) {
+              const { data: collaborators } = await github.repos.listCollaborators({ owner, repo });
+              const reviewer = context.payload.review.user.login;
+              const isOwner = collaborators.some(collab => collab.login === reviewer && collab.permissions.admin);
+
+              if (isOwner) {
+                await github.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pull_number,
+                  labels: ['approved','auto merge']
+                });
+              }
+            }

--- a/.github/workflows/label-on-approval.yml
+++ b/.github/workflows/label-on-approval.yml
@@ -10,14 +10,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
 
       - name: Check for approval and add label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v6
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         with:
           script: |
+            const github = require('@actions/github');
+            const context = github.context;
             const approved = context.payload.review.state === 'approved';
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/label-on-approval.yml
+++ b/.github/workflows/label-on-approval.yml
@@ -18,7 +18,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         with:
           script: |
-            const context = github.context;
             const approved = context.payload.review.state === 'approved';
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #542 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a workflow that automatically labels pull requests as "approved" and "auto merge" when a repository collaborator with admin permissions approves the PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->