### PR TITLE
[ISSUE #926]🔥Remoting connection implements read-write separation🚀

### DIFF
--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -37,6 +37,7 @@ use rocketmq_remoting::protocol::route::route_data_view::QueueData;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::remoting::RemotingService;
+use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
 use rocketmq_remoting::rpc::client_metadata::ClientMetadata;
 use rocketmq_remoting::rpc::rpc_client_impl::RpcClientImpl;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
@@ -55,7 +56,8 @@ pub struct BrokerOuterAPI {
 
 impl BrokerOuterAPI {
     pub fn new(tokio_client_config: Arc<TokioClientConfig>) -> Self {
-        let client = RocketmqDefaultClient::new(tokio_client_config);
+        let client =
+            RocketmqDefaultClient::new(tokio_client_config, DefaultRemotingRequestProcessor);
         let client_metadata = ClientMetadata::new();
         Self {
             remoting_client: client.clone(),
@@ -69,7 +71,8 @@ impl BrokerOuterAPI {
         tokio_client_config: Arc<TokioClientConfig>,
         rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
     ) -> Self {
-        let mut client = RocketmqDefaultClient::new(tokio_client_config);
+        let mut client =
+            RocketmqDefaultClient::new(tokio_client_config, DefaultRemotingRequestProcessor);
         let client_metadata = ClientMetadata::new();
         if let Some(rpc_hook) = rpc_hook {
             client.register_rpc_hook(rpc_hook);

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -14,12 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
 use rocketmq_remoting::runtime::server::ConnectionHandlerContext;
 use rocketmq_remoting::Result;
+use tracing::info;
 
 #[derive(Clone)]
 pub struct ClientRemotingProcessor {}
@@ -31,6 +32,18 @@ impl RequestProcessor for ClientRemotingProcessor {
         ctx: ConnectionHandlerContext,
         request: RemotingCommand,
     ) -> Result<Option<RemotingCommand>> {
-        todo!()
+        let request_code = RequestCode::from(request.code());
+        info!("process_request: {:?}", request_code);
+
+        match request_code {
+            RequestCode::PushReplyMessageToClient => {
+                info!("PushReplyMessageToClient");
+                Ok(None)
+            }
+            _ => {
+                info!("Unknown request code: {:?}", request_code);
+                Ok(None)
+            }
+        }
     }
 }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -43,6 +43,7 @@ use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::remoting::RemotingService;
+use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_remoting::runtime::RPCHook;
 use tracing::error;
@@ -89,7 +90,8 @@ impl MQClientAPIImpl {
         rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
         client_config: ClientConfig,
     ) -> Self {
-        let mut default_client = RocketmqDefaultClient::new(tokio_client_config);
+        let mut default_client =
+            RocketmqDefaultClient::new(tokio_client_config, DefaultRemotingRequestProcessor);
         if let Some(hook) = rpc_hook {
             default_client.register_rpc_hook(hook);
         }

--- a/rocketmq-remoting/src/base.rs
+++ b/rocketmq-remoting/src/base.rs
@@ -14,20 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-use crate::net::channel::Channel;
-use crate::protocol::remoting_command::RemotingCommand;
-use crate::runtime::server::ConnectionHandlerContext;
-use crate::Result;
-
-/// Trait for processing requests.
-#[trait_variant::make(RequestProcessor: Send )]
-pub trait LocalRequestProcessor {
-    /// Process a request.
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
-    ) -> Result<Option<RemotingCommand>>;
-}
+pub mod response_future;

--- a/rocketmq-remoting/src/base/response_future.rs
+++ b/rocketmq-remoting/src/base/response_future.rs
@@ -14,20 +14,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-use crate::net::channel::Channel;
 use crate::protocol::remoting_command::RemotingCommand;
-use crate::runtime::server::ConnectionHandlerContext;
 use crate::Result;
 
-/// Trait for processing requests.
-#[trait_variant::make(RequestProcessor: Send )]
-pub trait LocalRequestProcessor {
-    /// Process a request.
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
-    ) -> Result<Option<RemotingCommand>>;
+pub struct ResponseFuture {
+    pub(crate) opaque: i32,
+    pub(crate) timeout_millis: u64,
+    pub(crate) send_request_ok: bool,
+    //pub(crate) response_command: Option<RemotingCommand>,
+    pub(crate) tx: tokio::sync::oneshot::Sender<Result<RemotingCommand>>,
+}
+
+impl ResponseFuture {
+    pub fn new(
+        opaque: i32,
+        timeout_millis: u64,
+        send_request_ok: bool,
+        //response_command: Option<RemotingCommand>,
+        tx: tokio::sync::oneshot::Sender<Result<RemotingCommand>>,
+    ) -> Self {
+        Self {
+            opaque,
+            timeout_millis,
+            send_request_ok,
+            // response_command,
+            tx,
+        }
+    }
 }

--- a/rocketmq-remoting/src/clients.rs
+++ b/rocketmq-remoting/src/clients.rs
@@ -18,10 +18,11 @@
 pub use blocking_client::BlockingClient;
 pub use client::Client;
 
-use crate::net::ResponseFuture;
+use crate::base::response_future::ResponseFuture;
 use crate::protocol::remoting_command::RemotingCommand;
 use crate::remoting::InvokeCallback;
 use crate::remoting::RemotingService;
+use crate::runtime::processor::RequestProcessor;
 use crate::Result;
 
 mod async_client;
@@ -91,6 +92,8 @@ pub trait RemotingClient: RemotingService {
     /// # Arguments
     /// * `addrs` - A list of addresses whose clients should be closed.
     fn close_clients(&mut self, addrs: Vec<String>);
+
+    fn register_processor(&mut self, processor: impl RequestProcessor + Sync);
 }
 
 impl<T> InvokeCallback for T

--- a/rocketmq-remoting/src/clients/blocking_client.rs
+++ b/rocketmq-remoting/src/clients/blocking_client.rs
@@ -45,12 +45,13 @@ impl BlockingClient {
     /// # drop(client);
     /// }
     /// ```
-    pub fn connect<T: tokio::net::ToSocketAddrs>(addr: T) -> anyhow::Result<BlockingClient> {
-        let rt = tokio::runtime::Builder::new_current_thread()
+    pub fn connect<T: tokio::net::ToSocketAddrs>(_addr: T) -> anyhow::Result<BlockingClient> {
+        /*let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
         let inner = rt.block_on(crate::clients::Client::connect(addr))?;
-        Ok(BlockingClient { inner, rt })
+        Ok(BlockingClient { inner, rt })*/
+        unimplemented!("BlockingClient::connect")
     }
 
     /*    pub fn invoke_oneway(

--- a/rocketmq-remoting/src/clients/client.rs
+++ b/rocketmq-remoting/src/clients/client.rs
@@ -14,16 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashMap;
 
 use futures_util::SinkExt;
-use tokio_stream::StreamExt;
+use futures_util::StreamExt;
+use rocketmq_common::ArcRefCellWrapper;
+use tokio::sync::mpsc::Receiver;
+use tracing::error;
 
+use crate::base::response_future::ResponseFuture;
 use crate::connection::Connection;
 use crate::error::Error::ConnectionInvalid;
 use crate::error::Error::Io;
+use crate::error::Error::RemoteException;
+use crate::net::channel::Channel;
 use crate::protocol::remoting_command::RemotingCommand;
+use crate::runtime::processor::RequestProcessor;
+use crate::runtime::server::ConnectionHandlerContextWrapper;
 use crate::Result;
 
+#[derive(Clone)]
 pub struct Client {
     /// The TCP connection decorated with the rocketmq remoting protocol encoder / decoder
     /// implemented using a buffered `TcpStream`.
@@ -32,7 +42,134 @@ pub struct Client {
     /// passed to `Connection::new`, which initializes the associated buffers.
     /// `Connection` allows the handler to operate at the "frame" level and keep
     /// the byte level protocol parsing details encapsulated in `Connection`.
-    connection: Connection,
+    //connection: Connection,
+    inner: ArcRefCellWrapper<ClientInner>,
+    tx: tokio::sync::mpsc::Sender<SendMessage>,
+}
+
+struct ClientInner {
+    response_table: HashMap<i32, ResponseFuture>,
+    channel: Channel,
+    ctx: ArcRefCellWrapper<ConnectionHandlerContextWrapper>,
+}
+
+type SendMessage = (
+    RemotingCommand,
+    Option<tokio::sync::oneshot::Sender<Result<RemotingCommand>>>,
+    Option<u64>,
+);
+
+async fn run_send(mut client: ArcRefCellWrapper<ClientInner>, mut rx: Receiver<SendMessage>) {
+    while let Some((request, tx, timeout)) = rx.recv().await {
+        let _ = client.send(request, tx, timeout).await;
+    }
+}
+
+async fn run_recv<PR: RequestProcessor>(
+    mut client: ArcRefCellWrapper<ClientInner>,
+    mut processor: PR,
+) {
+    while let Some(response) = client.ctx.connection.reader.next().await {
+        match response {
+            Ok(response) => {
+                let opaque = response.opaque();
+                let process_result = processor
+                    .process_request(
+                        client.channel.clone(),
+                        ArcRefCellWrapper::downgrade(&client.ctx),
+                        response,
+                    )
+                    .await;
+                match process_result {
+                    Ok(result) => {
+                        if let Some(command) = result {
+                            if let Some(response_future) = client.response_table.remove(&opaque) {
+                                let _ = response_future.tx.send(Ok(command));
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        if let Some(response_future) = client.response_table.remove(&opaque) {
+                            let _ = response_future
+                                .tx
+                                .send(Err(RemoteException(err.to_string())));
+                        }
+                    }
+                }
+            }
+            Err(error) => match error {
+                Io(value) => {
+                    client.ctx.connection.ok = false;
+                    error!("error: {:?}", value);
+                    return;
+                }
+                _ => {
+                    error!("error: {:?}", error);
+                }
+            },
+        }
+    }
+}
+
+impl ClientInner {
+    pub async fn connect<T, PR>(
+        addr: T,
+        processor: PR,
+    ) -> Result<(
+        tokio::sync::mpsc::Sender<SendMessage>,
+        ArcRefCellWrapper<ClientInner>,
+    )>
+    where
+        T: tokio::net::ToSocketAddrs,
+        PR: RequestProcessor + 'static,
+    {
+        let tcp_stream = tokio::net::TcpStream::connect(addr).await;
+        if tcp_stream.is_err() {
+            return Err(Io(tcp_stream.err().unwrap()));
+        }
+        let stream = tcp_stream?;
+        let channel = Channel::new(stream.local_addr()?, stream.peer_addr()?);
+        let connection = Connection::new(stream);
+        let client = ClientInner {
+            ctx: ArcRefCellWrapper::new(ConnectionHandlerContextWrapper::new(connection)),
+            response_table: HashMap::new(),
+            channel,
+        };
+        let client = ArcRefCellWrapper::new(client);
+        let (tx, rx) = tokio::sync::mpsc::channel(32);
+        tokio::spawn(run_recv(client.clone(), processor));
+        tokio::spawn(run_send(client.clone(), rx));
+        Ok((tx, client))
+    }
+
+    pub async fn send(
+        &mut self,
+        request: RemotingCommand,
+        tx: Option<tokio::sync::oneshot::Sender<Result<RemotingCommand>>>,
+        timeout_millis: Option<u64>,
+    ) -> Result<()> {
+        let opaque = request.opaque();
+        if let Some(tx) = tx {
+            self.response_table.insert(
+                opaque,
+                ResponseFuture::new(opaque, timeout_millis.unwrap_or(0), false, tx),
+            );
+        }
+        match self.ctx.connection.writer.send(request).await {
+            Ok(_) => Ok(()),
+            Err(error) => match error {
+                Io(value) => {
+                    self.response_table.remove(&opaque);
+                    self.ctx.connection.ok = false;
+                    Err(ConnectionInvalid(value.to_string()))
+                }
+                _ => {
+                    self.response_table.remove(&opaque);
+                    Err(error)
+                }
+            },
+        }
+    }
 }
 
 impl Client {
@@ -45,13 +182,23 @@ impl Client {
     /// # Returns
     ///
     /// A new `Client` instance wrapped in a `Result`. Returns an error if the connection fails.
-    pub async fn connect<T: tokio::net::ToSocketAddrs>(addr: T) -> Result<Client> {
-        let tcp_stream = tokio::net::TcpStream::connect(addr).await;
+    pub async fn connect<T, PR>(addr: T, processor: PR) -> Result<Client>
+    where
+        T: tokio::net::ToSocketAddrs,
+        PR: RequestProcessor + 'static,
+    {
+        /*let tcp_stream = tokio::net::TcpStream::connect(addr).await;
         if tcp_stream.is_err() {
             return Err(Io(tcp_stream.err().unwrap()));
         }
         Ok(Client {
-            connection: Connection::new(tcp_stream.unwrap()),
+            connection: Connection::new(tcp_stream?),
+        })*/
+        let (tx, inner) = ClientInner::connect(addr, processor).await?;
+        Ok(Client {
+            //connection: inner.connection.clone(),
+            inner,
+            tx,
         })
     }
 
@@ -65,10 +212,28 @@ impl Client {
     ///
     /// The `RemotingCommand` representing the response, wrapped in a `Result`. Returns an error if
     /// the invocation fails.
-    pub async fn send_read(&mut self, request: RemotingCommand) -> Result<RemotingCommand> {
-        self.send(request).await?;
+    pub async fn send_read(
+        &mut self,
+        request: RemotingCommand,
+        timeout_millis: u64,
+    ) -> Result<RemotingCommand> {
+        /*self.send(request).await?;
         let response = self.read().await?;
-        Ok(response)
+        Ok(response)*/
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<RemotingCommand>>();
+
+        if let Err(err) = self
+            .tx
+            .send((request, Some(tx), Some(timeout_millis)))
+            .await
+        {
+            return Err(RemoteException(err.to_string()));
+        }
+        match rx.await {
+            Ok(value) => value,
+            Err(error) => Err(RemoteException(error.to_string())),
+        }
     }
 
     /// Invokes a remote operation with the given `RemotingCommand` and provides a callback function
@@ -96,16 +261,20 @@ impl Client {
     ///
     /// A `Result` indicating success or failure in sending the request.
     pub async fn send(&mut self, request: RemotingCommand) -> Result<()> {
-        match self.connection.framed.send(request).await {
+        /*match self.inner.ctx.connection.writer.send(request).await {
             Ok(_) => Ok(()),
             Err(error) => match error {
                 Io(value) => {
-                    self.connection.ok = false;
+                    self.inner.ctx.connection.ok = false;
                     Err(ConnectionInvalid(value.to_string()))
                 }
                 _ => Err(error),
             },
+        }*/
+        if let Err(err) = self.tx.send((request, None, None)).await {
+            return Err(RemoteException(err.to_string()));
         }
+        Ok(())
     }
 
     /// Reads and retrieves the response from the remote server.
@@ -115,16 +284,16 @@ impl Client {
     /// The `RemotingCommand` representing the response, wrapped in a `Result`. Returns an error if
     /// reading the response fails.
     async fn read(&mut self) -> Result<RemotingCommand> {
-        match self.connection.framed.next().await {
+        match self.inner.ctx.connection.reader.next().await {
             None => {
-                self.connection.ok = false;
+                self.inner.ctx.connection.ok = false;
                 Err(ConnectionInvalid("connection disconnection".to_string()))
             }
             Some(result) => match result {
                 Ok(response) => Ok(response),
                 Err(error) => match error {
                     Io(value) => {
-                        self.connection.ok = false;
+                        self.inner.ctx.connection.ok = false;
                         Err(ConnectionInvalid(value.to_string()))
                     }
                     _ => Err(error),
@@ -134,10 +303,10 @@ impl Client {
     }
 
     pub fn connection(&self) -> &Connection {
-        &self.connection
+        &self.inner.ctx.connection
     }
 
     pub fn connection_mut(&mut self) -> &mut Connection {
-        &mut self.connection
+        &mut self.inner.ctx.connection
     }
 }

--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -30,7 +30,9 @@ pub mod protocol;
 use crate::error::Error;
 pub use crate::protocol::rocketmq_serializable;
 
+pub mod base;
 pub mod remoting;
+pub mod request_processor;
 pub mod rpc;
 pub mod runtime;
 pub mod server;

--- a/rocketmq-remoting/src/net.rs
+++ b/rocketmq-remoting/src/net.rs
@@ -14,5 +14,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 pub mod channel;
-pub struct ResponseFuture;

--- a/rocketmq-remoting/src/remoting.rs
+++ b/rocketmq-remoting/src/remoting.rs
@@ -16,7 +16,7 @@
  */
 use std::sync::Arc;
 
-use crate::net::ResponseFuture;
+use crate::base::response_future::ResponseFuture;
 use crate::protocol::remoting_command::RemotingCommand;
 use crate::runtime::RPCHook;
 

--- a/rocketmq-remoting/src/request_processor.rs
+++ b/rocketmq-remoting/src/request_processor.rs
@@ -14,20 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-use crate::net::channel::Channel;
-use crate::protocol::remoting_command::RemotingCommand;
-use crate::runtime::server::ConnectionHandlerContext;
-use crate::Result;
-
-/// Trait for processing requests.
-#[trait_variant::make(RequestProcessor: Send )]
-pub trait LocalRequestProcessor {
-    /// Process a request.
-    async fn process_request(
-        &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
-    ) -> Result<Option<RemotingCommand>>;
-}
+pub mod default_request_processor;

--- a/rocketmq-remoting/src/request_processor/default_request_processor.rs
+++ b/rocketmq-remoting/src/request_processor/default_request_processor.rs
@@ -17,17 +17,20 @@
 
 use crate::net::channel::Channel;
 use crate::protocol::remoting_command::RemotingCommand;
+use crate::runtime::processor::RequestProcessor;
 use crate::runtime::server::ConnectionHandlerContext;
 use crate::Result;
 
-/// Trait for processing requests.
-#[trait_variant::make(RequestProcessor: Send )]
-pub trait LocalRequestProcessor {
-    /// Process a request.
+#[derive(Clone)]
+pub struct DefaultRemotingRequestProcessor;
+
+impl RequestProcessor for DefaultRemotingRequestProcessor {
     async fn process_request(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
         request: RemotingCommand,
-    ) -> Result<Option<RemotingCommand>>;
+    ) -> Result<Option<RemotingCommand>> {
+        Ok(Some(request))
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #926 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced request processing capabilities with the introduction of `DefaultRemotingRequestProcessor`.
	- Added asynchronous response handling through the new `response_future` module.
	- Improved flexibility in `RocketmqDefaultClient` with a generic parameter for request processors.

- **Bug Fixes**
	- Streamlined connection handling and error propagation in the `Client` implementation.

- **Refactor**
	- Reorganized `Connection` handling with separate `reader` and `writer` interfaces for better control.
	- Updated `LocalRequestProcessor` to remove the `Send` constraint, simplifying trait implementations.

- **Documentation**
	- New modules added for better modularity and clarity in the RocketMQ remoting framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->