### PR TITLE
[ISSUE #1870]⚡️Replace other structs attribute store_host with BrokerRuntime store_host

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -473,6 +473,7 @@ impl BrokerRuntime {
             self.transactional_message_service.as_ref().unwrap().clone(),
             self.rebalance_lock_manager.clone(),
             self.broker_stats_manager.clone(),
+            self.store_host,
         );
         let reply_message_processor = ReplyMessageProcessor::new(
             self.topic_queue_mapping_manager.clone(),
@@ -484,6 +485,7 @@ impl BrokerRuntime {
             self.broker_stats_manager.clone(),
             Some(self.producer_manager.clone()),
             self.transactional_message_service.as_ref().unwrap().clone(),
+            self.store_host,
         );
         let mut pull_message_result_handler =
             ArcMut::new(Box::new(DefaultPullMessageResultHandler::new(
@@ -566,6 +568,7 @@ impl BrokerRuntime {
             self.escape_bridge.clone(),
             self.broker_config.clone(),
             self.pop_inflight_message_counter.clone(),
+            self.store_host,
         ));
         BrokerRequestProcessor {
             send_message_processor: ArcMut::new(send_message_processor),
@@ -749,7 +752,8 @@ impl BrokerRuntime {
                     self.broker_stats_manager.clone(),
                     self.consumer_offset_manager.clone(),
                     self.broker_config.clone(),
-                     self.topic_config_manager.clone()
+                    self.topic_config_manager.clone(),
+                    self.store_host
                 );
                 let service = DefaultTransactionalMessageService::new(bridge);
                 self.transactional_message_service = Some(ArcMut::new(service));

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -76,10 +76,8 @@ where
         escape_bridge: ArcMut<EscapeBridge<MS>>,
         broker_config: Arc<BrokerConfig>,
         pop_inflight_message_counter: Arc<PopInflightMessageCounter>,
+        store_host: SocketAddr,
     ) -> AckMessageProcessor<MS> {
-        let store_host = format!("{}:{}", broker_config.broker_ip1, broker_config.listen_port)
-            .parse::<SocketAddr>()
-            .unwrap();
         AckMessageProcessor {
             topic_config_manager,
             message_store,

--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -73,10 +73,8 @@ where
         broker_stats_manager: Arc<BrokerStatsManager>,
         producer_manager: Option<Arc<ProducerManager>>,
         transactional_message_service: ArcMut<TS>,
+        store_host: SocketAddr,
     ) -> Self {
-        let store_host = format!("{}:{}", broker_config.broker_ip1, broker_config.listen_port)
-            .parse::<SocketAddr>()
-            .unwrap();
         Self {
             inner: Inner {
                 broker_config,

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -193,10 +193,8 @@ where
         transactional_message_service: ArcMut<TS>,
         rebalance_lock_manager: Arc<RebalanceLockManager>,
         broker_stats_manager: Arc<BrokerStatsManager>,
+        store_host: SocketAddr,
     ) -> Self {
-        let store_host = format!("{}:{}", broker_config.broker_ip1, broker_config.listen_port)
-            .parse::<SocketAddr>()
-            .unwrap();
         Self {
             inner: ArcMut::new(Inner {
                 broker_config,

--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -75,10 +75,8 @@ where
         consumer_offset_manager: ConsumerOffsetManager,
         broker_config: Arc<BrokerConfig>,
         topic_config_manager: TopicConfigManager,
+        store_host: SocketAddr,
     ) -> Self {
-        let store_host = format!("{}:{}", broker_config.broker_ip1, broker_config.listen_port)
-            .parse::<SocketAddr>()
-            .expect("parse store host failed");
         Self {
             op_queue_map: Arc::new(Mutex::new(HashMap::new())),
             message_store,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1870

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `store_host` parameter across multiple processors and the `TransactionalMessageBridge`, allowing for more straightforward initialization and improved contextual information during message handling.

- **Bug Fixes**
  - Streamlined the initialization process for the `AckMessageProcessor`, `ReplyMessageProcessor`, and `SendMessageProcessor` by removing unnecessary parsing logic from the broker configuration.

- **Documentation**
  - Updated method signatures to reflect the inclusion of the `store_host` parameter in relevant constructors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->