### PR TITLE
[ISSUE #1529]Add #[inline] for MessageExtBrokerInner methods

### DIFF
--- a/rocketmq-common/src/common/message/message_ext_broker_inner.rs
+++ b/rocketmq-common/src/common/message/message_ext_broker_inner.rs
@@ -47,6 +47,7 @@ pub struct MessageExtBrokerInner {
 impl MessageExtBrokerInner {
     const VERSION: MessageVersion = MessageVersion::V1;
 
+    #[inline]
     pub fn delete_property(&mut self, name: impl Into<CheetahString>) {
         let name = name.into();
         self.message_ext_inner.message.clear_property(name.as_str());
@@ -56,94 +57,117 @@ impl MessageExtBrokerInner {
         ));
     }
 
+    #[inline]
     pub fn with_version(&mut self, version: MessageVersion) {
         self.version = version;
     }
 
+    #[inline]
     pub fn version(&self) -> MessageVersion {
         self.version
     }
 
+    #[inline]
     pub fn topic(&self) -> &CheetahString {
         self.message_ext_inner.topic()
     }
 
+    #[inline]
     pub fn get_topic(&self) -> &CheetahString {
         self.message_ext_inner.get_topic()
     }
 
+    #[inline]
     pub fn born_host(&self) -> SocketAddr {
         self.message_ext_inner.born_host()
     }
 
+    #[inline]
     pub fn store_host(&self) -> SocketAddr {
         self.message_ext_inner.store_host()
     }
 
+    #[inline]
     pub fn with_born_host_v6_flag(&mut self) {
         self.message_ext_inner.with_born_host_v6_flag()
     }
 
+    #[inline]
     pub fn with_store_host_v6_flag(&mut self) {
         self.message_ext_inner.with_store_host_v6_flag()
     }
 
+    #[inline]
     pub fn body(&self) -> Option<bytes::Bytes> {
         self.message_ext_inner.body()
     }
 
+    #[inline]
     pub fn sys_flag(&self) -> i32 {
         self.message_ext_inner.sys_flag()
     }
 
+    #[inline]
     pub fn body_crc(&self) -> u32 {
         self.message_ext_inner.body_crc()
     }
 
+    #[inline]
     pub fn queue_id(&self) -> i32 {
         self.message_ext_inner.queue_id()
     }
 
+    #[inline]
     pub fn flag(&self) -> i32 {
         self.message_ext_inner.flag()
     }
 
+    #[inline]
     pub fn born_timestamp(&self) -> i64 {
         self.message_ext_inner.born_timestamp()
     }
 
+    #[inline]
     pub fn store_timestamp(&self) -> i64 {
         self.message_ext_inner.store_timestamp()
     }
 
+    #[inline]
     pub fn born_host_bytes(&self) -> bytes::Bytes {
         self.message_ext_inner.born_host_bytes()
     }
 
+    #[inline]
     pub fn store_host_bytes(&self) -> bytes::Bytes {
         self.message_ext_inner.born_store_bytes()
     }
 
+    #[inline]
     pub fn reconsume_times(&self) -> i32 {
         self.message_ext_inner.reconsume_times()
     }
 
+    #[inline]
     pub fn prepared_transaction_offset(&self) -> i64 {
         self.message_ext_inner.prepared_transaction_offset()
     }
 
+    #[inline]
     pub fn property(&self, name: &str) -> Option<CheetahString> {
         self.message_ext_inner.properties().get(name).cloned()
     }
 
+    #[inline]
     pub fn properties_string(&self) -> &str {
         self.properties_string.as_str()
     }
 
+    #[inline]
     pub fn queue_offset(&self) -> i64 {
         self.message_ext_inner.queue_offset()
     }
 
+    #[inline]
     pub fn tags_string2tags_code(_filter: &TopicFilterType, tags: &str) -> i64 {
         if tags.is_empty() {
             return 0;
@@ -151,6 +175,7 @@ impl MessageExtBrokerInner {
         JavaStringHasher::new().hash_str(tags) as i64
     }
 
+    #[inline]
     pub fn tags_string_to_tags_code(tags: &str) -> i64 {
         if tags.is_empty() {
             return 0;
@@ -158,14 +183,17 @@ impl MessageExtBrokerInner {
         JavaStringHasher::new().hash_str(tags) as i64
     }
 
+    #[inline]
     pub fn get_tags(&self) -> Option<CheetahString> {
         self.message_ext_inner.get_tags()
     }
 
+    #[inline]
     pub fn is_wait_store_msg_ok(&self) -> bool {
         self.message_ext_inner.message.is_wait_store_msg_ok()
     }
 
+    #[inline]
     pub fn body_len(&self) -> usize {
         self.message_ext_inner.message.body.as_ref().unwrap().len()
     }
@@ -222,75 +250,93 @@ impl Debug for MessageExtBrokerInner {
 }
 
 impl MessageTrait for MessageExtBrokerInner {
+    #[inline]
     fn put_property(&mut self, key: CheetahString, value: CheetahString) {
         self.message_ext_inner.put_property(key, value);
     }
 
+    #[inline]
     fn clear_property(&mut self, name: &str) {
         self.message_ext_inner.clear_property(name);
     }
 
+    #[inline]
     fn get_property(&self, name: &CheetahString) -> Option<CheetahString> {
         self.message_ext_inner.get_property(name)
     }
 
+    #[inline]
     fn get_topic(&self) -> &CheetahString {
         self.message_ext_inner.get_topic()
     }
 
+    #[inline]
     fn set_topic(&mut self, topic: CheetahString) {
         self.message_ext_inner.set_topic(topic);
     }
 
+    #[inline]
     fn get_flag(&self) -> i32 {
         self.message_ext_inner.get_flag()
     }
 
+    #[inline]
     fn set_flag(&mut self, flag: i32) {
         self.message_ext_inner.set_flag(flag);
     }
 
+    #[inline]
     fn get_body(&self) -> Option<&Bytes> {
         self.message_ext_inner.get_body()
     }
 
+    #[inline]
     fn set_body(&mut self, body: Bytes) {
         self.message_ext_inner.set_body(body);
     }
 
+    #[inline]
     fn get_properties(&self) -> &HashMap<CheetahString, CheetahString> {
         self.message_ext_inner.get_properties()
     }
 
+    #[inline]
     fn set_properties(&mut self, properties: HashMap<CheetahString, CheetahString>) {
         self.message_ext_inner.set_properties(properties);
     }
 
+    #[inline]
     fn get_transaction_id(&self) -> Option<&CheetahString> {
         self.message_ext_inner.get_transaction_id()
     }
 
+    #[inline]
     fn set_transaction_id(&mut self, transaction_id: CheetahString) {
         self.message_ext_inner.set_transaction_id(transaction_id);
     }
 
+    #[inline]
     fn get_compressed_body_mut(&mut self) -> &mut Option<Bytes> {
         self.message_ext_inner.get_compressed_body_mut()
     }
 
+    #[inline]
     fn get_compressed_body(&self) -> Option<&Bytes> {
         self.message_ext_inner.get_compressed_body()
     }
 
+    #[inline]
     fn set_compressed_body_mut(&mut self, compressed_body: Bytes) {
         self.message_ext_inner
             .set_compressed_body_mut(compressed_body);
     }
 
+    #[inline]
     fn as_any(&self) -> &dyn Any {
         self
     }
 
+    #[inline]
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1529

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message property management with new methods for adding, deleting, and retrieving properties.
	- Introduced version handling capabilities for messages.
	- Improved access to message topics and tags, including conversion utilities.
	- Added methods for retrieving host information related to messages.
	- Expanded access to message body and metadata attributes.

These updates significantly improve interaction with message properties and metadata, enhancing overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->