### PR TITLE
[ISSUE #1570]🚀Add ConsumeMessageDirectlyResultRequestHeader struct🔥

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -17,6 +17,7 @@
 pub mod broker;
 pub mod check_transaction_state_request_header;
 pub mod client_request_header;
+pub mod consume_message_directly_result_request_header;
 pub mod consumer_send_msg_back_request_header;
 pub mod create_topic_request_header;
 pub mod delete_topic_request_header;

--- a/rocketmq-remoting/src/protocol/header/consume_message_directly_result_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/consume_message_directly_result_request_header.rs
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumeMessageDirectlyResultRequestHeader {
+    #[required]
+    pub consumer_group: CheetahString,
+    pub client_id: Option<CheetahString>,
+    pub msg_id: Option<CheetahString>,
+    pub broker_name: Option<CheetahString>,
+    pub topic: Option<CheetahString>,
+    pub topic_sys_flag: Option<i32>,
+    pub group_sys_flag: Option<i32>,
+    #[serde(flatten)]
+    pub rpc_request_header: Option<RpcRequestHeader>,
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    #[test]
+    fn consume_message_directly_result_request_header_serializes_correctly() {
+        let header = ConsumeMessageDirectlyResultRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            client_id: Some(CheetahString::from_static_str("client_id")),
+            msg_id: Some(CheetahString::from_static_str("msg_id")),
+            broker_name: Some(CheetahString::from_static_str("broker_name")),
+            topic: Some(CheetahString::from_static_str("topic")),
+            topic_sys_flag: Some(1),
+            group_sys_flag: Some(2),
+            rpc_request_header: None,
+        };
+        let serialized = serde_json::to_string(&header).unwrap();
+        let expected = r#"{"consumerGroup":"test_group","clientId":"client_id","msgId":"msg_id","brokerName":"broker_name","topic":"topic","topicSysFlag":1,"groupSysFlag":2}"#;
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn consume_message_directly_result_request_header_deserializes_correctly() {
+        let data = r#"{"consumerGroup":"test_group","clientId":"client_id","msgId":"msg_id","brokerName":"broker_name","topic":"topic","topicSysFlag":1,"groupSysFlag":2}"#;
+        let header: ConsumeMessageDirectlyResultRequestHeader = serde_json::from_str(data).unwrap();
+        assert_eq!(
+            header.consumer_group,
+            CheetahString::from_static_str("test_group")
+        );
+        assert_eq!(
+            header.client_id.unwrap(),
+            CheetahString::from_static_str("client_id")
+        );
+        assert_eq!(
+            header.msg_id.unwrap(),
+            CheetahString::from_static_str("msg_id")
+        );
+        assert_eq!(
+            header.broker_name.unwrap(),
+            CheetahString::from_static_str("broker_name")
+        );
+        assert_eq!(
+            header.topic.unwrap(),
+            CheetahString::from_static_str("topic")
+        );
+        assert_eq!(header.topic_sys_flag.unwrap(), 1);
+        assert_eq!(header.group_sys_flag.unwrap(), 2);
+    }
+
+    #[test]
+    fn consume_message_directly_result_request_header_handles_missing_optional_fields() {
+        let data = r#"{"consumerGroup":"test_group"}"#;
+        let header: ConsumeMessageDirectlyResultRequestHeader = serde_json::from_str(data).unwrap();
+        assert_eq!(
+            header.consumer_group,
+            CheetahString::from_static_str("test_group")
+        );
+        assert!(header.client_id.is_none());
+        assert!(header.msg_id.is_none());
+        assert!(header.broker_name.is_none());
+        assert!(header.topic.is_none());
+        assert!(header.topic_sys_flag.is_none());
+        assert!(header.group_sys_flag.is_none());
+    }
+
+    #[test]
+    fn consume_message_directly_result_request_header_handles_invalid_data() {
+        let data = r#"{"consumerGroup":12345}"#;
+        let result: Result<ConsumeMessageDirectlyResultRequestHeader, _> =
+            serde_json::from_str(data);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1570

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for handling direct message consumption requests in RocketMQ.
	- Added a struct for managing request headers related to consuming messages directly, enhancing serialization and deserialization capabilities.

- **Tests**
	- Implemented tests to ensure the correctness of serialization, deserialization, and error handling for the new request header struct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->