### PR TITLE
[ISSUE #1928]⚡️Optimize AppendMessageStatus Display like Java AppendMessageStatus  toString

### DIFF
--- a/rocketmq-store/src/base/message_status_enum.rs
+++ b/rocketmq-store/src/base/message_status_enum.rs
@@ -25,6 +25,19 @@ pub enum AppendMessageStatus {
     UnknownError,
 }
 
+impl std::fmt::Display for AppendMessageStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Compatible with Java enums
+        match self {
+            AppendMessageStatus::PutOk => write!(f, "PUT_OK"),
+            AppendMessageStatus::EndOfFile => write!(f, "END_OF_FILE"),
+            AppendMessageStatus::MessageSizeExceeded => write!(f, "MESSAGE_SIZE_EXCEEDED"),
+            AppendMessageStatus::PropertiesSizeExceeded => write!(f, "PROPERTIES_SIZE_EXCEEDED"),
+            AppendMessageStatus::UnknownError => write!(f, "UNKNOWN_ERROR"),
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum PutMessageStatus {
     #[default]
@@ -70,5 +83,44 @@ pub enum GetMessageStatus {
 impl std::fmt::Display for GetMessageStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_message_status_display_put_ok() {
+        assert_eq!(AppendMessageStatus::PutOk.to_string(), "PUT_OK");
+    }
+
+    #[test]
+    fn append_message_status_display_end_of_file() {
+        assert_eq!(AppendMessageStatus::EndOfFile.to_string(), "END_OF_FILE");
+    }
+
+    #[test]
+    fn append_message_status_display_message_size_exceeded() {
+        assert_eq!(
+            AppendMessageStatus::MessageSizeExceeded.to_string(),
+            "MESSAGE_SIZE_EXCEEDED"
+        );
+    }
+
+    #[test]
+    fn append_message_status_display_properties_size_exceeded() {
+        assert_eq!(
+            AppendMessageStatus::PropertiesSizeExceeded.to_string(),
+            "PROPERTIES_SIZE_EXCEEDED"
+        );
+    }
+
+    #[test]
+    fn append_message_status_display_unknown_error() {
+        assert_eq!(
+            AppendMessageStatus::UnknownError.to_string(),
+            "UNKNOWN_ERROR"
+        );
     }
 }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1928

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced custom string representations for the `AppendMessageStatus` enum variants, enhancing compatibility with Java enums.

- **Tests**
	- Added unit tests to verify the string representations of the `AppendMessageStatus` enum variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->