### PR TITLE
[ISSUE #1374]🚀Add CheckRocksdbCqWriteProgressResponseBody and ProducerConnection

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -23,6 +23,7 @@ pub mod get_consumer_listby_group_response_body;
 pub mod consumer_connection;
 
 pub mod check_client_request_body;
+pub mod check_rocksdb_cqwrite_progress_response_body;
 pub mod cluster_acl_version_info;
 pub mod cm_result;
 pub mod connection;
@@ -31,6 +32,7 @@ pub mod group_list;
 pub mod kv_table;
 pub mod pop_process_queue_info;
 pub mod process_queue_info;
+pub mod producer_connection;
 pub mod query_assignment_request_body;
 pub mod query_assignment_response_body;
 pub mod request;

--- a/rocketmq-remoting/src/protocol/body/check_rocksdb_cqwrite_progress_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/check_rocksdb_cqwrite_progress_response_body.rs
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use cheetah_string::CheetahString;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ClusterAclVersionInfo {
+    pub diff_result: Option<CheetahString>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn cluster_acl_version_info_default_values() {
+        let info = ClusterAclVersionInfo::default();
+        assert!(info.diff_result.is_none());
+    }
+
+    #[test]
+    fn cluster_acl_version_info_with_diff_result() {
+        let info = ClusterAclVersionInfo {
+            diff_result: Some(CheetahString::from("diff")),
+        };
+        assert_eq!(info.diff_result, Some(CheetahString::from("diff")));
+    }
+
+    #[test]
+    fn serialize_cluster_acl_version_info() {
+        let info = ClusterAclVersionInfo {
+            diff_result: Some(CheetahString::from("diff")),
+        };
+        let serialized = serde_json::to_string(&info).unwrap();
+        assert_eq!(serialized, r#"{"diffResult":"diff"}"#);
+    }
+
+    #[test]
+    fn deserialize_cluster_acl_version_info() {
+        let json = r#"{"diffResult":"diff"}"#;
+        let deserialized: ClusterAclVersionInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized.diff_result, Some(CheetahString::from("diff")));
+    }
+
+    #[test]
+    fn deserialize_cluster_acl_version_info_missing_diff_result() {
+        let json = r#"{}"#;
+        let deserialized: ClusterAclVersionInfo = serde_json::from_str(json).unwrap();
+        assert!(deserialized.diff_result.is_none());
+    }
+}

--- a/rocketmq-remoting/src/protocol/body/connection.rs
+++ b/rocketmq-remoting/src/protocol/body/connection.rs
@@ -21,6 +21,7 @@ use serde::Serialize;
 use crate::protocol::LanguageCode;
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, Hash, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Connection {
     client_id: CheetahString,
     client_addr: CheetahString,

--- a/rocketmq-remoting/src/protocol/body/producer_connection.rs
+++ b/rocketmq-remoting/src/protocol/body/producer_connection.rs
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashSet;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::body::connection::Connection;
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ProducerConnection {
+    pub connection_set: HashSet<Connection>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use serde_json;
+
+    use super::*;
+    use crate::protocol::body::connection::Connection;
+
+    #[test]
+    fn producer_connection_default_values() {
+        let connection = ProducerConnection::default();
+        assert!(connection.connection_set.is_empty());
+    }
+
+    #[test]
+    fn producer_connection_with_connections() {
+        let mut connection_set = HashSet::new();
+        connection_set.insert(Connection::default());
+        let connection = ProducerConnection { connection_set };
+        assert_eq!(connection.connection_set.len(), 1);
+    }
+
+    #[test]
+    fn serialize_producer_connection() {
+        let mut connection_set = HashSet::new();
+        connection_set.insert(Connection::default());
+        let connection = ProducerConnection { connection_set };
+        let serialized = serde_json::to_string(&connection).unwrap();
+        assert!(serialized.contains("\"connectionSet\":["));
+    }
+
+    #[test]
+    fn deserialize_producer_connection_empty_set() {
+        let json = r#"{"connectionSet":[]}"#;
+        let deserialized: ProducerConnection = serde_json::from_str(json).unwrap();
+        assert!(deserialized.connection_set.is_empty());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1374 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new modules for handling request and response bodies related to RocksDB and producer connections.
	- Added `ClusterAclVersionInfo` struct for managing cluster ACL version information.
	- Added `ProducerConnection` struct for managing multiple producer connections.

- **Improvements**
	- Updated serialization behavior for existing `Connection` struct to use camelCase format.

- **Tests**
	- Comprehensive unit tests added for new structs to validate functionality, serialization, and deserialization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->