### PR TITLE
[ISSUE #782]🚀PullMessageResponseHeader implement FastCodesHeader🚀

### DIFF
--- a/rocketmq-remoting/src/error.rs
+++ b/rocketmq-remoting/src/error.rs
@@ -100,6 +100,7 @@ mod error_tests {
     }
 
     #[test]
+    #[allow(invalid_from_utf8)]
     fn utf8_error_is_correctly_mapped() {
         let utf8_error = std::str::from_utf8(&[0, 159, 146, 150]).unwrap_err();
         let error: Error = utf8_error.into();

--- a/rocketmq-remoting/src/protocol/command_custom_header.rs
+++ b/rocketmq-remoting/src/protocol/command_custom_header.rs
@@ -52,7 +52,7 @@ pub trait CommandCustomHeader: AsAny {
     fn write_if_not_null(&self, out: &mut bytes::BytesMut, key: &str, value: &str) {
         if !value.is_empty() {
             RocketMQSerializable::write_str(out, true, key);
-            RocketMQSerializable::write_str(out, false, key);
+            RocketMQSerializable::write_str(out, false, value);
         }
     }
 

--- a/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
@@ -18,13 +18,13 @@
 use std::collections::HashMap;
 
 use bytes::BytesMut;
-use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::FastCodesHeader;
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::FromMap;
 
-#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodec, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PullMessageResponseHeader {
     pub suggest_which_broker_id: Option<u64>,
@@ -37,46 +37,75 @@ pub struct PullMessageResponseHeader {
     pub forbidden_type: Option<i32>,
 }
 
-/*impl PullMessageResponseHeader {
-    const FORBIDDEN_TYPE: &'static str = "forbiddenType";
-    const GROUP_SYS_FLAG: &'static str = "groupSysFlag";
-    const MAX_OFFSET: &'static str = "maxOffset";
-    const MIN_OFFSET: &'static str = "minOffset";
-    const NEXT_BEGIN_OFFSET: &'static str = "nextBeginOffset";
-    const OFFSET_DELTA: &'static str = "offsetDelta";
-    const SUGGEST_WHICH_BROKER_ID: &'static str = "suggestWhichBrokerId";
-    const TOPIC_SYS_FLAG: &'static str = "topicSysFlag";
-}*/
+impl PullMessageResponseHeader {
+    pub const SUGGEST_WHICH_BROKER_ID: &'static str = "suggestWhichBrokerId";
+    pub const NEXT_BEGIN_OFFSET: &'static str = "nextBeginOffset";
+    pub const MIN_OFFSET: &'static str = "minOffset";
+    pub const MAX_OFFSET: &'static str = "maxOffset";
+    pub const OFFSET_DELTA: &'static str = "offsetDelta";
+    pub const TOPIC_SYS_FLAG: &'static str = "topicSysFlag";
+    pub const GROUP_SYS_FLAG: &'static str = "groupSysFlag";
+    pub const FORBIDDEN_TYPE: &'static str = "forbiddenType";
+}
 
-impl FastCodesHeader for PullMessageResponseHeader {
+impl CommandCustomHeader for PullMessageResponseHeader {
+    fn to_map(&self) -> Option<HashMap<String, String>> {
+        let mut map = HashMap::new();
+        if let Some(value) = self.suggest_which_broker_id {
+            map.insert(Self::SUGGEST_WHICH_BROKER_ID.to_string(), value.to_string());
+        }
+        if let Some(value) = self.next_begin_offset {
+            map.insert(Self::NEXT_BEGIN_OFFSET.to_string(), value.to_string());
+        }
+        if let Some(value) = self.min_offset {
+            map.insert(Self::MIN_OFFSET.to_string(), value.to_string());
+        }
+        if let Some(value) = self.max_offset {
+            map.insert(Self::MAX_OFFSET.to_string(), value.to_string());
+        }
+        if let Some(value) = self.offset_delta {
+            map.insert(Self::OFFSET_DELTA.to_string(), value.to_string());
+        }
+        if let Some(value) = self.topic_sys_flag {
+            map.insert(Self::TOPIC_SYS_FLAG.to_string(), value.to_string());
+        }
+        if let Some(value) = self.group_sys_flag {
+            map.insert(Self::GROUP_SYS_FLAG.to_string(), value.to_string());
+        }
+        if let Some(value) = self.forbidden_type {
+            map.insert(Self::FORBIDDEN_TYPE.to_string(), value.to_string());
+        }
+        Some(map)
+    }
+
     fn encode_fast(&mut self, out: &mut BytesMut) {
         if let Some(value) = self.suggest_which_broker_id {
-            Self::write_if_not_null(
+            self.write_if_not_null(
                 out,
                 Self::SUGGEST_WHICH_BROKER_ID,
                 value.to_string().as_str(),
             );
         }
         if let Some(value) = self.next_begin_offset {
-            Self::write_if_not_null(out, Self::NEXT_BEGIN_OFFSET, value.to_string().as_str());
+            self.write_if_not_null(out, Self::NEXT_BEGIN_OFFSET, value.to_string().as_str());
         }
         if let Some(value) = self.min_offset {
-            Self::write_if_not_null(out, Self::MIN_OFFSET, value.to_string().as_str());
+            self.write_if_not_null(out, Self::MIN_OFFSET, value.to_string().as_str());
         }
         if let Some(value) = self.max_offset {
-            Self::write_if_not_null(out, Self::MAX_OFFSET, value.to_string().as_str());
+            self.write_if_not_null(out, Self::MAX_OFFSET, value.to_string().as_str());
         }
         if let Some(value) = self.offset_delta {
-            Self::write_if_not_null(out, Self::OFFSET_DELTA, value.to_string().as_str());
+            self.write_if_not_null(out, Self::OFFSET_DELTA, value.to_string().as_str());
         }
         if let Some(value) = self.topic_sys_flag {
-            Self::write_if_not_null(out, Self::TOPIC_SYS_FLAG, value.to_string().as_str());
+            self.write_if_not_null(out, Self::TOPIC_SYS_FLAG, value.to_string().as_str());
         }
         if let Some(value) = self.group_sys_flag {
-            Self::write_if_not_null(out, Self::GROUP_SYS_FLAG, value.to_string().as_str());
+            self.write_if_not_null(out, Self::GROUP_SYS_FLAG, value.to_string().as_str());
         }
         if let Some(value) = self.forbidden_type {
-            Self::write_if_not_null(out, Self::FORBIDDEN_TYPE, value.to_string().as_str());
+            self.write_if_not_null(out, Self::FORBIDDEN_TYPE, value.to_string().as_str());
         }
     }
 
@@ -105,5 +134,142 @@ impl FastCodesHeader for PullMessageResponseHeader {
         if let Some(offset_delta) = fields.get(Self::FORBIDDEN_TYPE) {
             self.forbidden_type = Some(offset_delta.parse().unwrap());
         }
+    }
+
+    fn support_fast_codec(&self) -> bool {
+        true
+    }
+}
+
+impl FromMap for PullMessageResponseHeader {
+    type Target = Self;
+
+    fn from(map: &HashMap<String, String>) -> Option<Self::Target> {
+        let suggest_which_broker_id = map.get(PullMessageResponseHeader::SUGGEST_WHICH_BROKER_ID);
+        let next_begin_offset = map.get(PullMessageResponseHeader::NEXT_BEGIN_OFFSET);
+        let min_offset = map.get(PullMessageResponseHeader::MIN_OFFSET);
+        let max_offset = map.get(PullMessageResponseHeader::MAX_OFFSET);
+        let offset_delta = map.get(PullMessageResponseHeader::OFFSET_DELTA);
+        let topic_sys_flag = map.get(PullMessageResponseHeader::TOPIC_SYS_FLAG);
+        let group_sys_flag = map.get(PullMessageResponseHeader::GROUP_SYS_FLAG);
+        let forbidden_type = map.get(PullMessageResponseHeader::FORBIDDEN_TYPE);
+
+        Some(PullMessageResponseHeader {
+            suggest_which_broker_id: suggest_which_broker_id.map(|v| v.parse().unwrap()),
+            next_begin_offset: next_begin_offset.map(|v| v.parse().unwrap()),
+            min_offset: min_offset.map(|v| v.parse().unwrap()),
+            max_offset: max_offset.map(|v| v.parse().unwrap()),
+            offset_delta: offset_delta.map(|v| v.parse().unwrap()),
+            topic_sys_flag: topic_sys_flag.map(|v| v.parse().unwrap()),
+            group_sys_flag: group_sys_flag.map(|v| v.parse().unwrap()),
+            forbidden_type: forbidden_type.map(|v| v.parse().unwrap()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod pull_message_response_header_tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn from_map_creates_correct_instance() {
+        let mut map = HashMap::new();
+        map.insert("suggestWhichBrokerId".to_string(), "1".to_string());
+        map.insert("nextBeginOffset".to_string(), "100".to_string());
+        map.insert("minOffset".to_string(), "50".to_string());
+        map.insert("maxOffset".to_string(), "150".to_string());
+        map.insert("offsetDelta".to_string(), "5".to_string());
+        map.insert("topicSysFlag".to_string(), "2".to_string());
+        map.insert("groupSysFlag".to_string(), "3".to_string());
+        map.insert("forbiddenType".to_string(), "4".to_string());
+
+        let header = <PullMessageResponseHeader as FromMap>::from(&map).unwrap();
+
+        assert_eq!(header.suggest_which_broker_id, Some(1));
+        assert_eq!(header.next_begin_offset, Some(100));
+        assert_eq!(header.min_offset, Some(50));
+        assert_eq!(header.max_offset, Some(150));
+        assert_eq!(header.offset_delta, Some(5));
+        assert_eq!(header.topic_sys_flag, Some(2));
+        assert_eq!(header.group_sys_flag, Some(3));
+        assert_eq!(header.forbidden_type, Some(4));
+    }
+
+    #[test]
+    fn to_map_returns_correct_map() {
+        let header = PullMessageResponseHeader {
+            suggest_which_broker_id: Some(1),
+            next_begin_offset: Some(100),
+            min_offset: Some(50),
+            max_offset: Some(150),
+            offset_delta: Some(5),
+            topic_sys_flag: Some(2),
+            group_sys_flag: Some(3),
+            forbidden_type: Some(4),
+        };
+
+        let map = header.to_map().unwrap();
+
+        assert_eq!(map.get("suggestWhichBrokerId").unwrap(), "1");
+        assert_eq!(map.get("nextBeginOffset").unwrap(), "100");
+        assert_eq!(map.get("minOffset").unwrap(), "50");
+        assert_eq!(map.get("maxOffset").unwrap(), "150");
+        assert_eq!(map.get("offsetDelta").unwrap(), "5");
+        assert_eq!(map.get("topicSysFlag").unwrap(), "2");
+        assert_eq!(map.get("groupSysFlag").unwrap(), "3");
+        assert_eq!(map.get("forbiddenType").unwrap(), "4");
+    }
+
+    #[test]
+    fn encode_fast_writes_all_fields_correctly() {
+        let mut header = PullMessageResponseHeader {
+            suggest_which_broker_id: Some(1),
+            next_begin_offset: Some(100),
+            min_offset: Some(50),
+            max_offset: Some(150),
+            offset_delta: Some(5),
+            topic_sys_flag: Some(2),
+            group_sys_flag: Some(3),
+            forbidden_type: Some(4),
+        };
+        let mut out = BytesMut::new();
+
+        header.encode_fast(&mut out);
+        let result = String::from_utf8(out.to_vec()).unwrap();
+        assert!(result.contains("suggestWhichBrokerId"));
+        assert!(result.contains("nextBeginOffset"));
+        assert!(result.contains("minOffset"));
+        assert!(result.contains("maxOffset"));
+        assert!(result.contains("offsetDelta"));
+        assert!(result.contains("topicSysFlag"));
+        assert!(result.contains("groupSysFlag"));
+        assert!(result.contains("forbiddenType"));
+    }
+
+    #[test]
+    fn decode_fast_populates_all_fields_correctly() {
+        let mut header = PullMessageResponseHeader::default();
+        let mut fields = HashMap::new();
+        fields.insert("suggestWhichBrokerId".to_string(), "1".to_string());
+        fields.insert("nextBeginOffset".to_string(), "100".to_string());
+        fields.insert("minOffset".to_string(), "50".to_string());
+        fields.insert("maxOffset".to_string(), "150".to_string());
+        fields.insert("offsetDelta".to_string(), "5".to_string());
+        fields.insert("topicSysFlag".to_string(), "2".to_string());
+        fields.insert("groupSysFlag".to_string(), "3".to_string());
+        fields.insert("forbiddenType".to_string(), "4".to_string());
+
+        header.decode_fast(&fields);
+
+        assert_eq!(header.suggest_which_broker_id, Some(1));
+        assert_eq!(header.next_begin_offset, Some(100));
+        assert_eq!(header.min_offset, Some(50));
+        assert_eq!(header.max_offset, Some(150));
+        assert_eq!(header.offset_delta, Some(5));
+        assert_eq!(header.topic_sys_flag, Some(2));
+        assert_eq!(header.group_sys_flag, Some(3));
+        assert_eq!(header.forbidden_type, Some(4));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #782 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added constants and methods for the `PullMessageResponseHeader` to support mapping, encoding, and decoding functionalities.
  - Introduced unit tests to ensure the proper functioning of the new methods in `PullMessageResponseHeader`.

- **Bug Fixes**
  - Corrected the `write_if_not_null` function to write the `value` parameter instead of the `key` parameter.

- **Maintenance**
  - Added attribute to suppress invalid UTF-8 warnings in test functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->