### PR TITLE
[ISSUE #1247]🔨Add Sync Issue Labels to PR Github action CI

### DIFF
--- a/.github/workflows/sync-issue-labels.yml
+++ b/.github/workflows/sync-issue-labels.yml
@@ -2,7 +2,7 @@ name: Sync Issue Labels to PR
 
 on:
   pull_request:
-    types: [ opened, synchronize ] # Trigger when a PR is created or updated
+    types: [ opened, synchronize, edited ] # Trigger when a PR is created, updated, or edited
 
 jobs:
   sync-labels:

--- a/.github/workflows/sync-issue-labels.yml
+++ b/.github/workflows/sync-issue-labels.yml
@@ -21,8 +21,8 @@ jobs:
           script: |
             // Extract linked issue numbers from the PR description
             const issueNumbers = context.payload.pull_request.body
-              ?.match(/#\d+/g)
-              ?.map(match => parseInt(match.replace('#', ''))) || [];
+              ?.match(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)?(?:\s*)?#(\d+)/gi)
+              ?.map(match => parseInt(match.match(/\d+/)[0])) || [];
             
             if (issueNumbers.length === 0) {
               console.log("No linked issues found in the PR description.");

--- a/.github/workflows/sync-issue-labels.yml
+++ b/.github/workflows/sync-issue-labels.yml
@@ -1,0 +1,60 @@
+name: Sync Issue Labels to PR
+
+on:
+  pull_request:
+    types: [ opened, synchronize ] # Trigger when a PR is created or updated
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      # Sync labels from the linked issue to the PR
+      - name: Sync Labels from Linked Issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_TOKEN  }}
+          script: |
+            // Extract linked issue numbers from the PR description
+            const issueNumbers = context.payload.pull_request.body
+              ?.match(/#\d+/g)
+              ?.map(match => parseInt(match.replace('#', ''))) || [];
+            
+            if (issueNumbers.length === 0) {
+              console.log("No linked issues found in the PR description.");
+              return;
+            }
+            
+            for (const issueNumber of issueNumbers) {
+              console.log(`Processing linked issue: #${issueNumber}`);
+            
+              // Fetch labels from the linked issue
+              const issueResponse = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+            
+              const issueLabels = issueResponse.data.labels.map(label => label.name);
+            
+              if (issueLabels.length === 0) {
+                console.log(`No labels found on Issue #${issueNumber}`);
+                continue;
+              }
+            
+              console.log(`Labels from Issue #${issueNumber}: ${issueLabels.join(', ')}`);
+            
+              // Add labels to the PR
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: issueLabels,
+              });
+            
+              console.log(`Labels synced to PR: ${issueLabels.join(', ')}`);
+            }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1247 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated workflow to synchronize labels from linked issues to pull requests, enhancing organization and tracking of related work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->