### PR TITLE
[ISSUE #1029]🚀Support order message consume for client🔥

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -78,3 +78,7 @@ path = "examples/broadcast/push_consumer.rs"
 [[example]]
 name = "ordermessage-producer"
 path = "examples/ordermessage/ordermessage_producer.rs"
+
+[[example]]
+name = "ordermessage-consumer"
+path = "examples/ordermessage/ordermessage_consumer.rs"

--- a/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::sync::atomic::AtomicI64;
+use std::sync::Arc;
+
+use rocketmq_client::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
+use rocketmq_client::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
+use rocketmq_client::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
+use rocketmq_client::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
+use rocketmq_client::consumer::listener::message_listener_orderly::MessageListenerOrderly;
+use rocketmq_client::consumer::mq_push_consumer::MQPushConsumer;
+use rocketmq_client::Result;
+use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_rust::rocketmq;
+use tracing::info;
+
+pub const MESSAGE_COUNT: usize = 1;
+pub const CONSUMER_GROUP: &str = "please_rename_unique_group_name_3";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "TopicTest";
+pub const TAG: &str = "*";
+
+#[rocketmq::main]
+pub async fn main() -> Result<()> {
+    //init logger
+    rocketmq_common::log::init_logger();
+
+    // create a producer builder with default configuration
+    let builder = DefaultMQPushConsumer::builder();
+
+    let mut consumer = builder
+        .consumer_group(CONSUMER_GROUP.to_string())
+        .name_server_addr(DEFAULT_NAMESRVADDR.to_string())
+        .message_model(MessageModel::Clustering)
+        .build();
+    consumer.subscribe(TOPIC, TAG)?;
+    consumer.set_consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset);
+    consumer.register_message_listener_orderly(MyMessageListener::new());
+    consumer.start().await?;
+    let _ = tokio::signal::ctrl_c().await;
+    Ok(())
+}
+
+pub struct MyMessageListener {
+    consume_times: Arc<AtomicI64>,
+}
+
+impl MyMessageListener {
+    pub fn new() -> Self {
+        Self {
+            consume_times: Arc::new(AtomicI64::new(0)),
+        }
+    }
+}
+
+impl MessageListenerOrderly for MyMessageListener {
+    fn consume_message(
+        &self,
+        msgs: &[&MessageExt],
+        context: &mut ConsumeOrderlyContext,
+    ) -> Result<ConsumeOrderlyStatus> {
+        context.set_auto_commit(true);
+        for msg in msgs {
+            println!("Receive message: {:?}", msg);
+            info!("Receive message: {:?}", msg);
+        }
+        if self
+            .consume_times
+            .load(std::sync::atomic::Ordering::Acquire)
+            % 2
+            == 0
+        {
+            return Ok(ConsumeOrderlyStatus::Success);
+        } else if self
+            .consume_times
+            .load(std::sync::atomic::Ordering::Acquire)
+            % 5
+            == 0
+        {
+            context.set_suspend_current_queue_time_millis(3000);
+            return Ok(ConsumeOrderlyStatus::SuspendCurrentQueueAMoment);
+        }
+        Ok(ConsumeOrderlyStatus::Success)
+    }
+}

--- a/rocketmq-client/src/consumer.rs
+++ b/rocketmq-client/src/consumer.rs
@@ -20,6 +20,7 @@ pub mod default_mq_push_consumer;
 pub mod default_mq_push_consumer_builder;
 pub mod listener;
 pub mod message_queue_listener;
+pub(crate) mod message_queue_lock;
 pub mod message_selector;
 pub mod mq_consumer;
 pub(crate) mod mq_consumer_inner;

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -57,11 +57,11 @@ impl ConsumeMessagePopConcurrentlyService {
 }
 
 impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
-    fn start(&mut self, this: ArcRefCellWrapper<Self>) {
+    fn start(&mut self, this: WeakCellWrapper<Self>) {
         //todo!()
     }
 
-    fn shutdown(&mut self, await_terminate_millis: u64) {
+    async fn shutdown(&mut self, await_terminate_millis: u64) {
         todo!()
     }
 
@@ -91,7 +91,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
 
     async fn submit_consume_request(
         &self,
-        this: ArcRefCellWrapper<Self>,
+        this: WeakCellWrapper<Self>,
         msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -20,6 +20,7 @@ use rocketmq_common::common::message::message_client_ext::MessageClientExt;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::ArcRefCellWrapper;
+use rocketmq_common::WeakCellWrapper;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
@@ -29,11 +30,9 @@ use crate::consumer::consumer_impl::process_queue::ProcessQueue;
 pub struct ConsumeMessagePopOrderlyService;
 
 impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
-    fn start(&mut self, this: ArcRefCellWrapper<Self>) {
-        todo!()
-    }
+    fn start(&mut self, this: WeakCellWrapper<Self>) {}
 
-    fn shutdown(&mut self, await_terminate_millis: u64) {
+    async fn shutdown(&mut self, await_terminate_millis: u64) {
         todo!()
     }
 
@@ -63,7 +62,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
 
     async fn submit_consume_request(
         &self,
-        this: ArcRefCellWrapper<Self>,
+        this: WeakCellWrapper<Self>,
         msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
@@ -20,32 +20,224 @@ use rocketmq_common::common::message::message_client_ext::MessageClientExt;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::ArcRefCellWrapper;
+use rocketmq_common::WeakCellWrapper;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
 
-pub struct ConsumeMessageConcurrentlyServiceGeneral<T, K>
-where
-    T: ConsumeMessageServiceTrait,
-    K: ConsumeMessageServiceTrait,
-{
-    pub consume_message_concurrently_service: ArcRefCellWrapper<T>,
-    pub consume_message_pop_concurrently_service: ArcRefCellWrapper<K>,
+pub struct ConsumeMessageServiceGeneral<T, K> {
+    consume_message_concurrently_service: Option<ArcRefCellWrapper<T>>,
+    consume_message_orderly_service: Option<ArcRefCellWrapper<K>>,
 }
-pub struct ConsumeMessageOrderlyServiceGeneral<T, K>
+impl<T, K> ConsumeMessageServiceGeneral<T, K> {
+    pub fn new(
+        consume_message_concurrently_service: Option<ArcRefCellWrapper<T>>,
+        consume_message_orderly_service: Option<ArcRefCellWrapper<K>>,
+    ) -> Self {
+        Self {
+            consume_message_concurrently_service,
+            consume_message_orderly_service,
+        }
+    }
+
+    pub fn get_consume_message_concurrently_service_weak(&self) -> WeakCellWrapper<T> {
+        ArcRefCellWrapper::downgrade(self.consume_message_concurrently_service.as_ref().unwrap())
+    }
+}
+
+impl<T, K> ConsumeMessageServiceGeneral<T, K>
 where
     T: ConsumeMessageServiceTrait,
     K: ConsumeMessageServiceTrait,
 {
-    pub consume_message_orderly_service: ArcRefCellWrapper<T>,
-    pub consume_message_pop_orderly_service: ArcRefCellWrapper<K>,
+    pub fn start(&mut self) {
+        if let Some(consume_message_concurrently_service) =
+            &mut self.consume_message_concurrently_service
+        {
+            let consume_message_concurrently_service_weak =
+                ArcRefCellWrapper::downgrade(consume_message_concurrently_service);
+            consume_message_concurrently_service.start(consume_message_concurrently_service_weak);
+        }
+
+        if let Some(consume_message_orderly_service) = &mut self.consume_message_orderly_service {
+            let consume_message_pop_concurrently_service_weak =
+                ArcRefCellWrapper::downgrade(consume_message_orderly_service);
+            consume_message_orderly_service.start(consume_message_pop_concurrently_service_weak);
+        }
+    }
+
+    pub async fn shutdown(&mut self, await_terminate_millis: u64) {
+        todo!()
+    }
+
+    pub fn update_core_pool_size(&self, core_pool_size: usize) {
+        todo!()
+    }
+
+    pub fn inc_core_pool_size(&self) {
+        todo!()
+    }
+
+    pub fn dec_core_pool_size(&self) {
+        todo!()
+    }
+
+    pub fn get_core_pool_size(&self) -> usize {
+        todo!()
+    }
+
+    pub async fn consume_message_directly(
+        &self,
+        msg: &MessageExt,
+        broker_name: &str,
+    ) -> ConsumeMessageDirectlyResult {
+        todo!()
+    }
+
+    pub async fn submit_consume_request(
+        &self,
+        msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
+        process_queue: Arc<ProcessQueue>,
+        message_queue: MessageQueue,
+        dispatch_to_consume: bool,
+    ) {
+        if let Some(consume_message_concurrently_service) =
+            &self.consume_message_concurrently_service
+        {
+            consume_message_concurrently_service
+                .submit_consume_request(
+                    ArcRefCellWrapper::downgrade(consume_message_concurrently_service),
+                    msgs,
+                    process_queue,
+                    message_queue,
+                    dispatch_to_consume,
+                )
+                .await;
+        } else if let Some(consume_message_orderly_service) = &self.consume_message_orderly_service
+        {
+            consume_message_orderly_service
+                .submit_consume_request(
+                    ArcRefCellWrapper::downgrade(consume_message_orderly_service),
+                    msgs,
+                    process_queue,
+                    message_queue,
+                    dispatch_to_consume,
+                )
+                .await;
+        }
+    }
+
+    pub async fn submit_pop_consume_request(
+        &self,
+        msgs: Vec<MessageExt>,
+        process_queue: &PopProcessQueue,
+        message_queue: &MessageQueue,
+    ) {
+        unimplemented!("ConsumeMessageServiceGeneral not support submit_pop_consume_request")
+    }
+
+    pub fn get_consume_message_concurrently_service(&self) -> ArcRefCellWrapper<T> {
+        self.consume_message_concurrently_service
+            .as_ref()
+            .unwrap()
+            .clone()
+    }
+}
+
+pub struct ConsumeMessagePopServiceGeneral<T, K> {
+    consume_message_pop_concurrently_service: Option<ArcRefCellWrapper<T>>,
+    consume_message_pop_orderly_service: Option<ArcRefCellWrapper<K>>,
+}
+
+impl<T, K> ConsumeMessagePopServiceGeneral<T, K> {
+    pub fn new(
+        consume_message_pop_concurrently_service: Option<ArcRefCellWrapper<T>>,
+        consume_message_pop_orderly_service: Option<ArcRefCellWrapper<K>>,
+    ) -> Self {
+        Self {
+            consume_message_pop_concurrently_service,
+            consume_message_pop_orderly_service,
+        }
+    }
+}
+
+impl<T, K> ConsumeMessagePopServiceGeneral<T, K>
+where
+    T: ConsumeMessageServiceTrait,
+    K: ConsumeMessageServiceTrait,
+{
+    pub fn start(&mut self) {
+        if let Some(consume_message_pop_concurrently_service) =
+            &mut self.consume_message_pop_concurrently_service
+        {
+            let consume_message_pop_concurrently_service_weak =
+                ArcRefCellWrapper::downgrade(consume_message_pop_concurrently_service);
+            consume_message_pop_concurrently_service
+                .start(consume_message_pop_concurrently_service_weak);
+        }
+
+        if let Some(consume_message_pop_orderly_service) =
+            &mut self.consume_message_pop_orderly_service
+        {
+            let consume_message_pop_orderly_service_weak =
+                ArcRefCellWrapper::downgrade(consume_message_pop_orderly_service);
+            consume_message_pop_orderly_service.start(consume_message_pop_orderly_service_weak);
+        }
+    }
+
+    pub async fn shutdown(&mut self, await_terminate_millis: u64) {
+        todo!()
+    }
+
+    fn update_core_pool_size(&self, core_pool_size: usize) {
+        todo!()
+    }
+
+    fn inc_core_pool_size(&self) {
+        todo!()
+    }
+
+    fn dec_core_pool_size(&self) {
+        todo!()
+    }
+
+    fn get_core_pool_size(&self) -> usize {
+        todo!()
+    }
+
+    async fn consume_message_directly(
+        &self,
+        msg: &MessageExt,
+        broker_name: &str,
+    ) -> ConsumeMessageDirectlyResult {
+        todo!()
+    }
+
+    pub async fn submit_consume_request(
+        &self,
+        msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
+        process_queue: Arc<ProcessQueue>,
+        message_queue: MessageQueue,
+        dispatch_to_consume: bool,
+    ) {
+        unimplemented!("submit_consume_request")
+    }
+
+    async fn submit_pop_consume_request(
+        &self,
+        msgs: Vec<MessageExt>,
+        process_queue: &PopProcessQueue,
+        message_queue: &MessageQueue,
+    ) {
+        todo!()
+    }
 }
 
 pub trait ConsumeMessageServiceTrait {
-    fn start(&mut self, this: ArcRefCellWrapper<Self>);
+    fn start(&mut self, this: WeakCellWrapper<Self>);
 
-    fn shutdown(&mut self, await_terminate_millis: u64);
+    async fn shutdown(&mut self, await_terminate_millis: u64);
 
     fn update_core_pool_size(&self, core_pool_size: usize);
 
@@ -63,7 +255,7 @@ pub trait ConsumeMessageServiceTrait {
 
     async fn submit_consume_request(
         &self,
-        this: ArcRefCellWrapper<Self>,
+        this: WeakCellWrapper<Self>,
         msgs: Vec<ArcRefCellWrapper<MessageClientExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,

--- a/rocketmq-client/src/consumer/listener/message_listener_orderly.rs
+++ b/rocketmq-client/src/consumer/listener/message_listener_orderly.rs
@@ -25,8 +25,8 @@ use crate::Result;
 pub trait MessageListenerOrderly: Sync + Send {
     fn consume_message(
         &self,
-        msgs: Vec<MessageExt>,
-        context: ConsumeOrderlyContext,
+        msgs: &[&MessageExt],
+        context: &mut ConsumeOrderlyContext,
     ) -> Result<ConsumeOrderlyStatus>;
 }
 

--- a/rocketmq-client/src/consumer/message_queue_lock.rs
+++ b/rocketmq-client/src/consumer/message_queue_lock.rs
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rocketmq_common::common::message::message_queue::MessageQueue;
+use tokio::sync::Mutex;
+
+type LockObject = Arc<Mutex<()>>;
+type LockTable = Arc<Mutex<HashMap<MessageQueue, Arc<Mutex<HashMap<i32, LockObject>>>>>>;
+
+#[derive(Default)]
+pub(crate) struct MessageQueueLock {
+    mq_lock_table: LockTable,
+}
+
+impl MessageQueueLock {
+    pub fn new() -> Self {
+        MessageQueueLock {
+            mq_lock_table: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn fetch_lock_object(&self, mq: &MessageQueue) -> Arc<Mutex<()>> {
+        self.fetch_lock_object_with_sharding_key(mq, -1).await
+    }
+
+    pub async fn fetch_lock_object_with_sharding_key(
+        &self,
+        mq: &MessageQueue,
+        sharding_key_index: i32,
+    ) -> Arc<Mutex<()>> {
+        let mut mq_lock_table = self.mq_lock_table.lock().await;
+        let obj_map = mq_lock_table
+            .entry(mq.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(HashMap::new())));
+        let mut obj_map = obj_map.lock().await;
+        let lock = obj_map
+            .entry(sharding_key_index)
+            .or_insert_with(|| Arc::new(Mutex::new(())));
+        lock.clone()
+    }
+}

--- a/rocketmq-client/src/consumer/mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/mq_push_consumer.rs
@@ -75,9 +75,9 @@ pub trait MQPushConsumerLocal: MQConsumer {
             + Send
             + Sync;
 
-    async fn register_message_listener_orderly<ML>(&mut self, message_listener: ML)
+    fn register_message_listener_orderly<ML>(&mut self, message_listener: ML)
     where
-        ML: MessageListenerOrderly + Send + Sync;
+        ML: MessageListenerOrderly + Send + Sync + 'static;
 
     /// Subscribes to a topic with a subscription expression.
     ///

--- a/rocketmq-client/src/consumer/pull_callback.rs
+++ b/rocketmq-client/src/consumer/pull_callback.rs
@@ -24,7 +24,6 @@ use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use tracing::warn;
 
-use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::PULL_TIME_DELAY_MILLS_WHEN_BROKER_FLOW_CONTROL;
 use crate::consumer::consumer_impl::pull_request::PullRequest;
@@ -47,192 +46,6 @@ pub(crate) struct DefaultPullCallback {
     pub(crate) message_queue_inner: Option<MessageQueue>,
     pub(crate) subscription_data: Option<SubscriptionData>,
     pub(crate) pull_request: Option<PullRequest>,
-}
-
-impl DefaultPullCallback {
-    /*fn kkk(){
-        let pull_callback =
-            |pull_result_ext: Option<PullResultExt>,
-             err: Option<Box<dyn std::error::Error + Send>>| {
-                tokio::spawn(async move {
-                    if let Some(mut pull_result_ext) = pull_result_ext {
-                        this.pull_api_wrapper.as_mut().unwrap().process_pull_result(
-                            &message_queue_inner,
-                            &mut pull_result_ext,
-                            subscription_data.as_ref().unwrap(),
-                        );
-                        match pull_result_ext.pull_result.pull_status {
-                            PullStatus::Found => {
-                                let prev_request_offset = pull_request.next_offset;
-                                pull_request.set_next_offset(
-                                    pull_result_ext.pull_result.next_begin_offset as i64,
-                                );
-                                /*let pull_rt = get_current_millis() - begin_timestamp.elapsed().as_millis() as u64;
-                                self.client_instance.as_mut().unwrap().*/
-                                let mut first_msg_offset = i64::MAX;
-                                if pull_result_ext.pull_result.msg_found_list.is_empty() {
-                                    this.execute_pull_request_immediately(pull_request).await;
-                                } else {
-                                    first_msg_offset = pull_result_ext
-                                        .pull_result
-                                        .msg_found_list()
-                                        .first()
-                                        .unwrap()
-                                        .message_ext_inner
-                                        .queue_offset;
-                                    // DefaultMQPushConsumerImpl.this.getConsumerStatsManager().
-                                    // incPullTPS(pullRequest.getConsumerGroup(),
-                                    //
-                                    // pullRequest.getMessageQueue().getTopic(),
-                                    // pullResult.getMsgFoundList().size());
-                                    let vec = pull_result_ext
-                                        .pull_result
-                                        .msg_found_list
-                                        .clone()
-                                        .into_iter()
-                                        .map(|msg| msg.message_ext_inner)
-                                        .collect();
-                                    let dispatch_to_consume =
-                                        pull_request.process_queue.put_message(vec).await;
-                                    this.consume_message_concurrently_service
-                                        .as_mut()
-                                        .unwrap()
-                                        .consume_message_concurrently_service
-                                        .submit_consume_request(
-                                            pull_result_ext.pull_result.msg_found_list,
-                                            pull_request.get_process_queue().clone(),
-                                            pull_request.get_message_queue().clone(),
-                                            dispatch_to_consume,
-                                        )
-                                        .await;
-                                    if this.consumer_config.pull_interval > 0 {
-                                        this.execute_pull_request_later(
-                                            pull_request,
-                                            this.consumer_config.pull_interval,
-                                        );
-                                    } else {
-                                        this.execute_pull_request_immediately(pull_request).await;
-                                    }
-                                }
-                                if pull_result_ext.pull_result.next_begin_offset
-                                    < prev_request_offset as u64
-                                    || first_msg_offset < prev_request_offset
-                                {
-                                    warn!(
-                                        "[BUG] pull message result maybe data wrong, \
-                                         nextBeginOffset: {} firstMsgOffset: {} \
-                                         prevRequestOffset: {}",
-                                        pull_result_ext.pull_result.next_begin_offset,
-                                        prev_request_offset,
-                                        prev_request_offset
-                                    );
-                                }
-                            }
-                            PullStatus::NoNewMsg | PullStatus::NoMatchedMsg => {
-                                pull_request.next_offset =
-                                    pull_result_ext.pull_result.next_begin_offset as i64;
-                                this.correct_tags_offset(&pull_request).await;
-                                this.execute_pull_request_immediately(pull_request).await;
-                            }
-
-                            PullStatus::OffsetIllegal => {
-                                warn!(
-                                    "the pull request offset illegal, {},{}",
-                                    pull_result_ext.pull_result,
-                                    pull_result_ext.pull_result.pull_status
-                                );
-                                pull_request.next_offset =
-                                    pull_result_ext.pull_result.next_begin_offset as i64;
-                                pull_request.process_queue.set_dropped(true);
-                                tokio::spawn(async move {
-                                    let offset_store = this.offset_store.as_mut().unwrap();
-                                    offset_store
-                                        .update_and_freeze_offset(
-                                            pull_request.get_message_queue(),
-                                            pull_request.next_offset,
-                                        )
-                                        .await;
-                                    offset_store.persist(pull_request.get_message_queue()).await;
-                                    this.rebalance_impl
-                                        .remove_process_queue(pull_request.get_message_queue())
-                                        .await;
-                                    this.rebalance_impl
-                                        .rebalance_impl_inner
-                                        .client_instance
-                                        .as_ref()
-                                        .unwrap()
-                                        .re_balance_immediately()
-                                });
-                            }
-                        };
-                        return;
-                    }
-
-                    if let Some(err) = err {
-                        if !topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
-                            if let Some(er) = err.downcast_ref::<MQClientError>() {
-                                match er {
-                                    MQClientError::MQBrokerError(code, msg, addr) => {
-                                        if ResponseCode::from(*code)
-                                            == ResponseCode::SubscriptionNotLatest
-                                        {
-                                            warn!(
-                                                "the subscription is not latest, group={}",
-                                                this.consumer_config.consumer_group,
-                                            );
-                                        } else {
-                                            warn!(
-                                                "execute the pull request exception, group={}",
-                                                this.consumer_config.consumer_group
-                                            );
-                                        }
-                                    }
-                                    _ => {
-                                        warn!(
-                                            "execute the pull request exception, group={}",
-                                            this.consumer_config.consumer_group
-                                        );
-                                    }
-                                }
-                            } else {
-                                warn!(
-                                    "execute the pull request exception, group={}",
-                                    this.consumer_config.consumer_group
-                                );
-                            }
-                        }
-                        if let Some(er) = err.downcast_ref::<MQClientError>() {
-                            match er {
-                                MQClientError::MQBrokerError(code, msg, addr) => {
-                                    if ResponseCode::from(*code) == ResponseCode::FlowControl {
-                                        this.execute_pull_request_later(
-                                            pull_request,
-                                            PULL_TIME_DELAY_MILLS_WHEN_BROKER_FLOW_CONTROL,
-                                        );
-                                    } else {
-                                        this.execute_pull_request_later(
-                                            pull_request,
-                                            this.pull_time_delay_mills_when_exception,
-                                        );
-                                    }
-                                }
-                                _ => {
-                                    this.execute_pull_request_later(
-                                        pull_request,
-                                        this.pull_time_delay_mills_when_exception,
-                                    );
-                                }
-                            }
-                        } else {
-                            this.execute_pull_request_later(
-                                pull_request,
-                                this.pull_time_delay_mills_when_exception,
-                            );
-                        }
-                    }
-                });
-            };
-    }*/
 }
 
 impl PullCallback for DefaultPullCallback {
@@ -276,26 +89,13 @@ impl PullCallback for DefaultPullCallback {
                         .unwrap()
                         .message_ext_inner
                         .queue_offset;
-                    // DefaultMQPushConsumerImpl.self.push_consumer_impl.getConsumerStatsManager().
-                    // incPullTPS(pullRequest.getConsumerGroup(),
-                    //
-                    // pullRequest.getMessageQueue().getTopic(),
-                    // pullResult.getMsgFoundList().size());
                     let vec = pull_result_ext.pull_result.msg_found_list.clone();
                     let dispatch_to_consume = pull_request.process_queue.put_message(vec).await;
-                    let consume_message_concurrently_service_inner = push_consumer_impl
-                        .consume_message_concurrently_service
-                        .as_mut()
-                        .unwrap()
-                        .consume_message_concurrently_service
-                        .clone();
                     push_consumer_impl
-                        .consume_message_concurrently_service
+                        .consume_message_service
                         .as_mut()
                         .unwrap()
-                        .consume_message_concurrently_service
                         .submit_consume_request(
-                            consume_message_concurrently_service_inner,
                             pull_result_ext.pull_result.msg_found_list,
                             pull_request.get_process_queue().clone(),
                             pull_request.get_message_queue().clone(),
@@ -407,32 +207,14 @@ impl PullCallback for DefaultPullCallback {
             match er {
                 MQClientError::MQBrokerError(code, _, _) => {
                     if ResponseCode::from(*code) == ResponseCode::FlowControl {
-                        /*self.push_consumer_impl.execute_pull_request_later(
-                            pull_request,
-                            PULL_TIME_DELAY_MILLS_WHEN_BROKER_FLOW_CONTROL,
-                        );*/
                         PULL_TIME_DELAY_MILLS_WHEN_BROKER_FLOW_CONTROL
                     } else {
-                        /*self.push_consumer_impl.execute_pull_request_later(
-                            pull_request,
-                            self.push_consumer_impl.pull_time_delay_mills_when_exception,
-                        );*/
                         push_consumer_impl.pull_time_delay_mills_when_exception
                     }
                 }
-                _ => {
-                    /*self.push_consumer_impl.execute_pull_request_later(
-                        pull_request,
-                        self.push_consumer_impl.pull_time_delay_mills_when_exception,
-                    );*/
-                    push_consumer_impl.pull_time_delay_mills_when_exception
-                }
+                _ => push_consumer_impl.pull_time_delay_mills_when_exception,
             }
         } else {
-            /*self.push_consumer_impl.execute_pull_request_later(
-                pull_request,
-                self.push_consumer_impl.pull_time_delay_mills_when_exception,
-            );*/
             push_consumer_impl.pull_time_delay_mills_when_exception
         };
 

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -179,12 +179,6 @@ impl ClientRemotingProcessor {
         let request_header = request
             .decode_command_custom_header::<NotifyConsumerIdsChangedRequestHeader>()
             .unwrap();
-        println!(
-            "receive broker's notification[{}], the consumer group: {} changed, rebalance \
-             immediately",
-            channel.remote_address(),
-            request_header.consumer_group
-        );
         info!(
             "receive broker's notification[{}], the consumer group: {} changed, rebalance \
              immediately",

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -908,7 +908,6 @@ impl MQClientAPIImpl {
         {
             Ok(response) => {
                 let result = self.process_pull_response(response, addr).await;
-
                 match result {
                     Ok(pull_result) => {
                         pull_callback.on_success(pull_result).await;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1029 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new example configuration for an orderly message consumer.
	- Added a `MessageQueueLock` struct to manage locks for message queues.
	- Implemented new methods for managing message consumption and service lifecycle in `MQClientAPIImpl`.

- **Bug Fixes**
	- Updated method signatures to improve async handling and memory management across various services.

- **Refactor**
	- Streamlined logging practices and removed unnecessary complexity in `DefaultPullCallback`.
	- Consolidated message consumption services into a unified structure.

- **Documentation**
	- Enhanced clarity in method implementations and usage across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->