### PR TITLE
[ISSUE #696]🚀Support pull message consume-5

### DIFF
--- a/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
@@ -25,6 +25,7 @@ use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
+use crate::rpc::rpc_request_header::RpcRequestHeader;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -238,6 +239,11 @@ impl CommandCustomHeader for PullMessageRequestHeader {
         if let Some(str) = fields.get("proxyFrowardClientId") {
             self.proxy_forward_client_id = Some(str.clone());
         }
+
+        self.topic_request = Some(TopicRequestHeader {
+            rpc: Some(RpcRequestHeader::default()),
+            ..TopicRequestHeader::default()
+        });
 
         if let Some(str) = fields.get("lo") {
             self.topic_request.as_mut().unwrap().lo = Some(str.parse::<bool>().unwrap());

--- a/rocketmq-store/src/base/select_result.rs
+++ b/rocketmq-store/src/base/select_result.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use crate::log_file::mapped_file::default_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::MappedFile;
 
 /// Represents the result of selecting a mapped buffer.
 pub struct SelectMappedBufferResult {
@@ -37,5 +38,15 @@ impl SelectMappedBufferResult {
         self.mapped_file.as_ref().unwrap().get_mapped_file()
             [self.start_offset as usize..(self.start_offset + self.size as u64) as usize]
             .as_ref()
+    }
+
+    pub fn is_in_mem(&self) -> bool {
+        match self.mapped_file.as_ref() {
+            None => true,
+            Some(inner) => {
+                let pos = self.start_offset - inner.get_file_from_offset();
+                inner.is_loaded(pos as i64, self.size as usize)
+            }
+        }
     }
 }

--- a/rocketmq-store/src/consume_queue/consume_queue_ext.rs
+++ b/rocketmq-store/src/consume_queue/consume_queue_ext.rs
@@ -45,4 +45,20 @@ impl CqExtUnit {
             filter_bit_map,
         }
     }
+
+    pub fn size(&self) -> i16 {
+        self.size
+    }
+    pub fn tags_code(&self) -> i64 {
+        self.tags_code
+    }
+    pub fn msg_store_time(&self) -> i64 {
+        self.msg_store_time
+    }
+    pub fn bit_map_size(&self) -> i16 {
+        self.bit_map_size
+    }
+    pub fn filter_bit_map(&self) -> &Option<Vec<u8>> {
+        &self.filter_bit_map
+    }
 }

--- a/rocketmq-store/src/log_file/mapped_file/default_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_impl.rs
@@ -366,7 +366,7 @@ impl MappedFile for DefaultMappedFile {
                     start_offset: self.file_from_offset + pos as u64,
                     size,
                     mapped_file: Some(self),
-                    is_in_cache: false,
+                    is_in_cache: true,
                 })
             } else {
                 None
@@ -388,7 +388,7 @@ impl MappedFile for DefaultMappedFile {
                 start_offset: self.get_file_from_offset() + pos as u64,
                 size: read_position - pos,
                 mapped_file: Some(self),
-                is_in_cache: false,
+                is_in_cache: true,
             })
         } else {
             None
@@ -588,7 +588,7 @@ impl MappedFile for DefaultMappedFile {
     }*/
 
     fn is_loaded(&self, position: i64, size: usize) -> bool {
-        todo!()
+        true
     }
 }
 

--- a/rocketmq-store/src/queue.rs
+++ b/rocketmq-store/src/queue.rs
@@ -90,6 +90,21 @@ pub struct CqUnit {
     pub compacted_offset: i32,
 }
 
+impl Default for CqUnit {
+    fn default() -> Self {
+        CqUnit {
+            queue_offset: 0,
+            size: 0,
+            pos: 0,
+            batch_num: 1,
+            tags_code: 0,
+            cq_ext_unit: None,
+            native_buffer: vec![],
+            compacted_offset: 0,
+        }
+    }
+}
+
 impl CqUnit {
     pub fn get_valid_tags_code_as_long(&self) -> Option<i64> {
         if !self.is_tags_code_valid() {
@@ -291,7 +306,7 @@ pub trait ConsumeQueueTrait: Send + Sync + FileQueueLifeCycle {
     ) -> Result<Box<dyn Iterator<Item = CqUnit>>, RocksDBException>;*/
 
     /// Get cq unit at specified index.
-    fn get(&self, index: i64) -> CqUnit;
+    fn get(&self, index: i64) -> Option<CqUnit>;
 
     fn get_cq_unit_and_store_time(&self, index: i64) -> Option<(CqUnit, i64)>;
 

--- a/rocketmq-store/src/queue/batch_consume_queue.rs
+++ b/rocketmq-store/src/queue/batch_consume_queue.rs
@@ -205,7 +205,7 @@ impl ConsumeQueueTrait for BatchConsumeQueue {
         todo!()
     }
 
-    fn get(&self, index: i64) -> CqUnit {
+    fn get(&self, index: i64) -> Option<CqUnit> {
         todo!()
     }
 

--- a/rocketmq-store/src/queue/consume_queue_ext.rs
+++ b/rocketmq-store/src/queue/consume_queue_ext.rs
@@ -92,4 +92,8 @@ impl ConsumeQueueExt {
     pub fn destroy(&mut self) {
         self.mapped_file_queue.destroy();
     }
+
+    pub fn get(&self, address: i64, cq_ext_unit: &CqExtUnit) -> bool {
+        unimplemented!()
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #696 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added capability to check if a message is in memory by commit offset.
  - Introduced methods for iterating over mapped buffer results.
  
- **Improvements**
  - Enhanced `ConsumeQueueExt` with a new `get` method.
  - Updated `CqExtUnit` with public access methods.
  - Adjusted several functions to return optional values for better error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->