### PR TITLE
[ISSUE #676]♻️Refactor RemotingCommand struct🚀

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -178,7 +178,10 @@ impl BrokerRuntime {
             topic_config_manager,
             topic_queue_mapping_manager,
             consumer_offset_manager: Arc::new(Default::default()),
-            subscription_group_manager: Arc::new(SubscriptionGroupManager::new()),
+            subscription_group_manager: Arc::new(SubscriptionGroupManager::new(
+                broker_config.clone(),
+                None,
+            )),
             consumer_filter_manager: Arc::new(Default::default()),
             consumer_order_info_manager: Arc::new(Default::default()),
             message_store: None,

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -68,7 +68,7 @@ pub struct PullMessageProcessor<MS> {
 
 impl<MS> Default for PullMessageProcessor<MS> {
     fn default() -> Self {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
+++ b/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
@@ -42,8 +42,17 @@ pub(crate) struct SubscriptionGroupManager<MS> {
 }
 
 impl<MS> SubscriptionGroupManager<MS> {
-    pub fn new() -> SubscriptionGroupManager<MS> {
-        unimplemented!()
+    pub fn new(
+        broker_config: Arc<BrokerConfig>,
+        message_store: Option<MS>,
+    ) -> SubscriptionGroupManager<MS> {
+        Self {
+            broker_config,
+            subscription_group_wrapper: Arc::new(parking_lot::Mutex::new(
+                SubscriptionGroupWrapper::default(),
+            )),
+            message_store,
+        }
     }
 }
 

--- a/rocketmq-remoting/src/codec/remoting_command_codec.rs
+++ b/rocketmq-remoting/src/codec/remoting_command_codec.rs
@@ -161,22 +161,10 @@ impl Encoder<RemotingCommand> for RemotingCommandCodec {
     ///
     /// This function will return an error if the encoding process fails.
     fn encode(&mut self, item: RemotingCommand, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let header = item.fast_header_encode();
-        let header_length = header.as_ref().map_or(0, |h| h.len()) as i32;
-        let body_length = item.get_body().map_or(0, |b| b.len()) as i32;
-        let total_length = 4 + header_length + body_length;
-
-        dst.reserve((total_length + 4) as usize);
-        dst.put_i32(total_length);
-        let serialize_type =
-            RemotingCommand::mark_serialize_type(header_length, item.get_serialize_type());
-        dst.put_i32(serialize_type);
-
-        if let Some(header_inner) = header {
-            dst.put(header_inner);
-        }
+        let mut item = item;
+        item.fast_header_encode(dst);
         if let Some(body_inner) = item.get_body() {
-            dst.put(body_inner);
+            dst.put(body_inner.as_ref());
         }
         Ok(())
     }

--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #![allow(dead_code)]
+#![feature(sync_unsafe_cell)]
 
 pub mod clients;
 pub mod code;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #676 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new functions for custom header handling in remoting commands.

- **Refactor**
  - Updated subscription group manager initialization to accept additional parameters.
  - Modified `PullMessageProcessor` to replace `todo!()` with `unimplemented!()`.
  - Improved remoting command encoding logic for efficiency.

- **Chores**
  - Enabled `sync_unsafe_cell` feature in the remoting module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->