### PR TITLE
[ISSUE #1689]Adding inline for PutMessageResult methods

### DIFF
--- a/rocketmq-store/src/base/message_result.rs
+++ b/rocketmq-store/src/base/message_result.rs
@@ -104,6 +104,7 @@ pub struct PutMessageResult {
 }
 
 impl PutMessageResult {
+    #[inline]
     pub fn new(
         put_message_status: PutMessageStatus,
         append_message_result: Option<AppendMessageResult>,
@@ -116,6 +117,7 @@ impl PutMessageResult {
         }
     }
 
+    #[inline]
     pub fn new_append_result(
         put_message_status: PutMessageStatus,
         append_message_result: Option<AppendMessageResult>,
@@ -127,6 +129,7 @@ impl PutMessageResult {
         }
     }
 
+    #[inline]
     pub fn new_default(put_message_status: PutMessageStatus) -> Self {
         Self {
             put_message_status,
@@ -135,22 +138,27 @@ impl PutMessageResult {
         }
     }
 
+    #[inline]
     pub fn put_message_status(&self) -> PutMessageStatus {
         self.put_message_status
     }
 
+    #[inline]
     pub fn append_message_result(&self) -> Option<&AppendMessageResult> {
         self.append_message_result.as_ref()
     }
 
+    #[inline]
     pub fn remote_put(&self) -> bool {
         self.remote_put
     }
 
+    #[inline]
     pub fn set_put_message_status(&mut self, put_message_status: PutMessageStatus) {
         self.put_message_status = put_message_status;
     }
 
+    #[inline]
     pub fn set_append_message_result(
         &mut self,
         append_message_result: Option<AppendMessageResult>,
@@ -158,9 +166,11 @@ impl PutMessageResult {
         self.append_message_result = append_message_result;
     }
 
+    #[inline]
     pub fn set_remote_put(&mut self, remote_put: bool) {
         self.remote_put = remote_put;
     }
+
 
     #[inline]
     pub fn is_ok(&self) -> bool {

--- a/rocketmq-store/src/base/message_result.rs
+++ b/rocketmq-store/src/base/message_result.rs
@@ -171,7 +171,6 @@ impl PutMessageResult {
         self.remote_put = remote_put;
     }
 
-
     #[inline]
     pub fn is_ok(&self) -> bool {
         if self.remote_put {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

### Fixes #1689



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced multiple constructors for creating `PutMessageResult` instances with various parameters.
	- Added getter and setter methods for enhanced access to `put_message_status`, `append_message_result`, and `remote_put`.
- **Improvements**
	- Enhanced usability of the `PutMessageResult` struct with additional methods for better functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->