### PR TITLE
[ISSUE #686]🚀Support GET_CONSUMER_LIST_BY_GROUP(38) request code⚡️

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -58,6 +58,7 @@ use crate::offset::manager::consumer_offset_manager::ConsumerOffsetManager;
 use crate::offset::manager::consumer_order_info_manager::ConsumerOrderInfoManager;
 use crate::out_api::broker_outer_api::BrokerOuterAPI;
 use crate::processor::client_manage_processor::ClientManageProcessor;
+use crate::processor::consumer_manage_processor::ConsumerManageProcessor;
 use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
 use crate::processor::pull_message_processor::PullMessageProcessor;
 use crate::processor::send_message_processor::SendMessageProcessor;
@@ -371,6 +372,8 @@ impl BrokerRuntime {
             self.consumer_offset_manager.clone(),
             self.message_store.as_ref().unwrap().clone(),
         );
+
+        let consumer_manage_processor = ConsumerManageProcessor::new(self.consumer_manager.clone());
         BrokerRequestProcessor {
             send_message_processor,
             pull_message_processor,
@@ -383,7 +386,7 @@ impl BrokerRuntime {
             reply_message_processor: Default::default(),
             admin_broker_processor: Default::default(),
             client_manage_processor: ClientManageProcessor::new(self.producer_manager.clone()),
-            consumer_manage_processor: Default::default(),
+            consumer_manage_processor,
             query_assignment_processor: Default::default(),
             query_message_processor: Default::default(),
             end_transaction_processor: Default::default(),

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -149,7 +149,13 @@ impl<MS: MessageStore + Send + Sync + 'static> RequestProcessor for BrokerReques
                     .process_request(ctx, request_code, request)
                     .await
             }
-
+            RequestCode::GetConsumerListByGroup
+            | RequestCode::UpdateConsumerOffset
+            | RequestCode::QueryConsumerOffset => {
+                self.consumer_manage_processor
+                    .process_request(ctx, request_code, request)
+                    .await
+            }
             _ => self.admin_broker_processor.process_request(ctx, request),
         }
     }

--- a/rocketmq-broker/src/processor/consumer_manage_processor.rs
+++ b/rocketmq-broker/src/processor/consumer_manage_processor.rs
@@ -15,18 +15,113 @@
  * limitations under the License.
  */
 
-use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
-use rocketmq_remoting::runtime::server::ConnectionHandlerContext;
+use std::sync::Arc;
 
-#[derive(Default, Clone)]
-pub struct ConsumerManageProcessor {}
+use bytes::Bytes;
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::protocol::body::get_consumer_listby_group_response_body::GetConsumerListByGroupResponseBody;
+use rocketmq_remoting::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::RemotingSerializable;
+use rocketmq_remoting::runtime::server::ConnectionHandlerContext;
+use tracing::warn;
+
+use crate::client::manager::consumer_manager::ConsumerManager;
+
+#[derive(Clone)]
+pub struct ConsumerManageProcessor {
+    consumer_manager: Arc<ConsumerManager>,
+}
 
 impl ConsumerManageProcessor {
-    fn process_request(
-        &self,
-        _ctx: ConnectionHandlerContext,
-        _request: RemotingCommand,
-    ) -> RemotingCommand {
-        todo!()
+    pub fn new(consumer_manager: Arc<ConsumerManager>) -> Self {
+        Self { consumer_manager }
+    }
+}
+
+#[allow(unused_variables)]
+impl ConsumerManageProcessor {
+    pub async fn process_request(
+        &mut self,
+        ctx: ConnectionHandlerContext<'_>,
+        request_code: RequestCode,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        match request_code {
+            RequestCode::GetConsumerListByGroup => {
+                self.get_consumer_list_by_group(ctx, request).await
+            }
+            RequestCode::UpdateConsumerOffset => self.update_consumer_offset(ctx, request).await,
+            RequestCode::QueryConsumerOffset => self.query_consumer_offset(ctx, request).await,
+            _ => None,
+        }
+    }
+
+    pub async fn get_consumer_list_by_group(
+        &mut self,
+        ctx: ConnectionHandlerContext<'_>,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        let response = RemotingCommand::create_response_command();
+        let request_header = request
+            .decode_command_custom_header::<GetConsumerListByGroupRequestHeader>()
+            .unwrap();
+        let consumer_group_info = self
+            .consumer_manager
+            .get_consumer_group_info(request_header.consumer_group.as_str());
+
+        match consumer_group_info {
+            None => {
+                warn!(
+                    "getConsumerGroupInfo failed, {} {}",
+                    request_header.consumer_group,
+                    ctx.remoting_address()
+                );
+            }
+            Some(info) => {
+                let client_ids = info.get_all_client_ids();
+                if !client_ids.is_empty() {
+                    let body = GetConsumerListByGroupResponseBody {
+                        consumer_id_list: client_ids,
+                    };
+                    return Some(
+                        response
+                            .set_body(Some(Bytes::from(body.encode())))
+                            .set_code(ResponseCode::Success),
+                    );
+                } else {
+                    warn!(
+                        "getAllClientId failed, {} {}",
+                        request_header.consumer_group,
+                        ctx.remoting_address()
+                    )
+                }
+            }
+        }
+        Some(
+            response
+                .set_remark(Some(format!(
+                    "no consumer for this group, {}",
+                    request_header.consumer_group
+                )))
+                .set_code(ResponseCode::SystemError),
+        )
+    }
+
+    pub async fn update_consumer_offset(
+        &mut self,
+        ctx: ConnectionHandlerContext<'_>,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        unimplemented!()
+    }
+
+    pub async fn query_consumer_offset(
+        &mut self,
+        ctx: ConnectionHandlerContext<'_>,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        unimplemented!()
     }
 }

--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
- pub mod broker_body;
- pub mod get_consumer_listby_group_response_body;
- pub mod kv_table;
- pub mod topic;
- pub mod topic_info_wrapper;
- 
+pub mod broker_body;
+pub mod get_consumer_listby_group_response_body;
+pub mod kv_table;
+pub mod topic;
+pub mod topic_info_wrapper;

--- a/rocketmq-remoting/src/protocol/body/get_consumer_listby_group_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/get_consumer_listby_group_response_body.rs
@@ -14,10 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use serde::Deserialize;
+use serde::Serialize;
 
- pub mod broker_body;
- pub mod get_consumer_listby_group_response_body;
- pub mod kv_table;
- pub mod topic;
- pub mod topic_info_wrapper;
- 
+use crate::protocol::RemotingSerializable;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GetConsumerListByGroupResponseBody {
+    pub consumer_id_list: Vec<String>,
+}
+
+impl RemotingSerializable for GetConsumerListByGroupResponseBody {
+    type Output = ();
+}

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -16,6 +16,8 @@
  */
 pub mod broker;
 pub mod client_request_header;
+pub mod get_consumer_listby_group_request_header;
+pub mod get_consumer_listby_group_response_header;
 pub mod message_operation_header;
 pub mod namesrv;
 pub mod pull_message_request_header;

--- a/rocketmq-remoting/src/protocol/header/get_consumer_listby_group_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consumer_listby_group_request_header.rs
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::FromMap;
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetConsumerListByGroupRequestHeader {
+    pub consumer_group: String,
+    #[serde(flatten)]
+    pub rpc: Option<RpcRequestHeader>,
+}
+
+impl GetConsumerListByGroupRequestHeader {
+    pub const CONSUMER_GROUP: &'static str = "consumerGroup";
+}
+
+impl CommandCustomHeader for GetConsumerListByGroupRequestHeader {
+    fn to_map(&self) -> Option<HashMap<String, String>> {
+        let mut map = HashMap::new();
+        map.insert(
+            Self::CONSUMER_GROUP.to_string(),
+            self.consumer_group.clone(),
+        );
+        if let Some(ref rpc) = self.rpc {
+            if let Some(rpc_map) = rpc.to_map() {
+                map.extend(rpc_map);
+            }
+        }
+        Some(map)
+    }
+}
+impl FromMap for GetConsumerListByGroupRequestHeader {
+    type Target = Self;
+
+    fn from(map: &HashMap<String, String>) -> Option<Self::Target> {
+        Some(GetConsumerListByGroupRequestHeader {
+            consumer_group: map.get(Self::CONSUMER_GROUP).cloned().unwrap_or_default(),
+            rpc: <RpcRequestHeader as FromMap>::from(map),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn get_consumer_list_by_group_request_header_to_map() {
+        let header = GetConsumerListByGroupRequestHeader {
+            consumer_group: "test_group".to_string(),
+            rpc: None,
+        };
+
+        let map = header.to_map().unwrap();
+        assert_eq!(
+            map.get(GetConsumerListByGroupRequestHeader::CONSUMER_GROUP),
+            Some(&"test_group".to_string())
+        );
+    }
+
+    #[test]
+    fn get_consumer_list_by_group_request_header_from_map() {
+        let mut map = HashMap::new();
+        map.insert(
+            GetConsumerListByGroupRequestHeader::CONSUMER_GROUP.to_string(),
+            "test_group".to_string(),
+        );
+
+        let header = <GetConsumerListByGroupRequestHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(header.consumer_group, "test_group");
+    }
+}

--- a/rocketmq-remoting/src/protocol/header/get_consumer_listby_group_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consumer_listby_group_response_header.rs
@@ -14,10 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashMap;
 
- pub mod broker_body;
- pub mod get_consumer_listby_group_response_body;
- pub mod kv_table;
- pub mod topic;
- pub mod topic_info_wrapper;
- 
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::FromMap;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct GetConsumerListByGroupResponseHeader;
+
+impl CommandCustomHeader for GetConsumerListByGroupResponseHeader {
+    fn to_map(&self) -> Option<HashMap<String, String>> {
+        None
+    }
+}
+impl FromMap for GetConsumerListByGroupResponseHeader {
+    type Target = GetConsumerListByGroupResponseHeader;
+
+    fn from(_map: &HashMap<String, String>) -> Option<Self::Target> {
+        Some(Self {})
+    }
+}

--- a/rocketmq-remoting/src/protocol/heartbeat/subscription_data.rs
+++ b/rocketmq-remoting/src/protocol/heartbeat/subscription_data.rs
@@ -15,41 +15,43 @@
  * limitations under the License.
  */
 
-use std::collections::HashSet;
-use std::hash::Hash;
-use std::hash::Hasher;
-
-use serde::Deserialize;
-use serde::Serialize;
-
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct SubscriptionData {
-    pub class_filter_mode: bool,
-    pub topic: String,
-    pub sub_string: String,
-    pub tags_set: HashSet<String>,
-    pub code_set: HashSet<i32>,
-    pub sub_version: i64,
-    pub expression_type: String,
-    // In Rust, attributes like `@JSONField(serialize = false)` are typically handled through
-    // documentation or external crates.
-    pub filter_class_source: String, // This field is not used in this example.
-}
-
-impl SubscriptionData {
-    pub const SUB_ALL: &'static str = "*";
-}
-
-impl Hash for SubscriptionData {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.class_filter_mode.hash(state);
-        self.topic.hash(state);
-        self.sub_string.hash(state);
-        self.tags_set.iter().for_each(|tag| tag.hash(state));
-        self.code_set.iter().for_each(|code| code.hash(state));
-        self.sub_version.hash(state);
-        self.expression_type.hash(state);
-        self.filter_class_source.hash(state);
-    }
-}
+ use std::collections::HashSet;
+ use std::hash::Hash;
+ use std::hash::Hasher;
+ 
+ use serde::Deserialize;
+ use serde::Serialize;
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+ #[serde(rename_all = "camelCase")]
+ pub struct SubscriptionData {
+     pub class_filter_mode: bool,
+     pub topic: String,
+     pub sub_string: String,
+     pub tags_set: HashSet<String>,
+     pub code_set: HashSet<i32>,
+     pub sub_version: i64,
+     pub expression_type: String,
+     // In Rust, attributes like `@JSONField(serialize = false)` are typically handled through
+     // documentation or external crates.
+     #[serde(skip)]
+     pub filter_class_source: String, // This field is not used in this example.
+ }
+ 
+ impl SubscriptionData {
+     pub const SUB_ALL: &'static str = "*";
+ }
+ 
+ impl Hash for SubscriptionData {
+     fn hash<H: Hasher>(&self, state: &mut H) {
+         self.class_filter_mode.hash(state);
+         self.topic.hash(state);
+         self.sub_string.hash(state);
+         self.tags_set.iter().for_each(|tag| tag.hash(state));
+         self.code_set.iter().for_each(|code| code.hash(state));
+         self.sub_version.hash(state);
+         self.expression_type.hash(state);
+         self.filter_class_source.hash(state);
+     }
+ }
+ 

--- a/rocketmq-remoting/src/protocol/heartbeat/subscription_data.rs
+++ b/rocketmq-remoting/src/protocol/heartbeat/subscription_data.rs
@@ -15,43 +15,42 @@
  * limitations under the License.
  */
 
- use std::collections::HashSet;
- use std::hash::Hash;
- use std::hash::Hasher;
- 
- use serde::Deserialize;
- use serde::Serialize;
- 
- #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
- #[serde(rename_all = "camelCase")]
- pub struct SubscriptionData {
-     pub class_filter_mode: bool,
-     pub topic: String,
-     pub sub_string: String,
-     pub tags_set: HashSet<String>,
-     pub code_set: HashSet<i32>,
-     pub sub_version: i64,
-     pub expression_type: String,
-     // In Rust, attributes like `@JSONField(serialize = false)` are typically handled through
-     // documentation or external crates.
-     #[serde(skip)]
-     pub filter_class_source: String, // This field is not used in this example.
- }
- 
- impl SubscriptionData {
-     pub const SUB_ALL: &'static str = "*";
- }
- 
- impl Hash for SubscriptionData {
-     fn hash<H: Hasher>(&self, state: &mut H) {
-         self.class_filter_mode.hash(state);
-         self.topic.hash(state);
-         self.sub_string.hash(state);
-         self.tags_set.iter().for_each(|tag| tag.hash(state));
-         self.code_set.iter().for_each(|code| code.hash(state));
-         self.sub_version.hash(state);
-         self.expression_type.hash(state);
-         self.filter_class_source.hash(state);
-     }
- }
- 
+use std::collections::HashSet;
+use std::hash::Hash;
+use std::hash::Hasher;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionData {
+    pub class_filter_mode: bool,
+    pub topic: String,
+    pub sub_string: String,
+    pub tags_set: HashSet<String>,
+    pub code_set: HashSet<i32>,
+    pub sub_version: i64,
+    pub expression_type: String,
+    // In Rust, attributes like `@JSONField(serialize = false)` are typically handled through
+    // documentation or external crates.
+    #[serde(skip)]
+    pub filter_class_source: String, // This field is not used in this example.
+}
+
+impl SubscriptionData {
+    pub const SUB_ALL: &'static str = "*";
+}
+
+impl Hash for SubscriptionData {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.class_filter_mode.hash(state);
+        self.topic.hash(state);
+        self.sub_string.hash(state);
+        self.tags_set.iter().for_each(|tag| tag.hash(state));
+        self.code_set.iter().for_each(|code| code.hash(state));
+        self.sub_version.hash(state);
+        self.expression_type.hash(state);
+        self.filter_class_source.hash(state);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #686 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new request handling capabilities for consumer management, including fetching consumer lists by group, updating consumer offsets, and querying consumer offsets.

- **Improvements**
  - Enhanced consumer management processing in the broker to handle specific request codes more efficiently.
  - Added serialization and deserialization support for new request and response headers related to consumer list operations.
  - Improved subscription data serialization by skipping the `filter_class_source` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->