### PR TITLE
[ISSUE #765]♻️Refactor ConsumeQueueStore🚀

### DIFF
--- a/rocketmq-common/src/lib.rs
+++ b/rocketmq-common/src/lib.rs
@@ -143,8 +143,8 @@ mod arc_cell_wrapper_tests {
         let cloned_wrapper1 = wrapper.clone();
         let cloned_wrapper2 = wrapper.clone();
 
-        assert_eq!(Arc::strong_count(wrapper.as_ref()), 3);
-        assert_eq!(Arc::strong_count(cloned_wrapper1.as_ref()), 3);
-        assert_eq!(Arc::strong_count(cloned_wrapper2.as_ref()), 3);
+        assert_eq!(Arc::strong_count(wrapper.as_ref()), 1);
+        assert_eq!(Arc::strong_count(cloned_wrapper1.as_ref()), 1);
+        assert_eq!(Arc::strong_count(cloned_wrapper2.as_ref()), 1);
     }
 }

--- a/rocketmq-common/src/lib.rs
+++ b/rocketmq-common/src/lib.rs
@@ -17,6 +17,12 @@
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
+#![feature(sync_unsafe_cell)]
+
+use std::cell::SyncUnsafeCell;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::sync::Arc;
 
 pub use crate::common::attribute::topic_attributes as TopicAttributes;
 pub use crate::common::message::message_accessor as MessageAccessor;
@@ -40,5 +46,105 @@ pub mod log;
 mod thread_pool;
 pub mod utils;
 
+pub struct ArcCellWrapper<T: ?Sized> {
+    inner: Arc<SyncUnsafeCell<T>>,
+}
+
+impl<T> ArcCellWrapper<T> {
+    #[inline]
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: Arc::new(SyncUnsafeCell::new(value)),
+        }
+    }
+}
+
+impl<T: ?Sized> Clone for ArcCellWrapper<T> {
+    fn clone(&self) -> Self {
+        ArcCellWrapper {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T> AsRef<T> for ArcCellWrapper<T> {
+    fn as_ref(&self) -> &T {
+        unsafe { &*self.inner.get() }
+    }
+}
+
+impl<T> AsMut<T> for ArcCellWrapper<T> {
+    fn as_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.inner.get() }
+    }
+}
+
+impl<T> Deref for ArcCellWrapper<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<T> DerefMut for ArcCellWrapper<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut()
+    }
+}
+
 #[cfg(test)]
-mod tests {}
+mod arc_cell_wrapper_tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn new_creates_arc_cell_wrapper_with_provided_value() {
+        let wrapper = ArcCellWrapper::new(10);
+        assert_eq!(*wrapper.as_ref(), 10);
+    }
+
+    #[test]
+    fn clone_creates_a_new_instance_with_same_value() {
+        let wrapper = ArcCellWrapper::new(20);
+        let cloned_wrapper = wrapper.clone();
+        assert_eq!(*cloned_wrapper.as_ref(), 20);
+    }
+
+    #[test]
+    fn as_ref_returns_immutable_reference_to_value() {
+        let wrapper = ArcCellWrapper::new(30);
+        assert_eq!(*wrapper.as_ref(), 30);
+    }
+
+    #[test]
+    fn as_mut_returns_mutable_reference_to_value() {
+        let mut wrapper = ArcCellWrapper::new(40);
+        *wrapper.as_mut() = 50;
+        assert_eq!(*wrapper.as_ref(), 50);
+    }
+
+    #[test]
+    fn deref_returns_reference_to_inner_value() {
+        let wrapper = ArcCellWrapper::new(60);
+        assert_eq!(*wrapper, 60);
+    }
+
+    #[test]
+    fn deref_mut_allows_modification_of_inner_value() {
+        let mut wrapper = ArcCellWrapper::new(70);
+        *wrapper = 80;
+        assert_eq!(*wrapper, 80);
+    }
+
+    #[test]
+    fn multiple_clones_share_the_same_underlying_data() {
+        let wrapper = ArcCellWrapper::new(Arc::new(90));
+        let cloned_wrapper1 = wrapper.clone();
+        let cloned_wrapper2 = wrapper.clone();
+
+        assert_eq!(Arc::strong_count(wrapper.as_ref()), 3);
+        assert_eq!(Arc::strong_count(cloned_wrapper1.as_ref()), 3);
+        assert_eq!(Arc::strong_count(cloned_wrapper2.as_ref()), 3);
+    }
+}

--- a/rocketmq-store/src/log_file.rs
+++ b/rocketmq-store/src/log_file.rs
@@ -26,7 +26,7 @@ use crate::base::get_message_result::GetMessageResult;
 use crate::base::message_result::PutMessageResult;
 use crate::filter::MessageFilter;
 use crate::hook::put_message_hook::BoxedPutMessageHook;
-use crate::queue::ConsumeQueueTrait;
+use crate::queue::ArcConsumeQueue;
 use crate::stats::broker_stats_manager::BrokerStatsManager;
 use crate::store::running_flags::RunningFlags;
 
@@ -113,11 +113,7 @@ pub trait RocketMQMessageStore: Clone + 'static {
 
     fn notify_message_arrive_if_necessary(&self, dispatch_request: &mut DispatchRequest);
 
-    fn find_consume_queue(
-        &self,
-        topic: &str,
-        queue_id: i32,
-    ) -> Option<Arc<parking_lot::Mutex<Box<dyn ConsumeQueueTrait>>>>;
+    fn find_consume_queue(&self, topic: &str, queue_id: i32) -> Option<ArcConsumeQueue>;
 
     fn delete_topics(&self, delete_topics: Vec<String>);
 }

--- a/rocketmq-store/src/queue/batch_consume_queue.rs
+++ b/rocketmq-store/src/queue/batch_consume_queue.rs
@@ -197,7 +197,7 @@ impl Swappable for BatchConsumeQueue {
 }
 
 impl ConsumeQueueTrait for BatchConsumeQueue {
-    fn get_topic(&self) -> String {
+    fn get_topic(&self) -> &str {
         todo!()
     }
 

--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -493,8 +493,8 @@ impl Swappable for ConsumeQueue {
 
 #[allow(unused_variables)]
 impl ConsumeQueueTrait for ConsumeQueue {
-    fn get_topic(&self) -> String {
-        self.topic.clone()
+    fn get_topic(&self) -> &str {
+        self.topic.as_str()
     }
 
     fn get_queue_id(&self) -> i32 {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #765 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `ArcCellWrapper<T>` to safely create, clone, and access inner values, enhancing data handling efficiency.

- **Refactor**
  - Simplified `find_consume_queue` method signature for better readability and maintainability.
  - Refactored `DefaultMessageStore` to improve performance by directly accessing queue instances without locking.
  - Updated queue-related function signatures and types for streamlined code and improved abstraction.
  
- **Bug Fixes**
  - Ensured better code organization and structure to handle queue operations consistently and efficiently.
  
- **Performance Improvements**
  - Enhanced system performance by refining method signatures and reducing unnecessary string cloning in queue operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->