### PR TITLE
[ISSUE #1830]🐰Add BatchAck struct for rust🚀

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +281,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -509,6 +519,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,10 +561,20 @@ checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -793,7 +848,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -812,6 +867,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -826,7 +887,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -846,6 +907,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hostname"
@@ -995,6 +1062,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,12 +1079,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -1304,6 +1389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,7 +1491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1565,6 +1656,12 @@ checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1950,6 +2047,7 @@ name = "rocketmq-remoting"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "bit-vec",
  "bytes",
  "cheetah-string",
  "flate2",
@@ -1966,6 +2064,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "serde_with",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2226,6 +2325,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,6 +2571,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,7 +2708,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown",
+ "hashbrown 0.14.3",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -2581,7 +2741,7 @@ version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/rocketmq-remoting/Cargo.toml
+++ b/rocketmq-remoting/Cargo.toml
@@ -51,5 +51,8 @@ trait-variant.workspace = true
 uuid = { workspace = true }
 cheetah-string = { workspace = true }
 
+bit-vec = { version = "0.8.0", features = ["serde"] }
+serde_with = "3.11.0"
+
 [dev-dependencies]
 bytes = "1.9.0"

--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -23,6 +23,7 @@ pub mod get_consumer_listby_group_response_body;
 pub mod consumer_connection;
 
 pub mod acl_info;
+mod batch_ack;
 pub mod broker_item;
 pub mod check_client_request_body;
 pub mod check_rocksdb_cqwrite_progress_response_body;

--- a/rocketmq-remoting/src/protocol/body/batch_ack.rs
+++ b/rocketmq-remoting/src/protocol/body/batch_ack.rs
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use bit_vec::BitVec;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BatchAck {
+    #[serde(rename = "c", alias = "consumerGroup")]
+    pub consumer_group: String,
+
+    #[serde(rename = "t", alias = "topic")]
+    pub topic: String,
+
+    #[serde(rename = "r", alias = "retry")]
+    pub retry: String, // "1" if it's retry topic
+
+    #[serde(rename = "so", alias = "startOffset")]
+    pub start_offset: i64,
+
+    #[serde(rename = "q", alias = "queueId")]
+    pub queue_id: i32,
+
+    #[serde(rename = "rq", alias = "reviveQueueId")]
+    pub revive_queue_id: i32,
+
+    #[serde(rename = "pt", alias = "popTime")]
+    pub pop_time: i64,
+
+    #[serde(rename = "it", alias = "invisibleTime")]
+    pub invisible_time: i64,
+
+    #[serde(rename = "b", alias = "bitSet")]
+    pub bit_set: BitVec,
+}
+
+#[cfg(test)]
+mod tests {
+    use bit_vec::BitVec;
+
+    use super::*;
+
+    #[test]
+    fn batch_ack_serialization() {
+        let bit_set = BitVec::from_elem(8, true);
+        let batch_ack = BatchAck {
+            consumer_group: String::from("group1"),
+            topic: String::from("topic1"),
+            retry: String::from("1"),
+            start_offset: 100,
+            queue_id: 1,
+            revive_queue_id: 2,
+            pop_time: 123456789,
+            invisible_time: 987654321,
+            bit_set: bit_set.clone(),
+        };
+        let serialized = serde_json::to_string(&batch_ack).unwrap();
+        let deserialized: BatchAck = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.consumer_group, "group1");
+        assert_eq!(deserialized.topic, "topic1");
+        assert_eq!(deserialized.retry, "1");
+        assert_eq!(deserialized.start_offset, 100);
+        assert_eq!(deserialized.queue_id, 1);
+        assert_eq!(deserialized.revive_queue_id, 2);
+        assert_eq!(deserialized.pop_time, 123456789);
+        assert_eq!(deserialized.invisible_time, 987654321);
+        assert_eq!(deserialized.bit_set, bit_set);
+    }
+
+    #[test]
+    fn batch_ack_default_values() {
+        let bit_set = BitVec::from_elem(8, false);
+        let batch_ack = BatchAck {
+            consumer_group: String::new(),
+            topic: String::new(),
+            retry: String::new(),
+            start_offset: 0,
+            queue_id: 0,
+            revive_queue_id: 0,
+            pop_time: 0,
+            invisible_time: 0,
+            bit_set: bit_set.clone(),
+        };
+        assert_eq!(batch_ack.consumer_group, "");
+        assert_eq!(batch_ack.topic, "");
+        assert_eq!(batch_ack.retry, "");
+        assert_eq!(batch_ack.start_offset, 0);
+        assert_eq!(batch_ack.queue_id, 0);
+        assert_eq!(batch_ack.revive_queue_id, 0);
+        assert_eq!(batch_ack.pop_time, 0);
+        assert_eq!(batch_ack.invisible_time, 0);
+        assert_eq!(batch_ack.bit_set, bit_set);
+    }
+
+    #[test]
+    fn batch_ack_edge_case_empty_strings() {
+        let bit_set = BitVec::new();
+        let batch_ack = BatchAck {
+            consumer_group: String::from(""),
+            topic: String::from(""),
+            retry: String::from(""),
+            start_offset: -1,
+            queue_id: -1,
+            revive_queue_id: -1,
+            pop_time: -1,
+            invisible_time: -1,
+            bit_set: bit_set.clone(),
+        };
+        assert_eq!(batch_ack.consumer_group, "");
+        assert_eq!(batch_ack.topic, "");
+        assert_eq!(batch_ack.retry, "");
+        assert_eq!(batch_ack.start_offset, -1);
+        assert_eq!(batch_ack.queue_id, -1);
+        assert_eq!(batch_ack.revive_queue_id, -1);
+        assert_eq!(batch_ack.pop_time, -1);
+        assert_eq!(batch_ack.invisible_time, -1);
+        assert_eq!(batch_ack.bit_set, bit_set);
+    }
+}

--- a/rocketmq-remoting/src/protocol/body/batch_ack.rs
+++ b/rocketmq-remoting/src/protocol/body/batch_ack.rs
@@ -130,4 +130,25 @@ mod tests {
         assert_eq!(batch_ack.invisible_time, -1);
         assert_eq!(batch_ack.bit_set, bit_set);
     }
+
+    #[test]
+    fn batch_ack_invalid_json() {
+        // Test missing required fields
+        let invalid_json = r#"{"c":"group1"}"#;
+        let result = serde_json::from_str::<BatchAck>(invalid_json);
+        assert!(result.is_err());
+
+        // Test invalid field types
+        let invalid_types = r#"{"c":123,"t":"topic1","r":"1","so":"invalid","q":1,"rq":2,"pt":123456789,"it":987654321,"b":[]}"#;
+        let result = serde_json::from_str::<BatchAck>(invalid_types);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn batch_ack_invalid_retry_value() {
+        // Test invalid retry values
+        let invalid_retry = r#"{"c":"group1","t":"topic1","r":"invalid","so":100,"q":1,"rq":2,"pt":123456789,"it":987654321,"b":[]}"#;
+        let result = serde_json::from_str::<BatchAck>(invalid_retry);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1830

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new dependencies to enhance functionality: `bit-vec` and `serde_with`.
	- Introduced a new module `batch_ack` for internal use.
	- Defined a public struct `BatchAck` for serialization and deserialization, with associated test cases to ensure functionality.

- **Bug Fixes**
	- Implemented tests for the `BatchAck` struct to validate serialization, default values, and edge cases, ensuring robust error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->