### PR TITLE
[ISSUE #768]♻️Replace SyncUnsafeCell with ArcCellWrapper🔥

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -163,7 +163,11 @@ impl TopicRequestHandler {
                 .broker_runtime_inner()
                 .register_increment_broker_data(
                     vec![topic_config],
-                    self.inner.topic_config_manager.data_version().clone(),
+                    self.inner
+                        .topic_config_manager
+                        .data_version()
+                        .as_ref()
+                        .clone(),
                 )
                 .await;
         }
@@ -261,7 +265,11 @@ impl TopicRequestHandler {
                 .broker_runtime_inner()
                 .register_increment_broker_data(
                     request_body.topic_config_list,
-                    self.inner.topic_config_manager.data_version().clone(),
+                    self.inner
+                        .topic_config_manager
+                        .data_version()
+                        .as_ref()
+                        .clone(),
                 )
                 .await;
         }
@@ -364,7 +372,13 @@ impl TopicRequestHandler {
                     .lock()
                     .clone(),
             ),
-            data_version: Some(self.inner.topic_config_manager.data_version().clone()),
+            data_version: Some(
+                self.inner
+                    .topic_config_manager
+                    .data_version()
+                    .as_ref()
+                    .clone(),
+            ),
             ..Default::default()
         };
         let content = topic_config_and_mapping_serialize_wrapper.to_json();

--- a/rocketmq-broker/src/topic/manager/topic_config_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_config_manager.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-use std::cell::SyncUnsafeCell;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -29,6 +28,7 @@ use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
+use rocketmq_common::ArcCellWrapper;
 use rocketmq_common::TopicAttributes::ALL;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
@@ -45,7 +45,7 @@ use crate::broker_runtime::BrokerRuntimeInner;
 
 pub(crate) struct TopicConfigManager {
     topic_config_table: Arc<parking_lot::Mutex<HashMap<String, TopicConfig>>>,
-    data_version: Arc<SyncUnsafeCell<DataVersion>>,
+    data_version: ArcCellWrapper<DataVersion>,
     broker_config: Arc<BrokerConfig>,
     message_store: Option<DefaultMessageStore>,
     topic_config_table_lock: Arc<parking_lot::ReentrantMutex<()>>,
@@ -74,7 +74,7 @@ impl TopicConfigManager {
     ) -> Self {
         let mut manager = Self {
             topic_config_table: Arc::new(parking_lot::Mutex::new(HashMap::new())),
-            data_version: Arc::new(SyncUnsafeCell::new(DataVersion::default())),
+            data_version: ArcCellWrapper::new(DataVersion::default()),
             broker_config,
             message_store: None,
             topic_config_table_lock: Default::default(),
@@ -231,7 +231,7 @@ impl TopicConfigManager {
         topic_queue_mapping_info_map: HashMap<String, TopicQueueMappingInfo>,
     ) -> TopicConfigAndMappingSerializeWrapper {
         if self.broker_config.enable_split_registration {
-            self.data_version_mut().next_version();
+            self.data_version.mut_from_ref().next_version();
         }
         TopicConfigAndMappingSerializeWrapper {
             topic_config_table: Some(topic_config_table),
@@ -296,7 +296,7 @@ impl TopicConfigManager {
                         default_topic, topic_config, remote_address
                     );
                     self.put_topic_config(topic_config.clone());
-                    self.data_version_mut().next_version_with(
+                    self.data_version.mut_from_ref().next_version_with(
                         self.message_store
                             .as_ref()
                             .unwrap()
@@ -357,7 +357,7 @@ impl TopicConfigManager {
             config.order = is_order;
 
             self.put_topic_config(config.clone());
-            self.data_version_mut().next_version_with(
+            self.data_version.mut_from_ref().next_version_with(
                 self.message_store
                     .as_ref()
                     .unwrap()
@@ -410,7 +410,8 @@ impl TopicConfigManager {
             } else {
                 0
             };
-            self.data_version_mut()
+            self.data_version
+                .mut_from_ref()
                 .next_version_with(state_machine_version);
             self.persist();
         } else {
@@ -441,7 +442,7 @@ impl TopicConfigManager {
             }
         }
 
-        self.data_version_mut().next_version_with(
+        self.data_version.mut_from_ref().next_version_with(
             self.message_store
                 .as_ref()
                 .unwrap()
@@ -508,7 +509,7 @@ impl TopicConfigManager {
             config.topic_sys_flag = 0;
             info!("create new topic {:?}", config);
             self.put_topic_config(config.clone());
-            self.data_version_mut().next_version_with(
+            self.data_version.mut_from_ref().next_version_with(
                 self.message_store
                     .as_ref()
                     .unwrap()
@@ -530,12 +531,8 @@ impl TopicConfigManager {
         self.topic_config_table.lock().contains_key(topic)
     }
 
-    pub fn data_version(&self) -> &DataVersion {
-        unsafe { &*self.data_version.get() }
-    }
-
-    fn data_version_mut(&self) -> &mut DataVersion {
-        unsafe { &mut *self.data_version.get() }
+    pub fn data_version(&self) -> ArcCellWrapper<DataVersion> {
+        self.data_version.clone()
     }
 
     #[inline]
@@ -551,7 +548,7 @@ impl ConfigManager for TopicConfigManager {
 
     fn encode_pretty(&self, pretty_format: bool) -> String {
         let topic_config_table = self.topic_config_table.lock().clone();
-        let version = self.data_version().clone();
+        let version = self.data_version().as_ref().clone();
         match pretty_format {
             true => TopicConfigSerializeWrapper::new(Some(topic_config_table), Some(version))
                 .to_json_pretty(),
@@ -569,7 +566,7 @@ impl ConfigManager for TopicConfigManager {
         let wrapper = SerdeJsonUtils::from_json_str::<TopicConfigSerializeWrapper>(json_string)
             .expect("Decode TopicConfigSerializeWrapper from json failed");
         if let Some(value) = wrapper.data_version() {
-            self.data_version_mut().assign_new_one(value);
+            self.data_version.mut_from_ref().assign_new_one(value);
         }
         if let Some(map) = wrapper.topic_config_table() {
             for (key, value) in map {

--- a/rocketmq-remoting/src/protocol/command_custom_header.rs
+++ b/rocketmq-remoting/src/protocol/command_custom_header.rs
@@ -14,11 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::any::Any;
 use std::collections::HashMap;
 
 use crate::rocketmq_serializable::RocketMQSerializable;
 
-pub trait CommandCustomHeader {
+pub trait CommandCustomHeader: Any {
     /// Checks the fields of the implementing type.  
     ///  
     /// Returns a `Result` indicating whether the fields are valid or not.  

--- a/rocketmq-remoting/src/rpc/rpc_client_impl.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_impl.rs
@@ -102,7 +102,8 @@ impl RpcClientImpl {
                         .body()
                         .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
-                    let rpc_response = RpcResponse::new(response.code(), response_header, body);
+                    let rpc_response =
+                        RpcResponse::new(response.code(), Box::new(response_header), body);
                     Ok(rpc_response)
                 }
                 _ => Ok(RpcResponse::new_exception(Some(RpcException(
@@ -138,7 +139,8 @@ impl RpcClientImpl {
                         .body()
                         .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
-                    let rpc_response = RpcResponse::new(response.code(), response_header, body);
+                    let rpc_response =
+                        RpcResponse::new(response.code(), Box::new(response_header), body);
                     Ok(rpc_response)
                 }
                 _ => Ok(RpcResponse::new_exception(Some(RpcException(
@@ -173,7 +175,8 @@ impl RpcClientImpl {
                         .body()
                         .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
-                    let rpc_response = RpcResponse::new(response.code(), response_header, body);
+                    let rpc_response =
+                        RpcResponse::new(response.code(), Box::new(response_header), body);
                     Ok(rpc_response)
                 }
                 _ => Ok(RpcResponse::new_exception(Some(RpcException(
@@ -208,7 +211,8 @@ impl RpcClientImpl {
                         .body()
                         .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
-                    let rpc_response = RpcResponse::new(response.code(), response_header, body);
+                    let rpc_response =
+                        RpcResponse::new(response.code(), Box::new(response_header), body);
                     Ok(rpc_response)
                 }
                 _ => Ok(RpcResponse::new_exception(Some(RpcException(
@@ -243,7 +247,8 @@ impl RpcClientImpl {
                         .body()
                         .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
-                    let rpc_response = RpcResponse::new(response.code(), response_header, body);
+                    let rpc_response =
+                        RpcResponse::new(response.code(), Box::new(response_header), body);
                     Ok(rpc_response)
                 }
                 _ => Ok(RpcResponse::new_exception(Some(RpcException(
@@ -278,7 +283,8 @@ impl RpcClientImpl {
                         .body()
                         .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
-                    let rpc_response = RpcResponse::new(response.code(), response_header, body);
+                    let rpc_response =
+                        RpcResponse::new(response.code(), Box::new(response_header), body);
                     Ok(rpc_response)
                 }
                 ResponseCode::QueryNotFound => {
@@ -317,7 +323,8 @@ impl RpcClientImpl {
                         .body()
                         .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
-                    let rpc_response = RpcResponse::new(response.code(), response_header, body);
+                    let rpc_response =
+                        RpcResponse::new(response.code(), Box::new(response_header), body);
                     Ok(rpc_response)
                 }
                 _ => Ok(RpcResponse::new_exception(Some(RpcException(

--- a/rocketmq-store/src/queue.rs
+++ b/rocketmq-store/src/queue.rs
@@ -35,7 +35,6 @@ pub mod local_file_consume_queue_store;
 mod queue_offset_operator;
 pub mod single_consume_queue;
 
-//pub type ArcConsumeQueue = Arc<SyncUnsafeCell<Box<dyn ConsumeQueueTrait>>>;
 pub type ArcConsumeQueue = ArcCellWrapper<Box<dyn ConsumeQueueTrait>>;
 pub type ConsumeQueueTable = parking_lot::Mutex<HashMap<String, HashMap<i32, ArcConsumeQueue>>>;
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #768 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced data synchronization and control with the introduction of `ArcCellWrapper` across several modules.

- **Improvements**
  - Improved type safety and concurrency management by replacing `SyncUnsafeCell` with `ArcCellWrapper`.
  - Enhanced `TopicRequestHandler` methods for better data version management.

- **Code Clean-up**
  - Removed deprecated and commented-out code to improve code readability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->