### PR TITLE
Add BrokerOperatorResult and RollbackStats

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -44,6 +44,8 @@ use crate::processor::pop_inflight_message_counter::PopInflightMessageCounter;
 use crate::schedule::schedule_message_service::ScheduleMessageService;
 use crate::topic::manager::topic_config_manager::TopicConfigManager;
 use crate::topic::manager::topic_queue_mapping_manager::TopicQueueMappingManager;
+use rocketmq_remoting::protocol::admin::broker_operator_result::BrokerOperatorResult;
+use rocketmq_remoting::protocol::admin::rollback_stats::RollbackStats;
 
 mod batch_mq_handler;
 mod broker_config_request_handler;

--- a/rocketmq-tools/src/admin/mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/mq_admin_ext.rs
@@ -38,6 +38,8 @@ use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
 use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+use rocketmq_remoting::protocol::admin::broker_operator_result::BrokerOperatorResult;
+use rocketmq_remoting::protocol::admin::rollback_stats::RollbackStats;
 
 use crate::admin::common::admin_tool_result::AdminToolResult;
 use crate::Result;
@@ -205,11 +207,11 @@ pub trait MQAdminExt {
         topic: CheetahString,
     ) -> Result<()>;
 
-    /*fn delete_topic_in_broker_concurrent(
+    fn delete_topic_in_broker_concurrent(
         &self,
         addrs: HashSet<CheetahString>,
         topic: CheetahString,
-    ) -> AdminToolResult<BrokerOperatorResult>;*/
+    ) -> AdminToolResult<BrokerOperatorResult>;
 
     fn delete_topic_in_name_server(
         &self,
@@ -234,13 +236,13 @@ pub trait MQAdminExt {
 
     fn delete_kv_config(&self, namespace: CheetahString, key: CheetahString) -> Result<()>;
 
-    /*fn reset_offset_by_timestamp_old(
+    fn reset_offset_by_timestamp_old(
         &self,
         consumer_group: CheetahString,
         topic: CheetahString,
         timestamp: u64,
         force: bool,
-    ) -> Result<Vec<RollbackStats>>;*/
+    ) -> Result<Vec<RollbackStats>>;
 
     fn reset_offset_by_timestamp(
         &self,
@@ -258,12 +260,12 @@ pub trait MQAdminExt {
         timestamp: u64,
     ) -> Result<()>;
 
-    /*fn reset_offset_new_concurrent(
+    fn reset_offset_new_concurrent(
         &self,
         group: CheetahString,
         topic: CheetahString,
         timestamp: u64,
-    ) -> AdminToolResult<BrokerOperatorResult>;*/
+    ) -> AdminToolResult<BrokerOperatorResult>;
 
     fn get_consume_status(
         &self,

--- a/rocketmq-tools/src/admin/mq_admin_ext_async.rs
+++ b/rocketmq-tools/src/admin/mq_admin_ext_async.rs
@@ -37,6 +37,8 @@ use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
 use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+use rocketmq_remoting::protocol::admin::broker_operator_result::BrokerOperatorResult;
+use rocketmq_remoting::protocol::admin::rollback_stats::RollbackStats;
 
 use crate::admin::common::admin_tool_result::AdminToolResult;
 use crate::Result;
@@ -220,11 +222,11 @@ pub trait MQAdminExtLocal: Sync {
         topic: CheetahString,
     ) -> Result<()>;
 
-    /*async fn delete_topic_in_broker_concurrent(
+    async fn delete_topic_in_broker_concurrent(
         &self,
         addrs: HashSet<CheetahString>,
         topic: CheetahString,
-    ) -> AdminToolResult<BrokerOperatorResult>;*/
+    ) -> AdminToolResult<BrokerOperatorResult>;
 
     async fn delete_topic_in_name_server(
         &self,
@@ -249,13 +251,13 @@ pub trait MQAdminExtLocal: Sync {
 
     async fn delete_kv_config(&self, namespace: CheetahString, key: CheetahString) -> Result<()>;
 
-    /*async fn reset_offset_by_timestamp_old(
+    async fn reset_offset_by_timestamp_old(
         &self,
         consumer_group: CheetahString,
         topic: CheetahString,
         timestamp: u64,
         force: bool,
-    ) -> Result<Vec<RollbackStats>>;*/
+    ) -> Result<Vec<RollbackStats>>;
 
     async fn reset_offset_by_timestamp(
         &self,
@@ -273,12 +275,12 @@ pub trait MQAdminExtLocal: Sync {
         timestamp: u64,
     ) -> Result<()>;
 
-    /*async fn reset_offset_new_concurrent(
+    async fn reset_offset_new_concurrent(
         &self,
         group: CheetahString,
         topic: CheetahString,
         timestamp: u64,
-    ) -> AdminToolResult<BrokerOperatorResult>;*/
+    ) -> AdminToolResult<BrokerOperatorResult>;
 
     async fn get_consume_status(
         &self,


### PR DESCRIPTION
Related to #1376

Add `BrokerOperatorResult` and `RollbackStats` features to the project.

* **rocketmq-broker/src/processor/admin_broker_processor.rs**
  - Add `BrokerOperatorResult` and `RollbackStats` to the imports.
* **rocketmq-tools/src/admin/mq_admin_ext.rs**
  - Implement `BrokerOperatorResult` and `RollbackStats` in the `MQAdminExt` trait.
  - Update method signatures to include `BrokerOperatorResult` and `RollbackStats`.
* **rocketmq-tools/src/admin/mq_admin_ext_async.rs**
  - Implement `BrokerOperatorResult` and `RollbackStats` in the `MQAdminExtLocal` trait.
  - Update method signatures to include `BrokerOperatorResult` and `RollbackStats`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced broker operations with new methods for deleting topics and resetting offsets.
	- Added support for rollback statistics in broker commands.

- **Bug Fixes**
	- Activated previously commented-out methods for better functionality in broker management.

- **Documentation**
	- Updated method signatures in the `MQAdminExt` and `MQAdminExtLocal` traits for clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->