### PR TITLE
[ISSUE #1152] Add test case for MessageQueue

### DIFF
--- a/rocketmq-common/src/common/message/message_queue.rs
+++ b/rocketmq-common/src/common/message/message_queue.rs
@@ -140,3 +140,82 @@ impl Default for MessageQueue {
         MessageQueue::new()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn new_message_queue_has_default_values() {
+        let mq = MessageQueue::new();
+        assert_eq!(mq.get_topic(), "");
+        assert_eq!(mq.get_broker_name(), "");
+        assert_eq!(mq.get_queue_id(), 0);
+    }
+
+    #[test]
+    fn from_other_creates_identical_copy() {
+        let mq1 = MessageQueue::from_parts("topic1", "broker1", 1);
+        let mq2 = MessageQueue::from_other(&mq1);
+        assert_eq!(mq1, mq2);
+    }
+
+    #[test]
+    fn from_parts_creates_message_queue_with_given_values() {
+        let mq = MessageQueue::from_parts("topic1", "broker1", 1);
+        assert_eq!(mq.get_topic(), "topic1");
+        assert_eq!(mq.get_broker_name(), "broker1");
+        assert_eq!(mq.get_queue_id(), 1);
+    }
+
+    #[test]
+    fn set_topic_updates_topic() {
+        let mut mq = MessageQueue::new();
+        mq.set_topic(CheetahString::from("new_topic"));
+        assert_eq!(mq.get_topic(), "new_topic");
+    }
+
+    #[test]
+    fn set_broker_name_updates_broker_name() {
+        let mut mq = MessageQueue::new();
+        mq.set_broker_name(CheetahString::from("new_broker"));
+        assert_eq!(mq.get_broker_name(), "new_broker");
+    }
+
+    #[test]
+    fn set_queue_id_updates_queue_id() {
+        let mut mq = MessageQueue::new();
+        mq.set_queue_id(10);
+        assert_eq!(mq.get_queue_id(), 10);
+    }
+
+    #[test]
+    fn message_queue_equality() {
+        let mq1 = MessageQueue::from_parts("topic1", "broker1", 1);
+        let mq2 = MessageQueue::from_parts("topic1", "broker1", 1);
+        assert_eq!(mq1, mq2);
+    }
+
+    #[test]
+    fn message_queue_inequality() {
+        let mq1 = MessageQueue::from_parts("topic1", "broker1", 1);
+        let mq2 = MessageQueue::from_parts("topic2", "broker2", 2);
+        assert_ne!(mq1, mq2);
+    }
+
+    #[test]
+    fn message_queue_ordering() {
+        let mq1 = MessageQueue::from_parts("topic1", "broker1", 1);
+        let mq2 = MessageQueue::from_parts("topic1", "broker1", 2);
+        assert!(mq1 < mq2);
+    }
+
+    #[test]
+    fn message_queue_display_format() {
+        let mq = MessageQueue::from_parts("topic1", "broker1", 1);
+        assert_eq!(
+            format!("{}", mq),
+            "MessageQueue [topic=topic1, broker_name=broker1, queue_id=1]"
+        );
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1152 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced a new test module for the `MessageQueue` struct to enhance test coverage.
	- Added unit tests for default values, copy creation, value initialization, setter methods, equality checks, ordering, and display format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->