### PR TITLE
[ISSUE #996]📝Add doc for ConsumeFromWhere item

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
@@ -246,6 +246,7 @@ impl Rebalance for RebalancePushImpl {
         }
     }
 
+    #[allow(deprecated)]
     async fn compute_pull_from_where_with_exception(&mut self, mq: &MessageQueue) -> Result<i64> {
         let consume_from_where = self.consumer_config.consume_from_where;
         let default_mqpush_consumer_impl = self

--- a/rocketmq-common/src/common/consumer/consume_from_where.rs
+++ b/rocketmq-common/src/common/consumer/consume_from_where.rs
@@ -22,16 +22,32 @@ use serde::Serialize;
 use serde::Serializer;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[allow(deprecated)]
 pub enum ConsumeFromWhere {
+    ///On the first startup, consume from the last position of the queue; on subsequent startups,
+    /// continue consuming from the last consumed position.
     #[default]
     ConsumeFromLastOffset,
+
+    #[deprecated]
     ConsumeFromLastOffsetAndFromMinWhenBootFirst,
+
+    #[deprecated]
     ConsumeFromMinOffset,
+
+    #[deprecated]
     ConsumeFromMaxOffset,
+
+    ///On the first startup, consume from the initial position of the queue; on subsequent
+    /// startups, continue consuming from the last consumed position.
     ConsumeFromFirstOffset,
+
+    ///: On the first startup, consume from the specified timestamp position; on subsequent
+    /// startups, continue consuming from the last consumed position.
     ConsumeFromTimestamp,
 }
 
+#[allow(deprecated)]
 impl From<i32> for ConsumeFromWhere {
     fn from(value: i32) -> Self {
         match value {
@@ -46,6 +62,7 @@ impl From<i32> for ConsumeFromWhere {
     }
 }
 
+#[allow(deprecated)]
 impl From<ConsumeFromWhere> for i32 {
     fn from(consume_from_where: ConsumeFromWhere) -> i32 {
         match consume_from_where {
@@ -59,6 +76,7 @@ impl From<ConsumeFromWhere> for i32 {
     }
 }
 
+#[allow(deprecated)]
 impl Serialize for ConsumeFromWhere {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -78,6 +96,7 @@ impl Serialize for ConsumeFromWhere {
     }
 }
 
+#[allow(deprecated)]
 impl<'de> Deserialize<'de> for ConsumeFromWhere {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #996 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation for the `ConsumeFromWhere` enum, clarifying consumption behavior.
  
- **Bug Fixes**
	- Deprecated variants in `ConsumeFromWhere` are now clearly marked, aiding user understanding.

- **Documentation**
	- Added detailed explanations for `ConsumeFromFirstOffset` and `ConsumeFromTimestamp` variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->