### PR TITLE
[ISSUE #1144]Bump cheetah-string 0.1.2 to 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,4 +81,4 @@ uuid = { version = "1.11.0", features = ["v4", # Lets you generate random UUIDs
 
 futures = "0.3"
 
-cheetah-string = { version = "0.1.3", features = ["serde", "bytes"] }
+cheetah-string = { version = "0.1.4", features = ["serde", "bytes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,4 +81,4 @@ uuid = { version = "1.11.0", features = ["v4", # Lets you generate random UUIDs
 
 futures = "0.3"
 
-cheetah-string = { git = "https://github.com/mxsm/cheetah-string.git", features = ["serde", "bytes"] }
+cheetah-string = { version = "0.1.3", features = ["serde", "bytes"] }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1144 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the dependency for `cheetah-string` to a specific version, enhancing dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->