### PR TITLE
[ISSUE #916]🚀Support producer send rpc message-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,6 +1902,7 @@ version = "0.3.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
+ "once_cell",
  "parking_lot",
  "rand",
  "regex",
@@ -1960,6 +1961,7 @@ dependencies = [
  "tracing-subscriber",
  "trait-variant",
  "url",
+ "uuid",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,6 @@ mockall = "0.13.0"
 cfg-if = "1.0.0"
 
 sysinfo = "0.31.3"
+uuid = { version = "1.10.0", features = ["v4", # Lets you generate random UUIDs
+    "fast-rng", # Use a faster (but still sufficiently random) RNG
+    "macro-diagnostics", ] }

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -37,7 +37,7 @@ tracing-subscriber.workspace = true
 regex = { version = "1.10.6", features = [] }
 
 parking_lot = { workspace = true }
-
+once_cell = { workspace = true }
 [[example]]
 name = "simple-producer"
 path = "examples/producer/simple_producer.rs"

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -56,7 +56,7 @@ use crate::Result;
 #[derive(Clone)]
 pub struct MQClientInstance {
     client_config: Arc<ClientConfig>,
-    client_id: String,
+    pub(crate) client_id: String,
     boot_timestamp: u64,
     /**
      * The container of the producer in the current client. The key is the name of
@@ -75,7 +75,7 @@ pub struct MQClientInstance {
     admin_ext_table: Arc<RwLock<HashMap<String, Box<dyn MQAdminExtInner>>>>,
     pub(crate) mq_client_api_impl: ArcRefCellWrapper<MQClientAPIImpl>,
     pub(crate) mq_admin_impl: ArcRefCellWrapper<MQAdminImpl>,
-    topic_route_table: Arc<RwLock<HashMap<String /* Topic */, TopicRouteData>>>,
+    pub(crate) topic_route_table: Arc<RwLock<HashMap<String /* Topic */, TopicRouteData>>>,
     topic_end_points_table:
         Arc<RwLock<HashMap<String /* Topic */, HashMap<MessageQueue, String /* brokerName */>>>>,
     lock_namesrv: Arc<Mutex<()>>,

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -1129,8 +1129,13 @@ impl MQProducer for DefaultMQProducer {
             .await
     }
 
-    async fn request(&self, msg: &Message, timeout: u64) -> Result<Message> {
-        todo!()
+    async fn request(&mut self, mut msg: Message, timeout: u64) -> Result<Message> {
+        msg.set_topic(self.with_namespace(msg.topic.as_str()).as_str());
+        self.default_mqproducer_impl
+            .as_mut()
+            .unwrap()
+            .request(msg, timeout)
+            .await
     }
 
     async fn request_with_callback(

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -501,7 +501,7 @@ pub trait MQProducerLocal {
     ///
     /// # Returns
     /// A `Result` containing the response `Message`, or an error.
-    async fn request(&self, msg: &Message, timeout: u64) -> Result<Message>;
+    async fn request(&mut self, msg: Message, timeout: u64) -> Result<Message>;
 
     /// Sends a request message with a callback.
     ///

--- a/rocketmq-client/src/producer/request_callback.rs
+++ b/rocketmq-client/src/producer/request_callback.rs
@@ -14,9 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::sync::Arc;
+
 use rocketmq_common::common::message::message_single::Message;
+use rocketmq_common::common::message::MessageTrait;
 
 use crate::error::MQClientError;
+
+pub type RequestCallbackFn =
+    Arc<dyn Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync>;
 
 pub trait RequestCallback: Sync + Send {
     fn on_success(&self, response: &Message);

--- a/rocketmq-client/src/producer/request_future_holder.rs
+++ b/rocketmq-client/src/producer/request_future_holder.rs
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use once_cell::sync::Lazy;
+use tokio::sync::Mutex;
+use tokio::sync::RwLock;
+use tokio::task;
+use tokio::time::interval;
+
+use crate::common::client_error_code::ClientErrorCode;
+use crate::error::MQClientError::RequestTimeoutException;
+use crate::producer::request_response_future::RequestResponseFuture;
+
+pub static REQUEST_FUTURE_HOLDER: Lazy<Arc<RequestFutureHolder>> =
+    Lazy::new(|| Arc::new(RequestFutureHolder::new()));
+
+pub struct RequestFutureHolder {
+    request_future_table: Arc<RwLock<HashMap<String, Arc<RequestResponseFuture>>>>,
+    producer_set: Arc<Mutex<HashSet<String>>>,
+}
+
+impl RequestFutureHolder {
+    fn new() -> Self {
+        Self {
+            request_future_table: Arc::new(RwLock::new(HashMap::new())),
+            producer_set: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    pub async fn scan_expired_request(&self) {
+        let mut rf_list = Vec::new();
+        {
+            let mut table = self.request_future_table.write().await;
+            let mut expired_keys = Vec::new();
+
+            for (key, future) in table.iter() {
+                if future.is_timeout() {
+                    expired_keys.push(key.clone());
+                    rf_list.push(future.clone());
+                }
+            }
+
+            for key in expired_keys {
+                table.remove(&key);
+            }
+        }
+
+        for rf in rf_list {
+            let cause = Box::new(RequestTimeoutException(
+                ClientErrorCode::REQUEST_TIMEOUT_EXCEPTION,
+                "request timeout, no reply message.".to_string(),
+            ));
+            rf.set_cause(cause).await;
+            rf.execute_request_callback().await;
+        }
+    }
+
+    pub async fn start_scheduled_task(self: Arc<Self>) {
+        let holder = self.clone();
+        task::spawn(async move {
+            let mut interval = interval(Duration::from_millis(1000));
+            loop {
+                interval.tick().await;
+                holder.scan_expired_request().await;
+            }
+        });
+    }
+
+    pub async fn shutdown(&self) {
+        let mut producers = self.producer_set.lock().await;
+        producers.clear(); // Simulating producer removal
+
+        // Additional shutdown logic if needed
+    }
+
+    pub async fn put_request(&self, correlation_id: String, request: Arc<RequestResponseFuture>) {
+        let mut table = self.request_future_table.write().await;
+        table.insert(correlation_id, request);
+    }
+
+    pub async fn remove_request(&self, correlation_id: &str) {
+        let mut table = self.request_future_table.write().await;
+        table.remove(correlation_id);
+    }
+}

--- a/rocketmq-client/src/producer/request_response_future.rs
+++ b/rocketmq-client/src/producer/request_response_future.rs
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::error::Error;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use rocketmq_common::common::message::message_single::Message;
+use tokio::sync::Mutex;
+use tokio::sync::Notify;
+
+use crate::producer::request_callback::RequestCallbackFn;
+
+pub struct RequestResponseFuture {
+    correlation_id: String,
+    request_callback: Option<RequestCallbackFn>,
+    begin_timestamp: Instant,
+    request_msg: Option<Message>,
+    timeout_millis: u64,
+    notify: Arc<Notify>,
+    response_msg: Arc<Mutex<Option<Message>>>,
+    send_request_ok: Arc<AtomicBool>,
+    cause: Arc<Mutex<Option<Box<dyn Error + Send + Sync>>>>,
+}
+
+impl RequestResponseFuture {
+    pub fn new(
+        correlation_id: String,
+        timeout_millis: u64,
+        request_callback: Option<RequestCallbackFn>,
+    ) -> Self {
+        Self {
+            correlation_id,
+            request_callback,
+            begin_timestamp: Instant::now(),
+            request_msg: None,
+            timeout_millis,
+            notify: Arc::new(Notify::new()),
+            response_msg: Arc::new(Mutex::new(None)),
+            send_request_ok: Arc::new(AtomicBool::new(false)),
+            cause: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub async fn execute_request_callback(&self) {
+        if let Some(callback) = &self.request_callback {
+            let send_request_ok = self.send_request_ok.load(Ordering::Acquire);
+            let cause = self.cause.lock().await;
+            let response_msg = self.response_msg.lock().await;
+            if send_request_ok && cause.is_none() {
+                if let Some(response) = &*response_msg {
+                    callback(Some(response), None);
+                }
+            } else if let Some(e) = &*cause {
+                callback(None, Some(&**e));
+            }
+        }
+    }
+
+    pub fn is_timeout(&self) -> bool {
+        self.begin_timestamp.elapsed() > Duration::from_millis(self.timeout_millis)
+    }
+
+    pub async fn wait_response_message(&self, timeout: Duration) -> Option<Message> {
+        if tokio::time::timeout(timeout, self.notify.notified())
+            .await
+            .is_ok()
+        {
+            let response = self.response_msg.lock().await;
+            return response.clone();
+        }
+        None
+    }
+
+    pub async fn put_response_message(&self, response_msg: Option<Message>) {
+        let mut response = self.response_msg.lock().await;
+        *response = response_msg;
+        self.notify.notify_waiters();
+    }
+
+    // Getters and setters
+    pub fn get_correlation_id(&self) -> &str {
+        &self.correlation_id
+    }
+
+    pub fn get_timeout_millis(&self) -> u64 {
+        self.timeout_millis
+    }
+
+    pub fn set_timeout_millis(&mut self, timeout_millis: u64) {
+        self.timeout_millis = timeout_millis;
+    }
+
+    pub fn get_request_callback(&self) -> Option<&RequestCallbackFn> {
+        self.request_callback.as_ref()
+    }
+
+    pub fn get_begin_timestamp(&self) -> Instant {
+        self.begin_timestamp
+    }
+
+    pub fn get_notify(&self) -> Arc<Notify> {
+        Arc::clone(&self.notify)
+    }
+
+    pub async fn get_response_msg(&self) -> Option<Message> {
+        self.response_msg.lock().await.clone()
+    }
+
+    pub async fn set_response_msg(&self, response_msg: Message) {
+        let mut response = self.response_msg.lock().await;
+        *response = Some(response_msg);
+    }
+
+    pub async fn is_send_request_ok(&self) -> bool {
+        self.send_request_ok.load(Ordering::Acquire)
+    }
+
+    pub fn set_send_request_ok(&self, send_request_ok: bool) {
+        self.send_request_ok.store(false, Ordering::Release)
+    }
+
+    pub fn get_request_msg(&self) -> Option<&Message> {
+        self.request_msg.as_ref()
+    }
+
+    pub async fn get_cause(&self) -> Option<Box<dyn Error + Send + Sync>> {
+        //self.cause.lock().await.clone()
+        unimplemented!()
+    }
+
+    pub async fn set_cause(&self, cause: Box<dyn Error + Send + Sync>) {
+        let mut err = self.cause.lock().await;
+        *err = Some(cause);
+    }
+}

--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -61,5 +61,8 @@ hex = "0.4.3"
 reqwest = { version = "0.12", features = ["blocking"] }
 url = "2.5.2"
 form_urlencoded = "1.2.1"
+
+uuid = { workspace = true }
+
 [dev-dependencies]
 mockall = "0.13.0"

--- a/rocketmq-common/src/common/message/message_accessor.rs
+++ b/rocketmq-common/src/common/message/message_accessor.rs
@@ -21,6 +21,10 @@ use crate::common::message::MessageTrait;
 pub struct MessageAccessor;
 
 impl MessageAccessor {
+    pub fn put_property<T: MessageTrait>(msg: &mut T, name: &str, value: &str) {
+        msg.put_property(name, value);
+    }
+
     pub fn clear_property<T: MessageTrait>(msg: &mut T, name: &str) {
         msg.clear_property(name);
     }

--- a/rocketmq-common/src/utils.rs
+++ b/rocketmq-common/src/utils.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 pub mod cleanup_policy_utils;
+pub mod correlation_id_util;
 pub mod crc32_utils;
 pub mod env_utils;
 pub mod file_utils;

--- a/rocketmq-common/src/utils/correlation_id_util.rs
+++ b/rocketmq-common/src/utils/correlation_id_util.rs
@@ -14,18 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-pub mod default_mq_produce_builder;
-pub mod default_mq_producer;
-pub mod local_transaction_state;
-pub mod message_queue_selector;
-pub mod mq_producer;
-pub mod produce_accumulator;
-pub mod producer_impl;
-pub mod request_callback;
-pub(crate) mod request_future_holder;
-pub(crate) mod request_response_future;
-pub mod send_callback;
-pub mod send_result;
-pub mod send_status;
-pub mod transaction_listener;
-pub mod transaction_send_result;
+use uuid::Uuid;
+
+pub struct CorrelationIdUtil;
+
+impl CorrelationIdUtil {
+    pub fn create_correlation_id() -> String {
+        Uuid::new_v4().to_string()
+    }
+}

--- a/rocketmq-remoting/Cargo.toml
+++ b/rocketmq-remoting/Cargo.toml
@@ -47,9 +47,7 @@ futures-io = "0.3"
 num_cpus.workspace = true
 parking_lot.workspace = true
 trait-variant.workspace = true
-uuid = { version = "1.10.0", features = ["v4", # Lets you generate random UUIDs
-    "fast-rng", # Use a faster (but still sufficiently random) RNG
-    "macro-diagnostics", ] }
+uuid = { workspace = true }
 log = "0.4.22"
 [dev-dependencies]
 bytes = "1.7.1"

--- a/rocketmq-remoting/src/clients/blocking_client.rs
+++ b/rocketmq-remoting/src/clients/blocking_client.rs
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-use std::time::Duration;
-
-use crate::protocol::remoting_command::RemotingCommand;
-
 pub struct BlockingClient {
     /// The asynchronous `Client`.
     inner: crate::clients::Client,
@@ -57,7 +53,7 @@ impl BlockingClient {
         Ok(BlockingClient { inner, rt })
     }
 
-    pub fn invoke_oneway(
+    /*    pub fn invoke_oneway(
         &mut self,
         request: RemotingCommand,
         timeout: Duration,
@@ -69,5 +65,5 @@ impl BlockingClient {
             Ok(value) => value,
             Err(err) => Err(crate::error::Error::Elapsed(err)),
         }
-    }
+    }*/
 }

--- a/rocketmq-remoting/src/error.rs
+++ b/rocketmq-remoting/src/error.rs
@@ -54,9 +54,8 @@ pub enum Error {
     #[error("{0}")]
     ConnectionInvalid(String),
 
-    #[error("{0}")]
-    Elapsed(#[from] tokio::time::error::Elapsed),
-
+    /*    #[error("{0}")]
+    Elapsed(#[from] tokio::time::error::Elapsed),*/
     #[error("{0}-{1}")]
     AbortProcessException(i32, String),
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #916 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced UUID generation capabilities with the addition of the `uuid` crate.
	- Added new utility for generating unique correlation IDs.
	- Enhanced message handling through new methods for setting properties and managing asynchronous request-response futures.

- **Bug Fixes**
	- Commented out obsolete or unused methods to simplify functionality, such as the `invoke_oneway` function in `BlockingClient`.

- **Documentation**
	- Updated method signatures for better clarity and usability across message-related classes and utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->