### PR TITLE
[ISSUE #1748]🚀Implement netty TimerTask for rust trait🔥

### DIFF
--- a/rocketmq/src/netty_rust/timer_task.rs
+++ b/rocketmq/src/netty_rust/timer_task.rs
@@ -14,7 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::sync::Arc;
 
-///convert from netty [Timeout](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/TimerTask.java)
+use crate::netty_rust::timeout::Timeout;
+
+///convert from netty [TimerTask](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/TimerTask.java)
 #[allow(dead_code)]
-pub trait TimerTask {}
+pub trait TimerTask {
+    /// Executes the timer task.
+    ///
+    /// # Arguments
+    ///
+    /// * `timeout` - An `Arc` containing a reference to a `Timeout` object.
+    fn run(&self, timeout: Arc<dyn Timeout>);
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1748

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `TimerTask` trait to include a new method for executing timer tasks with a timeout reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->