### PR TITLE
[ISSUE #1664]🚀Add ChangeInvisibleTimeResponseHeader struct🔥

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -16,6 +16,7 @@
  */
 pub mod broker;
 pub mod change_invisible_time_request_header;
+mod change_invisible_time_response_header;
 pub mod check_transaction_state_request_header;
 pub mod client_request_header;
 pub mod consume_message_directly_result_request_header;

--- a/rocketmq-remoting/src/protocol/header/change_invisible_time_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/change_invisible_time_response_header.rs
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use rocketmq_macros::RequestHeaderCodec;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodec)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeInvisibleTimeResponseHeader {
+    #[required]
+    pub pop_time: u64,
+
+    #[required]
+    pub revive_qid: i32,
+
+    #[required]
+    pub invisible_time: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn change_invisible_time_response_header_display_format() {
+        let header = ChangeInvisibleTimeResponseHeader {
+            pop_time: 123456789,
+            revive_qid: 1,
+            invisible_time: 987654321,
+        };
+        assert_eq!(
+            format!("{:?}", header),
+            "ChangeInvisibleTimeResponseHeader { pop_time: 123456789, revive_qid: 1, \
+             invisible_time: 987654321 }"
+        );
+    }
+
+    #[test]
+    fn change_invisible_time_response_header_serialize() {
+        let header = ChangeInvisibleTimeResponseHeader {
+            pop_time: 123456789,
+            revive_qid: 1,
+            invisible_time: 987654321,
+        };
+        let serialized = serde_json::to_string(&header).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"popTime":123456789,"reviveQid":1,"invisibleTime":987654321}"#
+        );
+    }
+
+    #[test]
+    fn change_invisible_time_response_header_deserialize() {
+        let json = r#"{"popTime":123456789,"reviveQid":1,"invisibleTime":987654321}"#;
+        let header: ChangeInvisibleTimeResponseHeader = serde_json::from_str(json).unwrap();
+        assert_eq!(header.pop_time, 123456789);
+        assert_eq!(header.revive_qid, 1);
+        assert_eq!(header.invisible_time, 987654321);
+    }
+
+    #[test]
+    fn change_invisible_time_response_header_default() {
+        let header = ChangeInvisibleTimeResponseHeader::default();
+        assert_eq!(header.pop_time, 0);
+        assert_eq!(header.revive_qid, 0);
+        assert_eq!(header.invisible_time, 0);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1664

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for handling change invisible time response headers.
	- Added a `ChangeInvisibleTimeResponseHeader` struct for managing specific header data.

- **Tests**
	- Included unit tests to validate the functionality of the new struct, covering serialization, deserialization, and default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->