### PR TITLE
[ISSUE #1566]🚀Add QueryConsumeTimeSpanRequestHeader struct🍻

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -43,6 +43,7 @@ pub mod namesrv;
 pub mod notify_consumer_ids_changed_request_header;
 pub mod pull_message_request_header;
 pub mod pull_message_response_header;
+pub mod query_consume_time_span_request_header;
 pub mod query_consumer_offset_request_header;
 pub mod query_consumer_offset_response_header;
 pub mod query_message_request_header;

--- a/rocketmq-remoting/src/protocol/header/query_consume_time_span_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_consume_time_span_request_header.rs
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryConsumeTimeSpanRequestHeader {
+    #[required]
+    pub topic: CheetahString,
+
+    #[required]
+    pub group: CheetahString,
+
+    #[serde(flatten)]
+    pub rpc_request_header: Option<RpcRequestHeader>,
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    #[test]
+    fn query_consume_time_span_request_header_serializes_correctly() {
+        let header = QueryConsumeTimeSpanRequestHeader {
+            topic: CheetahString::from_static_str("test_topic"),
+            group: CheetahString::from_static_str("test_group"),
+            rpc_request_header: None,
+        };
+        let serialized = serde_json::to_string(&header).unwrap();
+        let expected = r#"{"topic":"test_topic","group":"test_group"}"#;
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn query_consume_time_span_request_header_deserializes_correctly() {
+        let data = r#"{"topic":"test_topic","group":"test_group"}"#;
+        let header: QueryConsumeTimeSpanRequestHeader = serde_json::from_str(data).unwrap();
+        assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
+        assert_eq!(header.group, CheetahString::from_static_str("test_group"));
+        assert!(!header.rpc_request_header.is_none());
+    }
+
+    #[test]
+    fn query_consume_time_span_request_header_handles_missing_optional_fields() {
+        let data = r#"{"topic":"test_topic","group":"test_group"}"#;
+        let header: QueryConsumeTimeSpanRequestHeader = serde_json::from_str(data).unwrap();
+        assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
+        assert_eq!(header.group, CheetahString::from_static_str("test_group"));
+        assert!(!header.rpc_request_header.is_none());
+    }
+
+    #[test]
+    fn query_consume_time_span_request_header_handles_invalid_data() {
+        let data = r#"{"topic":12345,"group":"test_group"}"#;
+        let result: Result<QueryConsumeTimeSpanRequestHeader, _> = serde_json::from_str(data);
+        assert!(result.is_err());
+    }
+}

--- a/rocketmq-remoting/src/protocol/header/query_consume_time_span_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_consume_time_span_request_header.rs
@@ -19,7 +19,7 @@ use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::rpc::rpc_request_header::RpcRequestHeader;
+use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
@@ -31,7 +31,7 @@ pub struct QueryConsumeTimeSpanRequestHeader {
     pub group: CheetahString,
 
     #[serde(flatten)]
-    pub rpc_request_header: Option<RpcRequestHeader>,
+    pub topic_request_header: Option<TopicRequestHeader>,
 }
 
 #[cfg(test)]
@@ -45,7 +45,7 @@ mod tests {
         let header = QueryConsumeTimeSpanRequestHeader {
             topic: CheetahString::from_static_str("test_topic"),
             group: CheetahString::from_static_str("test_group"),
-            rpc_request_header: None,
+            topic_request_header: None,
         };
         let serialized = serde_json::to_string(&header).unwrap();
         let expected = r#"{"topic":"test_topic","group":"test_group"}"#;
@@ -58,7 +58,7 @@ mod tests {
         let header: QueryConsumeTimeSpanRequestHeader = serde_json::from_str(data).unwrap();
         assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
         assert_eq!(header.group, CheetahString::from_static_str("test_group"));
-        assert!(!header.rpc_request_header.is_none());
+        assert!(!header.topic_request_header.is_none());
     }
 
     #[test]
@@ -67,7 +67,7 @@ mod tests {
         let header: QueryConsumeTimeSpanRequestHeader = serde_json::from_str(data).unwrap();
         assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
         assert_eq!(header.group, CheetahString::from_static_str("test_group"));
-        assert!(!header.rpc_request_header.is_none());
+        assert!(!header.topic_request_header.is_none());
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1566

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new request header for querying consumption time spans in the messaging system.
	- Added serialization and deserialization capabilities for the new request header.

- **Tests**
	- Implemented unit tests to validate the functionality of the new request header, including serialization, deserialization, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->