### PR TITLE
[ISSUES #833] Support AdminBrokerProcessor get_topic_stats_info.

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -109,6 +109,11 @@ impl AdminBrokerProcessor {
                     .get_system_topic_list_from_broker(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::GetTopicStatsInfo => {
+                self.topic_request_handler
+                    .get_topic_stats_info(channel, ctx, request_code, request)
+                    .await
+            }
             _ => Some(get_unknown_cmd_response(request_code)),
         }
     }

--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -33,6 +33,7 @@ use serde::Serializer;
 
 use crate::rocketmq_serializable::RocketMQSerializable;
 
+pub mod admin;
 pub mod body;
 pub mod command_custom_header;
 pub mod filter;

--- a/rocketmq-remoting/src/protocol/admin.rs
+++ b/rocketmq-remoting/src/protocol/admin.rs
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod topic_offset;
+pub mod topic_stats_table;

--- a/rocketmq-remoting/src/protocol/admin/topic_offset.rs
+++ b/rocketmq-remoting/src/protocol/admin/topic_offset.rs
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TopicOffset {
+    min_offset: i64,
+    max_offset: i64,
+    last_update_timestamp: i64,
+}
+
+impl TopicOffset {
+    pub fn new() -> Self {
+        Self {
+            min_offset: 0,
+            max_offset: 0,
+            last_update_timestamp: 0,
+        }
+    }
+
+    pub fn get_min_offset(&self) -> i64 {
+        self.min_offset
+    }
+
+    pub fn set_min_offset(&mut self, min_offset: i64) {
+        self.min_offset = min_offset;
+    }
+
+    pub fn get_max_offset(&self) -> i64 {
+        self.max_offset
+    }
+
+    pub fn set_max_offset(&mut self, max_offset: i64) {
+        self.max_offset = max_offset;
+    }
+
+    pub fn get_last_update_timestamp(&self) -> i64 {
+        self.last_update_timestamp
+    }
+
+    pub fn set_last_update_timestamp(&mut self, last_update_timestamp: i64) {
+        self.last_update_timestamp = last_update_timestamp;
+    }
+}
+
+impl std::fmt::Display for TopicOffset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TopicOffset{{min_offset={}, max_offset={}, last_update_timestamp={}}}",
+            self.min_offset, self.max_offset, self.last_update_timestamp
+        )
+    }
+}

--- a/rocketmq-remoting/src/protocol/admin/topic_stats_table.rs
+++ b/rocketmq-remoting/src/protocol/admin/topic_stats_table.rs
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+
+use rocketmq_common::common::message::message_queue::MessageQueue;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::admin::topic_offset::TopicOffset;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TopicStatsTable {
+    offset_table: HashMap<MessageQueue, TopicOffset>,
+}
+
+impl TopicStatsTable {
+    pub fn new() -> Self {
+        Self {
+            offset_table: HashMap::new(),
+        }
+    }
+
+    pub fn get_offset_table(&self) -> HashMap<MessageQueue, TopicOffset> {
+        self.offset_table.clone()
+    }
+
+    pub fn set_offset_table(&mut self, offset_table: HashMap<MessageQueue, TopicOffset>) {
+        self.offset_table = offset_table;
+    }
+}

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -25,6 +25,8 @@ pub mod get_consumer_listby_group_response_header;
 pub mod get_earliest_msg_storetime_response_header;
 pub mod get_max_offset_response_header;
 pub mod get_min_offset_response_header;
+
+pub mod get_topic_stats_request_header;
 pub mod message_operation_header;
 pub mod namesrv;
 pub mod pull_message_request_header;

--- a/rocketmq-remoting/src/protocol/header/get_topic_stats_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_topic_stats_request_header.rs
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::FromMap;
+use crate::rpc::topic_request_header::TopicRequestHeader;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GetTopicStatsRequestHeader {
+    #[serde(rename = "topic")]
+    pub topic: String,
+
+    #[serde(flatten)]
+    pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+impl GetTopicStatsRequestHeader {
+    pub const TOPIC: &'static str = "topic";
+}
+
+impl CommandCustomHeader for GetTopicStatsRequestHeader {
+    fn to_map(&self) -> Option<std::collections::HashMap<String, String>> {
+        let mut map = std::collections::HashMap::new();
+        map.insert(Self::TOPIC.to_string(), self.topic.clone());
+        if let Some(value) = self.topic_request_header.as_ref() {
+            if let Some(value) = value.to_map() {
+                map.extend(value);
+            }
+        }
+        Some(map)
+    }
+}
+
+impl FromMap for GetTopicStatsRequestHeader {
+    type Target = Self;
+
+    fn from(map: &std::collections::HashMap<String, String>) -> Option<Self::Target> {
+        Some(GetTopicStatsRequestHeader {
+            topic: map.get(Self::TOPIC).cloned().unwrap_or_default(),
+            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+        })
+    }
+}

--- a/rocketmq-store/src/log_file.rs
+++ b/rocketmq-store/src/log_file.rs
@@ -370,4 +370,22 @@ pub trait RocketMQMessageStore: Clone + 'static {
         commit_log_offset: i64,
         size: i32,
     ) -> Option<MessageExt>;
+
+    /// Gets the store time of the specified message.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The message topic.
+    /// * `queue_id` - The queue ID.
+    /// * `consume_queue_offset` - The consume queue offset.
+    ///
+    /// # Returns
+    ///
+    /// The store timestamp of the message.
+    fn get_message_store_timestamp(
+        &self,
+        topic: &str,
+        queue_id: i32,
+        consume_queue_offset: i64,
+    ) -> i64;
 }

--- a/rocketmq-store/src/message_store/default_message_store.rs
+++ b/rocketmq-store/src/message_store/default_message_store.rs
@@ -1224,6 +1224,26 @@ impl MessageStore for DefaultMessageStore {
             None
         }
     }
+
+    fn get_message_store_timestamp(
+        &self,
+        topic: &str,
+        queue_id: i32,
+        consume_queue_offset: i64,
+    ) -> i64 {
+        let consume_queue = self.find_consume_queue(topic, queue_id);
+        if let Some(consume_queue) = consume_queue {
+            if let Some((_, store_time)) =
+                consume_queue.get_cq_unit_and_store_time(consume_queue_offset)
+            {
+                store_time
+            } else {
+                -1
+            }
+        } else {
+            -1
+        }
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #833

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to retrieve topic statistics, including message queue offsets.
	- Introduced a method for getting the store timestamp of messages based on specific parameters.

- **Improvements**
	- Enhanced modular structure for administrative operations within the RocketMQ protocol.

- **Documentation**
	- Added public module declarations and structured support for topic statistics requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->