### PR TITLE
[ISSUE #1568]🔥Add ResetOffsetRequestHeader struct🚀

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -49,6 +49,7 @@ pub mod query_message_response_header;
 pub mod query_topic_consume_by_who_request_header;
 pub mod query_topics_by_consumer_request_header;
 pub mod reply_message_request_header;
+pub mod reset_offset_request_header;
 pub mod search_offset_response_header;
 pub mod unlock_batch_mq_request_header;
 pub mod unregister_client_request_header;

--- a/rocketmq-remoting/src/protocol/header/reset_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/reset_offset_request_header.rs
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodec)]
+#[serde(rename_all = "camelCase")]
+pub struct ResetOffsetRequestHeader {
+    #[required]
+    pub topic: CheetahString,
+    #[required]
+    pub group: CheetahString,
+    pub queue_id: i32,
+    pub offset: Option<i64>,
+    #[required]
+    pub timestamp: i64,
+    #[required]
+    pub is_force: bool,
+}
+
+impl Default for ResetOffsetRequestHeader {
+    fn default() -> Self {
+        ResetOffsetRequestHeader {
+            topic: CheetahString::empty(),
+            group: CheetahString::empty(),
+            queue_id: -1,
+            offset: None,
+            timestamp: 0,
+            is_force: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    #[test]
+    fn reset_offset_request_header_serializes_correctly() {
+        let header = ResetOffsetRequestHeader {
+            topic: CheetahString::from_static_str("test_topic"),
+            group: CheetahString::from_static_str("test_group"),
+            queue_id: 1,
+            offset: Some(100),
+            timestamp: 1234567890,
+            is_force: true,
+        };
+        let serialized = serde_json::to_string(&header).unwrap();
+        let expected = r#"{"topic":"test_topic","group":"test_group","queueId":1,"offset":100,"timestamp":1234567890,"isForce":true}"#;
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn reset_offset_request_header_deserializes_correctly() {
+        let data = r#"{"topic":"test_topic","group":"test_group","queueId":1,"offset":100,"timestamp":1234567890,"isForce":true}"#;
+        let header: ResetOffsetRequestHeader = serde_json::from_str(data).unwrap();
+        assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
+        assert_eq!(header.group, CheetahString::from_static_str("test_group"));
+        assert_eq!(header.queue_id, 1);
+        assert_eq!(header.offset.unwrap(), 100);
+        assert_eq!(header.timestamp, 1234567890);
+        assert!(header.is_force);
+    }
+
+    #[test]
+    fn reset_offset_request_header_handles_missing_optional_fields() {
+        let data = r#"{"topic":"test_topic","group":"test_group","queueId":1,"timestamp":1234567890,"isForce":true}"#;
+        let header: ResetOffsetRequestHeader = serde_json::from_str(data).unwrap();
+        assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
+        assert_eq!(header.group, CheetahString::from_static_str("test_group"));
+        assert_eq!(header.queue_id, 1);
+        assert!(header.offset.is_none());
+        assert_eq!(header.timestamp, 1234567890);
+        assert!(header.is_force);
+    }
+
+    #[test]
+    fn reset_offset_request_header_handles_invalid_data() {
+        let data = r#"{"topic":12345,"group":"test_group","queueId":1,"timestamp":1234567890,"isForce":true}"#;
+        let result: Result<ResetOffsetRequestHeader, _> = serde_json::from_str(data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn reset_offset_request_header_default_values() {
+        let header = ResetOffsetRequestHeader::default();
+        assert_eq!(header.topic, CheetahString::empty());
+        assert_eq!(header.group, CheetahString::empty());
+        assert_eq!(header.queue_id, -1);
+        assert!(header.offset.is_none());
+        assert_eq!(header.timestamp, 0);
+        assert!(!header.is_force);
+    }
+}

--- a/rocketmq-remoting/src/protocol/header/reset_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/reset_offset_request_header.rs
@@ -19,6 +19,8 @@ use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
 #[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct ResetOffsetRequestHeader {
@@ -32,6 +34,9 @@ pub struct ResetOffsetRequestHeader {
     pub timestamp: i64,
     #[required]
     pub is_force: bool,
+
+    #[serde(flatten)]
+    pub rpc_request_header: Option<RpcRequestHeader>,
 }
 
 impl Default for ResetOffsetRequestHeader {
@@ -43,6 +48,7 @@ impl Default for ResetOffsetRequestHeader {
             offset: None,
             timestamp: 0,
             is_force: false,
+            rpc_request_header: None,
         }
     }
 }

--- a/rocketmq-remoting/src/protocol/header/reset_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/reset_offset_request_header.rs
@@ -68,6 +68,7 @@ mod tests {
             offset: Some(100),
             timestamp: 1234567890,
             is_force: true,
+            rpc_request_header: None,
         };
         let serialized = serde_json::to_string(&header).unwrap();
         let expected = r#"{"topic":"test_topic","group":"test_group","queueId":1,"offset":100,"timestamp":1234567890,"isForce":true}"#;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1568

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new request header for resetting offsets in the messaging system, enhancing the RocketMQ remoting protocol.
- **Tests**
	- Added comprehensive unit tests to ensure the correct functionality of the new request header, including serialization, deserialization, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->