### PR TITLE
[ISSUE #1569]🔥Add GetConsumerRunningInfoRequestHeader struct🚀

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -27,6 +27,7 @@ pub mod get_consume_stats_request_header;
 pub mod get_consumer_connection_list_request_header;
 pub mod get_consumer_listby_group_request_header;
 pub mod get_consumer_listby_group_response_header;
+pub mod get_consumer_running_info_request_header;
 pub mod get_earliest_msg_storetime_response_header;
 pub mod get_max_offset_request_header;
 pub mod get_max_offset_response_header;

--- a/rocketmq-remoting/src/protocol/header/get_consumer_running_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consumer_running_info_request_header.rs
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
+#[serde(rename_all = "camelCase")]
+pub struct GetConsumerRunningInfoRequestHeader {
+    #[required]
+    pub consumer_group: CheetahString,
+
+    #[required]
+    pub client_id: CheetahString,
+
+    pub jstack_enable: bool,
+
+    #[serde(flatten)]
+    pub rpc_request_header: Option<RpcRequestHeader>,
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    #[test]
+    fn get_consumer_running_info_request_header_serializes_correctly() {
+        let header = GetConsumerRunningInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            client_id: CheetahString::from_static_str("client_id"),
+            jstack_enable: true,
+            rpc_request_header: None,
+        };
+        let serialized = serde_json::to_string(&header).unwrap();
+        let expected =
+            r#"{"consumerGroup":"test_group","clientId":"client_id","jstackEnable":true}"#;
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn get_consumer_running_info_request_header_deserializes_correctly() {
+        let data = r#"{"consumerGroup":"test_group","clientId":"client_id","jstackEnable":true}"#;
+        let header: GetConsumerRunningInfoRequestHeader = serde_json::from_str(data).unwrap();
+        assert_eq!(
+            header.consumer_group,
+            CheetahString::from_static_str("test_group")
+        );
+        assert_eq!(
+            header.client_id,
+            CheetahString::from_static_str("client_id")
+        );
+        assert!(header.jstack_enable);
+        assert!(!header.rpc_request_header.is_none());
+    }
+
+    #[test]
+    fn get_consumer_running_info_request_header_handles_missing_optional_fields() {
+        let data = r#"{"consumerGroup":"test_group","clientId":"client_id","jstackEnable":false}"#;
+        let header: GetConsumerRunningInfoRequestHeader = serde_json::from_str(data).unwrap();
+        assert_eq!(
+            header.consumer_group,
+            CheetahString::from_static_str("test_group")
+        );
+        assert_eq!(
+            header.client_id,
+            CheetahString::from_static_str("client_id")
+        );
+        assert!(!header.jstack_enable);
+        assert!(!header.rpc_request_header.is_none());
+    }
+
+    #[test]
+    fn get_consumer_running_info_request_header_handles_invalid_data() {
+        let data = r#"{"consumerGroup":12345,"clientId":"client_id"}"#;
+        let result: Result<GetConsumerRunningInfoRequestHeader, _> = serde_json::from_str(data);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1569 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for handling consumer running information requests.
	- Added a new request header structure to facilitate obtaining consumer running information, including fields for consumer group, client ID, and optional settings.
  
- **Tests**
	- Implemented tests for serialization, deserialization, and error handling of the new request header structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->