### PR TITLE
[ISSUE #1727]🍻Add PopBufferMergeService struct for rust 🚀

### DIFF
--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -53,6 +53,7 @@ pub(crate) mod peek_message_processor;
 pub(crate) mod polling_info_processor;
 pub(crate) mod pop_inflight_message_counter;
 pub(crate) mod pop_message_processor;
+pub(crate) mod processor_service;
 pub(crate) mod pull_message_processor;
 pub(crate) mod pull_message_result_handler;
 pub(crate) mod query_assignment_processor;

--- a/rocketmq-broker/src/processor/processor_service.rs
+++ b/rocketmq-broker/src/processor/processor_service.rs
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+pub(crate) mod pop_buffer_merge_service;

--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use rocketmq_store::pop::ack_msg::AckMsg;
+
+pub(crate) struct PopBufferMergeService;
+
+impl PopBufferMergeService {
+    pub fn add_ack(&mut self, _revive_qid: i32, _ack_msg: AckMsg) {
+        unimplemented!("Not implemented yet");
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1727

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for processing services, enhancing the existing functionality.
	- Added a `PopBufferMergeService` struct to manage pop buffer operations with a placeholder method for future implementation.

- **Documentation**
	- Included licensing information for new modules under the Apache License, Version 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->