### PR TITLE
[ISSUE #592]Add doc for StatisticsItemScheduledPrinter struct

### DIFF
--- a/rocketmq-common/src/common/statistics/statistics_item_scheduled_printer.rs
+++ b/rocketmq-common/src/common/statistics/statistics_item_scheduled_printer.rs
@@ -38,7 +38,7 @@ impl StatisticsItemScheduledPrinter {
     ///
     /// # Arguments
     ///
-    /// * `_statistics_item` - A reference to the `StatisticsItem` that needs to be removed.
+    /// * `statistics_item` - A reference to the `StatisticsItem` that needs to be removed.
     ///
     /// # Panics
     ///

--- a/rocketmq-common/src/common/statistics/statistics_item_scheduled_printer.rs
+++ b/rocketmq-common/src/common/statistics/statistics_item_scheduled_printer.rs
@@ -25,7 +25,7 @@ impl StatisticsItemScheduledPrinter {
     ///
     /// # Arguments
     ///
-    /// * `_statistics_item` - A reference to the `StatisticsItem` that needs to be scheduled.
+    /// * `statistics_item` - A reference to the `StatisticsItem` that needs to be scheduled.
     ///
     /// # Panics
     ///

--- a/rocketmq-common/src/common/statistics/statistics_item_scheduled_printer.rs
+++ b/rocketmq-common/src/common/statistics/statistics_item_scheduled_printer.rs
@@ -16,13 +16,33 @@
  */
 use crate::common::statistics::statistics_item::StatisticsItem;
 
+/// `StatisticsItemScheduledPrinter` is a struct that provides functionality for scheduling and
+/// removing `StatisticsItem`.
 pub struct StatisticsItemScheduledPrinter;
 
 impl StatisticsItemScheduledPrinter {
+    /// Schedules a `StatisticsItem`.
+    ///
+    /// # Arguments
+    ///
+    /// * `_statistics_item` - A reference to the `StatisticsItem` that needs to be scheduled.
+    ///
+    /// # Panics
+    ///
+    /// This function currently panics with `unimplemented!()`.
     pub fn schedule(&self, _statistics_item: &StatisticsItem) {
         unimplemented!()
     }
 
+    /// Removes a `StatisticsItem`.
+    ///
+    /// # Arguments
+    ///
+    /// * `_statistics_item` - A reference to the `StatisticsItem` that needs to be removed.
+    ///
+    /// # Panics
+    ///
+    /// This function currently panics with `unimplemented!()`.
     pub fn remove(&self, _statistics_item: &StatisticsItem) {
         unimplemented!()
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #592 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to schedule and remove `StatisticsItem` with the `StatisticsItemScheduledPrinter`.

- **Bug Fixes**
  - Fixed an issue where scheduling and removing `StatisticsItem` functionalities were not implemented correctly, now managed with `unimplemented!()` panic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->