### PR TITLE
[ISSUE #1910]🚨Add clone derive for PopMessageRequestHeader struct🚀

### DIFF
--- a/rocketmq-remoting/src/protocol/header/pop_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pop_message_request_header.rs
@@ -24,7 +24,7 @@ use serde::Serialize;
 
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
-#[derive(Debug, Serialize, Deserialize, RequestHeaderCodec)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct PopMessageRequestHeader {
     #[required]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1910

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `PopMessageRequestHeader` struct to support cloning, improving usability in various contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->