### PR TITLE
[ISSUE #1605]🚀Add a pop consume example🔥

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -84,3 +84,7 @@ path = "examples/ordermessage/ordermessage_consumer.rs"
 [[example]]
 name = "transaction-producer"
 path = "examples/transaction/transaction_producer.rs"
+
+[[example]]
+name = "pop-consumer"
+path = "examples/consumer/pop_consumer.rs"

--- a/rocketmq-client/examples/consumer/pop_consumer.rs
+++ b/rocketmq-client/examples/consumer/pop_consumer.rs
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
+use rocketmq_client_rust::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
+use rocketmq_client_rust::consumer::mq_push_consumer::MQPushConsumer;
+use rocketmq_client_rust::Result;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_rust::rocketmq;
+use tracing::info;
+
+pub const MESSAGE_COUNT: usize = 1;
+pub const CONSUMER_GROUP: &str = "please_rename_unique_group_name_4";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "TopicTest";
+pub const TAG: &str = "*";
+
+#[rocketmq::main]
+pub async fn main() -> Result<()> {
+    //init logger
+    rocketmq_common::log::init_logger();
+
+    // create a producer builder with default configuration
+    let builder = DefaultMQPushConsumer::builder();
+
+    let mut consumer = builder
+        .consumer_group(CONSUMER_GROUP.to_string())
+        .name_server_addr(DEFAULT_NAMESRVADDR.to_string())
+        // disable client side load balance, also is pop consumer
+        .client_rebalance(false)
+        .build();
+    consumer.subscribe(TOPIC, "*")?;
+    consumer.register_message_listener_concurrently(MyMessageListener);
+    consumer.start().await?;
+    let _ = tokio::signal::ctrl_c().await;
+    Ok(())
+}
+
+pub struct MyMessageListener;
+
+impl MessageListenerConcurrently for MyMessageListener {
+    fn consume_message(
+        &self,
+        msgs: &[&MessageExt],
+        _context: &ConsumeConcurrentlyContext,
+    ) -> Result<ConsumeConcurrentlyStatus> {
+        for msg in msgs {
+            info!("Receive message: {:?}", msg);
+        }
+        Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1605

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new example consumer implementation, `pop-consumer`, demonstrating how to use the RocketMQ client in Rust.
  
- **Documentation**
	- Updated `Cargo.toml` to include the new example entry for easier access and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->