### PR TITLE
[ISSUE #1049]Implement MessageUtil

### DIFF
--- a/rocketmq-client/src/utils.rs
+++ b/rocketmq-client/src/utils.rs
@@ -14,23 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(dead_code)]
-#![allow(unused_variables)]
-extern crate core;
-
-use crate::error::MQClientError;
-
-mod admin;
-pub mod base;
-mod common;
-pub mod consumer;
-pub mod error;
-mod factory;
-mod hook;
-mod implementation;
-mod latency;
-pub mod producer;
-mod trace;
-pub mod utils;
-
-pub type Result<T> = std::result::Result<T, MQClientError>;
+pub mod message_util;

--- a/rocketmq-client/src/utils/message_util.rs
+++ b/rocketmq-client/src/utils/message_util.rs
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use bytes::Bytes;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_common::common::message::MessageConst;
+use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::common::mix_all;
+use rocketmq_common::MessageAccessor::MessageAccessor;
+
+use crate::common::client_error_code::ClientErrorCode;
+use crate::error::MQClientError::MQClientErr;
+use crate::Result;
+
+pub struct MessageUtil;
+
+impl MessageUtil {
+    pub fn create_reply_message(request_message: &Message, body: &[u8]) -> Result<Message> {
+        let mut reply_message = Message::default();
+        let cluster = request_message.get_property(MessageConst::PROPERTY_CLUSTER);
+        if let Some(cluster) = cluster {
+            reply_message.set_body(Bytes::copy_from_slice(body));
+            let reply_topic = mix_all::get_retry_topic(&cluster);
+            reply_message.set_topic(&reply_topic);
+            MessageAccessor::put_property(
+                &mut reply_message,
+                MessageConst::PROPERTY_MESSAGE_TYPE,
+                mix_all::REPLY_MESSAGE_FLAG,
+            );
+            if let Some(reply_to) =
+                request_message.get_property(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT)
+            {
+                MessageAccessor::put_property(
+                    &mut reply_message,
+                    MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT,
+                    reply_to.as_str(),
+                );
+            }
+            if let Some(correlation_id) =
+                request_message.get_property(MessageConst::PROPERTY_CORRELATION_ID)
+            {
+                MessageAccessor::put_property(
+                    &mut reply_message,
+                    MessageConst::PROPERTY_CORRELATION_ID,
+                    correlation_id.as_str(),
+                );
+            }
+            if let Some(ttl) = request_message.get_property(MessageConst::PROPERTY_MESSAGE_TTL) {
+                MessageAccessor::put_property(
+                    &mut reply_message,
+                    MessageConst::PROPERTY_MESSAGE_TTL,
+                    ttl.as_str(),
+                );
+            }
+            Ok(reply_message)
+        } else {
+            Err(MQClientErr(
+                ClientErrorCode::CREATE_REPLY_MESSAGE_EXCEPTION,
+                format!(
+                    "create reply message fail, requestMessage error, property[{}] is null.",
+                    MessageConst::PROPERTY_CLUSTER
+                ),
+            ))
+        }
+    }
+
+    pub fn get_reply_to_client(reply_message: &Message) -> Option<String> {
+        reply_message.get_property(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rocketmq_common::common::message::message_single::Message;
+    use rocketmq_common::common::message::MessageConst;
+    use rocketmq_common::common::mix_all;
+    use rocketmq_common::MessageAccessor::MessageAccessor;
+
+    use super::*;
+    use crate::common::client_error_code::ClientErrorCode;
+    use crate::error::MQClientError::MQClientErr;
+
+    fn create_test_message(properties: HashMap<&str, &str>) -> Message {
+        let mut message = Message::default();
+        for (key, value) in properties {
+            MessageAccessor::put_property(&mut message, key, value);
+        }
+        message
+    }
+
+    #[test]
+    fn create_reply_message_success() {
+        let properties = HashMap::from([
+            (MessageConst::PROPERTY_CLUSTER, "testCluster"),
+            (MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT, "client1"),
+            (MessageConst::PROPERTY_CORRELATION_ID, "correlation1"),
+            (MessageConst::PROPERTY_MESSAGE_TTL, "1000"),
+        ]);
+        let request_message = create_test_message(properties);
+        let body = b"reply body";
+
+        let result = MessageUtil::create_reply_message(&request_message, body).unwrap();
+
+        assert_eq!(result.get_topic(), mix_all::get_retry_topic("testCluster"));
+        assert_eq!(
+            result.get_property(MessageConst::PROPERTY_MESSAGE_TYPE),
+            Some(mix_all::REPLY_MESSAGE_FLAG.to_string())
+        );
+        assert_eq!(
+            result.get_property(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT),
+            Some("client1".to_string())
+        );
+        assert_eq!(
+            result.get_property(MessageConst::PROPERTY_CORRELATION_ID),
+            Some("correlation1".to_string())
+        );
+        assert_eq!(
+            result.get_property(MessageConst::PROPERTY_MESSAGE_TTL),
+            Some("1000".to_string())
+        );
+    }
+
+    #[test]
+    fn create_reply_message_missing_cluster() {
+        let properties = HashMap::new();
+        let request_message = create_test_message(properties);
+        let body = b"reply body";
+
+        let result = MessageUtil::create_reply_message(&request_message, body);
+
+        assert!(result.is_err());
+        if let Err(MQClientErr(code, message)) = result {
+            assert_eq!(code, ClientErrorCode::CREATE_REPLY_MESSAGE_EXCEPTION);
+            assert!(message.contains("property[CLUSTER] is null"));
+        }
+    }
+
+    #[test]
+    fn get_reply_to_client_success() {
+        let properties =
+            HashMap::from([(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT, "client1")]);
+        let reply_message = create_test_message(properties);
+
+        let result = MessageUtil::get_reply_to_client(&reply_message);
+
+        assert_eq!(result, Some("client1".to_string()));
+    }
+
+    #[test]
+    fn get_reply_to_client_missing_property() {
+        let properties = HashMap::new();
+        let reply_message = create_test_message(properties);
+
+        let result = MessageUtil::get_reply_to_client(&reply_message);
+
+        assert_eq!(result, None);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1049 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `utils` module for enhanced functionality.
	- Added `message_util` module for managing reply messages.
	- Implemented `MessageUtil` struct with methods for creating and handling reply messages.

- **Bug Fixes**
	- Included unit tests to ensure the reliability of the new message handling features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->