### PR TITLE
[ISSUE #1615]Implement ConsumeMessageConcurrentlyService#consumeMessageDirectly

### DIFF
--- a/rocketmq-common/src/common/message/message_client_ext.rs
+++ b/rocketmq-common/src/common/message/message_client_ext.rs
@@ -32,6 +32,12 @@ pub struct MessageClientExt {
 }
 
 impl MessageClientExt {
+    pub fn new(message: MessageExt) -> Self {
+        Self {
+            message_ext_inner: message,
+        }
+    }
+
     pub fn get_offset_msg_id(&self) -> &str {
         self.message_ext_inner.msg_id()
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1615

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message consumption logic, including improved error handling and logging.
	- Introduced a new constructor for `MessageClientExt` to facilitate instance creation from `MessageExt`.

- **Bug Fixes**
	- Refined control flow for processing messages directly, ensuring better handling of exceptions and processing times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->