### PR TITLE
[ISSUE #1069]Add Shutdown struct

### DIFF
--- a/rocketmq/src/lib.rs
+++ b/rocketmq/src/lib.rs
@@ -16,12 +16,14 @@
  */
 pub mod count_down_latch;
 pub mod rocketmq_tokio_lock;
+mod shutdown;
 
 pub use count_down_latch::CountDownLatch;
 /// Re-export rocketmq main.
 pub use rocketmq::main;
 pub use rocketmq_tokio_lock::RocketMQTokioMutex;
 pub use rocketmq_tokio_lock::RocketMQTokioRwLock;
+pub use shutdown::Shutdown;
 /// Re-export tokio module.
 pub use tokio as rocketmq;
 

--- a/rocketmq/src/shutdown.rs
+++ b/rocketmq/src/shutdown.rs
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use tokio::sync::broadcast;
+
+pub struct Shutdown<T> {
+    /// `true` if the shutdown signal has been received
+    is_shutdown: bool,
+
+    /// The receiver half of the channel used to listen for shutdown.
+    notify: broadcast::Receiver<T>,
+}
+
+impl<T> Shutdown<T>
+where
+    T: Clone,
+{
+    /// Create a new `Shutdown` backed by the given `broadcast::Receiver`.
+    pub fn new(notify: broadcast::Receiver<T>) -> Shutdown<T> {
+        Shutdown {
+            is_shutdown: false,
+            notify,
+        }
+    }
+
+    /// Returns `true` if the shutdown signal has been received.
+    pub fn is_shutdown(&self) -> bool {
+        self.is_shutdown
+    }
+
+    /// Receive the shutdown notice, waiting if necessary.
+    pub async fn recv(&mut self) {
+        // If the shutdown signal has already been received, then return
+        // immediately.
+        if self.is_shutdown {
+            return;
+        }
+
+        // Cannot receive a "lag error" as only one value is ever sent.
+        let _ = self.notify.recv().await;
+
+        // Remember that the signal has been received.
+        self.is_shutdown = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::broadcast;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn shutdown_initial_state() {
+        let (_, rx) = broadcast::channel::<()>(1);
+        let shutdown = Shutdown::new(rx);
+        assert!(!shutdown.is_shutdown());
+    }
+
+    #[tokio::test]
+    async fn shutdown_signal_received() {
+        let (tx, rx) = broadcast::channel::<()>(1);
+        let mut shutdown = Shutdown::new(rx);
+        tx.send(()).unwrap();
+        shutdown.recv().await;
+        assert!(shutdown.is_shutdown());
+    }
+
+    #[tokio::test]
+    async fn shutdown_signal_already_received() {
+        let (tx, rx) = broadcast::channel::<()>(1);
+        let mut shutdown = Shutdown::new(rx);
+        tx.send(()).unwrap();
+        shutdown.recv().await;
+        shutdown.recv().await;
+        assert!(shutdown.is_shutdown());
+    }
+}

--- a/rocketmq/src/shutdown.rs
+++ b/rocketmq/src/shutdown.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use tokio::sync::broadcast;
+use tracing::warn;
 
 pub struct Shutdown<T> {
     /// `true` if the shutdown signal has been received
@@ -50,7 +51,10 @@ where
         }
 
         // Cannot receive a "lag error" as only one value is ever sent.
-        let _ = self.notify.recv().await;
+        let result = self.notify.recv().await;
+        if result.is_err() {
+            warn!("Failed to receive shutdown signal");
+        }
 
         // Remember that the signal has been received.
         self.is_shutdown = true;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1069 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Shutdown` module for managing shutdown signals in an asynchronous context.
	- Added methods to check shutdown status and wait for shutdown signals.

- **Tests**
	- Implemented asynchronous tests to verify the functionality of the `Shutdown` struct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->