### PR TITLE
[ISSUE #662]🚀Support pull message consume-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1257,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1346,6 +1346,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -72,7 +72,8 @@ pub(crate) struct BrokerRuntime {
     topic_config_manager: TopicConfigManager,
     topic_queue_mapping_manager: Arc<TopicQueueMappingManager>,
     consumer_offset_manager: Arc<ConsumerOffsetManager>,
-    subscription_group_manager: Arc<SubscriptionGroupManager>,
+    #[cfg(feature = "local_file_store")]
+    subscription_group_manager: Arc<SubscriptionGroupManager<DefaultMessageStore>>,
     consumer_filter_manager: Arc<ConsumerFilterManager>,
     consumer_order_info_manager: Arc<ConsumerOrderInfoManager>,
     #[cfg(feature = "local_file_store")]
@@ -106,7 +107,7 @@ impl Clone for BrokerRuntime {
             topic_config_manager: self.topic_config_manager.clone(),
             topic_queue_mapping_manager: self.topic_queue_mapping_manager.clone(),
             consumer_offset_manager: self.consumer_offset_manager.clone(),
-            subscription_group_manager: Arc::new(Default::default()),
+            subscription_group_manager: self.subscription_group_manager.clone(),
             consumer_filter_manager: Arc::new(Default::default()),
             consumer_order_info_manager: Arc::new(Default::default()),
             message_store: self.message_store.clone(),
@@ -171,7 +172,7 @@ impl BrokerRuntime {
             topic_config_manager,
             topic_queue_mapping_manager,
             consumer_offset_manager: Arc::new(Default::default()),
-            subscription_group_manager: Arc::new(Default::default()),
+            subscription_group_manager: Arc::new(SubscriptionGroupManager::new()),
             consumer_filter_manager: Arc::new(Default::default()),
             consumer_order_info_manager: Arc::new(Default::default()),
             message_store: None,

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -82,7 +82,7 @@ where
     MS: Clone,
 {
     pub(crate) send_message_processor: SendMessageProcessor<MS>,
-    pub(crate) pull_message_processor: PullMessageProcessor,
+    pub(crate) pull_message_processor: PullMessageProcessor<MS>,
     pub(crate) peek_message_processor: PeekMessageProcessor,
     pub(crate) pop_message_processor: PopMessageProcessor,
     pub(crate) ack_message_processor: AckMessageProcessor,

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -18,30 +18,55 @@ use std::sync::Arc;
 
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::constant::PermName;
+use rocketmq_common::common::filter::expression_type::ExpressionType;
+use rocketmq_common::common::sys_flag::pull_sys_flag::PullSysFlag;
+use rocketmq_common::common::FAQUrl;
 use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::RemotingSysResponseCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::protocol::filter::filter_api::FilterAPI;
+use rocketmq_remoting::protocol::forbidden_type::ForbiddenType;
 use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_remoting::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::request_source::RequestSource;
+use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_context::TopicQueueMappingContext;
 use rocketmq_remoting::runtime::server::ConnectionHandlerContext;
+use rocketmq_store::log_file::MessageStore;
+use tracing::error;
 
+use crate::client::manager::consumer_manager::ConsumerManager;
+use crate::filter::manager::consumer_filter_manager::ConsumerFilterManager;
 use crate::mqtrace::consume_message_hook::ConsumeMessageHook;
 use crate::processor::pull_message_result_handler::PullMessageResultHandler;
+use crate::subscription::manager::subscription_group_manager::SubscriptionGroupManager;
+use crate::topic::manager::topic_config_manager::TopicConfigManager;
+use crate::topic::manager::topic_queue_mapping_manager::TopicQueueMappingManager;
 
 #[derive(Clone)]
-pub struct PullMessageProcessor {
+pub struct PullMessageProcessor<MS> {
     consume_message_hook_vec: Arc<Vec<Box<dyn ConsumeMessageHook>>>,
     pull_message_result_handler: Arc<dyn PullMessageResultHandler>,
     broker_config: Arc<BrokerConfig>,
+    subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
+    topic_config_manager: Arc<TopicConfigManager>,
+    topic_queue_mapping_manager: Arc<TopicQueueMappingManager>,
+    consumer_manager: Arc<ConsumerManager>,
+    consumer_filter_manager: Arc<ConsumerFilterManager>,
 }
 
-impl Default for PullMessageProcessor {
+impl<MS> Default for PullMessageProcessor<MS> {
     fn default() -> Self {
         todo!()
     }
 }
 
-impl PullMessageProcessor {
+#[allow(unused_variables)]
+impl<MS> PullMessageProcessor<MS>
+where
+    MS: MessageStore,
+{
     pub async fn process_request(
         &mut self,
         ctx: ConnectionHandlerContext<'_>,
@@ -55,7 +80,7 @@ impl PullMessageProcessor {
     async fn process_request_inner(
         &mut self,
         request_code: RequestCode,
-        _ctx: ConnectionHandlerContext<'_>,
+        ctx: ConnectionHandlerContext<'_>,
         request: RemotingCommand,
         _broker_allow_suspend: bool,
         _broker_allow_flow_ctr_suspend: bool,
@@ -63,12 +88,16 @@ impl PullMessageProcessor {
         let _begin_time_mills = get_current_millis();
         let mut response = RemotingCommand::create_response_command();
         response.set_opaque_mut(request.opaque());
-        let _request_header =
-            request.decode_command_custom_header_fast::<PullMessageRequestHeader>();
+        let request_header = request
+            .decode_command_custom_header_fast::<PullMessageRequestHeader>()
+            .unwrap();
+        let mut response_header = PullMessageResponseHeader::default();
         if !PermName::is_readable(self.broker_config.broker_permission) {
+            response_header.forbidden_type = Some(ForbiddenType::BROKER_FORBIDDEN);
             return Some(
                 response
                     .set_code(ResponseCode::NoPermission)
+                    .set_command_custom_header(response_header)
                     .set_remark(Some(format!(
                         "the broker[{}] pulling message is forbidden",
                         self.broker_config.broker_ip1
@@ -78,15 +107,171 @@ impl PullMessageProcessor {
         if RequestCode::LitePullMessage == request_code
             && !self.broker_config.lite_pull_message_enable
         {
+            response_header.forbidden_type = Some(ForbiddenType::BROKER_FORBIDDEN);
             return Some(
                 response
                     .set_code(ResponseCode::NoPermission)
+                    .set_command_custom_header(response_header)
                     .set_remark(Some(format!(
                         "the broker[{}] pulling message is forbidden",
                         self.broker_config.broker_ip1
                     ))),
             );
         }
+        let subscription_group_config = self
+            .subscription_group_manager
+            .find_subscription_group_config(request_header.consumer_group.as_str());
+
+        if subscription_group_config.is_none() {
+            return Some(
+                response
+                    .set_code(ResponseCode::SubscriptionGroupNotExist)
+                    .set_remark(Some(format!(
+                        "subscription group [{}] does not exist, {}",
+                        request_header.consumer_group,
+                        FAQUrl::suggest_todo(FAQUrl::SUBSCRIPTION_GROUP_NOT_EXIST)
+                    ))),
+            );
+        }
+
+        if !subscription_group_config.as_ref().unwrap().consume_enable() {
+            response_header.forbidden_type = Some(ForbiddenType::GROUP_FORBIDDEN);
+            return Some(
+                response
+                    .set_code(ResponseCode::NoPermission)
+                    .set_remark(Some(format!(
+                        "subscription group no permission, {}",
+                        request_header.consumer_group,
+                    ))),
+            );
+        }
+        let topic_config = self
+            .topic_config_manager
+            .select_topic_config(request_header.topic.as_str());
+        if topic_config.is_none() {
+            error!(
+                "the topic {} not exist, consumer: {}",
+                request_header.topic,
+                ctx.as_ref().remoting_address()
+            );
+            return Some(
+                response
+                    .set_code(ResponseCode::TopicNotExist)
+                    .set_remark(Some(format!(
+                        "topic[{}] not exist, apply first please! {}",
+                        request_header.topic,
+                        FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
+                    ))),
+            );
+        }
+        if !PermName::is_readable(topic_config.as_ref().unwrap().perm) {
+            response_header.forbidden_type = Some(ForbiddenType::TOPIC_FORBIDDEN);
+            return Some(
+                response
+                    .set_code(ResponseCode::NoPermission)
+                    .set_remark(Some(format!(
+                        "the topic[{}] pulling message is forbidden",
+                        request_header.topic,
+                    ))),
+            );
+        }
+        let topic_queue_mapping_context = self
+            .topic_queue_mapping_manager
+            .build_topic_queue_mapping_context(&request_header, false);
+        if let Some(resp) =
+            self.rewrite_request_for_static_topic(&request_header, &topic_queue_mapping_context)
+        {
+            return Some(resp);
+        }
+        if request_header.queue_id.is_none()
+            || request_header.queue_id.unwrap() < 0
+            || request_header.queue_id.unwrap()
+                > topic_config.as_ref().unwrap().read_queue_nums as i32
+        {
+            return Some(
+                response
+                    .set_code(RemotingSysResponseCode::SystemError)
+                    .set_remark(Some(format!(
+                        "queueId[{}] is illegal, topic:[{}] topicConfig.readQueueNums:[{}] \
+                         consumer:[{}]",
+                        request_header.queue_id.unwrap(),
+                        request_header.topic,
+                        topic_config.as_ref().unwrap().read_queue_nums,
+                        ctx.as_ref().remoting_address()
+                    ))),
+            );
+        }
+        match RequestSource::parse_integer(request_header.request_source) {
+            RequestSource::ProxyForBroadcast => {}
+            RequestSource::ProxyForStream => {}
+            _ => {}
+        }
+        let has_subscription_flag =
+            PullSysFlag::has_subscription_flag(request_header.sys_flag as u32);
+        let (subscription_data, consumer_filter_data) = if has_subscription_flag {
+            let subscription_data = FilterAPI::build(
+                request_header.topic.as_str(),
+                request_header
+                    .subscription
+                    .as_ref()
+                    .map_or_else(|| "", |value| value.as_str()),
+                request_header.expression_type.clone(),
+            );
+            if subscription_data.is_err() {
+                return Some(
+                    response
+                        .set_code(ResponseCode::SubscriptionParseFailed)
+                        .set_remark(Some(String::from(
+                            "parse the consumer's subscription failed",
+                        ))),
+                );
+            }
+            let subscription_data = subscription_data.unwrap();
+            self.consumer_manager.compensate_subscribe_data(
+                request_header.consumer_group.as_str(),
+                request_header.topic.as_str(),
+                &subscription_data,
+            );
+            let consumer_filter_data =
+                if !ExpressionType::is_tag_type(Some(subscription_data.expression_type.as_str())) {
+                    let consumer_filter_data = ConsumerFilterManager::build(
+                        request_header.topic.as_str(),
+                        request_header.consumer_group.as_str(),
+                        request_header
+                            .subscription
+                            .as_ref()
+                            .map_or_else(|| "", |value| value.as_str()),
+                        request_header
+                            .expression_type
+                            .as_ref()
+                            .map_or_else(|| "", |value| value.as_str()),
+                        request_header.sub_version as u64,
+                    );
+                    if consumer_filter_data.is_none() {
+                        return Some(
+                            response
+                                .set_code(ResponseCode::SubscriptionParseFailed)
+                                .set_remark(Some(String::from(
+                                    "parse the consumer's subscription failed",
+                                ))),
+                        );
+                    }
+                    consumer_filter_data
+                } else {
+                    None
+                };
+            (Some(subscription_data), consumer_filter_data)
+        } else {
+            unimplemented!()
+        };
         Some(response)
+    }
+
+    fn rewrite_request_for_static_topic(
+        &mut self,
+        _request_header: &PullMessageRequestHeader,
+        _mapping_context: &TopicQueueMappingContext,
+    ) -> Option<RemotingCommand> {
+        unimplemented!()
     }
 }

--- a/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
+++ b/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
@@ -20,40 +20,47 @@ use std::sync::Arc;
 
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config_manager::ConfigManager;
+use rocketmq_common::common::mix_all::is_sys_consumer_group;
+use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 use rocketmq_remoting::protocol::DataVersion;
+use rocketmq_remoting::protocol::RemotingSerializable;
+use rocketmq_store::log_file::MessageStore;
 use serde::Deserialize;
 use serde::Serialize;
+use tracing::info;
 
 use crate::broker_path_config_helper::get_subscription_group_path;
 
-#[derive(Default)]
-pub(crate) struct SubscriptionGroupManager {
+pub const CHARACTER_MAX_LENGTH: usize = 255;
+pub const TOPIC_MAX_LENGTH: usize = 127;
+
+pub(crate) struct SubscriptionGroupManager<MS> {
     pub(crate) broker_config: Arc<BrokerConfig>,
-    subscription_group_wrapper: parking_lot::Mutex<SubscriptionGroupWrapper>,
+    subscription_group_wrapper: Arc<parking_lot::Mutex<SubscriptionGroupWrapper>>,
+    pub(crate) message_store: Option<MS>,
 }
 
-//Fully implemented will be removed
-#[allow(unused_variables)]
-impl ConfigManager for SubscriptionGroupManager {
-    fn decode0(&mut self, key: &[u8], body: &[u8]) {
-        todo!()
+impl<MS> SubscriptionGroupManager<MS> {
+    pub fn new() -> SubscriptionGroupManager<MS> {
+        unimplemented!()
     }
+}
 
-    fn stop(&mut self) -> bool {
-        todo!()
-    }
-
+impl<MS> ConfigManager for SubscriptionGroupManager<MS> {
     fn config_file_path(&self) -> String {
         get_subscription_group_path(self.broker_config.store_path_root_dir.as_str())
     }
 
-    fn encode(&mut self) -> String {
-        todo!()
-    }
-
     fn encode_pretty(&self, pretty_format: bool) -> String {
-        todo!()
+        match pretty_format {
+            true => self
+                .subscription_group_wrapper
+                .lock()
+                .clone()
+                .to_json_pretty(),
+            false => self.subscription_group_wrapper.lock().clone().to_json(),
+        }
     }
 
     fn decode(&self, json_string: &str) {
@@ -81,6 +88,60 @@ impl ConfigManager for SubscriptionGroupManager {
     }
 }
 
+impl<MS> SubscriptionGroupManager<MS>
+where
+    MS: MessageStore,
+{
+    pub fn find_subscription_group_config(&self, group: &str) -> Option<SubscriptionGroupConfig> {
+        let mut subscription_group_config = self.find_subscription_group_config_inner(group);
+        if subscription_group_config.is_none()
+            && (self.broker_config.auto_create_subscription_group || is_sys_consumer_group(group))
+        {
+            if group.len() > CHARACTER_MAX_LENGTH
+                || TopicValidator::is_topic_or_group_illegal(group)
+            {
+                return None;
+            }
+            let mut subscription_group_config_new = SubscriptionGroupConfig::default();
+            subscription_group_config_new.set_group_name(group.to_string());
+            let pre_config = self
+                .subscription_group_wrapper
+                .lock()
+                .subscription_group_table
+                .insert(group.to_string(), subscription_group_config_new.clone());
+            if pre_config.is_none() {
+                info!(
+                    "auto create a subscription group, {:?}",
+                    subscription_group_config_new
+                );
+            }
+            let state_machine_version = if let Some(ref store) = self.message_store {
+                store.get_state_machine_version()
+            } else {
+                0
+            };
+            self.subscription_group_wrapper
+                .lock()
+                .data_version
+                .next_version_with(state_machine_version);
+            self.persist();
+            subscription_group_config = Some(subscription_group_config_new);
+        }
+        subscription_group_config
+    }
+
+    pub fn find_subscription_group_config_inner(
+        &self,
+        group: &str,
+    ) -> Option<SubscriptionGroupConfig> {
+        self.subscription_group_wrapper
+            .lock()
+            .subscription_group_table
+            .get(group)
+            .cloned()
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct SubscriptionGroupWrapper {
@@ -97,4 +158,8 @@ impl SubscriptionGroupWrapper {
     pub fn forbidden_table(&self) -> &HashMap<String, HashMap<String, i32>> {
         &self.forbidden_table
     }
+}
+
+impl RemotingSerializable for SubscriptionGroupWrapper {
+    type Output = Self;
 }

--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -56,5 +56,6 @@ trait-variant.workspace = true
 time = "0.3.36"
 dashmap = "5.5.3"
 hostname = "0.4"
+regex = "1.10.5"
 [dev-dependencies]
 mockall = "0.12.1"

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -143,6 +143,7 @@ pub struct BrokerConfig {
     pub namesrv_addr: Option<String>,
     pub fetch_name_srv_addr_by_dns_lookup: bool,
     pub lite_pull_message_enable: bool,
+    pub auto_create_subscription_group: bool,
 }
 
 impl Default for BrokerConfig {
@@ -197,6 +198,7 @@ impl Default for BrokerConfig {
             namesrv_addr: NAMESRV_ADDR.clone(),
             fetch_name_srv_addr_by_dns_lookup: false,
             lite_pull_message_enable: true,
+            auto_create_subscription_group: true,
         }
     }
 }

--- a/rocketmq-common/src/common/filter/expression_type.rs
+++ b/rocketmq-common/src/common/filter/expression_type.rs
@@ -17,6 +17,14 @@
 pub struct ExpressionType;
 
 impl ExpressionType {
+    /// SQL92 expression type.
     pub const SQL92: &'static str = "SQL92";
+
+    /// TAG expression type.
     pub const TAG: &'static str = "TAG";
+
+    /// Checks if the given type is a TAG type.
+    pub fn is_tag_type(type_: Option<&str>) -> bool {
+        matches!(type_, None | Some("") | Some(ExpressionType::TAG))
+    }
 }

--- a/rocketmq-common/src/common/sys_flag.rs
+++ b/rocketmq-common/src/common/sys_flag.rs
@@ -15,4 +15,5 @@
  * limitations under the License.
  */
 pub mod message_sys_flag;
+pub mod pull_sys_flag;
 pub mod topic_sys_flag;

--- a/rocketmq-common/src/common/sys_flag/pull_sys_flag.rs
+++ b/rocketmq-common/src/common/sys_flag/pull_sys_flag.rs
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+pub struct PullSysFlag;
+
+impl PullSysFlag {
+    const FLAG_COMMIT_OFFSET: u32 = 0x1;
+    const FLAG_SUSPEND: u32 = 0x1 << 1;
+    const FLAG_SUBSCRIPTION: u32 = 0x1 << 2;
+    const FLAG_CLASS_FILTER: u32 = 0x1 << 3;
+    const FLAG_LITE_PULL_MESSAGE: u32 = 0x1 << 4;
+
+    pub fn build_sys_flag(
+        commit_offset: bool,
+        suspend: bool,
+        subscription: bool,
+        class_filter: bool,
+    ) -> u32 {
+        let mut flag = 0;
+
+        if commit_offset {
+            flag |= Self::FLAG_COMMIT_OFFSET;
+        }
+
+        if suspend {
+            flag |= Self::FLAG_SUSPEND;
+        }
+
+        if subscription {
+            flag |= Self::FLAG_SUBSCRIPTION;
+        }
+
+        if class_filter {
+            flag |= Self::FLAG_CLASS_FILTER;
+        }
+
+        flag
+    }
+
+    pub fn build_sys_flag_with_lite_pull(
+        commit_offset: bool,
+        suspend: bool,
+        subscription: bool,
+        class_filter: bool,
+        lite_pull: bool,
+    ) -> u32 {
+        let mut flag = Self::build_sys_flag(commit_offset, suspend, subscription, class_filter);
+
+        if lite_pull {
+            flag |= Self::FLAG_LITE_PULL_MESSAGE;
+        }
+
+        flag
+    }
+
+    pub fn clear_commit_offset_flag(sys_flag: u32) -> u32 {
+        sys_flag & (!Self::FLAG_COMMIT_OFFSET)
+    }
+
+    pub fn has_commit_offset_flag(sys_flag: u32) -> bool {
+        (sys_flag & Self::FLAG_COMMIT_OFFSET) == Self::FLAG_COMMIT_OFFSET
+    }
+
+    pub fn has_suspend_flag(sys_flag: u32) -> bool {
+        (sys_flag & Self::FLAG_SUSPEND) == Self::FLAG_SUSPEND
+    }
+
+    pub fn clear_suspend_flag(sys_flag: u32) -> u32 {
+        sys_flag & (!Self::FLAG_SUSPEND)
+    }
+
+    pub fn has_subscription_flag(sys_flag: u32) -> bool {
+        (sys_flag & Self::FLAG_SUBSCRIPTION) == Self::FLAG_SUBSCRIPTION
+    }
+
+    pub fn build_sys_flag_with_subscription(sys_flag: u32) -> u32 {
+        sys_flag | Self::FLAG_SUBSCRIPTION
+    }
+
+    pub fn has_class_filter_flag(sys_flag: u32) -> bool {
+        (sys_flag & Self::FLAG_CLASS_FILTER) == Self::FLAG_CLASS_FILTER
+    }
+
+    pub fn has_lite_pull_flag(sys_flag: u32) -> bool {
+        (sys_flag & Self::FLAG_LITE_PULL_MESSAGE) == Self::FLAG_LITE_PULL_MESSAGE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_sys_flag_sets_correct_flags() {
+        let flag = PullSysFlag::build_sys_flag(true, true, true, true);
+        assert_eq!(flag, 0b1111);
+    }
+
+    #[test]
+    fn build_sys_flag_with_lite_pull_sets_correct_flags() {
+        let flag = PullSysFlag::build_sys_flag_with_lite_pull(true, true, true, true, true);
+        assert_eq!(flag, 0b11111);
+    }
+
+    #[test]
+    fn clear_commit_offset_flag_clears_correct_flag() {
+        let flag = PullSysFlag::clear_commit_offset_flag(0b1111);
+        assert_eq!(flag, 0b1110);
+    }
+
+    #[test]
+    fn has_commit_offset_flag_returns_correct_result() {
+        assert!(PullSysFlag::has_commit_offset_flag(0b1));
+        assert!(!PullSysFlag::has_commit_offset_flag(0b10));
+    }
+
+    #[test]
+    fn has_suspend_flag_returns_correct_result() {
+        assert!(PullSysFlag::has_suspend_flag(0b10));
+        assert!(!PullSysFlag::has_suspend_flag(0b1));
+    }
+
+    #[test]
+    fn clear_suspend_flag_clears_correct_flag() {
+        let flag = PullSysFlag::clear_suspend_flag(0b1111);
+        assert_eq!(flag, 0b1101);
+    }
+
+    #[test]
+    fn has_subscription_flag_returns_correct_result() {
+        assert!(PullSysFlag::has_subscription_flag(0b100));
+        assert!(!PullSysFlag::has_subscription_flag(0b1));
+    }
+
+    #[test]
+    fn build_sys_flag_with_subscription_sets_correct_flag() {
+        let flag = PullSysFlag::build_sys_flag_with_subscription(0b1);
+        assert_eq!(flag, 0b101);
+    }
+
+    #[test]
+    fn has_class_filter_flag_returns_correct_result() {
+        assert!(PullSysFlag::has_class_filter_flag(0b1000));
+        assert!(!PullSysFlag::has_class_filter_flag(0b1));
+    }
+
+    #[test]
+    fn has_lite_pull_flag_returns_correct_result() {
+        assert!(PullSysFlag::has_lite_pull_flag(0b10000));
+        assert!(!PullSysFlag::has_lite_pull_flag(0b1));
+    }
+}

--- a/rocketmq-common/src/common/topic.rs
+++ b/rocketmq-common/src/common/topic.rs
@@ -15,55 +15,33 @@
  * limitations under the License.
  */
 
+use std::collections::HashSet;
+use std::sync::Mutex;
+
 use lazy_static::lazy_static;
 
-/*const VALID_CHAR_BIT_MAP: [bool; 128] = {
-    let mut bit_map = [false; 128];
-    bit_map['%' as usize] = true;
-    bit_map['-' as usize] = true;
-    bit_map['_' as usize] = true;
-    bit_map['|' as usize] = true;
-    for i in '0' as u8..'9' as u8 + 1 {
-        bit_map[i as usize] = true;
-    }
-    for i in 'A' as u8..'Z' as u8 + 1 {
-        bit_map[i as usize] = true;
-    }
-    for i in 'a' as u8..'z' as u8 + 1 {
-        bit_map[i as usize] = true;
-    }
-    bit_map
-};*/
-
-const TOPIC_MAX_LENGTH: usize = 127;
-
-pub struct ValidateTopicResult {
-    valid: bool,
-    remark: String,
-}
-
-impl ValidateTopicResult {
-    pub fn new(valid: bool, remark: impl Into<String>) -> Self {
-        Self {
-            valid,
-            remark: remark.into(),
-        }
-    }
-
-    pub fn valid(&self) -> bool {
-        self.valid
-    }
-
-    pub fn remark(&self) -> &str {
-        &self.remark
-    }
-}
-
-pub struct TopicValidator;
+pub const TOPIC_MAX_LENGTH: usize = 127;
 
 lazy_static! {
-    pub static ref SYSTEM_TOPIC_SET: std::collections::HashSet<&'static str> = {
-        let mut set = std::collections::HashSet::new();
+    static ref VALID_CHAR_BIT_MAP: [bool; 128] = {
+        let mut map = [false; 128];
+        map['%' as usize] = true;
+        map['-' as usize] = true;
+        map['_' as usize] = true;
+        map['|' as usize] = true;
+        for i in b'0'..=b'9' {
+            map[i as usize] = true;
+        }
+        for i in b'A'..=b'Z' {
+            map[i as usize] = true;
+        }
+        for i in b'a'..=b'z' {
+            map[i as usize] = true;
+        }
+        map
+    };
+    static ref SYSTEM_TOPIC_SET: Mutex<HashSet<&'static str>> = {
+        let mut set = HashSet::new();
         set.insert(TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC);
         set.insert(TopicValidator::RMQ_SYS_SCHEDULE_TOPIC);
         set.insert(TopicValidator::RMQ_SYS_BENCHMARK_TOPIC);
@@ -74,73 +52,124 @@ lazy_static! {
         set.insert(TopicValidator::RMQ_SYS_SELF_TEST_TOPIC);
         set.insert(TopicValidator::RMQ_SYS_OFFSET_MOVED_EVENT);
         set.insert(TopicValidator::RMQ_SYS_ROCKSDB_OFFSET_TOPIC);
-        set
+        Mutex::new(set)
     };
-    pub static ref NOT_ALLOWED_SEND_TOPIC_SET: std::collections::HashSet<&'static str> = {
-        let mut set = std::collections::HashSet::new();
-
+    static ref NOT_ALLOWED_SEND_TOPIC_SET: Mutex<HashSet<&'static str>> = {
+        let mut set = HashSet::new();
         set.insert(TopicValidator::RMQ_SYS_SCHEDULE_TOPIC);
         set.insert(TopicValidator::RMQ_SYS_TRANS_HALF_TOPIC);
         set.insert(TopicValidator::RMQ_SYS_TRANS_OP_HALF_TOPIC);
         set.insert(TopicValidator::RMQ_SYS_TRANS_CHECK_MAX_TIME_TOPIC);
         set.insert(TopicValidator::RMQ_SYS_SELF_TEST_TOPIC);
         set.insert(TopicValidator::RMQ_SYS_OFFSET_MOVED_EVENT);
-        set
+        Mutex::new(set)
     };
 }
 
+pub struct TopicValidator;
+
 impl TopicValidator {
     pub const AUTO_CREATE_TOPIC_KEY_TOPIC: &'static str = "TBW102";
+    pub const RMQ_SYS_SCHEDULE_TOPIC: &'static str = "SCHEDULE_TOPIC_XXXX";
     pub const RMQ_SYS_BENCHMARK_TOPIC: &'static str = "BenchmarkTest";
+    pub const RMQ_SYS_TRANS_HALF_TOPIC: &'static str = "RMQ_SYS_TRANS_HALF_TOPIC";
+    pub const RMQ_SYS_TRACE_TOPIC: &'static str = "RMQ_SYS_TRACE_TOPIC";
+    pub const RMQ_SYS_TRANS_OP_HALF_TOPIC: &'static str = "RMQ_SYS_TRANS_OP_HALF_TOPIC";
+    pub const RMQ_SYS_TRANS_CHECK_MAX_TIME_TOPIC: &'static str = "TRANS_CHECK_MAX_TIME_TOPIC";
+    pub const RMQ_SYS_SELF_TEST_TOPIC: &'static str = "SELF_TEST_TOPIC";
     pub const RMQ_SYS_OFFSET_MOVED_EVENT: &'static str = "OFFSET_MOVED_EVENT";
     pub const RMQ_SYS_ROCKSDB_OFFSET_TOPIC: &'static str = "CHECKPOINT_TOPIC";
-    pub const RMQ_SYS_SCHEDULE_TOPIC: &'static str = "SCHEDULE_TOPIC_XXXX";
-    pub const RMQ_SYS_SELF_TEST_TOPIC: &'static str = "SELF_TEST_TOPIC";
-    pub const RMQ_SYS_TRACE_TOPIC: &'static str = "RMQ_SYS_TRACE_TOPIC";
-    pub const RMQ_SYS_TRANS_CHECK_MAX_TIME_TOPIC: &'static str = "TRANS_CHECK_MAX_TIME_TOPIC";
-    pub const RMQ_SYS_TRANS_HALF_TOPIC: &'static str = "RMQ_SYS_TRANS_HALF_TOPIC";
-    pub const RMQ_SYS_TRANS_OP_HALF_TOPIC: &'static str = "RMQ_SYS_TRANS_OP_HALF_TOPIC";
-    pub const SYNC_BROKER_MEMBER_GROUP_PREFIX: &'static str = "SYNC_BROKER_MEMBER_";
+
     pub const SYSTEM_TOPIC_PREFIX: &'static str = "rmq_sys_";
+    pub const SYNC_BROKER_MEMBER_GROUP_PREFIX: &'static str = "rmq_sys_SYNC_BROKER_MEMBER_";
+}
 
-    pub fn is_system_topic(topic: &str) -> bool {
-        SYSTEM_TOPIC_SET.contains(topic) || topic.starts_with(Self::SYSTEM_TOPIC_PREFIX)
-    }
-
-    pub fn is_topic_or_group_illegal(_topic: &str) -> bool {
-        /*topic
-        .chars()
-        .any(|ch| ch as usize >= 128 || !VALID_CHAR_BIT_MAP[ch as usize])*/
+impl TopicValidator {
+    pub fn is_topic_or_group_illegal(name: &str) -> bool {
+        let len = VALID_CHAR_BIT_MAP.len();
+        for ch in name.chars() {
+            if (ch as usize) >= len || !VALID_CHAR_BIT_MAP[ch as usize] {
+                return true;
+            }
+        }
         false
     }
 
     pub fn validate_topic(topic: &str) -> ValidateTopicResult {
-        if topic.is_empty() {
-            return ValidateTopicResult::new(false, "The specified topic is blank.");
+        if topic.trim().is_empty() {
+            return ValidateTopicResult {
+                valid: false,
+                remark: String::from("The specified topic is blank."),
+            };
         }
 
         if Self::is_topic_or_group_illegal(topic) {
-            return ValidateTopicResult::new(
-                false,
-                "The specified topic contains illegal characters, allowing only ^[%|a-zA-Z0-9_-]+$",
-            );
+            return ValidateTopicResult {
+                valid: false,
+                remark: String::from(
+                    "The specified topic contains illegal characters, allowing only \
+                     ^[%|a-zA-Z0-9_-]+$",
+                ),
+            };
         }
 
         if topic.len() > TOPIC_MAX_LENGTH {
-            return ValidateTopicResult::new(
-                false,
-                "The specified topic is longer than topic max length.",
-            );
+            return ValidateTopicResult {
+                valid: false,
+                remark: format!(
+                    "The specified topic is longer than topic max length {}.",
+                    TOPIC_MAX_LENGTH
+                ),
+            };
         }
 
-        ValidateTopicResult::new(true, "")
+        ValidateTopicResult {
+            valid: true,
+            remark: String::new(),
+        }
+    }
+
+    pub fn is_system_topic(topic: &str) -> bool {
+        let system_topics = SYSTEM_TOPIC_SET.lock().unwrap();
+        system_topics.contains(topic) || topic.starts_with(TopicValidator::SYSTEM_TOPIC_PREFIX)
     }
 
     pub fn is_not_allowed_send_topic(topic: &str) -> bool {
-        NOT_ALLOWED_SEND_TOPIC_SET.contains(topic)
+        let not_allowed_topics = NOT_ALLOWED_SEND_TOPIC_SET.lock().unwrap();
+        not_allowed_topics.contains(topic)
     }
 
-    /*    pub fn add_system_topic(&mut self, system_topic: &str) {
-        self.system_topic_set.insert(system_topic.to_string());
-    }*/
+    pub fn add_system_topic(system_topic: &'static str) {
+        let mut system_topics = SYSTEM_TOPIC_SET.lock().unwrap();
+        system_topics.insert(system_topic);
+    }
+
+    pub fn get_system_topic_set() -> HashSet<&'static str> {
+        SYSTEM_TOPIC_SET.lock().unwrap().clone()
+    }
+
+    pub fn get_not_allowed_send_topic_set() -> HashSet<&'static str> {
+        NOT_ALLOWED_SEND_TOPIC_SET.lock().unwrap().clone()
+    }
+}
+
+pub struct ValidateTopicResult {
+    valid: bool,
+    remark: String,
+}
+
+impl ValidateTopicResult {
+    pub fn valid(&self) -> bool {
+        self.valid
+    }
+    pub fn remark(&self) -> &str {
+        &self.remark
+    }
+
+    pub fn set_valid(&mut self, valid: bool) {
+        self.valid = valid;
+    }
+    pub fn set_remark(&mut self, remark: String) {
+        self.remark = remark;
+    }
 }

--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -35,10 +35,13 @@ use crate::RocketMQSerializable;
 
 pub mod body;
 pub mod command_custom_header;
+pub mod filter;
+pub mod forbidden_type;
 pub mod header;
 pub mod heartbeat;
 pub mod namesrv;
 pub mod remoting_command;
+pub mod request_source;
 pub mod rocketmq_serializable;
 pub mod route;
 pub mod static_topic;

--- a/rocketmq-remoting/src/protocol/body/topic_info_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/topic_info_wrapper.rs
@@ -77,12 +77,4 @@ impl TopicConfigSerializeWrapper {
 
 impl RemotingSerializable for TopicConfigSerializeWrapper {
     type Output = Self;
-
-    /*fn decode(bytes: &[u8]) -> Self::Output {
-        serde_json::from_slice::<Self::Output>(bytes).unwrap()
-    }
-
-    fn encode(&self, _compress: bool) -> Vec<u8> {
-        todo!()
-    }*/
 }

--- a/rocketmq-remoting/src/protocol/filter.rs
+++ b/rocketmq-remoting/src/protocol/filter.rs
@@ -14,21 +14,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 
-#[derive(Default)]
-pub struct ConsumerManager {}
-
-impl ConsumerManager {
-    pub fn find_subscription_data(&self, _group: &str, _topic: &str) -> Option<SubscriptionData> {
-        None
-    }
-
-    pub fn compensate_subscribe_data(
-        &self,
-        _group: &str,
-        _topic: &str,
-        _subscription_data: &SubscriptionData,
-    ) {
-    }
-}
+pub mod filter_api;

--- a/rocketmq-remoting/src/protocol/filter/filter_api.rs
+++ b/rocketmq-remoting/src/protocol/filter/filter_api.rs
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use rocketmq_common::common::filter::expression_type::ExpressionType;
+use rocketmq_common::common::hasher::string_hasher::JavaStringHasher;
+
+use crate::protocol::heartbeat::subscription_data::SubscriptionData;
+
+pub struct FilterAPI;
+
+impl FilterAPI {
+    pub fn build_subscription_data(
+        topic: &str,
+        sub_string: &str,
+    ) -> Result<SubscriptionData, String> {
+        let mut subscription_data = SubscriptionData {
+            topic: topic.to_string(),
+            sub_string: sub_string.to_string(),
+            ..Default::default()
+        };
+
+        if sub_string.is_empty() || sub_string == SubscriptionData::SUB_ALL {
+            subscription_data.sub_string = SubscriptionData::SUB_ALL.to_string();
+            return Ok(subscription_data);
+        }
+
+        let tags: Vec<&str> = sub_string.split("||").collect();
+        if tags.is_empty() {
+            return Err("subString split error".to_string());
+        }
+
+        for tag in tags {
+            let trimmed_tag = tag.trim();
+            if !trimmed_tag.is_empty() {
+                subscription_data.tags_set.insert(trimmed_tag.to_string());
+                subscription_data
+                    .code_set
+                    .insert(JavaStringHasher::new().hash_str(tag));
+            }
+        }
+
+        Ok(subscription_data)
+    }
+
+    pub fn build_subscription_data_with_expression_type(
+        topic: &str,
+        sub_string: &str,
+        expression_type: Option<String>,
+    ) -> Result<SubscriptionData, String> {
+        let mut subscription_data = FilterAPI::build_subscription_data(topic, sub_string)?;
+        if let Some(expr_type) = expression_type {
+            subscription_data.expression_type = expr_type;
+        }
+        Ok(subscription_data)
+    }
+
+    pub fn build(
+        topic: &str,
+        sub_string: &str,
+        type_: Option<String>,
+    ) -> Result<SubscriptionData, String> {
+        if type_.as_deref() == Some(ExpressionType::TAG) || type_.is_none() {
+            return FilterAPI::build_subscription_data(topic, sub_string);
+        }
+
+        if sub_string.is_empty() {
+            return Err(format!(
+                "Expression can't be null! {}",
+                type_.unwrap_or_default()
+            ));
+        }
+
+        let mut subscription_data = SubscriptionData {
+            topic: topic.to_string(),
+            sub_string: sub_string.to_string(),
+            ..Default::default()
+        };
+        if let Some(type_) = type_ {
+            subscription_data.expression_type = type_;
+        }
+        Ok(subscription_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_subscription_data_creates_correct_subscription_data() {
+        let topic = "test_topic";
+        let sub_string = "tag1||tag2";
+        let subscription_data = FilterAPI::build_subscription_data(topic, sub_string).unwrap();
+
+        assert_eq!(subscription_data.topic, topic);
+        assert_eq!(subscription_data.sub_string, sub_string);
+        assert!(subscription_data.tags_set.contains("tag1"));
+        assert!(subscription_data.tags_set.contains("tag2"));
+    }
+
+    #[test]
+    fn build_subscription_data_with_empty_sub_string_creates_subscription_data_with_sub_all() {
+        let topic = "test_topic";
+        let sub_string = "";
+        let subscription_data = FilterAPI::build_subscription_data(topic, sub_string).unwrap();
+
+        assert_eq!(subscription_data.topic, topic);
+        assert_eq!(subscription_data.sub_string, SubscriptionData::SUB_ALL);
+    }
+
+    #[test]
+    fn build_subscription_data_with_expression_type_sets_expression_type() {
+        let topic = "test_topic";
+        let sub_string = "tag1||tag2";
+        let expression_type = Some("SQL92".to_string());
+        let subscription_data = FilterAPI::build_subscription_data_with_expression_type(
+            topic,
+            sub_string,
+            expression_type.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(subscription_data.topic, topic);
+        assert_eq!(subscription_data.sub_string, sub_string);
+        assert_eq!(subscription_data.expression_type, expression_type.unwrap());
+    }
+
+    #[test]
+    fn build_creates_correct_subscription_data_for_tag_expression_type() {
+        let topic = "test_topic";
+        let sub_string = "tag1||tag2";
+        let type_ = Some(ExpressionType::TAG.to_string());
+        let subscription_data = FilterAPI::build(topic, sub_string, type_).unwrap();
+
+        assert_eq!(subscription_data.topic, topic);
+        assert_eq!(subscription_data.sub_string, sub_string);
+    }
+
+    #[test]
+    fn build_returns_error_for_empty_sub_string_and_non_tag_expression_type() {
+        let topic = "test_topic";
+        let sub_string = "";
+        let type_ = Some(ExpressionType::SQL92.to_string());
+        let result = FilterAPI::build(topic, sub_string, type_);
+
+        assert!(result.is_err());
+    }
+}

--- a/rocketmq-remoting/src/protocol/forbidden_type.rs
+++ b/rocketmq-remoting/src/protocol/forbidden_type.rs
@@ -14,21 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
-
-#[derive(Default)]
-pub struct ConsumerManager {}
-
-impl ConsumerManager {
-    pub fn find_subscription_data(&self, _group: &str, _topic: &str) -> Option<SubscriptionData> {
-        None
-    }
-
-    pub fn compensate_subscribe_data(
-        &self,
-        _group: &str,
-        _topic: &str,
-        _subscription_data: &SubscriptionData,
-    ) {
-    }
+pub struct ForbiddenType;
+impl ForbiddenType {
+    pub const BROKER_FORBIDDEN: i32 = 1;
+    pub const GROUP_FORBIDDEN: i32 = 2;
+    pub const TOPIC_FORBIDDEN: i32 = 3;
+    pub const BROADCASTING_DISABLE_FORBIDDEN: i32 = 4;
+    pub const SUBSCRIPTION_FORBIDDEN: i32 = 5;
 }

--- a/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
@@ -18,25 +18,27 @@
 use std::collections::HashMap;
 
 use bytes::BytesMut;
+use rocketmq_macros::RemotingSerializable;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::FastCodesHeader;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, RemotingSerializable, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct PullMessageResponseHeader {
-    suggest_which_broker_id: Option<i64>,
-    next_begin_offset: Option<i64>,
-    min_offset: Option<i64>,
-    max_offset: Option<i64>,
-    offset_delta: Option<i64>,
-    topic_sys_flag: Option<i32>,
-    group_sys_flag: Option<i32>,
-    forbidden_type: Option<i32>,
+    pub suggest_which_broker_id: Option<i64>,
+    pub next_begin_offset: Option<i64>,
+    pub min_offset: Option<i64>,
+    pub max_offset: Option<i64>,
+    pub offset_delta: Option<i64>,
+    pub topic_sys_flag: Option<i32>,
+    pub group_sys_flag: Option<i32>,
+    pub forbidden_type: Option<i32>,
 }
 
-impl PullMessageResponseHeader {
+/*impl PullMessageResponseHeader {
     const FORBIDDEN_TYPE: &'static str = "forbiddenType";
     const GROUP_SYS_FLAG: &'static str = "groupSysFlag";
     const MAX_OFFSET: &'static str = "maxOffset";
@@ -45,7 +47,7 @@ impl PullMessageResponseHeader {
     const OFFSET_DELTA: &'static str = "offsetDelta";
     const SUGGEST_WHICH_BROKER_ID: &'static str = "suggestWhichBrokerId";
     const TOPIC_SYS_FLAG: &'static str = "topicSysFlag";
-}
+}*/
 
 impl FastCodesHeader for PullMessageResponseHeader {
     fn encode_fast(&mut self, out: &mut BytesMut) {

--- a/rocketmq-remoting/src/protocol/heartbeat/subscription_data.rs
+++ b/rocketmq-remoting/src/protocol/heartbeat/subscription_data.rs
@@ -22,7 +22,7 @@ use std::hash::Hasher;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionData {
     pub class_filter_mode: bool,
@@ -35,6 +35,10 @@ pub struct SubscriptionData {
     // In Rust, attributes like `@JSONField(serialize = false)` are typically handled through
     // documentation or external crates.
     pub filter_class_source: String, // This field is not used in this example.
+}
+
+impl SubscriptionData {
+    pub const SUB_ALL: &'static str = "*";
 }
 
 impl Hash for SubscriptionData {

--- a/rocketmq-remoting/src/protocol/request_source.rs
+++ b/rocketmq-remoting/src/protocol/request_source.rs
@@ -36,7 +36,7 @@ impl RequestSource {
 
     pub fn is_valid(value: Option<i32>) -> bool {
         if let Some(v) = value {
-            (-1..4).contains(&v)
+            (-1..3).contains(&v)
         } else {
             false
         }

--- a/rocketmq-remoting/src/protocol/request_source.rs
+++ b/rocketmq-remoting/src/protocol/request_source.rs
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum RequestSource {
+    SDK,
+    ProxyForOrder,
+    ProxyForBroadcast,
+    ProxyForStream,
+}
+
+impl RequestSource {
+    pub const SYSTEM_PROPERTY_KEY: &'static str = "rocketmq.requestSource";
+
+    pub fn get_value(&self) -> i32 {
+        match self {
+            RequestSource::SDK => -1,
+            RequestSource::ProxyForOrder => 0,
+            RequestSource::ProxyForBroadcast => 1,
+            RequestSource::ProxyForStream => 2,
+        }
+    }
+
+    pub fn is_valid(value: Option<i32>) -> bool {
+        if let Some(v) = value {
+            (-1..4).contains(&v)
+        } else {
+            false
+        }
+    }
+
+    pub fn parse_integer(value: Option<i32>) -> RequestSource {
+        if let Some(v) = value {
+            if Self::is_valid(Some(v)) {
+                return Self::from_value(v);
+            }
+        }
+        RequestSource::SDK
+    }
+
+    fn from_value(value: i32) -> RequestSource {
+        match value {
+            -1 => RequestSource::SDK,
+            0 => RequestSource::ProxyForOrder,
+            1 => RequestSource::ProxyForBroadcast,
+            2 => RequestSource::ProxyForStream,
+            _ => RequestSource::SDK,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_value_returns_correct_value_for_each_variant() {
+        assert_eq!(RequestSource::SDK.get_value(), -1);
+        assert_eq!(RequestSource::ProxyForOrder.get_value(), 0);
+        assert_eq!(RequestSource::ProxyForBroadcast.get_value(), 1);
+        assert_eq!(RequestSource::ProxyForStream.get_value(), 2);
+    }
+
+    #[test]
+    fn is_valid_returns_true_for_valid_values() {
+        assert!(RequestSource::is_valid(Some(-1)));
+        assert!(RequestSource::is_valid(Some(0)));
+        assert!(RequestSource::is_valid(Some(1)));
+        assert!(RequestSource::is_valid(Some(2)));
+    }
+
+    #[test]
+    fn is_valid_returns_false_for_invalid_values() {
+        assert!(!RequestSource::is_valid(Some(-2)));
+        assert!(!RequestSource::is_valid(Some(4)));
+        assert!(!RequestSource::is_valid(None));
+    }
+
+    #[test]
+    fn parse_integer_returns_correct_variant_for_valid_values() {
+        assert_eq!(RequestSource::parse_integer(Some(-1)), RequestSource::SDK);
+        assert_eq!(
+            RequestSource::parse_integer(Some(0)),
+            RequestSource::ProxyForOrder
+        );
+        assert_eq!(
+            RequestSource::parse_integer(Some(1)),
+            RequestSource::ProxyForBroadcast
+        );
+        assert_eq!(
+            RequestSource::parse_integer(Some(2)),
+            RequestSource::ProxyForStream
+        );
+    }
+
+    #[test]
+    fn parse_integer_returns_sdk_for_invalid_values() {
+        assert_eq!(RequestSource::parse_integer(Some(4)), RequestSource::SDK);
+        assert_eq!(RequestSource::parse_integer(Some(-2)), RequestSource::SDK);
+        assert_eq!(RequestSource::parse_integer(None), RequestSource::SDK);
+    }
+}

--- a/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
+++ b/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
@@ -109,4 +109,56 @@ impl SubscriptionGroupConfig {
     pub fn attributes(&self) -> &HashMap<String, String> {
         &self.attributes
     }
+
+    pub fn set_group_name(&mut self, group_name: String) {
+        self.group_name = group_name;
+    }
+    pub fn set_consume_enable(&mut self, consume_enable: bool) {
+        self.consume_enable = consume_enable;
+    }
+    pub fn set_consume_from_min_enable(&mut self, consume_from_min_enable: bool) {
+        self.consume_from_min_enable = consume_from_min_enable;
+    }
+    pub fn set_consume_broadcast_enable(&mut self, consume_broadcast_enable: bool) {
+        self.consume_broadcast_enable = consume_broadcast_enable;
+    }
+    pub fn set_consume_message_orderly(&mut self, consume_message_orderly: bool) {
+        self.consume_message_orderly = consume_message_orderly;
+    }
+    pub fn set_retry_queue_nums(&mut self, retry_queue_nums: i32) {
+        self.retry_queue_nums = retry_queue_nums;
+    }
+    pub fn set_retry_max_times(&mut self, retry_max_times: i32) {
+        self.retry_max_times = retry_max_times;
+    }
+    pub fn set_group_retry_policy(&mut self, group_retry_policy: GroupRetryPolicy) {
+        self.group_retry_policy = group_retry_policy;
+    }
+    pub fn set_broker_id(&mut self, broker_id: u64) {
+        self.broker_id = broker_id;
+    }
+    pub fn set_which_broker_when_consume_slowly(&mut self, which_broker_when_consume_slowly: u64) {
+        self.which_broker_when_consume_slowly = which_broker_when_consume_slowly;
+    }
+    pub fn set_notify_consumer_ids_changed_enable(
+        &mut self,
+        notify_consumer_ids_changed_enable: bool,
+    ) {
+        self.notify_consumer_ids_changed_enable = notify_consumer_ids_changed_enable;
+    }
+    pub fn set_group_sys_flag(&mut self, group_sys_flag: i32) {
+        self.group_sys_flag = group_sys_flag;
+    }
+    pub fn set_consume_timeout_minute(&mut self, consume_timeout_minute: i32) {
+        self.consume_timeout_minute = consume_timeout_minute;
+    }
+    pub fn set_subscription_data_set(
+        &mut self,
+        subscription_data_set: HashSet<SimpleSubscriptionData>,
+    ) {
+        self.subscription_data_set = subscription_data_set;
+    }
+    pub fn set_attributes(&mut self, attributes: HashMap<String, String>) {
+        self.attributes = attributes;
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #662 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `RequestSource` enum to represent different request sources, with methods for value retrieval, validation, and parsing.

- **Bug Fixes**
  - Corrected cloning behavior for the `subscription_group_manager` field in `BrokerRuntime`, ensuring proper duplication.

- **Configuration**
  - Added a new `auto_create_subscription_group` field to `BrokerConfig` to control the auto-creation of subscription groups.

- **Improvements**
  - Enhanced `PullMessageProcessor` to support generic message stores.
  - Introduced new constants and validation methods for `SubscriptionData`.

- **Dependencies**
  - Added the `regex` dependency to support regular expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->