### PR TITLE
[ISSUE #902]✨Implement Produer send batch message other methods🔥

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -50,3 +50,8 @@ path = "examples/quickstart/producer.rs"
 name = "simple-batch-producer"
 path = "examples/batch/simple_batch_producer.rs"
 
+
+[[example]]
+name = "callback-batch-producer"
+path = "examples/batch/callback_batch_producer.rs"
+

--- a/rocketmq-client/examples/batch/callback_batch_producer.rs
+++ b/rocketmq-client/examples/batch/callback_batch_producer.rs
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::sync::atomic::AtomicI32;
+use std::sync::Arc;
+use std::thread::sleep;
+
+use rocketmq_client::producer::default_mq_producer::DefaultMQProducer;
+use rocketmq_client::producer::mq_producer::MQProducer;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_rust::rocketmq;
+use tracing::info;
+
+pub const PRODUCER_GROUP: &str = "BatchProducerGroupName";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "TopicTest";
+pub const TAG: &str = "TagA";
+
+#[rocketmq::main]
+pub async fn main() -> rocketmq_client::Result<()> {
+    //init logger
+    rocketmq_common::log::init_logger();
+
+    // create a producer builder with default configuration
+    let builder = DefaultMQProducer::builder();
+
+    let mut producer = builder
+        .producer_group(PRODUCER_GROUP.to_string())
+        .name_server_addr(DEFAULT_NAMESRVADDR.to_string())
+        .build();
+    producer.start().await?;
+
+    let mut messages = Vec::new();
+    messages.push(Message::with_keys(
+        TOPIC,
+        TAG,
+        "OrderID001",
+        "Hello world 0".as_bytes(),
+    ));
+    messages.push(Message::with_keys(
+        TOPIC,
+        TAG,
+        "OrderID002",
+        "Hello world 1".as_bytes(),
+    ));
+    messages.push(Message::with_keys(
+        TOPIC,
+        TAG,
+        "OrderID003",
+        "Hello world 2".as_bytes(),
+    ));
+    let counter = Arc::new(AtomicI32::new(0));
+    for _ in 0..100 {
+        let vec = messages.clone();
+        let counter1 = counter.clone();
+        producer
+            .send_batch_with_callback(vec, move |result, _err| {
+                info!("send result: {:?}", result);
+                counter1.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            })
+            .await?;
+    }
+    let counter1 = counter.clone();
+    producer
+        .send_batch_with_callback(messages, move |result, _err| {
+            info!("send result: {:?}", result);
+            counter1.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        })
+        .await?;
+
+    /*    let (done_tx, mut done_rx) = tokio::sync::broadcast::channel(1);
+    let done_tx_clone = done_tx.clone();
+    producer
+        .send_batch_with_callback(messages, move |result, err| {
+            println!("send result: {:?}", result);
+            println!("send error: {:?}", err);
+            done_tx_clone.send(()).unwrap();
+        })
+        .await?;
+    let mut messages = Vec::new();
+    messages.push(Message::with_keys(
+        TOPIC,
+        TAG,
+        "OrderID001",
+        "Hello world 0".as_bytes(),
+    ));
+    messages.push(Message::with_keys(
+        TOPIC,
+        TAG,
+        "OrderID002",
+        "Hello world 1".as_bytes(),
+    ));
+    messages.push(Message::with_keys(
+        TOPIC,
+        TAG,
+        "OrderID003",
+        "Hello world 2".as_bytes(),
+    ));
+    producer
+        .send_batch_with_callback(messages, move |result, err| {
+            println!("send result: {:?}", result);
+            println!("send error: {:?}", err);
+            done_tx.send(()).unwrap();
+        })
+        .await?;
+    let _ = done_rx.recv().await;*/
+    sleep(std::time::Duration::from_secs(6));
+    let i = counter.load(std::sync::atomic::Ordering::SeqCst);
+    println!("send message count: {}", i);
+    Ok(())
+}

--- a/rocketmq-client/src/producer/send_callback.rs
+++ b/rocketmq-client/src/producer/send_callback.rs
@@ -18,7 +18,10 @@ use std::sync::Arc;
 
 use crate::producer::send_result::SendResult;
 
-pub(crate) type SendMessageCallback = Arc<Box<dyn SendCallback>>;
+pub(crate) type SendMessageCallbackInner = Arc<Box<dyn SendCallback>>;
+
+pub type SendMessageCallback =
+    Arc<dyn Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync>;
 
 pub trait SendCallback: Send + Sync + 'static {
     fn on_success(&self, send_result: &SendResult);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #902 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new example demonstrating a callback batch producer for the RocketMQ client.
	- Introduced new asynchronous methods for sending messages with optional callbacks and timeouts in the `DefaultMQProducerImpl`.
	- Enhanced callback functionality for better error handling and specificity in implementations.

- **Bug Fixes**
	- Improved error handling in message sending operations, including better logging for asynchronous tasks.

- **Documentation**
	- Expanded examples and documentation to assist developers in implementing batch processing with callbacks effectively.

- **Refactor**
	- Updated method signatures to enhance flexibility and performance, particularly for batch processing of messages.
	- Streamlined the client handling within the `RocketmqDefaultClient` for improved concurrency and safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->