### PR TITLE
[ISSUE #641]🎨Optimize ProducerManager#unregister_producer

### DIFF
--- a/rocketmq-broker/src/client/manager/producer_manager.rs
+++ b/rocketmq-broker/src/client/manager/producer_manager.rs
@@ -48,7 +48,7 @@ impl ProducerManager {
         !channels.unwrap().is_empty()
     }
 
-    pub fn unregister_producer(&self, group: &String, client_channel_info: &ClientChannelInfo) {
+    pub fn unregister_producer(&self, group: &str, client_channel_info: &ClientChannelInfo) {
         let mut mutex_guard = self.group_channel_table.lock();
         let channel_table = mutex_guard.get_mut(group);
         if let Some(ct) = channel_table {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #641

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `unregister_producer` function to accept a `&str` type for the `group` parameter for improved performance and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->