### PR TITLE
[ISSUE #1567]🔥Add DeleteSubscriptionGroupRequestHeader struct🍻

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -20,6 +20,7 @@ pub mod client_request_header;
 pub mod consume_message_directly_result_request_header;
 pub mod consumer_send_msg_back_request_header;
 pub mod create_topic_request_header;
+pub mod delete_subscription_group_request_header;
 pub mod delete_topic_request_header;
 pub mod end_transaction_request_header;
 pub mod get_all_topic_config_response_header;

--- a/rocketmq-remoting/src/protocol/header/delete_subscription_group_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/delete_subscription_group_request_header.rs
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteSubscriptionGroupRequestHeader {
+    #[required]
+    pub group_name: CheetahString,
+
+    pub clean_offset: bool,
+
+    #[serde(flatten)]
+    pub rpc_request_header: Option<RpcRequestHeader>,
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    #[test]
+    fn delete_subscription_group_request_header_serializes_correctly() {
+        let header = DeleteSubscriptionGroupRequestHeader {
+            group_name: CheetahString::from_static_str("test_group"),
+            clean_offset: true,
+            rpc_request_header: None,
+        };
+        let serialized = serde_json::to_string(&header).unwrap();
+        let expected = r#"{"groupName":"test_group","cleanOffset":true}"#;
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn delete_subscription_group_request_header_deserializes_correctly() {
+        let data = r#"{"groupName":"test_group","cleanOffset":true}"#;
+        let header: DeleteSubscriptionGroupRequestHeader = serde_json::from_str(data).unwrap();
+        assert_eq!(
+            header.group_name,
+            CheetahString::from_static_str("test_group")
+        );
+        assert!(header.clean_offset);
+        assert!(!header.rpc_request_header.is_none());
+    }
+
+    #[test]
+    fn delete_subscription_group_request_header_handles_missing_optional_fields() {
+        let data = r#"{"groupName":"test_group","cleanOffset":false}"#;
+        let header: DeleteSubscriptionGroupRequestHeader = serde_json::from_str(data).unwrap();
+        assert_eq!(
+            header.group_name,
+            CheetahString::from_static_str("test_group")
+        );
+        assert!(!header.clean_offset);
+        assert!(!header.rpc_request_header.is_none());
+    }
+
+    #[test]
+    fn delete_subscription_group_request_header_handles_invalid_data() {
+        let data = r#"{"groupName":12345}"#;
+        let result: Result<DeleteSubscriptionGroupRequestHeader, _> = serde_json::from_str(data);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1567

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new request header for deleting subscription groups in the RocketMQ protocol.
	- Added a data structure to manage the deletion request, including necessary fields and serialization support.

- **Tests**
	- Implemented unit tests to validate the functionality and data handling of the new request header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->