### PR TITLE
[ISSUE #1664]🚀Add ChangeInvisibleTimeRequestHeader struct🔥

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 pub mod broker;
+pub mod change_invisible_time_request_header;
 pub mod check_transaction_state_request_header;
 pub mod client_request_header;
 pub mod consume_message_directly_result_request_header;

--- a/rocketmq-remoting/src/protocol/header/change_invisible_time_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/change_invisible_time_request_header.rs
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::fmt::Display;
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::topic_request_header::TopicRequestHeader;
+
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodec)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeInvisibleTimeRequestHeader {
+    #[required]
+    pub consumer_group: CheetahString,
+
+    #[required]
+    pub topic: CheetahString,
+
+    #[required]
+    pub queue_id: i32,
+
+    //startOffset popTime invisibleTime queueId
+    #[required]
+    pub extra_info: CheetahString,
+
+    #[required]
+    pub offset: i64,
+
+    #[required]
+    pub invisible_time: i64,
+    #[serde(flatten)]
+    pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+impl Display for ChangeInvisibleTimeRequestHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ChangeInvisibleTimeRequestHeader {{ consumer_group: {}, topic: {}, queue_id: {}, \
+             extra_info: {}, offset: {}, invisible_time: {} }}",
+            self.consumer_group,
+            self.topic,
+            self.queue_id,
+            self.extra_info,
+            self.offset,
+            self.invisible_time
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn change_invisible_time_request_header_display_format() {
+        let header = ChangeInvisibleTimeRequestHeader {
+            consumer_group: CheetahString::from("group1"),
+            topic: CheetahString::from("topic1"),
+            queue_id: 1,
+            extra_info: CheetahString::from("info"),
+            offset: 12345,
+            invisible_time: 67890,
+            topic_request_header: None,
+        };
+        assert_eq!(
+            format!("{}", header),
+            "ChangeInvisibleTimeRequestHeader { consumer_group: group1, topic: topic1, queue_id: \
+             1, extra_info: info, offset: 12345, invisible_time: 67890 }"
+        );
+    }
+
+    #[test]
+    fn change_invisible_time_request_header_display_format_with_topic_request_header() {
+        let header = ChangeInvisibleTimeRequestHeader {
+            consumer_group: CheetahString::from("group1"),
+            topic: CheetahString::from("topic1"),
+            queue_id: 1,
+            extra_info: CheetahString::from("info"),
+            offset: 12345,
+            invisible_time: 67890,
+            topic_request_header: Some(TopicRequestHeader {
+                rpc_request_header: None,
+                lo: None,
+            }),
+        };
+        assert_eq!(
+            format!("{}", header),
+            "ChangeInvisibleTimeRequestHeader { consumer_group: group1, topic: topic1, queue_id: \
+             1, extra_info: info, offset: 12345, invisible_time: 67890 }"
+        );
+    }
+
+    #[test]
+    fn change_invisible_time_request_header_serialize() {
+        let header = ChangeInvisibleTimeRequestHeader {
+            consumer_group: CheetahString::from("group1"),
+            topic: CheetahString::from("topic1"),
+            queue_id: 1,
+            extra_info: CheetahString::from("info"),
+            offset: 12345,
+            invisible_time: 67890,
+            topic_request_header: None,
+        };
+        let serialized = serde_json::to_string(&header).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"consumerGroup":"group1","topic":"topic1","queueId":1,"extraInfo":"info","offset":12345,"invisibleTime":67890}"#
+        );
+    }
+
+    #[test]
+    fn change_invisible_time_request_header_deserialize() {
+        let json = r#"{"consumerGroup":"group1","topic":"topic1","queueId":1,"extraInfo":"info","offset":12345,"invisibleTime":67890}"#;
+        let header: ChangeInvisibleTimeRequestHeader = serde_json::from_str(json).unwrap();
+        assert_eq!(header.consumer_group, CheetahString::from("group1"));
+        assert_eq!(header.topic, CheetahString::from("topic1"));
+        assert_eq!(header.queue_id, 1);
+        assert_eq!(header.extra_info, CheetahString::from("info"));
+        assert_eq!(header.offset, 12345);
+        assert_eq!(header.invisible_time, 67890);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1664

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for handling change requests related to message visibility in the messaging system.
	- Added a new struct for managing the serialization and deserialization of request headers associated with changing invisible time.

- **Tests**
	- Included unit tests to verify the functionality of the new struct, ensuring correct serialization and display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->