### PR TITLE
[ISSUE #835]Optimize MappedFile#append_message_offset_length method

### DIFF
--- a/rocketmq-cli/src/content_show.rs
+++ b/rocketmq-cli/src/content_show.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 
 use bytes::Buf;
 use rocketmq_common::common::message::message_decoder;
-use rocketmq_store::log_file::mapped_file::default_impl::DefaultMappedFile;
+use rocketmq_store::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use rocketmq_store::log_file::mapped_file::MappedFile;
 use tabled::Table;
 use tabled::Tabled;

--- a/rocketmq-store/src/base/allocate_mapped_file_service.rs
+++ b/rocketmq-store/src/base/allocate_mapped_file_service.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use crate::log_file::mapped_file::default_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 
 pub struct AllocateMappedFileService {
     tx: Sender<AllocateRequest>,

--- a/rocketmq-store/src/base/select_result.rs
+++ b/rocketmq-store/src/base/select_result.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use bytes::BytesMut;
 
-use crate::log_file::mapped_file::default_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::MappedFile;
 
 /// Represents the result of selecting a mapped buffer.

--- a/rocketmq-store/src/base/store_checkpoint.rs
+++ b/rocketmq-store/src/base/store_checkpoint.rs
@@ -26,7 +26,7 @@ use memmap2::MmapMut;
 use rocketmq_common::UtilAll::ensure_dir_ok;
 use tracing::info;
 
-use crate::log_file::mapped_file::default_impl::OS_PAGE_SIZE;
+use crate::log_file::mapped_file::default_mapped_file_impl::OS_PAGE_SIZE;
 
 pub struct StoreCheckpoint {
     file: File,

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -27,7 +27,7 @@ use parking_lot::RwLock;
 use rocketmq_common::UtilAll::offset_to_file_name;
 use tracing::info;
 
-use crate::log_file::mapped_file::default_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::MappedFile;
 use crate::services::allocate_mapped_file_service::AllocateMappedFileService;
 

--- a/rocketmq-store/src/index/index_file.rs
+++ b/rocketmq-store/src/index/index_file.rs
@@ -23,7 +23,7 @@ use rocketmq_common::common::hasher::string_hasher::JavaStringHasher;
 
 use crate::index::index_header::IndexHeader;
 use crate::index::index_header::INDEX_HEADER_SIZE;
-use crate::log_file::mapped_file::default_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::MappedFile;
 
 const HASH_SLOT_SIZE: usize = 4;

--- a/rocketmq-store/src/index/index_header.rs
+++ b/rocketmq-store/src/index/index_header.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use bytes::Buf;
 use bytes::Bytes;
 
-use crate::log_file::mapped_file::default_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::MappedFile;
 
 pub const INDEX_HEADER_SIZE: usize = 40;

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -66,7 +66,7 @@ use crate::config::message_store_config::MessageStoreConfig;
 use crate::consume_queue::mapped_file_queue::MappedFileQueue;
 use crate::log_file::cold_data_check_service::ColdDataCheckService;
 use crate::log_file::flush_manager_impl::defalut_flush_manager::DefaultFlushManager;
-use crate::log_file::mapped_file::default_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::MappedFile;
 use crate::message_encoder::message_ext_encoder::MessageExtEncoder;
 use crate::message_store::default_message_store::CommitLogDispatcherDefault;

--- a/rocketmq-store/src/log_file/mapped_file.rs
+++ b/rocketmq-store/src/log_file/mapped_file.rs
@@ -30,7 +30,7 @@ use crate::base::put_message_context::PutMessageContext;
 use crate::base::select_result::SelectMappedBufferResult;
 use crate::config::flush_disk_type::FlushDiskType;
 
-pub mod default_impl;
+pub mod default_mapped_file_impl;
 
 pub trait MappedFile {
     /// Returns the file name of the mapped file.

--- a/rocketmq-store/src/queue/batch_consume_queue.rs
+++ b/rocketmq-store/src/queue/batch_consume_queue.rs
@@ -30,7 +30,7 @@ use crate::base::swappable::Swappable;
 use crate::config::message_store_config::MessageStoreConfig;
 use crate::consume_queue::mapped_file_queue::MappedFileQueue;
 use crate::filter::MessageFilter;
-use crate::log_file::mapped_file::default_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::queue::queue_offset_operator::QueueOffsetOperator;
 use crate::queue::ConsumeQueueTrait;
 use crate::queue::CqUnit;

--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -40,7 +40,7 @@ use crate::config::message_store_config::MessageStoreConfig;
 use crate::consume_queue::consume_queue_ext::CqExtUnit;
 use crate::consume_queue::mapped_file_queue::MappedFileQueue;
 use crate::filter::MessageFilter;
-use crate::log_file::mapped_file::default_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::MappedFile;
 use crate::queue::consume_queue_ext::ConsumeQueueExt;
 use crate::queue::queue_offset_operator::QueueOffsetOperator;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #835

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated import paths for `DefaultMappedFile` across multiple files to reflect a new module structure, enhancing clarity and organization.
	- Changed module name from `default_impl` to `default_mapped_file_impl` for improved readability.
  
- **Bug Fixes**
	- Enhanced error handling in the `append_message_offset_length` function to ensure proper data validation and logging of issues related to data slicing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->