### PR TITLE
[ISSUE #986]🚀Add Runtime for ConsumeMessageConcurrentlyService⚡️

### DIFF
--- a/rocketmq-client/examples/quickstart/consumer.rs
+++ b/rocketmq-client/examples/quickstart/consumer.rs
@@ -22,6 +22,7 @@ use rocketmq_client::consumer::mq_push_consumer::MQPushConsumer;
 use rocketmq_client::Result;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_rust::rocketmq;
+use tracing::info;
 
 pub const MESSAGE_COUNT: usize = 1;
 pub const CONSUMER_GROUP: &str = "please_rename_unique_group_name_4";
@@ -32,7 +33,7 @@ pub const TAG: &str = "*";
 #[rocketmq::main]
 pub async fn main() -> Result<()> {
     //init logger
-    //rocketmq_common::log::init_logger();
+    rocketmq_common::log::init_logger();
 
     // create a producer builder with default configuration
     let builder = DefaultMQPushConsumer::builder();
@@ -57,7 +58,7 @@ impl MessageListenerConcurrently for MyMessageListener {
         _context: &ConsumeConcurrentlyContext,
     ) -> Result<ConsumeConcurrentlyStatus> {
         for msg in msgs {
-            println!("Receive message: {:?}", msg);
+            info!("Receive message: {:?}", msg);
         }
         Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -30,6 +30,7 @@ use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_common::WeakCellWrapper;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_runtime::RocketMQRuntime;
 use tracing::info;
 use tracing::warn;
 
@@ -45,14 +46,13 @@ use crate::consumer::listener::consume_return_type::ConsumeReturnType;
 use crate::consumer::listener::message_listener_concurrently::ArcBoxMessageListenerConcurrently;
 use crate::hook::consume_message_context::ConsumeMessageContext;
 
-#[derive(Clone)]
 pub struct ConsumeMessageConcurrentlyService {
     pub(crate) default_mqpush_consumer_impl: Option<WeakCellWrapper<DefaultMQPushConsumerImpl>>,
     pub(crate) client_config: ArcRefCellWrapper<ClientConfig>,
     pub(crate) consumer_config: ArcRefCellWrapper<ConsumerConfig>,
     pub(crate) consumer_group: Arc<String>,
     pub(crate) message_listener: ArcBoxMessageListenerConcurrently,
-    // pub(crate) consume_runtime: Arc<RocketMQRuntime>,
+    pub(crate) consume_runtime: RocketMQRuntime,
 }
 
 impl ConsumeMessageConcurrentlyService {
@@ -70,10 +70,10 @@ impl ConsumeMessageConcurrentlyService {
             consumer_config,
             consumer_group: Arc::new(consumer_group),
             message_listener,
-            /*consume_runtime: Arc::new(RocketMQRuntime::new_multi(
+            consume_runtime: RocketMQRuntime::new_multi(
                 consume_thread as usize,
                 "ConsumeMessageThread_",
-            )),*/
+            ),
         }
     }
 }
@@ -85,6 +85,7 @@ impl ConsumeMessageConcurrentlyService {
 
     async fn process_consume_result(
         &mut self,
+        this: ArcRefCellWrapper<Self>,
         status: ConsumeConcurrentlyStatus,
         context: &ConsumeConcurrentlyContext,
         consume_request: &mut ConsumeRequest,
@@ -141,6 +142,7 @@ impl ConsumeMessageConcurrentlyService {
                     consume_request.msgs.append(&mut msg_back_success);
                     self.submit_consume_request_later(
                         msg_back_failed,
+                        this,
                         consume_request.process_queue.clone(),
                         consume_request.message_queue.clone(),
                     );
@@ -171,13 +173,14 @@ impl ConsumeMessageConcurrentlyService {
     fn submit_consume_request_later(
         &self,
         msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
+        this: ArcRefCellWrapper<Self>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
     ) {
-        let this = self.clone();
-        tokio::spawn(async move {
+        self.consume_runtime.get_handle().spawn(async move {
             tokio::time::sleep(Duration::from_secs(5)).await;
-            this.submit_consume_request(msgs, process_queue, message_queue, true)
+            let this_ = this.clone();
+            this.submit_consume_request(this_, msgs, process_queue, message_queue, true)
                 .await;
         });
     }
@@ -211,9 +214,8 @@ impl ConsumeMessageConcurrentlyService {
 }
 
 impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
-    fn start(&mut self) {
-        let mut this = self.clone();
-        tokio::spawn(async move {
+    fn start(&mut self, mut this: ArcRefCellWrapper<Self>) {
+        self.consume_runtime.get_handle().spawn(async move {
             let timeout = this.consumer_config.consume_timeout;
             let mut interval = tokio::time::interval(Duration::from_secs(timeout * 60));
             interval.tick().await;
@@ -254,6 +256,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
 
     async fn submit_consume_request(
         &self,
+        this: ArcRefCellWrapper<Self>,
         mut msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
@@ -270,13 +273,10 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
                 consumer_group: self.consumer_group.as_ref().clone(),
                 default_mqpush_consumer_impl: self.default_mqpush_consumer_impl.clone(),
             };
-            let consume_message_concurrently_service = self.clone();
 
-            tokio::spawn(async move {
-                consume_request
-                    .run(consume_message_concurrently_service)
-                    .await
-            });
+            self.consume_runtime
+                .get_handle()
+                .spawn(async move { consume_request.run(this).await });
         } else {
             loop {
                 let item = if msgs.len() > consume_batch_size as usize {
@@ -294,13 +294,8 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
                     consumer_group: self.consumer_group.as_ref().clone(),
                     default_mqpush_consumer_impl: self.default_mqpush_consumer_impl.clone(),
                 };
-                let consume_message_concurrently_service = self.clone();
-                /*                self.consume_runtime.get_handle().spawn(async move {
-                    consume_request
-                        .run(consume_message_concurrently_service)
-                        .await
-                });*/
-                tokio::spawn(async move {
+                let consume_message_concurrently_service = this.clone();
+                self.consume_runtime.get_handle().spawn(async move {
                     consume_request
                         .run(consume_message_concurrently_service)
                         .await
@@ -335,7 +330,9 @@ struct ConsumeRequest {
 impl ConsumeRequest {
     async fn run(
         &mut self,
-        mut consume_message_concurrently_service: ConsumeMessageConcurrentlyService,
+        mut consume_message_concurrently_service: ArcRefCellWrapper<
+            ConsumeMessageConcurrentlyService,
+        >,
     ) {
         if self.process_queue.is_dropped() {
             info!(
@@ -456,8 +453,9 @@ impl ConsumeRequest {
                 self.consumer_group, self.message_queue,
             );
         } else {
+            let this = consume_message_concurrently_service.clone();
             consume_message_concurrently_service
-                .process_consume_result(status.unwrap(), &context, self)
+                .process_consume_result(this, status.unwrap(), &context, self)
                 .await;
         }
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -29,7 +29,7 @@ use crate::consumer::consumer_impl::process_queue::ProcessQueue;
 pub struct ConsumeMessageOrderlyService;
 
 impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
-    fn start(&mut self) {
+    fn start(&mut self, this: ArcRefCellWrapper<Self>) {
         todo!()
     }
 
@@ -63,6 +63,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
 
     async fn submit_consume_request(
         &self,
+        this: ArcRefCellWrapper<Self>,
         msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -57,8 +57,8 @@ impl ConsumeMessagePopConcurrentlyService {
 }
 
 impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
-    fn start(&mut self) {
-        // nothing to do
+    fn start(&mut self, this: ArcRefCellWrapper<Self>) {
+        todo!()
     }
 
     fn shutdown(&mut self, await_terminate_millis: u64) {
@@ -91,6 +91,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
 
     async fn submit_consume_request(
         &self,
+        this: ArcRefCellWrapper<Self>,
         msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -58,7 +58,7 @@ impl ConsumeMessagePopConcurrentlyService {
 
 impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
     fn start(&mut self, this: ArcRefCellWrapper<Self>) {
-        todo!()
+        //todo!()
     }
 
     fn shutdown(&mut self, await_terminate_millis: u64) {

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -29,7 +29,7 @@ use crate::consumer::consumer_impl::process_queue::ProcessQueue;
 pub struct ConsumeMessagePopOrderlyService;
 
 impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
-    fn start(&mut self) {
+    fn start(&mut self, this: ArcRefCellWrapper<Self>) {
         todo!()
     }
 
@@ -63,6 +63,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
 
     async fn submit_consume_request(
         &self,
+        this: ArcRefCellWrapper<Self>,
         msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
@@ -30,20 +30,20 @@ where
     T: ConsumeMessageServiceTrait,
     K: ConsumeMessageServiceTrait,
 {
-    pub consume_message_concurrently_service: T,
-    pub consume_message_pop_concurrently_service: K,
+    pub consume_message_concurrently_service: ArcRefCellWrapper<T>,
+    pub consume_message_pop_concurrently_service: ArcRefCellWrapper<K>,
 }
 pub struct ConsumeMessageOrderlyServiceGeneral<T, K>
 where
     T: ConsumeMessageServiceTrait,
     K: ConsumeMessageServiceTrait,
 {
-    pub consume_message_orderly_service: T,
-    pub consume_message_pop_orderly_service: K,
+    pub consume_message_orderly_service: ArcRefCellWrapper<T>,
+    pub consume_message_pop_orderly_service: ArcRefCellWrapper<K>,
 }
 
 pub trait ConsumeMessageServiceTrait {
-    fn start(&mut self);
+    fn start(&mut self, this: ArcRefCellWrapper<Self>);
 
     fn shutdown(&mut self, await_terminate_millis: u64);
 
@@ -63,6 +63,7 @@ pub trait ConsumeMessageServiceTrait {
 
     async fn submit_consume_request(
         &self,
+        this: ArcRefCellWrapper<Self>,
         msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
@@ -273,11 +273,6 @@ where
         if !all_mq_locked {
             self.client_instance.as_mut().unwrap().rebalance_later(500);
         }
-        println!(
-            "PullRequestList============================={}================{}",
-            topic,
-            pull_request_list.len()
-        );
         sub_rebalance_impl
             .dispatch_pull_request(pull_request_list, 500)
             .await;

--- a/rocketmq-client/src/consumer/pull_callback.rs
+++ b/rocketmq-client/src/consumer/pull_callback.rs
@@ -275,12 +275,20 @@ impl PullCallback for DefaultPullCallback {
                     // pullResult.getMsgFoundList().size());
                     let vec = pull_result_ext.pull_result.msg_found_list.clone();
                     let dispatch_to_consume = pull_request.process_queue.put_message(vec).await;
+                    let consume_message_concurrently_service_inner = self
+                        .push_consumer_impl
+                        .consume_message_concurrently_service
+                        .as_mut()
+                        .unwrap()
+                        .consume_message_concurrently_service
+                        .clone();
                     self.push_consumer_impl
                         .consume_message_concurrently_service
                         .as_mut()
                         .unwrap()
                         .consume_message_concurrently_service
                         .submit_consume_request(
+                            consume_message_concurrently_service_inner,
                             pull_result_ext.pull_result.msg_found_list,
                             pull_request.get_process_queue().clone(),
                             pull_request.get_message_queue().clone(),

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -444,7 +444,8 @@ impl MQClientAPIImpl {
                     let send_result = self.process_send_response(broker_name, msg, &response, addr);
                     if let Ok(result) = send_result {
                         if context.is_some() {
-                            context.as_mut().unwrap().send_result = Some(result.clone());
+                            let inner = context.as_mut().unwrap();
+                            inner.send_result = Some(result.clone());
                             producer.execute_send_message_hook_after(context);
                         }
                     }
@@ -456,7 +457,8 @@ impl MQClientAPIImpl {
                 match send_result {
                     Ok(result) => {
                         if context.is_some() {
-                            context.as_mut().unwrap().send_result = Some(result.clone());
+                            let inner = context.as_mut().unwrap();
+                            inner.send_result = Some(result.clone());
                             producer.execute_send_message_hook_after(context);
                         }
                         let duration = (Instant::now() - begin_start_time).as_millis() as u64;
@@ -624,7 +626,8 @@ impl MQClientAPIImpl {
             ))
             .await;
         } else if context.is_some() {
-            context.as_mut().unwrap().exception = Some(Arc::new(Box::new(e)));
+            let inner = context.as_mut().unwrap();
+            inner.exception = Some(Arc::new(Box::new(e)));
             producer.execute_send_message_hook_after(context);
         }
     }
@@ -861,10 +864,6 @@ impl MQClientAPIImpl {
                     let _ = this
                         .pull_message_async(addr.as_str(), request, timeout_millis, pull_callback)
                         .await;
-                    println!(
-                        ">>>>>>>>>>>>>>>>>>pull_message_async cost: {:?}",
-                        instant.elapsed()
-                    );
                 });
                 Ok(None)
             }
@@ -901,10 +900,6 @@ impl MQClientAPIImpl {
             .await
         {
             Ok(response) => {
-                println!(
-                    "++++++++++++++++++++++++pull_message_async response: {}",
-                    response
-                );
                 let result = self.process_pull_response(response, addr).await;
 
                 match result {

--- a/rocketmq-remoting/src/clients/client.rs
+++ b/rocketmq-remoting/src/clients/client.rs
@@ -21,7 +21,6 @@ use futures_util::StreamExt;
 use rocketmq_common::ArcRefCellWrapper;
 use tokio::sync::mpsc::Receiver;
 use tracing::error;
-use tracing::info;
 use tracing::warn;
 
 use crate::base::connection_net_event::ConnectionNetEvent;
@@ -80,11 +79,6 @@ async fn run_recv<PR: RequestProcessor>(
             Ok(msg) => match msg.get_type() {
                 // handle request
                 RemotingCommandType::REQUEST => {
-                    info!(
-                        ">>>>>>>>>>>>>>>>>>>receive request, code={}, address={}",
-                        msg.code(),
-                        client.channel.remote_address()
-                    );
                     let opaque = msg.opaque();
                     let process_result = processor
                         .process_request(

--- a/rocketmq-runtime/src/lib.rs
+++ b/rocketmq-runtime/src/lib.rs
@@ -53,6 +53,12 @@ impl RocketMQRuntime {
         }
     }
 
+    pub fn shutdown_timeout(self, timeout: Duration) {
+        match self {
+            Self::Multi(runtime) => runtime.shutdown_timeout(timeout),
+        }
+    }
+
     pub fn schedule_at_fixed_rate<F>(
         &self,
         task: F,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #986

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new public method `shutdown_timeout` to handle shutdown timeouts for the runtime.
- **Improvements**
	- Enhanced logging mechanisms for better management and structured output.
	- Updated message consumption methods to support improved state management and concurrency.
- **Bug Fixes**
	- Improved handling of expired messages in the message queue.
- **Chores**
	- Removed unnecessary logging statements to streamline code and reduce verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->