### PR TITLE
[ISSUE #731]🚀Optimize SubscriptionGroupConfig default method 🔥

### DIFF
--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -16,6 +16,7 @@
  */
 #![allow(dead_code)]
 #![feature(sync_unsafe_cell)]
+#![feature(duration_constructors)]
 
 pub mod clients;
 pub mod code;
@@ -31,18 +32,3 @@ pub mod remoting;
 pub mod rpc;
 pub mod runtime;
 pub mod server;
-
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}

--- a/rocketmq-remoting/src/protocol/subscription/customized_retry_policy.rs
+++ b/rocketmq-remoting/src/protocol/subscription/customized_retry_policy.rs
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::subscription::retry_policy::RetryPolicy;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomizedRetryPolicy {
+    next: Vec<i64>,
+}
+
+impl CustomizedRetryPolicy {
+    pub fn next(&self) -> &[i64] {
+        &self.next
+    }
+}
+
+impl Default for CustomizedRetryPolicy {
+    fn default() -> Self {
+        let next = vec![
+            1_000,     // 1s
+            5_000,     // 5s
+            10_000,    // 10s
+            30_000,    // 30s
+            60_000,    // 1m
+            120_000,   // 2m
+            180_000,   // 3m
+            240_000,   // 4m
+            300_000,   // 5m
+            360_000,   // 6m
+            420_000,   // 7m
+            480_000,   // 8m
+            540_000,   // 9m
+            600_000,   // 10m
+            1_200_000, // 20m
+            1_800_000, // 30m
+            3_600_000, // 1h
+            7_200_000, // 2h
+        ];
+        CustomizedRetryPolicy { next }
+    }
+}
+
+impl RetryPolicy for CustomizedRetryPolicy {
+    fn next_delay_duration(&self, reconsume_times: i32) -> i64 {
+        let reconsume_times = reconsume_times.max(0) as usize;
+        let index = (reconsume_times + 2).min(self.next.len() - 1);
+        self.next[index]
+    }
+}
+
+#[cfg(test)]
+mod customized_retry_policy_tests {
+    use super::*;
+
+    #[test]
+    fn default_creates_expected_sequence() {
+        let policy = CustomizedRetryPolicy::default();
+        let expected_sequence = vec![
+            1_000, 5_000, 10_000, 30_000, 60_000, 120_000, 180_000, 240_000, 300_000, 360_000,
+            420_000, 480_000, 540_000, 600_000, 1_200_000, 1_800_000, 3_600_000, 7_200_000,
+        ];
+        assert_eq!(policy.next, expected_sequence);
+    }
+
+    #[test]
+    fn next_delay_duration_returns_correct_delay_for_valid_reconsume_times() {
+        let policy = CustomizedRetryPolicy::default();
+        let test_cases = vec![(0, 10000), (1, 30000), (16, 7_200_000), (17, 7_200_000)];
+
+        for (reconsume_times, expected_delay) in test_cases {
+            let delay = policy.next_delay_duration(reconsume_times);
+            assert_eq!(
+                delay, expected_delay,
+                "Failed for reconsume_times: {}",
+                reconsume_times
+            );
+        }
+    }
+
+    #[test]
+    fn next_delay_duration_handles_negative_reconsume_times() {
+        let policy = CustomizedRetryPolicy::default();
+        let delay = policy.next_delay_duration(-1);
+        assert_eq!(
+            delay, 10000,
+            "Should handle negative reconsume times by treating them as 0"
+        );
+    }
+
+    #[test]
+    fn next_delay_duration_scales_with_reconsume_times() {
+        let policy = CustomizedRetryPolicy::default();
+        let first_delay = policy.next_delay_duration(0);
+        let second_delay = policy.next_delay_duration(1);
+        assert!(
+            second_delay > first_delay,
+            "Delay should increase with reconsume times"
+        );
+    }
+}

--- a/rocketmq-remoting/src/protocol/subscription/exponential_retry_policy.rs
+++ b/rocketmq-remoting/src/protocol/subscription/exponential_retry_policy.rs
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::subscription::retry_policy::RetryPolicy;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExponentialRetryPolicy {
+    initial: u64,
+    max: u64,
+    multiplier: u64,
+}
+
+impl Default for ExponentialRetryPolicy {
+    fn default() -> Self {
+        ExponentialRetryPolicy {
+            initial: Duration::from_secs(5).as_millis() as u64,
+            max: Duration::from_hours(2).as_millis() as u64,
+            multiplier: 2,
+        }
+    }
+}
+
+impl ExponentialRetryPolicy {
+    pub fn new(initial: u64, max: u64, multiplier: u64) -> Self {
+        ExponentialRetryPolicy {
+            initial,
+            max,
+            multiplier,
+        }
+    }
+
+    pub fn initial(&self) -> u64 {
+        self.initial
+    }
+
+    pub fn max(&self) -> u64 {
+        self.max
+    }
+
+    pub fn multiplier(&self) -> u64 {
+        self.multiplier
+    }
+
+    pub fn set_initial(&mut self, initial: u64) {
+        self.initial = initial;
+    }
+
+    pub fn set_max(&mut self, max: u64) {
+        self.max = max;
+    }
+
+    pub fn set_multiplier(&mut self, multiplier: u64) {
+        self.multiplier = multiplier;
+    }
+}
+
+impl RetryPolicy for ExponentialRetryPolicy {
+    fn next_delay_duration(&self, reconsume_times: i32) -> i64 {
+        let reconsume_times = reconsume_times.clamp(0, 32) as u32;
+        let delay = self.initial * self.multiplier.pow(reconsume_times);
+        delay.min(self.max) as i64
+    }
+}
+
+#[cfg(test)]
+mod exponential_retry_policy_tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn default_policy_has_expected_values() {
+        let policy = ExponentialRetryPolicy::default();
+        assert_eq!(policy.initial(), Duration::from_secs(5).as_millis() as u64);
+        assert_eq!(policy.max(), Duration::from_hours(2).as_millis() as u64);
+        assert_eq!(policy.multiplier(), 2);
+    }
+
+    #[test]
+    fn custom_policy_values_are_set_correctly() {
+        let policy = ExponentialRetryPolicy::new(1000, 3600000, 3);
+        assert_eq!(policy.initial(), 1000);
+        assert_eq!(policy.max(), 3600000);
+        assert_eq!(policy.multiplier(), 3);
+    }
+
+    #[test]
+    fn next_delay_duration_does_not_exceed_max() {
+        let policy = ExponentialRetryPolicy::new(1000, 5000, 2);
+        let delay = policy.next_delay_duration(10);
+        assert_eq!(delay, 5000);
+    }
+
+    #[test]
+    fn next_delay_duration_follows_exponential_growth() {
+        let policy = ExponentialRetryPolicy::new(1000, 100000, 2);
+        let first_delay = policy.next_delay_duration(1);
+        let second_delay = policy.next_delay_duration(2);
+        assert!(second_delay > first_delay);
+        assert_eq!(first_delay, 2000);
+        assert_eq!(second_delay, 4000);
+    }
+
+    #[test]
+    fn next_delay_duration_handles_negative_reconsume_times_as_zero() {
+        let policy = ExponentialRetryPolicy::default();
+        let delay = policy.next_delay_duration(-1);
+        assert_eq!(delay, policy.initial() as i64);
+    }
+
+    #[test]
+    fn next_delay_duration_caps_reconsume_times_to_avoid_overflow() {
+        let policy = ExponentialRetryPolicy::new(1000, u64::MAX, 2);
+        let delay = policy.next_delay_duration(100); // Use a large number to test capping
+        assert!(delay > 0); // Exact value depends on implementation details
+    }
+}

--- a/rocketmq-remoting/src/protocol/subscription/group_retry_policy_type.rs
+++ b/rocketmq-remoting/src/protocol/subscription/group_retry_policy_type.rs
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::fmt;
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub enum GroupRetryPolicyType {
+    #[default]
+    Exponential,
+    Customized,
+}
+
+impl Serialize for GroupRetryPolicyType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = match self {
+            GroupRetryPolicyType::Exponential => "EXPONENTIAL",
+            GroupRetryPolicyType::Customized => "CUSTOMIZED",
+        };
+        serializer.serialize_str(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for GroupRetryPolicyType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct GroupRetryPolicyTypeVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for GroupRetryPolicyTypeVisitor {
+            type Value = GroupRetryPolicyType;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string representing GroupRetryPolicyTypeVisitor")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                match value {
+                    "EXPONENTIAL" => Ok(GroupRetryPolicyType::Exponential),
+                    "CUSTOMIZED" => Ok(GroupRetryPolicyType::Customized),
+                    _ => Err(serde::de::Error::unknown_variant(
+                        value,
+                        &["Exponential", "Customized"],
+                    )),
+                }
+            }
+        }
+
+        deserializer.deserialize_str(GroupRetryPolicyTypeVisitor)
+    }
+}
+
+#[cfg(test)]
+mod group_retry_policy_type_tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn serialization_of_exponential_policy() {
+        let policy = GroupRetryPolicyType::Exponential;
+        let serialized = serde_json::to_string(&policy).unwrap();
+        assert_eq!(serialized, "\"EXPONENTIAL\"");
+    }
+
+    #[test]
+    fn serialization_of_customized_policy() {
+        let policy = GroupRetryPolicyType::Customized;
+        let serialized = serde_json::to_string(&policy).unwrap();
+        assert_eq!(serialized, "\"CUSTOMIZED\"");
+    }
+
+    #[test]
+    fn deserialization_of_exponential_policy() {
+        let serialized = "\"EXPONENTIAL\"";
+        let policy: GroupRetryPolicyType = serde_json::from_str(serialized).unwrap();
+        assert_eq!(policy, GroupRetryPolicyType::Exponential);
+    }
+
+    #[test]
+    fn deserialization_of_customized_policy() {
+        let serialized = "\"CUSTOMIZED\"";
+        let policy: GroupRetryPolicyType = serde_json::from_str(serialized).unwrap();
+        assert_eq!(policy, GroupRetryPolicyType::Customized);
+    }
+
+    #[test]
+    fn deserialization_fails_for_invalid_value() {
+        let serialized = "\"UNKNOWN\"";
+        let result: Result<GroupRetryPolicyType, _> = serde_json::from_str(serialized);
+        assert!(result.is_err());
+    }
+}

--- a/rocketmq-remoting/src/protocol/subscription/retry_policy.rs
+++ b/rocketmq-remoting/src/protocol/subscription/retry_policy.rs
@@ -14,11 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-pub mod customized_retry_policy;
-pub mod exponential_retry_policy;
-pub mod group_retry_policy;
-pub mod group_retry_policy_type;
-pub mod retry_policy;
-pub mod simple_subscription_data;
-pub mod subscription_group_config;
+pub trait RetryPolicy {
+    /// Compute message's next delay duration by specify reconsume_times
+    ///
+    /// # Arguments
+    ///
+    /// * `reconsume_times` - Message reconsume times
+    ///
+    /// # Returns
+    ///
+    /// * Message's next delay duration in milliseconds
+    fn next_delay_duration(&self, reconsume_times: i32) -> i64;
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #731 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customized, exponential, and group retry policies to manage message retry intervals.
  - Introduced new configurations for subscription groups, allowing more flexible management of settings.
  
- **Improvements**
  - Enhanced `SubscriptionGroupConfig` struct for better initialization and field management.
  
- **Bug Fixes**
  - Ensured correct serialization and deserialization for group retry policy types.

- **Tests**
  - Added comprehensive tests for retry policies and `SubscriptionGroupConfig` to ensure reliability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->