### PR TITLE
[ISSUE #1562]⚡️Optimize DefaultRequestProcessor error handle

### DIFF
--- a/rocketmq-namesrv/src/namesrv_error.rs
+++ b/rocketmq-namesrv/src/namesrv_error.rs
@@ -19,8 +19,8 @@ use thiserror::Error;
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Error)]
 pub enum NamesrvError {
-    #[error("Namesrv error: {0}")]
-    NamesrvRemotingError(#[from] rocketmq_remoting::remoting_error::RemotingError),
+    #[error("{0}")]
+    NamesrvRemotingError(#[from] NamesrvRemotingErrorWithMessage),
 
     #[error("Common error: {0}")]
     NamesrvCommonError(#[from] rocketmq_common::error::Error),
@@ -29,16 +29,37 @@ pub enum NamesrvError {
     MQNamesrvError(String),
 }
 
+#[derive(Debug, Error)]
+#[error("Namesrv error: {error}, error message:{message}")]
+pub struct NamesrvRemotingErrorWithMessage {
+    pub error: rocketmq_remoting::remoting_error::RemotingError,
+    pub message: String,
+}
+
+impl NamesrvRemotingErrorWithMessage {
+    pub fn new(error: rocketmq_remoting::remoting_error::RemotingError, message: String) -> Self {
+        NamesrvRemotingErrorWithMessage { error, message }
+    }
+}
+
 impl From<NamesrvError> for rocketmq_remoting::remoting_error::RemotingError {
     #[inline]
     fn from(value: NamesrvError) -> Self {
         match value {
-            NamesrvError::NamesrvRemotingError(e) => e,
-            NamesrvError::NamesrvCommonError(e) => {
-                rocketmq_remoting::remoting_error::RemotingError::RemoteError(format!("{}", e))
+            NamesrvError::NamesrvRemotingError(e) => {
+                rocketmq_remoting::remoting_error::RemotingError::RemotingCommandError(
+                    e.to_string(),
+                )
             }
+            NamesrvError::NamesrvCommonError(e) => {
+                rocketmq_remoting::remoting_error::RemotingError::RemotingCommandError(format!(
+                    "{}",
+                    e
+                ))
+            }
+
             NamesrvError::MQNamesrvError(e) => {
-                rocketmq_remoting::remoting_error::RemotingError::RemoteError(e)
+                rocketmq_remoting::remoting_error::RemotingError::RemotingCommandError(e)
             }
         }
     }
@@ -46,31 +67,43 @@ impl From<NamesrvError> for rocketmq_remoting::remoting_error::RemotingError {
 
 #[cfg(test)]
 mod tests {
-    use rocketmq_common::error::Error;
     use rocketmq_remoting::remoting_error::RemotingError;
 
     use super::*;
 
     #[test]
-    fn namesrv_remoting_error_conversion() {
+    fn namesrv_remoting_error_with_message_creation() {
         let remoting_error = RemotingError::RemoteError("Remoting error".to_string());
         let remoting_error1 = RemotingError::RemoteError("Remoting error".to_string());
-        let namesrv_error = NamesrvError::NamesrvRemotingError(remoting_error);
-        let converted_error: RemotingError = namesrv_error.into();
-        assert_eq!(converted_error.to_string(), remoting_error1.to_string());
+        let message = "Error message".to_string();
+        let error_with_message =
+            NamesrvRemotingErrorWithMessage::new(remoting_error1, message.clone());
+        assert_eq!(
+            error_with_message.error.to_string(),
+            remoting_error.to_string()
+        );
+        assert_eq!(error_with_message.message, message);
     }
 
     #[test]
-    fn namesrv_common_error_conversion() {
-        let common_error = Error::UnsupportedOperationException("Common error".to_string());
-        let common_error1 = Error::UnsupportedOperationException("Common error".to_string());
-        let namesrv_error = NamesrvError::NamesrvCommonError(common_error);
+    fn namesrv_error_conversion_to_remoting_error() {
+        let remoting_error = RemotingError::RemoteError("Remoting error".to_string());
+        let remoting_error1 = RemotingError::RemoteError("Remoting error".to_string());
+        let namesrv_error = NamesrvError::NamesrvRemotingError(
+            NamesrvRemotingErrorWithMessage::new(remoting_error1, "Error message".to_string()),
+        );
         let converted_error: RemotingError = namesrv_error.into();
-        assert_eq!(converted_error.to_string(), format!("{}", common_error1));
+        assert_eq!(
+            converted_error.to_string(),
+            format!(
+                "Namesrv error: {}, error message:Error message",
+                remoting_error
+            )
+        );
     }
 
     #[test]
-    fn mq_namesrv_error_conversion() {
+    fn mq_namesrv_error_conversion_to_remoting_error() {
         let mq_error = "MQ Namesrv error".to_string();
         let namesrv_error = NamesrvError::MQNamesrvError(mq_error.clone());
         let converted_error: RemotingError = namesrv_error.into();
@@ -80,10 +113,13 @@ mod tests {
     #[test]
     fn namesrv_error_debug_format() {
         let remoting_error = RemotingError::RemoteError("Remoting error".to_string());
-        let namesrv_error = NamesrvError::NamesrvRemotingError(remoting_error);
+        let namesrv_error = NamesrvError::NamesrvRemotingError(
+            NamesrvRemotingErrorWithMessage::new(remoting_error, "Error message".to_string()),
+        );
         assert_eq!(
             format!("{:?}", namesrv_error),
-            "NamesrvRemotingError(RemoteError(\"Remoting error\"))"
+            "NamesrvRemotingError(NamesrvRemotingErrorWithMessage { error: RemoteError(\"Remoting \
+             error\"), message: \"Error message\" })"
         );
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1562 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new error type, `NamesrvRemotingErrorWithMessage`, for enhanced error handling.
	- Updated error handling in the `get_route_info_by_topic` method for clearer failure context.

- **Bug Fixes**
	- Improved error reporting in various methods of the `DefaultRequestProcessor` by using the new error type.

- **Documentation**
	- Updated tests to include coverage for the new error struct and its functionalities. 

- **Refactor**
	- Changed method return types across several methods in `DefaultRequestProcessor` to use `Result` for better error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->