### PR TITLE
[ISSUE #896]🔥Implement Produer send batch message🚀

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -285,7 +285,7 @@ impl<MS: MessageStore> SendMessageProcessor<MS> {
         message_ext
             .message_ext_inner
             .message
-            .put_property(MessageConst::PROPERTY_CLUSTER.to_string(), cluster_name);
+            .put_property(MessageConst::PROPERTY_CLUSTER, cluster_name.as_str());
 
         let mut batch_message = MessageExtBatch {
             message_ext_broker_inner: message_ext,
@@ -325,8 +325,8 @@ impl<MS: MessageStore> SendMessageProcessor<MS> {
                 .message_ext_inner
                 .message
                 .put_property(
-                    MessageConst::PROPERTY_INNER_NUM.to_string(),
-                    inner_num.to_string(),
+                    MessageConst::PROPERTY_INNER_NUM,
+                    inner_num.to_string().as_str(),
                 );
             batch_message.message_ext_broker_inner.properties_string = message_properties_to_string(
                 batch_message

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -41,3 +41,12 @@ parking_lot = { workspace = true }
 [[example]]
 name = "simple-producer"
 path = "examples/producer/simple_producer.rs"
+
+[[example]]
+name = "producer"
+path = "examples/quickstart/producer.rs"
+
+[[example]]
+name = "simple-batch-producer"
+path = "examples/batch/simple_batch_producer.rs"
+

--- a/rocketmq-client/examples/quickstart/producer.rs
+++ b/rocketmq-client/examples/quickstart/producer.rs
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 use rocketmq_client::producer::default_mq_producer::DefaultMQProducer;
 use rocketmq_client::producer::mq_producer::MQProducer;
 use rocketmq_client::Result;

--- a/rocketmq-client/src/base/validators.rs
+++ b/rocketmq-client/src/base/validators.rs
@@ -63,8 +63,8 @@ impl Validators {
     }
 
     pub fn check_message(
-        msg: &Option<Message>,
-        default_mq_producer: &DefaultMQProducer,
+        msg: Option<&Message>,
+        default_mq_producer: &mut DefaultMQProducer,
     ) -> Result<()> {
         if msg.is_none() {
             return Err(MQClientException(

--- a/rocketmq-client/src/hook/check_forbidden_context.rs
+++ b/rocketmq-client/src/hook/check_forbidden_context.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 use rocketmq_common::common::message::message_queue::MessageQueue;
-use rocketmq_common::common::message::message_single::Message;
+use rocketmq_common::common::message::MessageTrait;
 
 use crate::implementation::communication_mode::CommunicationMode;
 use crate::producer::send_result::SendResult;
@@ -24,7 +24,7 @@ use crate::producer::send_result::SendResult;
 pub struct CheckForbiddenContext<'a> {
     pub name_srv_addr: Option<String>,
     pub group: Option<String>,
-    pub message: Option<&'a Message>,
+    pub message: Option<&'a dyn MessageTrait>,
     pub mq: Option<&'a MessageQueue>,
     pub broker_addr: Option<String>,
     pub communication_mode: Option<CommunicationMode>,

--- a/rocketmq-client/src/hook/send_message_context.rs
+++ b/rocketmq-client/src/hook/send_message_context.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use rocketmq_common::common::message::message_enum::MessageType;
 use rocketmq_common::common::message::message_queue::MessageQueue;
-use rocketmq_common::common::message::message_single::Message;
+use rocketmq_common::common::message::MessageTrait;
 
 use crate::implementation::communication_mode::CommunicationMode;
 use crate::producer::producer_impl::default_mq_producer_impl::DefaultMQProducerImpl;
@@ -29,7 +29,7 @@ use crate::producer::send_result::SendResult;
 #[derive(Default)]
 pub struct SendMessageContext<'a> {
     pub producer_group: Option<String>,
-    pub message: Option<Message>,
+    pub message: Option<Box<dyn MessageTrait + Send + Sync>>,
     pub mq: Option<&'a MessageQueue>,
     pub broker_addr: Option<String>,
     pub born_host: Option<String>,

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -312,7 +312,7 @@ pub trait MQProducerLocal: Any + 'static {
     ///
     /// # Returns
     /// A `Result` containing the `SendResult`, or an error.
-    async fn send_batch(&self, msgs: &[Message]) -> Result<SendResult>;
+    async fn send_batch(&mut self, msgs: Vec<Message>) -> Result<SendResult>;
 
     /// Sends a batch of messages with a timeout.
     ///

--- a/rocketmq-common/src/common/message/message_accessor.rs
+++ b/rocketmq-common/src/common/message/message_accessor.rs
@@ -21,88 +21,73 @@ use crate::common::message::MessageTrait;
 pub struct MessageAccessor;
 
 impl MessageAccessor {
-    pub fn clear_property(msg: &mut Message, name: &str) {
+    pub fn clear_property<T: MessageTrait>(msg: &mut T, name: &str) {
         msg.clear_property(name);
     }
 
-    pub fn set_transfer_flag(msg: &mut Message, unit: &str) {
-        msg.put_property(
-            MessageConst::PROPERTY_TRANSFER_FLAG.to_string(),
-            unit.to_string(),
-        );
+    pub fn set_transfer_flag<T: MessageTrait>(msg: &mut T, unit: &str) {
+        msg.put_property(MessageConst::PROPERTY_TRANSFER_FLAG, unit);
     }
 
-    pub fn get_transfer_flag(msg: &Message) -> Option<String> {
+    pub fn get_transfer_flag<T: MessageTrait>(msg: &T) -> Option<String> {
         msg.get_property(MessageConst::PROPERTY_TRANSFER_FLAG)
     }
 
-    pub fn set_correction_flag(msg: &mut Message, unit: &str) {
-        msg.put_property(
-            MessageConst::PROPERTY_CORRECTION_FLAG.to_string(),
-            unit.to_string(),
-        );
+    pub fn set_correction_flag<T: MessageTrait>(msg: &mut T, unit: &str) {
+        msg.put_property(MessageConst::PROPERTY_CORRECTION_FLAG, unit);
     }
 
-    pub fn get_correction_flag(msg: &Message) -> Option<String> {
+    pub fn get_correction_flag<T: MessageTrait>(msg: &T) -> Option<String> {
         msg.get_property(MessageConst::PROPERTY_CORRECTION_FLAG)
     }
 
-    pub fn set_origin_message_id(msg: &mut Message, origin_message_id: &str) {
-        msg.put_property(
-            MessageConst::PROPERTY_ORIGIN_MESSAGE_ID.to_string(),
-            origin_message_id.to_string(),
-        );
+    pub fn set_origin_message_id<T: MessageTrait>(msg: &mut T, origin_message_id: &str) {
+        msg.put_property(MessageConst::PROPERTY_ORIGIN_MESSAGE_ID, origin_message_id);
     }
 
-    pub fn get_origin_message_id(msg: &Message) -> Option<String> {
+    pub fn get_origin_message_id<T: MessageTrait>(msg: &T) -> Option<String> {
         msg.get_property(MessageConst::PROPERTY_ORIGIN_MESSAGE_ID)
     }
 
-    pub fn set_mq2_flag(msg: &mut Message, flag: &str) {
-        msg.put_property(
-            MessageConst::PROPERTY_MQ2_FLAG.to_string(),
-            flag.to_string(),
-        );
+    pub fn set_mq2_flag<T: MessageTrait>(msg: &mut T, flag: &str) {
+        msg.put_property(MessageConst::PROPERTY_MQ2_FLAG, flag);
     }
 
-    pub fn get_mq2_flag(msg: &Message) -> Option<String> {
+    pub fn get_mq2_flag<T: MessageTrait>(msg: &T) -> Option<String> {
         msg.get_property(MessageConst::PROPERTY_MQ2_FLAG)
     }
 
-    pub fn set_reconsume_time(msg: &mut Message, reconsume_times: &str) {
-        msg.put_property(
-            MessageConst::PROPERTY_RECONSUME_TIME.to_string(),
-            reconsume_times.to_string(),
-        );
+    pub fn set_reconsume_time<T: MessageTrait>(msg: &mut T, reconsume_times: &str) {
+        msg.put_property(MessageConst::PROPERTY_RECONSUME_TIME, reconsume_times);
     }
 
     #[inline]
-    pub fn get_reconsume_time(msg: &Message) -> Option<String> {
+    pub fn get_reconsume_time<T: MessageTrait>(msg: &T) -> Option<String> {
         msg.get_property(MessageConst::PROPERTY_RECONSUME_TIME)
     }
 
-    pub fn set_max_reconsume_times(msg: &mut Message, max_reconsume_times: &str) {
+    pub fn set_max_reconsume_times<T: MessageTrait>(msg: &mut T, max_reconsume_times: &str) {
         msg.put_property(
-            MessageConst::PROPERTY_MAX_RECONSUME_TIMES.to_string(),
-            max_reconsume_times.to_string(),
+            MessageConst::PROPERTY_MAX_RECONSUME_TIMES,
+            max_reconsume_times,
         );
     }
 
-    pub fn get_max_reconsume_times(msg: &Message) -> Option<String> {
+    pub fn get_max_reconsume_times<T: MessageTrait>(msg: &T) -> Option<String> {
         msg.get_property(MessageConst::PROPERTY_MAX_RECONSUME_TIMES)
     }
 
-    pub fn set_consume_start_time_stamp(
-        msg: &mut Message,
+    pub fn set_consume_start_time_stamp<T: MessageTrait>(
+        msg: &mut T,
         property_consume_start_time_stamp: &str,
     ) {
         msg.put_property(
-            MessageConst::PROPERTY_CONSUME_START_TIMESTAMP.to_string(),
-            property_consume_start_time_stamp.to_string(),
+            MessageConst::PROPERTY_CONSUME_START_TIMESTAMP,
+            property_consume_start_time_stamp,
         );
     }
 
-    pub fn get_consume_start_time_stamp(msg: &Message) -> Option<String> {
+    pub fn get_consume_start_time_stamp<T: MessageTrait>(msg: &T) -> Option<String> {
         msg.get_property(MessageConst::PROPERTY_CONSUME_START_TIMESTAMP)
     }
 }

--- a/rocketmq-common/src/common/message/message_client_id_setter.rs
+++ b/rocketmq-common/src/common/message/message_client_id_setter.rs
@@ -68,7 +68,10 @@ pub struct MessageClientIDSetter;
 
 impl MessageClientIDSetter {
     #[inline]
-    pub fn get_uniq_id(message: &Message) -> Option<String> {
+    pub fn get_uniq_id<T>(message: &T) -> Option<String>
+    where
+        T: MessageTrait,
+    {
         message.get_property(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX)
     }
 
@@ -109,7 +112,10 @@ impl MessageClientIDSetter {
         sb.into_iter().collect()
     }
 
-    pub fn set_uniq_id(message: &mut Message) {
+    pub fn set_uniq_id<T>(message: &mut T)
+    where
+        T: MessageTrait,
+    {
         let uniq_id = Self::create_uniq_id();
         if message
             .get_property(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX)
@@ -117,7 +123,7 @@ impl MessageClientIDSetter {
         {
             message.put_property(
                 MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
-                uniq_id,
+                uniq_id.as_str(),
             );
         }
     }

--- a/rocketmq-common/src/common/message/message_single.rs
+++ b/rocketmq-common/src/common/message/message_single.rs
@@ -23,6 +23,7 @@ use std::net::SocketAddr;
 
 use bytes::Buf;
 use bytes::BufMut;
+use bytes::Bytes;
 
 use crate::common::hasher::string_hasher::JavaStringHasher;
 use crate::common::message::MessageConst;
@@ -102,13 +103,6 @@ impl Message {
             .insert(MessageConst::PROPERTY_KEYS.to_string(), keys);
     }
 
-    pub fn set_wait_store_msg_ok(&mut self, wait_store_msg_ok: bool) {
-        self.properties.insert(
-            MessageConst::PROPERTY_WAIT_STORE_MSG_OK.to_string(),
-            wait_store_msg_ok.to_string(),
-        );
-    }
-
     pub fn clear_property(&mut self, name: impl Into<String>) {
         self.properties.remove(name.into().as_str());
     }
@@ -184,40 +178,76 @@ impl Message {
 
 #[allow(unused_variables)]
 impl MessageTrait for Message {
-    fn topic(&self) -> &str {
-        todo!()
+    fn put_property(&mut self, key: &str, value: &str) {
+        self.properties.insert(key.to_string(), value.to_string());
     }
 
-    fn with_topic(&mut self, topic: impl Into<String>) {
-        todo!()
+    fn clear_property(&mut self, name: &str) {
+        self.properties.remove(name);
     }
 
-    fn tags(&self) -> Option<&str> {
-        todo!()
+    fn get_property(&self, name: &str) -> Option<String> {
+        self.properties.get(name).cloned()
     }
 
-    fn with_tags(&mut self, tags: impl Into<String>) {
-        todo!()
+    fn get_topic(&self) -> &str {
+        &self.topic
     }
 
-    fn put_property(&mut self, key: impl Into<String>, value: impl Into<String>) {
-        self.properties.insert(key.into(), value.into());
+    fn set_topic(&mut self, topic: &str) {
+        self.topic = topic.to_string();
     }
 
-    fn properties(&self) -> &HashMap<String, String> {
-        todo!()
+    fn get_flag(&self) -> i32 {
+        self.flag
     }
 
-    fn put_user_property(&mut self, name: impl Into<String>, value: impl Into<String>) {
-        todo!()
+    fn set_flag(&mut self, flag: i32) {
+        self.flag = flag;
     }
 
-    fn delay_time_level(&self) -> i32 {
-        todo!()
+    fn get_body(&self) -> Option<&Bytes> {
+        self.body.as_ref()
     }
 
-    fn with_delay_time_level(&self, level: i32) -> i32 {
-        todo!()
+    fn set_body(&mut self, body: Bytes) {
+        self.body = Some(body);
+    }
+
+    fn get_properties(&self) -> &HashMap<String, String> {
+        &self.properties
+    }
+
+    fn set_properties(&mut self, properties: HashMap<String, String>) {
+        self.properties = properties;
+    }
+
+    fn get_transaction_id(&self) -> &str {
+        self.transaction_id.as_deref().unwrap()
+    }
+
+    fn set_transaction_id(&mut self, transaction_id: &str) {
+        self.transaction_id = Some(transaction_id.to_string());
+    }
+
+    fn get_compressed_body_mut(&mut self) -> &mut Option<Bytes> {
+        &mut self.compressed_body
+    }
+
+    fn get_compressed_body(&self) -> Option<&Bytes> {
+        self.compressed_body.as_ref()
+    }
+
+    fn set_compressed_body_mut(&mut self, compressed_body: Bytes) {
+        self.compressed_body = Some(compressed_body);
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/rocketmq-common/src/error.rs
+++ b/rocketmq-common/src/error.rs
@@ -23,4 +23,7 @@ pub enum Error {
 
     #[error("{0}")]
     RuntimeException(String),
+
+    #[error("{0}")]
+    UnsupportedOperationException(String),
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #896 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new examples for message producers in the `rocketmq-client` project, enhancing user reference.
	- Introduced a simple batch producer example, demonstrating batch message sending.
	- Enhanced `DefaultMQProducer` with a new method for batch processing of messages.
	- Added support for encoding messages into a byte format for transmission.

- **Bug Fixes**
	- Improved error handling by adding `UnsupportedOperationException` to the error handling enum.

- **Documentation**
	- Updated example files to better illustrate usage of new features in message handling.

- **Refactor**
	- Enhanced flexibility of message handling methods by supporting any type that implements the `MessageTrait`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->