### PR TITLE
[ISSUE #1482]♻️Refactor create MQClientErr replace with mq_client_err! macro🔥

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -83,6 +83,7 @@ use crate::hook::consume_message_hook::ConsumeMessageHook;
 use crate::hook::filter_message_hook::FilterMessageHook;
 use crate::implementation::communication_mode::CommunicationMode;
 use crate::implementation::mq_client_manager::MQClientManager;
+use crate::mq_client_err;
 use crate::producer::mq_producer::MQProducer;
 use crate::Result;
 
@@ -354,21 +355,17 @@ impl DefaultMQPushConsumerImpl {
                 *self.service_state = ServiceState::Running;
             }
             ServiceState::Running => {
-                return Err(MQClientError::MQClientErr(ClientErr::new(
-                    "The PushConsumer service state is Running",
-                )));
+                return mq_client_err!("The PushConsumer service state is Running");
             }
             ServiceState::ShutdownAlready => {
-                return Err(MQClientError::MQClientErr(ClientErr::new(
-                    "The PushConsumer service state is ShutdownAlready",
-                )));
+                return mq_client_err!("The PushConsumer service state is ShutdownAlready");
             }
             ServiceState::StartFailed => {
-                return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+                return mq_client_err!(format!(
                     "The PushConsumer service state not OK, maybe started once,{:?},{}",
                     *self.service_state,
                     FAQUrl::suggest_todo(FAQUrl::CLIENT_SERVICE_NOT_OK)
-                ))));
+                ));
             }
         }
         self.update_topic_subscribe_info_when_subscription_changed()
@@ -448,18 +445,18 @@ impl DefaultMQPushConsumerImpl {
     fn check_config(&mut self) -> Result<()> {
         Validators::check_group(self.consumer_config.consumer_group.as_str())?;
         if self.consumer_config.consumer_group.is_empty() {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "consumer_group is empty, {}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.consumer_group == DEFAULT_CONSUMER_GROUP {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "consumer_group can not equal {} please specify another one.{}",
                 DEFAULT_CONSUMER_GROUP,
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self
@@ -467,17 +464,17 @@ impl DefaultMQPushConsumerImpl {
             .allocate_message_queue_strategy
             .is_none()
         {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "allocate_message_queue_strategy is null{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.message_listener.is_none() {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "messageListener is null{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self
@@ -495,120 +492,120 @@ impl DefaultMQPushConsumerImpl {
                 .message_listener_concurrently
                 .is_none()
         {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "messageListener must be instanceof MessageListenerOrderly or \
                  MessageListenerConcurrently{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         let consume_thread_min = self.consumer_config.consume_thread_min;
         let consume_thread_max = self.consumer_config.consume_thread_max;
         if !(1..=1000).contains(&consume_thread_min) {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "consumeThreadMin Out of range [1, 1000]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
         if !(1..=1000).contains(&consume_thread_max) {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "consumeThreadMax Out of range [1, 1000]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
         if consume_thread_min > consume_thread_max {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "consumeThreadMin ({}) is larger than consumeThreadMax ({})",
                 consume_thread_min, consume_thread_max
-            ))));
+            ));
         }
 
         if self.consumer_config.consume_concurrently_max_span < 1
             || self.consumer_config.consume_concurrently_max_span > 65535
         {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "consumeConcurrentlyMaxSpan Out of range [1, 65535]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.pull_threshold_for_queue < 1
             || self.consumer_config.pull_threshold_for_queue > 65535
         {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "pullThresholdForQueue Out of range [1, 65535]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.pull_threshold_for_topic != -1
             && (self.consumer_config.pull_threshold_for_topic < 1
                 || self.consumer_config.pull_threshold_for_topic > 6553500)
         {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "pullThresholdForTopic Out of range [1, 65535]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.pull_threshold_size_for_queue < 1
             || self.consumer_config.pull_threshold_size_for_queue > 1024
         {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "pullThresholdSizeForQueue Out of range [1, 1024]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.pull_threshold_size_for_topic != -1
             && (self.consumer_config.pull_threshold_size_for_topic < 1
                 || self.consumer_config.pull_threshold_size_for_topic > 102400)
         {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "pullThresholdSizeForTopic Out of range [1, 102400]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.pull_interval > 65535 {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "pullInterval Out of range [0, 65535]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.consume_message_batch_max_size < 1
             || self.consumer_config.consume_message_batch_max_size > 1024
         {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "consumeMessageBatchMaxSize Out of range [1, 1024]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.pull_batch_size < 1 || self.consumer_config.pull_batch_size > 1024 {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "pullBatchSize Out of range [1, 1024]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.pop_invisible_time < MIN_POP_INVISIBLE_TIME
             || self.consumer_config.pop_invisible_time > MAX_POP_INVISIBLE_TIME
         {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "popInvisibleTime Out of range [{}, {}]{}",
                 MIN_POP_INVISIBLE_TIME,
                 MAX_POP_INVISIBLE_TIME,
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         if self.consumer_config.pop_batch_nums < 1 || self.consumer_config.pop_batch_nums > 32 {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "popBatchNums Out of range [1, 32]{}",
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_PARAMETER_CHECK_URL)
-            ))));
+            ));
         }
 
         Ok(())
@@ -673,10 +670,7 @@ impl DefaultMQPushConsumerImpl {
     ) -> Result<()> {
         let subscription_data = FilterAPI::build_subscription_data(&topic, &sub_expression);
         if let Err(e) = subscription_data {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
-                "buildSubscriptionData exception, {}",
-                e
-            ))));
+            return mq_client_err!(format!("buildSubscriptionData exception, {}", e));
         }
         let subscription_data = subscription_data.unwrap();
         self.rebalance_impl
@@ -974,11 +968,11 @@ impl DefaultMQPushConsumerImpl {
 
     fn make_sure_state_ok(&self) -> Result<()> {
         if *self.service_state != ServiceState::Running {
-            return Err(MQClientError::MQClientErr(ClientErr::new(format!(
+            return mq_client_err!(format!(
                 "The consumer service state not OK, {},{}",
                 *self.service_state,
                 FAQUrl::suggest_todo(FAQUrl::CLIENT_SERVICE_NOT_OK)
-            ))));
+            ));
         }
         Ok(())
     }

--- a/rocketmq-client/src/consumer/store/local_file_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/local_file_offset_store.rs
@@ -32,14 +32,13 @@ use tokio::sync::Mutex;
 use tracing::error;
 use tracing::info;
 
-use crate::client_error::ClientErr;
-use crate::client_error::MQClientError;
 use crate::consumer::store::controllable_offset::ControllableOffset;
 use crate::consumer::store::offset_serialize::OffsetSerialize;
 use crate::consumer::store::offset_serialize_wrapper::OffsetSerializeWrapper;
 use crate::consumer::store::offset_store::OffsetStoreTrait;
 use crate::consumer::store::read_offset_type::ReadOffsetType;
 use crate::factory::mq_client_instance::MQClientInstance;
+use crate::mq_client_err;
 use crate::Result;
 
 static LOCAL_OFFSET_STORE_DIR: Lazy<PathBuf> = Lazy::new(|| {
@@ -89,10 +88,7 @@ impl LocalFileOffsetStore {
         } else {
             match OffsetSerialize::decode(content.as_bytes()) {
                 Ok(value) => Ok(Some(value.into())),
-                Err(e) => Err(MQClientError::MQClientErr(ClientErr::new(format!(
-                    "Failed to deserialize local offset: {}",
-                    e
-                )))),
+                Err(e) => mq_client_err!(format!("Failed to deserialize local offset: {}", e)),
             }
         }
     }
@@ -104,10 +100,10 @@ impl LocalFileOffsetStore {
         } else {
             match OffsetSerialize::decode(content.as_bytes()) {
                 Ok(value) => Ok(Some(value.into())),
-                Err(_) => Err(MQClientError::MQClientErr(ClientErr::new(format!(
+                Err(_) => mq_client_err!(format!(
                     "read local offset bak failed, content: {}",
                     content
-                )))),
+                )),
             }
         }
     }

--- a/rocketmq-client/src/consumer/store/remote_broker_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/remote_broker_offset_store.rs
@@ -31,12 +31,12 @@ use tracing::error;
 use tracing::info;
 use tracing::warn;
 
-use crate::client_error::ClientErr;
 use crate::client_error::MQClientError;
 use crate::consumer::store::controllable_offset::ControllableOffset;
 use crate::consumer::store::offset_store::OffsetStoreTrait;
 use crate::consumer::store::read_offset_type::ReadOffsetType;
 use crate::factory::mq_client_instance::MQClientInstance;
+use crate::mq_client_err;
 use crate::Result;
 
 pub struct RemoteBrokerOffsetStore {
@@ -110,10 +110,7 @@ impl RemoteBrokerOffsetStore {
                 )
                 .await
         } else {
-            Err(MQClientError::MQClientErr(ClientErr::new(format!(
-                "broker not found, {}",
-                mq.get_broker_name()
-            ))))
+            mq_client_err!(format!("broker not found, {}", mq.get_broker_name()))
         }
     }
 }
@@ -320,10 +317,7 @@ impl OffsetStoreTrait for RemoteBrokerOffsetStore {
             };
             Ok(())
         } else {
-            Err(MQClientError::MQClientErr(ClientErr::new(format!(
-                "broker not found, {}",
-                mq.get_broker_name()
-            ))))
+            mq_client_err!(format!("broker not found, {}", mq.get_broker_name()))
         }
     }
 }

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -51,7 +51,6 @@ use tracing::warn;
 
 use crate::admin::mq_admin_ext_inner::MQAdminExtInner;
 use crate::base::client_config::ClientConfig;
-use crate::client_error::ClientErr;
 use crate::client_error::MQClientError::MQClientErr;
 use crate::consumer::consumer_impl::pull_message_service::PullMessageService;
 use crate::consumer::consumer_impl::re_balance::rebalance_service::RebalanceService;
@@ -61,6 +60,7 @@ use crate::implementation::client_remoting_processor::ClientRemotingProcessor;
 use crate::implementation::find_broker_result::FindBrokerResult;
 use crate::implementation::mq_admin_impl::MQAdminImpl;
 use crate::implementation::mq_client_api_impl::MQClientAPIImpl;
+use crate::mq_client_err;
 use crate::producer::default_mq_producer::DefaultMQProducer;
 use crate::producer::default_mq_producer::ProducerConfig;
 use crate::producer::producer_impl::mq_producer_inner::MQProducerInnerImpl;
@@ -330,10 +330,10 @@ impl MQClientInstance {
             ServiceState::Running => {}
             ServiceState::ShutdownAlready => {}
             ServiceState::StartFailed => {
-                return Err(MQClientErr(ClientErr::new(format!(
+                return mq_client_err!(format!(
                     "The Factory object[{}] has been created before, and failed.",
                     self.client_id
-                ))));
+                ));
             }
         }
         Ok(())
@@ -986,7 +986,7 @@ impl MQClientInstance {
                                      the log!",
                                     subscription_data.expression_type
                                 );
-                                return Err(MQClientErr(ClientErr::new(desc)));
+                                return mq_client_err!(desc);
                             }
                         },
                     }

--- a/rocketmq-client/src/implementation/mq_admin_impl.rs
+++ b/rocketmq-client/src/implementation/mq_admin_impl.rs
@@ -19,11 +19,10 @@ use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_rust::ArcMut;
 
 use crate::base::client_config::ClientConfig;
-use crate::client_error::ClientErr;
-use crate::client_error::MQClientError::MQClientErr;
 use crate::factory::mq_client_instance;
 use crate::factory::mq_client_instance::MQClientInstance;
 use crate::implementation::mq_client_api_impl::MQClientAPIImpl;
+use crate::mq_client_err;
 use crate::Result;
 
 pub struct MQAdminImpl {
@@ -88,10 +87,10 @@ impl MQAdminImpl {
                 ));
             }
         }
-        Err(MQClientErr(ClientErr::new(format!(
+        mq_client_err!(format!(
             "Unknow why, Can not find Message Queue for this topic, {}",
             topic
-        ))))
+        ))
     }
 
     pub async fn max_offset(&mut self, mq: &MessageQueue) -> Result<i64> {

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -39,8 +39,7 @@ use tracing::error;
 
 use crate::base::client_config::ClientConfig;
 use crate::base::validators::Validators;
-use crate::client_error::ClientErr;
-use crate::client_error::MQClientError::MQClientErr;
+use crate::mq_client_err;
 use crate::producer::default_mq_produce_builder::DefaultMQProducerBuilder;
 use crate::producer::mq_producer::MQProducer;
 use crate::producer::produce_accumulator::ProduceAccumulator;
@@ -491,9 +490,7 @@ impl DefaultMQProducer {
             }
             Err(err) => {
                 error!("Failed to initiate the MessageBatch: {:?}", err);
-                Err(MQClientErr(ClientErr::new(
-                    "Failed to initiate the MessageBatch",
-                )))
+                mq_client_err!("Failed to initiate the MessageBatch")
             }
         }
     }

--- a/rocketmq-client/src/utils/message_util.rs
+++ b/rocketmq-client/src/utils/message_util.rs
@@ -22,9 +22,8 @@ use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 
-use crate::client_error::ClientErr;
-use crate::client_error::MQClientError::MQClientErr;
 use crate::common::client_error_code::ClientErrorCode;
+use crate::mq_client_err;
 use crate::Result;
 
 pub struct MessageUtil;
@@ -73,13 +72,13 @@ impl MessageUtil {
             }
             Ok(reply_message)
         } else {
-            Err(MQClientErr(ClientErr::new_with_code(
+            mq_client_err!(
                 ClientErrorCode::CREATE_REPLY_MESSAGE_EXCEPTION,
                 format!(
                     "create reply message fail, requestMessage error, property[{}] is null.",
                     MessageConst::PROPERTY_CLUSTER
-                ),
-            )))
+                )
+            )
         }
     }
 

--- a/rocketmq/src/shutdown.rs
+++ b/rocketmq/src/shutdown.rs
@@ -65,7 +65,6 @@ where
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[tokio::test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1482

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `Shutdown` struct for managing shutdown signals with a Tokio broadcast channel.
	- Added methods to the `Shutdown` struct for checking shutdown status and receiving notifications.

- **Bug Fixes**
	- Streamlined error handling across various components by replacing verbose error constructions with a new macro `mq_client_err!`.

- **Documentation**
	- Updated import statements to utilize the new error handling macro consistently across multiple files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->