### PR TITLE
[ISSUE #883]Implement Produer send single message-3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,7 @@ version = "0.3.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
+ "parking_lot",
  "rand",
  "regex",
  "rocketmq-common",

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -35,6 +35,9 @@ lazy_static = { workspace = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 regex = { version = "1.10.6", features = [] }
+
+parking_lot = { workspace = true }
+
 [[example]]
 name = "simple-producer"
 path = "examples/producer/simple_producer.rs"

--- a/rocketmq-client/examples/producer/simple_producer.rs
+++ b/rocketmq-client/examples/producer/simple_producer.rs
@@ -41,10 +41,12 @@ pub async fn main() -> Result<()> {
 
     producer.start().await?;
 
-    let message = Message::with_tags(TOPIC, TAG, "Hello RocketMQ".as_bytes());
+    for _ in 0..10 {
+        let message = Message::with_tags(TOPIC, TAG, "Hello RocketMQ".as_bytes());
 
-    producer.send_with_timeout(message, 2000).await?;
-
+        let send_result = producer.send_with_timeout(message, 2000).await?;
+        println!("send result: {}", send_result);
+    }
     producer.shutdown().await;
 
     Ok(())

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -429,11 +429,25 @@ impl MQClientInstance {
     }
 
     pub async fn get_broker_name_from_message_queue(&self, message_queue: &MessageQueue) -> String {
-        unimplemented!()
+        let guard = self.topic_end_points_table.read().await;
+        if let Some(broker_name) = guard.get(message_queue.get_topic()) {
+            if let Some(addr) = broker_name.get(message_queue) {
+                return addr.clone();
+            }
+        }
+        message_queue.get_broker_name().to_string()
     }
 
     pub async fn find_broker_address_in_publish(&self, broker_name: &str) -> Option<String> {
-        unimplemented!()
+        if broker_name.is_empty() {
+            return None;
+        }
+        let guard = self.broker_addr_table.read().await;
+        let map = guard.get(broker_name);
+        if let Some(map) = map {
+            return map.get(&(mix_all::MASTER_ID as i64)).cloned();
+        }
+        None
     }
 }
 

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -287,6 +287,16 @@ impl MQClientAPIImpl {
                         "sendMessage call timeout".to_string(),
                     ));
                 }
+                let result = self
+                    .send_message_sync(
+                        addr,
+                        broker_name,
+                        msg,
+                        timeout_millis - cost_time_sync,
+                        request,
+                    )
+                    .await?;
+                Ok(Some(result))
             }
             CommunicationMode::Async => {
                 let times = AtomicU32::new(0);
@@ -311,17 +321,15 @@ impl MQClientAPIImpl {
                     producer,
                 ))
                 .await;
-                return Ok(None);
+                Ok(None)
             }
             CommunicationMode::Oneway => {
                 self.remoting_client
                     .invoke_oneway(addr.to_string(), request, timeout_millis)
                     .await;
-                return Ok(None);
+                Ok(None)
             }
         }
-
-        unimplemented!()
     }
 
     pub async fn send_message_simple(

--- a/rocketmq-client/src/latency/latency_fault_tolerance.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance.rs
@@ -14,7 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-pub trait LatencyFaultTolerance<T> {
+use crate::latency::resolver::Resolver;
+use crate::latency::service_detector::ServiceDetector;
+
+pub trait LatencyFaultTolerance<T>: Send + Sync + 'static {
     /// Update brokers' states, to decide if they are good or not.
     ///
     /// # Arguments
@@ -105,4 +108,8 @@ pub trait LatencyFaultTolerance<T> {
     ///
     /// * `true` if the detector should be started, `false` otherwise.
     fn is_start_detector_enable(&self) -> bool;
+
+    fn set_resolver(&mut self, resolver: Box<dyn Resolver>);
+
+    fn set_service_detector(&mut self, service_detector: Box<dyn ServiceDetector>);
 }

--- a/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
@@ -14,20 +14,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashMap;
+
 use crate::latency::latency_fault_tolerance::LatencyFaultTolerance;
 use crate::latency::resolver::Resolver;
 use crate::latency::service_detector::ServiceDetector;
 
 pub struct LatencyFaultToleranceImpl {
-    resolver: Box<dyn Resolver>,
-    service_detector: Box<dyn ServiceDetector>,
+    fault_item_table: parking_lot::Mutex<HashMap<String, FaultItem>>,
+    detect_timeout: i32,
+    detect_interval: i32,
+    which_item_worst: ThreadLocalIndex,
+    start_detector_enable: AtomicBool,
+    resolver: Option<Box<dyn Resolver>>,
+    service_detector: Option<Box<dyn ServiceDetector>>,
 }
 
 impl LatencyFaultToleranceImpl {
-    pub fn new(fetcher: impl Resolver, service_detector: impl ServiceDetector) -> Self {
+    pub fn new(/*fetcher: impl Resolver, service_detector: impl ServiceDetector*/) -> Self {
         Self {
-            resolver: Box::new(fetcher),
-            service_detector: Box::new(service_detector),
+            resolver: None,
+            service_detector: None,
+            fault_item_table: Default::default(),
+            detect_timeout: 200,
+            detect_interval: 2000,
+            which_item_worst: Default::default(),
+            start_detector_enable: AtomicBool::new(false),
         }
     }
 }
@@ -40,11 +52,29 @@ impl LatencyFaultTolerance<String> for LatencyFaultToleranceImpl {
         not_available_duration: u64,
         reachable: bool,
     ) {
-        todo!()
+        let mut table = self.fault_item_table.lock();
+        let fault_item = table
+            .entry(name.clone())
+            .or_insert_with(|| FaultItem::new(name.clone()));
+
+        fault_item.set_current_latency(current_latency);
+        fault_item.update_not_available_duration(not_available_duration);
+        fault_item.set_reachable(reachable);
+
+        if !reachable {
+            info!(
+                "{} is unreachable, it will not be used until it's reachable",
+                name
+            );
+        }
     }
 
     fn is_available(&self, name: &String) -> bool {
-        todo!()
+        let fault_item_table = self.fault_item_table.lock();
+        if let Some(fault_item) = fault_item_table.get(name) {
+            return fault_item.is_available();
+        }
+        true
     }
 
     fn is_reachable(&self, name: &String) -> bool {
@@ -63,9 +93,7 @@ impl LatencyFaultTolerance<String> for LatencyFaultToleranceImpl {
         todo!()
     }
 
-    fn shutdown(&self) {
-        todo!()
-    }
+    fn shutdown(&self) {}
 
     fn detect_by_one_round(&self) {
         todo!()
@@ -80,10 +108,195 @@ impl LatencyFaultTolerance<String> for LatencyFaultToleranceImpl {
     }
 
     fn set_start_detector_enable(&mut self, start_detector_enable: bool) {
-        todo!()
+        self.start_detector_enable
+            .store(start_detector_enable, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn is_start_detector_enable(&self) -> bool {
         todo!()
+    }
+
+    fn set_resolver(&mut self, resolver: Box<dyn Resolver>) {
+        self.resolver = Some(resolver);
+    }
+
+    fn set_service_detector(&mut self, service_detector: Box<dyn ServiceDetector>) {
+        self.service_detector = Some(service_detector);
+    }
+}
+
+use std::cmp::Ordering;
+use std::hash::Hash;
+use std::sync::atomic::AtomicBool;
+
+use rocketmq_common::TimeUtils::get_current_millis;
+use tracing::info;
+
+use crate::common::thread_local_index::ThreadLocalIndex;
+
+#[derive(Debug)]
+pub struct FaultItem {
+    name: String,
+    current_latency: std::sync::atomic::AtomicU64,
+    start_timestamp: std::sync::atomic::AtomicU64,
+    check_stamp: std::sync::atomic::AtomicU64,
+    reachable_flag: std::sync::atomic::AtomicBool,
+}
+
+impl FaultItem {
+    pub fn new(name: String) -> Self {
+        FaultItem {
+            name,
+            current_latency: std::sync::atomic::AtomicU64::new(0),
+            start_timestamp: std::sync::atomic::AtomicU64::new(0),
+            check_stamp: std::sync::atomic::AtomicU64::new(0),
+            reachable_flag: std::sync::atomic::AtomicBool::new(true),
+        }
+    }
+
+    pub fn update_not_available_duration(&self, not_available_duration: u64) {
+        let now = get_current_millis();
+        if not_available_duration > 0
+            && now + not_available_duration
+                > self
+                    .start_timestamp
+                    .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            self.start_timestamp.store(
+                now + not_available_duration,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            println!(
+                "{} will be isolated for {} ms.",
+                self.name, not_available_duration
+            );
+        }
+    }
+
+    pub fn set_reachable(&self, reachable_flag: bool) {
+        self.reachable_flag
+            .store(reachable_flag, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn set_check_stamp(&self, check_stamp: u64) {
+        self.check_stamp
+            .store(check_stamp, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn is_available(&self) -> bool {
+        let now = get_current_millis();
+        now >= self
+            .start_timestamp
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn is_reachable(&self) -> bool {
+        self.reachable_flag
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn set_current_latency(&self, latency: u64) {
+        self.current_latency
+            .store(latency, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn get_current_latency(&self) -> u64 {
+        self.current_latency
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn get_start_timestamp(&self) -> u64 {
+        self.start_timestamp
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+impl Eq for FaultItem {}
+
+impl Ord for FaultItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.is_available() != other.is_available() {
+            if self.is_available() {
+                return Ordering::Less;
+            }
+            if other.is_available() {
+                return Ordering::Greater;
+            }
+        }
+
+        match self
+            .current_latency
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .cmp(
+                &other
+                    .current_latency
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            ) {
+            Ordering::Equal => (),
+            ord => return ord,
+        }
+
+        match self
+            .start_timestamp
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .cmp(
+                &other
+                    .start_timestamp
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            ) {
+            Ordering::Equal => (),
+            ord => return ord,
+        }
+
+        Ordering::Equal
+    }
+}
+
+impl PartialEq<Self> for FaultItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self
+                .current_latency
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == other
+                    .current_latency
+                    .load(std::sync::atomic::Ordering::Relaxed)
+            && self
+                .start_timestamp
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == other
+                    .start_timestamp
+                    .load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+impl PartialOrd for FaultItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Hash for FaultItem {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.current_latency
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .hash(state);
+        self.start_timestamp
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .hash(state);
+    }
+}
+
+impl std::fmt::Display for FaultItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "FaultItem{{ name='{}', current_latency={}, start_timestamp={}, reachable_flag={} }}",
+            self.name,
+            self.get_current_latency(),
+            self.get_start_timestamp(),
+            self.is_reachable()
+        )
     }
 }

--- a/rocketmq-client/src/latency/mq_fault_strategy.rs
+++ b/rocketmq-client/src/latency/mq_fault_strategy.rs
@@ -14,29 +14,67 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::cell::RefCell;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 
 use crate::base::client_config::ClientConfig;
+use crate::latency::latency_fault_tolerance::LatencyFaultTolerance;
+use crate::latency::latency_fault_tolerance_impl::LatencyFaultToleranceImpl;
 use crate::latency::resolver::Resolver;
 use crate::latency::service_detector::ServiceDetector;
+use crate::producer::producer_impl::queue_filter::QueueFilter;
 use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
 
-pub struct MQFaultStrategy {}
+thread_local! {
+    static THREAD_BROKER_FILTER: RefCell<BrokerFilter> = RefCell::new(BrokerFilter::default());
+}
+
+pub struct MQFaultStrategy {
+    latency_fault_tolerance: Arc<Mutex<dyn LatencyFaultTolerance<String>>>,
+    send_latency_fault_enable: AtomicBool,
+    start_detector_enable: AtomicBool,
+    latency_max: &'static [u64],
+    not_available_duration: &'static [u64],
+    reachable_filter: Box<dyn QueueFilter>,
+    available_filter: Box<dyn QueueFilter>,
+}
 
 impl MQFaultStrategy {
-    pub fn new(
-        client_config: ClientConfig,
-        /*fetcher: impl Resolver,
-        service_detector: impl ServiceDetector,*/
-    ) -> Self {
-        Self {}
+    pub fn new(client_config: &ClientConfig) -> Self {
+        let mut tolerance_impl = LatencyFaultToleranceImpl::new();
+        tolerance_impl.set_start_detector_enable(client_config.start_detector_enable);
+        let latency_fault_tolerance = Arc::new(Mutex::new(tolerance_impl));
+        Self {
+            latency_fault_tolerance: latency_fault_tolerance.clone(),
+            send_latency_fault_enable: AtomicBool::new(client_config.send_latency_enable),
+            start_detector_enable: AtomicBool::new(client_config.start_detector_enable),
+            latency_max: &[50, 100, 550, 1800, 3000, 5000, 15000],
+            not_available_duration: &[0, 0, 2000, 5000, 6000, 10000, 30000],
+            reachable_filter: Box::new(ReachableFilter {
+                latency_fault_tolerance: latency_fault_tolerance.clone(),
+            }),
+            available_filter: Box::new(AvailableFilter {
+                latency_fault_tolerance,
+            }),
+        }
     }
 
     pub fn start_detector(&mut self) {}
 
-    pub fn set_resolver(&mut self, resolver: impl Resolver) {}
+    pub fn set_resolver(&mut self, resolver: Box<dyn Resolver>) {
+        let mut tolerance = self.latency_fault_tolerance.lock();
+        tolerance.set_resolver(resolver);
+    }
 
-    pub fn set_service_detector(&mut self, service_detector: impl ServiceDetector) {}
+    pub fn set_service_detector(&mut self, service_detector: Box<dyn ServiceDetector>) {
+        let mut tolerance = self.latency_fault_tolerance.lock();
+        tolerance.set_service_detector(service_detector);
+    }
 
     pub fn is_start_detector_enable(&self) -> bool {
         unimplemented!("not implemented")
@@ -48,6 +86,107 @@ impl MQFaultStrategy {
         last_broker_name: Option<&str>,
         reset_index: bool,
     ) -> Option<MessageQueue> {
-        unimplemented!("not implemented")
+        THREAD_BROKER_FILTER.with(|filer| {
+            filer.borrow_mut().last_broker_name = last_broker_name.map(|s| s.to_string());
+        });
+        if self.send_latency_fault_enable.load(Ordering::Relaxed) {
+            if reset_index {
+                tp_info.reset_index();
+            }
+            let broker_filter = THREAD_BROKER_FILTER.with_borrow(|f| f.clone());
+            let filter = &[self.available_filter.as_ref(), &broker_filter];
+            let mut mq = tp_info.select_one_message_queue(filter);
+            if mq.is_some() {
+                return mq;
+            }
+            let filter = &[self.reachable_filter.as_ref(), &broker_filter];
+            mq = tp_info.select_one_message_queue(filter);
+            if mq.is_some() {
+                return mq;
+            }
+            return tp_info.select_one_message_queue(&[]);
+        }
+        let broker_filter = THREAD_BROKER_FILTER.with_borrow(|f| f.clone());
+        let mq = tp_info.select_one_message_queue(&[&broker_filter]);
+        if mq.is_some() {
+            return mq;
+        }
+        tp_info.select_one_message_queue(&[])
+    }
+
+    pub fn get_latency_max(&self) -> &'static [u64] {
+        self.latency_max
+    }
+
+    pub fn get_not_available_duration(&self) -> &'static [u64] {
+        self.not_available_duration
+    }
+
+    pub fn update_fault_item(
+        &self,
+        broker_name: &str,
+        current_latency: u64,
+        isolation: bool,
+        reachable: bool,
+    ) {
+        if self.send_latency_fault_enable.load(Ordering::Relaxed) {
+            let duration = self.compute_not_available_duration(if isolation {
+                10000
+            } else {
+                current_latency
+            });
+            self.latency_fault_tolerance.lock().update_fault_item(
+                broker_name.to_string(),
+                current_latency,
+                duration,
+                reachable,
+            );
+        }
+    }
+
+    fn compute_not_available_duration(&self, current_latency: u64) -> u64 {
+        for i in (0..self.latency_max.len()).rev() {
+            if current_latency >= self.latency_max[i] {
+                return self.not_available_duration[i];
+            }
+        }
+        0
+    }
+}
+
+#[derive(Default, Clone)]
+struct BrokerFilter {
+    last_broker_name: Option<String>,
+}
+
+impl QueueFilter for BrokerFilter {
+    fn filter(&self, message_queue: &MessageQueue) -> bool {
+        if let Some(last_broker_name) = &self.last_broker_name {
+            message_queue.get_broker_name() != last_broker_name
+        } else {
+            true
+        }
+    }
+}
+
+struct ReachableFilter {
+    latency_fault_tolerance: Arc<Mutex<dyn LatencyFaultTolerance<String>>>,
+}
+
+impl QueueFilter for ReachableFilter {
+    fn filter(&self, message_queue: &MessageQueue) -> bool {
+        let tolerance = self.latency_fault_tolerance.lock();
+        tolerance.is_reachable(&message_queue.get_broker_name().to_string())
+    }
+}
+
+struct AvailableFilter {
+    latency_fault_tolerance: Arc<Mutex<dyn LatencyFaultTolerance<String>>>,
+}
+
+impl QueueFilter for AvailableFilter {
+    fn filter(&self, message_queue: &MessageQueue) -> bool {
+        let tolerance = self.latency_fault_tolerance.lock();
+        tolerance.is_available(&message_queue.get_broker_name().to_string())
     }
 }

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -118,7 +118,7 @@ impl DefaultMQProducerImpl {
             rpc_hook: None,
             service_state: ServiceState::CreateJust,
             client_instance: None,
-            mq_fault_strategy: ArcRefCellWrapper::new(MQFaultStrategy::new(client_config)),
+            mq_fault_strategy: ArcRefCellWrapper::new(MQFaultStrategy::new(&client_config)),
             semaphore_async_send_num: Arc::new(semaphore_async_send_num),
             semaphore_async_send_size: Arc::new(semaphore_async_send_size),
         }
@@ -155,7 +155,8 @@ impl DefaultMQProducerImpl {
                     1
                 };
                 //let mut times = 0u32;
-                let mut brokers_sent = Vec::<String>::with_capacity(times_total as usize);
+                //let mut brokers_sent = Vec::<String>::with_capacity(times_total as usize);
+                let mut brokers_sent = vec![String::new(); times_total as usize];
                 let mut reset_index = false;
                 //handle send message
                 for times in 0..times_total {
@@ -779,9 +780,9 @@ impl DefaultMQProducerImpl {
                 let resolver = DefaultResolver {
                     client_instance: client_instance.clone(),
                 };
-                self.mq_fault_strategy.set_resolver(resolver);
+                self.mq_fault_strategy.set_resolver(Box::new(resolver));
                 self.mq_fault_strategy
-                    .set_service_detector(service_detector);
+                    .set_service_detector(Box::new(service_detector));
                 self.client_instance = Some(client_instance);
                 let self_clone = self.clone();
                 let register_ok = self

--- a/rocketmq-client/src/producer/producer_impl/queue_filter.rs
+++ b/rocketmq-client/src/producer/producer_impl/queue_filter.rs
@@ -19,7 +19,7 @@ use rocketmq_common::common::message::message_queue::MessageQueue;
 /// A trait for filtering message queues.
 ///
 /// This trait defines a method for filtering message queues based on custom criteria.
-pub trait QueueFilter {
+pub trait QueueFilter: Send + Sync + 'static {
     /// Filters a message queue.
     ///
     /// This method determines whether the specified message queue meets the filter criteria.


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #883 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced concurrent locking capabilities with the addition of the `parking_lot` dependency.
	- Enhanced message sending functionality by allowing multiple messages to be sent in a loop.
	- Implemented new methods for retrieving broker names and addresses, improving client instance functionality.
	- Added advanced latency fault tolerance mechanisms, enhancing broker selection based on availability and performance.
	- Expanded `TopicPublishInfo` capabilities for dynamic message queue selection using filters.

- **Bug Fixes**
	- Improved handling of asynchronous message sending results for better error management.

- **Documentation**
	- Updated comments and documentation to reflect new features and usage.

- **Chores**
	- Refined initialization logic and memory handling in various components to enhance performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->