### PR TITLE
[ISSUE #1785]🤡Implement DefaultMQPushConsumerImpl#pop_message function🚀

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
@@ -219,10 +219,10 @@ where
         message_queue: MessageQueue,
         dispatch_to_consume: bool,
     ) {
-        unimplemented!("submit_consume_request")
+        unimplemented!("ConsumeMessagePopServiceGeneral not support submit_consume_request")
     }
 
-    async fn submit_pop_consume_request(
+    pub async fn submit_pop_consume_request(
         &self,
         msgs: Vec<MessageExt>,
         process_queue: &PopProcessQueue,

--- a/rocketmq-client/src/consumer/consumer_impl/pop_request.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pop_request.rs
@@ -64,7 +64,7 @@ impl PopRequest {
     }
 
     #[inline]
-    pub fn get_consumer_group(&self) -> &str {
+    pub fn get_consumer_group(&self) -> &CheetahString {
         &self.consumer_group
     }
 

--- a/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
@@ -37,6 +37,7 @@ use rocketmq_remoting::rpc::rpc_request_header::RpcRequestHeader;
 use rocketmq_rust::ArcMut;
 
 use crate::consumer::consumer_impl::pull_request_ext::PullResultExt;
+use crate::consumer::pop_callback::PopCallback;
 use crate::consumer::pull_callback::PullCallback;
 use crate::consumer::pull_status::PullStatus;
 use crate::factory::mq_client_instance::MQClientInstance;
@@ -384,6 +385,26 @@ impl PullAPIWrapper {
             "Find Filter Server Failed, Broker Addr: {},topic:{}",
             broker_addr, topic
         ))
+    }
+
+    pub async fn pop_async<PC>(
+        &mut self,
+        mq: &MessageQueue,
+        invisible_time: u64,
+        max_nums: u32,
+        consumer_group: CheetahString,
+        timeout: u64,
+        pop_callback: PC,
+        poll: bool,
+        init_mode: i32,
+        order: bool,
+        expression_type: CheetahString,
+        expression: CheetahString,
+    ) -> Result<()>
+    where
+        PC: PopCallback + 'static,
+    {
+        unimplemented!()
     }
 }
 

--- a/rocketmq-client/src/consumer/pop_callback.rs
+++ b/rocketmq-client/src/consumer/pop_callback.rs
@@ -18,7 +18,19 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use rocketmq_common::common::message::message_queue::MessageQueue;
+use rocketmq_common::common::mix_all;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_rust::ArcMut;
+use tracing::warn;
+
+use crate::client_error::MQClientError;
+use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
+use crate::consumer::consumer_impl::default_mq_push_consumer_impl::PULL_TIME_DELAY_MILLS_WHEN_BROKER_FLOW_CONTROL;
+use crate::consumer::consumer_impl::pop_request::PopRequest;
 use crate::consumer::pop_result::PopResult;
+use crate::consumer::pop_status::PopStatus;
 
 /// Trait for handling the results of a pop operation.
 ///
@@ -30,23 +42,19 @@ pub trait PopCallbackInner {
     /// # Arguments
     ///
     /// * `pop_result` - The result of the pop operation.
-    async fn on_success(&self, pop_result: PopResult);
+    async fn on_success(&mut self, pop_result: PopResult);
 
     /// Called when the pop operation encounters an error.
     ///
     /// # Arguments
     ///
     /// * `e` - The error encountered during the pop operation.
-    fn on_error(&self, e: Box<dyn std::error::Error>);
+    fn on_error(&mut self, e: Box<dyn std::error::Error + Send>);
 }
 
-/// Implementation of the `PopCallback` trait for any function that matches the required signature.
-///
-/// This implementation allows any function that takes a `PopResult` and returns a future to be used
-/// as a `PopCallback`.
-impl<F, Fut> PopCallback for F
+/*impl<F, Fut> PopCallback for F
 where
-    F: Fn(Option<PopResult>, Option<Box<dyn std::error::Error>>) -> Fut + Send + Sync,
+    F: Fn(Option<PopResult>, Option<Box<dyn std::error::Error + Send>>) -> Fut + Send + Sync,
     Fut: Future<Output = ()> + Send,
 {
     /// Calls the function with the pop result when the pop operation is successful.
@@ -54,7 +62,7 @@ where
     /// # Arguments
     ///
     /// * `pop_result` - The result of the pop operation.
-    async fn on_success(&self, pop_result: PopResult) {
+    async fn on_success(&mut self, pop_result: PopResult) {
         (*self)(Some(pop_result), None).await;
     }
 
@@ -63,10 +71,10 @@ where
     /// # Arguments
     ///
     /// * `e` - The error encountered during the pop operation.
-    fn on_error(&self, e: Box<dyn std::error::Error>) {
+    fn on_error(&self, e: Box<dyn std::error::Error + Send>) {
         (*self)(None, Some(e));
     }
-}
+}*/
 
 /// Type alias for a callback function that handles the result of a pop operation.
 ///
@@ -80,67 +88,117 @@ pub type PopCallbackFn = Arc<
         + Sync,
 >;
 
-#[cfg(test)]
-mod tests {
-    use std::error::Error;
-    use std::sync::Arc;
+pub struct DefaultPopCallback {
+    pub(crate) push_consumer_impl: ArcMut<DefaultMQPushConsumerImpl>,
+    pub(crate) message_queue_inner: Option<MessageQueue>,
+    pub(crate) subscription_data: Option<SubscriptionData>,
+    pub(crate) pop_request: Option<PopRequest>,
+}
 
-    use super::*;
+impl PopCallback for DefaultPopCallback {
+    async fn on_success(&mut self, pop_result: PopResult) {
+        let mut push_consumer_impl = self.push_consumer_impl.clone();
 
-    struct MockPopCallback;
+        let message_queue_inner = self.message_queue_inner.take().unwrap();
+        let subscription_data = self.subscription_data.take().unwrap();
+        let pop_request = self.pop_request.take().unwrap();
 
-    impl PopCallbackInner for MockPopCallback {
-        async fn on_success(&self, _pop_result: PopResult) {
-            // Mock implementation
+        push_consumer_impl.process_pop_result(&pop_result, &subscription_data);
+        match pop_result.pop_status {
+            PopStatus::Found => {
+                if pop_result.msg_found_list.is_empty() {
+                    push_consumer_impl
+                        .execute_pop_request_immediately(pop_request)
+                        .await;
+                } else {
+                    push_consumer_impl
+                        .consume_message_pop_service
+                        .as_mut()
+                        .unwrap()
+                        .submit_pop_consume_request(
+                            pop_result.msg_found_list,
+                            pop_request.get_pop_process_queue(),
+                            pop_request.get_message_queue(),
+                        )
+                        .await;
+                    let pull_interval = push_consumer_impl.consumer_config.pull_interval;
+                    if pull_interval > 0 {
+                        push_consumer_impl.execute_pop_request_later(pop_request, pull_interval);
+                    } else {
+                        push_consumer_impl
+                            .execute_pop_request_immediately(pop_request)
+                            .await;
+                    }
+                }
+            }
+            PopStatus::NoNewMsg | PopStatus::PollingNotFound => {
+                push_consumer_impl
+                    .execute_pop_request_immediately(pop_request)
+                    .await;
+            }
+            PopStatus::PollingFull => {
+                let pull_time_delay_mills_when_exception =
+                    push_consumer_impl.pull_time_delay_mills_when_exception;
+                push_consumer_impl
+                    .execute_pop_request_later(pop_request, pull_time_delay_mills_when_exception);
+            }
         }
+    }
 
-        fn on_error(&self, _e: Box<dyn Error>) {
-            // Mock implementation
+    fn on_error(&mut self, err: Box<dyn std::error::Error + Send>) {
+        let mut push_consumer_impl = self.push_consumer_impl.clone();
+
+        let message_queue_inner = self.message_queue_inner.take().unwrap();
+        let pop_request = self.pop_request.take().unwrap();
+        let topic = message_queue_inner.get_topic();
+        if !topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
+            if let Some(er) = err.downcast_ref::<MQClientError>() {
+                match er {
+                    MQClientError::MQClientBrokerError(broker_error) => {
+                        if ResponseCode::from(broker_error.response_code())
+                            == ResponseCode::SubscriptionNotLatest
+                        {
+                            warn!(
+                                "the subscription is not latest, group={}",
+                                push_consumer_impl.consumer_config.consumer_group,
+                            );
+                        } else {
+                            warn!(
+                                "execute the pop request exception, group={}",
+                                push_consumer_impl.consumer_config.consumer_group
+                            );
+                        }
+                    }
+                    _ => {
+                        warn!(
+                            "execute the pop request exception, group={}",
+                            push_consumer_impl.consumer_config.consumer_group
+                        );
+                    }
+                }
+            } else {
+                warn!(
+                    "execute the pull request exception, group={}",
+                    push_consumer_impl.consumer_config.consumer_group
+                );
+            }
         }
-    }
-
-    #[tokio::test]
-    async fn pop_callback_on_success_called() {
-        let callback = MockPopCallback;
-        let pop_result = PopResult {
-            // Initialize with appropriate values
-            msg_found_list: vec![],
-            pop_status: Default::default(),
-            pop_time: 0,
-            invisible_time: 0,
-            rest_num: 0,
-        };
-        callback.on_success(pop_result).await;
-        // Assertions to verify on_success behavior
-    }
-
-    #[tokio::test]
-    async fn pop_callback_on_error_called() {
-        let callback = MockPopCallback;
-        let error: Box<dyn Error> =
-            Box::new(std::io::Error::new(std::io::ErrorKind::Other, "error"));
-        callback.on_error(error);
-        // Assertions to verify on_error behavior
-    }
-
-    #[tokio::test]
-    async fn pop_callback_fn_on_success_called() {
-        let callback_fn: Arc<
-            dyn Fn(PopResult) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>> + Send + Sync,
-        > = Arc::new(|_pop_result| {
-            Box::pin(async {}) as Pin<Box<dyn Future<Output = ()> + Send + Sync>>
-        });
-
-        let pop_result = PopResult {
-            // Initialize with appropriate values
-            msg_found_list: vec![],
-            pop_status: Default::default(),
-            pop_time: 0,
-            invisible_time: 0,
-            rest_num: 0,
+        let time_delay = if let Some(er) = err.downcast_ref::<MQClientError>() {
+            match er {
+                MQClientError::MQClientBrokerError(broker_error) => {
+                    if ResponseCode::from(broker_error.response_code()) == ResponseCode::FlowControl
+                    {
+                        PULL_TIME_DELAY_MILLS_WHEN_BROKER_FLOW_CONTROL
+                    } else {
+                        push_consumer_impl.pull_time_delay_mills_when_exception
+                    }
+                }
+                _ => push_consumer_impl.pull_time_delay_mills_when_exception,
+            }
+        } else {
+            push_consumer_impl.pull_time_delay_mills_when_exception
         };
 
-        callback_fn(pop_result).await;
-        // Assertions to verify callback_fn on_success behavior
+        push_consumer_impl.execute_pop_request_later(pop_request, time_delay);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1785

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced asynchronous message popping with the new `pop_async` method.
  - Enhanced pop callback mechanism with improved error handling and processing logic.

- **Bug Fixes**
  - Updated error handling and state checks in the `pop_message` method to ensure robustness.

- **Documentation**
  - Clarified method functionality and access levels in various service structures.

- **Refactor**
  - Improved thread safety for `last_pop_timestamp` using atomic operations.
  - Adjusted method signatures for better clarity and functionality across multiple structs.

- **Chores**
  - Added necessary imports to support new functionalities and improve code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->