### PR TITLE
[ISSUE #658]🚀Support pull message consume

### DIFF
--- a/rocketmq-broker/src/mqtrace/consume_message_hook.rs
+++ b/rocketmq-broker/src/mqtrace/consume_message_hook.rs
@@ -19,7 +19,7 @@ use crate::mqtrace::consume_message_context::ConsumeMessageContext;
 /// `ConsumeMessageHook` is a trait that provides hooks for consuming messages.
 /// Implementors of this trait provide their own logic for what should happen before and after a
 /// message is consumed.
-pub trait ConsumeMessageHook {
+pub trait ConsumeMessageHook: Sync + Send + 'static {
     /// Returns the name of the hook.
     /// This is typically used for logging and debugging purposes.
     fn hook_name(&self) -> &str;

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -71,6 +71,7 @@ pub(crate) mod peek_message_processor;
 pub(crate) mod polling_info_processor;
 pub(crate) mod pop_message_processor;
 pub(crate) mod pull_message_processor;
+pub(crate) mod pull_message_result_handler;
 pub(crate) mod query_assignment_processor;
 pub(crate) mod query_message_processor;
 pub(crate) mod reply_message_processor;
@@ -142,6 +143,12 @@ impl<MS: MessageStore + Send + Sync + 'static> RequestProcessor for BrokerReques
                     .process_request(ctx, request_code, request)
                     .await
             }
+            RequestCode::PullMessage | RequestCode::LitePullMessage => {
+                self.pull_message_processor
+                    .process_request(ctx, request_code, request)
+                    .await
+            }
+
             _ => self.admin_broker_processor.process_request(ctx, request),
         }
     }

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -14,18 +14,79 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::sync::Arc;
+
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_common::common::constant::PermName;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::server::ConnectionHandlerContext;
 
-#[derive(Default, Clone)]
-pub struct PullMessageProcessor {}
+use crate::mqtrace::consume_message_hook::ConsumeMessageHook;
+use crate::processor::pull_message_result_handler::PullMessageResultHandler;
+
+#[derive(Clone)]
+pub struct PullMessageProcessor {
+    consume_message_hook_vec: Arc<Vec<Box<dyn ConsumeMessageHook>>>,
+    pull_message_result_handler: Arc<dyn PullMessageResultHandler>,
+    broker_config: Arc<BrokerConfig>,
+}
+
+impl Default for PullMessageProcessor {
+    fn default() -> Self {
+        todo!()
+    }
+}
 
 impl PullMessageProcessor {
-    fn process_request(
-        &self,
-        _ctx: ConnectionHandlerContext,
-        _request: RemotingCommand,
-    ) -> RemotingCommand {
-        todo!()
+    pub async fn process_request(
+        &mut self,
+        ctx: ConnectionHandlerContext<'_>,
+        request_code: RequestCode,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        self.process_request_inner(request_code, ctx, request, true, true)
+            .await
+    }
+
+    async fn process_request_inner(
+        &mut self,
+        request_code: RequestCode,
+        _ctx: ConnectionHandlerContext<'_>,
+        request: RemotingCommand,
+        _broker_allow_suspend: bool,
+        _broker_allow_flow_ctr_suspend: bool,
+    ) -> Option<RemotingCommand> {
+        let _begin_time_mills = get_current_millis();
+        let mut response = RemotingCommand::create_response_command();
+        response.set_opaque_mut(request.opaque());
+        let _request_header =
+            request.decode_command_custom_header_fast::<PullMessageRequestHeader>();
+        if !PermName::is_readable(self.broker_config.broker_permission) {
+            return Some(
+                response
+                    .set_code(ResponseCode::NoPermission)
+                    .set_remark(Some(format!(
+                        "the broker[{}] pulling message is forbidden",
+                        self.broker_config.broker_ip1
+                    ))),
+            );
+        }
+        if RequestCode::LitePullMessage == request_code
+            && !self.broker_config.lite_pull_message_enable
+        {
+            return Some(
+                response
+                    .set_code(ResponseCode::NoPermission)
+                    .set_remark(Some(format!(
+                        "the broker[{}] pulling message is forbidden",
+                        self.broker_config.broker_ip1
+                    ))),
+            );
+        }
+        Some(response)
     }
 }

--- a/rocketmq-broker/src/processor/pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/pull_message_result_handler.rs
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_context::TopicQueueMappingContext;
+use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+use rocketmq_store::base::message_result::GetMessageResult;
+use rocketmq_store::filter::MessageFilter;
+
+pub trait PullMessageResultHandler: Sync + Send + 'static {
+    fn handle(
+        &self,
+        get_message_result: GetMessageResult,
+        request: RemotingCommand,
+        request_header: PullMessageRequestHeader,
+        subscription_data: SubscriptionData,
+        subscription_group_config: SubscriptionGroupConfig,
+        broker_allow_suspend: bool,
+        message_filter: &dyn MessageFilter,
+        response: RemotingCommand,
+        mapping_context: TopicQueueMappingContext,
+        begin_time_mills: i64,
+    ) -> Option<RemotingCommand>;
+}

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -142,6 +142,7 @@ pub struct BrokerConfig {
     pub skip_pre_online: bool,
     pub namesrv_addr: Option<String>,
     pub fetch_name_srv_addr_by_dns_lookup: bool,
+    pub lite_pull_message_enable: bool,
 }
 
 impl Default for BrokerConfig {
@@ -195,6 +196,7 @@ impl Default for BrokerConfig {
             skip_pre_online: false,
             namesrv_addr: NAMESRV_ADDR.clone(),
             fetch_name_srv_addr_by_dns_lookup: false,
+            lite_pull_message_enable: true,
         }
     }
 }

--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -365,7 +365,7 @@ pub trait RemotingSerializable {
 }
 
 pub trait FastCodesHeader {
-    fn write_if_not_null(&mut self, out: &mut bytes::BytesMut, key: &str, value: &str) {
+    fn write_if_not_null(out: &mut bytes::BytesMut, key: &str, value: &str) {
         if !value.is_empty() {
             RocketMQSerializable::write_str(out, true, key);
             RocketMQSerializable::write_str(out, false, key);

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -18,4 +18,6 @@ pub mod broker;
 pub mod client_request_header;
 pub mod message_operation_header;
 pub mod namesrv;
+pub mod pull_message_request_header;
+pub mod pull_message_response_header;
 pub mod unregister_client_request_header;

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_response_header.rs
@@ -93,15 +93,15 @@ impl SendMessageResponseHeader {
 
 impl FastCodesHeader for SendMessageResponseHeader {
     fn encode_fast(&mut self, out: &mut bytes::BytesMut) {
-        self.write_if_not_null(out, "msgId", self.msg_id.to_string().as_str());
-        self.write_if_not_null(out, "queueId", self.queue_id.to_string().as_str());
-        self.write_if_not_null(out, "queueOffset", self.queue_offset.to_string().as_str());
-        self.write_if_not_null(
+        Self::write_if_not_null(out, "msgId", self.msg_id.to_string().as_str());
+        Self::write_if_not_null(out, "queueId", self.queue_id.to_string().as_str());
+        Self::write_if_not_null(out, "queueOffset", self.queue_offset.to_string().as_str());
+        Self::write_if_not_null(
             out,
             "transactionId",
             self.transaction_id.clone().as_deref().unwrap(),
         );
-        self.write_if_not_null(
+        Self::write_if_not_null(
             out,
             "batchUniqId",
             self.batch_uniq_id.clone().as_deref().unwrap(),

--- a/rocketmq-remoting/src/protocol/header/namesrv/topic_operation_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/topic_operation_header.rs
@@ -137,7 +137,7 @@ impl FromMap for GetTopicsByClusterRequestHeader {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct TopicRequestHeader {
     pub lo: Option<bool>,

--- a/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+
+use bytes::BytesMut;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::FromMap;
+use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
+use crate::protocol::FastCodesHeader;
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PullMessageRequestHeader {
+    pub consumer_group: String,
+    pub topic: String,
+    pub queue_id: i32,
+    pub queue_offset: i64,
+    pub max_msg_nums: i32,
+    pub sys_flag: i32,
+    pub commit_offset: i64,
+    pub suspend_timeout_millis: i64,
+    pub subscription: Option<String>,
+    pub sub_version: i64,
+    pub expression_type: Option<String>,
+    pub max_msg_bytes: Option<i32>,
+    pub request_source: Option<i32>,
+    pub proxy_forward_client_id: Option<String>,
+    #[serde(flatten)]
+    pub topic_request: Option<TopicRequestHeader>,
+}
+
+impl PullMessageRequestHeader {
+    const COMMIT_OFFSET: &'static str = "commitOffset";
+    const CONSUMER_GROUP: &'static str = "consumerGroup";
+    const EXPRESSION_TYPE: &'static str = "expressionType";
+    const MAX_MSG_BYTES: &'static str = "maxMsgBytes";
+    const MAX_MSG_NUMS: &'static str = "maxMsgNums";
+    const PROXY_FORWARD_CLIENT_ID: &'static str = "proxyForwardClientId";
+    const QUEUE_ID: &'static str = "queueId";
+    const QUEUE_OFFSET: &'static str = "queueOffset";
+    const REQUEST_SOURCE: &'static str = "requestSource";
+    const SUBSCRIPTION: &'static str = "subscription";
+    const SUB_VERSION: &'static str = "subVersion";
+    const SUSPEND_TIMEOUT_MILLIS: &'static str = "suspendTimeoutMillis";
+    const SYS_FLAG: &'static str = "sysFlag";
+    const TOPIC: &'static str = "topic";
+}
+
+impl CommandCustomHeader for PullMessageRequestHeader {
+    fn to_map(&self) -> Option<HashMap<String, String>> {
+        let mut map = HashMap::new();
+
+        map.insert(
+            Self::CONSUMER_GROUP.to_string(),
+            self.consumer_group.clone(),
+        );
+        map.insert(Self::TOPIC.to_string(), self.topic.clone());
+        map.insert(Self::QUEUE_ID.to_string(), self.queue_id.to_string());
+        map.insert(
+            Self::QUEUE_OFFSET.to_string(),
+            self.queue_offset.to_string(),
+        );
+        map.insert(
+            Self::MAX_MSG_NUMS.to_string(),
+            self.max_msg_nums.to_string(),
+        );
+        map.insert(Self::SYS_FLAG.to_string(), self.sys_flag.to_string());
+        map.insert(
+            Self::COMMIT_OFFSET.to_string(),
+            self.commit_offset.to_string(),
+        );
+        map.insert(
+            Self::SUSPEND_TIMEOUT_MILLIS.to_string(),
+            self.suspend_timeout_millis.to_string(),
+        );
+
+        if let Some(ref value) = self.subscription {
+            map.insert(Self::SUBSCRIPTION.to_string(), value.clone());
+        }
+
+        map.insert(Self::SUB_VERSION.to_string(), self.sub_version.to_string());
+
+        if let Some(ref value) = self.expression_type {
+            map.insert(Self::EXPRESSION_TYPE.to_string(), value.clone());
+        }
+
+        if let Some(value) = self.max_msg_bytes {
+            map.insert(Self::MAX_MSG_BYTES.to_string(), value.to_string());
+        }
+        if let Some(value) = self.request_source {
+            map.insert(Self::REQUEST_SOURCE.to_string(), value.to_string());
+        }
+        if let Some(ref value) = self.proxy_forward_client_id {
+            map.insert(Self::PROXY_FORWARD_CLIENT_ID.to_string(), value.clone());
+        }
+
+        if let Some(ref rpc) = self.topic_request {
+            if let Some(rpc_map) = rpc.to_map() {
+                map.extend(rpc_map);
+            }
+        }
+        Some(map)
+    }
+}
+
+impl FromMap for PullMessageRequestHeader {
+    type Target = Self;
+
+    fn from(map: &HashMap<String, String>) -> Option<Self::Target> {
+        Some(Self {
+            consumer_group: map.get(Self::CONSUMER_GROUP).cloned().unwrap_or_default(),
+            topic: map.get(Self::TOPIC).cloned().unwrap_or_default(),
+            queue_id: map
+                .get(Self::QUEUE_ID)
+                .map_or(0, |value| value.parse().unwrap_or_default()),
+            queue_offset: map
+                .get(Self::QUEUE_OFFSET)
+                .map_or(0, |value| value.parse().unwrap_or_default()),
+            max_msg_nums: map
+                .get(Self::MAX_MSG_NUMS)
+                .map_or(0, |value| value.parse().unwrap_or_default()),
+            sys_flag: map
+                .get(Self::SYS_FLAG)
+                .map_or(0, |value| value.parse().unwrap_or_default()),
+            commit_offset: map
+                .get(Self::COMMIT_OFFSET)
+                .map_or(0, |value| value.parse().unwrap_or_default()),
+            suspend_timeout_millis: map
+                .get(Self::SUSPEND_TIMEOUT_MILLIS)
+                .map_or(0, |value| value.parse().unwrap_or_default()),
+            subscription: map.get(Self::SUBSCRIPTION).cloned(),
+            sub_version: map
+                .get(Self::SUB_VERSION)
+                .map_or(0, |value| value.parse().unwrap_or_default()),
+            expression_type: map.get(Self::EXPRESSION_TYPE).cloned(),
+            max_msg_bytes: map
+                .get(Self::MAX_MSG_BYTES)
+                .and_then(|value| value.parse::<i32>().ok()),
+            request_source: map
+                .get(Self::REQUEST_SOURCE)
+                .and_then(|value| value.parse::<i32>().ok()),
+            proxy_forward_client_id: map.get(Self::PROXY_FORWARD_CLIENT_ID).cloned(),
+            topic_request: <TopicRequestHeader as FromMap>::from(map),
+        })
+    }
+}
+
+impl FastCodesHeader for PullMessageRequestHeader {
+    fn encode_fast(&mut self, out: &mut BytesMut) {
+        Self::write_if_not_null(out, "consumerGroup", self.consumer_group.as_str());
+        Self::write_if_not_null(out, "topic", self.topic.as_str());
+        Self::write_if_not_null(out, "queueId", self.queue_id.to_string().as_str());
+        Self::write_if_not_null(out, "queueOffset", self.queue_offset.to_string().as_str());
+        Self::write_if_not_null(out, "maxMsgNums", self.max_msg_nums.to_string().as_str());
+        Self::write_if_not_null(out, "sysFlag", self.sys_flag.to_string().as_str());
+        Self::write_if_not_null(out, "commitOffset", self.commit_offset.to_string().as_str());
+        Self::write_if_not_null(
+            out,
+            "suspendTimeoutMillis",
+            self.suspend_timeout_millis.to_string().as_str(),
+        );
+        if let Some(ref value) = self.subscription {
+            Self::write_if_not_null(out, "subscription", value.as_str());
+        }
+
+        Self::write_if_not_null(out, "subVersion", self.sub_version.to_string().as_str());
+        if let Some(ref value) = self.expression_type {
+            Self::write_if_not_null(out, "expressionType", value.as_str());
+        }
+        if let Some(value) = self.max_msg_bytes {
+            Self::write_if_not_null(out, "maxMsgBytes", value.to_string().as_str());
+        }
+
+        if let Some(value) = self.request_source {
+            Self::write_if_not_null(out, "requestSource", value.to_string().as_str());
+        }
+        if let Some(ref value) = self.proxy_forward_client_id {
+            Self::write_if_not_null(out, "proxyFrowardClientId", value.as_str());
+        }
+
+        // Assuming "lo", "ns", "nsd", "bname", "oway" are other fields in the struct
+        if let Some(ref value) = self.topic_request {
+            if let Some(lo) = value.lo {
+                Self::write_if_not_null(out, "lo", lo.to_string().as_str());
+            }
+        }
+        if let Some(ref topic_request) = self.topic_request {
+            if let Some(ref rpc) = topic_request.rpc {
+                if let Some(ref np) = rpc.namespace {
+                    Self::write_if_not_null(out, "ns", np.as_str());
+                }
+                if let Some(ref nsd) = rpc.namespaced {
+                    Self::write_if_not_null(out, "nsd", nsd.to_string().as_str());
+                }
+                if let Some(ref bname) = rpc.broker_name {
+                    Self::write_if_not_null(out, "bname", bname.as_str());
+                }
+                if let Some(ref oway) = rpc.namespace {
+                    Self::write_if_not_null(out, "oway", oway.as_str());
+                }
+            }
+        }
+    }
+
+    fn decode_fast(&mut self, fields: &HashMap<String, String>) {
+        if let Some(str) = fields.get("consumerGroup") {
+            self.consumer_group.clone_from(str);
+        }
+
+        if let Some(str) = fields.get("topic") {
+            self.topic.clone_from(str);
+        }
+
+        if let Some(str) = fields.get("queueId") {
+            self.queue_id = str.parse::<i32>().unwrap();
+        }
+
+        if let Some(str) = fields.get("queueOffset") {
+            self.queue_offset = str.parse::<i64>().unwrap();
+        }
+
+        if let Some(str) = fields.get("maxMsgNums") {
+            self.max_msg_nums = str.parse::<i32>().unwrap();
+        }
+
+        if let Some(str) = fields.get("sysFlag") {
+            self.sys_flag = str.parse::<i32>().unwrap();
+        }
+
+        if let Some(str) = fields.get("commitOffset") {
+            self.commit_offset = str.parse::<i64>().unwrap();
+        }
+
+        if let Some(str) = fields.get("suspendTimeoutMillis") {
+            self.suspend_timeout_millis = str.parse::<i64>().unwrap();
+        }
+
+        if let Some(str) = fields.get("subscription") {
+            self.subscription = Some(str.clone());
+        }
+
+        if let Some(str) = fields.get("subVersion") {
+            self.sub_version = str.parse::<i64>().unwrap();
+        }
+
+        if let Some(str) = fields.get("expressionType") {
+            self.expression_type = Some(str.clone());
+        }
+
+        if let Some(str) = fields.get("maxMsgBytes") {
+            self.max_msg_bytes = Some(str.parse::<i32>().unwrap());
+        }
+
+        if let Some(str) = fields.get("requestSource") {
+            self.request_source = Some(str.parse::<i32>().unwrap());
+        }
+
+        if let Some(str) = fields.get("proxyFrowardClientId") {
+            self.proxy_forward_client_id = Some(str.clone());
+        }
+
+        if let Some(str) = fields.get("lo") {
+            self.topic_request.as_mut().unwrap().lo = Some(str.parse::<bool>().unwrap());
+        }
+
+        if let Some(str) = fields.get("ns") {
+            self.topic_request
+                .as_mut()
+                .unwrap()
+                .rpc
+                .as_mut()
+                .unwrap()
+                .namespace = Some(str.clone());
+        }
+
+        if let Some(str) = fields.get("nsd") {
+            self.topic_request
+                .as_mut()
+                .unwrap()
+                .rpc
+                .as_mut()
+                .unwrap()
+                .namespaced = Some(str.parse::<bool>().unwrap());
+        }
+
+        if let Some(str) = fields.get("bname") {
+            self.topic_request
+                .as_mut()
+                .unwrap()
+                .rpc
+                .as_mut()
+                .unwrap()
+                .broker_name = Some(str.clone());
+        }
+
+        if let Some(str) = fields.get("oway") {
+            self.topic_request
+                .as_mut()
+                .unwrap()
+                .rpc
+                .as_mut()
+                .unwrap()
+                .oneway = Some(str.parse::<bool>().unwrap());
+        }
+    }
+}

--- a/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+
+use bytes::BytesMut;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::FastCodesHeader;
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PullMessageResponseHeader {
+    suggest_which_broker_id: Option<i64>,
+    next_begin_offset: Option<i64>,
+    min_offset: Option<i64>,
+    max_offset: Option<i64>,
+    offset_delta: Option<i64>,
+    topic_sys_flag: Option<i32>,
+    group_sys_flag: Option<i32>,
+    forbidden_type: Option<i32>,
+}
+
+impl PullMessageResponseHeader {
+    const FORBIDDEN_TYPE: &'static str = "forbiddenType";
+    const GROUP_SYS_FLAG: &'static str = "groupSysFlag";
+    const MAX_OFFSET: &'static str = "maxOffset";
+    const MIN_OFFSET: &'static str = "minOffset";
+    const NEXT_BEGIN_OFFSET: &'static str = "nextBeginOffset";
+    const OFFSET_DELTA: &'static str = "offsetDelta";
+    const SUGGEST_WHICH_BROKER_ID: &'static str = "suggestWhichBrokerId";
+    const TOPIC_SYS_FLAG: &'static str = "topicSysFlag";
+}
+
+impl FastCodesHeader for PullMessageResponseHeader {
+    fn encode_fast(&mut self, out: &mut BytesMut) {
+        if let Some(value) = self.suggest_which_broker_id {
+            Self::write_if_not_null(
+                out,
+                Self::SUGGEST_WHICH_BROKER_ID,
+                value.to_string().as_str(),
+            );
+        }
+        if let Some(value) = self.next_begin_offset {
+            Self::write_if_not_null(out, Self::NEXT_BEGIN_OFFSET, value.to_string().as_str());
+        }
+        if let Some(value) = self.min_offset {
+            Self::write_if_not_null(out, Self::MIN_OFFSET, value.to_string().as_str());
+        }
+        if let Some(value) = self.max_offset {
+            Self::write_if_not_null(out, Self::MAX_OFFSET, value.to_string().as_str());
+        }
+        if let Some(value) = self.offset_delta {
+            Self::write_if_not_null(out, Self::OFFSET_DELTA, value.to_string().as_str());
+        }
+        if let Some(value) = self.topic_sys_flag {
+            Self::write_if_not_null(out, Self::TOPIC_SYS_FLAG, value.to_string().as_str());
+        }
+        if let Some(value) = self.group_sys_flag {
+            Self::write_if_not_null(out, Self::GROUP_SYS_FLAG, value.to_string().as_str());
+        }
+        if let Some(value) = self.forbidden_type {
+            Self::write_if_not_null(out, Self::FORBIDDEN_TYPE, value.to_string().as_str());
+        }
+    }
+
+    fn decode_fast(&mut self, fields: &HashMap<String, String>) {
+        if let Some(offset_delta) = fields.get(Self::SUGGEST_WHICH_BROKER_ID) {
+            self.suggest_which_broker_id = Some(offset_delta.parse().unwrap());
+        }
+        if let Some(offset_delta) = fields.get(Self::NEXT_BEGIN_OFFSET) {
+            self.next_begin_offset = Some(offset_delta.parse().unwrap());
+        }
+        if let Some(offset_delta) = fields.get(Self::MIN_OFFSET) {
+            self.min_offset = Some(offset_delta.parse().unwrap());
+        }
+        if let Some(offset_delta) = fields.get(Self::MAX_OFFSET) {
+            self.max_offset = Some(offset_delta.parse().unwrap());
+        }
+        if let Some(offset_delta) = fields.get(Self::OFFSET_DELTA) {
+            self.offset_delta = Some(offset_delta.parse().unwrap());
+        }
+        if let Some(offset_delta) = fields.get(Self::TOPIC_SYS_FLAG) {
+            self.topic_sys_flag = Some(offset_delta.parse().unwrap());
+        }
+        if let Some(offset_delta) = fields.get(Self::GROUP_SYS_FLAG) {
+            self.group_sys_flag = Some(offset_delta.parse().unwrap());
+        }
+        if let Some(offset_delta) = fields.get(Self::FORBIDDEN_TYPE) {
+            self.forbidden_type = Some(offset_delta.parse().unwrap());
+        }
+    }
+}

--- a/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
@@ -48,30 +48,61 @@ impl PullMessageResponseHeader {
 }
 
 impl FastCodesHeader for PullMessageResponseHeader {
+    fn encode_fast(&mut self, out: &mut BytesMut) {
+        if let Some(value) = self.suggest_which_broker_id {
+            Self::write_if_not_null(
+                out,
+                Self::SUGGEST_WHICH_BROKER_ID,
+                value.to_string().as_str(),
+            );
+        }
+        if let Some(value) = self.next_begin_offset {
+            Self::write_if_not_null(out, Self::NEXT_BEGIN_OFFSET, value.to_string().as_str());
+        }
+        if let Some(value) = self.min_offset {
+            Self::write_if_not_null(out, Self::MIN_OFFSET, value.to_string().as_str());
+        }
+        if let Some(value) = self.max_offset {
+            Self::write_if_not_null(out, Self::MAX_OFFSET, value.to_string().as_str());
+        }
+        if let Some(value) = self.offset_delta {
+            Self::write_if_not_null(out, Self::OFFSET_DELTA, value.to_string().as_str());
+        }
+        if let Some(value) = self.topic_sys_flag {
+            Self::write_if_not_null(out, Self::TOPIC_SYS_FLAG, value.to_string().as_str());
+        }
+        if let Some(value) = self.group_sys_flag {
+            Self::write_if_not_null(out, Self::GROUP_SYS_FLAG, value.to_string().as_str());
+        }
+        if let Some(value) = self.forbidden_type {
+            Self::write_if_not_null(out, Self::FORBIDDEN_TYPE, value.to_string().as_str());
+        }
+    }
+
     fn decode_fast(&mut self, fields: &HashMap<String, String>) {
         if let Some(offset_delta) = fields.get(Self::SUGGEST_WHICH_BROKER_ID) {
-            self.suggest_which_broker_id = offset_delta.parse().ok();
+            self.suggest_which_broker_id = Some(offset_delta.parse().unwrap());
         }
         if let Some(offset_delta) = fields.get(Self::NEXT_BEGIN_OFFSET) {
-            self.next_begin_offset = offset_delta.parse().ok();
+            self.next_begin_offset = Some(offset_delta.parse().unwrap());
         }
         if let Some(offset_delta) = fields.get(Self::MIN_OFFSET) {
-            self.min_offset = offset_delta.parse().ok();
+            self.min_offset = Some(offset_delta.parse().unwrap());
         }
         if let Some(offset_delta) = fields.get(Self::MAX_OFFSET) {
-            self.max_offset = offset_delta.parse().ok();
+            self.max_offset = Some(offset_delta.parse().unwrap());
         }
         if let Some(offset_delta) = fields.get(Self::OFFSET_DELTA) {
-            self.offset_delta = offset_delta.parse().ok();
+            self.offset_delta = Some(offset_delta.parse().unwrap());
         }
         if let Some(offset_delta) = fields.get(Self::TOPIC_SYS_FLAG) {
-            self.topic_sys_flag = offset_delta.parse().ok();
+            self.topic_sys_flag = Some(offset_delta.parse().unwrap());
         }
         if let Some(offset_delta) = fields.get(Self::GROUP_SYS_FLAG) {
-            self.group_sys_flag = offset_delta.parse().ok();
+            self.group_sys_flag = Some(offset_delta.parse().unwrap());
         }
         if let Some(offset_delta) = fields.get(Self::FORBIDDEN_TYPE) {
-            self.forbidden_type = offset_delta.parse().ok();
+            self.forbidden_type = Some(offset_delta.parse().unwrap());
         }
     }
 }

--- a/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
@@ -48,61 +48,30 @@ impl PullMessageResponseHeader {
 }
 
 impl FastCodesHeader for PullMessageResponseHeader {
-    fn encode_fast(&mut self, out: &mut BytesMut) {
-        if let Some(value) = self.suggest_which_broker_id {
-            Self::write_if_not_null(
-                out,
-                Self::SUGGEST_WHICH_BROKER_ID,
-                value.to_string().as_str(),
-            );
-        }
-        if let Some(value) = self.next_begin_offset {
-            Self::write_if_not_null(out, Self::NEXT_BEGIN_OFFSET, value.to_string().as_str());
-        }
-        if let Some(value) = self.min_offset {
-            Self::write_if_not_null(out, Self::MIN_OFFSET, value.to_string().as_str());
-        }
-        if let Some(value) = self.max_offset {
-            Self::write_if_not_null(out, Self::MAX_OFFSET, value.to_string().as_str());
-        }
-        if let Some(value) = self.offset_delta {
-            Self::write_if_not_null(out, Self::OFFSET_DELTA, value.to_string().as_str());
-        }
-        if let Some(value) = self.topic_sys_flag {
-            Self::write_if_not_null(out, Self::TOPIC_SYS_FLAG, value.to_string().as_str());
-        }
-        if let Some(value) = self.group_sys_flag {
-            Self::write_if_not_null(out, Self::GROUP_SYS_FLAG, value.to_string().as_str());
-        }
-        if let Some(value) = self.forbidden_type {
-            Self::write_if_not_null(out, Self::FORBIDDEN_TYPE, value.to_string().as_str());
-        }
-    }
-
     fn decode_fast(&mut self, fields: &HashMap<String, String>) {
         if let Some(offset_delta) = fields.get(Self::SUGGEST_WHICH_BROKER_ID) {
-            self.suggest_which_broker_id = Some(offset_delta.parse().unwrap());
+            self.suggest_which_broker_id = offset_delta.parse().ok();
         }
         if let Some(offset_delta) = fields.get(Self::NEXT_BEGIN_OFFSET) {
-            self.next_begin_offset = Some(offset_delta.parse().unwrap());
+            self.next_begin_offset = offset_delta.parse().ok();
         }
         if let Some(offset_delta) = fields.get(Self::MIN_OFFSET) {
-            self.min_offset = Some(offset_delta.parse().unwrap());
+            self.min_offset = offset_delta.parse().ok();
         }
         if let Some(offset_delta) = fields.get(Self::MAX_OFFSET) {
-            self.max_offset = Some(offset_delta.parse().unwrap());
+            self.max_offset = offset_delta.parse().ok();
         }
         if let Some(offset_delta) = fields.get(Self::OFFSET_DELTA) {
-            self.offset_delta = Some(offset_delta.parse().unwrap());
+            self.offset_delta = offset_delta.parse().ok();
         }
         if let Some(offset_delta) = fields.get(Self::TOPIC_SYS_FLAG) {
-            self.topic_sys_flag = Some(offset_delta.parse().unwrap());
+            self.topic_sys_flag = offset_delta.parse().ok();
         }
         if let Some(offset_delta) = fields.get(Self::GROUP_SYS_FLAG) {
-            self.group_sys_flag = Some(offset_delta.parse().unwrap());
+            self.group_sys_flag = offset_delta.parse().ok();
         }
         if let Some(offset_delta) = fields.get(Self::FORBIDDEN_TYPE) {
-            self.forbidden_type = Some(offset_delta.parse().unwrap());
+            self.forbidden_type = offset_delta.parse().ok();
         }
     }
 }

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -27,6 +27,7 @@ use rocketmq_common::common::mq_version::RocketMqVersion;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::FastCodesHeader;
 use super::RemotingCommandType;
 use super::SerializeType;
 use crate::code::response_code::RemotingSysResponseCode;
@@ -231,6 +232,10 @@ impl RemotingCommand {
         self
     }
 
+    pub fn set_opaque_mut(&mut self, opaque: i32) {
+        self.opaque = opaque;
+    }
+
     pub fn set_flag(mut self, flag: i32) -> Self {
         self.flag = flag;
         self
@@ -357,6 +362,20 @@ impl RemotingCommand {
         match self.ext_fields {
             None => None,
             Some(ref header) => T::from(header),
+        }
+    }
+
+    pub fn decode_command_custom_header_fast<T>(&self) -> Option<T>
+    where
+        T: FromMap<Target = T> + Default + FastCodesHeader,
+    {
+        match self.ext_fields {
+            None => None,
+            Some(ref header) => {
+                let mut target = T::default();
+                target.decode_fast(header);
+                Some(target)
+            }
         }
     }
 

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -20,7 +20,7 @@
 pub mod base;
 pub mod config;
 mod consume_queue;
-mod filter;
+pub mod filter;
 pub mod hook;
 mod index;
 mod kv;

--- a/rocketmq/src/lib.rs
+++ b/rocketmq/src/lib.rs
@@ -19,3 +19,24 @@
 pub use rocketmq::main;
 /// Re-export tokio module.
 pub use tokio as rocketmq;
+
+#[macro_export]
+macro_rules! is_trait_implemented {
+    ($t:ty, $tr:ident) => {{
+        struct Checker<T: ?Sized>(std::marker::PhantomData<T>);
+
+        impl<T: $tr + ?Sized> Checker<T> {
+            fn is_implemented() -> bool {
+                true
+            }
+        }
+
+        impl<T: ?Sized> Checker<T> {
+            fn is_implemented() -> bool {
+                false
+            }
+        }
+
+        Checker::<$t>::is_implemented()
+    }};
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #658 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new struct `PullMessageResponseHeader` for handling message pulling with fast serialization capabilities.
  - Added support for dynamic message consumption configuration with `lite_pull_message_enable` option.

- **Improvements**
  - Enhanced `ConsumeMessageHook` with additional trait constraints for better concurrency support.
  - Extended `PullMessageProcessor` with new fields and methods to improve message processing.
  - Updated method signatures and implementations for better performance and flexibility in message handling.

- **Refactor**
  - Refactored `SendMessageResponseHeader` to use static method calls for improved code clarity.
  - Promoted `filter` module to be publicly accessible.

- **Documentation**
  - Added detailed documentation for new modules and updated existing ones to reflect changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->