### PR TITLE
[ISSUE #1791]🤡Add PopStatus struct for rust🔥

### DIFF
--- a/rocketmq-client/src/consumer.rs
+++ b/rocketmq-client/src/consumer.rs
@@ -29,6 +29,7 @@ pub mod message_selector;
 pub mod mq_consumer;
 pub(crate) mod mq_consumer_inner;
 pub mod mq_push_consumer;
+pub(crate) mod pop_status;
 pub(crate) mod pull_callback;
 pub mod pull_result;
 pub mod pull_status;

--- a/rocketmq-client/src/consumer/pop_status.rs
+++ b/rocketmq-client/src/consumer/pop_status.rs
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::fmt::Display;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PopStatus {
+    /// Founded
+    #[default]
+    Found,
+    /// No new message can be pulled after polling timeout
+    NoNewMsg,
+    /// Polling pool is full, do not try again immediately
+    PollingFull,
+    /// Polling timeout but no message found
+    PollingNotFound,
+}
+
+impl Display for PopStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PopStatus::Found => write!(f, "FOUND"),
+            PopStatus::NoNewMsg => write!(f, "NO_NEW_MSG"),
+            PopStatus::PollingFull => write!(f, "POLLING_FULL"),
+            PopStatus::PollingNotFound => write!(f, "POLLING_NOT_FOUND"),
+        }
+    }
+}
+
+impl From<PopStatus> for i32 {
+    fn from(status: PopStatus) -> i32 {
+        match status {
+            PopStatus::Found => 0,
+            PopStatus::NoNewMsg => 1,
+            PopStatus::PollingFull => 2,
+            PopStatus::PollingNotFound => 3,
+        }
+    }
+}
+
+impl From<i32> for PopStatus {
+    fn from(status: i32) -> Self {
+        match status {
+            0 => PopStatus::Found,
+            1 => PopStatus::NoNewMsg,
+            2 => PopStatus::PollingFull,
+            3 => PopStatus::PollingNotFound,
+            _ => PopStatus::Found,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pop_status_display_found() {
+        assert_eq!(PopStatus::Found.to_string(), "FOUND");
+    }
+
+    #[test]
+    fn pop_status_display_no_new_msg() {
+        assert_eq!(PopStatus::NoNewMsg.to_string(), "NO_NEW_MSG");
+    }
+
+    #[test]
+    fn pop_status_display_polling_full() {
+        assert_eq!(PopStatus::PollingFull.to_string(), "POLLING_FULL");
+    }
+
+    #[test]
+    fn pop_status_display_polling_not_found() {
+        assert_eq!(PopStatus::PollingNotFound.to_string(), "POLLING_NOT_FOUND");
+    }
+
+    #[test]
+    fn pop_status_from_i32_found() {
+        assert_eq!(PopStatus::from(0), PopStatus::Found);
+    }
+
+    #[test]
+    fn pop_status_from_i32_no_new_msg() {
+        assert_eq!(PopStatus::from(1), PopStatus::NoNewMsg);
+    }
+
+    #[test]
+    fn pop_status_from_i32_polling_full() {
+        assert_eq!(PopStatus::from(2), PopStatus::PollingFull);
+    }
+
+    #[test]
+    fn pop_status_from_i32_polling_not_found() {
+        assert_eq!(PopStatus::from(3), PopStatus::PollingNotFound);
+    }
+
+    #[test]
+    fn pop_status_from_i32_default() {
+        assert_eq!(PopStatus::from(999), PopStatus::Found);
+    }
+
+    #[test]
+    fn pop_status_into_i32_found() {
+        let status: i32 = PopStatus::Found.into();
+        assert_eq!(status, 0);
+    }
+
+    #[test]
+    fn pop_status_into_i32_no_new_msg() {
+        let status: i32 = PopStatus::NoNewMsg.into();
+        assert_eq!(status, 1);
+    }
+
+    #[test]
+    fn pop_status_into_i32_polling_full() {
+        let status: i32 = PopStatus::PollingFull.into();
+        assert_eq!(status, 2);
+    }
+
+    #[test]
+    fn pop_status_into_i32_polling_not_found() {
+        let status: i32 = PopStatus::PollingNotFound.into();
+        assert_eq!(status, 3);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1791

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for message polling statuses.
	- Added an enumeration for various polling states: `Found`, `NoNewMsg`, `PollingFull`, and `PollingNotFound`.
	- Implemented string representation for polling statuses.
	- Enabled conversion between polling statuses and integer values.

- **Tests**
	- Added unit tests for verifying the functionality of polling statuses and conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->