### PR TITLE
[ISSUE #1158]Refactor message_utils#delete_property method

### DIFF
--- a/rocketmq-common/src/utils/message_utils.rs
+++ b/rocketmq-common/src/utils/message_utils.rs
@@ -75,15 +75,13 @@ pub fn delete_property(properties_string: &str, name: &str) -> String {
                     }
                     let idx1 = idx1.unwrap();
                     start_idx = idx1 + name.len();
-                    if idx1 == 0
-                        || properties_string.chars().nth(idx1 - 1) == Some(PROPERTY_SEPARATOR)
+                    if (idx1 == 0
+                        || properties_string.chars().nth(idx1 - 1) == Some(PROPERTY_SEPARATOR))
+                        && (properties_string.len() > idx1 + name.len())
+                        && properties_string.chars().nth(idx1 + name.len())
+                            == Some(NAME_VALUE_SEPARATOR)
                     {
-                        if properties_string.len() > idx1 + name.len()
-                            && properties_string.chars().nth(idx1 + name.len())
-                                == Some(NAME_VALUE_SEPARATOR)
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
                 if idx1.is_none() {

--- a/rocketmq-common/src/utils/message_utils.rs
+++ b/rocketmq-common/src/utils/message_utils.rs
@@ -61,7 +61,7 @@ pub fn delete_property(properties_string: &str, name: &str) -> String {
         let mut idx1;
         let mut idx2;
         idx1 = properties_string.find(name);
-        if let Some(_) = idx1 {
+        if idx1.is_some() {
             // cropping may be required
             let mut string_builder = String::with_capacity(properties_string.len());
             loop {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1158 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the property deletion functionality for more precise string manipulation, effectively handling various edge cases.

- **Tests**
	- Introduced new test cases to validate the updated behavior of the property deletion function under different scenarios, including edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->