### PR TITLE
[ISSUE #886]Optimize produer send single message

### DIFF
--- a/rocketmq-client/src/latency/mq_fault_strategy.rs
+++ b/rocketmq-client/src/latency/mq_fault_strategy.rs
@@ -152,6 +152,12 @@ impl MQFaultStrategy {
         }
         0
     }
+
+    #[inline]
+    pub fn set_send_latency_fault_enable(&mut self, send_latency_fault_enable: bool) {
+        self.send_latency_fault_enable
+            .store(send_latency_fault_enable, Ordering::Relaxed);
+    }
 }
 
 #[derive(Default, Clone)]

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -453,6 +453,13 @@ impl DefaultMQProducer {
     pub fn producer_config(&self) -> &ProducerConfig {
         &self.producer_config
     }
+
+    #[inline]
+    pub fn set_send_latency_fault_enable(&mut self, send_latency_fault_enable: bool) {
+        if let Some(ref mut default_mqproducer_impl) = self.default_mqproducer_impl {
+            default_mqproducer_impl.set_send_latency_fault_enable(send_latency_fault_enable);
+        }
+    }
 }
 
 impl DefaultMQProducer {
@@ -526,7 +533,7 @@ impl MQProducer for DefaultMQProducer {
             .unwrap()
             .send(msg, timeout)
             .await?;
-        Ok(result.unwrap())
+        Ok(result.expect("SendResult should not be None"))
     }
 
     async fn send_with_callback(&self, msg: &Message, send_callback: impl SendCallback) {

--- a/rocketmq-client/src/producer/producer_impl/topic_publish_info.rs
+++ b/rocketmq-client/src/producer/producer_impl/topic_publish_info.rs
@@ -48,6 +48,7 @@ impl TopicPublishInfo {
         self.send_which_queue.reset();
     }
 
+    #[inline]
     pub fn select_one_message_queue(&self, filters: &[&dyn QueueFilter]) -> Option<MessageQueue> {
         self.select_one_message_queue_with_filters(&self.message_queue_list, filters)
     }

--- a/rocketmq-client/src/producer/send_callback.rs
+++ b/rocketmq-client/src/producer/send_callback.rs
@@ -14,7 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::sync::Arc;
+
 use crate::producer::send_result::SendResult;
+
+pub(crate) type SendMessageCallback = Arc<Box<dyn SendCallback>>;
 
 pub trait SendCallback: Send + Sync + 'static {
     fn on_success(&self, send_result: &SendResult);

--- a/rocketmq-common/src/common/message/message_single.rs
+++ b/rocketmq-common/src/common/message/message_single.rs
@@ -37,7 +37,10 @@ pub struct Message {
     pub topic: String,
     pub flag: i32,
     pub properties: HashMap<String, String>,
+    // original bytes
     pub body: Option<bytes::Bytes>,
+    // compressed bytes, maybe none, if no need to compress
+    pub compressed_body: Option<bytes::Bytes>,
     pub transaction_id: Option<String>,
 }
 

--- a/rocketmq-remoting/src/clients.rs
+++ b/rocketmq-remoting/src/clients.rs
@@ -48,7 +48,7 @@ pub trait RemotingClient: RemotingService {
     ///
     /// # Returns
     /// A vector containing the current list of name server addresses.
-    fn get_name_server_address_list(&self) -> Vec<String>;
+    fn get_name_server_address_list(&self) -> &[String];
 
     /// Retrieves a list of available name server addresses.
     ///

--- a/rocketmq-remoting/src/clients/rocketmq_default_impl.rs
+++ b/rocketmq-remoting/src/clients/rocketmq_default_impl.rs
@@ -314,8 +314,8 @@ impl RemotingClient for RocketmqDefaultClient {
         }
     }
 
-    fn get_name_server_address_list(&self) -> Vec<String> {
-        self.namesrv_addr_list.as_ref().clone()
+    fn get_name_server_address_list(&self) -> &[String] {
+        self.namesrv_addr_list.as_ref()
     }
 
     fn get_available_name_srv_list(&self) -> Vec<String> {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #886

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Introduced methods to enable or disable sending latency faults in both `MQFaultStrategy` and `DefaultMQProducer`.
    - Added support for compressed message bodies in the `Message` struct, enhancing data handling flexibility.

- **Bug Fixes**
    - Improved error handling in the `send` method of `DefaultMQProducer` to provide clearer error messages.

- **Performance Improvements**
    - Adjusted return types in several methods to use borrowed slices instead of owned vectors, optimizing memory usage and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->