### PR TITLE
[ISSUE ##1052] Support request code LOCK_BATCH_MQ(41)

### DIFF
--- a/rocketmq-broker/src/client/net/broker_to_client.rs
+++ b/rocketmq-broker/src/client/net/broker_to_client.rs
@@ -18,7 +18,7 @@ use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 
 use crate::error::BrokerError::BrokerClientError;
-use crate::BrokerResult;
+use crate::Result;
 
 #[derive(Default, Clone)]
 pub struct Broker2Client;
@@ -29,7 +29,7 @@ impl Broker2Client {
         channel: &mut Channel,
         request: RemotingCommand,
         timeout_millis: u64,
-    ) -> BrokerResult<RemotingCommand> {
+    ) -> Result<RemotingCommand> {
         match channel.send_wait_response(request, timeout_millis).await {
             Ok(value) => Ok(value),
             Err(e) => Err(BrokerClientError(e)),

--- a/rocketmq-broker/src/error.rs
+++ b/rocketmq-broker/src/error.rs
@@ -20,4 +20,7 @@ use thiserror::Error;
 pub enum BrokerError {
     #[error("broker client error: {0}")]
     BrokerClientError(#[from] rocketmq_remoting::error::Error),
+
+    #[error("Client exception occurred: CODE:{0}, broker address:{2}, Message:{1}")]
+    MQBrokerError(i32, String, String),
 }

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -47,4 +47,4 @@ pub(crate) mod topic;
 pub(crate) mod util;
 
 type RemotingError = rocketmq_remoting::error::Error;
-type BrokerResult<T> = Result<T, BrokerError>;
+type Result<T> = std::result::Result<T, BrokerError>;

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -31,7 +31,6 @@ use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::body::broker_body::register_broker_body::RegisterBrokerBody;
 use rocketmq_remoting::protocol::body::kv_table::KVTable;
-use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
 use rocketmq_remoting::protocol::body::response::lock_batch_response_body::LockBatchResponseBody;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
 use rocketmq_remoting::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader;
@@ -351,7 +350,7 @@ impl BrokerOuterAPI {
                     Ok(lock_batch_response_body.lock_ok_mq_set)
                 } else {
                     Err(BrokerError::MQBrokerError(
-                        response.code() as i32,
+                        response.code(),
                         response.remark().cloned().unwrap_or("".to_string()),
                         "".to_string(),
                     ))

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -14,12 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::Weak;
 
 use dns_lookup::lookup_host;
 use rocketmq_common::common::broker::broker_config::BrokerIdentity;
 use rocketmq_common::common::config::TopicConfig;
+use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::utils::crc32_utils;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_common::ArcRefCellWrapper;
@@ -29,7 +31,10 @@ use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::body::broker_body::register_broker_body::RegisterBrokerBody;
 use rocketmq_remoting::protocol::body::kv_table::KVTable;
+use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
+use rocketmq_remoting::protocol::body::response::lock_batch_response_body::LockBatchResponseBody;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
+use rocketmq_remoting::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::register_broker_header::RegisterBrokerRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::register_broker_header::RegisterBrokerResponseHeader;
 use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::RegisterTopicRequestHeader;
@@ -37,6 +42,7 @@ use rocketmq_remoting::protocol::namesrv::RegisterBrokerResult;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::route::route_data_view::QueueData;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::remoting::RemotingService;
 use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
@@ -47,6 +53,10 @@ use rocketmq_remoting::runtime::RPCHook;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
+
+use crate::error::BrokerError;
+use crate::error::BrokerError::BrokerClientError;
+use crate::Result;
 
 pub struct BrokerOuterAPI {
     remoting_client: ArcRefCellWrapper<RocketmqDefaultClient<DefaultRemotingRequestProcessor>>,
@@ -316,6 +326,39 @@ impl BrokerOuterAPI {
 
     pub fn rpc_client(&self) -> &RpcClientImpl {
         &self.rpc_client
+    }
+
+    pub async fn lock_batch_mq_async(
+        &self,
+        addr: String,
+        request_body: bytes::Bytes,
+        timeout_millis: u64,
+    ) -> Result<HashSet<MessageQueue>> {
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::LockBatchMq,
+            LockBatchMqRequestHeader::default(),
+        );
+        request.set_body_mut_ref(Some(request_body));
+        let result = self
+            .remoting_client
+            .invoke_async(Some(addr), request, timeout_millis)
+            .await;
+        match result {
+            Ok(response) => {
+                if ResponseCode::from(response.code()) == ResponseCode::Success {
+                    let lock_batch_response_body =
+                        LockBatchResponseBody::decode(response.get_body().unwrap()).unwrap();
+                    Ok(lock_batch_response_body.lock_ok_mq_set)
+                } else {
+                    Err(BrokerError::MQBrokerError(
+                        response.code() as i32,
+                        response.remark().cloned().unwrap_or("".to_string()),
+                        "".to_string(),
+                    ))
+                }
+            }
+            Err(e) => Err(BrokerClientError(e)),
+        }
     }
 }
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/batch_mq_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/batch_mq_handler.rs
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::RemotingDeserializable;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+
+use crate::processor::admin_broker_processor::Inner;
+
+#[derive(Clone)]
+pub(super) struct BatchMqHandler {
+    inner: Inner,
+}
+
+impl BatchMqHandler {
+    pub(super) fn new(inner: Inner) -> Self {
+        Self { inner }
+    }
+
+    pub async fn lock_natch_mq(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        let mut request_body = LockBatchRequestBody::decode(request.get_body().unwrap()).unwrap();
+        let mut lock_ok_mqset = HashSet::new();
+        let self_lock_okmqset = self.inner.rebalance_lock_manager.try_lock_batch(
+            request_body.consumer_group.as_ref().unwrap(),
+            &request_body.mq_set,
+            request_body.client_id.as_ref().unwrap(),
+        );
+        if request_body.only_this_broker || !self.inner.broker_config.lock_in_strict_mode {
+            lock_ok_mqset = self_lock_okmqset;
+        } else {
+            request_body.only_this_broker = true;
+            let replica_size = self.inner.message_store_config.total_replicas;
+            let quorum = replica_size / 2 + 1;
+            if quorum <= 1 {
+                lock_ok_mqset = self_lock_okmqset;
+            } else {
+                let mut mq_lock_map = HashMap::with_capacity(32);
+                for mq in self_lock_okmqset.iter() {
+                    if !mq_lock_map.contains_key(mq) {
+                        mq_lock_map.insert(mq.clone(), 0);
+                    }
+                    mq_lock_map.insert(mq.clone(), mq_lock_map.get(mq).unwrap() + 1);
+                }
+                let mut addr_map = HashMap::with_capacity(8);
+                addr_map.extend(self.inner.broker_member_group.broker_addrs.clone());
+                addr_map.remove(&self.inner.broker_config.broker_identity.broker_id);
+
+                for (mq, broker_addr) in addr_map {
+
+                }
+            }
+        }
+        unimplemented!("lock_natch_mq")
+    }
+
+    pub async fn unlock_batch_mq(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        unimplemented!("unlockBatchMQ")
+    }
+}

--- a/rocketmq-client/src/error.rs
+++ b/rocketmq-client/src/error.rs
@@ -25,7 +25,7 @@ pub enum MQClientError {
     #[error("{0}")]
     RemotingTooMuchRequestError(String),
 
-    #[error("Client exception occurred: CODE:{0}, broker address:{1}, Message:{2}")]
+    #[error("Client exception occurred: CODE:{0}, broker address:{2}, Message:{1}")]
     MQBrokerError(i32, String, String),
 
     #[error("Client exception occurred: CODE:{0}, Message:{1}")]

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -169,6 +169,7 @@ pub struct BrokerConfig {
     pub auto_delete_unused_stats: bool,
     pub forward_timeout: u64,
     pub store_reply_message_enable: bool,
+    pub lock_in_strict_mode: bool,
 }
 
 impl Default for BrokerConfig {
@@ -245,6 +246,7 @@ impl Default for BrokerConfig {
             enable_mixed_message_type: false,
             auto_delete_unused_stats: false,
             store_reply_message_enable: true,
+            lock_in_strict_mode: false,
         }
     }
 }

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -648,15 +648,13 @@ impl RouteInfoManager {
         cluster_name: &str,
         broker_name: &str,
     ) -> Option<BrokerMemberGroup> {
+        let mut group_member =
+            BrokerMemberGroup::new(cluster_name.to_string(), broker_name.to_string());
         if let Some(broker_data) = self.broker_addr_table.get(broker_name) {
             let map = broker_data.broker_addrs().clone();
-            return Some(BrokerMemberGroup::new(
-                Some(cluster_name.to_string()),
-                Some(broker_name.to_string()),
-                Some(map),
-            ));
+            group_member.broker_addrs.extend(map);
         }
-        None
+        Some(group_member)
     }
 
     pub(crate) fn wipe_write_perm_of_broker_by_lock(&mut self, broker_name: &str) -> i32 {

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -652,7 +652,9 @@ impl RouteInfoManager {
             BrokerMemberGroup::new(cluster_name.to_string(), broker_name.to_string());
         if let Some(broker_data) = self.broker_addr_table.get(broker_name) {
             let map = broker_data.broker_addrs().clone();
-            group_member.broker_addrs.extend(map);
+            for (key, value) in map {
+                group_member.broker_addrs.insert(key as u64, value);
+            }
         }
         Some(group_member)
     }

--- a/rocketmq-remoting/src/protocol/body/broker_body/broker_member_group.rs
+++ b/rocketmq-remoting/src/protocol/body/broker_body/broker_member_group.rs
@@ -22,21 +22,17 @@ use serde::Serialize;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct BrokerMemberGroup {
-    pub cluster: Option<String>,
-    pub broker_name: Option<String>,
-    pub broker_addrs: Option<HashMap<i64, String>>,
+    pub cluster: String,
+    pub broker_name: String,
+    pub broker_addrs: HashMap<u64 /* brokerId */, String /* broker address */>,
 }
 
 impl BrokerMemberGroup {
-    pub fn new(
-        cluster: Option<String>,
-        broker_name: Option<String>,
-        broker_addrs: Option<HashMap<i64, String>>,
-    ) -> Self {
+    pub fn new(cluster: String, broker_name: String) -> Self {
         Self {
             cluster,
             broker_name,
-            broker_addrs,
+            broker_addrs: HashMap::new(),
         }
     }
 }

--- a/rocketmq-remoting/src/protocol/body/request/lock_batch_request_body.rs
+++ b/rocketmq-remoting/src/protocol/body/request/lock_batch_request_body.rs
@@ -21,7 +21,7 @@ use rocketmq_common::common::message::message_queue::MessageQueue;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LockBatchRequestBody {
     pub consumer_group: Option<String>,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1052 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new method for batch locking of message queues in the Broker API.
	- Added a new field for managing broker member groups in the BrokerRuntime.

- **Improvements**
	- Simplified error handling in the Broker2Client communication.
	- Enhanced the BrokerConfig with a strict mode option.
	- Updated the error message format for better clarity in client errors.

- **Bug Fixes**
	- Corrected the handling of message queue locking and unlocking.

- **Documentation**
	- Updated various method signatures and added new methods for better functionality and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->