### PR TITLE
[ISSUE #1519] Replace SendMessageProcessor#process_request return type to crate::Result<Option<RemotingCommand>>

### DIFF
--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -120,7 +120,8 @@ where
                 return self
                     .send_message_processor
                     .process_request(channel, ctx, request_code, request)
-                    .await;
+                    .await
+                    .map_err(Into::into);
             }
 
             RequestCode::SendReplyMessage | RequestCode::SendReplyMessageV2 => {

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -110,16 +110,13 @@ where
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
         request: RemotingCommand,
-    ) -> rocketmq_remoting::Result<Option<RemotingCommand>> {
+    ) -> crate::Result<Option<RemotingCommand>> {
         match request_code {
             RequestCode::ConsumerSendMsgBack => {
-                //need to optimize
-                self.inner
-                    .consumer_send_msg_back(&channel, &ctx, &request)
-                    .map_err(Into::into)
+                self.inner.consumer_send_msg_back(&channel, &ctx, &request)
             }
             _ => {
-                let mut request_header = parse_request_header(&request, request_code).unwrap(); //need to optimize
+                let mut request_header = parse_request_header(&request, request_code)?;
                 let mapping_context = self
                     .inner
                     .topic_queue_mapping_manager
@@ -628,58 +625,58 @@ where
     ) -> Option<RemotingCommand> {
         let mut send_ok = false;
         match put_message_result.put_message_status() {
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::PutOk => {
-                        send_ok = true;
-                        response.set_code_ref(RemotingSysResponseCode::Success);
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::FlushDiskTimeout => {
-                        send_ok = true;
-                        response.set_code_ref(ResponseCode::FlushDiskTimeout);
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::FlushSlaveTimeout => {
-                        send_ok = true;
-                        response.set_code_ref(ResponseCode::FlushSlaveTimeout);
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::SlaveNotAvailable =>{
-                        send_ok = true;
-                        response.set_code_ref(ResponseCode::SlaveNotAvailable);
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::ServiceNotAvailable => {
-                        response.set_code_mut(ResponseCode::ServiceNotAvailable).set_remark_mut("service not available now. It may be caused by one of the following reasons: \
-                        the broker's disk is full %s, messages are put to the slave, message store has been shut down, etc.");
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::CreateMappedFileFailed => {
-                       response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("create mapped file failed, remoting_server is busy or broken.");
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::MessageIllegal |
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::PropertiesSizeExceeded => {
-                       response.set_code_mut(ResponseCode::MessageIllegal).set_remark_mut("the message is illegal, maybe msg body or properties length not matched. msg body length limit B, msg properties length limit 32KB.");
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::OsPageCacheBusy =>{
-                        response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("[PC_SYNCHRONIZED]broker busy, start flow control for a while");
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::UnknownError => {
-                       response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("UNKNOWN_ERROR");
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::InSyncReplicasNotEnough => {
-                        response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("in-sync replicas not enough");
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::LmqConsumeQueueNumExceeded => {
-                        response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("[LMQ_CONSUME_QUEUE_NUM_EXCEEDED]broker config enableLmq and enableMultiDispatch, lmq consumeQueue num exceed maxLmqConsumeQueueNum config num, default limit 2w.");
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::WheelTimerFlowControl => {
-                        response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("timer message is under flow control, max num limit is %d or the current value is greater than %d and less than %d, trigger random flow control");
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::WheelTimerMsgIllegal => {
-                        response.set_code_mut(ResponseCode::MessageIllegal).set_remark_mut("timer message illegal, the delay time should not be bigger than the max delay %dms; or if set del msg, the delay time should be bigger than the current time");
-                    },
-                    rocketmq_store::base::message_status_enum::PutMessageStatus::WheelTimerNotEnable => {
-                        response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("accurate timer message is not enabled, timerWheelEnable is %s");
-                    },
-                    _ => {
-                        response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("UNKNOWN_ERROR DEFAULT");
-                    }
-                }
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::PutOk => {
+                         send_ok = true;
+                         response.set_code_ref(RemotingSysResponseCode::Success);
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::FlushDiskTimeout => {
+                         send_ok = true;
+                         response.set_code_ref(ResponseCode::FlushDiskTimeout);
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::FlushSlaveTimeout => {
+                         send_ok = true;
+                         response.set_code_ref(ResponseCode::FlushSlaveTimeout);
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::SlaveNotAvailable =>{
+                         send_ok = true;
+                         response.set_code_ref(ResponseCode::SlaveNotAvailable);
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::ServiceNotAvailable => {
+                         response.set_code_mut(ResponseCode::ServiceNotAvailable).set_remark_mut("service not available now. It may be caused by one of the following reasons: \
+                         the broker's disk is full %s, messages are put to the slave, message store has been shut down, etc.");
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::CreateMappedFileFailed => {
+                        response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("create mapped file failed, remoting_server is busy or broken.");
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::MessageIllegal |
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::PropertiesSizeExceeded => {
+                        response.set_code_mut(ResponseCode::MessageIllegal).set_remark_mut("the message is illegal, maybe msg body or properties length not matched. msg body length limit B, msg properties length limit 32KB.");
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::OsPageCacheBusy =>{
+                         response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("[PC_SYNCHRONIZED]broker busy, start flow control for a while");
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::UnknownError => {
+                        response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("UNKNOWN_ERROR");
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::InSyncReplicasNotEnough => {
+                         response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("in-sync replicas not enough");
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::LmqConsumeQueueNumExceeded => {
+                         response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("[LMQ_CONSUME_QUEUE_NUM_EXCEEDED]broker config enableLmq and enableMultiDispatch, lmq consumeQueue num exceed maxLmqConsumeQueueNum config num, default limit 2w.");
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::WheelTimerFlowControl => {
+                         response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("timer message is under flow control, max num limit is %d or the current value is greater than %d and less than %d, trigger random flow control");
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::WheelTimerMsgIllegal => {
+                         response.set_code_mut(ResponseCode::MessageIllegal).set_remark_mut("timer message illegal, the delay time should not be bigger than the max delay %dms; or if set del msg, the delay time should be bigger than the current time");
+                     },
+                     rocketmq_store::base::message_status_enum::PutMessageStatus::WheelTimerNotEnable => {
+                         response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("accurate timer message is not enabled, timerWheelEnable is %s");
+                     },
+                     _ => {
+                         response.set_code_mut(RemotingSysResponseCode::SystemError).set_remark_mut("UNKNOWN_ERROR DEFAULT");
+                     }
+                 }
 
         let binding = HashMap::new();
         let ext_fields = request.ext_fields().unwrap_or(&binding);


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1519 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for parsing request headers, enhancing the handling of message requests.
  
- **Bug Fixes**
	- Improved error handling in message processing, ensuring errors are properly propagated and reducing potential issues during message sending.

- **Tests**
	- Updated test suite to include scenarios for the new parsing functionality and error handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->