### PR TITLE
[ISSUE #1328]🧪Add test for ConsumerData

### DIFF
--- a/rocketmq-remoting/src/protocol/heartbeat/consumer_data.rs
+++ b/rocketmq-remoting/src/protocol/heartbeat/consumer_data.rs
@@ -49,3 +49,105 @@ impl Hash for ConsumerData {
         self.unit_mode.hash(state);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+
+    use super::*;
+    use crate::protocol::heartbeat::consume_type::ConsumeType;
+    use crate::protocol::heartbeat::message_model::MessageModel;
+    use crate::protocol::heartbeat::subscription_data::SubscriptionData;
+
+    #[test]
+    fn consumer_data_default_values() {
+        let consumer_data = ConsumerData::default();
+        assert_eq!(consumer_data.group_name, CheetahString::new());
+        assert_eq!(consumer_data.consume_type, ConsumeType::default());
+        assert_eq!(consumer_data.message_model, MessageModel::default());
+        assert_eq!(
+            consumer_data.consume_from_where,
+            ConsumeFromWhere::default()
+        );
+        assert!(consumer_data.subscription_data_set.is_empty());
+        assert!(!consumer_data.unit_mode);
+    }
+
+    #[test]
+    fn consumer_data_equality() {
+        let mut subscription_data_set = HashSet::new();
+        subscription_data_set.insert(SubscriptionData::default());
+
+        let consumer_data1 = ConsumerData {
+            group_name: CheetahString::from("group1"),
+            consume_type: ConsumeType::default(),
+            message_model: MessageModel::default(),
+            consume_from_where: ConsumeFromWhere::default(),
+            subscription_data_set: subscription_data_set.clone(),
+            unit_mode: false,
+        };
+
+        let consumer_data2 = ConsumerData {
+            group_name: CheetahString::from("group1"),
+            consume_type: ConsumeType::default(),
+            message_model: MessageModel::default(),
+            consume_from_where: ConsumeFromWhere::default(),
+            subscription_data_set,
+            unit_mode: false,
+        };
+
+        assert_eq!(consumer_data1, consumer_data2);
+    }
+
+    #[test]
+    fn consumer_data_inequality() {
+        let consumer_data1 = ConsumerData {
+            group_name: CheetahString::from("group1"),
+            consume_type: ConsumeType::default(),
+            message_model: MessageModel::default(),
+            consume_from_where: ConsumeFromWhere::default(),
+            subscription_data_set: HashSet::new(),
+            unit_mode: false,
+        };
+
+        let consumer_data2 = ConsumerData {
+            group_name: CheetahString::from("group2"),
+            consume_type: ConsumeType::default(),
+            message_model: MessageModel::default(),
+            consume_from_where: ConsumeFromWhere::default(),
+            subscription_data_set: HashSet::new(),
+            unit_mode: false,
+        };
+
+        assert_ne!(consumer_data1, consumer_data2);
+    }
+
+    #[test]
+    fn consumer_data_hash() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::Hash;
+        use std::hash::Hasher;
+
+        let consumer_data = ConsumerData {
+            group_name: CheetahString::from("group1"),
+            consume_type: ConsumeType::default(),
+            message_model: MessageModel::default(),
+            consume_from_where: ConsumeFromWhere::default(),
+            subscription_data_set: HashSet::new(),
+            unit_mode: false,
+        };
+
+        let mut hasher = DefaultHasher::new();
+        consumer_data.hash(&mut hasher);
+        let hash1 = hasher.finish();
+
+        let mut hasher = DefaultHasher::new();
+        consumer_data.hash(&mut hasher);
+        let hash2 = hasher.finish();
+
+        assert_eq!(hash1, hash2);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1328 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced a new test module for validating the functionality of the `ConsumerData` struct.
	- Added unit tests for default values, equality, inequality, and hashing of `ConsumerData` instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->