### PR TITLE
[ISSUE #1477]🚀derive RequestHeaderCodec support Struct🔥

### DIFF
--- a/rocketmq-macros/src/lib.rs
+++ b/rocketmq-macros/src/lib.rs
@@ -17,8 +17,10 @@
 
 use proc_macro::TokenStream;
 use quote::ToTokens;
+use syn::Field;
 use syn::PathArguments;
 use syn::Type;
+use syn::TypePath;
 
 use crate::remoting_serializable::remoting_serializable_inner;
 use crate::request_header_custom::request_header_codec_inner;
@@ -39,6 +41,25 @@ pub fn remoting_serializable(input: TokenStream) -> TokenStream {
 fn get_type_name(ty: &Type) -> String {
     ty.to_token_stream().to_string()
 }
+
+fn snake_to_camel_case(input: &str) -> String {
+    let mut camel_case = String::new();
+    let mut capitalize_next = false;
+
+    for c in input.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            camel_case.push(c.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            camel_case.push(c);
+        }
+    }
+
+    camel_case
+}
+
 fn is_option_type(ty: &Type) -> Option<&Type> {
     match ty {
         Type::Path(path) => {
@@ -57,20 +78,80 @@ fn is_option_type(ty: &Type) -> Option<&Type> {
     }
 }
 
-fn snake_to_camel_case(input: &str) -> String {
-    let mut camel_case = String::new();
-    let mut capitalize_next = false;
+fn is_struct_type(ty: &Type) -> bool {
+    // Check if the type is a path (i.e., a named type)
+    if let Type::Path(TypePath { path, .. }) = ty {
+        // Check if the type is Option<T>
+        if let Some(segment) = path.segments.first() {
+            // If it's Option, check its generic argument
+            if segment.ident == "Option" {
+                if let syn::PathArguments::AngleBracketed(ref args) = &segment.arguments {
+                    // Extract the first argument (T) inside Option
+                    if let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first() {
+                        // Recursively check the inner type, if it's not basic or String, return
+                        // true
+                        return !is_basic_or_string_type(inner_ty);
+                    }
+                }
+            }
+        }
 
-    for c in input.chars() {
-        if c == '_' {
-            capitalize_next = true;
-        } else if capitalize_next {
-            camel_case.push(c.to_ascii_uppercase());
-            capitalize_next = false;
-        } else {
-            camel_case.push(c);
+        // Check the last segment of the path to determine if it's a basic type or String,
+        // CheetahString
+        if let Some(_segment) = path.segments.last() {
+            // If it's a basic type or String/CheetahString, return false
+            if is_basic_or_string_type(ty) {
+                return false;
+            }
+
+            // If it's neither basic nor String/CheetahString, it's likely a struct
+            return true;
         }
     }
 
-    camel_case
+    // If none of the conditions match, it's not a struct
+    false
+}
+
+fn is_basic_or_string_type(ty: &Type) -> bool {
+    if let Type::Path(TypePath { path, .. }) = ty {
+        if let Some(segment) = path.segments.last() {
+            let segment_ident = &segment.ident;
+            // check if the type is a basic type or a string or a CheetahString
+            return segment_ident == "String"
+                || segment_ident == "CheetahString"
+                || segment_ident == "i8"
+                || segment_ident == "i16"
+                || segment_ident == "i32"
+                || segment_ident == "i64"
+                || segment_ident == "u8"
+                || segment_ident == "u16"
+                || segment_ident == "u32"
+                || segment_ident == "u64"
+                || segment_ident == "f32"
+                || segment_ident == "f64"
+                || segment_ident == "bool";
+        }
+    }
+    false
+}
+
+fn has_serde_flatten_attribute(field: &Field) -> bool {
+    for attr in &field.attrs {
+        if let Some(ident) = attr.path().get_ident() {
+            let mut has_serde_flatten_attribute = false;
+            if ident == "serde" {
+                let _ = attr.parse_nested_meta(|meta| {
+                    has_serde_flatten_attribute = meta
+                        .path
+                        .segments
+                        .iter()
+                        .any(|segment| segment.ident == "flatten");
+                    Ok(())
+                });
+            }
+            return has_serde_flatten_attribute;
+        }
+    }
+    false
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1477

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for string manipulation and type checking, including `snake_to_camel_case`, `is_struct_type`, `is_basic_or_string_type`, and `has_serde_flatten_attribute`.
	- Enhanced mapping logic to support complex data structures with optional fields and `serde(flatten)` attribute.

- **Bug Fixes**
	- Improved error handling for required fields in mapping logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->