### PR TITLE
[ISSUE #1142]🔥Use CheetahString to replace std String🍻

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,6 +1905,7 @@ name = "rocketmq-cli"
 version = "0.3.0"
 dependencies = [
  "bytes",
+ "cheetah-string",
  "clap",
  "rocketmq-common",
  "rocketmq-store",

--- a/rocketmq-broker/src/filter/expression_for_retry_message_filter.rs
+++ b/rocketmq-broker/src/filter/expression_for_retry_message_filter.rs
@@ -16,6 +16,7 @@
  */
 use std::collections::HashMap;
 
+use cheetah_string::CheetahString;
 use rocketmq_store::consume_queue::consume_queue_ext::CqExtUnit;
 use rocketmq_store::filter::MessageFilter;
 
@@ -34,7 +35,7 @@ impl MessageFilter for ExpressionForRetryMessageFilter {
     fn is_matched_by_commit_log(
         &self,
         msg_buffer: Option<&[u8]>,
-        properties: Option<&HashMap<String, String>>,
+        properties: Option<&HashMap<CheetahString, CheetahString>>,
     ) -> bool {
         true
     }

--- a/rocketmq-broker/src/filter/expression_message_filter.rs
+++ b/rocketmq-broker/src/filter/expression_message_filter.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::filter::expression_type::ExpressionType;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_store::consume_queue::consume_queue_ext::CqExtUnit;
@@ -87,7 +88,7 @@ impl MessageFilter for ExpressionMessageFilter {
     fn is_matched_by_commit_log(
         &self,
         msg_buffer: Option<&[u8]>,
-        properties: Option<&HashMap<String, String>>,
+        properties: Option<&HashMap<CheetahString, CheetahString>>,
     ) -> bool {
         if self.subscription_data.is_none() {
             return true;

--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -18,6 +18,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_rust::ArcMut;
@@ -139,7 +140,7 @@ where
         tags_code: Option<i64>,
         msg_store_time: i64,
         filter_bit_map: Option<Vec<u8>>,
-        properties: Option<&HashMap<String, String>>,
+        properties: Option<&HashMap<CheetahString, CheetahString>>,
     ) {
         let key = build_key(topic, queue_id);
         let mut table = self.pull_request_table.write();

--- a/rocketmq-broker/src/long_polling/notify_message_arriving_listener.rs
+++ b/rocketmq-broker/src/long_polling/notify_message_arriving_listener.rs
@@ -16,6 +16,7 @@
  */
 use std::collections::HashMap;
 
+use cheetah_string::CheetahString;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_arriving_listener::MessageArrivingListener;
 use rocketmq_store::log_file::MessageStore;
@@ -50,7 +51,7 @@ where
         tags_code: Option<i64>,
         msg_store_time: i64,
         filter_bit_map: Option<Vec<u8>>,
-        properties: Option<&HashMap<String, String>>,
+        properties: Option<&HashMap<CheetahString, CheetahString>>,
     ) {
         self.pull_request_hold_service.notify_message_arriving_ext(
             topic,

--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -188,11 +188,7 @@ where
             &mut msg_inner,
             MessageDecoder::string_to_message_properties(request_header.properties.as_ref()),
         );
-        msg_inner.properties_string = request_header
-            .properties
-            .clone()
-            .unwrap_or_default()
-            .to_string();
+        msg_inner.properties_string = request_header.properties.clone().unwrap_or_default();
         msg_inner.message_ext_inner.born_timestamp = request_header.born_timestamp;
         msg_inner.message_ext_inner.born_host = channel.remote_address();
         msg_inner.message_ext_inner.store_host = self.store_host;
@@ -391,7 +387,9 @@ where
         if let Some(body) = msg.get_body().cloned() {
             command.set_body_mut_ref(body);
         }
-        let sender_id = msg.get_property(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT);
+        let sender_id = msg.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT,
+        ));
         let mut push_reply_result = PushReplyResult(false, "".to_string());
         if let Some(sender_id) = sender_id {
             let channel = self

--- a/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
@@ -86,7 +86,7 @@ impl TopicQueueMappingManager {
         if let Some(value) = request_header.lo() {
             if !value {
                 return TopicQueueMappingContext::new(
-                    request_header.topic(),
+                    request_header.topic().clone(),
                     None,
                     None,
                     vec![],
@@ -100,10 +100,10 @@ impl TopicQueueMappingManager {
         let mut global_id: Option<i32> = request_header.queue_id();
 
         let mutex_guard = self.topic_queue_mapping_table.lock();
-        let tqmd = mutex_guard.get(topic);
+        let tqmd = mutex_guard.get(topic.as_str());
         if tqmd.is_none() {
             return TopicQueueMappingContext {
-                topic: topic.to_string(),
+                topic: topic.clone(),
                 global_id: None,
                 mapping_detail: None,
                 mapping_item_list: vec![],
@@ -124,7 +124,7 @@ impl TopicQueueMappingManager {
 
         if global_id.is_none() {
             return TopicQueueMappingContext {
-                topic: topic.to_string(),
+                topic: topic.clone(),
                 global_id: None,
                 mapping_detail: Some(mapping_detail.clone()),
                 mapping_item_list: vec![],
@@ -135,7 +135,7 @@ impl TopicQueueMappingManager {
         // If not find mappingItem, it encounters some errors
         if global_id.unwrap() < 0 && !select_one_when_miss {
             return TopicQueueMappingContext {
-                topic: topic.to_string(),
+                topic: topic.clone(),
                 global_id,
                 mapping_detail: Some(mapping_detail.clone()),
                 mapping_item_list: vec![],
@@ -156,7 +156,7 @@ impl TopicQueueMappingManager {
         if let Some(global_id_value) = global_id {
             if global_id_value < 0 {
                 return TopicQueueMappingContext {
-                    topic: topic.to_string(),
+                    topic: topic.clone(),
                     global_id,
                     mapping_detail: Some(mapping_detail.clone()),
                     mapping_item_list: vec![],
@@ -180,7 +180,7 @@ impl TopicQueueMappingManager {
             (None, vec![])
         };
         TopicQueueMappingContext {
-            topic: topic.to_string(),
+            topic: topic.clone(),
             global_id,
             mapping_detail: Some(mapping_detail.clone()),
             mapping_item_list,

--- a/rocketmq-broker/src/transaction/queue/transactional_message_util.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_util.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use rocketmq_common::common::message::MessageConst;
@@ -51,14 +52,18 @@ impl TransactionalMessageUtil {
         msg_inner.set_wait_store_msg_ok(false);
         msg_inner
             .message_ext_inner
-            .set_msg_id(msg_ext.msg_id().to_string());
+            .set_msg_id(msg_ext.msg_id().clone());
         msg_inner.set_topic(
             msg_ext
-                .get_property(MessageConst::PROPERTY_REAL_TOPIC)
+                .get_property(&CheetahString::from_static_str(
+                    MessageConst::PROPERTY_REAL_TOPIC,
+                ))
                 .unwrap_or_default(),
         );
         // msg_inner.set_body(msg_ext.get_body().clone());
-        if let Some(real_queue_id_str) = msg_ext.get_property("REAL_QUEUE_ID") {
+        if let Some(real_queue_id_str) =
+            msg_ext.get_property(&CheetahString::from_static_str("REAL_QUEUE_ID"))
+        {
             if let Ok(value) = real_queue_id_str.parse::<i32>() {
                 msg_inner.message_ext_inner.set_queue_id(value);
             }
@@ -76,15 +81,17 @@ impl TransactionalMessageUtil {
         msg_inner.message_ext_inner.set_born_host(msg_ext.born_host);
         msg_inner.set_transaction_id(
             msg_ext
-                .get_property(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX)
+                .get_property(&CheetahString::from_static_str(
+                    MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+                ))
                 .unwrap_or_default(),
         );
 
         MessageAccessor::set_properties(&mut msg_inner, msg_ext.get_properties().clone());
         MessageAccessor::put_property(
             &mut msg_inner,
-            MessageConst::PROPERTY_TRANSACTION_PREPARED.to_owned(),
-            "true".to_owned(),
+            CheetahString::from_static_str(MessageConst::PROPERTY_TRANSACTION_PREPARED),
+            CheetahString::from_string("true".to_owned()),
         );
         MessageAccessor::clear_property(
             &mut msg_inner,

--- a/rocketmq-cli/Cargo.toml
+++ b/rocketmq-cli/Cargo.toml
@@ -18,6 +18,7 @@ rocketmq-store = { workspace = true }
 clap = { version = "4.5.20", features = ["derive"] }
 tabled = "0.16.0"
 bytes = { workspace = true }
+cheetah-string = { workspace = true }
 [[bin]]
 name = "rocketmq-cli-rust"
 path = "src/bin/rocketmq_cli.rs"

--- a/rocketmq-cli/src/content_show.rs
+++ b/rocketmq-cli/src/content_show.rs
@@ -76,7 +76,7 @@ pub fn print_content(from: Option<u32>, to: Option<u32>, path: Option<PathBuf>) 
             None => {}
             Some(value) => {
                 table.push(MessagePrint {
-                    message_id: value.msg_id.clone(),
+                    message_id: value.msg_id.to_string(),
                 });
             }
         }

--- a/rocketmq-client/src/base/validators.rs
+++ b/rocketmq-client/src/base/validators.rs
@@ -16,6 +16,7 @@
  */
 use std::collections::HashMap;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::message::MessageConst;
@@ -97,7 +98,9 @@ impl Validators {
             ));
         }
 
-        let lmq_path = msg.get_user_property(MessageConst::PROPERTY_INNER_MULTI_DISPATCH);
+        let lmq_path = msg.get_user_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_INNER_MULTI_DISPATCH,
+        ));
         if let Some(value) = lmq_path {
             if value.contains(std::path::MAIN_SEPARATOR) {
                 return Err(MQClientErr(

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_client_ext::MessageClientExt;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
@@ -212,7 +213,9 @@ impl ConsumeMessageConcurrentlyService {
         context: &ConsumeConcurrentlyContext,
     ) -> bool {
         let delay_level = context.delay_level_when_next_consume;
-        msg.set_topic(self.client_config.with_namespace(msg.get_topic()));
+        msg.set_topic(CheetahString::from_string(
+            self.client_config.with_namespace(msg.get_topic().as_str()),
+        ));
         match self
             .default_mqpush_consumer_impl
             .as_ref()
@@ -389,7 +392,7 @@ impl ConsumeRequest {
             for msg in self.msgs.iter_mut() {
                 MessageAccessor::set_consume_start_time_stamp(
                     &mut msg.message_ext_inner,
-                    get_current_millis().to_string(),
+                    CheetahString::from_string(get_current_millis().to_string()),
                 );
             }
             if default_mqpush_consumer_impl.has_hook() {

--- a/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
@@ -149,7 +149,7 @@ impl PullAPIWrapper {
                     let mut msg_vec_again = Vec::with_capacity(msg_vec.len());
                     for msg in msg_vec {
                         if let Some(ref tag) = msg.get_tags() {
-                            if subscription_data.tags_set.contains(tag) {
+                            if subscription_data.tags_set.contains(tag.as_str()) {
                                 msg_vec_again.push(msg);
                             }
                         }
@@ -169,26 +169,29 @@ impl PullAPIWrapper {
 
             for msg in &mut msg_list_filter_again {
                 let tra_flag = msg
-                    .get_property(MessageConst::PROPERTY_TRANSACTION_PREPARED)
+                    .get_property(&CheetahString::from_static_str(
+                        MessageConst::PROPERTY_TRANSACTION_PREPARED,
+                    ))
                     .map_or(false, |v| v.parse().unwrap_or(false));
                 if tra_flag {
-                    if let Some(transaction_id) =
-                        msg.get_property(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX)
-                    {
+                    if let Some(transaction_id) = msg.get_property(&CheetahString::from_static_str(
+                        MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+                    )) {
                         msg.set_transaction_id(transaction_id);
                     }
                 }
                 MessageAccessor::put_property(
                     msg,
-                    MessageConst::PROPERTY_MIN_OFFSET.to_owned(),
-                    pull_result_ext.pull_result.min_offset.to_string(),
+                    CheetahString::from_static_str(MessageConst::PROPERTY_MIN_OFFSET),
+                    CheetahString::from_string(pull_result_ext.pull_result.min_offset.to_string()),
                 );
                 MessageAccessor::put_property(
                     msg,
-                    MessageConst::PROPERTY_MAX_OFFSET.to_owned(),
-                    pull_result_ext.pull_result.max_offset.to_string(),
+                    CheetahString::from_static_str(MessageConst::PROPERTY_MAX_OFFSET),
+                    CheetahString::from_string(pull_result_ext.pull_result.max_offset.to_string()),
                 );
-                msg.message_ext_inner.broker_name = message_queue.get_broker_name().to_string();
+                msg.message_ext_inner.broker_name =
+                    CheetahString::from_string(message_queue.get_broker_name().to_string());
                 msg.message_ext_inner.queue_id = message_queue.get_queue_id();
                 if let Some(offset_delta) = pull_result_ext.offset_delta {
                     msg.message_ext_inner.queue_offset += offset_delta;

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -283,7 +283,9 @@ impl MQClientAPIImpl {
         T: MessageTrait,
     {
         let begin_start_time = Instant::now();
-        let msg_type = msg.get_property(MessageConst::PROPERTY_MESSAGE_TYPE);
+        let msg_type = msg.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_MESSAGE_TYPE,
+        ));
         let is_reply = msg_type.is_some() && msg_type.unwrap() == mix_all::REPLY_MESSAGE_FLAG;
         let mut request = if is_reply {
             if *sendSmartMsg {
@@ -555,7 +557,7 @@ impl MQClientAPIImpl {
                 sb.push_str(if sb.is_empty() { "" } else { "," });
                 sb.push_str(MessageClientIDSetter::get_uniq_id(msg).unwrap().as_str());
             }
-            uniq_msg_id = Some(sb);
+            uniq_msg_id = Some(CheetahString::from_string(sb));
         }
 
         let region_id = response

--- a/rocketmq-client/src/producer/default_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/default_mq_produce_builder.rs
@@ -17,6 +17,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::compression::compression_type::CompressionType;
 use rocketmq_common::common::compression::compressor::Compressor;
 use rocketmq_remoting::runtime::RPCHook;
@@ -239,7 +240,7 @@ impl DefaultMQProducerBuilder {
             mq_producer.set_retry_response_codes(retry_response_codes);
         }
         if let Some(producer_group) = self.producer_group {
-            mq_producer.set_producer_group(producer_group);
+            mq_producer.set_producer_group(CheetahString::from_string(producer_group));
         }
         if let Some(topics) = self.topics {
             mq_producer.set_topics(topics);

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -18,6 +18,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::compression::compression_type::CompressionType;
 use rocketmq_common::common::compression::compressor::Compressor;
 use rocketmq_common::common::compression::compressor_factory::CompressorFactory;
@@ -62,7 +63,7 @@ pub struct ProducerConfig {
     /// For non-transactional messages, it does not matter as long as it's unique per process.
     ///
     /// See [core concepts](https://rocketmq.apache.org/docs/introduction/02concepts) for more discussion.
-    producer_group: String,
+    producer_group: CheetahString,
     /// Topics that need to be initialized for transaction producer
     topics: Vec<String>,
     create_topic_key: String,
@@ -210,7 +211,7 @@ impl Default for ProducerConfig {
         );
         Self {
             retry_response_codes,
-            producer_group: "".to_string(),
+            producer_group: CheetahString::empty(),
             topics: vec![],
             create_topic_key: TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC.to_string(),
             default_topic_queue_nums: 4,
@@ -361,7 +362,7 @@ impl DefaultMQProducer {
     }
 
     #[inline]
-    pub fn set_producer_group(&mut self, producer_group: String) {
+    pub fn set_producer_group(&mut self, producer_group: CheetahString) {
         self.producer_config.producer_group = producer_group;
     }
 
@@ -617,8 +618,8 @@ impl DefaultMQProducer {
 
 impl DefaultMQProducer {
     #[inline]
-    pub fn with_namespace(&mut self, resource: &str) -> String {
-        self.client_config.with_namespace(resource)
+    pub fn with_namespace(&mut self, resource: &str) -> CheetahString {
+        CheetahString::from_string(self.client_config.with_namespace(resource))
     }
 }
 

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread::Builder;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::TimeUtils::get_current_millis;
@@ -129,16 +130,16 @@ impl ProduceAccumulator {
 
 #[derive(Clone, Debug, Default)]
 pub struct AggregateKey {
-    pub topic: String,
+    pub topic: CheetahString,
     pub mq: Option<MessageQueue>,
     pub wait_store_msg_ok: bool,
-    pub tag: Option<String>,
+    pub tag: Option<CheetahString>,
 }
 
 impl AggregateKey {
     pub fn new_from_message<M: MessageTrait>(message: &M) -> Self {
         Self {
-            topic: message.get_topic().to_string(),
+            topic: message.get_topic().clone(),
             mq: None,
             wait_store_msg_ok: message.is_wait_store_msg_ok(),
             tag: message.get_tags(),
@@ -147,7 +148,7 @@ impl AggregateKey {
 
     pub fn new_from_message_queue<M: MessageTrait>(message: &M, mq: Option<MessageQueue>) -> Self {
         Self {
-            topic: message.get_topic().to_string(),
+            topic: message.get_topic().clone(),
             mq,
             wait_store_msg_ok: message.is_wait_store_msg_ok(),
             tag: message.get_tags(),
@@ -155,10 +156,10 @@ impl AggregateKey {
     }
 
     pub fn new(
-        topic: String,
+        topic: CheetahString,
         mq: Option<MessageQueue>,
         wait_store_msg_ok: bool,
-        tag: Option<String>,
+        tag: Option<CheetahString>,
     ) -> Self {
         Self {
             topic,

--- a/rocketmq-client/src/producer/request_response_future.rs
+++ b/rocketmq-client/src/producer/request_response_future.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageTrait;
 use tokio::sync::Notify;
@@ -32,7 +33,7 @@ type AtomicMessagePtr = AtomicPtr<Option<Box<dyn MessageTrait + Send>>>;
 type AtomicCausePtr = AtomicPtr<Box<dyn Error + Send + Sync>>;
 
 pub struct RequestResponseFuture {
-    correlation_id: String,
+    correlation_id: CheetahString,
     request_callback: Option<RequestCallbackFn>,
     begin_timestamp: Instant,
     request_msg: Option<Message>,
@@ -47,7 +48,7 @@ pub struct RequestResponseFuture {
 
 impl RequestResponseFuture {
     pub fn new(
-        correlation_id: String,
+        correlation_id: CheetahString,
         timeout_millis: u64,
         request_callback: Option<RequestCallbackFn>,
     ) -> Self {

--- a/rocketmq-client/src/producer/send_result.rs
+++ b/rocketmq-client/src/producer/send_result.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use serde::Deserialize;
 use serde::Serialize;
@@ -24,7 +24,7 @@ use crate::producer::send_status::SendStatus;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SendResult {
     pub send_status: SendStatus,
-    pub msg_id: Option<String>,
+    pub msg_id: Option<CheetahString>,
     pub message_queue: Option<MessageQueue>,
     pub queue_offset: u64,
     pub transaction_id: Option<String>,
@@ -53,7 +53,7 @@ impl Default for SendResult {
 impl SendResult {
     pub fn new(
         send_status: SendStatus,
-        msg_id: Option<String>,
+        msg_id: Option<CheetahString>,
         offset_msg_id: Option<String>,
         message_queue: Option<MessageQueue>,
         queue_offset: u64,
@@ -73,7 +73,7 @@ impl SendResult {
 
     pub fn new_with_additional_fields(
         send_status: SendStatus,
-        msg_id: Option<String>,
+        msg_id: Option<CheetahString>,
         message_queue: Option<MessageQueue>,
         queue_offset: u64,
         transaction_id: Option<String>,
@@ -105,7 +105,7 @@ impl SendResult {
         self.region_id = Some(region_id);
     }
 
-    pub fn set_msg_id(&mut self, msg_id: String) {
+    pub fn set_msg_id(&mut self, msg_id: CheetahString) {
         self.msg_id = Some(msg_id);
     }
 

--- a/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
@@ -17,6 +17,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::compression::compression_type::CompressionType;
 use rocketmq_common::common::compression::compressor::Compressor;
 use rocketmq_remoting::runtime::RPCHook;
@@ -252,7 +253,7 @@ impl TransactionMQProducerBuilder {
             mq_producer.set_retry_response_codes(retry_response_codes);
         }
         if let Some(producer_group) = self.producer_group {
-            mq_producer.set_producer_group(producer_group);
+            mq_producer.set_producer_group(CheetahString::from_string(producer_group));
         }
         if let Some(topics) = self.topics {
             mq_producer.set_topics(topics);

--- a/rocketmq-client/src/utils/message_util.rs
+++ b/rocketmq-client/src/utils/message_util.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use bytes::Bytes;
+use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
@@ -30,38 +31,42 @@ pub struct MessageUtil;
 impl MessageUtil {
     pub fn create_reply_message(request_message: &Message, body: &[u8]) -> Result<Message> {
         let mut reply_message = Message::default();
-        let cluster = request_message.get_property(MessageConst::PROPERTY_CLUSTER);
+        let cluster = request_message.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_CLUSTER,
+        ));
         if let Some(cluster) = cluster {
             reply_message.set_body(Bytes::copy_from_slice(body));
             let reply_topic = mix_all::get_retry_topic(&cluster);
-            reply_message.set_topic(reply_topic);
+            reply_message.set_topic(CheetahString::from_string(reply_topic));
             MessageAccessor::put_property(
                 &mut reply_message,
-                MessageConst::PROPERTY_MESSAGE_TYPE.to_owned(),
-                mix_all::REPLY_MESSAGE_FLAG.to_owned(),
+                CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_TYPE),
+                CheetahString::from_static_str(mix_all::REPLY_MESSAGE_FLAG),
             );
-            if let Some(reply_to) =
-                request_message.get_property(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT)
-            {
+            if let Some(reply_to) = request_message.get_property(&CheetahString::from_static_str(
+                MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT,
+            )) {
                 MessageAccessor::put_property(
                     &mut reply_message,
-                    MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT.to_owned(),
+                    CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT),
                     reply_to,
                 );
             }
-            if let Some(correlation_id) =
-                request_message.get_property(MessageConst::PROPERTY_CORRELATION_ID)
-            {
+            if let Some(correlation_id) = request_message.get_property(
+                &CheetahString::from_static_str(MessageConst::PROPERTY_CORRELATION_ID),
+            ) {
                 MessageAccessor::put_property(
                     &mut reply_message,
-                    MessageConst::PROPERTY_CORRELATION_ID.to_owned(),
+                    CheetahString::from_static_str(MessageConst::PROPERTY_CORRELATION_ID),
                     correlation_id,
                 );
             }
-            if let Some(ttl) = request_message.get_property(MessageConst::PROPERTY_MESSAGE_TTL) {
+            if let Some(ttl) = request_message.get_property(&CheetahString::from_static_str(
+                MessageConst::PROPERTY_MESSAGE_TTL,
+            )) {
                 MessageAccessor::put_property(
                     &mut reply_message,
-                    MessageConst::PROPERTY_MESSAGE_TTL.to_owned(),
+                    CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_TTL),
                     ttl,
                 );
             }
@@ -77,97 +82,9 @@ impl MessageUtil {
         }
     }
 
-    pub fn get_reply_to_client(reply_message: &Message) -> Option<String> {
-        reply_message.get_property(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use rocketmq_common::common::message::message_single::Message;
-    use rocketmq_common::common::message::MessageConst;
-    use rocketmq_common::common::mix_all;
-    use rocketmq_common::MessageAccessor::MessageAccessor;
-
-    use super::*;
-    use crate::common::client_error_code::ClientErrorCode;
-    use crate::error::MQClientError::MQClientErr;
-
-    fn create_test_message(properties: HashMap<&str, &str>) -> Message {
-        let mut message = Message::default();
-        for (key, value) in properties {
-            MessageAccessor::put_property(&mut message, key.to_owned(), value.to_owned());
-        }
-        message
-    }
-
-    #[test]
-    fn create_reply_message_success() {
-        let properties = HashMap::from([
-            (MessageConst::PROPERTY_CLUSTER, "testCluster"),
-            (MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT, "client1"),
-            (MessageConst::PROPERTY_CORRELATION_ID, "correlation1"),
-            (MessageConst::PROPERTY_MESSAGE_TTL, "1000"),
-        ]);
-        let request_message = create_test_message(properties);
-        let body = b"reply body";
-
-        let result = MessageUtil::create_reply_message(&request_message, body).unwrap();
-
-        assert_eq!(result.get_topic(), mix_all::get_retry_topic("testCluster"));
-        assert_eq!(
-            result.get_property(MessageConst::PROPERTY_MESSAGE_TYPE),
-            Some(mix_all::REPLY_MESSAGE_FLAG.to_string())
-        );
-        assert_eq!(
-            result.get_property(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT),
-            Some("client1".to_string())
-        );
-        assert_eq!(
-            result.get_property(MessageConst::PROPERTY_CORRELATION_ID),
-            Some("correlation1".to_string())
-        );
-        assert_eq!(
-            result.get_property(MessageConst::PROPERTY_MESSAGE_TTL),
-            Some("1000".to_string())
-        );
-    }
-
-    #[test]
-    fn create_reply_message_missing_cluster() {
-        let properties = HashMap::new();
-        let request_message = create_test_message(properties);
-        let body = b"reply body";
-
-        let result = MessageUtil::create_reply_message(&request_message, body);
-
-        assert!(result.is_err());
-        if let Err(MQClientErr(code, message)) = result {
-            assert_eq!(code, ClientErrorCode::CREATE_REPLY_MESSAGE_EXCEPTION);
-            assert!(message.contains("property[CLUSTER] is null"));
-        }
-    }
-
-    #[test]
-    fn get_reply_to_client_success() {
-        let properties =
-            HashMap::from([(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT, "client1")]);
-        let reply_message = create_test_message(properties);
-
-        let result = MessageUtil::get_reply_to_client(&reply_message);
-
-        assert_eq!(result, Some("client1".to_string()));
-    }
-
-    #[test]
-    fn get_reply_to_client_missing_property() {
-        let properties = HashMap::new();
-        let reply_message = create_test_message(properties);
-
-        let result = MessageUtil::get_reply_to_client(&reply_message);
-
-        assert_eq!(result, None);
+    pub fn get_reply_to_client(reply_message: &Message) -> Option<CheetahString> {
+        reply_message.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT,
+        ))
     }
 }

--- a/rocketmq-common/src/common/message/message_accessor.rs
+++ b/rocketmq-common/src/common/message/message_accessor.rs
@@ -16,6 +16,8 @@
  */
 use std::collections::HashMap;
 
+use cheetah_string::CheetahString;
+
 use crate::common::message::message_single::Message;
 use crate::common::message::MessageConst;
 use crate::common::message::MessageTrait;
@@ -30,7 +32,10 @@ impl MessageAccessor {
     /// * `msg` - A mutable reference to a message implementing the `MessageTrait`.
     /// * `properties` - A `HashMap` containing the properties to set.
     #[inline]
-    pub fn set_properties<T: MessageTrait>(msg: &mut T, properties: HashMap<String, String>) {
+    pub fn set_properties<T: MessageTrait>(
+        msg: &mut T,
+        properties: HashMap<CheetahString, CheetahString>,
+    ) {
         msg.set_properties(properties);
     }
 
@@ -42,7 +47,7 @@ impl MessageAccessor {
     /// * `name` - The name of the property.
     /// * `value` - The value of the property.
     #[inline]
-    pub fn put_property<T: MessageTrait>(msg: &mut T, name: String, value: String) {
+    pub fn put_property<T: MessageTrait>(msg: &mut T, name: CheetahString, value: CheetahString) {
         msg.put_property(name, value);
     }
 
@@ -64,8 +69,11 @@ impl MessageAccessor {
     /// * `msg` - A mutable reference to a message implementing the `MessageTrait`.
     /// * `unit` - The transfer flag value.
     #[inline]
-    pub fn set_transfer_flag<T: MessageTrait>(msg: &mut T, unit: String) {
-        msg.put_property(MessageConst::PROPERTY_TRANSFER_FLAG.to_owned(), unit);
+    pub fn set_transfer_flag<T: MessageTrait>(msg: &mut T, unit: CheetahString) {
+        msg.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_TRANSFER_FLAG),
+            unit,
+        );
     }
 
     /// Gets the transfer flag of a message.
@@ -78,8 +86,10 @@ impl MessageAccessor {
     ///
     /// * `Option<String>` - The transfer flag value if it exists.
     #[inline]
-    pub fn get_transfer_flag<T: MessageTrait>(msg: &T) -> Option<String> {
-        msg.get_property(MessageConst::PROPERTY_TRANSFER_FLAG)
+    pub fn get_transfer_flag<T: MessageTrait>(msg: &T) -> Option<CheetahString> {
+        msg.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_TRANSFER_FLAG,
+        ))
     }
 
     /// Sets the correction flag of a message.
@@ -89,8 +99,11 @@ impl MessageAccessor {
     /// * `msg` - A mutable reference to a message implementing the `MessageTrait`.
     /// * `unit` - The correction flag value.
     #[inline]
-    pub fn set_correction_flag<T: MessageTrait>(msg: &mut T, unit: String) {
-        msg.put_property(MessageConst::PROPERTY_CORRECTION_FLAG.to_owned(), unit);
+    pub fn set_correction_flag<T: MessageTrait>(msg: &mut T, unit: CheetahString) {
+        msg.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_CORRECTION_FLAG),
+            unit,
+        );
     }
 
     /// Gets the correction flag of a message.
@@ -103,8 +116,10 @@ impl MessageAccessor {
     ///
     /// * `Option<String>` - The correction flag value if it exists.
     #[inline]
-    pub fn get_correction_flag<T: MessageTrait>(msg: &T) -> Option<String> {
-        msg.get_property(MessageConst::PROPERTY_CORRECTION_FLAG)
+    pub fn get_correction_flag<T: MessageTrait>(msg: &T) -> Option<CheetahString> {
+        msg.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_CORRECTION_FLAG,
+        ))
     }
 
     /// Sets the origin message ID of a message.
@@ -114,9 +129,9 @@ impl MessageAccessor {
     /// * `msg` - A mutable reference to a message implementing the `MessageTrait`.
     /// * `origin_message_id` - The origin message ID value.
     #[inline]
-    pub fn set_origin_message_id<T: MessageTrait>(msg: &mut T, origin_message_id: String) {
+    pub fn set_origin_message_id<T: MessageTrait>(msg: &mut T, origin_message_id: CheetahString) {
         msg.put_property(
-            MessageConst::PROPERTY_ORIGIN_MESSAGE_ID.to_owned(),
+            CheetahString::from_static_str(MessageConst::PROPERTY_ORIGIN_MESSAGE_ID),
             origin_message_id,
         );
     }
@@ -131,8 +146,10 @@ impl MessageAccessor {
     ///
     /// * `Option<String>` - The origin message ID value if it exists.
     #[inline]
-    pub fn get_origin_message_id<T: MessageTrait>(msg: &T) -> Option<String> {
-        msg.get_property(MessageConst::PROPERTY_ORIGIN_MESSAGE_ID)
+    pub fn get_origin_message_id<T: MessageTrait>(msg: &T) -> Option<CheetahString> {
+        msg.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_ORIGIN_MESSAGE_ID,
+        ))
     }
 
     /// Sets the MQ2 flag of a message.
@@ -142,8 +159,11 @@ impl MessageAccessor {
     /// * `msg` - A mutable reference to a message implementing the `MessageTrait`.
     /// * `flag` - The MQ2 flag value.
     #[inline]
-    pub fn set_mq2_flag<T: MessageTrait>(msg: &mut T, flag: String) {
-        msg.put_property(MessageConst::PROPERTY_MQ2_FLAG.to_owned(), flag);
+    pub fn set_mq2_flag<T: MessageTrait>(msg: &mut T, flag: CheetahString) {
+        msg.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_MQ2_FLAG),
+            flag,
+        );
     }
 
     /// Gets the MQ2 flag of a message.
@@ -156,8 +176,10 @@ impl MessageAccessor {
     ///
     /// * `Option<String>` - The MQ2 flag value if it exists.
     #[inline]
-    pub fn get_mq2_flag<T: MessageTrait>(msg: &T) -> Option<String> {
-        msg.get_property(MessageConst::PROPERTY_MQ2_FLAG)
+    pub fn get_mq2_flag<T: MessageTrait>(msg: &T) -> Option<CheetahString> {
+        msg.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_MQ2_FLAG,
+        ))
     }
 
     /// Sets the reconsume time of a message.
@@ -167,9 +189,9 @@ impl MessageAccessor {
     /// * `msg` - A mutable reference to a message implementing the `MessageTrait`.
     /// * `reconsume_times` - The reconsume time value.
     #[inline]
-    pub fn set_reconsume_time<T: MessageTrait>(msg: &mut T, reconsume_times: String) {
+    pub fn set_reconsume_time<T: MessageTrait>(msg: &mut T, reconsume_times: CheetahString) {
         msg.put_property(
-            MessageConst::PROPERTY_RECONSUME_TIME.to_owned(),
+            CheetahString::from_static_str(MessageConst::PROPERTY_RECONSUME_TIME),
             reconsume_times,
         );
     }
@@ -184,8 +206,10 @@ impl MessageAccessor {
     ///
     /// * `Option<String>` - The reconsume time value if it exists.
     #[inline]
-    pub fn get_reconsume_time<T: MessageTrait>(msg: &T) -> Option<String> {
-        msg.get_property(MessageConst::PROPERTY_RECONSUME_TIME)
+    pub fn get_reconsume_time<T: MessageTrait>(msg: &T) -> Option<CheetahString> {
+        msg.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_RECONSUME_TIME,
+        ))
     }
 
     /// Sets the maximum reconsume times of a message.
@@ -195,9 +219,12 @@ impl MessageAccessor {
     /// * `msg` - A mutable reference to a message implementing the `MessageTrait`.
     /// * `max_reconsume_times` - The maximum reconsume times value.
     #[inline]
-    pub fn set_max_reconsume_times<T: MessageTrait>(msg: &mut T, max_reconsume_times: String) {
+    pub fn set_max_reconsume_times<T: MessageTrait>(
+        msg: &mut T,
+        max_reconsume_times: CheetahString,
+    ) {
         msg.put_property(
-            MessageConst::PROPERTY_MAX_RECONSUME_TIMES.to_owned(),
+            CheetahString::from_static_str(MessageConst::PROPERTY_MAX_RECONSUME_TIMES),
             max_reconsume_times,
         );
     }
@@ -212,8 +239,10 @@ impl MessageAccessor {
     ///
     /// * `Option<String>` - The maximum reconsume times value if it exists.
     #[inline]
-    pub fn get_max_reconsume_times<T: MessageTrait>(msg: &T) -> Option<String> {
-        msg.get_property(MessageConst::PROPERTY_MAX_RECONSUME_TIMES)
+    pub fn get_max_reconsume_times<T: MessageTrait>(msg: &T) -> Option<CheetahString> {
+        msg.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_MAX_RECONSUME_TIMES,
+        ))
     }
 
     /// Sets the consume start timestamp of a message.
@@ -225,10 +254,10 @@ impl MessageAccessor {
     #[inline]
     pub fn set_consume_start_time_stamp<T: MessageTrait>(
         msg: &mut T,
-        property_consume_start_time_stamp: String,
+        property_consume_start_time_stamp: CheetahString,
     ) {
         msg.put_property(
-            MessageConst::PROPERTY_CONSUME_START_TIMESTAMP.to_owned(),
+            CheetahString::from_static_str(MessageConst::PROPERTY_CONSUME_START_TIMESTAMP),
             property_consume_start_time_stamp,
         );
     }
@@ -243,7 +272,9 @@ impl MessageAccessor {
     ///
     /// * `Option<String>` - The consume start timestamp value if it exists.
     #[inline]
-    pub fn get_consume_start_time_stamp<T: MessageTrait>(msg: &T) -> Option<String> {
-        msg.get_property(MessageConst::PROPERTY_CONSUME_START_TIMESTAMP)
+    pub fn get_consume_start_time_stamp<T: MessageTrait>(msg: &T) -> Option<CheetahString> {
+        msg.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_CONSUME_START_TIMESTAMP,
+        ))
     }
 }

--- a/rocketmq-common/src/common/message/message_batch.rs
+++ b/rocketmq-common/src/common/message/message_batch.rs
@@ -23,6 +23,7 @@ use std::fmt::Formatter;
 use std::path::Iter;
 
 use bytes::Bytes;
+use cheetah_string::CheetahString;
 
 use crate::common::message::message_decoder;
 use crate::common::message::message_ext_broker_inner::MessageExtBrokerInner;
@@ -134,7 +135,7 @@ impl fmt::Display for MessageBatch {
 
 #[allow(unused_variables)]
 impl MessageTrait for MessageBatch {
-    fn put_property(&mut self, key: String, value: String) {
+    fn put_property(&mut self, key: CheetahString, value: CheetahString) {
         self.final_message.properties.insert(key, value);
     }
 
@@ -142,15 +143,15 @@ impl MessageTrait for MessageBatch {
         self.final_message.properties.remove(name);
     }
 
-    fn get_property(&self, name: &str) -> Option<String> {
+    fn get_property(&self, name: &CheetahString) -> Option<CheetahString> {
         self.final_message.properties.get(name).cloned()
     }
 
-    fn get_topic(&self) -> &str {
+    fn get_topic(&self) -> &CheetahString {
         &self.final_message.topic
     }
 
-    fn set_topic(&mut self, topic: String) {
+    fn set_topic(&mut self, topic: CheetahString) {
         self.final_message.topic = topic;
     }
 
@@ -170,11 +171,11 @@ impl MessageTrait for MessageBatch {
         self.final_message.body = Some(body);
     }
 
-    fn get_properties(&self) -> &HashMap<String, String> {
+    fn get_properties(&self) -> &HashMap<CheetahString, CheetahString> {
         &self.final_message.properties
     }
 
-    fn set_properties(&mut self, properties: HashMap<String, String>) {
+    fn set_properties(&mut self, properties: HashMap<CheetahString, CheetahString>) {
         self.final_message.properties = properties;
     }
 
@@ -182,7 +183,7 @@ impl MessageTrait for MessageBatch {
         self.final_message.transaction_id.as_deref().unwrap()
     }
 
-    fn set_transaction_id(&mut self, transaction_id: String) {
+    fn set_transaction_id(&mut self, transaction_id: CheetahString) {
         self.final_message.transaction_id = Some(transaction_id);
     }
 
@@ -219,7 +220,7 @@ impl MessageExtBatch {
         self.message_ext_broker_inner.body()
     }
 
-    pub fn get_tags(&self) -> Option<String> {
+    pub fn get_tags(&self) -> Option<CheetahString> {
         self.message_ext_broker_inner.get_tags()
     }
 }

--- a/rocketmq-common/src/common/message/message_client_ext.rs
+++ b/rocketmq-common/src/common/message/message_client_ext.rs
@@ -20,6 +20,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 
 use bytes::Bytes;
+use cheetah_string::CheetahString;
 
 use crate::common::message::message_client_id_setter::MessageClientIDSetter;
 use crate::common::message::message_ext::MessageExt;
@@ -35,16 +36,16 @@ impl MessageClientExt {
         self.message_ext_inner.msg_id()
     }
 
-    pub fn set_offset_msg_id(&mut self, offset_msg_id: impl Into<String>) {
+    pub fn set_offset_msg_id(&mut self, offset_msg_id: impl Into<CheetahString>) {
         self.message_ext_inner.set_msg_id(offset_msg_id.into());
     }
 
-    pub fn get_msg_id(&self) -> String {
+    pub fn get_msg_id(&self) -> CheetahString {
         let uniq_id = MessageClientIDSetter::get_uniq_id(&self.message_ext_inner);
         if let Some(uniq_id) = uniq_id {
             uniq_id
         } else {
-            self.message_ext_inner.msg_id().to_string()
+            self.message_ext_inner.msg_id().clone()
         }
     }
 }
@@ -60,7 +61,7 @@ impl Display for MessageClientExt {
 }
 
 impl MessageTrait for MessageClientExt {
-    fn put_property(&mut self, key: String, value: String) {
+    fn put_property(&mut self, key: CheetahString, value: CheetahString) {
         self.message_ext_inner.put_property(key, value);
     }
 
@@ -68,15 +69,15 @@ impl MessageTrait for MessageClientExt {
         self.message_ext_inner.clear_property(name);
     }
 
-    fn get_property(&self, name: &str) -> Option<String> {
+    fn get_property(&self, name: &CheetahString) -> Option<CheetahString> {
         self.message_ext_inner.get_property(name)
     }
 
-    fn get_topic(&self) -> &str {
+    fn get_topic(&self) -> &CheetahString {
         self.message_ext_inner.get_topic()
     }
 
-    fn set_topic(&mut self, topic: String) {
+    fn set_topic(&mut self, topic: CheetahString) {
         self.message_ext_inner.set_topic(topic);
     }
 
@@ -96,11 +97,11 @@ impl MessageTrait for MessageClientExt {
         self.message_ext_inner.set_body(body);
     }
 
-    fn get_properties(&self) -> &HashMap<String, String> {
+    fn get_properties(&self) -> &HashMap<CheetahString, CheetahString> {
         self.message_ext_inner.get_properties()
     }
 
-    fn set_properties(&mut self, properties: HashMap<String, String>) {
+    fn set_properties(&mut self, properties: HashMap<CheetahString, CheetahString>) {
         self.message_ext_inner.set_properties(properties);
     }
 
@@ -108,7 +109,7 @@ impl MessageTrait for MessageClientExt {
         self.message_ext_inner.get_transaction_id()
     }
 
-    fn set_transaction_id(&mut self, transaction_id: String) {
+    fn set_transaction_id(&mut self, transaction_id: CheetahString) {
         self.message_ext_inner.set_transaction_id(transaction_id);
     }
 

--- a/rocketmq-common/src/common/message/message_client_id_setter.rs
+++ b/rocketmq-common/src/common/message/message_client_id_setter.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::Ordering;
 
 use bytes::BufMut;
 use bytes::BytesMut;
+use cheetah_string::CheetahString;
 use chrono::Datelike;
 use chrono::Months;
 use chrono::TimeZone;
@@ -68,11 +69,13 @@ pub struct MessageClientIDSetter;
 
 impl MessageClientIDSetter {
     #[inline]
-    pub fn get_uniq_id<T>(message: &T) -> Option<String>
+    pub fn get_uniq_id<T>(message: &T) -> Option<CheetahString>
     where
         T: MessageTrait,
     {
-        message.get_property(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX)
+        message.get_property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+        ))
     }
 
     fn set_start_time(millis: i64) {
@@ -117,13 +120,17 @@ impl MessageClientIDSetter {
         T: MessageTrait,
     {
         if message
-            .get_property(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX)
+            .get_property(&CheetahString::from_static_str(
+                MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+            ))
             .is_none()
         {
             let uniq_id = Self::create_uniq_id();
             message.put_property(
-                MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX.to_owned(),
-                uniq_id,
+                CheetahString::from_static_str(
+                    MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+                ),
+                CheetahString::from_string(uniq_id),
             );
         }
     }

--- a/rocketmq-common/src/common/message/message_ext.rs
+++ b/rocketmq-common/src/common/message/message_ext.rs
@@ -24,6 +24,7 @@ use std::net::SocketAddr;
 use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
+use cheetah_string::CheetahString;
 
 use crate::common::message::message_single::Message;
 use crate::common::message::MessageTrait;
@@ -32,7 +33,7 @@ use crate::common::sys_flag::message_sys_flag::MessageSysFlag;
 #[derive(Clone, Debug)]
 pub struct MessageExt {
     pub message: Message,
-    pub broker_name: String,
+    pub broker_name: CheetahString,
     pub queue_id: i32,
     pub store_size: i32,
     pub queue_offset: i64,
@@ -41,7 +42,7 @@ pub struct MessageExt {
     pub born_host: SocketAddr,
     pub store_timestamp: i64,
     pub store_host: SocketAddr,
-    pub msg_id: String,
+    pub msg_id: CheetahString,
     pub commit_log_offset: i64,
     pub body_crc: u32,
     pub reconsume_times: i32,
@@ -141,7 +142,7 @@ impl MessageExt {
         self.store_timestamp
     }
 
-    pub fn msg_id(&self) -> &str {
+    pub fn msg_id(&self) -> &CheetahString {
         &self.msg_id
     }
 
@@ -161,7 +162,7 @@ impl MessageExt {
         self.message = message_inner;
     }
 
-    pub fn set_broker_name(&mut self, broker_name: String) {
+    pub fn set_broker_name(&mut self, broker_name: CheetahString) {
         self.broker_name = broker_name;
     }
 
@@ -197,7 +198,7 @@ impl MessageExt {
         self.store_host = store_host;
     }
 
-    pub fn set_msg_id(&mut self, msg_id: String) {
+    pub fn set_msg_id(&mut self, msg_id: CheetahString) {
         self.msg_id = msg_id;
     }
 
@@ -217,11 +218,11 @@ impl MessageExt {
         self.prepared_transaction_offset = prepared_transaction_offset;
     }
 
-    pub fn properties(&self) -> &HashMap<String, String> {
+    pub fn properties(&self) -> &HashMap<CheetahString, CheetahString> {
         self.message.properties()
     }
 
-    pub fn get_tags(&self) -> Option<String> {
+    pub fn get_tags(&self) -> Option<CheetahString> {
         self.message.get_tags()
     }
 }
@@ -230,7 +231,7 @@ impl Default for MessageExt {
     fn default() -> Self {
         Self {
             message: Default::default(),
-            broker_name: "".to_string(),
+            broker_name: CheetahString::default(),
             queue_id: 0,
             store_size: 0,
             queue_offset: 0,
@@ -239,7 +240,7 @@ impl Default for MessageExt {
             born_host: "127.0.0.1:10911".parse().unwrap(),
             store_timestamp: 0,
             store_host: "127.0.0.1:10911".parse().unwrap(),
-            msg_id: "".to_string(),
+            msg_id: CheetahString::default(),
             commit_log_offset: 0,
             body_crc: 0,
             reconsume_times: 0,
@@ -275,7 +276,7 @@ impl fmt::Display for MessageExt {
     }
 }
 impl MessageTrait for MessageExt {
-    fn put_property(&mut self, key: String, value: String) {
+    fn put_property(&mut self, key: CheetahString, value: CheetahString) {
         self.message.put_property(key, value);
     }
 
@@ -283,15 +284,15 @@ impl MessageTrait for MessageExt {
         self.message.clear_property(name);
     }
 
-    fn get_property(&self, name: &str) -> Option<String> {
+    fn get_property(&self, name: &CheetahString) -> Option<CheetahString> {
         self.message.get_property(name)
     }
 
-    fn get_topic(&self) -> &str {
+    fn get_topic(&self) -> &CheetahString {
         self.message.get_topic()
     }
 
-    fn set_topic(&mut self, topic: String) {
+    fn set_topic(&mut self, topic: CheetahString) {
         self.message.set_topic(topic);
     }
 
@@ -311,11 +312,11 @@ impl MessageTrait for MessageExt {
         self.message.set_body(body);
     }
 
-    fn get_properties(&self) -> &HashMap<String, String> {
+    fn get_properties(&self) -> &HashMap<CheetahString, CheetahString> {
         self.message.get_properties()
     }
 
-    fn set_properties(&mut self, properties: HashMap<String, String>) {
+    fn set_properties(&mut self, properties: HashMap<CheetahString, CheetahString>) {
         self.message.set_properties(properties);
     }
 
@@ -323,7 +324,7 @@ impl MessageTrait for MessageExt {
         self.message.get_transaction_id()
     }
 
-    fn set_transaction_id(&mut self, transaction_id: String) {
+    fn set_transaction_id(&mut self, transaction_id: CheetahString) {
         self.message.set_transaction_id(transaction_id);
     }
 

--- a/rocketmq-common/src/common/message/message_ext_broker_inner.rs
+++ b/rocketmq-common/src/common/message/message_ext_broker_inner.rs
@@ -22,6 +22,7 @@ use std::fmt::Formatter;
 use std::net::SocketAddr;
 
 use bytes::Bytes;
+use cheetah_string::CheetahString;
 
 use crate::common::hasher::string_hasher::JavaStringHasher;
 use crate::common::message::message_ext::MessageExt;
@@ -34,7 +35,7 @@ use crate::MessageUtils;
 #[derive(Debug, Default)]
 pub struct MessageExtBrokerInner {
     pub message_ext_inner: MessageExt,
-    pub properties_string: String,
+    pub properties_string: CheetahString,
     pub tags_code: i64,
     pub encoded_buff: Option<bytes::BytesMut>,
     pub encode_completed: bool,
@@ -44,11 +45,13 @@ pub struct MessageExtBrokerInner {
 impl MessageExtBrokerInner {
     const VERSION: MessageVersion = MessageVersion::V1;
 
-    pub fn delete_property(&mut self, name: impl Into<String>) {
+    pub fn delete_property(&mut self, name: impl Into<CheetahString>) {
         let name = name.into();
         self.message_ext_inner.message.clear_property(name.as_str());
-        self.properties_string =
-            MessageUtils::delete_property(self.properties_string.as_str(), name.as_str());
+        self.properties_string = CheetahString::from_string(MessageUtils::delete_property(
+            self.properties_string.as_str(),
+            name.as_str(),
+        ));
     }
 
     pub fn with_version(&mut self, version: MessageVersion) {
@@ -123,7 +126,7 @@ impl MessageExtBrokerInner {
         self.message_ext_inner.prepared_transaction_offset()
     }
 
-    pub fn property(&self, name: &str) -> Option<String> {
+    pub fn property(&self, name: &str) -> Option<CheetahString> {
         self.message_ext_inner.properties().get(name).cloned()
     }
 
@@ -149,7 +152,7 @@ impl MessageExtBrokerInner {
         JavaStringHasher::new().hash_str(tags) as i64
     }
 
-    pub fn get_tags(&self) -> Option<String> {
+    pub fn get_tags(&self) -> Option<CheetahString> {
         self.message_ext_inner.get_tags()
     }
 
@@ -184,7 +187,7 @@ impl fmt::Display for MessageExtBrokerInner {
 }
 
 impl MessageTrait for MessageExtBrokerInner {
-    fn put_property(&mut self, key: String, value: String) {
+    fn put_property(&mut self, key: CheetahString, value: CheetahString) {
         self.message_ext_inner.put_property(key, value);
     }
 
@@ -192,15 +195,15 @@ impl MessageTrait for MessageExtBrokerInner {
         self.message_ext_inner.clear_property(name);
     }
 
-    fn get_property(&self, name: &str) -> Option<String> {
+    fn get_property(&self, name: &CheetahString) -> Option<CheetahString> {
         self.message_ext_inner.get_property(name)
     }
 
-    fn get_topic(&self) -> &str {
+    fn get_topic(&self) -> &CheetahString {
         self.message_ext_inner.get_topic()
     }
 
-    fn set_topic(&mut self, topic: String) {
+    fn set_topic(&mut self, topic: CheetahString) {
         self.message_ext_inner.set_topic(topic);
     }
 
@@ -220,11 +223,11 @@ impl MessageTrait for MessageExtBrokerInner {
         self.message_ext_inner.set_body(body);
     }
 
-    fn get_properties(&self) -> &HashMap<String, String> {
+    fn get_properties(&self) -> &HashMap<CheetahString, CheetahString> {
         self.message_ext_inner.get_properties()
     }
 
-    fn set_properties(&mut self, properties: HashMap<String, String>) {
+    fn set_properties(&mut self, properties: HashMap<CheetahString, CheetahString>) {
         self.message_ext_inner.set_properties(properties);
     }
 
@@ -232,7 +235,7 @@ impl MessageTrait for MessageExtBrokerInner {
         self.message_ext_inner.get_transaction_id()
     }
 
-    fn set_transaction_id(&mut self, transaction_id: String) {
+    fn set_transaction_id(&mut self, transaction_id: CheetahString) {
         self.message_ext_inner.set_transaction_id(transaction_id);
     }
 

--- a/rocketmq-common/src/utils/message_utils.rs
+++ b/rocketmq-common/src/utils/message_utils.rs
@@ -156,8 +156,8 @@ mod tests {
     fn test_get_sharding_key_index_by_msg() {
         let mut message = MessageExt::default();
         message.message.properties.insert(
-            MessageConst::PROPERTY_SHARDING_KEY.to_owned(),
-            "example_key".to_owned(),
+            MessageConst::PROPERTY_SHARDING_KEY.into(),
+            "example_key".into(),
         );
         let index_size = 10;
         let result = get_sharding_key_index_by_msg(&message, index_size);
@@ -168,16 +168,16 @@ mod tests {
     fn test_get_sharding_key_indexes() {
         let mut messages = Vec::new();
         let mut message1 = MessageExt::default();
-        message1.message.properties.insert(
-            MessageConst::PROPERTY_SHARDING_KEY.to_owned(),
-            "key1".to_owned(),
-        );
+        message1
+            .message
+            .properties
+            .insert(MessageConst::PROPERTY_SHARDING_KEY.into(), "key1".into());
         messages.push(message1);
         let mut message2 = MessageExt::default();
-        message2.message.properties.insert(
-            MessageConst::PROPERTY_SHARDING_KEY.to_owned(),
-            "key2".to_owned(),
-        );
+        message2
+            .message
+            .properties
+            .insert(MessageConst::PROPERTY_SHARDING_KEY.into(), "key2".into());
         messages.push(message2);
         let index_size = 10;
         let result = get_sharding_key_indexes(&messages, index_size);

--- a/rocketmq-common/src/utils/string_utils.rs
+++ b/rocketmq-common/src/utils/string_utils.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use cheetah_string::CheetahString;
 
 pub struct StringUtils;
 
@@ -25,6 +26,11 @@ impl StringUtils {
 
     #[inline]
     pub fn is_not_empty_string(s: Option<&String>) -> bool {
+        s.map_or(false, |s| !s.is_empty())
+    }
+
+    #[inline]
+    pub fn is_not_empty_ch_string(s: Option<&CheetahString>) -> bool {
         s.map_or(false, |s| !s.is_empty())
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_max_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_max_offset_request_header.rs
@@ -120,8 +120,8 @@ impl TopicRequestHeaderTrait for GetMaxOffsetRequestHeader {
         self.topic = topic;
     }
 
-    fn topic(&self) -> &str {
-        self.topic.as_str()
+    fn topic(&self) -> &CheetahString {
+        &self.topic
     }
 
     fn broker_name(&self) -> Option<&str> {

--- a/rocketmq-remoting/src/protocol/header/get_min_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_min_offset_request_header.rs
@@ -96,8 +96,8 @@ impl TopicRequestHeaderTrait for GetMinOffsetRequestHeader {
         self.topic = topic;
     }
 
-    fn topic(&self) -> &str {
-        self.topic.as_str()
+    fn topic(&self) -> &CheetahString {
+        &self.topic
     }
 
     fn broker_name(&self) -> Option<&str> {

--- a/rocketmq-remoting/src/protocol/header/message_operation_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header.rs
@@ -27,7 +27,7 @@ pub trait TopicRequestHeaderTrait: Sync + Send {
 
     fn set_topic(&mut self, topic: CheetahString);
 
-    fn topic(&self) -> &str;
+    fn topic(&self) -> &CheetahString;
 
     fn broker_name(&self) -> Option<&str>;
 

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
@@ -212,8 +212,8 @@ impl TopicRequestHeaderTrait for SendMessageRequestHeader {
         self.topic = topic;
     }
 
-    fn topic(&self) -> &str {
-        self.topic.as_str()
+    fn topic(&self) -> &CheetahString {
+        &self.topic
     }
 
     fn broker_name(&self) -> Option<&str> {

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -297,8 +297,8 @@ impl TopicRequestHeaderTrait for SendMessageRequestHeaderV2 {
         self.b = topic;
     }
 
-    fn topic(&self) -> &str {
-        self.b.as_str()
+    fn topic(&self) -> &CheetahString {
+        &self.b
     }
 
     fn broker_name(&self) -> Option<&str> {

--- a/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
@@ -394,8 +394,8 @@ impl TopicRequestHeaderTrait for PullMessageRequestHeader {
         self.topic = topic;
     }
 
-    fn topic(&self) -> &str {
-        self.topic.as_str()
+    fn topic(&self) -> &CheetahString {
+        &self.topic
     }
 
     fn broker_name(&self) -> Option<&str> {

--- a/rocketmq-remoting/src/protocol/header/query_consumer_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_consumer_offset_request_header.rs
@@ -110,8 +110,8 @@ impl TopicRequestHeaderTrait for QueryConsumerOffsetRequestHeader {
         self.topic = topic;
     }
 
-    fn topic(&self) -> &str {
-        self.topic.as_str()
+    fn topic(&self) -> &CheetahString {
+        &self.topic
     }
 
     fn broker_name(&self) -> Option<&str> {

--- a/rocketmq-remoting/src/protocol/header/update_consumer_offset_header.rs
+++ b/rocketmq-remoting/src/protocol/header/update_consumer_offset_header.rs
@@ -124,8 +124,8 @@ impl TopicRequestHeaderTrait for UpdateConsumerOffsetRequestHeader {
         self.topic = topic;
     }
 
-    fn topic(&self) -> &str {
-        self.topic.as_str()
+    fn topic(&self) -> &CheetahString {
+        &self.topic
     }
 
     fn broker_name(&self) -> Option<&str> {

--- a/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_context.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_context.rs
@@ -14,12 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use cheetah_string::CheetahString;
+
 use crate::protocol::static_topic::logic_queue_mapping_item::LogicQueueMappingItem;
 use crate::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
 
 #[derive(Default)]
 pub struct TopicQueueMappingContext {
-    pub topic: String,
+    pub topic: CheetahString,
     pub global_id: Option<i32>,
     pub mapping_detail: Option<TopicQueueMappingDetail>,
     pub mapping_item_list: Vec<LogicQueueMappingItem>,
@@ -29,7 +31,7 @@ pub struct TopicQueueMappingContext {
 
 impl TopicQueueMappingContext {
     pub fn new(
-        topic: impl Into<String>,
+        topic: impl Into<CheetahString>,
         global_id: Option<i32>,
         mapping_detail: Option<TopicQueueMappingDetail>,
         mapping_item_list: Vec<LogicQueueMappingItem>,

--- a/rocketmq-store/src/base/dispatch_request.rs
+++ b/rocketmq-store/src/base/dispatch_request.rs
@@ -19,6 +19,8 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
+use cheetah_string::CheetahString;
+
 #[derive(Debug)]
 pub struct DispatchRequest {
     pub topic: String,
@@ -28,12 +30,12 @@ pub struct DispatchRequest {
     pub tags_code: i64,
     pub store_timestamp: i64,
     pub consume_queue_offset: i64,
-    pub keys: String,
+    pub keys: CheetahString,
     pub success: bool,
-    pub uniq_key: Option<String>,
+    pub uniq_key: Option<CheetahString>,
     pub sys_flag: i32,
     pub prepared_transaction_offset: i64,
-    pub properties_map: Option<HashMap<String, String>>,
+    pub properties_map: Option<HashMap<CheetahString, CheetahString>>,
     pub bit_map: Option<Vec<u8>>,
     pub buffer_size: i32,
     pub msg_base_offset: i64,
@@ -52,7 +54,7 @@ impl Default for DispatchRequest {
             tags_code: 0,
             store_timestamp: 0,
             consume_queue_offset: 0,
-            keys: "".to_string(),
+            keys: CheetahString::empty(),
             success: false,
             uniq_key: None,
             sys_flag: 0,

--- a/rocketmq-store/src/base/message_arriving_listener.rs
+++ b/rocketmq-store/src/base/message_arriving_listener.rs
@@ -16,6 +16,8 @@
  */
 use std::collections::HashMap;
 
+use cheetah_string::CheetahString;
+
 pub trait MessageArrivingListener {
     /// This method is called when a new message arrives.
     ///
@@ -37,6 +39,6 @@ pub trait MessageArrivingListener {
         tags_code: Option<i64>,
         msg_store_time: i64,
         filter_bit_map: Option<Vec<u8>>,
-        properties: Option<&HashMap<String, String>>,
+        properties: Option<&HashMap<CheetahString, CheetahString>>,
     );
 }

--- a/rocketmq-store/src/filter.rs
+++ b/rocketmq-store/src/filter.rs
@@ -17,6 +17,8 @@
 
 use std::collections::HashMap;
 
+use cheetah_string::CheetahString;
+
 use crate::consume_queue::consume_queue_ext::CqExtUnit;
 
 /// Represents a message filter.
@@ -36,6 +38,6 @@ pub trait MessageFilter: Send + Sync {
     fn is_matched_by_commit_log(
         &self,
         msg_buffer: Option<&[u8]>,
-        properties: Option<&HashMap<String, String>>,
+        properties: Option<&HashMap<CheetahString, CheetahString>>,
     ) -> bool;
 }

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -166,10 +166,13 @@ pub fn get_message_num(
     if MessageSysFlag::check(msg_inner.sys_flag(), MessageSysFlag::INNER_BATCH_FLAG)
         || cq_type == CQType::BatchCQ
     {
-        if let Some(num) = msg_inner
-            .message_ext_inner
-            .message
-            .get_property(MessageConst::PROPERTY_INNER_NUM)
+        if let Some(num) =
+            msg_inner
+                .message_ext_inner
+                .message
+                .get_property(&CheetahString::from_static_str(
+                    MessageConst::PROPERTY_INNER_NUM,
+                ))
         {
             message_num = num.parse().unwrap_or(1i16);
         }
@@ -1271,12 +1274,12 @@ pub fn check_message_and_return_size(
         let tags_code = tags_string2tags_code(tags);
         (
             tags_code,
-            keys.unwrap_or("".to_string()),
+            keys.unwrap_or_default(),
             uniq_key,
             properties_map,
         )
     } else {
-        (0, "".to_string(), None, HashMap::new())
+        (0, CheetahString::new(), None, HashMap::new())
     };
 
     if check_crc && !message_store_config.force_verify_prop_crc {
@@ -1325,7 +1328,7 @@ pub fn check_message_and_return_size(
 }
 
 fn set_batch_size_if_needed(
-    properties_map: &HashMap<String, String>,
+    properties_map: &HashMap<CheetahString, CheetahString>,
     dispatch_request: &mut DispatchRequest,
 ) {
     if !properties_map.is_empty()


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1142 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `CheetahString` for enhanced string handling across various components.
  
- **Bug Fixes**
	- Corrected logic in the `set_oneway` method for `SendMessageRequestHeader`.
  
- **Refactor**
	- Updated multiple method signatures to replace `String` with `CheetahString`, improving type safety and performance.
	- Streamlined property handling in the `CommitLog` and `DispatchRequest` structs to utilize `CheetahString`.
  
- **Chores**
	- Added new dependency on `cheetah_string` crate across multiple files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->