### PR TITLE
[ISSUE #702]🚀Support pull message result handle-2🚀

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -94,6 +94,7 @@ pub(crate) struct BrokerRuntime {
     broker_runtime: Option<RocketMQRuntime>,
     producer_manager: Arc<ProducerManager>,
     consumer_manager: Arc<ConsumerManager>,
+    broadcast_offset_manager: Arc<BroadcastOffsetManager>,
     drop: Arc<AtomicBool>,
     shutdown: Arc<AtomicBool>,
     shutdown_hook: Option<BrokerShutdownHook>,
@@ -124,6 +125,7 @@ impl Clone for BrokerRuntime {
             broker_runtime: None,
             producer_manager: self.producer_manager.clone(),
             consumer_manager: self.consumer_manager.clone(),
+            broadcast_offset_manager: self.broadcast_offset_manager.clone(),
             drop: self.drop.clone(),
             shutdown: self.shutdown.clone(),
             shutdown_hook: self.shutdown_hook.clone(),
@@ -196,6 +198,7 @@ impl BrokerRuntime {
             broker_runtime: Some(runtime),
             producer_manager,
             consumer_manager,
+            broadcast_offset_manager: Arc::new(Default::default()),
             drop: Arc::new(AtomicBool::new(false)),
             shutdown: Arc::new(AtomicBool::new(false)),
             shutdown_hook: None,
@@ -361,6 +364,10 @@ impl BrokerRuntime {
         );
         let pull_message_result_handler = DefaultPullMessageResultHandler::new(
             Arc::new(self.topic_config_manager.clone()),
+            Arc::new(self.consumer_offset_manager.clone()),
+            self.consumer_manager.clone(),
+            self.broadcast_offset_manager.clone(),
+            self.broker_stats_manager.clone(),
             self.broker_config.clone(),
             Arc::new(Default::default()),
         );

--- a/rocketmq-broker/src/offset/manager/broadcast_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/broadcast_offset_manager.rs
@@ -30,4 +30,16 @@ impl BroadcastOffsetManager {
     ) -> i64 {
         unimplemented!()
     }
+
+    pub fn update_offset(
+        &self,
+        topic: &str,
+        group: &str,
+        queue_id: i32,
+        offset: i64,
+        client_id: &str,
+        from_proxy: bool,
+    ) {
+        unimplemented!()
+    }
 }

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -180,6 +180,23 @@ impl ConfigManager for ConsumerOffsetManager {
 
 #[allow(unused_variables)]
 impl ConsumerOffsetManager {
+    pub fn commit_pull_offset(
+        &self,
+        _client_host: SocketAddr,
+        group: &str,
+        topic: &str,
+        queue_id: i32,
+        offset: i64,
+    ) {
+        let key = format!("{}{}{}", topic, TOPIC_GROUP_SEPARATOR, group);
+        self.consumer_offset_wrapper
+            .lock()
+            .pull_offset_table
+            .entry(key)
+            .or_default()
+            .insert(queue_id, offset);
+    }
+
     pub fn query_then_erase_reset_offset(
         &self,
         topic: &str,

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -154,6 +154,7 @@ pub struct BrokerConfig {
     pub reject_pull_consumer_enable: bool,
     pub consumer_offset_update_version_step: i64,
     pub enable_broadcast_offset_store: bool,
+    pub transfer_msg_by_heap: bool,
 }
 
 impl Default for BrokerConfig {
@@ -219,6 +220,7 @@ impl Default for BrokerConfig {
             reject_pull_consumer_enable: false,
             consumer_offset_update_version_step: 500,
             enable_broadcast_offset_store: true,
+            transfer_msg_by_heap: true,
         }
     }
 }

--- a/rocketmq-remoting/src/protocol/request_source.rs
+++ b/rocketmq-remoting/src/protocol/request_source.rs
@@ -51,7 +51,7 @@ impl RequestSource {
         RequestSource::SDK
     }
 
-    fn from_value(value: i32) -> RequestSource {
+    pub fn from_value(value: i32) -> RequestSource {
         match value {
             -1 => RequestSource::SDK,
             0 => RequestSource::ProxyForOrder,

--- a/rocketmq-remoting/src/rpc/rpc_client_utils.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_utils.rs
@@ -18,8 +18,10 @@
 use std::any::Any;
 
 use bytes::Bytes;
+use bytes::BytesMut;
 
 use crate::protocol::remoting_command::RemotingCommand;
+use crate::protocol::RemotingSerializable;
 use crate::rpc::rpc_request::RpcRequest;
 use crate::rpc::rpc_response::RpcResponse;
 
@@ -28,7 +30,7 @@ pub struct RpcClientUtils;
 impl RpcClientUtils {
     pub fn create_command_for_rpc_request(rpc_request: RpcRequest) -> RemotingCommand {
         let cmd = RemotingCommand::create_request_command(rpc_request.code, rpc_request.header);
-        cmd.set_body(Self::encode_body(rpc_request.body))
+        cmd.set_body(Self::encode_body(&**rpc_request.body))
     }
 
     pub fn create_command_for_rpc_response(mut rpc_response: RpcResponse) -> RemotingCommand {
@@ -41,32 +43,26 @@ impl RpcClientUtils {
             None => {}
             Some(value) => cmd.set_remark_ref(Some(value.1.clone())),
         }
-        cmd.set_body(Self::encode_body(rpc_response.body))
+        if let Some(ref body) = rpc_response.body {
+            return cmd.set_body(Self::encode_body(&**body));
+        }
+        cmd
     }
 
-    pub fn encode_body(_body: Option<Box<dyn Any>>) -> Option<Bytes> {
-        /*if body.is_none() {
-            return None;
-        }
-        let body = body.unwrap();
-        if body.is::<Bytes>() {
-            return Some(body.downcast_ref::<Bytes>().unwrap().clone());
-        } else if body.is::<Vec<u8>>() {
-            return Some(Bytes::from(
-                body.downcast_ref::<Vec<u8>>().unwrap().as_ref(),
-            ));
-        }
-        /*else if body.is::<dyn RemotingSerializable<Output = Self>>() {
-             return Some(Bytes::from(
-                body.downcast_ref::<dyn RemotingSerializable<Output = Self>>()
-                    .unwrap()
-                    .encode(),
-            ));
-
-        }*/
-        else {
-            None
-        }*/
+    pub fn encode_body(body: &dyn Any) -> Option<Bytes> {
+        // if body.is::<()>() {
+        //     None
+        // } else if let Some(bytes) = body.downcast_ref::<Bytes>() {
+        //     Ok(Some(bytes.clone()))
+        // } else if let Some(remoting_serializable) = body.downcast_ref::<&dyn RemotingSerializable>()
+        // {
+        //     Ok(Some(Bytes::from(*remoting_serializable.encode())))
+        // } else if let Some(buffer) = body.downcast_ref::<BytesMut>() {
+        //     let data = buffer.clone().freeze();
+        //     Some(data)
+        // } else {
+        //     None
+        // }
         None
     }
 }

--- a/rocketmq-remoting/src/rpc/rpc_client_utils.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_utils.rs
@@ -18,10 +18,8 @@
 use std::any::Any;
 
 use bytes::Bytes;
-use bytes::BytesMut;
 
 use crate::protocol::remoting_command::RemotingCommand;
-use crate::protocol::RemotingSerializable;
 use crate::rpc::rpc_request::RpcRequest;
 use crate::rpc::rpc_response::RpcResponse;
 
@@ -29,8 +27,8 @@ pub struct RpcClientUtils;
 
 impl RpcClientUtils {
     pub fn create_command_for_rpc_request(rpc_request: RpcRequest) -> RemotingCommand {
-        let cmd = RemotingCommand::create_request_command(rpc_request.code, rpc_request.header);
-        cmd.set_body(Self::encode_body(&**rpc_request.body))
+        RemotingCommand::create_request_command(rpc_request.code, rpc_request.header)
+        //cmd.set_body(Self::encode_body(&**rpc_request.body))
     }
 
     pub fn create_command_for_rpc_response(mut rpc_response: RpcResponse) -> RemotingCommand {
@@ -43,13 +41,13 @@ impl RpcClientUtils {
             None => {}
             Some(value) => cmd.set_remark_ref(Some(value.1.clone())),
         }
-        if let Some(ref body) = rpc_response.body {
-            return cmd.set_body(Self::encode_body(&**body));
+        if let Some(ref _body) = rpc_response.body {
+            return cmd;
         }
         cmd
     }
 
-    pub fn encode_body(body: &dyn Any) -> Option<Bytes> {
+    pub fn encode_body(_body: &dyn Any) -> Option<Bytes> {
         // if body.is::<()>() {
         //     None
         // } else if let Some(bytes) = body.downcast_ref::<Bytes>() {

--- a/rocketmq-remoting/src/rpc/rpc_client_utils.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_utils.rs
@@ -54,8 +54,8 @@ impl RpcClientUtils {
         //     None
         // } else if let Some(bytes) = body.downcast_ref::<Bytes>() {
         //     Ok(Some(bytes.clone()))
-        // } else if let Some(remoting_serializable) = body.downcast_ref::<&dyn RemotingSerializable>()
-        // {
+        // } else if let Some(remoting_serializable) = body.downcast_ref::<&dyn
+        // RemotingSerializable>() {
         //     Ok(Some(Bytes::from(*remoting_serializable.encode())))
         // } else if let Some(buffer) = body.downcast_ref::<BytesMut>() {
         //     let data = buffer.clone().freeze();

--- a/rocketmq-store/src/base/get_message_result.rs
+++ b/rocketmq-store/src/base/get_message_result.rs
@@ -155,6 +155,10 @@ impl GetMessageResult {
         self.message_queue_offset.push(queue_offset);
         self.message_mapped_list.push(maped_buffer);
     }
+
+    pub fn message_mapped_list(&self) -> &[SelectMappedBufferResult] {
+        self.message_mapped_list.as_slice()
+    }
 }
 
 #[cfg(test)]

--- a/rocketmq-store/src/stats/broker_stats_manager.rs
+++ b/rocketmq-store/src/stats/broker_stats_manager.rs
@@ -473,6 +473,18 @@ impl BrokerStatsManager {
         fall_behind: i64,
     ) {
     }
+
+    pub fn inc_topic_put_nums(&self, topic: &str, num: i32, times: i32) {}
+
+    pub fn inc_topic_put_size(&self, topic: &str, size: i32) {}
+
+    pub fn inc_group_get_nums(&self, group: &str, topic: &str, inc_value: i32) {}
+    pub fn inc_group_get_size(&self, group: &str, topic: &str, inc_value: i32) {}
+
+    pub fn inc_group_ck_nums(&self, group: &str, topic: &str, inc_value: i32) {}
+
+    pub fn inc_group_ack_nums(&self, group: &str, topic: &str, inc_value: i32) {}
+    pub fn inc_broker_get_nums(&self, group: &str, inc_value: i32) {}
 }
 
 pub fn create_statistics_kind_meta(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #702 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced offset management capabilities in broadcast and consumer contexts.
  - Added various statistical tracking methods for topics, groups, and brokers.

- **Enhancements**
  - Improved message pulling and response handling within the broker processor.

- **Configuration**
  - Added a new configuration option `transfer_msg_by_heap` in `BrokerConfig`.

- **API Changes**
  - Exposed new public methods in `BroadcastOffsetManager`, `ConsumerOffsetManager`, `GetMessageResult`, and `BrokerStatsManager`.
  - Made the `from_value` function in `RequestSource` public for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->