### PR TITLE
[ISSUE #1746]🍻Implement netty Timeout for rust trait🤡

### DIFF
--- a/rocketmq/src/netty_rust/timeout.rs
+++ b/rocketmq/src/netty_rust/timeout.rs
@@ -14,7 +14,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::sync::Arc;
+
+use crate::netty_rust::timer_task::TimerTask;
+use crate::Timer;
 
 ///convert from netty [Timeout](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/Timeout.java)
+/// A trait representing a timeout that can be managed by a timer.
 #[allow(dead_code)]
-pub trait Timeout {}
+pub trait Timeout {
+    /// Returns the timer associated with this timeout.
+    ///
+    /// # Returns
+    ///
+    /// An `Arc` containing the timer.
+    fn timer(&self) -> Arc<dyn Timer>;
+
+    /// Returns the task associated with this timeout.
+    ///
+    /// # Returns
+    ///
+    /// An `Arc` containing the timer task.
+    fn task(&self) -> Arc<dyn TimerTask>;
+
+    /// Checks if the timeout has expired.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the timeout has expired, `false` otherwise.
+    fn is_expired(&self) -> bool;
+
+    /// Checks if the timeout has been cancelled.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the timeout has been cancelled, `false` otherwise.
+    fn is_cancelled(&self) -> bool;
+
+    /// Cancels the timeout.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the timeout was successfully cancelled, `false` otherwise.
+    fn cancel(&self) -> bool;
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1746

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the `Timeout` functionality with five new methods for enhanced timeout management:
		- Retrieve associated timer and task.
		- Check if the timeout has expired or been cancelled.
		- Attempt to cancel the timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->