### PR TITLE
[ISSUE #1618]🚀Implement ConsumeMessagePopOrderlyService#consumeMessageDirectly🔥

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -15,19 +15,60 @@
  * limitations under the License.
  */
 use std::sync::Arc;
+use std::time::Instant;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_client_ext::MessageClientExt;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
+use rocketmq_remoting::protocol::body::cm_result::CMResult;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
+use rocketmq_runtime::RocketMQRuntime;
 use rocketmq_rust::ArcMut;
+use tracing::info;
 
+use crate::base::client_config::ClientConfig;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
+use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
+use crate::consumer::default_mq_push_consumer::ConsumerConfig;
+use crate::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
+use crate::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
+use crate::consumer::listener::message_listener_orderly::ArcBoxMessageListenerOrderly;
 
-pub struct ConsumeMessagePopOrderlyService;
+pub struct ConsumeMessagePopOrderlyService {
+    pub(crate) default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
+    pub(crate) client_config: ArcMut<ClientConfig>,
+    pub(crate) consumer_config: ArcMut<ConsumerConfig>,
+    pub(crate) consumer_group: CheetahString,
+    pub(crate) message_listener: ArcBoxMessageListenerOrderly,
+    pub(crate) consume_runtime: RocketMQRuntime,
+}
+
+impl ConsumeMessagePopOrderlyService {
+    pub fn new(
+        client_config: ArcMut<ClientConfig>,
+        consumer_config: ArcMut<ConsumerConfig>,
+        consumer_group: CheetahString,
+        message_listener: ArcBoxMessageListenerOrderly,
+        default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
+    ) -> Self {
+        let consume_thread = consumer_config.consume_thread_max;
+        let consumer_group_tag = format!("{}_{}", "PopConsumeMessageThread_", consumer_group);
+        Self {
+            default_mqpush_consumer_impl,
+            client_config,
+            consumer_config,
+            consumer_group,
+            message_listener,
+            consume_runtime: RocketMQRuntime::new_multi(
+                consume_thread as usize,
+                consumer_group_tag.as_str(),
+            ),
+        }
+    }
+}
 
 impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
     fn start(&mut self, this: ArcMut<Self>) {}
@@ -52,12 +93,61 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
         todo!()
     }
 
+    #[allow(deprecated)]
     async fn consume_message_directly(
         &self,
         msg: MessageExt,
         broker_name: Option<CheetahString>,
     ) -> ConsumeMessageDirectlyResult {
-        todo!()
+        info!("consumeMessageDirectly receive new message: {}", msg);
+        let mq = MessageQueue::from_parts(
+            msg.topic().clone(),
+            broker_name.unwrap_or_default(),
+            msg.queue_id(),
+        );
+        let mut msgs = vec![ArcMut::new(MessageClientExt::new(msg))];
+        let mut context = ConsumeOrderlyContext::new(mq);
+        self.default_mqpush_consumer_impl
+            .as_ref()
+            .unwrap()
+            .mut_from_ref()
+            .reset_retry_and_namespace(msgs.as_mut_slice(), self.consumer_group.as_str());
+
+        let begin_timestamp = Instant::now();
+
+        let status = self.message_listener.consume_message(
+            &msgs
+                .iter()
+                .map(|msg| &msg.message_ext_inner)
+                .collect::<Vec<&MessageExt>>(),
+            &mut context,
+        );
+        let mut result = ConsumeMessageDirectlyResult::default();
+        result.set_order(true);
+        result.set_auto_commit(context.is_auto_commit());
+        match status {
+            Ok(status) => match status {
+                ConsumeOrderlyStatus::Success => {
+                    result.set_consume_result(CMResult::CRSuccess);
+                }
+                ConsumeOrderlyStatus::Rollback => {
+                    result.set_consume_result(CMResult::CRRollback);
+                }
+                ConsumeOrderlyStatus::Commit => {
+                    result.set_consume_result(CMResult::CRCommit);
+                }
+                ConsumeOrderlyStatus::SuspendCurrentQueueAMoment => {
+                    result.set_consume_result(CMResult::CRLater);
+                }
+            },
+            Err(e) => {
+                result.set_consume_result(CMResult::CRThrowException);
+                result.set_remark(CheetahString::from_string(e.to_string()))
+            }
+        }
+        result.set_spent_time_mills(begin_timestamp.elapsed().as_millis() as u64);
+        info!("consumeMessageDirectly Result: {}", result);
+        result
     }
 
     async fn submit_consume_request(

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -315,7 +315,13 @@ impl DefaultMQPushConsumerImpl {
                             )));
 
                         let consume_message_pop_orderly_service =
-                            ArcMut::new(ConsumeMessagePopOrderlyService);
+                            ArcMut::new(ConsumeMessagePopOrderlyService::new(
+                                self.client_config.clone(),
+                                self.consumer_config.clone(),
+                                self.consumer_config.consumer_group.clone(),
+                                listener.expect("listener is None"),
+                                self.default_mqpush_consumer_impl.clone(),
+                            ));
                         self.consume_message_pop_service =
                             Some(ArcMut::new(ConsumeMessagePopServiceGeneral::new(
                                 None,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1618

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced initialization of the message consumption service with improved configuration management.
	- Detailed logging added for message consumption processes, providing better visibility into operations.

- **Bug Fixes**
	- Improved error handling and logging mechanisms for service state transitions.

- **Refactor**
	- Updated methods to accommodate new parameters for better service behavior and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->