### PR TITLE
[ISSUE #1913]🚨Add PollingResult struct for rust🚀

### DIFF
--- a/rocketmq-broker/src/long_polling.rs
+++ b/rocketmq-broker/src/long_polling.rs
@@ -18,5 +18,6 @@
 pub(crate) mod long_polling_service;
 pub(crate) mod many_pull_request;
 pub(crate) mod notify_message_arriving_listener;
-mod polling_header;
+pub(crate) mod polling_header;
+pub(crate) mod polling_result;
 pub(crate) mod pull_request;

--- a/rocketmq-broker/src/long_polling/polling_result.rs
+++ b/rocketmq-broker/src/long_polling/polling_result.rs
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::fmt::Display;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default, Hash)]
+pub enum PollingResult {
+    #[default]
+    PollingSuc,
+    PollingFull,
+    PollingTimeout,
+    NotPolling,
+}
+
+impl Display for PollingResult {
+    //compatible with the toString method in java
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PollingResult::PollingSuc => write!(f, "POLLING_SUC"),
+            PollingResult::PollingFull => write!(f, "POLLING_FULL"),
+            PollingResult::PollingTimeout => write!(f, "POLLING_TIMEOUT"),
+            PollingResult::NotPolling => write!(f, "NOT_POLLING"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn polling_result_display_polling_suc() {
+        let result = PollingResult::PollingSuc;
+        assert_eq!(format!("{}", result), "POLLING_SUC");
+    }
+
+    #[test]
+    fn polling_result_display_polling_full() {
+        let result = PollingResult::PollingFull;
+        assert_eq!(format!("{}", result), "POLLING_FULL");
+    }
+
+    #[test]
+    fn polling_result_display_polling_timeout() {
+        let result = PollingResult::PollingTimeout;
+        assert_eq!(format!("{}", result), "POLLING_TIMEOUT");
+    }
+
+    #[test]
+    fn polling_result_display_not_polling() {
+        let result = PollingResult::NotPolling;
+        assert_eq!(format!("{}", result), "NOT_POLLING");
+    }
+
+    #[test]
+    fn polling_result_default() {
+        let result: PollingResult = Default::default();
+        assert_eq!(result, PollingResult::PollingSuc);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1913

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `PollingResult` enumeration with multiple variants to represent polling outcomes.
	- Added formatted string output for each `PollingResult` variant for better readability.

- **Bug Fixes**
	- Updated module visibility to enhance accessibility of the `polling_header` module.

- **Tests**
	- Included unit tests to validate the string representation and default value of the `PollingResult` enum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->