### PR TITLE
[ISSUE #1360]🧪Add unit test for DeleteTopicRequestHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/delete_topic_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/delete_topic_request_header.rs
@@ -64,3 +64,87 @@ impl FromMap for DeleteTopicRequestHeader {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn delete_topic_request_header_to_map() {
+        let header = DeleteTopicRequestHeader {
+            topic: CheetahString::from("test_topic"),
+            topic_request_header: None,
+        };
+
+        let map = header.to_map().unwrap();
+        assert_eq!(
+            map.get(&CheetahString::from_static_str(
+                DeleteTopicRequestHeader::TOPIC
+            ))
+            .unwrap(),
+            &CheetahString::from("test_topic")
+        );
+    }
+
+    #[test]
+    fn delete_topic_request_header_to_map_with_topic_request_header() {
+        let topic_request_header = TopicRequestHeader {
+            // Initialize fields as needed
+            rpc_request_header: None,
+            lo: None,
+        };
+        let header = DeleteTopicRequestHeader {
+            topic: CheetahString::from("test_topic"),
+            topic_request_header: Some(topic_request_header),
+        };
+
+        let map = header.to_map().unwrap();
+        assert_eq!(
+            map.get(&CheetahString::from_static_str(
+                DeleteTopicRequestHeader::TOPIC
+            ))
+            .unwrap(),
+            &CheetahString::from("test_topic")
+        );
+        // Add assertions for fields from topic_request_header
+    }
+
+    #[test]
+    fn delete_topic_request_header_from_map() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str(DeleteTopicRequestHeader::TOPIC),
+            CheetahString::from("test_topic"),
+        );
+
+        let header = <DeleteTopicRequestHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(header.topic, CheetahString::from("test_topic"));
+        assert!(!header.topic_request_header.is_none());
+    }
+
+    #[test]
+    fn delete_topic_request_header_from_map_with_topic_request_header() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str(DeleteTopicRequestHeader::TOPIC),
+            CheetahString::from("test_topic"),
+        );
+        // Add entries for fields from topic_request_header
+
+        let header = <DeleteTopicRequestHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(header.topic, CheetahString::from("test_topic"));
+        assert!(header.topic_request_header.is_some());
+        // Add assertions for fields from topic_request_header
+    }
+
+    #[test]
+    fn delete_topic_request_header_from_map_missing_topic() {
+        let map = HashMap::new();
+
+        let header = <DeleteTopicRequestHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(header.topic, CheetahString::default());
+        assert!(!header.topic_request_header.is_none());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1360 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced a new test module for the `DeleteTopicRequestHeader` struct, enhancing test coverage for its conversion methods.
	- Added unit tests to validate functionality under various scenarios, including basic conversions and handling of optional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->