### PR TITLE
[ISSUE #1809]🍻Implement MQClientAPIImpl#process_pop_response method logic

### DIFF
--- a/rocketmq-client/src/consumer/pop_result.rs
+++ b/rocketmq-client/src/consumer/pop_result.rs
@@ -20,6 +20,7 @@ use rocketmq_common::common::message::message_ext::MessageExt;
 
 use crate::consumer::pop_status::PopStatus;
 
+#[derive(Default, Clone)]
 pub struct PopResult {
     pub msg_found_list: Vec<MessageExt>,
     pub pop_status: PopStatus,

--- a/rocketmq-remoting/src/protocol/header/pop_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pop_message_response_header.rs
@@ -25,19 +25,19 @@ use serde::Serialize;
 pub struct PopMessageResponseHeader {
     #[serde(rename = "popTime")]
     #[required]
-    pub pop_time: i64,
+    pub pop_time: u64,
 
     #[serde(rename = "invisibleTime")]
     #[required]
-    pub invisible_time: i64,
+    pub invisible_time: u64,
 
     #[serde(rename = "reviveQid")]
     #[required]
-    pub revive_qid: i32,
+    pub revive_qid: u32,
 
     #[serde(rename = "restNum")]
     #[required]
-    pub rest_num: i64,
+    pub rest_num: u64,
 
     #[serde(rename = "startOffsetInfo", skip_serializing_if = "Option::is_none")]
     pub start_offset_info: Option<CheetahString>,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1809

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `PopResult` struct for enhanced message retrieval results.
  - Expanded the `process_pop_response` method to handle various response scenarios and construct `PopResult` objects.
  
- **Bug Fixes**
  - Updated numeric types in `PopMessageResponseHeader` for improved data handling.

- **Tests**
  - Added unit tests to validate the `Display` implementation of `PopResult`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->