### PR TITLE
[ISSUE #1617]🚀Implement ConsumeMessagePopConcurrentlyService#consumeMessageDirectly🔥

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -288,6 +288,7 @@ impl DefaultMQPushConsumerImpl {
                                 self.consumer_config.clone(),
                                 self.consumer_config.consumer_group.clone(),
                                 listener.expect("listener is None"),
+                                self.default_mqpush_consumer_impl.clone(),
                             ));
 
                         self.consume_message_pop_service =


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1617

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced message handling and logging capabilities in the message consumption service.
  - Added a new method to register message listeners for improved flexibility.

- **Bug Fixes**
  - Improved error handling and state management during message pulling and consumption.

- **Documentation**
  - Updated method signatures and functionality descriptions to reflect recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->