### PR TITLE
[ISSUE #813]🔥Refactor processor error handle🚀

### DIFF
--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -78,7 +78,7 @@ where
                     ))
                 };
                 tokio::select! {
-                    _ = handle_future => {info!("PullRequestHoldService: handle_future..........");}
+                    _ = handle_future => {}
                     _ = self_clone.shutdown.notified() => {
                         info!("PullRequestHoldService: shutdown..........");
                         break;

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -20,6 +20,7 @@ use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
 use rocketmq_remoting::runtime::server::ConnectionHandlerContext;
+use rocketmq_remoting::Result;
 use rocketmq_store::log_file::MessageStore;
 use tracing::info;
 
@@ -106,10 +107,10 @@ impl<MS: MessageStore + Send + Sync + 'static> RequestProcessor for BrokerReques
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request: RemotingCommand,
-    ) -> Option<RemotingCommand> {
+    ) -> Result<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!("process_request: {:?}", request_code);
-        match request_code {
+        let result = match request_code {
             RequestCode::SendMessage
             | RequestCode::SendMessageV2
             | RequestCode::SendBatchMessage
@@ -149,6 +150,7 @@ impl<MS: MessageStore + Send + Sync + 'static> RequestProcessor for BrokerReques
                     .process_request(channel, ctx, request_code, request)
                     .await
             }
-        }
+        };
+        Ok(result)
     }
 }

--- a/rocketmq-namesrv/src/processor.rs
+++ b/rocketmq-namesrv/src/processor.rs
@@ -22,6 +22,7 @@ use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
 use rocketmq_remoting::runtime::server::ConnectionHandlerContext;
+use rocketmq_remoting::Result;
 use tracing::info;
 
 pub use self::client_request_processor::ClientRequestProcessor;
@@ -50,16 +51,17 @@ impl RequestProcessor for NameServerRequestProcessor {
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request: RemotingCommand,
-    ) -> Option<RemotingCommand> {
+    ) -> Result<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!("process_request: {:?}", request_code);
-        match request_code {
+        let result = match request_code {
             RequestCode::GetRouteinfoByTopic => self
                 .client_request_processor
                 .process_request(channel, ctx, request),
             _ => self
                 .default_request_processor
                 .process_request(channel, ctx, request),
-        }
+        };
+        Ok(result)
     }
 }

--- a/rocketmq-remoting/src/error.rs
+++ b/rocketmq-remoting/src/error.rs
@@ -56,6 +56,9 @@ pub enum Error {
 
     #[error("{0}")]
     Elapsed(#[from] tokio::time::error::Elapsed),
+
+    #[error("{0}-{1}")]
+    AbortProcessException(i32, String),
 }
 
 #[cfg(test)]

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -578,6 +578,7 @@ impl RemotingCommand {
         (self.flag & bits) == bits
     }
 
+    #[inline]
     pub fn is_oneway_rpc(&self) -> bool {
         let bits = 1 << Self::RPC_ONEWAY;
         (self.flag & bits) == bits

--- a/rocketmq-remoting/src/runtime/processor.rs
+++ b/rocketmq-remoting/src/runtime/processor.rs
@@ -18,6 +18,7 @@
 use crate::net::channel::Channel;
 use crate::protocol::remoting_command::RemotingCommand;
 use crate::runtime::server::ConnectionHandlerContext;
+use crate::Result;
 
 /// Trait for processing requests.
 #[trait_variant::make(RequestProcessor: Send )]
@@ -28,5 +29,5 @@ pub trait LocalRequestProcessor: Clone {
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request: RemotingCommand,
-    ) -> Option<RemotingCommand>;
+    ) -> Result<Option<RemotingCommand>>;
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #813 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in request processing methods for both `BrokerRequest` and `NameServerRequestProcessor`.
	- Introduced RPC hooks for customizable behavior before and after RPC requests in connection handling.
	- Added new error variant to improve error context during process abort scenarios.

- **Bug Fixes**
	- Removed unnecessary logging in the pull request hold service to reduce log clutter and improve performance. 

- **Documentation**
	- Expanded documentation for the `do_before_request` and `do_after_response` methods to clarify usage and expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->