### PR TITLE
[ISSUE #1890]🔖Replace ProcessQueue MessageClietExt with MessageExt🚀

### DIFF
--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -26,7 +26,6 @@ use rocketmq_client_rust::consumer::pull_status::PullStatus;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::constant::PermName;
-use rocketmq_common::common::message::message_client_ext::MessageClientExt;
 use rocketmq_common::common::message::message_client_id_setter::MessageClientIDSetter;
 use rocketmq_common::common::message::message_decoder;
 use rocketmq_common::common::message::message_ext::MessageExt;
@@ -227,13 +226,13 @@ where
         }
     }
 
-    fn decode_msg_list(get_message_result: &GetMessageResult) -> Vec<MessageClientExt> {
+    fn decode_msg_list(get_message_result: &GetMessageResult) -> Vec<MessageExt> {
         let mut found_list = Vec::new();
         for bb in get_message_result.message_mapped_list() {
             let data = &bb.mapped_file.as_ref().unwrap().get_mapped_file()
                 [bb.start_offset as usize..(bb.start_offset + bb.size as u64) as usize];
             let mut bytes = Bytes::copy_from_slice(data);
-            let msg_ext = message_decoder::decode_client(&mut bytes, true, false, false, false);
+            let msg_ext = message_decoder::decode(&mut bytes, true, false, false, false, false);
             if let Some(msg_ext) = msg_ext {
                 found_list.push(msg_ext);
             }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use cheetah_string::CheetahString;
-use rocketmq_common::common::message::message_client_ext::MessageClientExt;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_remoting::protocol::body::cm_result::CMResult;
@@ -123,7 +122,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
             broker_name.unwrap_or_default(),
             msg.queue_id(),
         );
-        let mut msgs = vec![ArcMut::new(MessageClientExt::new(msg))];
+        let mut msgs = vec![ArcMut::new(msg)];
         let mut context = ConsumeOrderlyContext::new(mq);
         self.default_mqpush_consumer_impl
             .as_ref()
@@ -136,7 +135,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
         let status = self.message_listener.consume_message(
             &msgs
                 .iter()
-                .map(|msg| &msg.message_ext_inner)
+                .map(|msg| msg.as_ref())
                 .collect::<Vec<&MessageExt>>(),
             &mut context,
         );
@@ -171,7 +170,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
     async fn submit_consume_request(
         &self,
         this: ArcMut<Self>,
-        msgs: Vec<ArcMut<MessageClientExt>>,
+        msgs: Vec<ArcMut<MessageExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
         dispatch_to_consume: bool,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_service.rs
@@ -96,7 +96,7 @@ where
 
     pub async fn submit_consume_request(
         &self,
-        msgs: Vec<ArcMut<MessageClientExt>>,
+        msgs: Vec<ArcMut<MessageExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
         dispatch_to_consume: bool,
@@ -312,7 +312,7 @@ pub trait ConsumeMessageServiceTrait {
     async fn submit_consume_request(
         &self,
         this: ArcMut<Self>,
-        msgs: Vec<ArcMut<MessageClientExt>>,
+        msgs: Vec<ArcMut<MessageExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
         dispatch_to_consume: bool,

--- a/rocketmq-client/src/consumer/pull_callback.rs
+++ b/rocketmq-client/src/consumer/pull_callback.rs
@@ -94,7 +94,6 @@ impl PullCallback for DefaultPullCallback {
                         .unwrap()
                         .first()
                         .unwrap()
-                        .message_ext_inner
                         .queue_offset;
                     let vec = pull_result_ext.pull_result.msg_found_list.clone();
                     let dispatch_to_consume = pull_request

--- a/rocketmq-client/src/consumer/pull_result.rs
+++ b/rocketmq-client/src/consumer/pull_result.rs
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use rocketmq_common::common::message::message_client_ext::MessageClientExt;
+
+use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_rust::ArcMut;
 
 use crate::consumer::pull_status::PullStatus;
@@ -24,7 +25,7 @@ pub struct PullResult {
     pub next_begin_offset: u64,
     pub min_offset: u64,
     pub max_offset: u64,
-    pub msg_found_list: Option<Vec<ArcMut<MessageClientExt>>>,
+    pub msg_found_list: Option<Vec<ArcMut<MessageExt>>>,
 }
 
 impl PullResult {
@@ -33,7 +34,7 @@ impl PullResult {
         next_begin_offset: u64,
         min_offset: u64,
         max_offset: u64,
-        msg_found_list: Option<Vec<ArcMut<MessageClientExt>>>,
+        msg_found_list: Option<Vec<ArcMut<MessageExt>>>,
     ) -> Self {
         Self {
             pull_status,
@@ -60,11 +61,11 @@ impl PullResult {
         self.max_offset
     }
 
-    pub fn msg_found_list(&self) -> &Option<Vec<ArcMut<MessageClientExt>>> {
+    pub fn msg_found_list(&self) -> &Option<Vec<ArcMut<MessageExt>>> {
         &self.msg_found_list
     }
 
-    pub fn set_msg_found_list(&mut self, msg_found_list: Option<Vec<ArcMut<MessageClientExt>>>) {
+    pub fn set_msg_found_list(&mut self, msg_found_list: Option<Vec<ArcMut<MessageExt>>>) {
         self.msg_found_list = msg_found_list;
     }
 }

--- a/rocketmq-client/src/hook/consume_message_context.rs
+++ b/rocketmq-client/src/hook/consume_message_context.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
-use rocketmq_common::common::message::message_client_ext::MessageClientExt;
+use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_rust::ArcMut;
 
@@ -27,7 +27,7 @@ use crate::base::access_channel::AccessChannel;
 #[derive(Default)]
 pub struct ConsumeMessageContext<'a> {
     pub consumer_group: CheetahString,
-    pub msg_list: &'a [ArcMut<MessageClientExt>],
+    pub msg_list: &'a [ArcMut<MessageExt>],
     pub mq: Option<MessageQueue>,
     pub success: bool,
     pub status: CheetahString,

--- a/rocketmq-client/src/hook/filter_message_context.rs
+++ b/rocketmq-client/src/hook/filter_message_context.rs
@@ -16,13 +16,13 @@
  */
 use std::fmt;
 
-use rocketmq_common::common::message::message_client_ext::MessageClientExt;
+use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 
 #[derive(Default)]
 pub struct FilterMessageContext<'a> {
     pub(crate) consumer_group: Option<String>,
-    pub(crate) msg_list: &'a [MessageClientExt],
+    pub(crate) msg_list: &'a [MessageExt],
     pub(crate) mq: Option<&'a MessageQueue>,
     pub(crate) arg: Option<Box<dyn std::any::Any>>,
     pub(crate) unit_mode: bool,
@@ -31,7 +31,7 @@ pub struct FilterMessageContext<'a> {
 impl<'a> FilterMessageContext<'a> {
     pub fn new(
         consumer_group: Option<String>,
-        msg_list: &'a [MessageClientExt],
+        msg_list: &'a [MessageExt],
         mq: Option<&'a MessageQueue>,
         arg: Option<Box<dyn std::any::Any>>,
         unit_mode: bool,
@@ -49,7 +49,7 @@ impl<'a> FilterMessageContext<'a> {
         &self.consumer_group
     }
 
-    pub fn msg_list(&self) -> &'a [MessageClientExt] {
+    pub fn msg_list(&self) -> &'a [MessageExt] {
         self.msg_list
     }
 
@@ -69,7 +69,7 @@ impl<'a> FilterMessageContext<'a> {
         self.consumer_group = consumer_group;
     }
 
-    pub fn set_msg_list(&mut self, msg_list: &'a [MessageClientExt]) {
+    pub fn set_msg_list(&mut self, msg_list: &'a [MessageExt]) {
         self.msg_list = msg_list;
     }
 

--- a/rocketmq-common/src/common/message/message_decoder.rs
+++ b/rocketmq-common/src/common/message/message_decoder.rs
@@ -471,30 +471,28 @@ pub fn decodes_batch_client(
     messages
 }
 
-pub fn decode_message_client(mut message_ext: MessageExt, vec_: &mut Vec<MessageClientExt>) {
+pub fn decode_messages_from(mut message_ext: MessageExt, vec_: &mut Vec<MessageExt>) {
     let messages = decode_messages(message_ext.message.body.as_mut().unwrap());
     for message in messages {
-        let mut message_client_ext = MessageClientExt {
-            message_ext_inner: MessageExt {
-                message,
-                ..MessageExt::default()
-            },
+        let mut message_ext_inner = MessageExt {
+            message,
+            ..MessageExt::default()
         };
-        message_client_ext.set_topic(message_ext.get_topic().to_owned());
-        message_client_ext.message_ext_inner.queue_offset = message_ext.queue_offset;
-        message_client_ext.message_ext_inner.queue_id = message_ext.queue_id;
-        message_client_ext.set_flag(message_ext.get_flag());
+        message_ext_inner.set_topic(message_ext.get_topic().to_owned());
+        message_ext_inner.queue_offset = message_ext.queue_offset;
+        message_ext_inner.queue_id = message_ext.queue_id;
+        message_ext_inner.set_flag(message_ext.get_flag());
         //MessageAccessor::set_properties(&mut
         // message_client_ext,message.get_properties().clone()); messageClientExt.
         // setBody(message.getBody())
-        message_client_ext.message_ext_inner.store_host = message_ext.store_host;
-        message_client_ext.message_ext_inner.born_host = message_ext.born_host;
-        message_client_ext.message_ext_inner.store_timestamp = message_ext.store_timestamp;
-        message_client_ext.message_ext_inner.born_timestamp = message_ext.born_timestamp;
-        message_client_ext.message_ext_inner.sys_flag = message_ext.sys_flag;
-        message_client_ext.message_ext_inner.commit_log_offset = message_ext.commit_log_offset;
-        message_client_ext.set_wait_store_msg_ok(message_ext.is_wait_store_msg_ok());
-        vec_.push(message_client_ext);
+        message_ext_inner.store_host = message_ext.store_host;
+        message_ext_inner.born_host = message_ext.born_host;
+        message_ext_inner.store_timestamp = message_ext.store_timestamp;
+        message_ext_inner.born_timestamp = message_ext.born_timestamp;
+        message_ext_inner.sys_flag = message_ext.sys_flag;
+        message_ext_inner.commit_log_offset = message_ext.commit_log_offset;
+        message_ext_inner.set_wait_store_msg_ok(message_ext.is_wait_store_msg_ok());
+        vec_.push(message_ext_inner);
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1890

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message processing logic with a focus on `MessageExt` type across various services.
	- Simplified handling of message decoding and acknowledgment processes.

- **Bug Fixes**
	- Improved error handling in pull callbacks and message consumption processes.

- **Documentation**
	- Updated method signatures and field types to reflect changes in message handling.

- **Refactor**
	- Transitioned from `MessageClientExt` to `MessageExt` in multiple components for consistency and clarity.
	- Streamlined message processing logic in various services and methods.

- **Chores**
	- Minor adjustments to internal logic and method implementations to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->