### PR TITLE
[ISSUE #1825]🧑‍💻Add AckMessageRequestHeader for rust

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+pub mod ack_message_request_header;
 pub mod broker;
 pub mod change_invisible_time_request_header;
 pub mod change_invisible_time_response_header;

--- a/rocketmq-remoting/src/protocol/header/ack_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/ack_message_request_header.rs
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::topic_request_header::TopicRequestHeader;
+
+/// Represents the request header for acknowledging a message.
+#[derive(Debug, Serialize, Deserialize, Clone, RequestHeaderCodec)]
+pub struct AckMessageRequestHeader {
+    /// Consumer group name (required)
+    #[serde(rename = "consumerGroup")]
+    #[required]
+    pub consumer_group: CheetahString,
+
+    /// Topic name (required)
+    #[serde(rename = "topic")]
+    #[required]
+    pub topic: CheetahString,
+
+    /// Queue ID (required)
+    #[serde(rename = "queueId")]
+    #[required]
+    pub queue_id: i32,
+
+    /// Extra information (required)
+    #[serde(rename = "extraInfo")]
+    #[required]
+    pub extra_info: CheetahString,
+
+    /// Offset (required)
+    #[serde(rename = "offset")]
+    #[required]
+    pub offset: i64,
+
+    #[serde(flatten)]
+    pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn serialize_ack_message_request_header() {
+        let header = AckMessageRequestHeader {
+            consumer_group: CheetahString::from("test_group"),
+            topic: CheetahString::from("test_topic"),
+            queue_id: 1,
+            extra_info: CheetahString::from("extra_info"),
+            offset: 12345,
+            topic_request_header: None,
+        };
+        let json = serde_json::to_string(&header).unwrap();
+        let expected = r#"{"consumerGroup":"test_group","topic":"test_topic","queueId":1,"extraInfo":"extra_info","offset":12345}"#;
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn deserialize_ack_message_request_header() {
+        let json = r#"{"consumerGroup":"test_group","topic":"test_topic","queueId":1,"extraInfo":"extra_info","offset":12345}"#;
+        let header: AckMessageRequestHeader = serde_json::from_str(json).unwrap();
+        assert_eq!(header.consumer_group, CheetahString::from("test_group"));
+        assert_eq!(header.topic, CheetahString::from("test_topic"));
+        assert_eq!(header.queue_id, 1);
+        assert_eq!(header.extra_info, CheetahString::from("extra_info"));
+        assert_eq!(header.offset, 12345);
+        assert!(!header.topic_request_header.is_none());
+    }
+
+    #[test]
+    fn deserialize_ack_message_request_header_with_topic_request_header() {
+        let json = r#"{"consumerGroup":"test_group","topic":"test_topic","queueId":1,"extraInfo":"extra_info","offset":12345,"topicRequestHeader":{"someField":"someValue"}}"#;
+        let header: AckMessageRequestHeader = serde_json::from_str(json).unwrap();
+        assert_eq!(header.consumer_group, CheetahString::from("test_group"));
+        assert_eq!(header.topic, CheetahString::from("test_topic"));
+        assert_eq!(header.queue_id, 1);
+        assert_eq!(header.extra_info, CheetahString::from("extra_info"));
+        assert_eq!(header.offset, 12345);
+        assert!(header.topic_request_header.is_some());
+    }
+
+    #[test]
+    fn serialize_ack_message_request_header_with_topic_request_header() {
+        let header = AckMessageRequestHeader {
+            consumer_group: CheetahString::from("test_group"),
+            topic: CheetahString::from("test_topic"),
+            queue_id: 1,
+            extra_info: CheetahString::from("extra_info"),
+            offset: 12345,
+            topic_request_header: None,
+        };
+        let json = serde_json::to_string(&header).unwrap();
+        let expected = r#"{"consumerGroup":"test_group","topic":"test_topic","queueId":1,"extraInfo":"extra_info","offset":12345}"#;
+        assert_eq!(json, expected);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1825

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for handling acknowledgment message request headers in the RocketMQ protocol.
	- Added a new struct for `AckMessageRequestHeader`, which includes essential fields for message acknowledgment.

- **Tests**
	- Implemented unit tests for validating the serialization and deserialization of the `AckMessageRequestHeader`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->