### PR TITLE
[ISSUE #1581]🚀Add QueueTimeSpan struct

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -36,6 +36,7 @@ pub mod process_queue_info;
 pub mod producer_connection;
 pub mod query_assignment_request_body;
 pub mod query_assignment_response_body;
+pub mod queue_time_span;
 pub mod request;
 pub mod response;
 pub mod set_message_request_mode_request_body;

--- a/rocketmq-remoting/src/protocol/body/queue_time_span.rs
+++ b/rocketmq-remoting/src/protocol/body/queue_time_span.rs
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use rocketmq_common::common::message::message_queue::MessageQueue;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueTimeSpan {
+    pub message_queue: Option<MessageQueue>,
+    pub min_time_stamp: i64,
+    pub max_time_stamp: i64,
+    pub consume_time_stamp: i64,
+    pub delay_time: i64,
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1581 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module `queue_time_span` for enhanced message queue time management.
	- Added a public struct `QueueTimeSpan` to encapsulate time-related data for message queues.

These updates improve the system's ability to handle and represent time spans associated with message queues effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->