### PR TITLE
[ISSUE #1577]🍻Replace ConsumeMessageDirectlyResultRequestHeader and ResetOffsetRequestHeader's RpcRequestHeader with TopicRequestHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/consume_message_directly_result_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/consume_message_directly_result_request_header.rs
@@ -19,7 +19,7 @@ use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::rpc::rpc_request_header::RpcRequestHeader;
+use crate::rpc::topic_request_header::TopicRequestHeader;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
@@ -33,7 +33,7 @@ pub struct ConsumeMessageDirectlyResultRequestHeader {
     pub topic_sys_flag: Option<i32>,
     pub group_sys_flag: Option<i32>,
     #[serde(flatten)]
-    pub rpc_request_header: Option<RpcRequestHeader>,
+    pub topic_request_header: Option<TopicRequestHeader>,
 }
 
 #[cfg(test)]
@@ -52,7 +52,7 @@ mod tests {
             topic: Some(CheetahString::from_static_str("topic")),
             topic_sys_flag: Some(1),
             group_sys_flag: Some(2),
-            rpc_request_header: None,
+            topic_request_header: None,
         };
         let serialized = serde_json::to_string(&header).unwrap();
         let expected = r#"{"consumerGroup":"test_group","clientId":"client_id","msgId":"msg_id","brokerName":"broker_name","topic":"topic","topicSysFlag":1,"groupSysFlag":2}"#;

--- a/rocketmq-remoting/src/protocol/header/reset_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/reset_offset_request_header.rs
@@ -19,7 +19,7 @@ use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::rpc::rpc_request_header::RpcRequestHeader;
+use crate::rpc::topic_request_header::TopicRequestHeader;
 
 #[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
@@ -36,7 +36,7 @@ pub struct ResetOffsetRequestHeader {
     pub is_force: bool,
 
     #[serde(flatten)]
-    pub rpc_request_header: Option<RpcRequestHeader>,
+    pub topic_request_header: Option<TopicRequestHeader>,
 }
 
 impl Default for ResetOffsetRequestHeader {
@@ -48,7 +48,7 @@ impl Default for ResetOffsetRequestHeader {
             offset: None,
             timestamp: 0,
             is_force: false,
-            rpc_request_header: None,
+            topic_request_header: None,
         }
     }
 }
@@ -68,7 +68,7 @@ mod tests {
             offset: Some(100),
             timestamp: 1234567890,
             is_force: true,
-            rpc_request_header: None,
+            topic_request_header: None,
         };
         let serialized = serde_json::to_string(&header).unwrap();
         let expected = r#"{"topic":"test_topic","group":"test_group","queueId":1,"offset":100,"timestamp":1234567890,"isForce":true}"#;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1577

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated request headers in message consumption and offset reset functionalities to support new topic-based request structures.

- **Bug Fixes**
	- Improved serialization and deserialization processes for the updated request headers, ensuring correct handling of optional fields.

- **Tests**
	- Updated test cases to reflect changes in request header structures, ensuring continued validation of functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->