### PR TITLE
[ISSUES #894] Support AdminBrokerProcessor query_topic_consume_by_who

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -457,6 +457,7 @@ impl BrokerRuntime {
             self.message_store.as_ref().unwrap().clone(),
             self.schedule_message_service.clone(),
             self.broker_stats.clone(),
+            self.consumer_manager.clone(),
         );
 
         BrokerRequestProcessor {

--- a/rocketmq-broker/src/client/manager/consumer_manager.rs
+++ b/rocketmq-broker/src/client/manager/consumer_manager.rs
@@ -241,4 +241,14 @@ impl ConsumerManager {
             listener.handle(event, group, args);
         }
     }
+
+    pub fn query_topic_consume_by_who(&self, topic: &str) -> HashSet<String> {
+        let mut groups = HashSet::new();
+        for (group, consumer_group_info) in self.consumer_table.read().iter() {
+            if consumer_group_info.find_subscription_data(topic).is_some() {
+                groups.insert(group.clone());
+            }
+        }
+        groups
+    }
 }

--- a/rocketmq-remoting/src/protocol/body/group_list.rs
+++ b/rocketmq-remoting/src/protocol/body/group_list.rs
@@ -15,12 +15,26 @@
  * limitations under the License.
  */
 
-pub mod broker_body;
-pub mod consumer_running_info;
-pub mod create_topic_list_request_body;
-pub mod get_consumer_listby_group_response_body;
+use std::collections::HashSet;
 
-pub mod group_list;
-pub mod kv_table;
-pub mod topic;
-pub mod topic_info_wrapper;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+pub struct GroupList {
+    pub group_list: HashSet<String>,
+}
+
+impl GroupList {
+    pub fn new(group_list: HashSet<String>) -> Self {
+        Self { group_list }
+    }
+
+    pub fn get_group_list(&self) -> &HashSet<String> {
+        &self.group_list
+    }
+
+    pub fn set_group_list(&mut self, group_list: HashSet<String>) {
+        self.group_list = group_list;
+    }
+}

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -37,6 +37,7 @@ pub mod query_consumer_offset_response_header;
 pub mod query_message_request_header;
 pub mod query_message_response_header;
 
+pub mod query_topic_consume_by_who_request_header;
 pub mod query_topics_by_consumer_request_header;
 pub mod search_offset_response_header;
 pub mod unregister_client_request_header;

--- a/rocketmq-remoting/src/protocol/header/query_topic_consume_by_who_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_topic_consume_by_who_request_header.rs
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::FromMap;
+use crate::rpc::topic_request_header::TopicRequestHeader;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct QueryTopicConsumeByWhoRequestHeader {
+    #[serde(rename = "topic")]
+    pub topic: String,
+
+    #[serde(flatten)]
+    pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+impl QueryTopicConsumeByWhoRequestHeader {
+    pub const TOPIC: &'static str = "topic";
+}
+
+impl CommandCustomHeader for QueryTopicConsumeByWhoRequestHeader {
+    fn to_map(&self) -> Option<std::collections::HashMap<String, String>> {
+        let mut map = std::collections::HashMap::new();
+        map.insert(Self::TOPIC.to_string(), self.topic.clone());
+        if let Some(value) = self.topic_request_header.as_ref() {
+            if let Some(value) = value.to_map() {
+                map.extend(value);
+            }
+        }
+        Some(map)
+    }
+}
+
+impl FromMap for QueryTopicConsumeByWhoRequestHeader {
+    type Target = Self;
+
+    fn from(map: &std::collections::HashMap<String, String>) -> Option<Self::Target> {
+        Some(QueryTopicConsumeByWhoRequestHeader {
+            topic: map.get(Self::TOPIC).cloned().unwrap_or_default(),
+            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+        })
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #894 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to query which consumer groups are subscribed to specific topics.
	- Introduced a new asynchronous method for handling topic consumption queries in the request handler.
	- Enhanced protocol with new data structures for managing group lists and request headers related to topic consumption.

- **Improvements**
	- Streamlined overall management of consumer-related operations within the Broker system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->