### PR TITLE
[ISSUE #1747]🤡Implement netty Timer for rust trait🚀

### DIFF
--- a/rocketmq/src/lib.rs
+++ b/rocketmq/src/lib.rs
@@ -19,6 +19,8 @@
 mod arc_mut;
 mod blocking_queue;
 pub mod count_down_latch;
+mod netty_rust;
+pub use netty_rust::timer::Timer;
 pub mod rocketmq_tokio_lock;
 mod shutdown;
 

--- a/rocketmq/src/netty_rust.rs
+++ b/rocketmq/src/netty_rust.rs
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+pub mod timeout;
+pub mod timer;
+pub mod timer_task;

--- a/rocketmq/src/netty_rust/timeout.rs
+++ b/rocketmq/src/netty_rust/timeout.rs
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+///convert from netty [Timeout](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/Timeout.java)
+#[allow(dead_code)]
+pub trait Timeout {}

--- a/rocketmq/src/netty_rust/timer.rs
+++ b/rocketmq/src/netty_rust/timer.rs
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::netty_rust::timeout::Timeout;
+use crate::netty_rust::timer_task::TimerTask;
+
+///convert from netty [Timeout](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/Timer.java)
+/// A trait representing a timer that can schedule and manage timed tasks.
+#[allow(dead_code)]
+pub trait Timer: Send + Sync {
+    /// Schedules a new timeout task to be executed after the specified delay.
+    ///
+    /// # Arguments
+    ///
+    /// * `task` - An `Arc` containing the task to be executed.
+    /// * `delay` - The duration to wait before executing the task.
+    ///
+    /// # Returns
+    ///
+    /// An `Arc` containing the scheduled timeout.
+    fn new_timeout(&self, task: Arc<dyn TimerTask>, delay: Duration) -> Arc<dyn Timeout>;
+
+    /// Stops the timer and cancels all scheduled tasks.
+    ///
+    /// # Returns
+    ///
+    /// A `HashSet` containing all the cancelled timeouts.
+    fn stop(&self) -> HashSet<Arc<dyn Timeout>>;
+}

--- a/rocketmq/src/netty_rust/timer_task.rs
+++ b/rocketmq/src/netty_rust/timer_task.rs
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+///convert from netty [Timeout](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/TimerTask.java)
+#[allow(dead_code)]
+pub trait TimerTask {}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1747

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module `netty_rust` with public traits for `Timer` and `TimerTask`.
	- Added functionality for scheduling and managing timed tasks through the `Timer` trait.
	- Implemented a `Timeout` trait for timeout management.

- **Documentation**
	- Added licensing information and documentation comments across new files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->