### PR TITLE
[ISSUE #1409]🔥Remove unused crate in rocketmq-namesrv🚨

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,29 +596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,12 +897,6 @@ name = "httparse"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1959,16 +1930,9 @@ name = "rocketmq-namesrv"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "bytes",
  "cheetah-string",
  "clap",
  "config",
- "env_logger",
- "futures",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-util",
  "parking_lot",
  "rocketmq-common",
  "rocketmq-remoting",
@@ -1977,10 +1941,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-stream",
- "tokio-util",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/rocketmq-namesrv/Cargo.toml
+++ b/rocketmq-namesrv/Cargo.toml
@@ -20,25 +20,16 @@ rocketmq-runtime = { workspace = true }
 
 
 anyhow.workspace = true
-env_logger.workspace = true
 
 tokio.workspace = true
-tokio-util.workspace = true
-tokio-stream.workspace = true
 
 tracing.workspace = true
-tracing-subscriber.workspace = true
+
 
 #json spupport
 serde.workspace = true
 serde_json.workspace = true
 
-futures-core = "0.3.0"
-futures-sink = "0.3.0"
-futures-io = { version = "0.3.0" }
-futures-util = { version = "0.3.31" }
-futures = "0.3.31"
-bytes = "1.8.0"
 config.workspace = true
 parking_lot.workspace = true
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1409

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined dependencies by removing several unused libraries, potentially improving project efficiency.
	- Retained essential dependencies for continued functionality, including `anyhow`, `tokio`, `tracing`, `serde`, and `serde_json`. 
	- Added comments to clarify the focus on JSON support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->