### PR TITLE
[ISSUE #1121]🧪Add test case for AccessChannel

### DIFF
--- a/rocketmq-client/src/base/access_channel.rs
+++ b/rocketmq-client/src/base/access_channel.rs
@@ -54,3 +54,45 @@ impl<'de> Deserialize<'de> for AccessChannel {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn serialize_access_channel_local() {
+        let channel = AccessChannel::Local;
+        let serialized = serde_json::to_string(&channel).unwrap();
+        assert_eq!(serialized, r#"{"AccessChannel":"LOCAL"}"#);
+    }
+
+    #[test]
+    fn serialize_access_channel_cloud() {
+        let channel = AccessChannel::Cloud;
+        let serialized = serde_json::to_string(&channel).unwrap();
+        assert_eq!(serialized, r#"{"AccessChannel":"CLOUD"}"#);
+    }
+
+    #[test]
+    fn deserialize_access_channel_local() {
+        let json = r#""LOCAL""#;
+        let deserialized: AccessChannel = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, AccessChannel::Local);
+    }
+
+    #[test]
+    fn deserialize_access_channel_cloud() {
+        let json = r#""CLOUD""#;
+        let deserialized: AccessChannel = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, AccessChannel::Cloud);
+    }
+
+    #[test]
+    fn deserialize_access_channel_unknown_variant() {
+        let json = r#""UNKNOWN""#;
+        let result: Result<AccessChannel, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1121 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced a new test module for validating serialization and deserialization of the `AccessChannel` enum.
	- Added tests for both `AccessChannel::Local` and `AccessChannel::Cloud` variants, ensuring accurate JSON conversion and error handling for unknown variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->