### PR TITLE
[ISSUE #1305]🚀Add SetMessageRequestModeRequestBody

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -34,6 +34,7 @@ pub mod query_assignment_request_body;
 pub mod query_assignment_response_body;
 pub mod request;
 pub mod response;
+pub mod set_message_request_mode_request_body;
 pub mod topic;
 pub mod topic_info_wrapper;
 pub mod unlock_batch_request_body;

--- a/rocketmq-remoting/src/protocol/body/set_message_request_mode_request_body.rs
+++ b/rocketmq-remoting/src/protocol/body/set_message_request_mode_request_body.rs
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_common::common::message::message_enum::MessageRequestMode;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetMessageRequestModeRequestBody {
+    pub topic: CheetahString,
+    pub consumer_group: CheetahString,
+    pub mode: MessageRequestMode,
+    /*
+    consumer working in pop mode could share the MessageQueues assigned to
+    the N (N = popShareQueueNum) consumers following it in the cid list
+     */
+    pub pop_share_queue_num: i32,
+}
+
+impl Default for SetMessageRequestModeRequestBody {
+    fn default() -> Self {
+        SetMessageRequestModeRequestBody {
+            topic: CheetahString::new(),
+            consumer_group: CheetahString::new(),
+            mode: MessageRequestMode::Pull,
+            pop_share_queue_num: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn serialize_set_message_request_mode_request_body() {
+        let body = SetMessageRequestModeRequestBody {
+            topic: CheetahString::from("test_topic"),
+            consumer_group: CheetahString::from("test_group"),
+            mode: MessageRequestMode::Pop,
+            pop_share_queue_num: 5,
+        };
+        let serialized = serde_json::to_string(&body).unwrap();
+        assert!(serialized.contains("\"topic\":\"test_topic\""));
+        assert!(serialized.contains("\"consumerGroup\":\"test_group\""));
+        assert!(serialized.contains("\"mode\":\"POP\""));
+        assert!(serialized.contains("\"popShareQueueNum\":5"));
+    }
+
+    #[test]
+    fn default_set_message_request_mode_request_body() {
+        let default_body = SetMessageRequestModeRequestBody::default();
+        assert_eq!(default_body.topic, CheetahString::new());
+        assert_eq!(default_body.consumer_group, CheetahString::new());
+        assert_eq!(default_body.mode, MessageRequestMode::Pull);
+        assert_eq!(default_body.pop_share_queue_num, 0);
+    }
+
+    #[test]
+    fn deserialize_set_message_request_mode_request_body() {
+        let json = r#"
+            {
+            "topic": "test_topic",
+            "consumerGroup": "test_group",
+            "mode": "PULL",
+            "popShareQueueNum": 3
+        }"#;
+        let deserialized: SetMessageRequestModeRequestBody = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized.topic, CheetahString::from("test_topic"));
+        assert_eq!(
+            deserialized.consumer_group,
+            CheetahString::from("test_group")
+        );
+        assert_eq!(deserialized.mode, MessageRequestMode::Pull);
+        assert_eq!(deserialized.pop_share_queue_num, 3);
+    }
+
+    #[test]
+    fn deserialize_set_message_request_mode_request_body_invalid_mode() {
+        let json = r#"{
+                                        "topic": "test_topic",
+                                        "consumerGroup": "test_group",
+                                        "mode": "INVALID",
+                                        "popShareQueueNum": 3
+                                    }"#;
+        let deserialized: Result<SetMessageRequestModeRequestBody, _> = serde_json::from_str(json);
+        assert!(deserialized.is_err());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1305 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for setting message request modes, enhancing the messaging system's functionality.
	- Added a structured request body for configuring message request modes, including fields for topic, consumer group, and mode.

- **Tests**
	- Implemented comprehensive unit tests to ensure proper serialization, deserialization, and error handling for the new request body structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->