### PR TITLE
[ISSUE #779]🎨Optimize CommandCustomHeader trait✨

### DIFF
--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -204,7 +204,7 @@ impl<MS> PullMessageProcessor<MS> {
                 ));
             }
         };
-        let response_header = rpc_response.get_header_mut::<PullMessageResponseHeader>();
+        let response_header = rpc_response.get_header_mut_from_ref::<PullMessageResponseHeader>();
         let rewrite_result = rewrite_response_for_static_topic(
             request_header,
             response_header.unwrap(),

--- a/rocketmq-remoting/src/protocol/command_custom_header.rs
+++ b/rocketmq-remoting/src/protocol/command_custom_header.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 use crate::rocketmq_serializable::RocketMQSerializable;
 
-pub trait CommandCustomHeader: Any {
+pub trait CommandCustomHeader: AsAny {
     /// Checks the fields of the implementing type.  
     ///  
     /// Returns a `Result` indicating whether the fields are valid or not.  
@@ -78,6 +78,22 @@ pub trait CommandCustomHeader: Any {
     /// support fast codec. This can be overridden by implementing types.
     fn support_fast_codec(&self) -> bool {
         false
+    }
+}
+
+pub trait AsAny: Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: CommandCustomHeader> AsAny for T {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/rocketmq-remoting/src/rpc/rpc_response.rs
+++ b/rocketmq-remoting/src/rpc/rpc_response.rs
@@ -32,27 +32,31 @@ pub struct RpcResponse {
 impl RpcResponse {
     pub fn get_header<T>(&self) -> Option<&T>
     where
-        T: CommandCustomHeader + Any + Send + Sync + 'static,
+        T: CommandCustomHeader + Send + Sync + 'static,
     {
         match self.header.as_ref() {
             None => None,
-            Some(value) => {
-                let ptr_raw = std::ptr::from_ref(&**value.as_ref()) as *const T;
-                unsafe { Some(&*ptr_raw) }
-            }
+            Some(value) => value.as_ref().as_any().downcast_ref::<T>(),
         }
     }
 
-    pub fn get_header_mut<T>(&self) -> Option<&mut T>
+    pub fn get_header_mut_from_ref<T>(&self) -> Option<&mut T>
     where
-        T: CommandCustomHeader + Any + Send + Sync + 'static,
+        T: CommandCustomHeader + Send + Sync + 'static,
     {
         match self.header.as_ref() {
             None => None,
-            Some(value) => {
-                let ptr_raw = std::ptr::from_mut(&mut **value.mut_from_ref()) as *mut T;
-                unsafe { Some(&mut *ptr_raw) }
-            }
+            Some(value) => value.mut_from_ref().as_any_mut().downcast_mut::<T>(),
+        }
+    }
+
+    pub fn get_header_mut<T>(&mut self) -> Option<&mut T>
+    where
+        T: CommandCustomHeader + Send + Sync + 'static,
+    {
+        match self.header.as_mut() {
+            None => None,
+            Some(value) => value.as_mut().as_any_mut().downcast_mut::<T>(),
         }
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #779 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of headers in `PullMessageProcessor`.
  - Updated `CommandCustomHeader` trait to require `AsAny` trait instead of `Any`.
  - Refactored and added new methods for reading custom headers in `RemotingCommand`.

- **New Features**
  - Introduced new methods for obtaining references to custom headers in `RpcResponse`.

- **Style**
  - Removed deprecated and commented-out methods for cleaner codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->