### PR TITLE
[ISSUE #1330]🧪Add unit test for MessageModel

### DIFF
--- a/rocketmq-remoting/src/protocol/heartbeat/message_model.rs
+++ b/rocketmq-remoting/src/protocol/heartbeat/message_model.rs
@@ -89,3 +89,57 @@ impl Display for MessageModel {
         write!(f, "{}", self.get_mode_cn())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn serialize_message_model_broadcasting() {
+        let model = MessageModel::Broadcasting;
+        let serialized = serde_json::to_string(&model).unwrap();
+        assert_eq!(serialized, "\"BROADCASTING\"");
+    }
+
+    #[test]
+    fn serialize_message_model_clustering() {
+        let model = MessageModel::Clustering;
+        let serialized = serde_json::to_string(&model).unwrap();
+        assert_eq!(serialized, "\"CLUSTERING\"");
+    }
+
+    #[test]
+    fn deserialize_message_model_broadcasting() {
+        let json = "\"BROADCASTING\"";
+        let deserialized: MessageModel = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, MessageModel::Broadcasting);
+    }
+
+    #[test]
+    fn deserialize_message_model_clustering() {
+        let json = "\"CLUSTERING\"";
+        let deserialized: MessageModel = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, MessageModel::Clustering);
+    }
+
+    #[test]
+    fn deserialize_message_model_invalid() {
+        let json = "\"INVALID\"";
+        let deserialized: Result<MessageModel, _> = serde_json::from_str(json);
+        assert!(deserialized.is_err());
+    }
+
+    #[test]
+    fn display_message_model_broadcasting() {
+        let model = MessageModel::Broadcasting;
+        assert_eq!(model.to_string(), "BROADCASTING");
+    }
+
+    #[test]
+    fn display_message_model_clustering() {
+        let model = MessageModel::Clustering;
+        assert_eq!(model.to_string(), "CLUSTERING");
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1330 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced a new test module for the `MessageModel` enum to enhance test coverage.
	- Added tests for serialization and deserialization of `MessageModel` values.
	- Included validation tests for string representations and error handling during deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->