### PR TITLE
[ISSUE #1470]♻️FromMap trait from mehtod return type changed from Option<Self::Target> to Result<Self::Target,Self::Error>🚀

### DIFF
--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -274,7 +274,7 @@ impl BrokerOuterAPI {
                     let register_broker_result =
                         response.decode_command_custom_header::<RegisterBrokerResponseHeader>();
                     let mut result = RegisterBrokerResult::default();
-                    if let Some(header) = register_broker_result {
+                    if let Ok(header) = register_broker_result {
                         result.ha_server_addr = header
                             .ha_server_addr
                             .clone()

--- a/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
@@ -51,7 +51,9 @@ impl OffsetRequestHandler {
         _request_code: RequestCode,
         request: RemotingCommand,
     ) -> Option<RemotingCommand> {
-        let request_header = request.decode_command_custom_header::<GetMaxOffsetRequestHeader>()?;
+        let request_header = request
+            .decode_command_custom_header::<GetMaxOffsetRequestHeader>()
+            .unwrap(); //need to optimize
         let mapping_context = self
             .inner
             .topic_queue_mapping_manager
@@ -82,7 +84,9 @@ impl OffsetRequestHandler {
         _request_code: RequestCode,
         request: RemotingCommand,
     ) -> Option<RemotingCommand> {
-        let request_header = request.decode_command_custom_header::<GetMinOffsetRequestHeader>()?;
+        let request_header = request
+            .decode_command_custom_header::<GetMinOffsetRequestHeader>()
+            .unwrap(); //need to optimize
 
         let mapping_context = self
             .inner

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -113,10 +113,13 @@ where
     ) -> Option<RemotingCommand> {
         match request_code {
             RequestCode::ConsumerSendMsgBack => {
-                self.inner.consumer_send_msg_back(&channel, &ctx, &request)
+                //need to optimize
+                self.inner
+                    .consumer_send_msg_back(&channel, &ctx, &request)
+                    .unwrap()
             }
             _ => {
-                let mut request_header = parse_request_header(&request, request_code)?;
+                let mut request_header = parse_request_header(&request, request_code).unwrap(); //need to optimize
                 let mapping_context = self
                     .inner
                     .topic_queue_mapping_manager
@@ -979,7 +982,7 @@ impl<MS, TS> Inner<MS, TS> {
     ) {
         for hook in self.send_message_hook_vec.iter() {
             if let Some(ref response) = response {
-                if let Some(ref header) =
+                if let Ok(ref header) =
                     response.decode_command_custom_header::<SendMessageResponseHeader>()
                 {
                     context.msg_id = header.msg_id().clone();
@@ -999,7 +1002,7 @@ impl<MS, TS> Inner<MS, TS> {
         _channel: &Channel,
         _ctx: &ConnectionHandlerContext,
         _request: &RemotingCommand,
-    ) -> Option<RemotingCommand> {
+    ) -> crate::Result<Option<RemotingCommand>> {
         todo!()
     }
 

--- a/rocketmq-macros/src/request_header_custom.rs
+++ b/rocketmq-macros/src/request_header_custom.rs
@@ -158,10 +158,13 @@ pub(super) fn request_header_codec_inner(
         }
 
         impl crate::protocol::command_custom_header::FromMap for #struct_name {
+
+            type Error = crate::remoting_error::RemotingError;
+
             type Target = Self;
 
-            fn from(map: &std::collections::HashMap<cheetah_string::CheetahString, cheetah_string::CheetahString>) -> Option<Self::Target> {
-                Some(#struct_name {
+            fn from(map: &std::collections::HashMap<cheetah_string::CheetahString, cheetah_string::CheetahString>) -> Result<Self::Target, Self::Error> {
+                Ok(#struct_name {
                     #(#from_map)*
                 })
             }

--- a/rocketmq-remoting/src/protocol/command_custom_header.rs
+++ b/rocketmq-remoting/src/protocol/command_custom_header.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
 
+use crate::remoting_error::RemotingError;
 use crate::rocketmq_serializable::RocketMQSerializable;
 
 pub trait CommandCustomHeader: AsAny {
@@ -100,9 +101,11 @@ impl<T: CommandCustomHeader> AsAny for T {
 }
 
 pub trait FromMap {
+    type Error: From<RemotingError>;
+
     type Target;
     /// Converts the implementing type from a map.
     ///
     /// Returns an instance of `Self::Target` that is created from the provided map.
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target>;
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error>;
 }

--- a/rocketmq-remoting/src/protocol/header/broker/broker_heartbeat_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/broker/broker_heartbeat_request_header.rs
@@ -82,10 +82,12 @@ impl BrokerHeartbeatRequestHeader {
 }
 
 impl FromMap for BrokerHeartbeatRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = BrokerHeartbeatRequestHeader;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(BrokerHeartbeatRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(BrokerHeartbeatRequestHeader {
             cluster_name: map
                 .get(&CheetahString::from_static_str(
                     BrokerHeartbeatRequestHeader::CLUSTER_NAME,

--- a/rocketmq-remoting/src/protocol/header/check_transaction_state_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/check_transaction_state_request_header.rs
@@ -84,10 +84,14 @@ impl CommandCustomHeader for CheckTransactionStateRequestHeader {
 }
 
 impl FromMap for CheckTransactionStateRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(CheckTransactionStateRequestHeader {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
+        Ok(CheckTransactionStateRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(Self::TOPIC))
                 .cloned(),
@@ -110,7 +114,7 @@ impl FromMap for CheckTransactionStateRequestHeader {
             offset_msg_id: map
                 .get(&CheetahString::from_static_str(Self::OFFSET_MSG_ID))
                 .cloned(),
-            rpc_request_header: <RpcRequestHeader as FromMap>::from(map),
+            rpc_request_header: Some(<RpcRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/client_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/client_request_header.rs
@@ -50,10 +50,12 @@ impl GetRouteInfoRequestHeader {
 }
 
 impl FromMap for GetRouteInfoRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = GetRouteInfoRequestHeader;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetRouteInfoRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(GetRouteInfoRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(
                     GetRouteInfoRequestHeader::TOPIC,
@@ -65,7 +67,7 @@ impl FromMap for GetRouteInfoRequestHeader {
                     GetRouteInfoRequestHeader::ACCEPT_STANDARD_JSON_ONLY,
                 ))
                 .and_then(|s| s.parse::<bool>().ok()),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/create_topic_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/create_topic_request_header.rs
@@ -132,10 +132,14 @@ impl CommandCustomHeader for CreateTopicRequestHeader {
 }
 
 impl FromMap for CreateTopicRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(CreateTopicRequestHeader {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
+        Ok(CreateTopicRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(Self::TOPIC))
                 .cloned()
@@ -173,7 +177,7 @@ impl FromMap for CreateTopicRequestHeader {
             force: map
                 .get(&CheetahString::from_static_str(Self::FORCE))
                 .and_then(|v| v.parse().ok()),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/delete_topic_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/delete_topic_request_header.rs
@@ -52,15 +52,19 @@ impl CommandCustomHeader for DeleteTopicRequestHeader {
 }
 
 impl FromMap for DeleteTopicRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(DeleteTopicRequestHeader {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
+        Ok(DeleteTopicRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(Self::TOPIC))
                 .cloned()
                 .unwrap_or_default(),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/end_transaction_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/end_transaction_request_header.rs
@@ -111,10 +111,14 @@ impl CommandCustomHeader for EndTransactionRequestHeader {
 }
 
 impl FromMap for EndTransactionRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(EndTransactionRequestHeader {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
+        Ok(EndTransactionRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(
                     EndTransactionRequestHeader::TOPIC,

--- a/rocketmq-remoting/src/protocol/header/get_all_topic_config_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_all_topic_config_response_header.rs
@@ -32,9 +32,11 @@ impl CommandCustomHeader for GetAllTopicConfigResponseHeader {
     }
 }
 impl FromMap for GetAllTopicConfigResponseHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(_map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(Self {})
+    fn from(_map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(Self {})
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_consume_stats_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consume_stats_request_header.rs
@@ -73,10 +73,14 @@ impl CommandCustomHeader for GetConsumeStatsRequestHeader {
 }
 
 impl FromMap for GetConsumeStatsRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetConsumeStatsRequestHeader {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
+        Ok(GetConsumeStatsRequestHeader {
             consumer_group: map
                 .get(&CheetahString::from_static_str(Self::CONSUMER_GROUP))
                 .cloned()
@@ -85,7 +89,7 @@ impl FromMap for GetConsumeStatsRequestHeader {
                 .get(&CheetahString::from_static_str(Self::TOPIC))
                 .cloned()
                 .unwrap_or_default(),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_consumer_connection_list_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consumer_connection_list_request_header.rs
@@ -42,15 +42,19 @@ impl GetConsumerConnectionListRequestHeader {
 }
 
 impl FromMap for GetConsumerConnectionListRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetConsumerConnectionListRequestHeader {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
+        Ok(GetConsumerConnectionListRequestHeader {
             consumer_group: map
                 .get(&CheetahString::from_static_str(Self::CONSUMER_GROUP))
                 .cloned()
                 .unwrap_or_default(),
-            rpc_request_header: <RpcRequestHeader as FromMap>::from(map),
+            rpc_request_header: Some(<RpcRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_consumer_listby_group_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consumer_listby_group_request_header.rs
@@ -52,15 +52,17 @@ impl CommandCustomHeader for GetConsumerListByGroupRequestHeader {
     }
 }
 impl FromMap for GetConsumerListByGroupRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetConsumerListByGroupRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(GetConsumerListByGroupRequestHeader {
             consumer_group: map
                 .get(&CheetahString::from_static_str(Self::CONSUMER_GROUP))
                 .cloned()
                 .unwrap_or_default(),
-            rpc: <RpcRequestHeader as FromMap>::from(map),
+            rpc: Some(<RpcRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_consumer_listby_group_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consumer_listby_group_response_header.rs
@@ -32,9 +32,11 @@ impl CommandCustomHeader for GetConsumerListByGroupResponseHeader {
     }
 }
 impl FromMap for GetConsumerListByGroupResponseHeader {
-    type Target = GetConsumerListByGroupResponseHeader;
+    type Error = crate::remoting_error::RemotingError;
 
-    fn from(_map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(Self {})
+    type Target = Self;
+
+    fn from(_map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(Self {})
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_max_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_max_offset_request_header.rs
@@ -80,10 +80,12 @@ impl CommandCustomHeader for GetMaxOffsetRequestHeader {
 }
 
 impl FromMap for GetMaxOffsetRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetMaxOffsetRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(GetMaxOffsetRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(
                     GetMaxOffsetRequestHeader::TOPIC,
@@ -102,7 +104,7 @@ impl FromMap for GetMaxOffsetRequestHeader {
                 ))
                 .map(|s| s.parse().unwrap())
                 .unwrap_or(true),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_min_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_min_offset_request_header.rs
@@ -62,10 +62,12 @@ impl CommandCustomHeader for GetMinOffsetRequestHeader {
 }
 
 impl FromMap for GetMinOffsetRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetMinOffsetRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(GetMinOffsetRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(
                     GetMinOffsetRequestHeader::TOPIC,
@@ -78,7 +80,7 @@ impl FromMap for GetMinOffsetRequestHeader {
                 ))
                 .map(|s| s.parse().unwrap())
                 .unwrap_or_default(),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_topic_config_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_topic_config_request_header.rs
@@ -59,15 +59,19 @@ impl CommandCustomHeader for GetTopicConfigRequestHeader {
 }
 
 impl FromMap for GetTopicConfigRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetTopicConfigRequestHeader {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
+        Ok(GetTopicConfigRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(Self::TOPIC))
                 .cloned()
                 .unwrap_or_default(),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_topic_stats_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_topic_stats_request_header.rs
@@ -52,15 +52,19 @@ impl CommandCustomHeader for GetTopicStatsRequestHeader {
 }
 
 impl FromMap for GetTopicStatsRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetTopicStatsRequestHeader {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
+        Ok(GetTopicStatsRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(Self::TOPIC))
                 .cloned()
                 .unwrap_or_default(),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/heartbeat_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/heartbeat_request_header.rs
@@ -44,11 +44,13 @@ impl CommandCustomHeader for HeartbeatRequestHeader {
 }
 
 impl FromMap for HeartbeatRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(HeartbeatRequestHeader {
-            rpc_request: <RpcRequestHeader as FromMap>::from(map),
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(HeartbeatRequestHeader {
+            rpc_request: Some(<RpcRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/lock_batch_mq_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/lock_batch_mq_request_header.rs
@@ -44,10 +44,14 @@ impl CommandCustomHeader for LockBatchMqRequestHeader {
 }
 
 impl FromMap for LockBatchMqRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        let rpc_request_header = <RpcRequestHeader as FromMap>::from(map);
-        Some(LockBatchMqRequestHeader { rpc_request_header })
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        let rpc_request_header = <RpcRequestHeader as FromMap>::from(map)?;
+        Ok(LockBatchMqRequestHeader {
+            rpc_request_header: Some(rpc_request_header),
+        })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -204,18 +204,69 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
 }
 
 impl FromMap for SendMessageRequestHeaderV2 {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(SendMessageRequestHeaderV2 {
-            a: map.get(&CheetahString::from_slice("a"))?.clone(),
-            b: map.get(&CheetahString::from_slice("b"))?.clone(),
-            c: map.get(&CheetahString::from_slice("c"))?.clone(),
-            d: map.get(&CheetahString::from_slice("d"))?.parse().ok()?,
-            e: map.get(&CheetahString::from_slice("e"))?.parse().ok()?,
-            f: map.get(&CheetahString::from_slice("f"))?.parse().ok()?,
-            g: map.get(&CheetahString::from_slice("g"))?.parse().ok()?,
-            h: map.get(&CheetahString::from_slice("h"))?.parse().ok()?,
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(SendMessageRequestHeaderV2 {
+            a: map.get(&CheetahString::from_slice("a")).cloned().ok_or(
+                Self::Error::RemotingCommandError("Miss a field".to_string()),
+            )?,
+            b: map.get(&CheetahString::from_slice("b")).cloned().ok_or(
+                Self::Error::RemotingCommandError("Miss b field".to_string()),
+            )?,
+            c: map.get(&CheetahString::from_slice("c")).cloned().ok_or(
+                Self::Error::RemotingCommandError("Miss c field".to_string()),
+            )?,
+            d: map
+                .get(&CheetahString::from_slice("d"))
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss d field".to_string(),
+                ))?
+                .parse()
+                .map_err(|_| {
+                    Self::Error::RemotingCommandError("Parse d field error".to_string())
+                })?,
+            e: map
+                .get(&CheetahString::from_slice("e"))
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss e field".to_string(),
+                ))?
+                .parse()
+                .map_err(|_| {
+                    Self::Error::RemotingCommandError("Parse e field error".to_string())
+                })?,
+            f: map
+                .get(&CheetahString::from_slice("f"))
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss f field".to_string(),
+                ))?
+                .parse()
+                .map_err(|_| {
+                    Self::Error::RemotingCommandError("Parse f field error".to_string())
+                })?,
+            g: map
+                .get(&CheetahString::from_slice("g"))
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss g field".to_string(),
+                ))?
+                .parse()
+                .map_err(|_| {
+                    Self::Error::RemotingCommandError("Parse g field error".to_string())
+                })?,
+            h: map
+                .get(&CheetahString::from_slice("h"))
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss h field".to_string(),
+                ))?
+                .parse()
+                .map_err(|_| {
+                    Self::Error::RemotingCommandError("Parse h field error".to_string())
+                })?,
             i: map.get(&CheetahString::from_slice("i")).cloned(),
             j: map
                 .get(&CheetahString::from_slice("j"))
@@ -230,7 +281,7 @@ impl FromMap for SendMessageRequestHeaderV2 {
                 .get(&CheetahString::from_slice("m"))
                 .and_then(|v| v.parse().ok()),
             n: map.get(&CheetahString::from_slice("n")).cloned(),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/namesrv/broker_request.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/broker_request.rs
@@ -78,10 +78,11 @@ impl CommandCustomHeader for UnRegisterBrokerRequestHeader {
 }
 
 impl FromMap for UnRegisterBrokerRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(UnRegisterBrokerRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(UnRegisterBrokerRequestHeader {
             broker_name: map
                 .get(&CheetahString::from_static_str(Self::BROKER_NAME))
                 .cloned()
@@ -209,10 +210,12 @@ impl CommandCustomHeader for BrokerHeartbeatRequestHeader {
 }
 
 impl FromMap for BrokerHeartbeatRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(BrokerHeartbeatRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(BrokerHeartbeatRequestHeader {
             cluster_name: map
                 .get(&CheetahString::from_static_str(Self::CLUSTER_NAME))
                 .cloned()
@@ -288,10 +291,11 @@ impl CommandCustomHeader for GetBrokerMemberGroupRequestHeader {
 }
 
 impl FromMap for GetBrokerMemberGroupRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetBrokerMemberGroupRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(GetBrokerMemberGroupRequestHeader {
             cluster_name: map
                 .get(&CheetahString::from_static_str(Self::CLUSTER_NAME))
                 .cloned()

--- a/rocketmq-remoting/src/protocol/header/namesrv/brokerid_change_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/brokerid_change_request_header.rs
@@ -51,10 +51,12 @@ impl NotifyMinBrokerIdChangeRequestHeader {
 }
 
 impl FromMap for NotifyMinBrokerIdChangeRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(NotifyMinBrokerIdChangeRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(NotifyMinBrokerIdChangeRequestHeader {
             min_broker_id: map
                 .get(&CheetahString::from_static_str(
                     NotifyMinBrokerIdChangeRequestHeader::MIN_BROKER_ID,

--- a/rocketmq-remoting/src/protocol/header/namesrv/kv_config_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/kv_config_header.rs
@@ -76,25 +76,36 @@ impl CommandCustomHeader for PutKVConfigRequestHeader {
 }
 
 impl FromMap for PutKVConfigRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = PutKVConfigRequestHeader;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(PutKVConfigRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(PutKVConfigRequestHeader {
             namespace: map
                 .get(&CheetahString::from_static_str(
                     PutKVConfigRequestHeader::NAMESPACE,
                 ))
-                .cloned()?,
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss namespace field".to_string(),
+                ))?,
             key: map
                 .get(&CheetahString::from_static_str(
                     PutKVConfigRequestHeader::KEY,
                 ))
-                .cloned()?,
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss key field".to_string(),
+                ))?,
             value: map
                 .get(&CheetahString::from_static_str(
                     PutKVConfigRequestHeader::VALUE,
                 ))
-                .cloned()?,
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss value field".to_string(),
+                ))?,
         })
     }
 }
@@ -133,20 +144,28 @@ impl CommandCustomHeader for GetKVConfigRequestHeader {
 }
 
 impl FromMap for GetKVConfigRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = GetKVConfigRequestHeader;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetKVConfigRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(GetKVConfigRequestHeader {
             namespace: map
                 .get(&CheetahString::from_static_str(
                     GetKVConfigRequestHeader::NAMESPACE,
                 ))
-                .cloned()?,
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss namespace field".to_string(),
+                ))?,
             key: map
                 .get(&CheetahString::from_static_str(
                     GetKVConfigRequestHeader::KEY,
                 ))
-                .cloned()?,
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss key field".to_string(),
+                ))?,
         })
     }
 }
@@ -177,10 +196,12 @@ impl CommandCustomHeader for GetKVConfigResponseHeader {
 }
 
 impl FromMap for GetKVConfigResponseHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = GetKVConfigResponseHeader;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetKVConfigResponseHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(GetKVConfigResponseHeader {
             value: map
                 .get(&CheetahString::from_static_str(
                     GetKVConfigResponseHeader::VALUE,
@@ -224,20 +245,28 @@ impl CommandCustomHeader for DeleteKVConfigRequestHeader {
 }
 
 impl FromMap for DeleteKVConfigRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = DeleteKVConfigRequestHeader;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(DeleteKVConfigRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(DeleteKVConfigRequestHeader {
             namespace: map
                 .get(&CheetahString::from_static_str(
                     DeleteKVConfigRequestHeader::NAMESPACE,
                 ))
-                .cloned()?,
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss namespace field".to_string(),
+                ))?,
             key: map
                 .get(&CheetahString::from_static_str(
                     DeleteKVConfigRequestHeader::KEY,
                 ))
-                .cloned()?,
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss key field".to_string(),
+                ))?,
         })
     }
 }
@@ -267,15 +296,20 @@ impl CommandCustomHeader for GetKVListByNamespaceRequestHeader {
 }
 
 impl FromMap for GetKVListByNamespaceRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = GetKVListByNamespaceRequestHeader;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetKVListByNamespaceRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(GetKVListByNamespaceRequestHeader {
             namespace: map
                 .get(&CheetahString::from_static_str(
                     GetKVListByNamespaceRequestHeader::NAMESPACE,
                 ))
-                .cloned()?,
+                .cloned()
+                .ok_or(Self::Error::RemotingCommandError(
+                    "Miss namespace field".to_string(),
+                ))?,
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
@@ -49,10 +49,12 @@ impl CommandCustomHeader for WipeWritePermOfBrokerRequestHeader {
 }
 
 impl FromMap for WipeWritePermOfBrokerRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(WipeWritePermOfBrokerRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(WipeWritePermOfBrokerRequestHeader {
             broker_name: map
                 .get(&CheetahString::from_static_str(
                     WipeWritePermOfBrokerRequestHeader::BROKER_NAME,
@@ -87,10 +89,12 @@ impl CommandCustomHeader for WipeWritePermOfBrokerResponseHeader {
 }
 
 impl FromMap for WipeWritePermOfBrokerResponseHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(WipeWritePermOfBrokerResponseHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(WipeWritePermOfBrokerResponseHeader {
             wipe_topic_count: map
                 .get(&CheetahString::from_static_str(
                     WipeWritePermOfBrokerResponseHeader::WIPE_TOPIC_COUNT,
@@ -127,10 +131,12 @@ impl CommandCustomHeader for AddWritePermOfBrokerRequestHeader {
 }
 
 impl FromMap for AddWritePermOfBrokerRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(AddWritePermOfBrokerRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(AddWritePermOfBrokerRequestHeader {
             broker_name: map
                 .get(&CheetahString::from_static_str(
                     AddWritePermOfBrokerRequestHeader::BROKER_NAME,
@@ -165,10 +171,12 @@ impl CommandCustomHeader for AddWritePermOfBrokerResponseHeader {
 }
 
 impl FromMap for AddWritePermOfBrokerResponseHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(AddWritePermOfBrokerResponseHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(AddWritePermOfBrokerResponseHeader {
             add_topic_count: map
                 .get(&CheetahString::from_static_str(
                     AddWritePermOfBrokerResponseHeader::ADD_TOPIC_COUNT,

--- a/rocketmq-remoting/src/protocol/header/namesrv/query_data_version_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/query_data_version_header.rs
@@ -77,10 +77,12 @@ impl CommandCustomHeader for QueryDataVersionRequestHeader {
 }
 
 impl FromMap for QueryDataVersionRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(QueryDataVersionRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(QueryDataVersionRequestHeader {
             broker_name: map
                 .get(&CheetahString::from_static_str(
                     QueryDataVersionRequestHeader::BROKER_NAME,
@@ -132,10 +134,12 @@ impl CommandCustomHeader for QueryDataVersionResponseHeader {
 }
 
 impl FromMap for QueryDataVersionResponseHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(QueryDataVersionResponseHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(QueryDataVersionResponseHeader {
             changed: map
                 .get(&CheetahString::from_static_str(
                     QueryDataVersionResponseHeader::CHANGED,

--- a/rocketmq-remoting/src/protocol/header/namesrv/register_broker_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/register_broker_header.rs
@@ -119,10 +119,12 @@ impl RegisterBrokerRequestHeader {
 }
 
 impl FromMap for RegisterBrokerRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(RegisterBrokerRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(RegisterBrokerRequestHeader {
             broker_name: map
                 .get(&CheetahString::from_static_str(
                     RegisterBrokerRequestHeader::BROKER_NAME,
@@ -282,10 +284,12 @@ impl CommandCustomHeader for RegisterBrokerResponseHeader {
 }
 
 impl FromMap for RegisterBrokerResponseHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(RegisterBrokerResponseHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(RegisterBrokerResponseHeader {
             ha_server_addr: map
                 .get(&CheetahString::from_static_str(
                     RegisterBrokerResponseHeader::HA_SERVER_ADDR,

--- a/rocketmq-remoting/src/protocol/header/namesrv/topic_operation_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/topic_operation_header.rs
@@ -64,10 +64,12 @@ impl CommandCustomHeader for DeleteTopicFromNamesrvRequestHeader {
 }
 
 impl FromMap for DeleteTopicFromNamesrvRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(DeleteTopicFromNamesrvRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(DeleteTopicFromNamesrvRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(Self::TOPIC))
                 .cloned()
@@ -113,15 +115,17 @@ impl CommandCustomHeader for RegisterTopicRequestHeader {
     }
 }
 impl FromMap for RegisterTopicRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(RegisterTopicRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(RegisterTopicRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(Self::TOPIC))
                 .cloned()
                 .unwrap_or_default(),
-            topic_request: <TopicRequestHeader as FromMap>::from(map),
+            topic_request: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }
@@ -152,10 +156,12 @@ impl CommandCustomHeader for GetTopicsByClusterRequestHeader {
 }
 
 impl FromMap for GetTopicsByClusterRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(GetTopicsByClusterRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(GetTopicsByClusterRequestHeader {
             cluster: map
                 .get(&CheetahString::from_static_str(Self::CLUSTER))
                 .cloned()
@@ -195,14 +201,16 @@ impl CommandCustomHeader for TopicRequestHeader {
 }
 
 impl FromMap for TopicRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(TopicRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(TopicRequestHeader {
             lo: map
                 .get(&CheetahString::from_static_str(Self::LO))
                 .and_then(|s| s.parse::<bool>().ok()),
-            rpc: <RpcRequestHeader as FromMap>::from(map),
+            rpc: Some(<RpcRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/notify_consumer_ids_changed_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/notify_consumer_ids_changed_request_header.rs
@@ -52,17 +52,21 @@ impl CommandCustomHeader for NotifyConsumerIdsChangedRequestHeader {
 }
 
 impl FromMap for NotifyConsumerIdsChangedRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
         let consumer_group = map
             .get(&CheetahString::from_static_str(Self::CONSUMER_GROUP))
             .cloned()
             .unwrap_or_default();
-        let rpc_request_header = <RpcRequestHeader as FromMap>::from(map);
-        Some(NotifyConsumerIdsChangedRequestHeader {
+        let rpc_request_header = <RpcRequestHeader as FromMap>::from(map)?;
+        Ok(NotifyConsumerIdsChangedRequestHeader {
             consumer_group,
-            rpc_request_header,
+            rpc_request_header: Some(rpc_request_header),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
@@ -324,10 +324,12 @@ impl CommandCustomHeader for PullMessageRequestHeader {
 }
 
 impl FromMap for PullMessageRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(Self {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(Self {
             consumer_group: map
                 .get(&CheetahString::from_static_str(Self::CONSUMER_GROUP))
                 .cloned()
@@ -376,7 +378,7 @@ impl FromMap for PullMessageRequestHeader {
                     Self::PROXY_FORWARD_CLIENT_ID,
                 ))
                 .cloned(),
-            topic_request: <TopicRequestHeader as FromMap>::from(map),
+            topic_request: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_response_header.rs
@@ -178,9 +178,11 @@ impl CommandCustomHeader for PullMessageResponseHeader {
 }
 
 impl FromMap for PullMessageResponseHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
         let suggest_which_broker_id = map.get(&CheetahString::from_static_str(
             PullMessageResponseHeader::SUGGEST_WHICH_BROKER_ID,
         ));
@@ -206,7 +208,7 @@ impl FromMap for PullMessageResponseHeader {
             PullMessageResponseHeader::FORBIDDEN_TYPE,
         ));
 
-        Some(PullMessageResponseHeader {
+        Ok(PullMessageResponseHeader {
             suggest_which_broker_id: suggest_which_broker_id.map(|v| v.parse().unwrap()),
             next_begin_offset: next_begin_offset.map(|v| v.parse().unwrap()),
             min_offset: min_offset.map(|v| v.parse().unwrap()),

--- a/rocketmq-remoting/src/protocol/header/query_consumer_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_consumer_offset_request_header.rs
@@ -74,10 +74,12 @@ impl CommandCustomHeader for QueryConsumerOffsetRequestHeader {
 }
 
 impl FromMap for QueryConsumerOffsetRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(QueryConsumerOffsetRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(QueryConsumerOffsetRequestHeader {
             consumer_group: map
                 .get(&CheetahString::from_static_str(Self::CONSUMER_GROUP))
                 .cloned()
@@ -92,7 +94,7 @@ impl FromMap for QueryConsumerOffsetRequestHeader {
             set_zero_if_not_found: map
                 .get(&CheetahString::from_static_str(Self::SET_ZERO_IF_NOT_FOUND))
                 .and_then(|value| value.parse::<bool>().ok()),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/query_topic_consume_by_who_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_topic_consume_by_who_request_header.rs
@@ -52,15 +52,19 @@ impl CommandCustomHeader for QueryTopicConsumeByWhoRequestHeader {
 }
 
 impl FromMap for QueryTopicConsumeByWhoRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(QueryTopicConsumeByWhoRequestHeader {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
+        Ok(QueryTopicConsumeByWhoRequestHeader {
             topic: map
                 .get(&CheetahString::from_static_str(Self::TOPIC))
                 .cloned()
                 .unwrap_or_default(),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/query_topics_by_consumer_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_topics_by_consumer_request_header.rs
@@ -59,15 +59,19 @@ impl CommandCustomHeader for QueryTopicsByConsumerRequestHeader {
 }
 
 impl FromMap for QueryTopicsByConsumerRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &std::collections::HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(QueryTopicsByConsumerRequestHeader {
+    fn from(
+        map: &std::collections::HashMap<CheetahString, CheetahString>,
+    ) -> Result<Self::Target, Self::Error> {
+        Ok(QueryTopicsByConsumerRequestHeader {
             group: map
                 .get(&CheetahString::from_static_str(Self::GROUP))
                 .cloned()
                 .unwrap_or_default(),
-            rpc_request_header: <RpcRequestHeader as FromMap>::from(map),
+            rpc_request_header: Some(<RpcRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/reply_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/reply_message_request_header.rs
@@ -168,10 +168,12 @@ impl CommandCustomHeader for ReplyMessageRequestHeader {
 }
 
 impl FromMap for ReplyMessageRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(ReplyMessageRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(ReplyMessageRequestHeader {
             producer_group: map
                 .get(&CheetahString::from_static_str(Self::PRODUCER_GROUP))
                 .cloned()
@@ -227,7 +229,7 @@ impl FromMap for ReplyMessageRequestHeader {
                 .get(&CheetahString::from_static_str(Self::STORE_TIMESTAMP))
                 .and_then(|value| value.parse().ok())
                 .unwrap_or_default(),
-            topic_request: <TopicRequestHeader as FromMap>::from(map),
+            topic_request: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/unlock_batch_mq_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/unlock_batch_mq_request_header.rs
@@ -44,10 +44,14 @@ impl CommandCustomHeader for UnlockBatchMqRequestHeader {
 }
 
 impl FromMap for UnlockBatchMqRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        let rpc_request_header = <RpcRequestHeader as FromMap>::from(map);
-        Some(UnlockBatchMqRequestHeader { rpc_request_header })
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        let rpc_request_header = <RpcRequestHeader as FromMap>::from(map)?;
+        Ok(UnlockBatchMqRequestHeader {
+            rpc_request_header: Some(rpc_request_header),
+        })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/unregister_client_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/unregister_client_request_header.rs
@@ -42,10 +42,12 @@ impl UnregisterClientRequestHeader {
 }
 
 impl FromMap for UnregisterClientRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(UnregisterClientRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(UnregisterClientRequestHeader {
             client_id: map
                 .get(&CheetahString::from_static_str(
                     UnregisterClientRequestHeader::CLIENT_ID,
@@ -62,7 +64,7 @@ impl FromMap for UnregisterClientRequestHeader {
                     UnregisterClientRequestHeader::CONSUMER_GROUP,
                 ))
                 .cloned(),
-            rpc_request_header: <RpcRequestHeader as FromMap>::from(map),
+            rpc_request_header: Some(<RpcRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/header/update_consumer_offset_header.rs
+++ b/rocketmq-remoting/src/protocol/header/update_consumer_offset_header.rs
@@ -80,10 +80,12 @@ impl CommandCustomHeader for UpdateConsumerOffsetRequestHeader {
 }
 
 impl FromMap for UpdateConsumerOffsetRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(UpdateConsumerOffsetRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(UpdateConsumerOffsetRequestHeader {
             consumer_group: map
                 .get(&CheetahString::from_static_str(
                     UpdateConsumerOffsetRequestHeader::CONSUMER_GROUP,
@@ -106,7 +108,7 @@ impl FromMap for UpdateConsumerOffsetRequestHeader {
                     UpdateConsumerOffsetRequestHeader::COMMIT_OFFSET,
                 ))
                 .and_then(|v| v.parse().ok()),
-            topic_request_header: <TopicRequestHeader as FromMap>::from(map),
+            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
         })
     }
 }

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -580,28 +580,32 @@ impl RemotingCommand {
         self.serialize_type
     }
 
-    pub fn decode_command_custom_header<T>(&self) -> Option<T>
+    pub fn decode_command_custom_header<T>(&self) -> crate::Result<T>
     where
-        T: FromMap<Target = T>,
+        T: FromMap<Target = T, Error = RemotingError>,
     {
         match self.ext_fields {
-            None => None,
+            None => Err(RemotingError::RemotingCommandError(
+                "ExtFields is None".to_string(),
+            )),
             Some(ref header) => T::from(header),
         }
     }
 
-    pub fn decode_command_custom_header_fast<T>(&self) -> Option<T>
+    pub fn decode_command_custom_header_fast<T>(&self) -> crate::Result<T>
     where
-        T: FromMap<Target = T>,
+        T: FromMap<Target = T, Error = RemotingError>,
         T: Default + CommandCustomHeader,
     {
         match self.ext_fields {
-            None => None,
+            None => Err(RemotingError::RemotingCommandError(
+                "ExtFields is None".to_string(),
+            )),
             Some(ref header) => {
                 let mut target = T::default();
                 if target.support_fast_codec() {
                     target.decode_fast(header);
-                    Some(target)
+                    Ok(target)
                 } else {
                     T::from(header)
                 }

--- a/rocketmq-remoting/src/rpc/rpc_request_header.rs
+++ b/rocketmq-remoting/src/rpc/rpc_request_header.rs
@@ -23,6 +23,7 @@ use serde::Serialize;
 
 use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
+use crate::remoting_error::RemotingError;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct RpcRequestHeader {
@@ -62,10 +63,11 @@ impl RpcRequestHeader {
 }
 
 impl FromMap for RpcRequestHeader {
+    type Error = RemotingError;
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(RpcRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(RpcRequestHeader {
             namespace: map
                 .get(&CheetahString::from_static_str(RpcRequestHeader::NAMESPACE))
                 .cloned(),

--- a/rocketmq-remoting/src/rpc/topic_request_header.rs
+++ b/rocketmq-remoting/src/rpc/topic_request_header.rs
@@ -50,14 +50,16 @@ impl TopicRequestHeader {
 }
 
 impl FromMap for TopicRequestHeader {
+    type Error = crate::remoting_error::RemotingError;
+
     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Option<Self::Target> {
-        Some(TopicRequestHeader {
+    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+        Ok(TopicRequestHeader {
             lo: map
                 .get(&CheetahString::from_static_str(Self::LO))
                 .and_then(|v| v.parse().ok()),
-            rpc_request_header: <RpcRequestHeader as FromMap>::from(map),
+            rpc_request_header: Some(<RpcRequestHeader as FromMap>::from(map)?),
         })
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1470 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling across multiple request and response headers, improving robustness and clarity in data conversion.
- **Bug Fixes**
	- Updated methods to return `Result` types instead of `Option`, allowing for explicit error reporting.
- **Documentation**
	- Improved error messages for missing fields and parsing failures in various headers.
- **Refactor**
	- Streamlined error propagation using the `?` operator in several methods, enhancing code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->