### PR TITLE
[ISSUE #767]🔥Refactor all error handling🚀

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,6 +1656,7 @@ name = "rocketmq-rust"
 version = "0.3.0"
 dependencies = [
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -42,3 +42,5 @@ pub(crate) mod schedule;
 pub(crate) mod subscription;
 pub(crate) mod topic;
 pub(crate) mod util;
+
+type RemotingError = rocketmq_remoting::error::Error;

--- a/rocketmq-common/src/error.rs
+++ b/rocketmq-common/src/error.rs
@@ -17,7 +17,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum SerdeJsonError {
+pub enum Error {
     #[error("Serialization error: {0}")]
     JsonError(#[from] serde_json::Error),
 }

--- a/rocketmq-common/src/utils/serde_json_utils.rs
+++ b/rocketmq-common/src/utils/serde_json_utils.rs
@@ -14,58 +14,58 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use crate::error::SerdeJsonError;
+use crate::error::Error;
 
 pub struct SerdeJsonUtils;
 
 impl SerdeJsonUtils {
-    pub fn decode<T>(bytes: &[u8]) -> Result<T, SerdeJsonError>
+    pub fn decode<T>(bytes: &[u8]) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned,
     {
-        serde_json::from_slice::<T>(bytes).map_err(SerdeJsonError::JsonError)
+        serde_json::from_slice::<T>(bytes).map_err(Error::JsonError)
     }
 
-    pub fn from_json_str<T>(json: &str) -> Result<T, SerdeJsonError>
+    pub fn from_json_str<T>(json: &str) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned,
     {
-        serde_json::from_str(json).map_err(SerdeJsonError::JsonError)
+        serde_json::from_str(json).map_err(Error::JsonError)
     }
 
-    pub fn from_json_slice<T>(json: &[u8]) -> Result<T, SerdeJsonError>
+    pub fn from_json_slice<T>(json: &[u8]) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned,
     {
-        serde_json::from_slice(json).map_err(SerdeJsonError::JsonError)
+        serde_json::from_slice(json).map_err(Error::JsonError)
     }
 
-    pub fn to_json<T>(value: &T) -> Result<String, SerdeJsonError>
+    pub fn to_json<T>(value: &T) -> Result<String, Error>
     where
         T: serde::Serialize,
     {
-        serde_json::to_string(value).map_err(SerdeJsonError::JsonError)
+        serde_json::to_string(value).map_err(Error::JsonError)
     }
 
-    pub fn to_json_pretty<T>(value: &T) -> Result<String, SerdeJsonError>
+    pub fn to_json_pretty<T>(value: &T) -> Result<String, Error>
     where
         T: serde::Serialize,
     {
-        serde_json::to_string_pretty(value).map_err(SerdeJsonError::JsonError)
+        serde_json::to_string_pretty(value).map_err(Error::JsonError)
     }
 
-    pub fn to_json_vec<T>(value: &T) -> Result<Vec<u8>, SerdeJsonError>
+    pub fn to_json_vec<T>(value: &T) -> Result<Vec<u8>, Error>
     where
         T: serde::Serialize,
     {
-        serde_json::to_vec(value).map_err(SerdeJsonError::JsonError)
+        serde_json::to_vec(value).map_err(Error::JsonError)
     }
 
-    pub fn to_json_vec_pretty<T>(value: &T) -> Result<Vec<u8>, SerdeJsonError>
+    pub fn to_json_vec_pretty<T>(value: &T) -> Result<Vec<u8>, Error>
     where
         T: serde::Serialize,
     {
-        serde_json::to_vec_pretty(value).map_err(SerdeJsonError::JsonError)
+        serde_json::to_vec_pretty(value).map_err(Error::JsonError)
     }
 }
 
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn test_from_json_error() {
         let json_str = r#"{"name":"Alice","age":"thirty"}"#;
-        let result: Result<TestStruct, SerdeJsonError> = SerdeJsonUtils::from_json_str(json_str);
+        let result: Result<TestStruct, Error> = SerdeJsonUtils::from_json_str(json_str);
         assert!(result.is_err());
     }
 
@@ -176,8 +176,7 @@ mod tests {
     #[test]
     fn test_from_json_slice_error() {
         let json_slice = r#"{"name":"Bob","age":"twenty-five"}"#.as_bytes();
-        let result: Result<TestStruct, SerdeJsonError> =
-            SerdeJsonUtils::from_json_slice(json_slice);
+        let result: Result<TestStruct, Error> = SerdeJsonUtils::from_json_slice(json_slice);
         assert!(result.is_err());
     }
 
@@ -202,7 +201,7 @@ mod tests {
             name: "Charlie".to_string(),
             age: 40,
         };
-        let result: Result<String, SerdeJsonError> = SerdeJsonUtils::to_json(&value);
+        let result: Result<String, Error> = SerdeJsonUtils::to_json(&value);
         assert!(result.is_ok());
     }
 }

--- a/rocketmq-common/src/utils/serde_json_utils.rs
+++ b/rocketmq-common/src/utils/serde_json_utils.rs
@@ -136,7 +136,8 @@ mod tests {
 
     use serde::Deserialize;
     use serde::Serialize;
-    use serde_json::Error;
+
+    use crate::error::Error;
 
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct TestStruct {

--- a/rocketmq-remoting/src/clients.rs
+++ b/rocketmq-remoting/src/clients.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 pub use blocking_client::BlockingClient;
 pub use client::Client;
 
-use crate::error::RemotingError;
+use crate::error::Error;
 use crate::net::ResponseFuture;
 use crate::protocol::remoting_command::RemotingCommand;
 use crate::remoting::InvokeCallback;
@@ -88,7 +88,7 @@ pub trait RemotingClient: RemotingService {
         addr: String,
         request: RemotingCommand,
         timeout_millis: u64,
-    ) -> Result<RemotingCommand, RemotingError>;
+    ) -> Result<RemotingCommand, Error>;
 
     async fn invoke_oneway(&self, addr: String, request: RemotingCommand, timeout_millis: u64);
 

--- a/rocketmq-remoting/src/clients/rocketmq_default_impl.rs
+++ b/rocketmq-remoting/src/clients/rocketmq_default_impl.rs
@@ -29,7 +29,7 @@ use tracing::warn;
 
 use crate::clients::Client;
 use crate::clients::RemotingClient;
-use crate::error::RemotingError;
+use crate::error::Error;
 use crate::protocol::remoting_command::RemotingCommand;
 use crate::remoting::RemotingService;
 use crate::runtime::config::client_config::TokioClientConfig;
@@ -210,7 +210,7 @@ impl RemotingClient for RocketmqDefaultClient {
         addr: String,
         request: RemotingCommand,
         timeout_millis: u64,
-    ) -> Result<RemotingCommand, RemotingError> {
+    ) -> Result<RemotingCommand, Error> {
         let client = self.get_and_create_client(addr.clone()).unwrap();
         match time::timeout(Duration::from_millis(timeout_millis), async move {
             client.lock().await.send_read(request).await
@@ -219,9 +219,9 @@ impl RemotingClient for RocketmqDefaultClient {
         {
             Ok(result) => match result {
                 Ok(response) => Ok(response),
-                Err(err) => Err(RemotingError::RemoteException(err.to_string())),
+                Err(err) => Err(Error::RemoteException(err.to_string())),
             },
-            Err(err) => Err(RemotingError::RemoteException(err.to_string())),
+            Err(err) => Err(Error::RemoteException(err.to_string())),
         }
     }
 
@@ -234,7 +234,7 @@ impl RemotingClient for RocketmqDefaultClient {
             .await
             {
                 Ok(_) => Ok(()),
-                Err(err) => Err(RemotingError::RemoteException(err.to_string())),
+                Err(err) => Err(Error::RemoteException(err.to_string())),
             }
         });
     }

--- a/rocketmq-remoting/src/code/broker_request_code.rs
+++ b/rocketmq-remoting/src/code/broker_request_code.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use crate::error::RemotingError;
-use crate::error::RemotingError::FromStrError;
+use crate::error::Error;
+use crate::error::Error::FromStrError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum BrokerRequestCode {
@@ -34,7 +34,7 @@ impl BrokerRequestCode {
 }
 
 impl FromStr for BrokerRequestCode {
-    type Err = RemotingError;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_uppercase().as_str() {

--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -26,9 +26,12 @@ pub mod error;
 pub mod net;
 pub mod protocol;
 
+use crate::error::Error;
 pub use crate::protocol::rocketmq_serializable;
 
 pub mod remoting;
 pub mod rpc;
 pub mod runtime;
 pub mod server;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -25,7 +25,7 @@ use std::time::SystemTime;
 
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::topic::TopicValidator;
-use rocketmq_common::error::SerdeJsonError;
+use rocketmq_common::error::Error;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_common::utils::time_utils;
 use serde::ser::SerializeStruct;
@@ -360,7 +360,7 @@ pub trait RemotingSerializable {
 
 pub trait RemotingDeserializable {
     type Output;
-    fn decode(bytes: &[u8]) -> Result<Self::Output, SerdeJsonError>;
+    fn decode(bytes: &[u8]) -> Result<Self::Output, Error>;
 }
 
 pub trait JsonSerializable: Serialize + RemotingSerializable {}
@@ -381,7 +381,7 @@ impl<T: Serialize> RemotingSerializable for T {
 
 impl<T: serde::de::DeserializeOwned> RemotingDeserializable for T {
     type Output = T;
-    fn decode(bytes: &[u8]) -> Result<Self::Output, SerdeJsonError> {
+    fn decode(bytes: &[u8]) -> Result<Self::Output, Error> {
         SerdeJsonUtils::decode(bytes)
     }
 }

--- a/rocketmq-remoting/src/rpc/rpc_client.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client.rs
@@ -16,22 +16,18 @@
  */
 use rocketmq_common::common::message::message_queue::MessageQueue;
 
-use crate::error::RpcException;
 use crate::rpc::rpc_request::RpcRequest;
 use crate::rpc::rpc_response::RpcResponse;
+use crate::Result;
 
 #[trait_variant::make(RpcClient:Send)]
 pub trait RpcClientLocal {
-    async fn invoke(
-        &self,
-        request: RpcRequest,
-        timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException>;
+    async fn invoke(&self, request: RpcRequest, timeout_millis: u64) -> Result<RpcResponse>;
 
     async fn invoke_mq(
         &self,
         mq: MessageQueue,
         request: RpcRequest,
         timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException>;
+    ) -> Result<RpcResponse>;
 }

--- a/rocketmq-remoting/src/rpc/rpc_client_hook.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_hook.rs
@@ -14,15 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use crate::error::RpcException;
+
 use crate::rpc::rpc_request::RpcRequest;
 use crate::rpc::rpc_response::RpcResponse;
+use crate::Result;
 
 pub trait RpcClientHook {
-    fn before_request(&self, rpc_request: &RpcRequest)
-        -> Result<Option<RpcResponse>, RpcException>;
-    fn after_response(
-        &self,
-        rpc_response: &RpcResponse,
-    ) -> Result<Option<RpcResponse>, RpcException>;
+    fn before_request(&self, rpc_request: &RpcRequest) -> Result<Option<RpcResponse>>;
+    fn after_response(&self, rpc_response: &RpcResponse) -> Result<Option<RpcResponse>>;
 }

--- a/rocketmq-remoting/src/rpc/rpc_client_impl.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_impl.rs
@@ -23,7 +23,7 @@ use crate::clients::rocketmq_default_impl::RocketmqDefaultClient;
 use crate::clients::RemotingClient;
 use crate::code::request_code::RequestCode;
 use crate::code::response_code::ResponseCode;
-use crate::error::RpcException;
+use crate::error::Error::RpcException;
 use crate::protocol::header::get_earliest_msg_storetime_response_header::GetEarliestMsgStoretimeResponseHeader;
 use crate::protocol::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
 use crate::protocol::header::get_min_offset_response_header::GetMinOffsetResponseHeader;
@@ -37,6 +37,7 @@ use crate::rpc::rpc_client_hook::RpcClientHook;
 use crate::rpc::rpc_client_utils::RpcClientUtils;
 use crate::rpc::rpc_request::RpcRequest;
 use crate::rpc::rpc_response::RpcResponse;
+use crate::Result;
 
 #[derive(Clone)]
 pub struct RpcClientImpl {
@@ -65,10 +66,7 @@ impl RpcClientImpl {
         self.client_hook_list.clear();
     }
 
-    fn get_broker_addr_by_name_or_exception(
-        &self,
-        broker_name: &str,
-    ) -> Result<String, RpcException> {
+    fn get_broker_addr_by_name_or_exception(&self, broker_name: &str) -> Result<String> {
         match self.client_metadata.find_master_broker_addr(broker_name) {
             None => Err(RpcException(
                 From::from(ResponseCode::SystemError),
@@ -83,7 +81,7 @@ impl RpcClientImpl {
         addr: String,
         request: RpcRequest,
         timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException> {
+    ) -> Result<RpcResponse> {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
@@ -123,7 +121,7 @@ impl RpcClientImpl {
         addr: String,
         request: RpcRequest,
         timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException> {
+    ) -> Result<RpcResponse> {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
@@ -159,7 +157,7 @@ impl RpcClientImpl {
         addr: String,
         request: RpcRequest,
         timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException> {
+    ) -> Result<RpcResponse> {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
@@ -195,7 +193,7 @@ impl RpcClientImpl {
         addr: String,
         request: RpcRequest,
         timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException> {
+    ) -> Result<RpcResponse> {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
@@ -231,7 +229,7 @@ impl RpcClientImpl {
         addr: String,
         request: RpcRequest,
         timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException> {
+    ) -> Result<RpcResponse> {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
@@ -267,7 +265,7 @@ impl RpcClientImpl {
         addr: String,
         request: RpcRequest,
         timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException> {
+    ) -> Result<RpcResponse> {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
@@ -307,7 +305,7 @@ impl RpcClientImpl {
         addr: String,
         request: RpcRequest,
         timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException> {
+    ) -> Result<RpcResponse> {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
@@ -343,7 +341,7 @@ impl RpcClientImpl {
         addr: String,
         request: RpcRequest,
         timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException> {
+    ) -> Result<RpcResponse> {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
@@ -373,11 +371,7 @@ impl RpcClientImpl {
 }
 
 impl RpcClient for RpcClientImpl {
-    async fn invoke(
-        &self,
-        request: RpcRequest,
-        timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException> {
+    async fn invoke(&self, request: RpcRequest, timeout_millis: u64) -> Result<RpcResponse> {
         if !self.client_hook_list.is_empty() {
             for hook in self.client_hook_list.iter() {
                 let result = hook.before_request(&request)?;
@@ -445,7 +439,7 @@ impl RpcClient for RpcClientImpl {
         mq: MessageQueue,
         mut request: RpcRequest,
         timeout_millis: u64,
-    ) -> Result<RpcResponse, RpcException> {
+    ) -> Result<RpcResponse> {
         let bname = self.client_metadata.get_broker_name_from_message_queue(&mq);
         request.header.broker_name = bname;
         self.invoke(request, timeout_millis).await

--- a/rocketmq-remoting/src/rpc/rpc_client_utils.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_utils.rs
@@ -44,7 +44,7 @@ impl RpcClientUtils {
         };
         match rpc_response.exception {
             None => {}
-            Some(value) => cmd.set_remark_ref(Some(value.1.clone())),
+            Some(value) => cmd.set_remark_ref(Some(value.to_string())),
         }
         if let Some(ref _body) = rpc_response.body {
             return cmd;

--- a/rocketmq-remoting/src/rpc/rpc_response.rs
+++ b/rocketmq-remoting/src/rpc/rpc_response.rs
@@ -18,7 +18,7 @@ use std::any::Any;
 
 use rocketmq_common::ArcCellWrapper;
 
-use crate::error::RpcException;
+use crate::error::Error;
 use crate::protocol::command_custom_header::CommandCustomHeader;
 
 #[derive(Default)]
@@ -26,7 +26,7 @@ pub struct RpcResponse {
     pub code: i32,
     pub header: Option<ArcCellWrapper<Box<dyn CommandCustomHeader + Send + Sync + 'static>>>,
     pub body: Option<Box<dyn Any>>,
-    pub exception: Option<RpcException>,
+    pub exception: Option<Error>,
 }
 
 impl RpcResponse {
@@ -56,9 +56,12 @@ impl RpcResponse {
         }
     }
 
-    pub fn new_exception(exception: Option<RpcException>) -> Self {
+    pub fn new_exception(exception: Option<Error>) -> Self {
         Self {
-            code: exception.as_ref().map_or(0, |e| e.0),
+            code: exception.as_ref().map_or(0, |e| match e {
+                Error::RpcException(code, _) => *code,
+                _ => 0,
+            }),
             header: None,
             body: None,
             exception,

--- a/rocketmq-store/src/message_store/default_message_store.rs
+++ b/rocketmq-store/src/message_store/default_message_store.rs
@@ -29,7 +29,6 @@ use std::time::Duration;
 use std::time::Instant;
 
 use bytes::Buf;
-use log::info;
 use rocketmq_common::common::attribute::cleanup_policy::CleanupPolicy;
 use rocketmq_common::common::message::message_batch::MessageExtBatch;
 use rocketmq_common::common::mix_all::is_lmq;
@@ -53,6 +52,7 @@ use rocketmq_common::{
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
 use tracing::error;
+use tracing::info;
 use tracing::warn;
 
 use crate::base::allocate_mapped_file_service::AllocateMappedFileService;

--- a/rocketmq/Cargo.toml
+++ b/rocketmq/Cargo.toml
@@ -14,3 +14,4 @@ description.workspace = true
 
 [dependencies]
 tokio.workspace = true
+tracing.workspace = true

--- a/rocketmq/src/lib.rs
+++ b/rocketmq/src/lib.rs
@@ -20,23 +20,25 @@ pub use rocketmq::main;
 /// Re-export tokio module.
 pub use tokio as rocketmq;
 
-#[macro_export]
-macro_rules! is_trait_implemented {
-    ($t:ty, $tr:ident) => {{
-        struct Checker<T: ?Sized>(std::marker::PhantomData<T>);
+/// On unix platforms we want to intercept SIGINT and SIGTERM
+/// This method returns if either are signalled
+#[cfg(unix)]
+pub async fn wait_for_signal() {
+    use observability_deps::tracing::info;
+    use tokio::signal::unix::signal;
+    use tokio::signal::unix::SignalKind;
+    let mut term = signal(SignalKind::terminate()).expect("failed to register signal handler");
+    let mut int = signal(SignalKind::interrupt()).expect("failed to register signal handler");
 
-        impl<T: $tr + ?Sized> Checker<T> {
-            fn is_implemented() -> bool {
-                true
-            }
-        }
+    tokio::select! {
+        _ = term.recv() => info!("Received SIGTERM"),
+        _ = int.recv() => info!("Received SIGINT"),
+    }
+}
 
-        impl<T: ?Sized> Checker<T> {
-            fn is_implemented() -> bool {
-                false
-            }
-        }
-
-        Checker::<$t>::is_implemented()
-    }};
+#[cfg(windows)]
+/// ctrl_c is the cross-platform way to intercept the equivalent of SIGINT
+/// This method returns if this occurs
+pub async fn wait_for_signal() {
+    let _ = tokio::signal::ctrl_c().await;
 }

--- a/rocketmq/src/lib.rs
+++ b/rocketmq/src/lib.rs
@@ -24,7 +24,6 @@ pub use tokio as rocketmq;
 /// This method returns if either are signalled
 #[cfg(unix)]
 pub async fn wait_for_signal() {
-    use observability_deps::tracing::info;
     use tokio::signal::unix::signal;
     use tokio::signal::unix::SignalKind;
     let mut term = signal(SignalKind::terminate()).expect("failed to register signal handler");

--- a/rocketmq/src/lib.rs
+++ b/rocketmq/src/lib.rs
@@ -26,6 +26,7 @@ pub use tokio as rocketmq;
 pub async fn wait_for_signal() {
     use tokio::signal::unix::signal;
     use tokio::signal::unix::SignalKind;
+    use tracing::info;
     let mut term = signal(SignalKind::terminate()).expect("failed to register signal handler");
     let mut int = signal(SignalKind::interrupt()).expect("failed to register signal handler");
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #767 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified error handling across the project by renaming various error types to a general `Error`.
  - Simplified method signatures and return types for consistency and clarity.

- **Chores**
  - Updated logging from `log::info` to `tracing::info` for better tracing capabilities.
  - Added `tracing` dependency alongside `tokio`.

- **New Features**
  - Introduced platform-specific signal handling for Unix and Windows, including a new function `wait_for_signal()` to handle SIGINT and SIGTERM signals using tokio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->