### PR TITLE
[ISSUE #1160]🔥Optimize ValidateTopicResult String with CheetahString

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -87,7 +87,7 @@ impl TopicRequestHandler {
             return Some(
                 response
                     .set_code(ResponseCode::SystemError)
-                    .set_remark(result.remark()),
+                    .set_remark(result.remark().clone()),
             );
         }
         if self
@@ -213,7 +213,7 @@ impl TopicRequestHandler {
                 return Some(
                     response
                         .set_code(ResponseCode::SystemError)
-                        .set_remark(result.remark()),
+                        .set_remark(result.remark().clone()),
                 );
             }
             if self


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1160 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced string handling in topic validation using `CheetahString`.
	- Improved remarks for topic validation results.

- **Bug Fixes**
	- Adjusted handling of the `remark` field in response commands for invalid topics.

- **Tests**
	- Added unit tests for various topic validation scenarios, ensuring robust functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->