### PR TITLE
[ISSUE #784]🔥Support ROCKETMQ SerializeType🔥

### DIFF
--- a/rocketmq-remoting/src/codec/remoting_command_codec.rs
+++ b/rocketmq-remoting/src/codec/remoting_command_codec.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-use bytes::Buf;
 use bytes::BufMut;
 use bytes::BytesMut;
 use tokio_util::codec::Decoder;
@@ -90,7 +89,8 @@ impl Decoder for RemotingCommandCodec {
     ///
     /// This function will return an error if the decoding process fails.
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        let read_to = src.len();
+        RemotingCommand::decode(src)
+        /* let read_to = src.len();
         if read_to < 4 {
             // Wait for more data when there are less than 4 bytes.
             return Ok(None);
@@ -131,7 +131,7 @@ impl Decoder for RemotingCommandCodec {
             ));
         }
 
-        Ok(Some(cmd))
+        Ok(Some(cmd))*/
     }
 }
 

--- a/rocketmq-remoting/src/error.rs
+++ b/rocketmq-remoting/src/error.rs
@@ -47,6 +47,9 @@ pub enum Error {
 
     #[error("RemotingCommandEncoderError:{0}")]
     RemotingCommandEncoderError(String),
+
+    #[error("Not support serialize type: {0}")]
+    NotSupportSerializeType(u8),
 }
 
 #[cfg(test)]

--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -17,6 +17,7 @@
 #![allow(dead_code)]
 #![feature(sync_unsafe_cell)]
 #![feature(duration_constructors)]
+extern crate core;
 
 pub mod clients;
 pub mod code;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #784 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for multiple serialization types in remoting commands.

- **Enhancements**
  - Improved decoding logic for remoting commands.
  - Updated `RemotingCommand` to default to a configurable serialization type.

- **Bug Fixes**
  - Added new error handling for unsupported serialization types.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->