### PR TITLE
[ISSUE ##656] 🎨Add ConsumeMessageContext struct and ConsumeMessageHook trait

### DIFF
--- a/rocketmq-broker/src/mqtrace.rs
+++ b/rocketmq-broker/src/mqtrace.rs
@@ -15,5 +15,7 @@
  * limitations under the License.
  */
 
+pub(crate) mod consume_message_context;
+pub(crate) mod consume_message_hook;
 pub(crate) mod send_message_context;
 pub(crate) mod send_message_hook;

--- a/rocketmq-broker/src/mqtrace/consume_message_context.rs
+++ b/rocketmq-broker/src/mqtrace/consume_message_context.rs
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rocketmq_common::common::config::TopicConfig;
+use rocketmq_store::stats::stats_type::StatsType;
+
+#[derive(Default)]
+pub struct ConsumeMessageContext {
+    pub consumer_group: String,
+    pub topic: String,
+    pub queue_id: Option<i32>,
+    pub client_host: String,
+    pub store_host: String,
+    pub message_ids: HashMap<String, i64>,
+    pub body_length: i32,
+    pub success: bool,
+    pub status: String,
+    //mq_trace_context: Option<Box<dyn std::any::Any>>, // Replace with actual type
+    pub topic_config: Arc<TopicConfig>,
+
+    pub account_auth_type: String,
+    pub account_owner_parent: String,
+    pub account_owner_self: String,
+    pub rcv_msg_num: i32,
+    pub rcv_msg_size: i32,
+    pub rcv_stat: StatsType,
+    pub commercial_rcv_msg_num: i32,
+
+    pub commercial_owner: String,
+    pub commercial_rcv_stats: StatsType,
+    pub commercial_rcv_times: i32,
+    pub commercial_rcv_size: i32,
+
+    pub namespace: String,
+}

--- a/rocketmq-broker/src/mqtrace/consume_message_hook.rs
+++ b/rocketmq-broker/src/mqtrace/consume_message_hook.rs
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use crate::mqtrace::consume_message_context::ConsumeMessageContext;
+
+/// `ConsumeMessageHook` is a trait that provides hooks for consuming messages.
+/// Implementors of this trait provide their own logic for what should happen before and after a
+/// message is consumed.
+pub trait ConsumeMessageHook {
+    /// Returns the name of the hook.
+    /// This is typically used for logging and debugging purposes.
+    fn hook_name(&self) -> &str;
+
+    /// This method is called before a message is consumed.
+    /// The `context` parameter provides information about the message that is about to be consumed.
+    /// Implementors can use this method to perform setup or configuration tasks before the message
+    /// is consumed.
+    fn consume_message_before(&self, context: &mut ConsumeMessageContext);
+
+    /// This method is called after a message is consumed.
+    /// The `context` parameter provides information about the message that was just consumed.
+    /// Implementors can use this method to perform cleanup or logging tasks after the message is
+    /// consumed.
+    fn consume_message_after(&self, context: &mut ConsumeMessageContext);
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #656 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Enhanced message consumption tracking with additional context details such as account information, message statistics, and namespace.
    - Introduced hooks for handling tasks before and after message consumption, allowing for more customized message processing.
- **Improvements**
    - Improved modularity by adding new modules for message consumption context and hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->