### PR TITLE
[ISSUE #1579]🐛get_topic_stats_info_request_header inner struct incorrect

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_topic_stats_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_topic_stats_info_request_header.rs
@@ -23,7 +23,7 @@ use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
-pub struct QueryConsumeTimeSpanRequestHeader {
+pub struct GetTopicStatsInfoRequestHeader {
     #[required]
     pub topic: CheetahString,
 
@@ -38,8 +38,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn query_consume_time_span_request_header_serializes_correctly() {
-        let header = QueryConsumeTimeSpanRequestHeader {
+    fn get_topic_stats_info_request_header_serializes_correctly() {
+        let header = GetTopicStatsInfoRequestHeader {
             topic: CheetahString::from_static_str("test_topic"),
             topic_request_header: None,
         };
@@ -49,25 +49,25 @@ mod tests {
     }
 
     #[test]
-    fn query_consume_time_span_request_header_deserializes_correctly() {
+    fn get_topic_stats_info_request_header_deserializes_correctly() {
         let data = r#"{"topic":"test_topic"}"#;
-        let header: QueryConsumeTimeSpanRequestHeader = serde_json::from_str(data).unwrap();
+        let header: GetTopicStatsInfoRequestHeader = serde_json::from_str(data).unwrap();
         assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
         assert!(!header.topic_request_header.is_none());
     }
 
     #[test]
-    fn query_consume_time_span_request_header_handles_missing_optional_fields() {
+    fn get_topic_stats_info_request_header_handles_missing_optional_fields() {
         let data = r#"{"topic":"test_topic"}"#;
-        let header: QueryConsumeTimeSpanRequestHeader = serde_json::from_str(data).unwrap();
+        let header: GetTopicStatsInfoRequestHeader = serde_json::from_str(data).unwrap();
         assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
         assert!(!header.topic_request_header.is_none());
     }
 
     #[test]
-    fn query_consume_time_span_request_header_handles_invalid_data() {
+    fn get_topic_stats_info_request_header_handles_invalid_data() {
         let data = r#"{"topic":12345}"#;
-        let result: Result<QueryConsumeTimeSpanRequestHeader, _> = serde_json::from_str(data);
+        let result: Result<GetTopicStatsInfoRequestHeader, _> = serde_json::from_str(data);
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1579

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new struct for better clarity: `GetTopicStatsInfoRequestHeader`.

- **Bug Fixes**
	- Updated test functions to ensure accurate serialization and deserialization of the new struct.

- **Documentation**
	- Improved naming conventions for better understanding of topic statistics requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->