### PR TITLE
[ISSUE #1729]🚀Implement PopMessageProcessor static Method

### DIFF
--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -14,10 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use rocketmq_common::common::pop_ack_constants::PopAckConstants;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_store::pop::ack_msg::AckMsg;
+use rocketmq_store::pop::batch_ack_msg::BatchAckMsg;
+use rocketmq_store::pop::pop_check_point::PopCheckPoint;
 
 #[derive(Default)]
 pub struct PopMessageProcessor {}
@@ -31,5 +35,128 @@ impl PopMessageProcessor {
         _request: RemotingCommand,
     ) -> crate::Result<Option<RemotingCommand>> {
         unimplemented!("PopMessageProcessor process_request")
+    }
+}
+
+impl PopMessageProcessor {
+    pub fn gen_ack_unique_id(ack_msg: &AckMsg) -> String {
+        format!(
+            "{}{}{}{}{}{}{}{}{}{}{}{}{}",
+            ack_msg.topic,
+            PopAckConstants::SPLIT,
+            ack_msg.queue_id,
+            PopAckConstants::SPLIT,
+            ack_msg.ack_offset,
+            PopAckConstants::SPLIT,
+            ack_msg.consumer_group,
+            PopAckConstants::SPLIT,
+            ack_msg.pop_time,
+            PopAckConstants::SPLIT,
+            ack_msg.broker_name,
+            PopAckConstants::SPLIT,
+            PopAckConstants::ACK_TAG
+        )
+    }
+
+    pub fn gen_batch_ack_unique_id(batch_ack_msg: &BatchAckMsg) -> String {
+        format!(
+            "{}{}{}{}{:?}{}{}{}{}{}{}",
+            batch_ack_msg.ack_msg.topic,
+            PopAckConstants::SPLIT,
+            batch_ack_msg.ack_msg.queue_id,
+            PopAckConstants::SPLIT,
+            batch_ack_msg.ack_offset_list,
+            PopAckConstants::SPLIT,
+            batch_ack_msg.ack_msg.consumer_group,
+            PopAckConstants::SPLIT,
+            batch_ack_msg.ack_msg.pop_time,
+            PopAckConstants::SPLIT,
+            PopAckConstants::BATCH_ACK_TAG
+        )
+    }
+
+    pub fn gen_ck_unique_id(ck: &PopCheckPoint) -> String {
+        format!(
+            "{}{}{}{}{}{}{}{}{}{}{}{}{}",
+            ck.topic,
+            PopAckConstants::SPLIT,
+            ck.queue_id,
+            PopAckConstants::SPLIT,
+            ck.start_offset,
+            PopAckConstants::SPLIT,
+            ck.cid,
+            PopAckConstants::SPLIT,
+            ck.pop_time,
+            PopAckConstants::SPLIT,
+            ck.broker_name
+                .as_ref()
+                .map_or("null".to_string(), |x| x.to_string()),
+            PopAckConstants::SPLIT,
+            PopAckConstants::CK_TAG
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    #[test]
+    fn gen_ack_unique_id_formats_correctly() {
+        let ack_msg = AckMsg {
+            ack_offset: 123,
+            start_offset: 456,
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 1,
+            pop_time: 789,
+            broker_name: CheetahString::from_static_str("test_broker"),
+        };
+        let result = PopMessageProcessor::gen_ack_unique_id(&ack_msg);
+        let expected = "test_topic@1@123@test_group@789@test_broker@ack";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn gen_batch_ack_unique_id_formats_correctly() {
+        let ack_msg = AckMsg {
+            ack_offset: 123,
+            start_offset: 456,
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 1,
+            pop_time: 789,
+            broker_name: CheetahString::from_static_str("test_broker"),
+        };
+        let batch_ack_msg = BatchAckMsg {
+            ack_msg,
+            ack_offset_list: vec![1, 2, 3],
+        };
+        let result = PopMessageProcessor::gen_batch_ack_unique_id(&batch_ack_msg);
+        let expected = "test_topic@1@[1, 2, 3]@test_group@789@bAck";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn gen_ck_unique_id_formats_correctly() {
+        let ck = PopCheckPoint {
+            topic: String::from("test_topic"),
+            queue_id: 1,
+            start_offset: 456,
+            cid: String::from("test_cid"),
+            revive_offset: 0,
+            pop_time: 789,
+            invisible_time: 0,
+            bit_map: 0,
+            broker_name: Some(String::from("test_broker")),
+            num: 0,
+            queue_offset_diff: vec![],
+            re_put_times: None,
+        };
+        let result = PopMessageProcessor::gen_ck_unique_id(&ck);
+        let expected = "test_topic@1@456@test_cid@789@test_broker@ck";
+        assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1729

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced three new methods for generating unique identifiers related to message acknowledgment and checkpointing.
		- `gen_ack_unique_id` for acknowledgment messages.
		- `gen_batch_ack_unique_id` for batch acknowledgment messages.
		- `gen_ck_unique_id` for checkpointing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->