### PR TITLE
[ISSUE #1899]🚨PopMessageProcessor supports process_request handle🚀

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -561,7 +561,15 @@ impl BrokerRuntime {
             self.broker_member_group.clone(),
             self.pop_inflight_message_counter.clone(),
         );
-        let pop_message_processor = ArcMut::new(PopMessageProcessor::default());
+        let pop_message_processor = ArcMut::new(PopMessageProcessor::new(
+            self.consumer_manager.clone(),
+            self.broker_config.clone(),
+            self.message_store.clone().unwrap(),
+            self.message_store_config.clone(),
+            Arc::new(self.topic_config_manager.clone()),
+            self.subscription_group_manager.clone(),
+            self.consumer_filter_manager.clone(),
+        ));
         let ack_message_processor = ArcMut::new(AckMessageProcessor::new(
             self.topic_config_manager.clone(),
             self.message_store.as_ref().unwrap().clone(),

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -65,7 +65,7 @@ pub struct BrokerRequestProcessor<MS, TS> {
     pub(crate) send_message_processor: ArcMut<SendMessageProcessor<MS, TS>>,
     pub(crate) pull_message_processor: ArcMut<PullMessageProcessor<MS>>,
     pub(crate) peek_message_processor: ArcMut<PeekMessageProcessor>,
-    pub(crate) pop_message_processor: ArcMut<PopMessageProcessor>,
+    pub(crate) pop_message_processor: ArcMut<PopMessageProcessor<MS>>,
     pub(crate) ack_message_processor: ArcMut<AckMessageProcessor<MS>>,
     pub(crate) change_invisible_time_processor: ArcMut<ChangeInvisibleTimeProcessor<MS>>,
     pub(crate) notification_processor: ArcMut<NotificationProcessor>,
@@ -180,6 +180,14 @@ where
             RequestCode::AckMessage | RequestCode::BatchAckMessage => {
                 return self
                     .ack_message_processor
+                    .process_request(channel, ctx, request_code, request)
+                    .await
+                    .map_err(Into::into);
+            }
+
+            RequestCode::PopMessage => {
+                return self
+                    .pop_message_processor
                     .process_request(channel, ctx, request_code, request)
                     .await
                     .map_err(Into::into);

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -69,7 +69,7 @@ pub struct AckMessageProcessor<MS> {
     pop_inflight_message_counter: Arc<PopInflightMessageCounter>,
     consumer_offset_manager: Arc<ConsumerOffsetManager>,
     consumer_order_info_manager: Arc<ConsumerOrderInfoManager<MS>>,
-    pop_message_processor: ArcMut<PopMessageProcessor>,
+    pop_message_processor: ArcMut<PopMessageProcessor<MS>>,
 }
 
 impl<MS> AckMessageProcessor<MS>
@@ -84,7 +84,7 @@ where
         pop_inflight_message_counter: Arc<PopInflightMessageCounter>,
         store_host: SocketAddr,
         consumer_offset_manager: Arc<ConsumerOffsetManager>,
-        pop_message_processor: ArcMut<PopMessageProcessor>,
+        pop_message_processor: ArcMut<PopMessageProcessor<MS>>,
         consumer_order_info_manager: Arc<ConsumerOrderInfoManager<MS>>,
     ) -> AckMessageProcessor<MS> {
         AckMessageProcessor {
@@ -394,7 +394,9 @@ where
                 CheetahString::from_static_str(
                     MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
                 ),
-                CheetahString::from(PopMessageProcessor::gen_batch_ack_unique_id(batch_ack)),
+                CheetahString::from(PopMessageProcessor::<MS>::gen_batch_ack_unique_id(
+                    batch_ack,
+                )),
             );
         } else if let Some(ack_msg) = ack_msg.as_any().downcast_ref::<AckMsg>() {
             inner.set_body(Bytes::from(ack_msg.encode().unwrap()));
@@ -403,7 +405,7 @@ where
                 CheetahString::from_static_str(
                     MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
                 ),
-                CheetahString::from(PopMessageProcessor::gen_ack_unique_id(
+                CheetahString::from(PopMessageProcessor::<MS>::gen_ack_unique_id(
                     ack_msg as &dyn AckMessage,
                 )),
             );
@@ -413,7 +415,9 @@ where
         inner.set_delay_time_ms((pop_time + invisible_time) as u64);
         inner.put_property(
             CheetahString::from_static_str(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX),
-            CheetahString::from(PopMessageProcessor::gen_ack_unique_id(ack_msg.as_ref())),
+            CheetahString::from(PopMessageProcessor::<MS>::gen_ack_unique_id(
+                ack_msg.as_ref(),
+            )),
         );
         inner.properties_string =
             message_decoder::message_properties_to_string(inner.get_properties());

--- a/rocketmq-broker/src/processor/change_invisible_time_processor.rs
+++ b/rocketmq-broker/src/processor/change_invisible_time_processor.rs
@@ -65,7 +65,7 @@ pub struct ChangeInvisibleTimeProcessor<MS> {
     escape_bridge: ArcMut<EscapeBridge<MS>>,
     revive_topic: CheetahString,
     store_host: SocketAddr,
-    pop_message_processor: ArcMut<PopMessageProcessor>,
+    pop_message_processor: ArcMut<PopMessageProcessor<MS>>,
 }
 
 impl<MS> ChangeInvisibleTimeProcessor<MS> {
@@ -78,7 +78,7 @@ impl<MS> ChangeInvisibleTimeProcessor<MS> {
         broker_stats_manager: Arc<BrokerStatsManager>,
         pop_buffer_merge_service: ArcMut<PopBufferMergeService>,
         escape_bridge: ArcMut<EscapeBridge<MS>>,
-        pop_message_processor: ArcMut<PopMessageProcessor>,
+        pop_message_processor: ArcMut<PopMessageProcessor<MS>>,
     ) -> Self {
         let revive_topic = PopAckConstants::build_cluster_revive_topic(
             broker_config.broker_identity.broker_cluster_name.as_str(),
@@ -291,7 +291,7 @@ where
         inner.set_delay_time_ms(deliver_time_ms as u64);
         inner.message_ext_inner.put_property(
             CheetahString::from_static_str(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX),
-            CheetahString::from(PopMessageProcessor::gen_ack_unique_id(&ack_msg)),
+            CheetahString::from(PopMessageProcessor::<MS>::gen_ack_unique_id(&ack_msg)),
         );
         inner.properties_string =
             message_decoder::message_properties_to_string(inner.get_properties());
@@ -358,7 +358,7 @@ where
         inner.set_delay_time_ms(deliver_time_ms);
         inner.message_ext_inner.put_property(
             CheetahString::from_static_str(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX),
-            CheetahString::from(PopMessageProcessor::gen_ck_unique_id(&ck)),
+            CheetahString::from(PopMessageProcessor::<MS>::gen_ck_unique_id(&ck)),
         );
         inner.properties_string =
             message_decoder::message_properties_to_string(inner.get_properties());

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![allow(unused_variables)]
+
 use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
@@ -21,29 +23,360 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_common::common::constant::PermName;
+use rocketmq_common::common::filter::expression_type::ExpressionType;
+use rocketmq_common::common::key_builder::KeyBuilder;
 use rocketmq_common::common::pop_ack_constants::PopAckConstants;
+use rocketmq_common::common::FAQUrl;
 use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::filter::filter_api::FilterAPI;
+use rocketmq_remoting::protocol::header::pop_message_request_header::PopMessageRequestHeader;
+use rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType;
+use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::config::message_store_config::MessageStoreConfig;
+use rocketmq_store::filter::MessageFilter;
+use rocketmq_store::log_file::MessageStore;
 use rocketmq_store::pop::batch_ack_msg::BatchAckMsg;
 use rocketmq_store::pop::pop_check_point::PopCheckPoint;
 use rocketmq_store::pop::AckMessage;
 use tokio::sync::Mutex;
 use tracing::info;
+use tracing::warn;
 
-#[derive(Default)]
-pub struct PopMessageProcessor {}
+use crate::broker_error::BrokerError;
+use crate::client::manager::consumer_manager::ConsumerManager;
+use crate::filter::expression_message_filter::ExpressionMessageFilter;
+use crate::filter::manager::consumer_filter_manager::ConsumerFilterManager;
+use crate::subscription::manager::subscription_group_manager::SubscriptionGroupManager;
+use crate::topic::manager::topic_config_manager::TopicConfigManager;
 
-impl PopMessageProcessor {
+const BORN_TIME: &str = "bornTime";
+
+pub struct PopMessageProcessor<MS> {
+    consumer_manager: Arc<ConsumerManager>,
+    broker_config: Arc<BrokerConfig>,
+    message_store: ArcMut<MS>,
+    message_store_config: Arc<MessageStoreConfig>,
+    topic_config_manager: Arc<TopicConfigManager>,
+    subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
+    consumer_filter_manager: Arc<ConsumerFilterManager>,
+}
+
+impl<MS> PopMessageProcessor<MS> {
+    pub fn new(
+        consumer_manager: Arc<ConsumerManager>,
+        broker_config: Arc<BrokerConfig>,
+        message_store: ArcMut<MS>,
+        message_store_config: Arc<MessageStoreConfig>,
+        topic_config_manager: Arc<TopicConfigManager>,
+        subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
+        consumer_filter_manager: Arc<ConsumerFilterManager>,
+    ) -> Self {
+        PopMessageProcessor {
+            consumer_manager,
+            broker_config,
+            message_store,
+            message_store_config,
+            topic_config_manager,
+            subscription_group_manager,
+            consumer_filter_manager,
+        }
+    }
+}
+
+impl<MS> PopMessageProcessor<MS>
+where
+    MS: MessageStore,
+{
     pub async fn process_request(
         &mut self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
-        _request_code: RequestCode,
-        _request: RemotingCommand,
+        channel: Channel,
+        ctx: ConnectionHandlerContext,
+        request_code: RequestCode,
+        mut request: RemotingCommand,
     ) -> crate::Result<Option<RemotingCommand>> {
+        let begin_time_mills = get_current_millis();
+        request.add_ext_field_if_not_exist(
+            CheetahString::from_static_str(BORN_TIME),
+            begin_time_mills.to_string(),
+        );
+        //need optimize
+        let old = request
+            .get_ext_fields()
+            .map_or(CheetahString::empty(), |fields| {
+                fields.get(BORN_TIME).cloned().unwrap_or_default()
+            });
+        if "0" == old {
+            request.add_ext_field(
+                CheetahString::from_static_str(BORN_TIME),
+                begin_time_mills.to_string(),
+            );
+        }
+        let request_header = request
+            .decode_command_custom_header::<PopMessageRequestHeader>()
+            .map_err(BrokerError::BrokerRemotingError)?;
+
+        self.consumer_manager.compensate_basic_consumer_info(
+            &request_header.consumer_group,
+            ConsumeType::ConsumePop,
+            MessageModel::Clustering,
+        );
+
+        if request_header.is_timeout_too_much() {
+            return Ok(Some(
+                RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::PollingTimeout,
+                    format!(
+                        "the broker[{}] pop message is timeout too much",
+                        self.broker_config.broker_ip1
+                    ),
+                ),
+            ));
+        }
+
+        if !PermName::is_readable(self.broker_config.broker_permission) {
+            return Ok(Some(
+                RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::NoPermission,
+                    format!(
+                        "the broker[{}] pop message is forbidden",
+                        self.broker_config.broker_ip1
+                    ),
+                ),
+            ));
+        }
+
+        if request_header.max_msg_nums > 32 {
+            return Ok(Some(
+                RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::SystemError,
+                    format!(
+                        "the broker[{}] pop message's num is greater than 32",
+                        self.broker_config.broker_ip1
+                    ),
+                ),
+            ));
+        }
+
+        if !self.message_store_config.timer_wheel_enable {
+            return Ok(Some(
+                RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::SystemError,
+                    format!(
+                        "the broker[{}] pop message is forbidden because timerWheelEnable is false",
+                        self.broker_config.broker_ip1
+                    ),
+                ),
+            ));
+        }
+        let topic_config = self
+            .topic_config_manager
+            .select_topic_config(&request_header.topic);
+        if topic_config.is_none() {
+            return Ok(Some(
+                RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::TopicNotExist,
+                    format!(
+                        "topic[{}] not exist, apply first please! {}",
+                        request_header.topic,
+                        FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
+                    ),
+                ),
+            ));
+        }
+        let topic_config = topic_config.unwrap();
+        if !PermName::is_readable(topic_config.perm) {
+            return Ok(Some(
+                RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::NoPermission,
+                    format!(
+                        "the topic[{}] peeking message is forbidden",
+                        request_header.topic
+                    ),
+                ),
+            ));
+        }
+        if request_header.queue_id >= topic_config.read_queue_nums as i32 {
+            return Ok(Some(
+                RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::SystemError,
+                    format!(
+                        "the queueId[{}] is illegal, topic[{}]  topicConfig readQueueNums[{}] \
+                         consumer[{}]",
+                        request_header.queue_id,
+                        request_header.topic,
+                        topic_config.read_queue_nums,
+                        channel.remote_address()
+                    ),
+                ),
+            ));
+        }
+        let subscription_group_config = self
+            .subscription_group_manager
+            .find_subscription_group_config(&request_header.consumer_group);
+        if subscription_group_config.is_none() {
+            return Ok(Some(
+                RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::SubscriptionGroupNotExist,
+                    format!(
+                        "the consumer group[{}] not online, apply first please! {}",
+                        request_header.consumer_group,
+                        FAQUrl::suggest_todo(FAQUrl::SUBSCRIPTION_GROUP_NOT_EXIST)
+                    ),
+                ),
+            ));
+        }
+        let subscription_group_config = subscription_group_config.unwrap();
+        if !subscription_group_config.consume_enable() {
+            return Ok(Some(
+                RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::NoPermission,
+                    format!(
+                        "the consumer group[{}], not permitted to consume",
+                        request_header.consumer_group
+                    ),
+                ),
+            ));
+        }
+
+        let exp = request_header.exp.as_ref();
+
+        let (subscription_data, message_filter) = if exp.is_some() && !exp.unwrap().is_empty() {
+            let subscription_data = match FilterAPI::build(
+                &request_header.topic,
+                &request_header.exp.clone().unwrap_or_default(),
+                request_header.exp_type.clone(),
+            ) {
+                Ok(value) => value,
+                Err(_) => {
+                    return Ok(Some(
+                        RemotingCommand::create_response_command_with_code_remark(
+                            ResponseCode::SubscriptionParseFailed,
+                            "parse the consumer's subscription failed",
+                        ),
+                    ));
+                }
+            };
+            self.consumer_manager.compensate_subscribe_data(
+                &request_header.consumer_group,
+                &request_header.topic,
+                &subscription_data,
+            );
+            let retry_topic = CheetahString::from_string(KeyBuilder::build_pop_retry_topic(
+                &request_header.topic,
+                &request_header.consumer_group,
+                self.broker_config.enable_retry_topic_v2,
+            ));
+            let retry_subscription_data = match FilterAPI::build(
+                &retry_topic,
+                &CheetahString::from_static_str(SubscriptionData::SUB_ALL),
+                request_header.exp_type.clone(),
+            ) {
+                Ok(value) => value,
+                Err(_) => {
+                    return Ok(Some(
+                        RemotingCommand::create_response_command_with_code_remark(
+                            ResponseCode::SubscriptionParseFailed,
+                            "parse the consumer's subscription failed",
+                        ),
+                    ));
+                }
+            };
+            self.consumer_manager.compensate_subscribe_data(
+                &request_header.consumer_group,
+                &retry_topic,
+                &retry_subscription_data,
+            );
+            let message_filter =
+                if !ExpressionType::is_tag_type(Some(subscription_data.expression_type.as_str())) {
+                    let consumer_filter_data = ConsumerFilterManager::build(
+                        request_header.consumer_group.clone(),
+                        request_header.topic.clone(),
+                        request_header.exp.clone(),
+                        request_header.exp_type.clone(),
+                        get_current_millis(),
+                    );
+                    if consumer_filter_data.is_none() {
+                        warn!(
+                            "Parse the consumer's subscription[{:?}] failed, group: {}",
+                            request_header.exp, request_header.consumer_group
+                        );
+                        return Ok(Some(
+                            RemotingCommand::create_response_command_with_code_remark(
+                                ResponseCode::SubscriptionParseFailed,
+                                "parse the consumer's subscription failed",
+                            ),
+                        ));
+                    }
+                    let consumer_filter_data = consumer_filter_data.unwrap();
+                    let message_filter: Box<dyn MessageFilter> =
+                        Box::new(ExpressionMessageFilter::new(
+                            Some(subscription_data.clone()),
+                            Some(consumer_filter_data.clone()),
+                            self.consumer_filter_manager.clone(),
+                        ));
+                    Some(message_filter)
+                } else {
+                    None
+                };
+            (subscription_data, message_filter)
+        } else {
+            let subscription_data = match FilterAPI::build(
+                &request_header.topic,
+                &request_header.exp.clone().unwrap_or_default(),
+                request_header.exp_type.clone(),
+            ) {
+                Ok(value) => value,
+                Err(_) => {
+                    return Ok(Some(
+                        RemotingCommand::create_response_command_with_code_remark(
+                            ResponseCode::SubscriptionParseFailed,
+                            "parse the consumer's subscription failed",
+                        ),
+                    ));
+                }
+            };
+            self.consumer_manager.compensate_subscribe_data(
+                &request_header.consumer_group,
+                &request_header.topic,
+                &subscription_data,
+            );
+            let retry_topic = CheetahString::from_string(KeyBuilder::build_pop_retry_topic(
+                &request_header.topic,
+                &request_header.consumer_group,
+                self.broker_config.enable_retry_topic_v2,
+            ));
+            let retry_subscription_data = match FilterAPI::build(
+                &retry_topic,
+                &CheetahString::from_static_str(SubscriptionData::SUB_ALL),
+                request_header.exp_type.clone(),
+            ) {
+                Ok(value) => value,
+                Err(_) => {
+                    return Ok(Some(
+                        RemotingCommand::create_response_command_with_code_remark(
+                            ResponseCode::SubscriptionParseFailed,
+                            "parse the consumer's subscription failed",
+                        ),
+                    ));
+                }
+            };
+            self.consumer_manager.compensate_subscribe_data(
+                &request_header.consumer_group,
+                &retry_topic,
+                &retry_subscription_data,
+            );
+            (subscription_data, None)
+        };
+
         unimplemented!("PopMessageProcessor process_request")
     }
 
@@ -65,7 +398,7 @@ impl PopMessageProcessor {
     }
 }
 
-impl PopMessageProcessor {
+impl<MS> PopMessageProcessor<MS> {
     pub fn gen_ack_unique_id(ack_msg: &dyn AckMessage) -> String {
         format!(
             "{}{}{}{}{}{}{}{}{}{}{}{}{}",

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -578,6 +578,7 @@ impl QueueLockManager {
 #[cfg(test)]
 mod tests {
     use cheetah_string::CheetahString;
+    use rocketmq_store::message_store::default_message_store::DefaultMessageStore;
     use rocketmq_store::pop::ack_msg::AckMsg;
 
     use super::*;
@@ -593,7 +594,7 @@ mod tests {
             pop_time: 789,
             broker_name: CheetahString::from_static_str("test_broker"),
         };
-        let result = PopMessageProcessor::gen_ack_unique_id(&ack_msg);
+        let result = PopMessageProcessor::<DefaultMessageStore>::gen_ack_unique_id(&ack_msg);
         let expected = "test_topic@1@123@test_group@789@test_broker@ack";
         assert_eq!(result, expected);
     }
@@ -613,7 +614,8 @@ mod tests {
             ack_msg,
             ack_offset_list: vec![1, 2, 3],
         };
-        let result = PopMessageProcessor::gen_batch_ack_unique_id(&batch_ack_msg);
+        let result =
+            PopMessageProcessor::<DefaultMessageStore>::gen_batch_ack_unique_id(&batch_ack_msg);
         let expected = "test_topic@1@[1, 2, 3]@test_group@789@bAck";
         assert_eq!(result, expected);
     }
@@ -634,7 +636,7 @@ mod tests {
             queue_offset_diff: vec![],
             re_put_times: None,
         };
-        let result = PopMessageProcessor::gen_ck_unique_id(&ck);
+        let result = PopMessageProcessor::<DefaultMessageStore>::gen_ck_unique_id(&ck);
         let expected = "test_topic@1@456@test_cid@789@test_broker@ck";
         assert_eq!(result, expected);
     }

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -180,6 +180,7 @@ pub struct BrokerConfig {
     pub server_load_balancer_enable: bool,
     pub enable_remote_escape: bool,
     pub enable_pop_log: bool,
+    pub enable_retry_topic_v2: bool,
 }
 
 impl Default for BrokerConfig {
@@ -268,6 +269,7 @@ impl Default for BrokerConfig {
             server_load_balancer_enable: true,
             enable_remote_escape: false,
             enable_pop_log: false,
+            enable_retry_topic_v2: false,
         }
     }
 }

--- a/rocketmq-remoting/src/protocol/header/pop_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pop_message_request_header.rs
@@ -17,6 +17,7 @@
 use std::fmt::Display;
 
 use cheetah_string::CheetahString;
+use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
@@ -49,6 +50,12 @@ pub struct PopMessageRequestHeader {
 
     #[serde(flatten)]
     pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+impl PopMessageRequestHeader {
+    pub fn is_timeout_too_much(&self) -> bool {
+        get_current_millis() - self.born_time - self.poll_time > 500
+    }
 }
 
 impl Default for PopMessageRequestHeader {

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -729,6 +729,17 @@ impl RemotingCommand {
     pub fn create_new_request_id() -> i32 {
         requestId.fetch_add(1, Ordering::AcqRel)
     }
+
+    #[inline]
+    pub fn add_ext_field_if_not_exist(
+        &mut self,
+        key: impl Into<CheetahString>,
+        value: impl Into<CheetahString>,
+    ) {
+        if let Some(ref mut ext) = self.ext_fields {
+            ext.entry(key.into()).or_insert(value.into());
+        }
+    }
 }
 
 pub fn parse_header_length(size: i32) -> usize {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1899

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option `enable_retry_topic_v2` in the BrokerConfig.
	- Added a method `is_timeout_too_much` to the PopMessageRequestHeader for timeout checks.
	- Implemented a method `add_ext_field_if_not_exist` in RemotingCommand for managing extension fields.

- **Bug Fixes**
	- Enhanced error handling and request processing in PopMessageProcessor.

- **Documentation**
	- Added comments to improve code clarity across various processors.

- **Refactor**
	- Updated processor structures to use generic types for improved type safety and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->