### PR TITLE
[ISSUE #1430] Add TopicMessageQueueChangeListener trait for client

### DIFF
--- a/rocketmq-client/src/consumer.rs
+++ b/rocketmq-client/src/consumer.rs
@@ -30,3 +30,4 @@ pub mod pull_result;
 pub mod pull_status;
 pub mod rebalance_strategy;
 pub(crate) mod store;
+pub mod topic_message_queue_change_listener;

--- a/rocketmq-client/src/consumer/topic_message_queue_change_listener.rs
+++ b/rocketmq-client/src/consumer/topic_message_queue_change_listener.rs
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashSet;
+
+use rocketmq_common::common::message::message_queue::MessageQueue;
+
+/// A trait for listening to changes in the message queues of a specific topic.
+pub trait TopicMessageQueueChangeListener: Send + Sync {
+    /// Called when the message queues for a topic have changed.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The name of the topic whose message queues have changed.
+    /// * `message_queues` - A set of `MessageQueue` instances representing the new state of the
+    ///   message queues.
+    fn on_changed(&self, topic: &str, message_queues: HashSet<MessageQueue>);
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1430

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for listening to changes in message queues associated with specific topics.
	- Added a trait for handling message queue changes, allowing for efficient updates when message queues are modified.

- **Documentation**
	- Included licensing information for compliance with the Apache License, Version 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->