### PR TITLE
[ISSUE #1521]🔥Remove SendMessageRequestHeader queue_id Option🚀

### DIFF
--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -167,7 +167,7 @@ where
         if response.code() != -1 {
             return response;
         }
-        let mut queue_id_int = request_header.queue_id.unwrap_or(0);
+        let mut queue_id_int = request_header.queue_id;
         let topic_config = self
             .inner
             .topic_config_manager
@@ -371,7 +371,7 @@ where
             topic: request_header.topic.clone(),
             default_topic: request_header.default_topic.clone(),
             default_topic_queue_nums: request_header.default_topic_queue_nums,
-            queue_id: request_header.queue_id.unwrap_or(0),
+            queue_id: request_header.queue_id,
             sys_flag: request_header.sys_flag,
             born_timestamp: request_header.born_timestamp,
             flag: request_header.flag,

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -231,8 +231,8 @@ where
             .select_topic_config(request_header.topic())
             .unwrap();
         let mut queue_id = request_header.queue_id;
-        if queue_id.is_none() || queue_id.unwrap() < 0 {
-            queue_id = Some(self.inner.random_queue_id(topic_config.write_queue_nums) as i32);
+        if queue_id < 0 {
+            queue_id = self.inner.random_queue_id(topic_config.write_queue_nums) as i32;
         }
 
         if request_header.topic.len() > i8::MAX as usize {
@@ -260,7 +260,7 @@ where
         }
         let mut message_ext = MessageExtBrokerInner::default();
         message_ext.message_ext_inner.message.topic = request_header.topic().clone();
-        message_ext.message_ext_inner.queue_id = queue_id.unwrap();
+        message_ext.message_ext_inner.queue_id = queue_id;
         let mut sys_flag = request_header.sys_flag;
         if TopicFilterType::MultiTag == topic_config.topic_filter_type {
             sys_flag |= MessageSysFlag::MULTI_TAGS_FLAG;
@@ -377,7 +377,7 @@ where
                 transaction_id,
                 &mut send_message_context,
                 ctx,
-                queue_id.unwrap(),
+                queue_id,
                 start,
                 &mut mapping_context,
                 MessageType::NormalMsg,
@@ -402,7 +402,7 @@ where
                 transaction_id,
                 &mut send_message_context,
                 ctx,
-                queue_id.unwrap(),
+                queue_id,
                 start,
                 &mut mapping_context,
                 MessageType::NormalMsg,
@@ -437,13 +437,13 @@ where
             .select_topic_config(request_header.topic())
             .unwrap();
         let mut queue_id = request_header.queue_id;
-        if queue_id.is_none() || queue_id.unwrap() < 0 {
-            queue_id = Some(self.inner.random_queue_id(topic_config.write_queue_nums) as i32);
+        if queue_id < 0 {
+            queue_id = self.inner.random_queue_id(topic_config.write_queue_nums) as i32;
         }
 
         let mut message_ext = MessageExtBrokerInner::default();
         message_ext.message_ext_inner.message.topic = request_header.topic().clone();
-        message_ext.message_ext_inner.queue_id = *queue_id.as_ref().unwrap();
+        message_ext.message_ext_inner.queue_id = queue_id;
         let mut ori_props =
             MessageDecoder::string_to_message_properties(request_header.properties.as_ref());
         if !self.handle_retry_and_dlq(
@@ -572,7 +572,7 @@ where
                 transaction_id,
                 &mut send_message_context,
                 ctx,
-                queue_id.unwrap(),
+                queue_id,
                 start,
                 &mut mapping_context,
                 MessageType::NormalMsg,
@@ -598,7 +598,7 @@ where
                 transaction_id,
                 &mut send_message_context,
                 ctx,
-                queue_id.unwrap(),
+                queue_id,
                 start,
                 &mut mapping_context,
                 MessageType::NormalMsg,
@@ -1033,7 +1033,7 @@ impl<MS, TS> Inner<MS, TS> {
         send_message_context.broker_addr(CheetahString::from_string(
             self.broker_config.get_broker_addr(),
         ));
-        send_message_context.queue_id(request_header.queue_id);
+        send_message_context.queue_id(Some(request_header.queue_id));
         send_message_context.broker_region_id(CheetahString::from_string(
             self.broker_config.region_id().to_string(),
         ));
@@ -1160,7 +1160,7 @@ impl<MS, TS> Inner<MS, TS> {
             }
         }
 
-        let queue_id_int = request_header.queue_id.unwrap();
+        let queue_id_int = request_header.queue_id;
         let topic_config_inner = topic_config.as_ref().unwrap();
         let id_valid = topic_config_inner
             .write_queue_nums

--- a/rocketmq-client/src/common/thread_local_index.rs
+++ b/rocketmq-client/src/common/thread_local_index.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(clippy::missing_const_for_thread_local)]
+
 use std::cell::RefCell;
 use std::fmt;
 

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -1067,7 +1067,7 @@ impl DefaultMQProducerImpl {
                 self.producer_config.create_topic_key().to_string(),
             ),
             default_topic_queue_nums: self.producer_config.default_topic_queue_nums() as i32,
-            queue_id: Some(mq.get_queue_id()),
+            queue_id: mq.get_queue_id(),
             sys_flag,
             born_timestamp: get_current_millis() as i64,
             flag: msg.get_flag(),

--- a/rocketmq-remoting/src/protocol/header/get_max_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_max_offset_request_header.rs
@@ -208,11 +208,11 @@ impl TopicRequestHeaderTrait for GetMaxOffsetRequestHeader {
             .oneway = Some(oneway);
     }
 
-    fn queue_id(&self) -> Option<i32> {
-        Some(self.queue_id)
+    fn queue_id(&self) -> i32 {
+        self.queue_id
     }
 
-    fn set_queue_id(&mut self, queue_id: Option<i32>) {
-        self.queue_id = queue_id.unwrap_or_default();
+    fn set_queue_id(&mut self, queue_id: i32) {
+        self.queue_id = queue_id;
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_min_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_min_offset_request_header.rs
@@ -180,11 +180,11 @@ impl TopicRequestHeaderTrait for GetMinOffsetRequestHeader {
             .oneway = Some(oneway);
     }
 
-    fn queue_id(&self) -> Option<i32> {
-        Some(self.queue_id)
+    fn queue_id(&self) -> i32 {
+        self.queue_id
     }
 
-    fn set_queue_id(&mut self, queue_id: Option<i32>) {
-        self.queue_id = queue_id.unwrap_or_default();
+    fn set_queue_id(&mut self, queue_id: i32) {
+        self.queue_id = queue_id;
     }
 }

--- a/rocketmq-remoting/src/protocol/header/message_operation_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header.rs
@@ -45,7 +45,7 @@ pub trait TopicRequestHeaderTrait: Sync + Send {
 
     fn set_oneway(&mut self, oneway: bool);
 
-    fn queue_id(&self) -> Option<i32>;
+    fn queue_id(&self) -> i32;
 
-    fn set_queue_id(&mut self, queue_id: Option<i32>);
+    fn set_queue_id(&mut self, queue_id: i32);
 }

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
@@ -435,7 +435,7 @@ mod tests {
             topic: CheetahString::from_static_str("test_topic"),
             default_topic: CheetahString::from_static_str("test_default_topic"),
             default_topic_queue_nums: 8,
-            queue_id: Some(1),
+            queue_id: 1,
             sys_flag: 0,
             born_timestamp: 1622547800000,
             flag: 0,
@@ -570,7 +570,7 @@ mod tests {
         assert_eq!(header.topic, "test_topic");
         assert_eq!(header.default_topic, "test_default_topic");
         assert_eq!(header.default_topic_queue_nums, 8);
-        assert_eq!(header.queue_id.unwrap(), 1);
+        assert_eq!(header.queue_id, 1);
         assert_eq!(header.sys_flag, 0);
         assert_eq!(header.born_timestamp, 1622547800000);
         assert_eq!(header.flag, 0);
@@ -622,7 +622,7 @@ mod tests {
         assert_eq!(header.topic, "test_topic");
         assert_eq!(header.default_topic, "test_default_topic");
         assert_eq!(header.default_topic_queue_nums, 8);
-        assert!(header.queue_id.is_some());
+        //assert!(header.queue_id.is_some());
         assert_eq!(header.sys_flag, 0);
         assert_eq!(header.born_timestamp, 1622547800000);
         assert_eq!(header.flag, 0);

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
@@ -42,7 +42,7 @@ pub struct SendMessageRequestHeader {
     pub default_topic_queue_nums: i32,
 
     #[required]
-    pub queue_id: Option<i32>,
+    pub queue_id: i32,
 
     #[required]
     pub sys_flag: i32,
@@ -353,11 +353,11 @@ impl TopicRequestHeaderTrait for SendMessageRequestHeader {
             .namespaced = Some(oneway);
     }
 
-    fn queue_id(&self) -> Option<i32> {
+    fn queue_id(&self) -> i32 {
         self.queue_id
     }
 
-    fn set_queue_id(&mut self, queue_id: Option<i32>) {
+    fn set_queue_id(&mut self, queue_id: i32) {
         self.queue_id = queue_id;
     }
 }

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -301,7 +301,7 @@ impl SendMessageRequestHeaderV2 {
             topic: this.b.clone(),
             default_topic: this.c.clone(),
             default_topic_queue_nums: this.d,
-            queue_id: Some(this.e),
+            queue_id: this.e,
             sys_flag: this.f,
             born_timestamp: this.g,
             flag: this.h,
@@ -322,7 +322,7 @@ impl SendMessageRequestHeaderV2 {
             b: v1.topic.clone(),
             c: v1.default_topic.clone(),
             d: v1.default_topic_queue_nums,
-            e: v1.queue_id.unwrap(),
+            e: v1.queue_id,
             f: v1.sys_flag,
             g: v1.born_timestamp,
             h: v1.flag,
@@ -438,12 +438,12 @@ impl TopicRequestHeaderTrait for SendMessageRequestHeaderV2 {
             .namespaced = Some(oneway);
     }
 
-    fn queue_id(&self) -> Option<i32> {
-        Some(self.e)
+    fn queue_id(&self) -> i32 {
+        self.e
     }
 
-    fn set_queue_id(&mut self, queue_id: Option<i32>) {
-        self.e = queue_id.unwrap();
+    fn set_queue_id(&mut self, queue_id: i32) {
+        self.e = queue_id;
     }
 }
 

--- a/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
@@ -541,12 +541,12 @@ impl TopicRequestHeaderTrait for PullMessageRequestHeader {
             .oneway = Some(oneway);
     }
 
-    fn queue_id(&self) -> Option<i32> {
-        Some(self.queue_id)
+    fn queue_id(&self) -> i32 {
+        self.queue_id
     }
 
-    fn set_queue_id(&mut self, queue_id: Option<i32>) {
-        self.queue_id = queue_id.unwrap();
+    fn set_queue_id(&mut self, queue_id: i32) {
+        self.queue_id = queue_id;
     }
 }
 

--- a/rocketmq-remoting/src/protocol/header/query_consumer_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_consumer_offset_request_header.rs
@@ -198,11 +198,11 @@ impl TopicRequestHeaderTrait for QueryConsumerOffsetRequestHeader {
             .oneway = Some(oneway);
     }
 
-    fn queue_id(&self) -> Option<i32> {
-        Some(self.queue_id)
+    fn queue_id(&self) -> i32 {
+        self.queue_id
     }
 
-    fn set_queue_id(&mut self, queue_id: Option<i32>) {
-        self.queue_id = queue_id.unwrap();
+    fn set_queue_id(&mut self, queue_id: i32) {
+        self.queue_id = queue_id;
     }
 }

--- a/rocketmq-remoting/src/protocol/header/update_consumer_offset_header.rs
+++ b/rocketmq-remoting/src/protocol/header/update_consumer_offset_header.rs
@@ -213,12 +213,12 @@ impl TopicRequestHeaderTrait for UpdateConsumerOffsetRequestHeader {
             .oneway = Some(oneway);
     }
 
-    fn queue_id(&self) -> Option<i32> {
-        Some(self.queue_id)
+    fn queue_id(&self) -> i32 {
+        self.queue_id
     }
 
-    fn set_queue_id(&mut self, queue_id: Option<i32>) {
-        self.queue_id = queue_id.unwrap();
+    fn set_queue_id(&mut self, queue_id: i32) {
+        self.queue_id = queue_id;
     }
 }
 

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(clippy::missing_const_for_thread_local)]
-
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::mem;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1521

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of `queue_id` across various components, ensuring it is treated as a required field, simplifying the interface for message processing.
  
- **Bug Fixes**
	- Improved error handling and logging during message encoding and mapped file management in the commit log.

- **Documentation**
	- Updated comments to reflect changes in logic and handling of `queue_id` and `global_id`.

- **Chores**
	- Removed unnecessary directives and cleaned up code for better readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->