### PR TITLE
[ISSUE #1076]PullMessageService and RebalanceService add shutdown method

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
@@ -141,8 +141,12 @@ impl PullMessageService {
     }
 
     pub fn shutdown(&self) {
-        if let Err(e) = self.tx_shutdown.as_ref().unwrap().send(()) {
-            warn!("Failed to send shutdown signal to pull_tx, error: {:?}", e);
+        if let Some(tx_shutdown) = &self.tx_shutdown {
+            if let Err(e) = tx_shutdown.send(()) {
+                warn!("Failed to send shutdown signal to pull_tx, error: {:?}", e);
+            }
+        } else {
+            warn!("Attempted to shutdown but tx_shutdown is None. Ensure `start` is called before `shutdown`.");
         }
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
@@ -16,6 +16,7 @@
  */
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_common::ArcRefCellWrapper;
+use rocketmq_rust::Shutdown;
 use tracing::info;
 use tracing::warn;
 
@@ -27,19 +28,25 @@ use crate::factory::mq_client_instance::MQClientInstance;
 #[derive(Clone)]
 pub struct PullMessageService {
     tx: Option<tokio::sync::mpsc::Sender<Box<dyn MessageRequest + Send + 'static>>>,
+    tx_shutdown: Option<tokio::sync::broadcast::Sender<()>>,
 }
 
 impl PullMessageService {
     pub fn new() -> Self {
-        PullMessageService { tx: None }
+        PullMessageService {
+            tx: None,
+            tx_shutdown: None,
+        }
     }
     pub async fn start(&mut self, mut instance: ArcRefCellWrapper<MQClientInstance>) {
         let (tx, mut rx) =
             tokio::sync::mpsc::channel::<Box<dyn MessageRequest + Send + 'static>>(1024 * 4);
+        let (mut shutdown, tx_shutdown) = Shutdown::new(1);
         self.tx = Some(tx);
+        self.tx_shutdown = Some(tx_shutdown);
         tokio::spawn(async move {
             info!(">>>>>>>>>>>>>>>>>>>>>>>PullMessageService  started<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
-            while let Some(request) = rx.recv().await {
+            /*while let Some(request) = rx.recv().await {
                 if request.get_message_request_mode() == MessageRequestMode::Pull {
                     let pull_request =
                         unsafe { *Box::from_raw(Box::into_raw(request) as *mut PullRequest) };
@@ -48,6 +55,32 @@ impl PullMessageService {
                     let pop_request =
                         unsafe { *Box::from_raw(Box::into_raw(request) as *mut PopRequest) };
                     PullMessageService::pop_message(pop_request, instance.as_mut()).await;
+                }
+            }*/
+            if shutdown.is_shutdown() {
+                info!("PullMessageService shutdown");
+                return;
+            }
+            loop {
+                tokio::select! {
+                    _ = shutdown.recv() => {
+                        info!("PullMessageService shutdown");
+                    }
+                    Some(request) = rx.recv() => {
+                        if request.get_message_request_mode() == MessageRequestMode::Pull {
+                            let pull_request =
+                                unsafe { *Box::from_raw(Box::into_raw(request) as *mut PullRequest) };
+                            PullMessageService::pull_message(pull_request, instance.as_mut()).await;
+                        } else {
+                            let pop_request =
+                                unsafe { *Box::from_raw(Box::into_raw(request) as *mut PopRequest) };
+                            PullMessageService::pop_message(pop_request, instance.as_mut()).await;
+                        }
+                    }
+                }
+                if shutdown.is_shutdown() {
+                    info!("PullMessageService shutdown");
+                    break;
                 }
             }
         });
@@ -104,6 +137,12 @@ impl PullMessageService {
     pub async fn execute_pop_pull_request_immediately(&self, pop_request: PopRequest) {
         if let Err(e) = self.tx.as_ref().unwrap().send(Box::new(pop_request)).await {
             warn!("Failed to send pull request to pull_tx, error: {:?}", e);
+        }
+    }
+
+    pub fn shutdown(&self) {
+        if let Err(e) = self.tx_shutdown.as_ref().unwrap().send(()) {
+            warn!("Failed to send shutdown signal to pull_tx, error: {:?}", e);
         }
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
@@ -146,7 +146,10 @@ impl PullMessageService {
                 warn!("Failed to send shutdown signal to pull_tx, error: {:?}", e);
             }
         } else {
-            warn!("Attempted to shutdown but tx_shutdown is None. Ensure `start` is called before `shutdown`.");
+            warn!(
+                "Attempted to shutdown but tx_shutdown is None. Ensure `start` is called before \
+                 `shutdown`."
+            );
         }
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
@@ -19,10 +19,12 @@ use std::time::Duration;
 
 use once_cell::sync::Lazy;
 use rocketmq_common::ArcRefCellWrapper;
+use rocketmq_rust::Shutdown;
 use tokio::select;
 use tokio::sync::Notify;
 use tokio::time::Instant;
 use tracing::info;
+use tracing::warn;
 
 use crate::factory::mq_client_instance::MQClientInstance;
 
@@ -47,17 +49,21 @@ static MIN_INTERVAL: Lazy<Duration> = Lazy::new(|| {
 #[derive(Clone)]
 pub struct RebalanceService {
     notify: Arc<Notify>,
+    tx_shutdown: Option<tokio::sync::broadcast::Sender<()>>,
 }
 
 impl RebalanceService {
     pub fn new() -> Self {
         RebalanceService {
             notify: Arc::new(Notify::new()),
+            tx_shutdown: None,
         }
     }
 
     pub async fn start(&mut self, mut instance: ArcRefCellWrapper<MQClientInstance>) {
         let notify = self.notify.clone();
+        let (mut shutdown, tx_shutdown) = Shutdown::new(1);
+        self.tx_shutdown = Some(tx_shutdown);
         tokio::spawn(async move {
             let mut last_rebalance_timestamp = Instant::now();
             let min_interval = *MIN_INTERVAL;
@@ -66,7 +72,11 @@ impl RebalanceService {
             loop {
                 select! {
                     _ = notify.notified() => {}
+                    _ = shutdown.recv() => {info!("RebalanceService shutdown");}
                     _ = tokio::time::sleep(real_wait_interval) => {}
+                }
+                if shutdown.is_shutdown() {
+                    return;
                 }
                 let interval = Instant::now() - last_rebalance_timestamp;
                 if interval < min_interval {
@@ -86,5 +96,11 @@ impl RebalanceService {
 
     pub fn wakeup(&self) {
         self.notify.notify_waiters();
+    }
+
+    pub fn shutdown(&self) {
+        if let Err(e) = self.tx_shutdown.as_ref().unwrap().send(()) {
+            warn!("Failed to send shutdown signal to pull_tx, error: {:?}", e);
+        }
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
@@ -99,8 +99,12 @@ impl RebalanceService {
     }
 
     pub fn shutdown(&self) {
-        if let Err(e) = self.tx_shutdown.as_ref().unwrap().send(()) {
-            warn!("Failed to send shutdown signal to pull_tx, error: {:?}", e);
+        if let Some(tx_shutdown) = &self.tx_shutdown {
+            if let Err(e) = tx_shutdown.send(()) {
+                warn!("Failed to send shutdown signal to RebalanceService, error: {:?}", e);
+            }
+        } else {
+            warn!("Shutdown called before start; no shutdown signal sent");
         }
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
@@ -101,7 +101,10 @@ impl RebalanceService {
     pub fn shutdown(&self) {
         if let Some(tx_shutdown) = &self.tx_shutdown {
             if let Err(e) = tx_shutdown.send(()) {
-                warn!("Failed to send shutdown signal to RebalanceService, error: {:?}", e);
+                warn!(
+                    "Failed to send shutdown signal to RebalanceService, error: {:?}",
+                    e
+                );
             }
         } else {
             warn!("Shutdown called before start; no shutdown signal sent");


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1076 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a shutdown signaling mechanism for improved service responsiveness in both PullMessageService and RebalanceService.
	- Added a public `shutdown` method to gracefully handle shutdown requests.

- **Bug Fixes**
	- Enhanced control flow to ensure proper handling of shutdown signals, preventing potential service interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->