### PR TITLE
[ISSUE #1611]🚀ClientRemotingProcessor supports RequestCode::ConsumeMessageDirectly(309)🔥

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -272,8 +272,8 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
 
     async fn consume_message_directly(
         &self,
-        msg: &MessageExt,
-        broker_name: &str,
+        msg: MessageExt,
+        broker_name: Option<CheetahString>,
     ) -> ConsumeMessageDirectlyResult {
         todo!()
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -437,8 +437,8 @@ impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
 
     async fn consume_message_directly(
         &self,
-        msg: &MessageExt,
-        broker_name: &str,
+        msg: MessageExt,
+        broker_name: Option<CheetahString>,
     ) -> ConsumeMessageDirectlyResult {
         todo!()
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -84,8 +84,8 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
 
     async fn consume_message_directly(
         &self,
-        msg: &MessageExt,
-        broker_name: &str,
+        msg: MessageExt,
+        broker_name: Option<CheetahString>,
     ) -> ConsumeMessageDirectlyResult {
         todo!()
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -16,6 +16,7 @@
  */
 use std::sync::Arc;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_client_ext::MessageClientExt;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
@@ -54,8 +55,8 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
 
     async fn consume_message_directly(
         &self,
-        msg: &MessageExt,
-        broker_name: &str,
+        msg: MessageExt,
+        broker_name: Option<CheetahString>,
     ) -> ConsumeMessageDirectlyResult {
         todo!()
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
@@ -16,6 +16,7 @@
  */
 use std::sync::Arc;
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_client_ext::MessageClientExt;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
@@ -89,8 +90,8 @@ where
 
     pub async fn consume_message_directly(
         &self,
-        msg: &MessageExt,
-        broker_name: &str,
+        msg: MessageExt,
+        broker_name: Option<CheetahString>,
     ) -> ConsumeMessageDirectlyResult {
         todo!()
     }
@@ -206,10 +207,10 @@ where
         todo!()
     }
 
-    async fn consume_message_directly(
+    pub(crate) async fn consume_message_directly(
         &self,
-        msg: &MessageExt,
-        broker_name: &str,
+        msg: MessageExt,
+        broker_name: Option<CheetahString>,
     ) -> ConsumeMessageDirectlyResult {
         todo!()
     }
@@ -249,8 +250,8 @@ pub trait ConsumeMessageServiceTrait {
 
     async fn consume_message_directly(
         &self,
-        msg: &MessageExt,
-        broker_name: &str,
+        msg: MessageExt,
+        broker_name: Option<CheetahString>,
     ) -> ConsumeMessageDirectlyResult;
 
     async fn submit_consume_request(

--- a/rocketmq-client/src/consumer/mq_consumer_inner.rs
+++ b/rocketmq-client/src/consumer/mq_consumer_inner.rs
@@ -19,7 +19,9 @@ use std::collections::HashSet;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
+use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInfo;
 use rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
@@ -126,6 +128,21 @@ impl MQConsumerInnerImpl {
                     .await;
             }
         }
+    }
+
+    pub(crate) async fn consume_message_directly(
+        &self,
+        msg: MessageExt,
+        broker_name: Option<CheetahString>,
+    ) -> Option<ConsumeMessageDirectlyResult> {
+        if let Some(ref default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl {
+            if let Some(default_mqpush_consumer_impl) = default_mqpush_consumer_impl.upgrade() {
+                return default_mqpush_consumer_impl
+                    .consume_message_directly(msg, broker_name)
+                    .await;
+            }
+        }
+        None
     }
 }
 

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -27,11 +27,13 @@ use rand::seq::SliceRandom;
 use rocketmq_common::common::base::service_state::ServiceState;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::filter::expression_type::ExpressionType;
+use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_queue_assignment::MessageQueueAssignment;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_remoting::base::connection_net_event::ConnectionNetEvent;
+use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::heartbeat::consumer_data::ConsumerData;
 use rocketmq_remoting::protocol::heartbeat::heartbeat_data::HeartbeatData;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
@@ -1181,6 +1183,23 @@ impl MQClientInstance {
         } else {
             Ok(None)
         }
+    }
+
+    pub async fn consume_message_directly(
+        &self,
+        message: MessageExt,
+        consumer_group: &CheetahString,
+        broker_name: Option<CheetahString>,
+    ) -> Option<ConsumeMessageDirectlyResult> {
+        let consumer_table = self.consumer_table.read().await;
+        let consumer_inner = consumer_table.get(consumer_group);
+        if let Some(consumer) = consumer_inner {
+            consumer
+                .consume_message_directly(message, broker_name)
+                .await;
+        }
+
+        None
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1611

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for direct message consumption across various services, enhancing flexibility in message handling.
	- Updated method signatures to allow optional broker names, improving the handling of message consumption scenarios.

- **Bug Fixes**
	- Refined error handling and acknowledgment processes for message consumption, ensuring more reliable message processing.

- **Documentation**
	- Added import statements for new types related to direct message consumption, improving clarity and functionality.

- **Chores**
	- Cleaned up method signatures and improved internal logic for better performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->