### PR TITLE
[ISSUE #1067] Supprot mq fault strategy

### DIFF
--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -457,7 +457,9 @@ impl MQClientAPIImpl {
                         }
                     }
                     let duration = (Instant::now() - begin_start_time).as_millis() as u64;
-                    producer.update_fault_item(broker_name, duration, false, true);
+                    producer
+                        .update_fault_item(broker_name, duration, false, true)
+                        .await;
                     return;
                 }
                 let send_result = self.process_send_response(broker_name, msg, &response, addr);
@@ -470,11 +472,15 @@ impl MQClientAPIImpl {
                         }
                         let duration = (Instant::now() - begin_start_time).as_millis() as u64;
                         send_callback.as_ref().unwrap()(Some(&result), None);
-                        producer.update_fault_item(broker_name, duration, false, true);
+                        producer
+                            .update_fault_item(broker_name, duration, false, true)
+                            .await;
                     }
                     Err(err) => {
                         let duration = (Instant::now() - begin_start_time).as_millis() as u64;
-                        producer.update_fault_item(broker_name, duration, true, true);
+                        producer
+                            .update_fault_item(broker_name, duration, true, true)
+                            .await;
                         Box::pin(self.on_exception_impl(
                             broker_name,
                             msg,

--- a/rocketmq-client/src/latency/latency_fault_tolerance.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance.rs
@@ -14,10 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use crate::latency::resolver::Resolver;
-use crate::latency::service_detector::ServiceDetector;
+use std::any::Any;
 
-pub trait LatencyFaultTolerance<T>: Send + Sync + 'static {
+use rocketmq_common::ArcRefCellWrapper;
+
+#[allow(async_fn_in_trait)]
+pub trait LatencyFaultTolerance<T, R, S>: Send + Sync + 'static {
     /// Update brokers' states, to decide if they are good or not.
     ///
     /// # Arguments
@@ -27,7 +29,7 @@ pub trait LatencyFaultTolerance<T>: Send + Sync + 'static {
     /// * `not_available_duration` - Corresponding not available time, ms. The broker will be not
     ///   available until it
     /// * `reachable` - To decide if this broker is reachable or not.
-    fn update_fault_item(
+    async fn update_fault_item(
         &mut self,
         name: T,
         current_latency: u64,
@@ -44,7 +46,7 @@ pub trait LatencyFaultTolerance<T>: Send + Sync + 'static {
     /// # Returns
     ///
     /// * `true` if the broker is available, `false` otherwise.
-    fn is_available(&self, name: &T) -> bool;
+    async fn is_available(&self, name: &T) -> bool;
 
     /// To check if this broker is reachable.
     ///
@@ -72,13 +74,13 @@ pub trait LatencyFaultTolerance<T>: Send + Sync + 'static {
     fn pick_one_at_least(&self) -> T;
 
     /// Start a new thread, to detect the broker's reachable tag.
-    fn start_detector(&self);
+    fn start_detector(this: ArcRefCellWrapper<Self>);
 
     /// Shutdown threads that started by `LatencyFaultTolerance`.
     fn shutdown(&self);
 
     /// A function reserved, just detect by once, won't create a new thread.
-    fn detect_by_one_round(&self);
+    async fn detect_by_one_round(&self);
 
     /// Use it to set the detect timeout bound.
     ///
@@ -109,7 +111,11 @@ pub trait LatencyFaultTolerance<T>: Send + Sync + 'static {
     /// * `true` if the detector should be started, `false` otherwise.
     fn is_start_detector_enable(&self) -> bool;
 
-    fn set_resolver(&mut self, resolver: Box<dyn Resolver>);
+    fn set_resolver(&mut self, resolver: R);
 
-    fn set_service_detector(&mut self, service_detector: Box<dyn ServiceDetector>);
+    fn set_service_detector(&mut self, service_detector: S);
+
+    fn as_any(&self) -> &dyn Any;
+
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 }

--- a/rocketmq-client/src/latency/latency_fault_tolerance.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance.rs
@@ -57,21 +57,21 @@ pub trait LatencyFaultTolerance<T, R, S>: Send + Sync + 'static {
     /// # Returns
     ///
     /// * `true` if the broker is reachable, `false` otherwise.
-    fn is_reachable(&self, name: &T) -> bool;
+    async fn is_reachable(&self, name: &T) -> bool;
 
     /// Remove the broker in this fault item table.
     ///
     /// # Arguments
     ///
     /// * `name` - Broker's name.
-    fn remove(&mut self, name: &T);
+    async fn remove(&mut self, name: &T);
 
     /// The worst situation, no broker can be available. Then choose a random one.
     ///
     /// # Returns
     ///
     /// * A random broker will be returned.
-    fn pick_one_at_least(&self) -> T;
+    async fn pick_one_at_least(&self) -> Option<T>;
 
     /// Start a new thread, to detect the broker's reachable tag.
     fn start_detector(this: ArcRefCellWrapper<Self>);

--- a/rocketmq-client/src/latency/resolver.rs
+++ b/rocketmq-client/src/latency/resolver.rs
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-pub trait Resolver: Send + Sync + 'static {
-    fn resolve(&self, name: &str) -> String;
+
+#[trait_variant::make(Resolver: Send)]
+pub trait ResolverLocal: Send + Sync + 'static {
+    async fn resolve(&self, name: &str) -> Option<String>;
 }

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -247,11 +247,12 @@ pub struct DefaultMQProducer {
 }
 
 impl DefaultMQProducer {
+    #[inline]
     pub fn builder() -> DefaultMQProducerBuilder {
         DefaultMQProducerBuilder::new()
     }
     pub fn new() -> Self {
-        unimplemented!()
+        Self::builder().build()
     }
 
     pub fn client_config(&self) -> &ClientConfig {

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -741,7 +741,8 @@ impl DefaultMQProducerImpl {
                                     (end_timestamp - begin_timestamp_prev).as_millis() as u64,
                                     false,
                                     true,
-                                );
+                                )
+                                .await;
                                 return match communication_mode {
                                     CommunicationMode::Sync => {
                                         if let Some(ref result) = send_result {
@@ -770,7 +771,8 @@ impl DefaultMQProducerImpl {
                                         elapsed,
                                         false,
                                         true,
-                                    );
+                                    )
+                                    .await;
                                     warn!(
                                         "sendKernelImpl exception, resend at once, InvokeID: {}, \
                                          RT: {}ms, Broker: {:?},{}",
@@ -792,7 +794,8 @@ impl DefaultMQProducerImpl {
                                         elapsed,
                                         true,
                                         false,
-                                    );
+                                    )
+                                    .await;
                                     if self.producer_config.retry_response_codes().contains(&code) {
                                         exception = Some(err);
                                         continue;
@@ -813,14 +816,16 @@ impl DefaultMQProducerImpl {
                                             elapsed,
                                             true,
                                             false,
-                                        );
+                                        )
+                                        .await;
                                     } else {
                                         self.update_fault_item(
                                             mq.as_ref().unwrap().get_broker_name(),
                                             elapsed,
                                             true,
                                             true,
-                                        );
+                                        )
+                                        .await;
                                     }
                                     exception = Some(err);
                                     continue;
@@ -901,19 +906,17 @@ impl DefaultMQProducerImpl {
     }
 
     #[inline]
-    pub fn update_fault_item(
+    pub async fn update_fault_item(
         &self,
         broker_name: &str,
         current_latency: u64,
         isolation: bool,
         reachable: bool,
     ) {
-        self.mq_fault_strategy.mut_from_ref().update_fault_item(
-            broker_name,
-            current_latency,
-            isolation,
-            reachable,
-        );
+        self.mq_fault_strategy
+            .mut_from_ref()
+            .update_fault_item(broker_name, current_latency, isolation, reachable)
+            .await;
     }
 
     async fn send_kernel_impl<T>(

--- a/rocketmq-remoting/src/protocol/route/route_data_view.rs
+++ b/rocketmq-remoting/src/protocol/route/route_data_view.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
 use rand::seq::IteratorRandom;
@@ -33,6 +34,18 @@ pub struct BrokerData {
     zone_name: Option<String>,
     #[serde(rename = "enableActingMaster")]
     enable_acting_master: bool,
+}
+
+impl PartialOrd for BrokerData {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BrokerData {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.broker_name.cmp(&other.broker_name)
+    }
 }
 
 impl BrokerData {

--- a/rocketmq-remoting/src/protocol/route/topic_route_data.rs
+++ b/rocketmq-remoting/src/protocol/route/topic_route_data.rs
@@ -44,10 +44,10 @@ impl TopicRouteData {
         }
         let mut now = TopicRouteData::from_existing(self);
         let mut old = TopicRouteData::from_existing(old_data.unwrap());
-        now.queue_datas.sort_by(|a, b| a.cmp(&b));
-        now.broker_datas.sort_by(|a, b| a.cmp(&b));
-        old.queue_datas.sort_by(|a, b| a.cmp(&b));
-        old.broker_datas.sort_by(|a, b| a.cmp(&b));
+        now.queue_datas.sort();
+        now.broker_datas.sort();
+        old.queue_datas.sort();
+        old.broker_datas.sort();
         now != old
     }
 

--- a/rocketmq-remoting/src/protocol/route/topic_route_data.rs
+++ b/rocketmq-remoting/src/protocol/route/topic_route_data.rs
@@ -42,14 +42,13 @@ impl TopicRouteData {
         if old_data.is_none() {
             return true;
         }
-        /*let mut now = TopicRouteData::from_existing(self);
-        let mut old = TopicRouteData::from_existing(old_data.unwrap());*/
-        /*now.queue_datas.sort_by(|a, b| a.cmp(&b));
+        let mut now = TopicRouteData::from_existing(self);
+        let mut old = TopicRouteData::from_existing(old_data.unwrap());
+        now.queue_datas.sort_by(|a, b| a.cmp(&b));
         now.broker_datas.sort_by(|a, b| a.cmp(&b));
         old.queue_datas.sort_by(|a, b| a.cmp(&b));
-        old.broker_datas.sort_by(|a, b| a.cmp(&b));*/
-        //now != old
-        false
+        old.broker_datas.sort_by(|a, b| a.cmp(&b));
+        now != old
     }
 
     pub fn new() -> Self {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1067 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced asynchronous capabilities for message sending and fault tolerance mechanisms.
	- Introduced new `ResolverLocal` trait for non-blocking resolution of broker addresses.

- **Bug Fixes**
	- Improved error handling for message sending and topic routing.
	- Fixed comparison logic in `topic_route_data_changed` to ensure accurate topic route data changes.

- **Documentation**
	- Updated method signatures and added inline attributes for better performance.

- **Refactor**
	- Streamlined the instantiation process of `DefaultMQProducer` using a builder pattern.
	- Modified fault strategy methods for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->