### PR TITLE
[ISSUE #715]✅Add test case for ClientChannelInfo

### DIFF
--- a/rocketmq-broker/src/client/client_channel_info.rs
+++ b/rocketmq-broker/src/client/client_channel_info.rs
@@ -78,3 +78,55 @@ impl ClientChannelInfo {
         self.channel = channel;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_remoting::net::channel::Channel;
+    use rocketmq_remoting::protocol::LanguageCode;
+
+    use super::*;
+
+    #[test]
+    fn client_channel_info_new() {
+        let channel = Channel::new(
+            "127.0.0.1:8080".parse().unwrap(),
+            "127.0.0.1:8080".parse().unwrap(),
+        );
+        let client_info = ClientChannelInfo::new(
+            channel.clone(),
+            "client1".to_string(),
+            LanguageCode::JAVA,
+            1,
+        );
+        assert_eq!(client_info.client_id(), "client1");
+        assert_eq!(client_info.language(), LanguageCode::JAVA);
+        assert_eq!(client_info.version(), 1);
+        assert_eq!(client_info.channel(), &channel);
+    }
+
+    #[test]
+    fn client_channel_info_setters() {
+        let channel = Channel::new(
+            "127.0.0.1:8080".parse().unwrap(),
+            "127.0.0.1:8080".parse().unwrap(),
+        );
+        let mut client_info = ClientChannelInfo::new(
+            channel.clone(),
+            "client1".to_string(),
+            LanguageCode::JAVA,
+            1,
+        );
+        client_info.set_client_id("client2".to_string());
+        client_info.set_language(LanguageCode::CPP);
+        client_info.set_version(2);
+        let new_channel = Channel::new(
+            "127.0.0.1:8081".parse().unwrap(),
+            "127.0.0.1:8080".parse().unwrap(),
+        );
+        client_info.set_channel(new_channel.clone());
+        assert_eq!(client_info.client_id(), "client2");
+        assert_eq!(client_info.language(), LanguageCode::CPP);
+        assert_eq!(client_info.version(), 2);
+        assert_eq!(client_info.channel(), &new_channel);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #715 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added test cases for `ClientChannelInfo` to ensure proper functionality of its creation, getters, and setters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->