### PR TITLE
[ISSUE #1134]🔥Remove BrokerConfig duplicate codes🔥

### DIFF
--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -312,10 +312,6 @@ impl BrokerConfig {
             self.broker_identity.is_broker_container.to_string(),
         );
         properties.insert(
-            "isInBrokerContainer".to_string(),
-            self.broker_identity.is_in_broker_container.to_string(),
-        );
-        properties.insert(
             "defaultTopicQueueNums".to_string(),
             self.topic_queue_config.default_topic_queue_nums.to_string(),
         );


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1134 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the property indicating whether the broker is within a container from the broker configuration, streamlining the configuration representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->