### PR TITLE
[ISSUE #1263]🔨Optimize TopicConfig encode📝

### DIFF
--- a/rocketmq-common/src/common/config.rs
+++ b/rocketmq-common/src/common/config.rs
@@ -121,7 +121,12 @@ impl TopicConfig {
 
     pub fn encode(&self) -> String {
         let mut sb = String::new();
-        sb.push_str(self.topic_name.as_deref().unwrap_or(""));
+        sb.push_str(
+            self.topic_name
+                .clone()
+                .unwrap_or(CheetahString::empty())
+                .as_str(),
+        );
         sb.push_str(Self::SEPARATOR);
         sb.push_str(&self.read_queue_nums.to_string());
         sb.push_str(Self::SEPARATOR);
@@ -129,9 +134,9 @@ impl TopicConfig {
         sb.push_str(Self::SEPARATOR);
         sb.push_str(&self.perm.to_string());
         sb.push_str(Self::SEPARATOR);
-        sb.push_str(&format!("{:?}", self.topic_filter_type));
+        sb.push_str(&format!("{}", self.topic_filter_type));
+        sb.push_str(Self::SEPARATOR);
         if !self.attributes.is_empty() {
-            sb.push_str(Self::SEPARATOR);
             sb.push_str(&serde_json::to_string(&self.attributes).unwrap());
         }
         sb


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1263 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `topic_name` field to prevent panics when the value is absent.
	- Enhanced formatting for `topic_filter_type` for better representation in encoded strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->