### PR TITLE
[ISSUES #969] Support AdminBrokerProcessor get_all_consumer_offset

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -156,6 +156,11 @@ impl AdminBrokerProcessor {
                     .get_consume_stats(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::GetAllConsumerOffset => {
+                self.consumer_request_handler
+                    .get_all_consumer_offset(channel, ctx, request_code, request)
+                    .await
+            }
             RequestCode::GetTopicConfig => {
                 self.topic_request_handler
                     .get_topic_config(channel, ctx, request_code, request)

--- a/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashSet;
 
+use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
@@ -215,5 +216,26 @@ impl ConsumerRequestHandler {
         let body = consume_stats.encode();
         response.set_body_mut_ref(Some(body));
         Some(response)
+    }
+
+    pub async fn get_all_consumer_offset(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        _request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        let mut response = RemotingCommand::create_response_command();
+        let content = self.inner.consumer_offset_manager.encode();
+        if !content.is_empty() {
+            response.set_body_mut_ref(Some(content));
+            Some(response)
+        } else {
+            Some(
+                response
+                    .set_code(ResponseCode::SystemError)
+                    .set_remark(Some("No consumer offset in this broker".to_string())),
+            )
+        }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #969 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to retrieve all consumer offsets, enhancing data management capabilities.
	- Added a new request handling case for `GetAllConsumerOffset` in the admin broker processor.

- **Bug Fixes**
	- Improved response handling for cases where no consumer offsets are available, ensuring proper error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->