### PR TITLE
[ISSUE #1902]🔖Add SendMessageBackHook trait for rust🚀

### DIFF
--- a/rocketmq-store/src/hook.rs
+++ b/rocketmq-store/src/hook.rs
@@ -15,3 +15,4 @@
  * limitations under the License.
  */
 pub mod put_message_hook;
+pub mod send_message_back_hook;

--- a/rocketmq-store/src/hook/send_message_back_hook.rs
+++ b/rocketmq-store/src/hook/send_message_back_hook.rs
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_common::common::message::message_ext::MessageExt;
+
+pub trait SendMessageBackHook {
+    fn execute_send_message_back(
+        &self,
+        msg_list: &mut [MessageExt],
+        broker_name: &CheetahString,
+        broker_addr: &CheetahString,
+    ) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::message::message_ext::MessageExt;
+
+    use super::*;
+
+    struct MockSendMessageBackHook;
+
+    impl SendMessageBackHook for MockSendMessageBackHook {
+        fn execute_send_message_back(
+            &self,
+            msg_list: &mut [MessageExt],
+            broker_name: &CheetahString,
+            broker_addr: &CheetahString,
+        ) -> bool {
+            !msg_list.is_empty() && !broker_name.is_empty() && !broker_addr.is_empty()
+        }
+    }
+
+    #[test]
+    fn execute_send_message_back_success() {
+        let hook = MockSendMessageBackHook;
+        let mut msg_list = vec![MessageExt::default()];
+        let broker_name = CheetahString::from("broker1");
+        let broker_addr = CheetahString::from("127.0.0.1:10911");
+        assert!(hook.execute_send_message_back(&mut msg_list, &broker_name, &broker_addr));
+    }
+
+    #[test]
+    fn execute_send_message_back_empty_message_list() {
+        let hook = MockSendMessageBackHook;
+        let mut msg_list = vec![];
+        let broker_name = CheetahString::from("broker1");
+        let broker_addr = CheetahString::from("127.0.0.1:10911");
+        assert!(!hook.execute_send_message_back(&mut msg_list, &broker_name, &broker_addr));
+    }
+
+    #[test]
+    fn execute_send_message_back_empty_broker_name() {
+        let hook = MockSendMessageBackHook;
+        let mut msg_list = vec![MessageExt::default()];
+        let broker_name = CheetahString::new();
+        let broker_addr = CheetahString::from("127.0.0.1:10911");
+        assert!(!hook.execute_send_message_back(&mut msg_list, &broker_name, &broker_addr));
+    }
+
+    #[test]
+    fn execute_send_message_back_empty_broker_addr() {
+        let hook = MockSendMessageBackHook;
+        let mut msg_list = vec![MessageExt::default()];
+        let broker_name = CheetahString::from("broker1");
+        let broker_addr = CheetahString::new();
+        assert!(!hook.execute_send_message_back(&mut msg_list, &broker_name, &broker_addr));
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1902

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for handling message backhooks.
	- Added a trait for executing send message back functionality, including a method to validate message conditions.

- **Tests**
	- Implemented unit tests to verify the behavior of the new send message back functionality under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->