### PR TITLE
[ISSUES #892] Support AdminBrokerProcessor query_topics_by_consumer

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -449,6 +449,7 @@ impl BrokerRuntime {
 
         let admin_broker_processor = AdminBrokerProcessor::new(
             self.broker_config.clone(),
+            self.server_config.clone(),
             self.message_store_config.clone(),
             self.topic_config_manager.clone(),
             self.consumer_offset_manager.clone(),

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -189,6 +189,19 @@ impl ConsumerOffsetManager {
         }
         -1
     }
+
+    pub fn which_topic_by_consumer(&self, group: &str) -> HashSet<String> {
+        let read_guard = self.consumer_offset_wrapper.offset_table.read();
+        let mut topics = HashSet::new();
+        for (key, _) in read_guard.iter() {
+            let arr: Vec<&str> = key.split(TOPIC_GROUP_SEPARATOR).collect();
+            if arr.len() == 2 && arr[1] == group {
+                let topic = arr[0].to_string();
+                topics.insert(topic);
+            }
+        }
+        topics
+    }
 }
 
 impl ConfigManager for ConsumerOffsetManager {

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_common::common::server::config::ServerConfig;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -47,6 +48,7 @@ pub struct AdminBrokerProcessor {
 impl AdminBrokerProcessor {
     pub fn new(
         broker_config: Arc<BrokerConfig>,
+        server_config: Arc<ServerConfig>,
         message_store_config: Arc<MessageStoreConfig>,
         topic_config_manager: TopicConfigManager,
         consumer_offset_manager: ConsumerOffsetManager,
@@ -57,6 +59,7 @@ impl AdminBrokerProcessor {
     ) -> Self {
         let inner = Inner {
             broker_config,
+            server_config,
             message_store_config,
             topic_config_manager,
             consumer_offset_manager,
@@ -134,6 +137,11 @@ impl AdminBrokerProcessor {
                     .get_broker_runtime_info(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::QueryTopicsByConsumer => {
+                self.topic_request_handler
+                    .query_topics_by_consumer(channel, ctx, request_code, request)
+                    .await
+            }
             _ => Some(get_unknown_cmd_response(request_code)),
         }
     }
@@ -154,6 +162,7 @@ fn get_unknown_cmd_response(request_code: RequestCode) -> RemotingCommand {
 #[derive(Clone)]
 struct Inner {
     broker_config: Arc<BrokerConfig>,
+    server_config: Arc<ServerConfig>,
     message_store_config: Arc<MessageStoreConfig>,
     topic_config_manager: TopicConfigManager,
     consumer_offset_manager: ConsumerOffsetManager,

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -36,6 +36,8 @@ pub mod query_consumer_offset_request_header;
 pub mod query_consumer_offset_response_header;
 pub mod query_message_request_header;
 pub mod query_message_response_header;
+
+pub mod query_topics_by_consumer_request_header;
 pub mod search_offset_response_header;
 pub mod unregister_client_request_header;
 pub mod update_consumer_offset_header;

--- a/rocketmq-remoting/src/protocol/header/query_topics_by_consumer_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_topics_by_consumer_request_header.rs
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::FromMap;
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct QueryTopicsByConsumerRequestHeader {
+    #[serde(rename = "group")]
+    pub group: String,
+
+    #[serde(flatten)]
+    pub rpc_request_header: Option<RpcRequestHeader>,
+}
+
+impl QueryTopicsByConsumerRequestHeader {
+    pub const GROUP: &'static str = "group";
+
+    pub fn get_group(&self) -> &String {
+        &self.group
+    }
+    pub fn set_group(&mut self, group: String) {
+        self.group = group;
+    }
+}
+
+impl CommandCustomHeader for QueryTopicsByConsumerRequestHeader {
+    fn to_map(&self) -> Option<std::collections::HashMap<String, String>> {
+        let mut map = std::collections::HashMap::new();
+        map.insert(Self::GROUP.to_string(), self.group.clone());
+        if let Some(value) = self.rpc_request_header.as_ref() {
+            if let Some(value) = value.to_map() {
+                map.extend(value);
+            }
+        }
+        Some(map)
+    }
+}
+
+impl FromMap for QueryTopicsByConsumerRequestHeader {
+    type Target = Self;
+
+    fn from(map: &std::collections::HashMap<String, String>) -> Option<Self::Target> {
+        Some(QueryTopicsByConsumerRequestHeader {
+            group: map.get(Self::GROUP).cloned().unwrap_or_default(),
+            rpc_request_header: <RpcRequestHeader as FromMap>::from(map),
+        })
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #892 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `AdminBrokerProcessor` with server configuration management.
	- Introduced a method to retrieve topics by consumer group in `ConsumerOffsetManager`.
	- Added asynchronous functionality for querying topics by consumer in `TopicRequestHandler`.
	- New module for handling consumer-related topic query requests.

- **Documentation**
	- Updated public interface with new request header for consumer queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->