### PR TITLE
[ISSUE #847]🚀Implement DefaultMQProducer#start-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,7 @@ dependencies = [
 name = "rocketmq-client"
 version = "0.3.0"
 dependencies = [
+ "lazy_static",
  "num_cpus",
  "rand",
  "rocketmq-common",
@@ -1536,6 +1537,11 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
  "trait-variant",
 ]
 

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -27,7 +27,7 @@ use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::server::config::ServerConfig;
 use rocketmq_common::common::statistics::state_getter::StateGetter;
-use rocketmq_common::ArcCellWrapper;
+use rocketmq_common::ArcRefCellWrapper;
 use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_common::UtilAll::compute_next_morning_time_millis;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
@@ -385,7 +385,7 @@ impl BrokerRuntime {
             self.broker_stats_manager.clone(),
         );
         let mut pull_message_result_handler =
-            ArcCellWrapper::new(Box::new(DefaultPullMessageResultHandler::new(
+            ArcRefCellWrapper::new(Box::new(DefaultPullMessageResultHandler::new(
                 self.message_store_config.clone(),
                 Arc::new(self.topic_config_manager.clone()),
                 Arc::new(self.consumer_offset_manager.clone()),

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
-use rocketmq_common::ArcCellWrapper;
+use rocketmq_common::ArcRefCellWrapper;
 use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_store::log_file::MessageStore;
@@ -60,7 +60,7 @@ impl ConsumerOffsetManager {
         ConsumerOffsetManager {
             broker_config,
             consumer_offset_wrapper: ConsumerOffsetWrapper {
-                data_version: ArcCellWrapper::new(DataVersion::default()),
+                data_version: ArcRefCellWrapper::new(DataVersion::default()),
                 offset_table: Arc::new(parking_lot::RwLock::new(HashMap::new())),
                 reset_offset_table: Arc::new(parking_lot::RwLock::new(HashMap::new())),
                 pull_offset_table: Arc::new(parking_lot::RwLock::new(HashMap::new())),
@@ -257,7 +257,7 @@ impl ConsumerOffsetManager {
 
 #[derive(Default, Clone)]
 struct ConsumerOffsetWrapper {
-    data_version: ArcCellWrapper<DataVersion>,
+    data_version: ArcRefCellWrapper<DataVersion>,
     offset_table: Arc<parking_lot::RwLock<HashMap<String /* topic@group */, HashMap<i32, i64>>>>,
     reset_offset_table: Arc<parking_lot::RwLock<HashMap<String, HashMap<i32, i64>>>>,
     pull_offset_table:
@@ -392,7 +392,7 @@ impl<'de> Deserialize<'de> for ConsumerOffsetWrapper {
                 let pull_offset_table = pull_offset_table.unwrap_or_default();
 
                 Ok(ConsumerOffsetWrapper {
-                    data_version: ArcCellWrapper::new(data_version),
+                    data_version: ArcRefCellWrapper::new(data_version),
                     offset_table: Arc::new(parking_lot::RwLock::new(offset_table)),
                     reset_offset_table: Arc::new(parking_lot::RwLock::new(reset_offset_table)),
                     pull_offset_table: Arc::new(parking_lot::RwLock::new(pull_offset_table)),

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -22,7 +22,7 @@ use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::filter::expression_type::ExpressionType;
 use rocketmq_common::common::sys_flag::pull_sys_flag::PullSysFlag;
 use rocketmq_common::common::FAQUrl;
-use rocketmq_common::ArcCellWrapper;
+use rocketmq_common::ArcRefCellWrapper;
 use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::RemotingSysResponseCode;
@@ -70,7 +70,7 @@ use crate::topic::manager::topic_queue_mapping_manager::TopicQueueMappingManager
 
 #[derive(Clone)]
 pub struct PullMessageProcessor<MS> {
-    pull_message_result_handler: ArcCellWrapper<Box<dyn PullMessageResultHandler>>,
+    pull_message_result_handler: ArcRefCellWrapper<Box<dyn PullMessageResultHandler>>,
     broker_config: Arc<BrokerConfig>,
     subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
     topic_config_manager: Arc<TopicConfigManager>,
@@ -90,7 +90,7 @@ pub struct PullMessageProcessor<MS> {
 
 impl<MS> PullMessageProcessor<MS> {
     pub fn new(
-        pull_message_result_handler: ArcCellWrapper<Box<dyn PullMessageResultHandler>>,
+        pull_message_result_handler: ArcRefCellWrapper<Box<dyn PullMessageResultHandler>>,
         broker_config: Arc<BrokerConfig>,
         subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
         topic_config_manager: Arc<TopicConfigManager>,

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -43,7 +43,7 @@ use rocketmq_common::common::TopicSysFlag::build_sys_flag;
 use rocketmq_common::utils::message_utils;
 use rocketmq_common::utils::queue_type_utils::QueueTypeUtils;
 use rocketmq_common::utils::util_all;
-use rocketmq_common::ArcCellWrapper;
+use rocketmq_common::ArcRefCellWrapper;
 use rocketmq_common::CleanupPolicyUtils;
 use rocketmq_common::MessageDecoder;
 use rocketmq_common::MessageDecoder::message_properties_to_string;
@@ -191,7 +191,7 @@ impl<MS: MessageStore> SendMessageProcessor<MS> {
             inner: Inner {
                 broker_config,
                 topic_config_manager,
-                send_message_hook_vec: ArcCellWrapper::new(Vec::new()),
+                send_message_hook_vec: ArcRefCellWrapper::new(Vec::new()),
                 topic_queue_mapping_manager,
                 subscription_group_manager,
                 message_store: message_store.clone(),
@@ -929,7 +929,7 @@ const DLQ_NUMS_PER_GROUP: u32 = 1;
 #[derive(Clone)]
 pub(crate) struct Inner<MS> {
     topic_config_manager: TopicConfigManager,
-    send_message_hook_vec: ArcCellWrapper<Vec<Box<dyn SendMessageHook>>>,
+    send_message_hook_vec: ArcRefCellWrapper<Vec<Box<dyn SendMessageHook>>>,
     topic_queue_mapping_manager: Arc<TopicQueueMappingManager>,
     subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
     broker_config: Arc<BrokerConfig>,

--- a/rocketmq-broker/src/topic/manager/topic_config_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_config_manager.rs
@@ -28,7 +28,7 @@ use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
-use rocketmq_common::ArcCellWrapper;
+use rocketmq_common::ArcRefCellWrapper;
 use rocketmq_common::TopicAttributes::ALL;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
@@ -45,7 +45,7 @@ use crate::broker_runtime::BrokerRuntimeInner;
 
 pub(crate) struct TopicConfigManager {
     topic_config_table: Arc<parking_lot::Mutex<HashMap<String, TopicConfig>>>,
-    data_version: ArcCellWrapper<DataVersion>,
+    data_version: ArcRefCellWrapper<DataVersion>,
     broker_config: Arc<BrokerConfig>,
     message_store: Option<DefaultMessageStore>,
     topic_config_table_lock: Arc<parking_lot::ReentrantMutex<()>>,
@@ -74,7 +74,7 @@ impl TopicConfigManager {
     ) -> Self {
         let mut manager = Self {
             topic_config_table: Arc::new(parking_lot::Mutex::new(HashMap::new())),
-            data_version: ArcCellWrapper::new(DataVersion::default()),
+            data_version: ArcRefCellWrapper::new(DataVersion::default()),
             broker_config,
             message_store: None,
             topic_config_table_lock: Default::default(),
@@ -534,7 +534,7 @@ impl TopicConfigManager {
         self.topic_config_table.lock().contains_key(topic)
     }
 
-    pub fn data_version(&self) -> ArcCellWrapper<DataVersion> {
+    pub fn data_version(&self) -> ArcRefCellWrapper<DataVersion> {
         self.data_version.clone()
     }
 

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -20,6 +20,15 @@ thiserror = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 
+tokio.workspace = true
+tokio-util.workspace = true
+tokio-stream.workspace = true
+
 trait-variant = { workspace = true }
 num_cpus = { workspace = true }
 rand = { workspace = true }
+lazy_static = { workspace = true }
+
+#log
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/rocketmq-client/src/factory.rs
+++ b/rocketmq-client/src/factory.rs
@@ -14,19 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub mod mq_client_instance;

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -14,19 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
+use std::sync::Arc;
 
-use crate::error::MQClientError;
+use rocketmq_remoting::runtime::RPCHook;
 
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
+use crate::base::client_config::ClientConfig;
 
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub struct MQClientInstance {}
+
+impl MQClientInstance {
+    pub fn new(
+        client_config: ClientConfig,
+        instance_index: i32,
+        client_id: String,
+        rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    ) -> Self {
+        MQClientInstance {}
+    }
+}

--- a/rocketmq-client/src/hook.rs
+++ b/rocketmq-client/src/hook.rs
@@ -14,19 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+mod check_forbidden_context;
+pub(crate) mod check_forbidden_hook;
+pub(crate) mod end_transaction_context;
+pub(crate) mod end_transaction_hook;
+pub(crate) mod send_message_context;
+pub(crate) mod send_message_hook;

--- a/rocketmq-client/src/hook/check_forbidden_context.rs
+++ b/rocketmq-client/src/hook/check_forbidden_context.rs
@@ -14,19 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub struct CheckForbiddenContext {}

--- a/rocketmq-client/src/hook/check_forbidden_hook.rs
+++ b/rocketmq-client/src/hook/check_forbidden_hook.rs
@@ -14,19 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
+use crate::hook::check_forbidden_context::CheckForbiddenContext;
+use crate::Result;
 
-use crate::error::MQClientError;
+pub trait CheckForbiddenHook: Send + Sync {
+    fn hook_name(&self) -> &str;
 
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+    fn check_forbidden(&self, context: &CheckForbiddenContext) -> Result<()>;
+}

--- a/rocketmq-client/src/hook/end_transaction_context.rs
+++ b/rocketmq-client/src/hook/end_transaction_context.rs
@@ -14,19 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub struct EndTransactionContext {}

--- a/rocketmq-client/src/hook/end_transaction_hook.rs
+++ b/rocketmq-client/src/hook/end_transaction_hook.rs
@@ -14,19 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
+use crate::hook::end_transaction_context::EndTransactionContext;
 
-use crate::error::MQClientError;
+pub trait EndTransactionHook: Send + Sync {
+    fn hook_name(&self) -> &str;
 
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+    fn end_transaction(&self, context: &EndTransactionContext);
+}

--- a/rocketmq-client/src/hook/send_message_context.rs
+++ b/rocketmq-client/src/hook/send_message_context.rs
@@ -14,19 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub struct SendMessageContext {}

--- a/rocketmq-client/src/hook/send_message_hook.rs
+++ b/rocketmq-client/src/hook/send_message_hook.rs
@@ -14,19 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
+use crate::hook::send_message_context::SendMessageContext;
 
-use crate::error::MQClientError;
+pub trait SendMessageHook: Send + Sync {
+    fn hook_name(&self) -> &str;
 
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
+    fn send_message_before(&self, context: &SendMessageContext);
 
-pub type Result<T> = std::result::Result<T, MQClientError>;
+    fn send_message_after(&self, context: &SendMessageContext);
+}

--- a/rocketmq-client/src/implementation.rs
+++ b/rocketmq-client/src/implementation.rs
@@ -14,19 +14,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
 
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub(crate) mod mq_client_manager;

--- a/rocketmq-client/src/implementation/mq_client_manager.rs
+++ b/rocketmq-client/src/implementation/mq_client_manager.rs
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+use std::sync::atomic::AtomicI32;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use lazy_static::lazy_static;
+use rocketmq_common::ArcRefCellWrapper;
+use rocketmq_remoting::runtime::RPCHook;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use crate::base::client_config::ClientConfig;
+use crate::factory::mq_client_instance::MQClientInstance;
+use crate::producer::produce_accumulator::ProduceAccumulator;
+
+type ClientInstanceHashMap =
+    HashMap<String /* clientId */, ArcRefCellWrapper<MQClientInstance>>;
+type AccumulatorHashMap =
+    HashMap<String /* clientId */, ArcRefCellWrapper<ProduceAccumulator>>;
+
+#[derive(Default)]
+pub struct MQClientManager {
+    factory_table: Arc<RwLock<ClientInstanceHashMap>>,
+    accumulator_table: Arc<RwLock<AccumulatorHashMap>>,
+    factory_index_generator: AtomicI32,
+}
+
+impl MQClientManager {
+    fn new() -> Self {
+        MQClientManager {
+            factory_index_generator: AtomicI32::new(0),
+            factory_table: Arc::new(RwLock::new(HashMap::new())),
+            accumulator_table: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn get_instance() -> &'static MQClientManager {
+        lazy_static! {
+            static ref INSTANCE: MQClientManager = MQClientManager::new();
+        }
+        &INSTANCE
+    }
+
+    pub async fn get_or_create_mq_client_instance(
+        &self,
+        client_config: ClientConfig,
+        rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    ) -> ArcRefCellWrapper<MQClientInstance> {
+        let client_id = client_config.build_mq_client_id();
+        let mut factory_table = self.factory_table.write().await;
+        let instance = factory_table.entry(client_id.clone()).or_insert_with(|| {
+            let instance = MQClientInstance::new(
+                client_config.clone(),
+                self.factory_index_generator.fetch_add(1, Ordering::SeqCst),
+                client_id.clone(),
+                rpc_hook,
+            );
+            info!("Created new MQClientInstance for clientId: [{}]", client_id);
+            ArcRefCellWrapper::new(instance)
+        });
+        instance.clone()
+    }
+
+    pub async fn get_or_create_produce_accumulator(
+        &self,
+        client_config: ClientConfig,
+    ) -> ArcRefCellWrapper<ProduceAccumulator> {
+        let client_id = client_config.build_mq_client_id();
+        let mut accumulator_table = self.accumulator_table.write().await;
+        let accumulator = accumulator_table
+            .entry(client_id.clone())
+            .or_insert_with(|| {
+                let accumulator = ProduceAccumulator::new();
+                info!(
+                    "Created new ProduceAccumulator for clientId: [{}]",
+                    client_id
+                );
+                ArcRefCellWrapper::new(accumulator)
+            });
+        accumulator.clone()
+    }
+
+    pub async fn remove_client_factory(&self, client_id: &str) {
+        self.factory_table.write().await.remove(client_id);
+    }
+}

--- a/rocketmq-client/src/latency.rs
+++ b/rocketmq-client/src/latency.rs
@@ -14,19 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub(crate) mod latency_fault_tolerance;
+pub(crate) mod latency_fault_tolerance_impl;
+pub(crate) mod mq_fault_strategy;
+pub(crate) mod resolver;
+pub(crate) mod service_detector;

--- a/rocketmq-client/src/latency/latency_fault_tolerance.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance.rs
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+pub trait LatencyFaultTolerance<T> {
+    /// Update brokers' states, to decide if they are good or not.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Broker's name.
+    /// * `current_latency` - Current message sending process's latency.
+    /// * `not_available_duration` - Corresponding not available time, ms. The broker will be not
+    ///   available until it
+    /// * `reachable` - To decide if this broker is reachable or not.
+    fn update_fault_item(
+        &mut self,
+        name: T,
+        current_latency: u64,
+        not_available_duration: u64,
+        reachable: bool,
+    );
+
+    /// To check if this broker is available.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Broker's name.
+    ///
+    /// # Returns
+    ///
+    /// * `true` if the broker is available, `false` otherwise.
+    fn is_available(&self, name: &T) -> bool;
+
+    /// To check if this broker is reachable.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Broker's name.
+    ///
+    /// # Returns
+    ///
+    /// * `true` if the broker is reachable, `false` otherwise.
+    fn is_reachable(&self, name: &T) -> bool;
+
+    /// Remove the broker in this fault item table.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Broker's name.
+    fn remove(&mut self, name: &T);
+
+    /// The worst situation, no broker can be available. Then choose a random one.
+    ///
+    /// # Returns
+    ///
+    /// * A random broker will be returned.
+    fn pick_one_at_least(&self) -> T;
+
+    /// Start a new thread, to detect the broker's reachable tag.
+    fn start_detector(&self);
+
+    /// Shutdown threads that started by `LatencyFaultTolerance`.
+    fn shutdown(&self);
+
+    /// A function reserved, just detect by once, won't create a new thread.
+    fn detect_by_one_round(&self);
+
+    /// Use it to set the detect timeout bound.
+    ///
+    /// # Arguments
+    ///
+    /// * `detect_timeout` - Timeout bound.
+    fn set_detect_timeout(&mut self, detect_timeout: u32);
+
+    /// Use it to set the detector's interval for each broker (each broker will be detected once
+    /// during this time).
+    ///
+    /// # Arguments
+    ///
+    /// * `detect_interval` - Each broker's detecting interval.
+    fn set_detect_interval(&mut self, detect_interval: u32);
+
+    /// Use it to set the detector work or not.
+    ///
+    /// # Arguments
+    ///
+    /// * `start_detector_enable` - Set the detector's work status.
+    fn set_start_detector_enable(&mut self, start_detector_enable: bool);
+
+    /// Use it to judge if the detector is enabled.
+    ///
+    /// # Returns
+    ///
+    /// * `true` if the detector should be started, `false` otherwise.
+    fn is_start_detector_enable(&self) -> bool;
+}

--- a/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use crate::latency::latency_fault_tolerance::LatencyFaultTolerance;
+use crate::latency::resolver::Resolver;
+use crate::latency::service_detector::ServiceDetector;
+
+pub struct LatencyFaultToleranceImpl {
+    resolver: Box<dyn Resolver>,
+    service_detector: Box<dyn ServiceDetector>,
+}
+
+impl LatencyFaultToleranceImpl {
+    pub fn new(fetcher: impl Resolver, service_detector: impl ServiceDetector) -> Self {
+        Self {
+            resolver: Box::new(fetcher),
+            service_detector: Box::new(service_detector),
+        }
+    }
+}
+
+impl LatencyFaultTolerance<String> for LatencyFaultToleranceImpl {
+    fn update_fault_item(
+        &mut self,
+        name: String,
+        current_latency: u64,
+        not_available_duration: u64,
+        reachable: bool,
+    ) {
+        todo!()
+    }
+
+    fn is_available(&self, name: &String) -> bool {
+        todo!()
+    }
+
+    fn is_reachable(&self, name: &String) -> bool {
+        todo!()
+    }
+
+    fn remove(&mut self, name: &String) {
+        todo!()
+    }
+
+    fn pick_one_at_least(&self) -> String {
+        todo!()
+    }
+
+    fn start_detector(&self) {
+        todo!()
+    }
+
+    fn shutdown(&self) {
+        todo!()
+    }
+
+    fn detect_by_one_round(&self) {
+        todo!()
+    }
+
+    fn set_detect_timeout(&mut self, detect_timeout: u32) {
+        todo!()
+    }
+
+    fn set_detect_interval(&mut self, detect_interval: u32) {
+        todo!()
+    }
+
+    fn set_start_detector_enable(&mut self, start_detector_enable: bool) {
+        todo!()
+    }
+
+    fn is_start_detector_enable(&self) -> bool {
+        todo!()
+    }
+}

--- a/rocketmq-client/src/latency/mq_fault_strategy.rs
+++ b/rocketmq-client/src/latency/mq_fault_strategy.rs
@@ -14,19 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
+use crate::base::client_config::ClientConfig;
+use crate::latency::resolver::Resolver;
+use crate::latency::service_detector::ServiceDetector;
 
-use crate::error::MQClientError;
+pub struct MQFaultStrategy {}
 
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+impl MQFaultStrategy {
+    pub fn new(
+        client_config: ClientConfig,
+        fetcher: impl Resolver,
+        service_detector: impl ServiceDetector,
+    ) -> Self {
+        Self {}
+    }
+}

--- a/rocketmq-client/src/latency/resolver.rs
+++ b/rocketmq-client/src/latency/resolver.rs
@@ -14,19 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub trait Resolver: Send + Sync + 'static {
+    fn resolve(&self, name: &str) -> String;
+}

--- a/rocketmq-client/src/latency/service_detector.rs
+++ b/rocketmq-client/src/latency/service_detector.rs
@@ -14,19 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub trait ServiceDetector: Send + Sync + 'static {
+    fn detect(&self, endpoint: &str, timeout_millis: u64) -> bool;
+}

--- a/rocketmq-client/src/producer/default_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/default_mq_produce_builder.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use rocketmq_common::common::compression::compression_type::CompressionType;
 use rocketmq_common::common::compression::compressor::Compressor;
@@ -41,16 +42,16 @@ pub struct DefaultMQProducerBuilder {
     retry_times_when_send_async_failed: Option<u32>,
     retry_another_broker_when_not_store_ok: Option<bool>,
     max_message_size: Option<u32>,
-    trace_dispatcher: Option<Box<dyn TraceDispatcher + Send + Sync>>,
+    trace_dispatcher: Option<Arc<Box<dyn TraceDispatcher + Send + Sync>>>,
     auto_batch: Option<bool>,
     produce_accumulator: Option<ProduceAccumulator>,
     enable_backpressure_for_async_mode: Option<bool>,
     back_pressure_for_async_send_num: Option<u32>,
     back_pressure_for_async_send_size: Option<u32>,
-    rpc_hook: Option<Box<dyn RPCHook>>,
+    rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
     compress_level: Option<i32>,
     compress_type: Option<CompressionType>,
-    compressor: Option<Box<dyn Compressor + Send + Sync>>,
+    compressor: Option<Arc<Box<dyn Compressor + Send + Sync>>>,
 }
 
 impl DefaultMQProducerBuilder {
@@ -158,7 +159,7 @@ impl DefaultMQProducerBuilder {
 
     pub fn trace_dispatcher(
         mut self,
-        trace_dispatcher: Box<dyn TraceDispatcher + Send + Sync>,
+        trace_dispatcher: Arc<Box<dyn TraceDispatcher + Send + Sync>>,
     ) -> Self {
         self.trace_dispatcher = Some(trace_dispatcher);
         self
@@ -199,7 +200,7 @@ impl DefaultMQProducerBuilder {
     }
 
     pub fn rpc_hook(mut self, rpc_hook: Box<dyn RPCHook>) -> Self {
-        self.rpc_hook = Some(rpc_hook);
+        self.rpc_hook = Some(Arc::new(rpc_hook));
         self
     }
 
@@ -213,7 +214,7 @@ impl DefaultMQProducerBuilder {
         self
     }
 
-    pub fn compressor(mut self, compressor: Box<dyn Compressor + Send + Sync>) -> Self {
+    pub fn compressor(mut self, compressor: Arc<Box<dyn Compressor + Send + Sync>>) -> Self {
         self.compressor = Some(compressor);
         self
     }

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::any::Any;
 
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_single::Message;
@@ -26,7 +27,7 @@ use crate::producer::transaction_send_result::TransactionSendResult;
 use crate::Result;
 
 #[trait_variant::make(MQProducer: Send)]
-pub trait MQProducerLocal {
+pub trait MQProducerLocal: Any {
     /// Starts the MQ producer.
     ///
     /// This method initializes and starts the MQ producer, preparing it for sending messages.
@@ -526,4 +527,8 @@ pub trait MQProducerLocal {
         request_callback: impl FnOnce(Result<Message>) + Send + Sync,
         timeout: u64,
     );
+
+    fn as_any(&self) -> &dyn Any;
+
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 }

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -15,4 +15,16 @@
  * limitations under the License.
  */
 
+#[derive(Default)]
 pub struct ProduceAccumulator;
+
+impl ProduceAccumulator {
+    pub fn new() -> Self {
+        ProduceAccumulator
+    }
+}
+
+impl ProduceAccumulator {
+    pub fn start(&mut self) {}
+    pub fn shutdown(&self) {}
+}

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -14,17 +14,90 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use rocketmq_common::common::base::service_state::ServiceState;
 use rocketmq_common::common::message::message_single::MessageExt;
+use rocketmq_common::common::mix_all::CLIENT_INNER_PRODUCER_GROUP;
+use rocketmq_common::common::FAQUrl;
+use rocketmq_common::ArcRefCellWrapper;
 use rocketmq_remoting::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
+use rocketmq_remoting::runtime::RPCHook;
+use tokio::sync::RwLock;
+use tokio::sync::Semaphore;
 
+use crate::base::client_config::ClientConfig;
+use crate::error::MQClientError;
+use crate::factory::mq_client_instance::MQClientInstance;
+use crate::hook::check_forbidden_hook::CheckForbiddenHook;
+use crate::hook::end_transaction_hook::EndTransactionHook;
+use crate::hook::send_message_hook::SendMessageHook;
+use crate::implementation::mq_client_manager::MQClientManager;
+use crate::latency::mq_fault_strategy::MQFaultStrategy;
+use crate::latency::resolver::Resolver;
+use crate::latency::service_detector::ServiceDetector;
+use crate::producer::default_mq_producer::ProducerConfig;
 use crate::producer::producer_impl::mq_producer_inner::MQProducerInner;
 use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
 use crate::producer::transaction_listener::TransactionListener;
+use crate::Result;
 
-pub struct DefaultMQProducerImpl {}
+pub struct DefaultMQProducerImpl {
+    client_config: ClientConfig,
+    producer_config: ProducerConfig,
+    topic_publish_info_table: Arc<RwLock<HashMap<String /* topic */, TopicPublishInfo>>>,
+    send_message_hook_list: Vec<Box<dyn SendMessageHook>>,
+    end_transaction_hook_list: Vec<Box<dyn EndTransactionHook>>,
+    check_forbidden_hook_list: Vec<Box<dyn CheckForbiddenHook>>,
+    rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    service_state: ServiceState,
+    client_instance: ArcRefCellWrapper<MQClientInstance>,
+    mq_fault_strategy: MQFaultStrategy,
+    semaphore_async_send_num: Semaphore,
+    semaphore_async_send_size: Semaphore,
+}
+
+impl DefaultMQProducerImpl {
+    pub fn new(
+        client_config: ClientConfig,
+        producer_config: ProducerConfig,
+        rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    ) -> Self {
+        let semaphore_async_send_num =
+            Semaphore::new(producer_config.back_pressure_for_async_send_num().max(10) as usize);
+        let semaphore_async_send_size = Semaphore::new(
+            producer_config
+                .back_pressure_for_async_send_size()
+                .max(1024 * 1024) as usize,
+        );
+        let client_instance = ArcRefCellWrapper::new(MQClientInstance {});
+        let topic_publish_info_table = Arc::new(RwLock::new(HashMap::new()));
+
+        let service_detector = DefaultServiceDetector {
+            client_instance: client_instance.clone(),
+            topic_publish_info_table: topic_publish_info_table.clone(),
+        };
+        let resolver = DefaultResolver {
+            client_instance: client_instance.clone(),
+        };
+        DefaultMQProducerImpl {
+            client_config: client_config.clone(),
+            producer_config,
+            topic_publish_info_table,
+            send_message_hook_list: vec![],
+            end_transaction_hook_list: vec![],
+            check_forbidden_hook_list: vec![],
+            rpc_hook: None,
+            service_state: ServiceState::CreateJust,
+            client_instance,
+            mq_fault_strategy: MQFaultStrategy::new(client_config, resolver, service_detector),
+            semaphore_async_send_num,
+            semaphore_async_send_size,
+        }
+    }
+}
 
 impl MQProducerInner for DefaultMQProducerImpl {
     fn get_publish_topic_list(&self) -> HashSet<String> {
@@ -53,6 +126,89 @@ impl MQProducerInner for DefaultMQProducerImpl {
     }
 
     fn is_unit_mode(&self) -> bool {
+        todo!()
+    }
+}
+
+impl DefaultMQProducerImpl {
+    pub async fn start(&mut self) -> Result<()> {
+        self.start_with_factory(true).await
+    }
+
+    pub async fn start_with_factory(&mut self, start_factory: bool) -> Result<()> {
+        match self.service_state {
+            ServiceState::CreateJust => {
+                self.service_state = ServiceState::StartFailed;
+                self.check_config()?;
+
+                if self.producer_config.producer_group() != CLIENT_INNER_PRODUCER_GROUP {
+                    self.client_config.change_instance_name_to_pid();
+                }
+
+                self.client_instance = MQClientManager::get_instance()
+                    .get_or_create_mq_client_instance(
+                        self.client_config.clone(),
+                        self.rpc_hook.clone(),
+                    )
+                    .await;
+            }
+            ServiceState::Running => {
+                return Err(MQClientError::MQClientException(
+                    -1,
+                    "The producer service state is Running".to_string(),
+                ));
+            }
+            ServiceState::ShutdownAlready => {
+                return Err(MQClientError::MQClientException(
+                    -1,
+                    "The producer service state is ShutdownAlready".to_string(),
+                ));
+            }
+            ServiceState::StartFailed => {
+                return Err(MQClientError::MQClientException(
+                    -1,
+                    format!(
+                        "The producer service state not OK, maybe started once,{:?},{}",
+                        self.service_state,
+                        FAQUrl::suggest_todo(FAQUrl::CLIENT_SERVICE_NOT_OK)
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn register_end_transaction_hook(&mut self, hook: impl EndTransactionHook) {
+        todo!()
+    }
+
+    pub fn register_send_message_hook(&mut self, hook: impl SendMessageHook) {
+        todo!()
+    }
+
+    #[inline]
+    fn check_config(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+struct DefaultServiceDetector {
+    client_instance: ArcRefCellWrapper<MQClientInstance>,
+    topic_publish_info_table: Arc<RwLock<HashMap<String /* topic */, TopicPublishInfo>>>,
+}
+
+impl ServiceDetector for DefaultServiceDetector {
+    fn detect(&self, endpoint: &str, timeout_millis: u64) -> bool {
+        todo!()
+    }
+}
+
+struct DefaultResolver {
+    client_instance: ArcRefCellWrapper<MQClientInstance>,
+}
+
+impl Resolver for DefaultResolver {
+    fn resolve(&self, name: &str) -> String {
         todo!()
     }
 }

--- a/rocketmq-client/src/trace.rs
+++ b/rocketmq-client/src/trace.rs
@@ -14,4 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+pub mod async_trace_dispatcher;
+pub mod hook;
 pub mod trace_dispatcher;

--- a/rocketmq-client/src/trace/async_trace_dispatcher.rs
+++ b/rocketmq-client/src/trace/async_trace_dispatcher.rs
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::any::Any;
+use std::sync::Arc;
+
+use rocketmq_common::ArcRefCellWrapper;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::base::access_channel::AccessChannel;
+use crate::producer::producer_impl::default_mq_producer_impl::DefaultMQProducerImpl;
+use crate::trace::trace_dispatcher::TraceDispatcher;
+use crate::trace::trace_dispatcher::Type;
+
+pub struct AsyncTraceDispatcher;
+
+impl AsyncTraceDispatcher {
+    pub fn new(
+        group: &str,
+        type_: Type,
+        trace_topic_name: &str,
+        rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    ) -> Self {
+        AsyncTraceDispatcher
+    }
+}
+
+impl TraceDispatcher for AsyncTraceDispatcher {
+    fn start(&self, name_srv_addr: &str, access_channel: AccessChannel) -> crate::Result<()> {
+        todo!()
+    }
+
+    fn append(&self, ctx: &dyn Any) -> bool {
+        todo!()
+    }
+
+    fn flush(&self) -> crate::Result<()> {
+        todo!()
+    }
+
+    fn shutdown(&self) {
+        todo!()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl AsyncTraceDispatcher {
+    pub fn set_host_producer(&mut self, host_producer: ArcRefCellWrapper<DefaultMQProducerImpl>) {}
+
+    pub fn set_namespace_v2(&mut self, namespace_v2: Option<String>) {}
+}

--- a/rocketmq-client/src/trace/hook.rs
+++ b/rocketmq-client/src/trace/hook.rs
@@ -14,19 +14,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub mod end_transaction_trace_hook_impl;
+pub mod send_message_trace_hook_impl;

--- a/rocketmq-client/src/trace/hook/end_transaction_trace_hook_impl.rs
+++ b/rocketmq-client/src/trace/hook/end_transaction_trace_hook_impl.rs
@@ -14,19 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
+use std::sync::Arc;
 
-use crate::error::MQClientError;
+use crate::hook::end_transaction_context::EndTransactionContext;
+use crate::hook::end_transaction_hook::EndTransactionHook;
+use crate::trace::trace_dispatcher::TraceDispatcher;
 
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
+pub struct EndTransactionTraceHookImpl {
+    trace_dispatcher: Arc<Box<dyn TraceDispatcher + Send + Sync>>,
+}
 
-pub type Result<T> = std::result::Result<T, MQClientError>;
+impl EndTransactionTraceHookImpl {
+    pub fn new(trace_dispatcher: Arc<Box<dyn TraceDispatcher + Send + Sync>>) -> Self {
+        Self { trace_dispatcher }
+    }
+}
+
+impl EndTransactionHook for EndTransactionTraceHookImpl {
+    fn hook_name(&self) -> &str {
+        "EndTransactionTraceHookImpl"
+    }
+
+    fn end_transaction(&self, context: &EndTransactionContext) {
+        todo!()
+    }
+}

--- a/rocketmq-client/src/trace/hook/send_message_trace_hook_impl.rs
+++ b/rocketmq-client/src/trace/hook/send_message_trace_hook_impl.rs
@@ -14,19 +14,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
+use std::sync::Arc;
 
-use crate::error::MQClientError;
+use crate::hook::send_message_context::SendMessageContext;
+use crate::hook::send_message_hook::SendMessageHook;
+use crate::trace::trace_dispatcher::TraceDispatcher;
 
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
+pub struct SendMessageTraceHookImpl {
+    trace_dispatcher: Arc<Box<dyn TraceDispatcher + Send + Sync>>,
+}
 
-pub type Result<T> = std::result::Result<T, MQClientError>;
+impl SendMessageTraceHookImpl {
+    pub fn new(trace_dispatcher: Arc<Box<dyn TraceDispatcher + Send + Sync>>) -> Self {
+        Self { trace_dispatcher }
+    }
+}
+impl SendMessageHook for SendMessageTraceHookImpl {
+    fn hook_name(&self) -> &str {
+        todo!()
+    }
+
+    fn send_message_before(&self, context: &SendMessageContext) {
+        todo!()
+    }
+
+    fn send_message_after(&self, context: &SendMessageContext) {
+        todo!()
+    }
+}

--- a/rocketmq-client/src/trace/trace_dispatcher.rs
+++ b/rocketmq-client/src/trace/trace_dispatcher.rs
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::any::Any;
+
 use crate::base::access_channel::AccessChannel;
 use crate::Result;
 
@@ -22,9 +24,11 @@ pub enum Type {
     Consume,
 }
 
-pub trait TraceDispatcher {
+pub trait TraceDispatcher: Any {
     fn start(&self, name_srv_addr: &str, access_channel: AccessChannel) -> Result<()>;
     fn append(&self, ctx: &dyn std::any::Any) -> bool;
     fn flush(&self) -> Result<()>;
     fn shutdown(&self);
+    fn as_any(&self) -> &dyn Any;
+    fn as_mut_any(&mut self) -> &mut dyn Any;
 }

--- a/rocketmq-common/src/common.rs
+++ b/rocketmq-common/src/common.rs
@@ -27,6 +27,7 @@ use serde::Serializer;
 pub use crate::common::sys_flag::topic_sys_flag as TopicSysFlag;
 
 pub mod attribute;
+pub mod base;
 pub mod boundary_type;
 pub mod broker;
 pub mod compression;

--- a/rocketmq-common/src/common/base.rs
+++ b/rocketmq-common/src/common/base.rs
@@ -14,19 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub mod service_state;

--- a/rocketmq-common/src/common/base/service_state.rs
+++ b/rocketmq-common/src/common/base/service_state.rs
@@ -14,19 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-use crate::error::MQClientError;
-
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceState {
+    /// Service just created, not started
+    CreateJust,
+    /// Service running
+    Running,
+    /// Service shutdown
+    ShutdownAlready,
+    /// Service start failure
+    StartFailed,
+}

--- a/rocketmq-common/src/lib.rs
+++ b/rocketmq-common/src/lib.rs
@@ -65,19 +65,19 @@ impl<T: ?Sized> Clone for WeakCellWrapper<T> {
 }
 
 impl<T> WeakCellWrapper<T> {
-    pub fn upgrade(&self) -> Option<ArcCellWrapper<T>> {
+    pub fn upgrade(&self) -> Option<ArcRefCellWrapper<T>> {
         self.inner
             .upgrade()
-            .map(|value| ArcCellWrapper { inner: value })
+            .map(|value| ArcRefCellWrapper { inner: value })
     }
 }
 
 #[derive(Default)]
-pub struct ArcCellWrapper<T: ?Sized> {
+pub struct ArcRefCellWrapper<T: ?Sized> {
     inner: Arc<SyncUnsafeCell<T>>,
 }
 
-impl<T> ArcCellWrapper<T> {
+impl<T> ArcRefCellWrapper<T> {
     #[allow(clippy::mut_from_ref)]
     pub fn mut_from_ref(&self) -> &mut T {
         unsafe { &mut *self.inner.get() }
@@ -90,7 +90,7 @@ impl<T> ArcCellWrapper<T> {
     }
 }
 
-impl<T> ArcCellWrapper<T> {
+impl<T> ArcRefCellWrapper<T> {
     #[inline]
     pub fn new(value: T) -> Self {
         Self {
@@ -99,34 +99,34 @@ impl<T> ArcCellWrapper<T> {
     }
 }
 
-impl<T: ?Sized> Clone for ArcCellWrapper<T> {
+impl<T: ?Sized> Clone for ArcRefCellWrapper<T> {
     fn clone(&self) -> Self {
-        ArcCellWrapper {
+        ArcRefCellWrapper {
             inner: Arc::clone(&self.inner),
         }
     }
 }
 
-impl<T> AsRef<T> for ArcCellWrapper<T> {
+impl<T> AsRef<T> for ArcRefCellWrapper<T> {
     fn as_ref(&self) -> &T {
         unsafe { &*self.inner.get() }
     }
 }
 
-impl<T> AsMut<T> for ArcCellWrapper<T> {
+impl<T> AsMut<T> for ArcRefCellWrapper<T> {
     fn as_mut(&mut self) -> &mut T {
         unsafe { &mut *self.inner.get() }
     }
 }
 
-impl<T> Deref for ArcCellWrapper<T> {
+impl<T> Deref for ArcRefCellWrapper<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         self.as_ref()
     }
 }
 
-impl<T> DerefMut for ArcCellWrapper<T> {
+impl<T> DerefMut for ArcRefCellWrapper<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.as_mut()
     }
@@ -185,46 +185,46 @@ mod arc_cell_wrapper_tests {
 
     #[test]
     fn new_creates_arc_cell_wrapper_with_provided_value() {
-        let wrapper = ArcCellWrapper::new(10);
+        let wrapper = ArcRefCellWrapper::new(10);
         assert_eq!(*wrapper.as_ref(), 10);
     }
 
     #[test]
     fn clone_creates_a_new_instance_with_same_value() {
-        let wrapper = ArcCellWrapper::new(20);
+        let wrapper = ArcRefCellWrapper::new(20);
         let cloned_wrapper = wrapper.clone();
         assert_eq!(*cloned_wrapper.as_ref(), 20);
     }
 
     #[test]
     fn as_ref_returns_immutable_reference_to_value() {
-        let wrapper = ArcCellWrapper::new(30);
+        let wrapper = ArcRefCellWrapper::new(30);
         assert_eq!(*wrapper.as_ref(), 30);
     }
 
     #[test]
     fn as_mut_returns_mutable_reference_to_value() {
-        let mut wrapper = ArcCellWrapper::new(40);
+        let mut wrapper = ArcRefCellWrapper::new(40);
         *wrapper.as_mut() = 50;
         assert_eq!(*wrapper.as_ref(), 50);
     }
 
     #[test]
     fn deref_returns_reference_to_inner_value() {
-        let wrapper = ArcCellWrapper::new(60);
+        let wrapper = ArcRefCellWrapper::new(60);
         assert_eq!(*wrapper, 60);
     }
 
     #[test]
     fn deref_mut_allows_modification_of_inner_value() {
-        let mut wrapper = ArcCellWrapper::new(70);
+        let mut wrapper = ArcRefCellWrapper::new(70);
         *wrapper = 80;
         assert_eq!(*wrapper, 80);
     }
 
     #[test]
     fn multiple_clones_share_the_same_underlying_data() {
-        let wrapper = ArcCellWrapper::new(Arc::new(90));
+        let wrapper = ArcRefCellWrapper::new(Arc::new(90));
         let cloned_wrapper1 = wrapper.clone();
         let cloned_wrapper2 = wrapper.clone();
 

--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -44,6 +44,7 @@ pub mod namespace_util;
 pub mod namesrv;
 pub mod remoting_command;
 pub mod request_source;
+pub mod request_type;
 pub mod rocketmq_serializable;
 pub mod route;
 pub mod static_topic;

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -31,7 +31,7 @@ use bytes::BytesMut;
 use lazy_static::lazy_static;
 use rocketmq_common::common::mq_version::RocketMqVersion;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
-use rocketmq_common::ArcCellWrapper;
+use rocketmq_common::ArcRefCellWrapper;
 use serde::Deserialize;
 use serde::Serialize;
 use tracing::error;
@@ -112,7 +112,7 @@ pub struct RemotingCommand {
     suspended: bool,
     #[serde(skip)]
     command_custom_header:
-        Option<ArcCellWrapper<Box<dyn CommandCustomHeader + Send + Sync + 'static>>>,
+        Option<ArcRefCellWrapper<Box<dyn CommandCustomHeader + Send + Sync + 'static>>>,
     #[serde(rename = "serializeTypeCurrentRPC")]
     serialize_type: SerializeType,
 }
@@ -235,14 +235,14 @@ impl RemotingCommand {
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
-        self.command_custom_header = Some(ArcCellWrapper::new(Box::new(command_custom_header)));
+        self.command_custom_header = Some(ArcRefCellWrapper::new(Box::new(command_custom_header)));
         self
     }
 
     pub fn set_command_custom_header_origin(
         mut self,
         command_custom_header: Option<
-            ArcCellWrapper<Box<dyn CommandCustomHeader + Send + Sync + 'static>>,
+            ArcRefCellWrapper<Box<dyn CommandCustomHeader + Send + Sync + 'static>>,
         >,
     ) -> Self {
         self.command_custom_header = command_custom_header;
@@ -253,7 +253,7 @@ impl RemotingCommand {
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
-        self.command_custom_header = Some(ArcCellWrapper::new(Box::new(command_custom_header)));
+        self.command_custom_header = Some(ArcRefCellWrapper::new(Box::new(command_custom_header)));
     }
 
     pub fn set_code(mut self, code: impl Into<i32>) -> Self {

--- a/rocketmq-remoting/src/protocol/request_type.rs
+++ b/rocketmq-remoting/src/protocol/request_type.rs
@@ -14,19 +14,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
+use std::fmt::Display;
 
-use crate::error::MQClientError;
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum RequestType {
+    Stream,
+}
 
-pub mod base;
-mod common;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
+impl Display for RequestType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestType::Stream => write!(f, "STREAM"),
+        }
+    }
+}
 
-pub type Result<T> = std::result::Result<T, MQClientError>;
+impl RequestType {
+    pub fn value_of(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(RequestType::Stream),
+            _ => None,
+        }
+    }
+
+    pub fn get_code(&self) -> u8 {
+        match self {
+            RequestType::Stream => 0,
+        }
+    }
+}

--- a/rocketmq-remoting/src/rpc/rpc_response.rs
+++ b/rocketmq-remoting/src/rpc/rpc_response.rs
@@ -16,7 +16,7 @@
  */
 use std::any::Any;
 
-use rocketmq_common::ArcCellWrapper;
+use rocketmq_common::ArcRefCellWrapper;
 
 use crate::error::Error;
 use crate::protocol::command_custom_header::CommandCustomHeader;
@@ -24,7 +24,7 @@ use crate::protocol::command_custom_header::CommandCustomHeader;
 #[derive(Default)]
 pub struct RpcResponse {
     pub code: i32,
-    pub header: Option<ArcCellWrapper<Box<dyn CommandCustomHeader + Send + Sync + 'static>>>,
+    pub header: Option<ArcRefCellWrapper<Box<dyn CommandCustomHeader + Send + Sync + 'static>>>,
     pub body: Option<Box<dyn Any>>,
     pub exception: Option<Error>,
 }
@@ -79,7 +79,7 @@ impl RpcResponse {
     ) -> Self {
         Self {
             code,
-            header: Some(ArcCellWrapper::new(header)),
+            header: Some(ArcRefCellWrapper::new(header)),
             body,
             exception: None,
         }

--- a/rocketmq-store/src/queue.rs
+++ b/rocketmq-store/src/queue.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use rocketmq_common::common::attribute::cq_type::CQType;
 use rocketmq_common::common::boundary_type::BoundaryType;
 use rocketmq_common::common::message::message_single::MessageExtBrokerInner;
-use rocketmq_common::ArcCellWrapper;
+use rocketmq_common::ArcRefCellWrapper;
 
 use crate::base::dispatch_request::DispatchRequest;
 use crate::base::swappable::Swappable;
@@ -36,7 +36,7 @@ pub mod local_file_consume_queue_store;
 mod queue_offset_operator;
 pub mod single_consume_queue;
 
-pub type ArcConsumeQueue = ArcCellWrapper<Box<dyn ConsumeQueueTrait>>;
+pub type ArcConsumeQueue = ArcRefCellWrapper<Box<dyn ConsumeQueueTrait>>;
 pub type ConsumeQueueTable = parking_lot::Mutex<HashMap<String, HashMap<i32, ArcConsumeQueue>>>;
 
 /// Trait defining the lifecycle of a file-based queue, including operations for loading,

--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -27,7 +27,7 @@ use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::message::message_single::MessageExtBrokerInner;
 use rocketmq_common::utils::queue_type_utils::QueueTypeUtils;
-use rocketmq_common::ArcCellWrapper;
+use rocketmq_common::ArcRefCellWrapper;
 use tracing::info;
 
 use crate::base::dispatch_request::DispatchRequest;
@@ -332,7 +332,7 @@ impl ConsumeQueueStoreTrait for ConsumeQueueStore {
                 .get(&topic.to_string())
                 .cloned();
             match QueueTypeUtils::get_cq_type(&option) {
-                CQType::SimpleCQ => ArcCellWrapper::new(Box::new(ConsumeQueue::new(
+                CQType::SimpleCQ => ArcRefCellWrapper::new(Box::new(ConsumeQueue::new(
                     topic.to_string(),
                     queue_id,
                     get_store_path_consume_queue(
@@ -345,7 +345,7 @@ impl ConsumeQueueStoreTrait for ConsumeQueueStore {
                     self.running_flags.clone(),
                     self.store_checkpoint.clone(),
                 ))),
-                CQType::BatchCQ => ArcCellWrapper::new(Box::new(BatchConsumeQueue::new(
+                CQType::BatchCQ => ArcRefCellWrapper::new(Box::new(BatchConsumeQueue::new(
                     topic.to_string(),
                     queue_id,
                     get_store_path_batch_consume_queue(
@@ -460,7 +460,7 @@ impl ConsumeQueueStore {
     ) {
         let mut consume_queue_table = self.inner.consume_queue_table.lock();
         let topic_table = consume_queue_table.entry(topic).or_default();
-        topic_table.insert(queue_id, ArcCellWrapper::new(consume_queue));
+        topic_table.insert(queue_id, ArcRefCellWrapper::new(consume_queue));
     }
 
     fn queue_type_should_be(&self, topic: &str, cq_type: CQType) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #847 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new modules for enhanced functionality, including `mq_client_instance`, `latency`, and `trace`.
  - Added asynchronous tracing capabilities with the `AsyncTraceDispatcher`.
  - Enhanced `ClientConfig` with new methods to manage namespace states.

- **Improvements**
  - Replaced `ArcCellWrapper` with `ArcRefCellWrapper` across multiple components for better thread safety and mutable access.
  - Updated various structs and fields to support enhanced functionality and shared ownership.

- **Bug Fixes**
  - Resolved issues related to mutable state management by updating wrapper types across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->