### PR TITLE
[ISSUE #1714]⚡️Add #[inline] for SendResult struct methods

### DIFF
--- a/rocketmq-client/src/producer/send_result.rs
+++ b/rocketmq-client/src/producer/send_result.rs
@@ -150,7 +150,6 @@ impl SendResult {
 }
 
 impl std::fmt::Display for SendResult {
-
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(

--- a/rocketmq-client/src/producer/send_result.rs
+++ b/rocketmq-client/src/producer/send_result.rs
@@ -93,52 +93,65 @@ impl SendResult {
         }
     }
 
+    #[inline]
     pub fn is_trace_on(&self) -> bool {
         self.trace_on
     }
 
+    #[inline]
     pub fn set_trace_on(&mut self, trace_on: bool) {
         self.trace_on = trace_on;
     }
 
+    #[inline]
     pub fn set_region_id(&mut self, region_id: String) {
         self.region_id = Some(region_id);
     }
 
+    #[inline]
     pub fn set_msg_id(&mut self, msg_id: CheetahString) {
         self.msg_id = Some(msg_id);
     }
 
+    #[inline]
     pub fn set_send_status(&mut self, send_status: SendStatus) {
         self.send_status = send_status;
     }
 
+    #[inline]
     pub fn set_message_queue(&mut self, message_queue: MessageQueue) {
         self.message_queue = Some(message_queue);
     }
 
+    #[inline]
     pub fn set_queue_offset(&mut self, queue_offset: u64) {
         self.queue_offset = queue_offset;
     }
 
+    #[inline]
     pub fn set_transaction_id(&mut self, transaction_id: String) {
         self.transaction_id = Some(transaction_id);
     }
 
+    #[inline]
     pub fn set_offset_msg_id(&mut self, offset_msg_id: String) {
         self.offset_msg_id = Some(offset_msg_id);
     }
 
+    #[inline]
     pub fn set_raw_resp_body(&mut self, body: Vec<u8>) {
         self.raw_resp_body = Some(body);
     }
 
+    #[inline]
     pub fn get_raw_resp_body(&self) -> Option<&[u8]> {
         self.raw_resp_body.as_deref()
     }
 }
 
 impl std::fmt::Display for SendResult {
+
+    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1714

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced multiple new methods for manipulating the SendResult, enhancing its functionality.
	- Added methods to retrieve and set various fields, including trace_on, region_id, msg_id, and more.

- **Performance Improvements**
	- New methods are optimized for performance with inline annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->