### PR TITLE
[ISSUE #1544]🍻Add #[inline] for SubscriptionGroupConfig methods

### DIFF
--- a/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
+++ b/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
@@ -179,8 +179,7 @@ impl SubscriptionGroupConfig {
 
     #[inline]
     pub fn set_consume_from_min_enable(&mut self, consume_from_min_enable: bool) {
-        self.co
-        nsume_from_min_enable = consume_from_min_enable;
+        self.consume_from_min_enable = consume_from_min_enable;
     }
 
     #[inline]

--- a/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
+++ b/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
@@ -91,114 +91,160 @@ impl Default for SubscriptionGroupConfig {
 }
 
 impl SubscriptionGroupConfig {
+
+    #[inline]
     pub fn group_name(&self) -> &str {
         &self.group_name
     }
 
+    #[inline]
     pub fn consume_enable(&self) -> bool {
         self.consume_enable
     }
 
+    #[inline]
     pub fn consume_from_min_enable(&self) -> bool {
         self.consume_from_min_enable
     }
 
+    #[inline]
     pub fn consume_broadcast_enable(&self) -> bool {
         self.consume_broadcast_enable
     }
 
+    #[inline]
     pub fn consume_message_orderly(&self) -> bool {
         self.consume_message_orderly
     }
 
+    #[inline]
     pub fn retry_queue_nums(&self) -> i32 {
         self.retry_queue_nums
     }
 
+    #[inline]
     pub fn retry_max_times(&self) -> i32 {
         self.retry_max_times
     }
 
+    #[inline]
     pub fn group_retry_policy(&self) -> &GroupRetryPolicy {
         &self.group_retry_policy
     }
 
+    #[inline]
     pub fn broker_id(&self) -> u64 {
         self.broker_id
     }
 
+    #[inline]
     pub fn which_broker_when_consume_slowly(&self) -> u64 {
         self.which_broker_when_consume_slowly
     }
 
+    #[inline]
     pub fn notify_consumer_ids_changed_enable(&self) -> bool {
         self.notify_consumer_ids_changed_enable
     }
 
+    #[inline]
     pub fn group_sys_flag(&self) -> i32 {
         self.group_sys_flag
     }
 
+    #[inline]
     pub fn consume_timeout_minute(&self) -> i32 {
         self.consume_timeout_minute
     }
 
+    #[inline]
     pub fn subscription_data_set(&self) -> Option<&HashSet<SimpleSubscriptionData>> {
         self.subscription_data_set.as_ref()
     }
 
+    #[inline]
     pub fn attributes(&self) -> &HashMap<CheetahString, CheetahString> {
         &self.attributes
     }
 
+    #[inline]
     pub fn set_group_name(&mut self, group_name: CheetahString) {
         self.group_name = group_name;
     }
+
+    #[inline]
     pub fn set_consume_enable(&mut self, consume_enable: bool) {
         self.consume_enable = consume_enable;
     }
+
+    #[inline]
     pub fn set_consume_from_min_enable(&mut self, consume_from_min_enable: bool) {
-        self.consume_from_min_enable = consume_from_min_enable;
+        self.co
+        nsume_from_min_enable = consume_from_min_enable;
     }
+
+    #[inline]
     pub fn set_consume_broadcast_enable(&mut self, consume_broadcast_enable: bool) {
         self.consume_broadcast_enable = consume_broadcast_enable;
     }
+
+    #[inline]
     pub fn set_consume_message_orderly(&mut self, consume_message_orderly: bool) {
         self.consume_message_orderly = consume_message_orderly;
     }
+
+    #[inline]
     pub fn set_retry_queue_nums(&mut self, retry_queue_nums: i32) {
         self.retry_queue_nums = retry_queue_nums;
     }
+
+    #[inline]
     pub fn set_retry_max_times(&mut self, retry_max_times: i32) {
         self.retry_max_times = retry_max_times;
     }
+
+    #[inline]
     pub fn set_group_retry_policy(&mut self, group_retry_policy: GroupRetryPolicy) {
         self.group_retry_policy = group_retry_policy;
     }
+
+    #[inline]
     pub fn set_broker_id(&mut self, broker_id: u64) {
         self.broker_id = broker_id;
     }
+
+    #[inline]
     pub fn set_which_broker_when_consume_slowly(&mut self, which_broker_when_consume_slowly: u64) {
         self.which_broker_when_consume_slowly = which_broker_when_consume_slowly;
     }
+
+    #[inline]
     pub fn set_notify_consumer_ids_changed_enable(
         &mut self,
         notify_consumer_ids_changed_enable: bool,
     ) {
         self.notify_consumer_ids_changed_enable = notify_consumer_ids_changed_enable;
     }
+
+    #[inline]
     pub fn set_group_sys_flag(&mut self, group_sys_flag: i32) {
         self.group_sys_flag = group_sys_flag;
     }
+
+    #[inline]
     pub fn set_consume_timeout_minute(&mut self, consume_timeout_minute: i32) {
         self.consume_timeout_minute = consume_timeout_minute;
     }
+
+    #[inline]
     pub fn set_subscription_data_set(
         &mut self,
         subscription_data_set: Option<HashSet<SimpleSubscriptionData>>,
     ) {
         self.subscription_data_set = subscription_data_set;
     }
+
+    #[inline]
     pub fn set_attributes(&mut self, attributes: HashMap<CheetahString, CheetahString>) {
         self.attributes = attributes;
     }

--- a/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
+++ b/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
@@ -91,7 +91,6 @@ impl Default for SubscriptionGroupConfig {
 }
 
 impl SubscriptionGroupConfig {
-
     #[inline]
     pub fn group_name(&self) -> &str {
         &self.group_name


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1544  🍻

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced getter and setter methods for the `SubscriptionGroupConfig`, enhancing access and modification of subscription group properties.

- **Bug Fixes**
	- Corrected a minor typo in the setter for `consume_from_min_enable`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->