### PR TITLE
[ISSUES #850] Support AdminBrokerProcessor get_topic_config.

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -114,6 +114,11 @@ impl AdminBrokerProcessor {
                     .get_topic_stats_info(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::GetTopicConfig => {
+                self.topic_request_handler
+                    .get_topic_config(channel, ctx, request_code, request)
+                    .await
+            }
             _ => Some(get_unknown_cmd_response(request_code)),
         }
     }

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -25,8 +25,9 @@ pub mod get_consumer_listby_group_response_header;
 pub mod get_earliest_msg_storetime_response_header;
 pub mod get_max_offset_response_header;
 pub mod get_min_offset_response_header;
-
 pub mod get_topic_stats_request_header;
+
+pub mod get_topic_config_request_header;
 pub mod message_operation_header;
 pub mod namesrv;
 pub mod pull_message_request_header;

--- a/rocketmq-remoting/src/protocol/header/get_topic_config_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_topic_config_request_header.rs
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::FromMap;
+use crate::rpc::topic_request_header::TopicRequestHeader;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GetTopicConfigRequestHeader {
+    #[serde(rename = "topic")]
+    pub topic: String,
+
+    #[serde(flatten)]
+    pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+impl GetTopicConfigRequestHeader {
+    pub const TOPIC: &'static str = "topic";
+
+    pub fn get_topic(&self) -> &String {
+        &self.topic
+    }
+    pub fn set_topic(&mut self, topic: String) {
+        self.topic = topic;
+    }
+}
+
+impl CommandCustomHeader for GetTopicConfigRequestHeader {
+    fn to_map(&self) -> Option<std::collections::HashMap<String, String>> {
+        let mut map = std::collections::HashMap::new();
+        map.insert(Self::TOPIC.to_string(), self.topic.clone());
+        if let Some(value) = self.topic_request_header.as_ref() {
+            if let Some(value) = value.to_map() {
+                map.extend(value);
+            }
+        }
+        Some(map)
+    }
+}
+
+impl FromMap for GetTopicConfigRequestHeader {
+    type Target = Self;
+
+    fn from(map: &std::collections::HashMap<String, String>) -> Option<Self::Target> {
+        Some(GetTopicConfigRequestHeader {
+            topic: map.get(Self::TOPIC).cloned().unwrap_or_default(),
+            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+        })
+    }
+}

--- a/rocketmq-remoting/src/protocol/static_topic.rs
+++ b/rocketmq-remoting/src/protocol/static_topic.rs
@@ -16,6 +16,8 @@
  */
 
 pub mod logic_queue_mapping_item;
+
+pub mod topic_config_and_queue_mapping;
 pub mod topic_queue_info;
 pub mod topic_queue_mapping_context;
 pub mod topic_queue_mapping_detail;

--- a/rocketmq-remoting/src/protocol/static_topic/topic_config_and_queue_mapping.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/topic_config_and_queue_mapping.rs
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use rocketmq_common::common::config::TopicConfig;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct TopicConfigAndQueueMapping {
+    pub topic_config: TopicConfig,
+
+    pub topic_queue_mapping_detail: Option<TopicQueueMappingDetail>,
+}
+
+impl TopicConfigAndQueueMapping {
+    pub fn new(
+        topic_config: TopicConfig,
+        topic_queue_mapping_detail: Option<TopicQueueMappingDetail>,
+    ) -> Self {
+        Self {
+            topic_config,
+            topic_queue_mapping_detail,
+        }
+    }
+
+    pub fn get_topic_queue_mapping_detail(&self) -> Option<&TopicQueueMappingDetail> {
+        self.topic_queue_mapping_detail.as_ref()
+    }
+
+    pub fn set_topic_queue_mapping_detail(
+        &mut self,
+        topic_queue_mapping_detail: Option<TopicQueueMappingDetail>,
+    ) {
+        self.topic_queue_mapping_detail = topic_queue_mapping_detail;
+    }
+}

--- a/rocketmq-remoting/src/rpc/topic_request_header.rs
+++ b/rocketmq-remoting/src/rpc/topic_request_header.rs
@@ -32,6 +32,14 @@ pub struct TopicRequestHeader {
 
 impl TopicRequestHeader {
     pub const LO: &'static str = "lo";
+
+    pub fn get_lo(&self) -> Option<&bool> {
+        self.lo.as_ref()
+    }
+
+    pub fn set_lo(&mut self, lo: bool) {
+        self.lo = Some(lo);
+    }
 }
 
 impl FromMap for TopicRequestHeader {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #850 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new functionality for retrieving topic configuration details.
	- Added a new method to handle topic configuration requests, enhancing the messaging system's capabilities.
	- Implemented structures for managing topic configuration and associated queue mappings.
  
- **Bug Fixes**
	- Improved error handling for requests involving non-existing topic configurations.

- **Documentation**
	- Enhanced comments and documentation surrounding topic configuration handling for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->