### PR TITLE
[ISSUE #1601]Optimize PopProcessQueue

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/pop_process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pop_process_queue.rs
@@ -92,7 +92,7 @@ impl PopProcessQueue {
 
     pub(crate) fn is_pull_expired(&self) -> bool {
         let current_time = get_current_millis();
-        (current_time - self.last_pop_timestamp) > *PULL_MAX_IDLE_TIME
+        current_time.saturating_sub(self.last_pop_timestamp) > *PULL_MAX_IDLE_TIME
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1601

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced thread safety for the `PopProcessQueue` struct with atomic operations for the dropped state.
	- Added a `Default` implementation for easier initialization of `PopProcessQueue`.
	- Introduced a `Display` implementation for improved formatted output of the struct.

- **Bug Fixes**
	- Updated methods to ensure thread-safe access and modification of the dropped state.

- **Tests**
	- Comprehensive unit tests added to verify the functionality and correctness of the `PopProcessQueue` struct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->