### PR TITLE
[ISSUE #1607]♻️Remove Rebalance trait useless method remove_unnecessary_pop_message_queue_pop🔥

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/re_balance.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance.rs
@@ -45,12 +45,6 @@ pub trait RebalanceLocal {
 
     fn remove_unnecessary_pop_message_queue(
         &mut self,
-        mq: &MessageQueue,
-        pq: &PopProcessQueue,
-    ) -> bool;
-
-    fn remove_unnecessary_pop_message_queue_pop(
-        &mut self,
         _mq: &MessageQueue,
         _pq: &PopProcessQueue,
     ) -> bool {

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
@@ -243,14 +243,6 @@ impl Rebalance for RebalancePushImpl {
         }
     }
 
-    fn remove_unnecessary_pop_message_queue(
-        &mut self,
-        mq: &MessageQueue,
-        pq: &PopProcessQueue,
-    ) -> bool {
-        todo!()
-    }
-
     fn consume_type(&self) -> ConsumeType {
         ConsumeType::ConsumePassively
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1607 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for handling pop pull requests, marked for future implementation.

- **Bug Fixes**
  - Removed the method for handling unnecessary pop message queues, streamlining message queue management.

- **Chores**
  - Updated the `RebalanceLocal` and `RebalancePushImpl` structures to reflect the removal of outdated methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->