### PR TITLE
[ISSUE #1267]⚡️Optimize Name server DefaultRequestProcessor#query_broker_topic_config

### DIFF
--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -51,6 +51,7 @@ use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::Regist
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_remoting::protocol::DataVersion;
+use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use tracing::warn;
@@ -165,10 +166,8 @@ impl DefaultRequestProcessor {
         let request_header = request
             .decode_command_custom_header::<QueryDataVersionRequestHeader>()
             .expect("decode QueryDataVersionRequestHeader failed");
-        let data_version = SerdeJsonUtils::decode::<DataVersion>(
-            request.body().as_ref().map(|v| v.as_ref()).unwrap(),
-        )
-        .unwrap();
+        let data_version = DataVersion::decode(request.get_body().expect("body is empty"))
+            .expect("decode DataVersion failed");
         let changed = self.route_info_manager.is_broker_topic_config_changed(
             &request_header.cluster_name,
             &request_header.broker_addr,

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -513,11 +513,10 @@ impl RouteInfoManager {
     ) -> bool {
         let option = self.query_broker_topic_config(cluster_name.clone(), broker_addr.clone());
         if let Some(pre) = option {
-            if pre != data_version {
-                return true;
-            }
+            pre != data_version
+        } else {
+            true
         }
-        false
     }
 
     pub(crate) fn query_broker_topic_config(


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1267 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for decoding `DataVersion` to ensure the request body is not empty.
	- Enhanced broker unregistration logic to notify changes only when necessary and clean up associated topics more effectively.

- **Refactor**
	- Simplified the `is_broker_topic_config_changed` method for better clarity and maintainability.
	- Streamlined control flow and logging within broker registration and unregistration methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->