### PR TITLE
[ISSUE #1433]🐛Fix LitePullConsumerLocal trait_variant::make error

### DIFF
--- a/rocketmq-client/src/consumer/lite_pull_consumer.rs
+++ b/rocketmq-client/src/consumer/lite_pull_consumer.rs
@@ -25,7 +25,7 @@ use crate::consumer::message_selector::MessageSelector;
 use crate::consumer::topic_message_queue_change_listener::TopicMessageQueueChangeListener;
 use crate::Result;
 
-#[trait_variant::make(MQProducer: Send)]
+#[trait_variant::make(LitePullConsumer: Send)]
 pub trait LitePullConsumerLocal: Sync {
     /// Starts the LitePullConsumer.
     ///


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1433 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the trait context for `LitePullConsumerLocal`, enhancing its specificity to the `LitePullConsumer`.

- **Bug Fixes**
	- Resolved ambiguity in trait usage by refining the associated attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->