### PR TITLE
[ISSUE #1908]🚨Add NotificationRequestHeader for rust🚀

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -45,6 +45,7 @@ pub mod heartbeat_request_header;
 pub mod lock_batch_mq_request_header;
 pub mod message_operation_header;
 pub mod namesrv;
+pub mod notification_request_header;
 pub mod notify_consumer_ids_changed_request_header;
 pub mod pop_message_request_header;
 pub mod pop_message_response_header;

--- a/rocketmq-remoting/src/protocol/header/notification_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/notification_request_header.rs
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
+
+#[derive(Debug, Serialize, Deserialize, RequestHeaderCodec)]
+pub struct NotificationRequestHeader {
+    #[serde(rename = "consumerGroup")]
+    #[required]
+    pub consumer_group: CheetahString,
+
+    #[serde(rename = "topic")]
+    #[required]
+    pub topic: CheetahString,
+
+    #[serde(rename = "queueId")]
+    #[required]
+    pub queue_id: i32,
+
+    #[serde(rename = "pollTime")]
+    #[required]
+    pub poll_time: i64,
+
+    #[serde(rename = "bornTime")]
+    #[required]
+    pub born_time: i64,
+
+    /// Indicates if the message is ordered; defaults to false.
+    #[serde(default)]
+    pub order: bool,
+
+    /// Attempt ID
+    #[serde(rename = "attemptId", skip_serializing_if = "Option::is_none")]
+    pub attempt_id: Option<CheetahString>,
+
+    #[serde(flatten)]
+    pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn test_notification_request_header_serialization() {
+        let header = NotificationRequestHeader {
+            consumer_group: CheetahString::from("consumer_group_1"),
+            topic: CheetahString::from("test_topic"),
+            queue_id: 10,
+            poll_time: 1234567890,
+            born_time: 1234567891,
+            order: true,
+            attempt_id: Some(CheetahString::from("attempt_1")),
+            topic_request_header: None,
+        };
+
+        let serialized = serde_json::to_string(&header).expect("Failed to serialize header");
+
+        let deserialized: NotificationRequestHeader =
+            serde_json::from_str(&serialized).expect("Failed to deserialize header");
+        assert_eq!(header.queue_id, deserialized.queue_id);
+    }
+
+    #[test]
+    fn test_notification_request_header_default_order() {
+        let header = NotificationRequestHeader {
+            consumer_group: CheetahString::from("consumer_group_1"),
+            topic: CheetahString::from("test_topic"),
+            queue_id: 10,
+            poll_time: 1234567890,
+            born_time: 1234567891,
+            order: false, // Defaults to false
+            attempt_id: None,
+            topic_request_header: None,
+        };
+
+        let serialized = serde_json::to_string(&header).expect("Failed to serialize header");
+
+        let deserialized: NotificationRequestHeader =
+            serde_json::from_str(&serialized).expect("Failed to deserialize header");
+        assert_eq!(header.queue_id, deserialized.queue_id);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1908

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for notification request headers in the RocketMQ remoting protocol.
	- Added the `NotificationRequestHeader` struct for handling notification requests with various fields.
  
- **Tests**
	- Implemented unit tests to ensure proper serialization and default values for the `NotificationRequestHeader`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->