### PR TITLE
[ISSUE #1612]⚡️Optimize ConsumeMessageDirectlyResult struct🔥

### DIFF
--- a/rocketmq-remoting/src/protocol/body/consume_message_directly_result.rs
+++ b/rocketmq-remoting/src/protocol/body/consume_message_directly_result.rs
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::fmt::Display;
+
+use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -23,9 +26,33 @@ use crate::protocol::body::cm_result::CMResult;
 pub struct ConsumeMessageDirectlyResult {
     order: bool,
     auto_commit: bool,
-    consume_result: CMResult,
-    remark: String,
+    consume_result: Option<CMResult>,
+    remark: Option<CheetahString>,
     spent_time_mills: u64,
+}
+
+impl Default for ConsumeMessageDirectlyResult {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            order: false,
+            auto_commit: true,
+            consume_result: None,
+            remark: None,
+            spent_time_mills: 0,
+        }
+    }
+}
+
+impl Display for ConsumeMessageDirectlyResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ConsumeMessageDirectlyResult [order={}, auto_commit={}, consume_result={:?}, \
+             remark={:?}, spent_time_mills={}]",
+            self.order, self.auto_commit, self.consume_result, self.remark, self.spent_time_mills
+        )
+    }
 }
 
 impl ConsumeMessageDirectlyResult {
@@ -33,55 +60,140 @@ impl ConsumeMessageDirectlyResult {
         order: bool,
         auto_commit: bool,
         consume_result: CMResult,
-        remark: String,
+        remark: CheetahString,
         spent_time_mills: u64,
     ) -> Self {
         Self {
             order,
             auto_commit,
-            consume_result,
-            remark,
+            consume_result: Some(consume_result),
+            remark: Some(remark),
             spent_time_mills,
         }
     }
 
+    #[inline]
     pub fn order(&self) -> bool {
         self.order
     }
 
+    #[inline]
     pub fn set_order(&mut self, order: bool) {
         self.order = order;
     }
 
+    #[inline]
     pub fn auto_commit(&self) -> bool {
         self.auto_commit
     }
 
+    #[inline]
     pub fn set_auto_commit(&mut self, auto_commit: bool) {
         self.auto_commit = auto_commit;
     }
 
-    pub fn consume_result(&self) -> &CMResult {
+    #[inline]
+    pub fn consume_result(&self) -> &Option<CMResult> {
         &self.consume_result
     }
 
+    #[inline]
     pub fn set_consume_result(&mut self, consume_result: CMResult) {
-        self.consume_result = consume_result;
+        self.consume_result = Some(consume_result);
     }
 
-    pub fn remark(&self) -> &str {
+    #[inline]
+    pub fn remark(&self) -> &Option<CheetahString> {
         &self.remark
     }
 
-    pub fn set_remark(&mut self, remark: String) {
-        self.remark = remark;
+    #[inline]
+    pub fn set_remark(&mut self, remark: CheetahString) {
+        self.remark = Some(remark);
     }
 
+    #[inline]
     pub fn spent_time_mills(&self) -> u64 {
         self.spent_time_mills
     }
 
+    #[inline]
     pub fn set_spent_time_mills(&mut self, spent_time_mills: u64) {
         self.spent_time_mills = spent_time_mills;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+    use crate::protocol::body::cm_result::CMResult;
+
+    #[test]
+    fn consume_message_directly_result_default_initializes_correctly() {
+        let result = ConsumeMessageDirectlyResult::default();
+        assert!(!result.order());
+        assert!(result.auto_commit());
+        assert!(result.consume_result().is_none());
+        assert!(result.remark().is_none());
+        assert_eq!(result.spent_time_mills(), 0);
+    }
+
+    #[test]
+    fn consume_message_directly_result_new_initializes_correctly() {
+        let consume_result = CMResult::default();
+        let remark = CheetahString::from_static_str("test remark");
+        let result = ConsumeMessageDirectlyResult::new(
+            true,
+            false,
+            consume_result.clone(),
+            remark.clone(),
+            12345,
+        );
+        assert!(result.order());
+        assert!(!result.auto_commit());
+        assert_eq!(result.consume_result().as_ref().unwrap(), &consume_result);
+        assert_eq!(result.remark().as_ref().unwrap(), &remark);
+        assert_eq!(result.spent_time_mills(), 12345);
+    }
+
+    #[test]
+    fn consume_message_directly_result_setters_work_correctly() {
+        let mut result = ConsumeMessageDirectlyResult::default();
+        result.set_order(true);
+        result.set_auto_commit(false);
+        let consume_result = CMResult::default();
+        result.set_consume_result(consume_result.clone());
+        let remark = CheetahString::from_static_str("updated remark");
+        result.set_remark(remark.clone());
+        result.set_spent_time_mills(67890);
+
+        assert!(result.order());
+        assert!(!result.auto_commit());
+        assert_eq!(result.consume_result().as_ref().unwrap(), &consume_result);
+        assert_eq!(result.remark().as_ref().unwrap(), &remark);
+        assert_eq!(result.spent_time_mills(), 67890);
+    }
+
+    #[test]
+    fn consume_message_directly_result_display_formats_correctly() {
+        let consume_result = CMResult::default();
+        let remark = CheetahString::from_static_str("test remark");
+        let result = ConsumeMessageDirectlyResult::new(
+            true,
+            false,
+            consume_result.clone(),
+            remark.clone(),
+            12345,
+        );
+        let display = format!("{}", result);
+        let expected = format!(
+            "ConsumeMessageDirectlyResult [order=true, auto_commit=false, consume_result={:?}, \
+             remark={:?}, spent_time_mills=12345]",
+            Some(consume_result),
+            Some(remark)
+        );
+        assert_eq!(display, expected);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1612

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility of the `ConsumeMessageDirectlyResult` struct with optional fields for `consume_result` and `remark`.
	- Introduced a default initialization for `ConsumeMessageDirectlyResult`.
	- Added formatted output capability for the `ConsumeMessageDirectlyResult` struct.

- **Bug Fixes**
	- Improved handling of cases where `consume_result` and `remark` may not have values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->