### PR TITLE
[ISSUE #1338]🧪Add Unit test for ProducerData

### DIFF
--- a/rocketmq-remoting/src/protocol/heartbeat/producer_data.rs
+++ b/rocketmq-remoting/src/protocol/heartbeat/producer_data.rs
@@ -23,3 +23,79 @@ use serde::Serialize;
 pub struct ProducerData {
     pub group_name: CheetahString,
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn producer_data_default_values() {
+        let producer_data = ProducerData::default();
+        assert_eq!(producer_data.group_name, CheetahString::new());
+    }
+
+    #[test]
+    fn producer_data_equality() {
+        let producer_data1 = ProducerData {
+            group_name: CheetahString::from("group1"),
+        };
+
+        let producer_data2 = ProducerData {
+            group_name: CheetahString::from("group1"),
+        };
+
+        assert_eq!(producer_data1, producer_data2);
+    }
+
+    #[test]
+    fn producer_data_inequality() {
+        let producer_data1 = ProducerData {
+            group_name: CheetahString::from("group1"),
+        };
+
+        let producer_data2 = ProducerData {
+            group_name: CheetahString::from("group2"),
+        };
+
+        assert_ne!(producer_data1, producer_data2);
+    }
+
+    #[test]
+    fn serialize_producer_data() {
+        let producer_data = ProducerData {
+            group_name: CheetahString::from("group1"),
+        };
+        let serialized = serde_json::to_string(&producer_data).unwrap();
+        assert_eq!(serialized, r#"{"groupName":"group1"}"#);
+    }
+
+    #[test]
+    fn deserialize_producer_data() {
+        let json = r#"{"groupName":"group1"}"#;
+        let deserialized: ProducerData = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized.group_name, CheetahString::from("group1"));
+    }
+
+    #[test]
+    fn producer_data_hash() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::Hash;
+        use std::hash::Hasher;
+
+        let producer_data = ProducerData {
+            group_name: CheetahString::from("group1"),
+        };
+
+        let mut hasher = DefaultHasher::new();
+        producer_data.hash(&mut hasher);
+        let hash1 = hasher.finish();
+
+        let mut hasher = DefaultHasher::new();
+        producer_data.hash(&mut hasher);
+        let hash2 = hasher.finish();
+
+        assert_eq!(hash1, hash2);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1338 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced a new test module for validating the functionality of the `ProducerData` struct.
	- Added unit tests covering default values, equality, inequality, serialization, deserialization, and hashing. 

These enhancements improve the reliability and confidence in the `ProducerData` functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->