### PR TITLE
[ISSUE #1425]🚀Add TraceType struct

### DIFF
--- a/rocketmq-client/src/trace.rs
+++ b/rocketmq-client/src/trace.rs
@@ -19,3 +19,4 @@ pub mod hook;
 pub mod trace_bean;
 pub mod trace_constants;
 pub mod trace_dispatcher;
+pub mod trace_type;

--- a/rocketmq-client/src/trace/trace_type.rs
+++ b/rocketmq-client/src/trace/trace_type.rs
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::fmt::Display;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum TraceType {
+    #[default]
+    Pub,
+    SubBefore,
+    SubAfter,
+    EndTransaction,
+}
+
+impl Display for TraceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TraceType::Pub => write!(f, "Pub"),
+            TraceType::SubBefore => write!(f, "SubBefore"),
+            TraceType::SubAfter => write!(f, "SubAfter"),
+            TraceType::EndTransaction => write!(f, "EndTransaction"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Write;
+
+    use super::*;
+
+    #[test]
+    fn trace_type_default_value() {
+        let trace_type = TraceType::default();
+        assert_eq!(trace_type, TraceType::Pub);
+    }
+
+    #[test]
+    fn trace_type_display_pub() {
+        let trace_type = TraceType::Pub;
+        let mut output = String::new();
+        write!(&mut output, "{}", trace_type).unwrap();
+        assert_eq!(output, "Pub");
+    }
+
+    #[test]
+    fn trace_type_display_sub_before() {
+        let trace_type = TraceType::SubBefore;
+        let mut output = String::new();
+        write!(&mut output, "{}", trace_type).unwrap();
+        assert_eq!(output, "SubBefore");
+    }
+
+    #[test]
+    fn trace_type_display_sub_after() {
+        let trace_type = TraceType::SubAfter;
+        let mut output = String::new();
+        write!(&mut output, "{}", trace_type).unwrap();
+        assert_eq!(output, "SubAfter");
+    }
+
+    #[test]
+    fn trace_type_display_end_transaction() {
+        let trace_type = TraceType::EndTransaction;
+        let mut output = String::new();
+        write!(&mut output, "{}", trace_type).unwrap();
+        assert_eq!(output, "EndTransaction");
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1425 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `TraceType` enum for categorizing tracing events, enhancing the tracing functionality within the RocketMQ client.
	- Added custom string representations for each tracing event type.

- **Tests**
	- Implemented unit tests to validate the functionality and string representations of the `TraceType` enum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->