### PR TITLE
[ISSUE #1943]Adding #[inline] for PutMessageContext's methods

### DIFF
--- a/rocketmq-store/src/base/put_message_context.rs
+++ b/rocketmq-store/src/base/put_message_context.rs
@@ -22,6 +22,7 @@ pub struct PutMessageContext {
 }
 
 impl PutMessageContext {
+    #[inline]
     pub fn new(topic_queue_table_key: String) -> Self {
         PutMessageContext {
             topic_queue_table_key,
@@ -30,30 +31,37 @@ impl PutMessageContext {
         }
     }
 
+    #[inline]
     pub fn get_topic_queue_table_key(&self) -> &str {
         &self.topic_queue_table_key
     }
 
+    #[inline]
     pub fn get_phy_pos(&self) -> &[i64] {
         &self.phy_pos
     }
 
+    #[inline]
     pub fn set_phy_pos(&mut self, phy_pos: Vec<i64>) {
         self.phy_pos = phy_pos;
     }
 
+    #[inline]
     pub fn get_phy_pos_mut(&mut self) -> &mut [i64] {
         &mut self.phy_pos
     }
 
+    #[inline]
     pub fn get_batch_size(&self) -> i32 {
         self.batch_size
     }
 
+    #[inline]
     pub fn set_batch_size(&mut self, batch_size: i32) {
         self.batch_size = batch_size;
     }
 
+    #[inline]
     pub fn set_topic_queue_table_key(&mut self, topic_queue_table_key: String) {
         self.topic_queue_table_key = topic_queue_table_key;
     }


### PR DESCRIPTION


#### Which Issue(s) This PR Fixes(Closes)
Add #[inline] for PutMessageContext's methods

Fixes #1943 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced several new methods for managing message context, including getters and setters for topic queue keys, physical positions, and batch size.
- **Improvements**
	- Enhanced encapsulation and usability of the `PutMessageContext` structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->