### PR TITLE
[ISSUE #1106]Fix When topic not create the client can not consume

### DIFF
--- a/rocketmq-client/examples/quickstart/consumer.rs
+++ b/rocketmq-client/examples/quickstart/consumer.rs
@@ -33,7 +33,7 @@ pub const TAG: &str = "*";
 #[rocketmq::main]
 pub async fn main() -> Result<()> {
     //init logger
-    rocketmq_common::log::init_logger();
+    //rocketmq_common::log::init_logger();
 
     // create a producer builder with default configuration
     let builder = DefaultMQPushConsumer::builder();
@@ -59,6 +59,7 @@ impl MessageListenerConcurrently for MyMessageListener {
     ) -> Result<ConsumeConcurrentlyStatus> {
         for msg in msgs {
             info!("Receive message: {:?}", msg);
+            println!("Receive message: {:?}", msg);
         }
         Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
     }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -1317,7 +1317,7 @@ impl MQConsumerInner for DefaultMQPushConsumerImpl {
         }
     }
 
-    async fn update_topic_subscribe_info(&mut self, topic: &str, info: &HashSet<MessageQueue>) {
+    async fn update_topic_subscribe_info(&self, topic: &str, info: &HashSet<MessageQueue>) {
         let sub_table = self.rebalance_impl.get_subscription_inner();
         let sub_table_inner = sub_table.read().await;
         if sub_table_inner.contains_key(topic) {

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
@@ -327,9 +327,6 @@ where
                 }
             }
             MessageModel::Clustering => {
-                let topic_sub_cloned = self.topic_subscribe_info_table.clone();
-                let topic_subscribe_info_table_inner = topic_sub_cloned.read().await;
-                let mq_set = topic_subscribe_info_table_inner.get(topic);
                 //get consumer id list from broker
                 let cid_all = self
                     .client_instance
@@ -337,6 +334,9 @@ where
                     .unwrap()
                     .find_consumer_id_list(topic, self.consumer_group.as_ref().unwrap())
                     .await;
+                let topic_sub_cloned = self.topic_subscribe_info_table.clone();
+                let topic_subscribe_info_table_inner = topic_sub_cloned.read().await;
+                let mq_set = topic_subscribe_info_table_inner.get(topic);
                 if mq_set.is_none() && !topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
                     if let Some(mut sub_rebalance_impl) =
                         self.sub_rebalance_impl.as_ref().unwrap().upgrade()

--- a/rocketmq-client/src/consumer/mq_consumer_inner.rs
+++ b/rocketmq-client/src/consumer/mq_consumer_inner.rs
@@ -67,7 +67,7 @@ pub trait MQConsumerInnerLocal: MQConsumerInnerAny + Sync + 'static {
     ///
     /// * `topic` - A string slice that holds the name of the topic.
     /// * `info` - A reference to a `HashSet` containing `MessageQueue` information.
-    async fn update_topic_subscribe_info(&mut self, topic: &str, info: &HashSet<MessageQueue>);
+    async fn update_topic_subscribe_info(&self, topic: &str, info: &HashSet<MessageQueue>);
 
     /// Checks if the subscription information for a given topic needs to be updated asynchronously.
     ///
@@ -204,7 +204,7 @@ impl MQConsumerInner for MQConsumerInnerImpl {
         panic!("default_mqpush_consumer_impl is None");
     }
 
-    async fn update_topic_subscribe_info(&mut self, topic: &str, info: &HashSet<MessageQueue>) {
+    async fn update_topic_subscribe_info(&self, topic: &str, info: &HashSet<MessageQueue>) {
         if let Some(ref default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl {
             if let Some(mut default_mqpush_consumer_impl) = default_mqpush_consumer_impl.upgrade() {
                 return MQConsumerInner::update_topic_subscribe_info(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1106 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced message visibility with direct output of received messages.
	- Introduced a method to retrieve the maximum offset for message queues, improving message management.
	- Added a client management feature in the admin implementation for better integration.

- **Bug Fixes**
	- Improved error handling and logging in message queue operations to ensure clearer context and warnings.

- **Refactor**
	- Adjusted method signatures to allow immutable access, enhancing thread safety and flexibility.
	- Streamlined logic for handling message queues and consumer subscriptions, improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->