### PR TITLE
[ISSUE #1321]🧪Add unit test for OperationResult

### DIFF
--- a/rocketmq-broker/src/transaction/operation_result.rs
+++ b/rocketmq-broker/src/transaction/operation_result.rs
@@ -34,3 +34,48 @@ impl Default for OperationResult {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_common::common::message::message_ext::MessageExt;
+    use rocketmq_remoting::code::response_code::ResponseCode;
+
+    use super::*;
+
+    #[test]
+    fn default_operation_result_has_none_fields() {
+        let result = OperationResult::default();
+        assert!(result.prepare_message.is_none());
+        assert!(result.response_remark.is_none());
+        assert_eq!(result.response_code, ResponseCode::Success);
+    }
+
+    #[test]
+    fn operation_result_with_some_fields() {
+        let message = MessageExt::default();
+        let remark = Some(String::from("Test remark"));
+        let response_code = ResponseCode::SystemError;
+
+        let result = OperationResult {
+            prepare_message: Some(message.clone()),
+            response_remark: remark.clone(),
+            response_code,
+        };
+
+        assert_eq!(result.response_remark, remark);
+        assert_eq!(result.response_code, response_code);
+    }
+
+    #[test]
+    fn operation_result_with_none_fields() {
+        let result = OperationResult {
+            prepare_message: None,
+            response_remark: None,
+            response_code: ResponseCode::Success,
+        };
+
+        assert!(result.prepare_message.is_none());
+        assert!(result.response_remark.is_none());
+        assert_eq!(result.response_code, ResponseCode::Success);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1321 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced a new test module for validating the `OperationResult` struct.
	- Added three unit tests to ensure correct behavior and default values of `OperationResult`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->