### PR TITLE
[ISSUE #981]🔥Optimize client clusting consume⚡️

### DIFF
--- a/rocketmq-client/examples/quickstart/consumer.rs
+++ b/rocketmq-client/examples/quickstart/consumer.rs
@@ -32,7 +32,7 @@ pub const TAG: &str = "*";
 #[rocketmq::main]
 pub async fn main() -> Result<()> {
     //init logger
-    rocketmq_common::log::init_logger();
+    //rocketmq_common::log::init_logger();
 
     // create a producer builder with default configuration
     let builder = DefaultMQPushConsumer::builder();

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -33,8 +33,8 @@ impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
         todo!()
     }
 
-    fn shutdown(&self, await_terminate_millis: u64) {
-        todo!()
+    fn shutdown(&mut self, await_terminate_millis: u64) {
+        unimplemented!("shutdown")
     }
 
     fn update_core_pool_size(&self, core_pool_size: usize) {

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -61,7 +61,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
         // nothing to do
     }
 
-    fn shutdown(&self, await_terminate_millis: u64) {
+    fn shutdown(&mut self, await_terminate_millis: u64) {
         todo!()
     }
 

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -33,7 +33,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
         todo!()
     }
 
-    fn shutdown(&self, await_terminate_millis: u64) {
+    fn shutdown(&mut self, await_terminate_millis: u64) {
         todo!()
     }
 

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
@@ -45,7 +45,7 @@ where
 pub trait ConsumeMessageServiceTrait {
     fn start(&mut self);
 
-    fn shutdown(&self, await_terminate_millis: u64);
+    fn shutdown(&mut self, await_terminate_millis: u64);
 
     fn update_core_pool_size(&self, core_pool_size: usize);
 

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance.rs
@@ -70,4 +70,5 @@ pub trait RebalanceLocal {
     async fn do_rebalance(&mut self, is_order: bool) -> bool;
 
     fn client_rebalance(&mut self, topic: &str) -> bool;
+    fn destroy(&mut self);
 }

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
@@ -459,4 +459,8 @@ impl Rebalance for RebalancePushImpl {
                 false
             }
     }
+
+    fn destroy(&mut self) {
+        unimplemented!()
+    }
 }

--- a/rocketmq-client/src/consumer/mq_consumer_inner.rs
+++ b/rocketmq-client/src/consumer/mq_consumer_inner.rs
@@ -41,7 +41,7 @@ pub trait MQConsumerInnerLocal: MQConsumerInnerAny + Sync + 'static {
 
     async fn try_rebalance(&self) -> Result<bool>;
 
-    fn persist_consumer_offset(&self);
+    async fn persist_consumer_offset(&self);
 
     async fn update_topic_subscribe_info(&mut self, topic: &str, info: &HashSet<MessageQueue>);
 

--- a/rocketmq-remoting/src/clients/rocketmq_default_impl.rs
+++ b/rocketmq-remoting/src/clients/rocketmq_default_impl.rs
@@ -373,7 +373,8 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
             Some(mut client) => {
                 self.client_runtime.get_handle().spawn(async move {
                     match time::timeout(Duration::from_millis(timeout_millis), async move {
-                        //client.lock().await.send(request).await
+                        let mut request = request;
+                        request.mark_oneway_rpc_ref();
                         client.send(request).await
                     })
                     .await

--- a/rocketmq-remoting/src/protocol/header/unregister_client_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/unregister_client_request_header.rs
@@ -31,7 +31,7 @@ pub struct UnregisterClientRequestHeader {
     pub producer_group: Option<String>,
     pub consumer_group: Option<String>,
     #[serde(flatten)]
-    pub rpc_request_header: RpcRequestHeader,
+    pub rpc_request_header: Option<RpcRequestHeader>,
 }
 
 impl UnregisterClientRequestHeader {
@@ -55,27 +55,33 @@ impl FromMap for UnregisterClientRequestHeader {
             consumer_group: map
                 .get(UnregisterClientRequestHeader::CONSUMER_GROUP)
                 .cloned(),
-            rpc_request_header: <RpcRequestHeader as FromMap>::from(map).unwrap(),
+            rpc_request_header: <RpcRequestHeader as FromMap>::from(map),
         })
     }
 }
 
 impl CommandCustomHeader for UnregisterClientRequestHeader {
     fn to_map(&self) -> Option<HashMap<String, String>> {
-        let mut map = self.rpc_request_header.to_map();
-        map.as_mut()
-            .unwrap()
-            .insert(Self::CLIENT_ID.to_string(), self.client_id.clone());
-        if let Some(ref producer_group) = self.producer_group {
-            map.as_mut()
-                .unwrap()
-                .insert(Self::PRODUCER_GROUP.to_string(), producer_group.clone());
+        let mut map = HashMap::new();
+        map.insert(
+            UnregisterClientRequestHeader::CLIENT_ID.to_string(),
+            self.client_id.clone(),
+        );
+        if let Some(producer_group) = &self.producer_group {
+            map.insert(
+                UnregisterClientRequestHeader::PRODUCER_GROUP.to_string(),
+                producer_group.clone(),
+            );
         }
-        if let Some(ref consumer_group) = self.consumer_group {
-            map.as_mut()
-                .unwrap()
-                .insert(Self::CONSUMER_GROUP.to_string(), consumer_group.clone());
+        if let Some(consumer_group) = &self.consumer_group {
+            map.insert(
+                UnregisterClientRequestHeader::CONSUMER_GROUP.to_string(),
+                consumer_group.clone(),
+            );
         }
-        map
+        if let Some(rpc_request_header) = &self.rpc_request_header {
+            map.extend(rpc_request_header.to_map()?);
+        }
+        Some(map)
     }
 }

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -357,6 +357,10 @@ impl RemotingCommand {
         self.flag |= mark;
         self
     }
+    pub fn mark_oneway_rpc_ref(&mut self) {
+        let mark = 1 << Self::RPC_ONEWAY;
+        self.flag |= mark;
+    }
 
     pub fn get_serialize_type(&self) -> SerializeType {
         self.serialize_type


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #981 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a global lock mechanism for enhanced thread safety during shutdown operations in the consumer implementation.
	- Added new asynchronous methods for managing client registrations and offsets, including `unregister_consumer` and `unregister_producer`.

- **Bug Fixes**
	- Updated method signatures for `shutdown` across multiple services to allow mutable references, enabling state modifications during shutdown.

- **Improvements**
	- Enhanced logging and error handling in the rebalance process for better traceability.
	- Simplified message pulling logic in the `PullAPIWrapper` for clearer structure and execution.

- **Documentation**
	- Updated method signatures and added comments for clarity on asynchronous operations and their implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->