### PR TITLE
[ISSUE #1101] fix "subtract with overflow" bug for allocate_message_queue_averagely

### DIFF
--- a/rocketmq-client/examples/quickstart/consumer.rs
+++ b/rocketmq-client/examples/quickstart/consumer.rs
@@ -58,7 +58,7 @@ impl MessageListenerConcurrently for MyMessageListener {
         _context: &ConsumeConcurrentlyContext,
     ) -> Result<ConsumeConcurrentlyStatus> {
         for msg in msgs {
-            info!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaReceive message: {:?}", msg);
+            info!("Receive message: {:?}", msg);
         }
         Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
     }

--- a/rocketmq-client/examples/quickstart/consumer.rs
+++ b/rocketmq-client/examples/quickstart/consumer.rs
@@ -58,7 +58,7 @@ impl MessageListenerConcurrently for MyMessageListener {
         _context: &ConsumeConcurrentlyContext,
     ) -> Result<ConsumeConcurrentlyStatus> {
         for msg in msgs {
-            info!("Receive message: {:?}", msg);
+            info!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaReceive message: {:?}", msg);
         }
         Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
     }

--- a/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_averagely.rs
+++ b/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_averagely.rs
@@ -52,13 +52,14 @@ impl AllocateMessageQueueStrategy for AllocateMessageQueueAveragely {
         } else {
             index * average_size + mod_val
         };
+        //let range = average_size.min(mq_all.len() - start_index);
         //fix the bug " subtract with overflow" caused by (mq_all.len() - start_index )
         let mut range: usize = 0;
         if mq_all.len() > start_index {
             range = average_size.min(mq_all.len() - start_index);
         }
         //in case of  mq_all.len() < start_index ,  means the customers is much more than queue
-        // so let range ==0 ,the for loop not work, then no queue alloced to this customerID
+        // so let range ==0 ,the for loop not work, and then no queue alloced to this customerID
         for i in 0..range {
             result.push(mq_all[start_index + i].clone());
         }

--- a/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_averagely.rs
+++ b/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_averagely.rs
@@ -52,7 +52,13 @@ impl AllocateMessageQueueStrategy for AllocateMessageQueueAveragely {
         } else {
             index * average_size + mod_val
         };
-        let range = average_size.min(mq_all.len() - start_index);
+        //fix the bug " subtract with overflow" caused by (mq_all.len() - start_index )
+        let mut range: usize = 0;
+        if mq_all.len() > start_index {
+            range = average_size.min(mq_all.len() - start_index);
+        }
+        //in case of  mq_all.len() < start_index ,  means the customers is much more than queue
+        // so let range ==0 ,the for loop not work, then no queue alloced to this customerID
         for i in 0..range {
             result.push(mq_all[start_index + i].clone());
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

Fixes #1101 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

bug found in allocate_message_queue_averagely.rs  allocate function.
step1 cargo run --bin rocketmq-namesrv-rust
step2 cargo run --bin rocketmq-broker-rust
setp3 cargo run --package rocketmq-client --example consumer

repeat step3 ,when  consumer's count is large than the queue count，there will be "subtract with overflow" bug as shown in the issue #1101  

this is because in rust code , the variable use usize(int used in java version)。


### How Did You Test This Change?

tested with 4 queues and 6 consumers, 2 consumers alloced no queue, and there is no panic exception reported


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in message queue allocation to prevent overflow errors.
	- Added checks to ensure allocation attempts are only made when queues are available. 

- **Documentation**
	- Enhanced comments for clarity regarding the changes and their purpose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->