### PR TITLE
[ISSUE #1822] ConsumeMessageServiceTrait trait provides default implementations of some methods

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -235,22 +235,6 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
         // todo!()
     }
 
-    fn update_core_pool_size(&self, core_pool_size: usize) {
-        todo!()
-    }
-
-    fn inc_core_pool_size(&self) {
-        todo!()
-    }
-
-    fn dec_core_pool_size(&self) {
-        todo!()
-    }
-
-    fn get_core_pool_size(&self) -> usize {
-        todo!()
-    }
-
     async fn consume_message_directly(
         &self,
         mut msg: MessageExt,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -388,22 +388,6 @@ impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
         }
     }
 
-    fn update_core_pool_size(&self, core_pool_size: usize) {
-        todo!()
-    }
-
-    fn inc_core_pool_size(&self) {
-        todo!()
-    }
-
-    fn dec_core_pool_size(&self) {
-        todo!()
-    }
-
-    fn get_core_pool_size(&self) -> usize {
-        todo!()
-    }
-
     #[allow(deprecated)]
     async fn consume_message_directly(
         &self,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -91,22 +91,6 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
         todo!()
     }
 
-    fn update_core_pool_size(&self, core_pool_size: usize) {
-        todo!()
-    }
-
-    fn inc_core_pool_size(&self) {
-        todo!()
-    }
-
-    fn dec_core_pool_size(&self) {
-        todo!()
-    }
-
-    fn get_core_pool_size(&self) -> usize {
-        todo!()
-    }
-
     async fn consume_message_directly(
         &self,
         msg: MessageExt,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -77,22 +77,6 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
         todo!()
     }
 
-    fn update_core_pool_size(&self, core_pool_size: usize) {
-        todo!()
-    }
-
-    fn inc_core_pool_size(&self) {
-        todo!()
-    }
-
-    fn dec_core_pool_size(&self) {
-        todo!()
-    }
-
-    fn get_core_pool_size(&self) -> usize {
-        todo!()
-    }
-
     #[allow(deprecated)]
     async fn consume_message_directly(
         &self,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
@@ -267,20 +267,22 @@ pub trait ConsumeMessageServiceTrait {
     /// # Arguments
     ///
     /// * `core_pool_size` - The new core pool size.
-    fn update_core_pool_size(&self, core_pool_size: usize);
+    fn update_core_pool_size(&self, core_pool_size: usize) {}
 
     /// Increases the core pool size of the service by one.
-    fn inc_core_pool_size(&self);
+    fn inc_core_pool_size(&self) {}
 
     /// Decreases the core pool size of the service by one.
-    fn dec_core_pool_size(&self);
+    fn dec_core_pool_size(&self) {}
 
     /// Gets the current core pool size of the service.
     ///
     /// # Returns
     ///
     /// The current core pool size.
-    fn get_core_pool_size(&self) -> usize;
+    fn get_core_pool_size(&self) -> usize {
+        num_cpus::get()
+    }
 
     /// Consumes a message directly.
     ///


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1822

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging for message consumption processes, including elapsed time and status results.
	- Default implementations added for core pool size management methods in the service trait.

- **Bug Fixes**
	- Removed unused core pool size management methods to streamline the service interface.

- **Refactor**
	- Improved handling of message batches during consumption for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->