### PR TITLE
[ISSUE #1456]🔥Refactor rocketmq-broker crate error handle🚨

### DIFF
--- a/rocketmq-broker/src/broker_error.rs
+++ b/rocketmq-broker/src/broker_error.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum BrokerError {
     #[error("broker client error: {0}")]
-    BrokerClientError(#[from] rocketmq_remoting::remoting_error::RemotingError),
+    BrokerRemotingError(#[from] rocketmq_remoting::remoting_error::RemotingError),
 
     #[error("Common error: {0}")]
     BrokerCommonError(#[from] rocketmq_common::error::Error),
@@ -33,4 +33,35 @@ pub enum BrokerError {
 
     #[error("Client error: {0}")]
     ClientError(#[from] rocketmq_client_rust::error::MQClientError),
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_remoting::remoting_error::RemotingError;
+
+    use super::*;
+
+    #[test]
+    fn broker_remoting_error_displays_correctly() {
+        let error = BrokerError::BrokerRemotingError(RemotingError::RemoteError(
+            "remote error".to_string(),
+        ));
+        assert_eq!(format!("{}", error), "broker client error: remote error");
+    }
+
+    #[test]
+    fn mq_broker_error_displays_correctly() {
+        let error =
+            BrokerError::MQBrokerError(404, "not found".to_string(), "127.0.0.1".to_string());
+        assert_eq!(
+            format!("{}", error),
+            "Client exception occurred: CODE:404, broker address:127.0.0.1, Message:not found"
+        );
+    }
+
+    #[test]
+    fn illegal_argument_error_displays_correctly() {
+        let error = BrokerError::IllegalArgumentError("illegal argument".to_string());
+        assert_eq!(format!("{}", error), "illegal argument");
+    }
 }

--- a/rocketmq-broker/src/client/net/broker_to_client.rs
+++ b/rocketmq-broker/src/client/net/broker_to_client.rs
@@ -22,8 +22,8 @@ use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 
-use crate::error::BrokerError::BrokerClientError;
-use crate::error::BrokerError::BrokerCommonError;
+use crate::broker_error::BrokerError::BrokerCommonError;
+use crate::broker_error::BrokerError::BrokerRemotingError;
 use crate::Result;
 
 #[derive(Default, Clone)]
@@ -38,7 +38,7 @@ impl Broker2Client {
     ) -> Result<RemotingCommand> {
         match channel.send_wait_response(request, timeout_millis).await {
             Ok(value) => Ok(value),
-            Err(e) => Err(BrokerClientError(e)),
+            Err(e) => Err(BrokerRemotingError(e)),
         }
     }
 
@@ -63,7 +63,7 @@ impl Broker2Client {
         }
         match channel.send_one_way(request, 100).await {
             Ok(_) => Ok(()),
-            Err(e) => Err(BrokerClientError(e)),
+            Err(e) => Err(BrokerRemotingError(e)),
         }
     }
 }

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -22,7 +22,7 @@
 pub use broker_bootstrap::BrokerBootstrap;
 pub use broker_bootstrap::Builder;
 
-use crate::error::BrokerError;
+use crate::broker_error::BrokerError;
 
 pub mod command;
 
@@ -33,7 +33,7 @@ pub(crate) mod broker_runtime;
 pub(crate) mod client;
 pub(crate) mod coldctr;
 pub(crate) mod controller;
-pub(crate) mod error;
+pub(crate) mod broker_error;
 pub(crate) mod filter;
 pub(crate) mod hook;
 pub(crate) mod load_balance;

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -28,12 +28,12 @@ pub mod command;
 
 pub(crate) mod broker;
 pub(crate) mod broker_bootstrap;
+pub(crate) mod broker_error;
 pub(crate) mod broker_path_config_helper;
 pub(crate) mod broker_runtime;
 pub(crate) mod client;
 pub(crate) mod coldctr;
 pub(crate) mod controller;
-pub(crate) mod broker_error;
 pub(crate) mod filter;
 pub(crate) mod hook;
 pub(crate) mod load_balance;

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -57,8 +57,8 @@ use tracing::error;
 use tracing::info;
 use tracing::warn;
 
-use crate::error::BrokerError;
-use crate::error::BrokerError::BrokerClientError;
+use crate::broker_error::BrokerError;
+use crate::broker_error::BrokerError::BrokerRemotingError;
 use crate::Result;
 
 pub struct BrokerOuterAPI {
@@ -367,7 +367,7 @@ impl BrokerOuterAPI {
                     ))
                 }
             }
-            Err(e) => Err(BrokerClientError(e)),
+            Err(e) => Err(BrokerRemotingError(e)),
         }
     }
 
@@ -402,7 +402,7 @@ impl BrokerOuterAPI {
                     ))
                 }
             }
-            Err(e) => Err(BrokerClientError(e)),
+            Err(e) => Err(BrokerRemotingError(e)),
         }
     }
 

--- a/rocketmq-broker/src/processor/query_assignment_processor.rs
+++ b/rocketmq-broker/src/processor/query_assignment_processor.rs
@@ -41,8 +41,8 @@ use rocketmq_remoting::protocol::body::set_message_request_mode_request_body::Se
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::protocol::{RemotingDeserializable, RemotingSerializable};
 use crate::client::manager::consumer_manager::ConsumerManager;
-use crate::error::BrokerError;
-use crate::error::BrokerError::IllegalArgumentError;
+use crate::broker_error::BrokerError;
+use crate::broker_error::BrokerError::IllegalArgumentError;
 use crate::topic::manager::topic_route_info_manager::TopicRouteInfoManager;
 use crate::Result;
 

--- a/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
@@ -34,7 +34,7 @@ use rocketmq_rust::RocketMQTokioMutex;
 use tracing::info;
 use tracing::warn;
 
-use crate::error::BrokerError::MQBrokerError;
+use crate::broker_error::BrokerError::MQBrokerError;
 use crate::out_api::broker_outer_api::BrokerOuterAPI;
 
 const GET_TOPIC_ROUTE_TIMEOUT: u64 = 3000;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1456

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error handling to improve clarity and consistency by renaming `BrokerClientError` to `BrokerRemotingError` across various components.
	- Adjusted error reporting in multiple methods to utilize the new error type, ensuring accurate error communication.

- **Refactor**
	- Restructured error handling imports to reflect the new module organization, enhancing code maintainability.

- **Tests**
	- Introduced unit tests to verify the correct display of error messages for updated error types, ensuring robust error handling functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->