### PR TITLE
[ISSUE #1849]Add AckMessage trait for AckMsg and BatchAckMsg

### DIFF
--- a/rocketmq-store/src/pop.rs
+++ b/rocketmq-store/src/pop.rs
@@ -18,3 +18,20 @@
 pub mod ack_msg;
 pub mod batch_ack_msg;
 pub mod pop_check_point;
+
+/// A trait representing an acknowledgment message that can be converted to and from `Any`.
+pub trait AckMessage {
+    /// Converts the acknowledgment message to a reference of type `Any`.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the acknowledgment message as `Any`.
+    fn as_any(&self) -> &dyn std::any::Any;
+
+    /// Converts the acknowledgment message to a mutable reference of type `Any`.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the acknowledgment message as `Any`.
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+}

--- a/rocketmq-store/src/pop/ack_msg.rs
+++ b/rocketmq-store/src/pop/ack_msg.rs
@@ -20,6 +20,8 @@ use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::pop::AckMessage;
+
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct AckMsg {
     #[serde(rename = "ao", alias = "ackOffset")]
@@ -42,6 +44,16 @@ pub struct AckMsg {
 
     #[serde(rename = "bn", alias = "brokerName")]
     pub broker_name: CheetahString,
+}
+
+impl AckMessage for AckMsg {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
 }
 
 impl Display for AckMsg {

--- a/rocketmq-store/src/pop/batch_ack_msg.rs
+++ b/rocketmq-store/src/pop/batch_ack_msg.rs
@@ -20,6 +20,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::pop::ack_msg::AckMsg;
+use crate::pop::AckMessage;
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct BatchAckMsg {
@@ -28,6 +29,16 @@ pub struct BatchAckMsg {
 
     #[serde(rename = "aol", alias = "ackOffsetList")]
     pub ack_offset_list: Vec<i64>,
+}
+
+impl AckMessage for BatchAckMsg {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
 }
 
 impl Display for BatchAckMsg {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1849

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new trait, `AckMessage`, enhancing acknowledgment message handling.
	- Implemented `AckMessage` trait for `AckMsg` and `BatchAckMsg` structs, enabling dynamic type casting.

- **Bug Fixes**
	- Ensured existing functionalities for serialization, deserialization, and display formatting of `AckMsg` and `BatchAckMsg` remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->