### PR TITLE
[ISSUE #1939]🔖PopMessageProcessor supports process_request handle-4🚀

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -563,12 +563,15 @@ impl BrokerRuntime {
         );
         let pop_message_processor = ArcMut::new(PopMessageProcessor::new(
             self.consumer_manager.clone(),
+            Arc::new(self.consumer_offset_manager.clone()),
+            self.consumer_order_info_manager.clone(),
             self.broker_config.clone(),
             self.message_store.clone().unwrap(),
             self.message_store_config.clone(),
             Arc::new(self.topic_config_manager.clone()),
             self.subscription_group_manager.clone(),
             self.consumer_filter_manager.clone(),
+            self.pop_inflight_message_counter.clone(),
         ));
         let ack_message_processor = ArcMut::new(AckMessageProcessor::new(
             self.topic_config_manager.clone(),

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -50,7 +50,7 @@ impl PopLongPollingService {
         remoting_command: RemotingCommand,
         request_header: PollingHeader,
         subscription_data: SubscriptionData,
-        message_filter: Arc<Option<Box<dyn MessageFilter>>>,
+        message_filter: Option<Arc<Box<dyn MessageFilter>>>,
     ) -> PollingResult {
         unimplemented!("PopLongPollingService::polling")
     }

--- a/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
@@ -14,593 +14,609 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(unused_variables)]
+ #![allow(unused_variables)]
 
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::fmt::Display;
-use std::ops::Deref;
-use std::sync::Arc;
-
-use cheetah_string::CheetahString;
-use rocketmq_common::common::broker::broker_config::BrokerConfig;
-use rocketmq_common::common::config_manager::ConfigManager;
-use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
-use rocketmq_common::TimeUtils::get_current_millis;
-use serde::Deserialize;
-use serde::Serialize;
-use tracing::info;
-use tracing::warn;
-
-use crate::broker_path_config_helper::get_consumer_order_info_path;
-use crate::offset::manager::consumer_order_info_lock_manager::ConsumerOrderInfoLockManager;
-use crate::subscription::manager::subscription_group_manager::SubscriptionGroupManager;
-use crate::topic::manager::topic_config_manager::TopicConfigManager;
-
-const TOPIC_GROUP_SEPARATOR: &str = "@";
-const CLEAN_SPAN_FROM_LAST: u64 = 24 * 3600 * 1000;
-
-pub(crate) struct ConsumerOrderInfoManager<MS> {
-    pub(crate) broker_config: Arc<BrokerConfig>,
-    pub(crate) consumer_order_info_wrapper: parking_lot::Mutex<ConsumerOrderInfoWrapper>,
-    pub(crate) consumer_order_info_lock_manager: Option<ConsumerOrderInfoLockManager>,
-    pub(crate) topic_config_manager: Arc<TopicConfigManager>,
-    pub(crate) subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
-}
-
-impl<MS> ConsumerOrderInfoManager<MS> {
-    pub fn new(
-        broker_config: Arc<BrokerConfig>,
-        topic_config_manager: Arc<TopicConfigManager>,
-        subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
-    ) -> ConsumerOrderInfoManager<MS> {
-        Self {
-            broker_config,
-            consumer_order_info_wrapper: parking_lot::Mutex::new(
-                ConsumerOrderInfoWrapper::default(),
-            ),
-            consumer_order_info_lock_manager: None,
-            topic_config_manager,
-            subscription_group_manager,
-        }
-    }
-}
-
-//Fully implemented will be removed
-#[allow(unused_variables)]
-impl<MS> ConfigManager for ConsumerOrderInfoManager<MS> {
-    fn config_file_path(&self) -> String {
-        get_consumer_order_info_path(self.broker_config.store_path_root_dir.as_str())
-    }
-
-    fn encode_pretty(&self, pretty_format: bool) -> String {
-        self.auto_clean();
-        let wrapper = self.consumer_order_info_wrapper.lock();
-        match pretty_format {
-            true => SerdeJsonUtils::to_json_pretty(&wrapper.table)
-                .expect("Failed to serialize consumer order info wrapper"),
-            false => serde_json::to_string(&wrapper.table)
-                .expect("Failed to serialize consumer order info wrapper"),
-        }
-    }
-
-    fn decode(&self, json_string: &str) {
-        if json_string.is_empty() {
-            return;
-        }
-        let wrapper =
-            serde_json::from_str::<ConsumerOrderInfoWrapper>(json_string).unwrap_or_default();
-        if !wrapper.table.is_empty() {
-            self.consumer_order_info_wrapper
-                .lock()
-                .table
-                .clone_from(&wrapper.table);
-            if self.consumer_order_info_lock_manager.is_some() {
-                self.consumer_order_info_lock_manager
-                    .as_ref()
-                    .unwrap()
-                    .recover(self.consumer_order_info_wrapper.lock().deref());
-            }
-        }
-    }
-}
-
-impl<MS> ConsumerOrderInfoManager<MS> {
-    pub fn auto_clean(&self) {
-        let mut consumer_order_info_wrapper = self.consumer_order_info_wrapper.lock();
-        let table = &mut consumer_order_info_wrapper.table;
-
-        // Iterate through the `table` entries (topic@group -> queueId -> OrderInfo)
-        let mut keys_to_remove = Vec::new(); // Temporary storage for keys to remove
-
-        for (topic_at_group, qs) in table.iter_mut() {
-            let arrays: Vec<&str> = topic_at_group.split('@').collect();
-            if arrays.len() != 2 {
-                continue;
-            }
-            let topic = arrays[0];
-            let group = arrays[1];
-
-            let topic_config = self
-                .topic_config_manager
-                .select_topic_config(&CheetahString::from(topic));
-            if topic_config.is_none() {
-                info!(
-                    "Topic not exist, Clean order info, {}:{:?}",
-                    topic_at_group, qs
-                );
-                keys_to_remove.push(topic_at_group.clone());
-                continue;
-            }
-            let subscription_group_wrapper = self
-                .subscription_group_manager
-                .subscription_group_wrapper()
-                .lock();
-            let subscription_group_config = subscription_group_wrapper
-                .subscription_group_table()
-                .get(&CheetahString::from(group));
-            if subscription_group_config.is_none() {
-                info!(
-                    "Group not exist, Clean order info, {}:{:?}",
-                    topic_at_group, qs
-                );
-                keys_to_remove.push(topic_at_group.clone());
-                continue;
-            }
-
-            if qs.is_empty() {
-                info!(
-                    "Order table is empty, Clean order info, {}:{:?}",
-                    topic_at_group, qs
-                );
-                keys_to_remove.push(topic_at_group.clone());
-                continue;
-            }
-            let topic_config = topic_config.unwrap();
-            // Clean individual queues in the current topic@group
-            let mut queues_to_remove = Vec::new();
-            for (queue_id, order_info) in qs.iter_mut() {
-                if *queue_id == topic_config.read_queue_nums as i32 {
-                    queues_to_remove.push(*queue_id);
-                    info!(
-                        "Queue not exist, Clean order info, {}:{}, {}",
-                        topic_at_group, order_info, topic_config
-                    );
-                    continue;
-                }
-            }
-
-            // Remove stale or invalid queues
-            for queue_id in queues_to_remove {
-                qs.remove(&queue_id);
-                info!(
-                    "Removed queue {} for topic@group {}",
-                    queue_id, topic_at_group
-                );
-            }
-
-            // If all queues are removed, mark topic@group for removal
-            if qs.is_empty() {
-                keys_to_remove.push(topic_at_group.clone());
-            }
-        }
-
-        // Now, remove all topics/groups from the table that need to be cleaned
-        for key in keys_to_remove {
-            table.remove(&key);
-            info!("Removed topic@group {}", key);
-        }
-    }
-
-    pub fn update_next_visible_time(
-        &self,
-        topic: &CheetahString,
-        group: &CheetahString,
-        queue_id: i32,
-        queue_offset: u64,
-        pop_time: u64,
-        next_visible_time: u64,
-    ) {
-        let key = CheetahString::from_string(build_key(topic, group));
-        let mut table = self.consumer_order_info_wrapper.lock();
-        let qs = table.table.get_mut(&key);
-        if qs.is_none() {
-            warn!(
-                "orderInfo of queueId is null. key: {}, queueOffset: {}, queueId: {}",
-                key, queue_offset, queue_id
-            );
-            return;
-        }
-        let qs = qs.unwrap();
-        let order_info = qs.get_mut(&queue_id);
-        if order_info.is_none() {
-            warn!(
-                "orderInfo of queueId is null. key: {}, queueOffset: {}, queueId: {}",
-                key, queue_offset, queue_id
-            );
-            return;
-        }
-        let order_info = order_info.unwrap();
-        if pop_time != order_info.pop_time {
-            warn!(
-                "popTime is not equal to orderInfo saved. key: {}, queueOffset: {}, orderInfo: \
-                 {}, popTime: {}",
-                key, queue_offset, queue_id, pop_time,
-            );
-            return;
-        }
-        order_info.update_offset_next_visible_time(queue_offset, next_visible_time);
-        self.update_lock_free_timestamp(topic, group, queue_id, order_info);
-    }
-
-    fn update_lock_free_timestamp(
-        &self,
-        _topic: &CheetahString,
-        _group: &CheetahString,
-        _queue_id: i32,
-        _order_info: &OrderInfo,
-    ) {
-        unimplemented!("")
-    }
-
-    pub fn commit_and_next(
-        &self,
-        topic: &CheetahString,
-        group: &CheetahString,
-        queue_id: i32,
-        queue_offset: u64,
-        pop_time: u64,
-    ) -> i64 {
-        unimplemented!()
-    }
-
-    pub fn check_block(
-        &self,
-        attempt_id: &CheetahString,
-        topic: &CheetahString,
-        group: &CheetahString,
-        queue_id: i32,
-        invisible_time: u64,
-    ) -> bool {
-        unimplemented!()
-    }
-}
-
-#[inline]
-#[must_use]
-fn build_key(topic: &CheetahString, group: &CheetahString) -> String {
-    format!("{}{}{}", topic, TOPIC_GROUP_SEPARATOR, group)
-}
-
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub(crate) struct ConsumerOrderInfoWrapper {
-    table: HashMap<CheetahString /* topic@group */, HashMap<i32, OrderInfo>>,
-}
-
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub(crate) struct OrderInfo {
-    #[serde(rename = "popTime")]
-    pop_time: u64,
-    #[serde(rename = "i")]
-    invisible_time: Option<u64>,
-    #[serde(rename = "0")]
-    offset_list: Vec<u64>,
-    #[serde(rename = "ot")]
-    offset_next_visible_time: HashMap<u64, u64>,
-    #[serde(rename = "oc")]
-    offset_consumed_count: HashMap<u64, i32>,
-    #[serde(rename = "l")]
-    last_consume_timestamp: u64,
-    #[serde(rename = "cm")]
-    commit_offset_bit: u64,
-    #[serde(rename = "a")]
-    attempt_id: String,
-}
-
-impl Display for OrderInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "OrderInfo {{ popTime: {}, invisibleTime: {:?}, offsetList: {:?}, \
-             offsetNextVisibleTime: {:?}, offsetConsumedCount: {:?}, lastConsumeTimestamp: {}, \
-             commitOffsetBit: {}, attemptId: {} }}",
-            self.pop_time,
-            self.invisible_time,
-            self.offset_list,
-            self.offset_next_visible_time,
-            self.offset_consumed_count,
-            self.last_consume_timestamp,
-            self.commit_offset_bit,
-            self.attempt_id
-        )
-    }
-}
-
-impl OrderInfo {
-    /// Builds a list of offsets from a given list of queue offsets.
-    /// If the list contains only one element, it returns the same list.
-    /// Otherwise, it returns a list where each element is the difference
-    /// between the current and the first element.
-    ///
-    /// # Arguments
-    ///
-    /// * `queue_offset_list` - A vector of queue offsets.
-    ///
-    /// # Returns
-    ///
-    /// A vector of offsets.
-    pub fn build_offset_list(queue_offset_list: Vec<u64>) -> Vec<u64> {
-        let mut simple = Vec::new();
-        if queue_offset_list.len() == 1 {
-            simple.extend(queue_offset_list);
-            return simple;
-        }
-        let first = queue_offset_list[0];
-        simple.push(first);
-        for item in queue_offset_list.iter().skip(1) {
-            simple.push(*item - first);
-        }
-        simple
-    }
-
-    /// Determines if the current order info needs to be blocked based on the attempt ID
-    /// and the current invisible time.
-    ///
-    /// # Arguments
-    ///
-    /// * `attempt_id` - The attempt ID to check.
-    /// * `current_invisible_time` - The current invisible time.
-    ///
-    /// # Returns
-    ///
-    /// `true` if the order info needs to be blocked, `false` otherwise.
-    pub fn need_block(&mut self, attempt_id: &str, current_invisible_time: u64) -> bool {
-        if self.offset_list.is_empty() {
-            return false;
-        }
-        if self.attempt_id == attempt_id {
-            return false;
-        }
-        let num = self.offset_list.len();
-        if self.invisible_time.is_none() || self.invisible_time.unwrap_or(0) == 0 {
-            self.invisible_time = Some(current_invisible_time);
-        }
-        let current_time = get_current_millis();
-        for (i, _) in (0..num).enumerate() {
-            if self.is_not_ack(i) {
-                let mut next_visible_time = self.pop_time + self.invisible_time.unwrap_or(0);
-                if let Some(time) = self.offset_next_visible_time.get(&self.get_queue_offset(i)) {
-                    next_visible_time = *time;
-                }
-                if current_time < next_visible_time {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
-    /// Gets the lock-free timestamp for the current order info.
-    ///
-    /// # Returns
-    ///
-    /// An `Option<u64>` containing the lock-free timestamp if available, `None` otherwise.
-    pub fn get_lock_free_timestamp(&self) -> Option<u64> {
-        if self.offset_list.is_empty() {
-            return None;
-        }
-        let current_time = get_current_millis();
-        for i in 0..self.offset_list.len() {
-            if self.is_not_ack(i) {
-                if self.invisible_time.is_none() || self.invisible_time.unwrap_or(0) == 0 {
-                    return None;
-                }
-                let mut next_visible_time = self.pop_time + self.invisible_time.unwrap_or(0);
-                if let Some(time) = self.offset_next_visible_time.get(&self.get_queue_offset(i)) {
-                    next_visible_time = *time;
-                }
-                if current_time < next_visible_time {
-                    return Some(next_visible_time);
-                }
-            }
-        }
-        Some(current_time)
-    }
-
-    /// Updates the next visible time for a given queue offset.
-    ///
-    /// # Arguments
-    ///
-    /// * `queue_offset` - The queue offset to update.
-    /// * `next_visible_time` - The next visible time to set.
-    #[inline]
-    pub fn update_offset_next_visible_time(&mut self, queue_offset: u64, next_visible_time: u64) {
-        self.offset_next_visible_time
-            .insert(queue_offset, next_visible_time);
-    }
-
-    /// Gets the next offset for the current order info.
-    ///
-    /// # Returns
-    ///
-    /// An `i64` representing the next offset. Returns -2 if the offset list is empty.
-    pub fn get_next_offset(&self) -> i64 {
-        if self.offset_list.is_empty() {
-            return -2;
-        }
-        let mut i = 0;
-        for j in 0..self.offset_list.len() {
-            if self.is_not_ack(j) {
-                break;
-            }
-            i += 1;
-        }
-        if i == self.offset_list.len() {
-            self.get_queue_offset(self.offset_list.len() - 1) as i64 + 1
-        } else {
-            self.get_queue_offset(i) as i64
-        }
-    }
-
-    /// Gets the queue offset for a given offset index.
-    ///
-    /// # Arguments
-    ///
-    /// * `offset_index` - The index of the offset to get.
-    ///
-    /// # Returns
-    ///
-    /// A `u64` representing the queue offset.
-    pub fn get_queue_offset(&self, offset_index: usize) -> u64 {
-        if offset_index == 0 {
-            return self.offset_list[0];
-        }
-        self.offset_list[0] + self.offset_list[offset_index]
-    }
-
-    /// Checks if the offset at the given index is not acknowledged.
-    ///
-    /// # Arguments
-    ///
-    /// * `offset_index` - The index of the offset to check.
-    ///
-    /// # Returns
-    ///
-    /// `true` if the offset is not acknowledged, `false` otherwise.
-    pub fn is_not_ack(&self, offset_index: usize) -> bool {
-        if offset_index >= 64 {
-            return false;
-        }
-        (self.commit_offset_bit & (1 << offset_index)) == 0
-    }
-
-    /// Merges the offset consumed count with the previous attempt ID and offset list.
-    ///
-    /// # Arguments
-    ///
-    /// * `pre_attempt_id` - The previous attempt ID.
-    /// * `pre_offset_list` - The previous offset list.
-    /// * `prev_offset_consumed_count` - The previous offset consumed count.
-    pub fn merge_offset_consumed_count(
-        &mut self,
-        pre_attempt_id: &str,
-        pre_offset_list: Vec<u64>,
-        prev_offset_consumed_count: HashMap<u64, i32>,
-    ) {
-        let mut offset_consumed_count = HashMap::new();
-        if pre_attempt_id == self.attempt_id {
-            self.offset_consumed_count = prev_offset_consumed_count;
-            return;
-        }
-        let mut pre_queue_offset_set = HashSet::new();
-        for (index, _) in pre_offset_list.iter().enumerate() {
-            pre_queue_offset_set.insert(Self::get_queue_offset_from_list(&pre_offset_list, index));
-        }
-        for i in 0..self.offset_list.len() {
-            let queue_offset = self.get_queue_offset(i);
-            if pre_queue_offset_set.contains(&queue_offset) {
-                let mut count = 1;
-                if let Some(pre_count) = prev_offset_consumed_count.get(&queue_offset) {
-                    count += pre_count;
-                }
-                offset_consumed_count.insert(queue_offset, count);
-            }
-        }
-        self.offset_consumed_count = offset_consumed_count;
-    }
-
-    /// Gets the queue offset from a list of offsets for a given index.
-    ///
-    /// # Arguments
-    ///
-    /// * `pre_offset_list` - The list of previous offsets.
-    /// * `offset_index` - The index of the offset to get.
-    ///
-    /// # Returns
-    ///
-    /// A `u64` representing the queue offset.
-    fn get_queue_offset_from_list(pre_offset_list: &[u64], offset_index: usize) -> u64 {
-        if offset_index == 0 {
-            return pre_offset_list[0];
-        }
-        pre_offset_list[0] + pre_offset_list[offset_index]
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use super::*;
-
-    #[test]
-    fn build_offset_list_with_single_element() {
-        let queue_offset_list = vec![10];
-        let expected = vec![10];
-        assert_eq!(OrderInfo::build_offset_list(queue_offset_list), expected);
-    }
-
-    #[test]
-    fn need_block_returns_false_for_empty_offset_list() {
-        let mut order_info = OrderInfo {
-            pop_time: 1000,
-            invisible_time: Some(3000),
-            offset_list: vec![],
-            offset_next_visible_time: HashMap::new(),
-            offset_consumed_count: HashMap::new(),
-            last_consume_timestamp: 0,
-            commit_offset_bit: 0,
-            attempt_id: "test".to_string(),
-        };
-        assert!(!order_info.need_block("another_test", 2000));
-    }
-
-    #[test]
-    fn get_lock_free_timestamp_returns_none_for_empty_offset_list() {
-        let order_info = OrderInfo {
-            pop_time: 1000,
-            invisible_time: Some(3000),
-            offset_list: vec![],
-            offset_next_visible_time: HashMap::new(),
-            offset_consumed_count: HashMap::new(),
-            last_consume_timestamp: 0,
-            commit_offset_bit: 0,
-            attempt_id: "test".to_string(),
-        };
-        assert_eq!(order_info.get_lock_free_timestamp(), None);
-    }
-
-    #[test]
-    fn get_next_offset_returns_minus_two_for_empty_offset_list() {
-        let order_info = OrderInfo {
-            pop_time: 1000,
-            invisible_time: Some(3000),
-            offset_list: vec![],
-            offset_next_visible_time: HashMap::new(),
-            offset_consumed_count: HashMap::new(),
-            last_consume_timestamp: 0,
-            commit_offset_bit: 0,
-            attempt_id: "test".to_string(),
-        };
-        assert_eq!(order_info.get_next_offset(), -2);
-    }
-
-    #[test]
-    fn merge_offset_consumed_count_with_same_attempt_id() {
-        let mut order_info = OrderInfo {
-            pop_time: 0,
-            invisible_time: None,
-            offset_list: vec![1, 2, 3],
-            offset_next_visible_time: HashMap::new(),
-            offset_consumed_count: HashMap::new(),
-            last_consume_timestamp: 0,
-            commit_offset_bit: 0,
-            attempt_id: "test".to_string(),
-        };
-        let pre_offset_list = vec![1, 2];
-        let prev_offset_consumed_count = HashMap::from([(1, 1), (2, 1)]);
-        order_info.merge_offset_consumed_count("test", pre_offset_list, prev_offset_consumed_count);
-        assert_eq!(order_info.offset_consumed_count.get(&1), Some(&1));
-        assert_eq!(order_info.offset_consumed_count.get(&2), Some(&1));
-    }
-}
+ use std::collections::HashMap;
+ use std::collections::HashSet;
+ use std::fmt::Display;
+ use std::ops::Deref;
+ use std::sync::Arc;
+ 
+ use cheetah_string::CheetahString;
+ use rocketmq_common::common::broker::broker_config::BrokerConfig;
+ use rocketmq_common::common::config_manager::ConfigManager;
+ use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
+ use rocketmq_common::TimeUtils::get_current_millis;
+ use serde::Deserialize;
+ use serde::Serialize;
+ use tracing::info;
+ use tracing::warn;
+ 
+ use crate::broker_path_config_helper::get_consumer_order_info_path;
+ use crate::offset::manager::consumer_order_info_lock_manager::ConsumerOrderInfoLockManager;
+ use crate::subscription::manager::subscription_group_manager::SubscriptionGroupManager;
+ use crate::topic::manager::topic_config_manager::TopicConfigManager;
+ 
+ const TOPIC_GROUP_SEPARATOR: &str = "@";
+ const CLEAN_SPAN_FROM_LAST: u64 = 24 * 3600 * 1000;
+ 
+ pub(crate) struct ConsumerOrderInfoManager<MS> {
+     pub(crate) broker_config: Arc<BrokerConfig>,
+     pub(crate) consumer_order_info_wrapper: parking_lot::Mutex<ConsumerOrderInfoWrapper>,
+     pub(crate) consumer_order_info_lock_manager: Option<ConsumerOrderInfoLockManager>,
+     pub(crate) topic_config_manager: Arc<TopicConfigManager>,
+     pub(crate) subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
+ }
+ 
+ impl<MS> ConsumerOrderInfoManager<MS> {
+     pub fn new(
+         broker_config: Arc<BrokerConfig>,
+         topic_config_manager: Arc<TopicConfigManager>,
+         subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
+     ) -> ConsumerOrderInfoManager<MS> {
+         Self {
+             broker_config,
+             consumer_order_info_wrapper: parking_lot::Mutex::new(
+                 ConsumerOrderInfoWrapper::default(),
+             ),
+             consumer_order_info_lock_manager: None,
+             topic_config_manager,
+             subscription_group_manager,
+         }
+     }
+ }
+ 
+ //Fully implemented will be removed
+ #[allow(unused_variables)]
+ impl<MS> ConfigManager for ConsumerOrderInfoManager<MS> {
+     fn config_file_path(&self) -> String {
+         get_consumer_order_info_path(self.broker_config.store_path_root_dir.as_str())
+     }
+ 
+     fn encode_pretty(&self, pretty_format: bool) -> String {
+         self.auto_clean();
+         let wrapper = self.consumer_order_info_wrapper.lock();
+         match pretty_format {
+             true => SerdeJsonUtils::to_json_pretty(&wrapper.table)
+                 .expect("Failed to serialize consumer order info wrapper"),
+             false => serde_json::to_string(&wrapper.table)
+                 .expect("Failed to serialize consumer order info wrapper"),
+         }
+     }
+ 
+     fn decode(&self, json_string: &str) {
+         if json_string.is_empty() {
+             return;
+         }
+         let wrapper =
+             serde_json::from_str::<ConsumerOrderInfoWrapper>(json_string).unwrap_or_default();
+         if !wrapper.table.is_empty() {
+             self.consumer_order_info_wrapper
+                 .lock()
+                 .table
+                 .clone_from(&wrapper.table);
+             if self.consumer_order_info_lock_manager.is_some() {
+                 self.consumer_order_info_lock_manager
+                     .as_ref()
+                     .unwrap()
+                     .recover(self.consumer_order_info_wrapper.lock().deref());
+             }
+         }
+     }
+ }
+ 
+ impl<MS> ConsumerOrderInfoManager<MS> {
+     pub fn auto_clean(&self) {
+         let mut consumer_order_info_wrapper = self.consumer_order_info_wrapper.lock();
+         let table = &mut consumer_order_info_wrapper.table;
+ 
+         // Iterate through the `table` entries (topic@group -> queueId -> OrderInfo)
+         let mut keys_to_remove = Vec::new(); // Temporary storage for keys to remove
+ 
+         for (topic_at_group, qs) in table.iter_mut() {
+             let arrays: Vec<&str> = topic_at_group.split('@').collect();
+             if arrays.len() != 2 {
+                 continue;
+             }
+             let topic = arrays[0];
+             let group = arrays[1];
+ 
+             let topic_config = self
+                 .topic_config_manager
+                 .select_topic_config(&CheetahString::from(topic));
+             if topic_config.is_none() {
+                 info!(
+                     "Topic not exist, Clean order info, {}:{:?}",
+                     topic_at_group, qs
+                 );
+                 keys_to_remove.push(topic_at_group.clone());
+                 continue;
+             }
+             let subscription_group_wrapper = self
+                 .subscription_group_manager
+                 .subscription_group_wrapper()
+                 .lock();
+             let subscription_group_config = subscription_group_wrapper
+                 .subscription_group_table()
+                 .get(&CheetahString::from(group));
+             if subscription_group_config.is_none() {
+                 info!(
+                     "Group not exist, Clean order info, {}:{:?}",
+                     topic_at_group, qs
+                 );
+                 keys_to_remove.push(topic_at_group.clone());
+                 continue;
+             }
+ 
+             if qs.is_empty() {
+                 info!(
+                     "Order table is empty, Clean order info, {}:{:?}",
+                     topic_at_group, qs
+                 );
+                 keys_to_remove.push(topic_at_group.clone());
+                 continue;
+             }
+             let topic_config = topic_config.unwrap();
+             // Clean individual queues in the current topic@group
+             let mut queues_to_remove = Vec::new();
+             for (queue_id, order_info) in qs.iter_mut() {
+                 if *queue_id == topic_config.read_queue_nums as i32 {
+                     queues_to_remove.push(*queue_id);
+                     info!(
+                         "Queue not exist, Clean order info, {}:{}, {}",
+                         topic_at_group, order_info, topic_config
+                     );
+                     continue;
+                 }
+             }
+ 
+             // Remove stale or invalid queues
+             for queue_id in queues_to_remove {
+                 qs.remove(&queue_id);
+                 info!(
+                     "Removed queue {} for topic@group {}",
+                     queue_id, topic_at_group
+                 );
+             }
+ 
+             // If all queues are removed, mark topic@group for removal
+             if qs.is_empty() {
+                 keys_to_remove.push(topic_at_group.clone());
+             }
+         }
+ 
+         // Now, remove all topics/groups from the table that need to be cleaned
+         for key in keys_to_remove {
+             table.remove(&key);
+             info!("Removed topic@group {}", key);
+         }
+     }
+ 
+     pub fn update_next_visible_time(
+         &self,
+         topic: &CheetahString,
+         group: &CheetahString,
+         queue_id: i32,
+         queue_offset: u64,
+         pop_time: u64,
+         next_visible_time: u64,
+     ) {
+         let key = CheetahString::from_string(build_key(topic, group));
+         let mut table = self.consumer_order_info_wrapper.lock();
+         let qs = table.table.get_mut(&key);
+         if qs.is_none() {
+             warn!(
+                 "orderInfo of queueId is null. key: {}, queueOffset: {}, queueId: {}",
+                 key, queue_offset, queue_id
+             );
+             return;
+         }
+         let qs = qs.unwrap();
+         let order_info = qs.get_mut(&queue_id);
+         if order_info.is_none() {
+             warn!(
+                 "orderInfo of queueId is null. key: {}, queueOffset: {}, queueId: {}",
+                 key, queue_offset, queue_id
+             );
+             return;
+         }
+         let order_info = order_info.unwrap();
+         if pop_time != order_info.pop_time {
+             warn!(
+                 "popTime is not equal to orderInfo saved. key: {}, queueOffset: {}, orderInfo: \
+                  {}, popTime: {}",
+                 key, queue_offset, queue_id, pop_time,
+             );
+             return;
+         }
+         order_info.update_offset_next_visible_time(queue_offset, next_visible_time);
+         self.update_lock_free_timestamp(topic, group, queue_id, order_info);
+     }
+ 
+     fn update_lock_free_timestamp(
+         &self,
+         _topic: &CheetahString,
+         _group: &CheetahString,
+         _queue_id: i32,
+         _order_info: &OrderInfo,
+     ) {
+         unimplemented!("")
+     }
+ 
+     pub fn commit_and_next(
+         &self,
+         topic: &CheetahString,
+         group: &CheetahString,
+         queue_id: i32,
+         queue_offset: u64,
+         pop_time: u64,
+     ) -> i64 {
+         unimplemented!()
+     }
+ 
+     pub fn check_block(
+         &self,
+         attempt_id: &CheetahString,
+         topic: &CheetahString,
+         group: &CheetahString,
+         queue_id: i32,
+         invisible_time: u64,
+     ) -> bool {
+         unimplemented!()
+     }
+ 
+     pub fn update(
+         &self,
+         attempt_id: CheetahString,
+         is_retry: bool,
+         topic: &CheetahString,
+         group: &CheetahString,
+         queue_id: i32,
+         pop_time: u64,
+         invisible_time: u64,
+         msg_queue_offset_list: Vec<u64>,
+         order_info_builder: &str,
+     ) -> bool {
+         unimplemented!()
+     }
+ }
+ 
+ #[inline]
+ #[must_use]
+ fn build_key(topic: &CheetahString, group: &CheetahString) -> String {
+     format!("{}{}{}", topic, TOPIC_GROUP_SEPARATOR, group)
+ }
+ 
+ #[derive(Debug, Default, Serialize, Deserialize, Clone)]
+ pub(crate) struct ConsumerOrderInfoWrapper {
+     table: HashMap<CheetahString /* topic@group */, HashMap<i32, OrderInfo>>,
+ }
+ 
+ #[derive(Debug, Default, Serialize, Deserialize, Clone)]
+ pub(crate) struct OrderInfo {
+     #[serde(rename = "popTime")]
+     pop_time: u64,
+     #[serde(rename = "i")]
+     invisible_time: Option<u64>,
+     #[serde(rename = "0")]
+     offset_list: Vec<u64>,
+     #[serde(rename = "ot")]
+     offset_next_visible_time: HashMap<u64, u64>,
+     #[serde(rename = "oc")]
+     offset_consumed_count: HashMap<u64, i32>,
+     #[serde(rename = "l")]
+     last_consume_timestamp: u64,
+     #[serde(rename = "cm")]
+     commit_offset_bit: u64,
+     #[serde(rename = "a")]
+     attempt_id: String,
+ }
+ 
+ impl Display for OrderInfo {
+     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+         write!(
+             f,
+             "OrderInfo {{ popTime: {}, invisibleTime: {:?}, offsetList: {:?}, \
+              offsetNextVisibleTime: {:?}, offsetConsumedCount: {:?}, lastConsumeTimestamp: {}, \
+              commitOffsetBit: {}, attemptId: {} }}",
+             self.pop_time,
+             self.invisible_time,
+             self.offset_list,
+             self.offset_next_visible_time,
+             self.offset_consumed_count,
+             self.last_consume_timestamp,
+             self.commit_offset_bit,
+             self.attempt_id
+         )
+     }
+ }
+ 
+ impl OrderInfo {
+     /// Builds a list of offsets from a given list of queue offsets.
+     /// If the list contains only one element, it returns the same list.
+     /// Otherwise, it returns a list where each element is the difference
+     /// between the current and the first element.
+     ///
+     /// # Arguments
+     ///
+     /// * `queue_offset_list` - A vector of queue offsets.
+     ///
+     /// # Returns
+     ///
+     /// A vector of offsets.
+     pub fn build_offset_list(queue_offset_list: Vec<u64>) -> Vec<u64> {
+         let mut simple = Vec::new();
+         if queue_offset_list.len() == 1 {
+             simple.extend(queue_offset_list);
+             return simple;
+         }
+         let first = queue_offset_list[0];
+         simple.push(first);
+         for item in queue_offset_list.iter().skip(1) {
+             simple.push(*item - first);
+         }
+         simple
+     }
+ 
+     /// Determines if the current order info needs to be blocked based on the attempt ID
+     /// and the current invisible time.
+     ///
+     /// # Arguments
+     ///
+     /// * `attempt_id` - The attempt ID to check.
+     /// * `current_invisible_time` - The current invisible time.
+     ///
+     /// # Returns
+     ///
+     /// `true` if the order info needs to be blocked, `false` otherwise.
+     pub fn need_block(&mut self, attempt_id: &str, current_invisible_time: u64) -> bool {
+         if self.offset_list.is_empty() {
+             return false;
+         }
+         if self.attempt_id == attempt_id {
+             return false;
+         }
+         let num = self.offset_list.len();
+         if self.invisible_time.is_none() || self.invisible_time.unwrap_or(0) == 0 {
+             self.invisible_time = Some(current_invisible_time);
+         }
+         let current_time = get_current_millis();
+         for (i, _) in (0..num).enumerate() {
+             if self.is_not_ack(i) {
+                 let mut next_visible_time = self.pop_time + self.invisible_time.unwrap_or(0);
+                 if let Some(time) = self.offset_next_visible_time.get(&self.get_queue_offset(i)) {
+                     next_visible_time = *time;
+                 }
+                 if current_time < next_visible_time {
+                     return true;
+                 }
+             }
+         }
+         false
+     }
+ 
+     /// Gets the lock-free timestamp for the current order info.
+     ///
+     /// # Returns
+     ///
+     /// An `Option<u64>` containing the lock-free timestamp if available, `None` otherwise.
+     pub fn get_lock_free_timestamp(&self) -> Option<u64> {
+         if self.offset_list.is_empty() {
+             return None;
+         }
+         let current_time = get_current_millis();
+         for i in 0..self.offset_list.len() {
+             if self.is_not_ack(i) {
+                 if self.invisible_time.is_none() || self.invisible_time.unwrap_or(0) == 0 {
+                     return None;
+                 }
+                 let mut next_visible_time = self.pop_time + self.invisible_time.unwrap_or(0);
+                 if let Some(time) = self.offset_next_visible_time.get(&self.get_queue_offset(i)) {
+                     next_visible_time = *time;
+                 }
+                 if current_time < next_visible_time {
+                     return Some(next_visible_time);
+                 }
+             }
+         }
+         Some(current_time)
+     }
+ 
+     /// Updates the next visible time for a given queue offset.
+     ///
+     /// # Arguments
+     ///
+     /// * `queue_offset` - The queue offset to update.
+     /// * `next_visible_time` - The next visible time to set.
+     #[inline]
+     pub fn update_offset_next_visible_time(&mut self, queue_offset: u64, next_visible_time: u64) {
+         self.offset_next_visible_time
+             .insert(queue_offset, next_visible_time);
+     }
+ 
+     /// Gets the next offset for the current order info.
+     ///
+     /// # Returns
+     ///
+     /// An `i64` representing the next offset. Returns -2 if the offset list is empty.
+     pub fn get_next_offset(&self) -> i64 {
+         if self.offset_list.is_empty() {
+             return -2;
+         }
+         let mut i = 0;
+         for j in 0..self.offset_list.len() {
+             if self.is_not_ack(j) {
+                 break;
+             }
+             i += 1;
+         }
+         if i == self.offset_list.len() {
+             self.get_queue_offset(self.offset_list.len() - 1) as i64 + 1
+         } else {
+             self.get_queue_offset(i) as i64
+         }
+     }
+ 
+     /// Gets the queue offset for a given offset index.
+     ///
+     /// # Arguments
+     ///
+     /// * `offset_index` - The index of the offset to get.
+     ///
+     /// # Returns
+     ///
+     /// A `u64` representing the queue offset.
+     pub fn get_queue_offset(&self, offset_index: usize) -> u64 {
+         if offset_index == 0 {
+             return self.offset_list[0];
+         }
+         self.offset_list[0] + self.offset_list[offset_index]
+     }
+ 
+     /// Checks if the offset at the given index is not acknowledged.
+     ///
+     /// # Arguments
+     ///
+     /// * `offset_index` - The index of the offset to check.
+     ///
+     /// # Returns
+     ///
+     /// `true` if the offset is not acknowledged, `false` otherwise.
+     pub fn is_not_ack(&self, offset_index: usize) -> bool {
+         if offset_index >= 64 {
+             return false;
+         }
+         (self.commit_offset_bit & (1 << offset_index)) == 0
+     }
+ 
+     /// Merges the offset consumed count with the previous attempt ID and offset list.
+     ///
+     /// # Arguments
+     ///
+     /// * `pre_attempt_id` - The previous attempt ID.
+     /// * `pre_offset_list` - The previous offset list.
+     /// * `prev_offset_consumed_count` - The previous offset consumed count.
+     pub fn merge_offset_consumed_count(
+         &mut self,
+         pre_attempt_id: &str,
+         pre_offset_list: Vec<u64>,
+         prev_offset_consumed_count: HashMap<u64, i32>,
+     ) {
+         let mut offset_consumed_count = HashMap::new();
+         if pre_attempt_id == self.attempt_id {
+             self.offset_consumed_count = prev_offset_consumed_count;
+             return;
+         }
+         let mut pre_queue_offset_set = HashSet::new();
+         for (index, _) in pre_offset_list.iter().enumerate() {
+             pre_queue_offset_set.insert(Self::get_queue_offset_from_list(&pre_offset_list, index));
+         }
+         for i in 0..self.offset_list.len() {
+             let queue_offset = self.get_queue_offset(i);
+             if pre_queue_offset_set.contains(&queue_offset) {
+                 let mut count = 1;
+                 if let Some(pre_count) = prev_offset_consumed_count.get(&queue_offset) {
+                     count += pre_count;
+                 }
+                 offset_consumed_count.insert(queue_offset, count);
+             }
+         }
+         self.offset_consumed_count = offset_consumed_count;
+     }
+ 
+     /// Gets the queue offset from a list of offsets for a given index.
+     ///
+     /// # Arguments
+     ///
+     /// * `pre_offset_list` - The list of previous offsets.
+     /// * `offset_index` - The index of the offset to get.
+     ///
+     /// # Returns
+     ///
+     /// A `u64` representing the queue offset.
+     fn get_queue_offset_from_list(pre_offset_list: &[u64], offset_index: usize) -> u64 {
+         if offset_index == 0 {
+             return pre_offset_list[0];
+         }
+         pre_offset_list[0] + pre_offset_list[offset_index]
+     }
+ }
+ 
+ #[cfg(test)]
+ mod tests {
+     use std::collections::HashMap;
+ 
+     use super::*;
+ 
+     #[test]
+     fn build_offset_list_with_single_element() {
+         let queue_offset_list = vec![10];
+         let expected = vec![10];
+         assert_eq!(OrderInfo::build_offset_list(queue_offset_list), expected);
+     }
+ 
+     #[test]
+     fn need_block_returns_false_for_empty_offset_list() {
+         let mut order_info = OrderInfo {
+             pop_time: 1000,
+             invisible_time: Some(3000),
+             offset_list: vec![],
+             offset_next_visible_time: HashMap::new(),
+             offset_consumed_count: HashMap::new(),
+             last_consume_timestamp: 0,
+             commit_offset_bit: 0,
+             attempt_id: "test".to_string(),
+         };
+         assert!(!order_info.need_block("another_test", 2000));
+     }
+ 
+     #[test]
+     fn get_lock_free_timestamp_returns_none_for_empty_offset_list() {
+         let order_info = OrderInfo {
+             pop_time: 1000,
+             invisible_time: Some(3000),
+             offset_list: vec![],
+             offset_next_visible_time: HashMap::new(),
+             offset_consumed_count: HashMap::new(),
+             last_consume_timestamp: 0,
+             commit_offset_bit: 0,
+             attempt_id: "test".to_string(),
+         };
+         assert_eq!(order_info.get_lock_free_timestamp(), None);
+     }
+ 
+     #[test]
+     fn get_next_offset_returns_minus_two_for_empty_offset_list() {
+         let order_info = OrderInfo {
+             pop_time: 1000,
+             invisible_time: Some(3000),
+             offset_list: vec![],
+             offset_next_visible_time: HashMap::new(),
+             offset_consumed_count: HashMap::new(),
+             last_consume_timestamp: 0,
+             commit_offset_bit: 0,
+             attempt_id: "test".to_string(),
+         };
+         assert_eq!(order_info.get_next_offset(), -2);
+     }
+ 
+     #[test]
+     fn merge_offset_consumed_count_with_same_attempt_id() {
+         let mut order_info = OrderInfo {
+             pop_time: 0,
+             invisible_time: None,
+             offset_list: vec![1, 2, 3],
+             offset_next_visible_time: HashMap::new(),
+             offset_consumed_count: HashMap::new(),
+             last_consume_timestamp: 0,
+             commit_offset_bit: 0,
+             attempt_id: "test".to_string(),
+         };
+         let pre_offset_list = vec![1, 2];
+         let prev_offset_consumed_count = HashMap::from([(1, 1), (2, 1)]);
+         order_info.merge_offset_consumed_count("test", pre_offset_list, prev_offset_consumed_count);
+         assert_eq!(order_info.offset_consumed_count.get(&1), Some(&1));
+         assert_eq!(order_info.offset_consumed_count.get(&2), Some(&1));
+     }
+ }
+ 

--- a/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
@@ -14,609 +14,608 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- #![allow(unused_variables)]
+#![allow(unused_variables)]
 
- use std::collections::HashMap;
- use std::collections::HashSet;
- use std::fmt::Display;
- use std::ops::Deref;
- use std::sync::Arc;
- 
- use cheetah_string::CheetahString;
- use rocketmq_common::common::broker::broker_config::BrokerConfig;
- use rocketmq_common::common::config_manager::ConfigManager;
- use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
- use rocketmq_common::TimeUtils::get_current_millis;
- use serde::Deserialize;
- use serde::Serialize;
- use tracing::info;
- use tracing::warn;
- 
- use crate::broker_path_config_helper::get_consumer_order_info_path;
- use crate::offset::manager::consumer_order_info_lock_manager::ConsumerOrderInfoLockManager;
- use crate::subscription::manager::subscription_group_manager::SubscriptionGroupManager;
- use crate::topic::manager::topic_config_manager::TopicConfigManager;
- 
- const TOPIC_GROUP_SEPARATOR: &str = "@";
- const CLEAN_SPAN_FROM_LAST: u64 = 24 * 3600 * 1000;
- 
- pub(crate) struct ConsumerOrderInfoManager<MS> {
-     pub(crate) broker_config: Arc<BrokerConfig>,
-     pub(crate) consumer_order_info_wrapper: parking_lot::Mutex<ConsumerOrderInfoWrapper>,
-     pub(crate) consumer_order_info_lock_manager: Option<ConsumerOrderInfoLockManager>,
-     pub(crate) topic_config_manager: Arc<TopicConfigManager>,
-     pub(crate) subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
- }
- 
- impl<MS> ConsumerOrderInfoManager<MS> {
-     pub fn new(
-         broker_config: Arc<BrokerConfig>,
-         topic_config_manager: Arc<TopicConfigManager>,
-         subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
-     ) -> ConsumerOrderInfoManager<MS> {
-         Self {
-             broker_config,
-             consumer_order_info_wrapper: parking_lot::Mutex::new(
-                 ConsumerOrderInfoWrapper::default(),
-             ),
-             consumer_order_info_lock_manager: None,
-             topic_config_manager,
-             subscription_group_manager,
-         }
-     }
- }
- 
- //Fully implemented will be removed
- #[allow(unused_variables)]
- impl<MS> ConfigManager for ConsumerOrderInfoManager<MS> {
-     fn config_file_path(&self) -> String {
-         get_consumer_order_info_path(self.broker_config.store_path_root_dir.as_str())
-     }
- 
-     fn encode_pretty(&self, pretty_format: bool) -> String {
-         self.auto_clean();
-         let wrapper = self.consumer_order_info_wrapper.lock();
-         match pretty_format {
-             true => SerdeJsonUtils::to_json_pretty(&wrapper.table)
-                 .expect("Failed to serialize consumer order info wrapper"),
-             false => serde_json::to_string(&wrapper.table)
-                 .expect("Failed to serialize consumer order info wrapper"),
-         }
-     }
- 
-     fn decode(&self, json_string: &str) {
-         if json_string.is_empty() {
-             return;
-         }
-         let wrapper =
-             serde_json::from_str::<ConsumerOrderInfoWrapper>(json_string).unwrap_or_default();
-         if !wrapper.table.is_empty() {
-             self.consumer_order_info_wrapper
-                 .lock()
-                 .table
-                 .clone_from(&wrapper.table);
-             if self.consumer_order_info_lock_manager.is_some() {
-                 self.consumer_order_info_lock_manager
-                     .as_ref()
-                     .unwrap()
-                     .recover(self.consumer_order_info_wrapper.lock().deref());
-             }
-         }
-     }
- }
- 
- impl<MS> ConsumerOrderInfoManager<MS> {
-     pub fn auto_clean(&self) {
-         let mut consumer_order_info_wrapper = self.consumer_order_info_wrapper.lock();
-         let table = &mut consumer_order_info_wrapper.table;
- 
-         // Iterate through the `table` entries (topic@group -> queueId -> OrderInfo)
-         let mut keys_to_remove = Vec::new(); // Temporary storage for keys to remove
- 
-         for (topic_at_group, qs) in table.iter_mut() {
-             let arrays: Vec<&str> = topic_at_group.split('@').collect();
-             if arrays.len() != 2 {
-                 continue;
-             }
-             let topic = arrays[0];
-             let group = arrays[1];
- 
-             let topic_config = self
-                 .topic_config_manager
-                 .select_topic_config(&CheetahString::from(topic));
-             if topic_config.is_none() {
-                 info!(
-                     "Topic not exist, Clean order info, {}:{:?}",
-                     topic_at_group, qs
-                 );
-                 keys_to_remove.push(topic_at_group.clone());
-                 continue;
-             }
-             let subscription_group_wrapper = self
-                 .subscription_group_manager
-                 .subscription_group_wrapper()
-                 .lock();
-             let subscription_group_config = subscription_group_wrapper
-                 .subscription_group_table()
-                 .get(&CheetahString::from(group));
-             if subscription_group_config.is_none() {
-                 info!(
-                     "Group not exist, Clean order info, {}:{:?}",
-                     topic_at_group, qs
-                 );
-                 keys_to_remove.push(topic_at_group.clone());
-                 continue;
-             }
- 
-             if qs.is_empty() {
-                 info!(
-                     "Order table is empty, Clean order info, {}:{:?}",
-                     topic_at_group, qs
-                 );
-                 keys_to_remove.push(topic_at_group.clone());
-                 continue;
-             }
-             let topic_config = topic_config.unwrap();
-             // Clean individual queues in the current topic@group
-             let mut queues_to_remove = Vec::new();
-             for (queue_id, order_info) in qs.iter_mut() {
-                 if *queue_id == topic_config.read_queue_nums as i32 {
-                     queues_to_remove.push(*queue_id);
-                     info!(
-                         "Queue not exist, Clean order info, {}:{}, {}",
-                         topic_at_group, order_info, topic_config
-                     );
-                     continue;
-                 }
-             }
- 
-             // Remove stale or invalid queues
-             for queue_id in queues_to_remove {
-                 qs.remove(&queue_id);
-                 info!(
-                     "Removed queue {} for topic@group {}",
-                     queue_id, topic_at_group
-                 );
-             }
- 
-             // If all queues are removed, mark topic@group for removal
-             if qs.is_empty() {
-                 keys_to_remove.push(topic_at_group.clone());
-             }
-         }
- 
-         // Now, remove all topics/groups from the table that need to be cleaned
-         for key in keys_to_remove {
-             table.remove(&key);
-             info!("Removed topic@group {}", key);
-         }
-     }
- 
-     pub fn update_next_visible_time(
-         &self,
-         topic: &CheetahString,
-         group: &CheetahString,
-         queue_id: i32,
-         queue_offset: u64,
-         pop_time: u64,
-         next_visible_time: u64,
-     ) {
-         let key = CheetahString::from_string(build_key(topic, group));
-         let mut table = self.consumer_order_info_wrapper.lock();
-         let qs = table.table.get_mut(&key);
-         if qs.is_none() {
-             warn!(
-                 "orderInfo of queueId is null. key: {}, queueOffset: {}, queueId: {}",
-                 key, queue_offset, queue_id
-             );
-             return;
-         }
-         let qs = qs.unwrap();
-         let order_info = qs.get_mut(&queue_id);
-         if order_info.is_none() {
-             warn!(
-                 "orderInfo of queueId is null. key: {}, queueOffset: {}, queueId: {}",
-                 key, queue_offset, queue_id
-             );
-             return;
-         }
-         let order_info = order_info.unwrap();
-         if pop_time != order_info.pop_time {
-             warn!(
-                 "popTime is not equal to orderInfo saved. key: {}, queueOffset: {}, orderInfo: \
-                  {}, popTime: {}",
-                 key, queue_offset, queue_id, pop_time,
-             );
-             return;
-         }
-         order_info.update_offset_next_visible_time(queue_offset, next_visible_time);
-         self.update_lock_free_timestamp(topic, group, queue_id, order_info);
-     }
- 
-     fn update_lock_free_timestamp(
-         &self,
-         _topic: &CheetahString,
-         _group: &CheetahString,
-         _queue_id: i32,
-         _order_info: &OrderInfo,
-     ) {
-         unimplemented!("")
-     }
- 
-     pub fn commit_and_next(
-         &self,
-         topic: &CheetahString,
-         group: &CheetahString,
-         queue_id: i32,
-         queue_offset: u64,
-         pop_time: u64,
-     ) -> i64 {
-         unimplemented!()
-     }
- 
-     pub fn check_block(
-         &self,
-         attempt_id: &CheetahString,
-         topic: &CheetahString,
-         group: &CheetahString,
-         queue_id: i32,
-         invisible_time: u64,
-     ) -> bool {
-         unimplemented!()
-     }
- 
-     pub fn update(
-         &self,
-         attempt_id: CheetahString,
-         is_retry: bool,
-         topic: &CheetahString,
-         group: &CheetahString,
-         queue_id: i32,
-         pop_time: u64,
-         invisible_time: u64,
-         msg_queue_offset_list: Vec<u64>,
-         order_info_builder: &str,
-     ) -> bool {
-         unimplemented!()
-     }
- }
- 
- #[inline]
- #[must_use]
- fn build_key(topic: &CheetahString, group: &CheetahString) -> String {
-     format!("{}{}{}", topic, TOPIC_GROUP_SEPARATOR, group)
- }
- 
- #[derive(Debug, Default, Serialize, Deserialize, Clone)]
- pub(crate) struct ConsumerOrderInfoWrapper {
-     table: HashMap<CheetahString /* topic@group */, HashMap<i32, OrderInfo>>,
- }
- 
- #[derive(Debug, Default, Serialize, Deserialize, Clone)]
- pub(crate) struct OrderInfo {
-     #[serde(rename = "popTime")]
-     pop_time: u64,
-     #[serde(rename = "i")]
-     invisible_time: Option<u64>,
-     #[serde(rename = "0")]
-     offset_list: Vec<u64>,
-     #[serde(rename = "ot")]
-     offset_next_visible_time: HashMap<u64, u64>,
-     #[serde(rename = "oc")]
-     offset_consumed_count: HashMap<u64, i32>,
-     #[serde(rename = "l")]
-     last_consume_timestamp: u64,
-     #[serde(rename = "cm")]
-     commit_offset_bit: u64,
-     #[serde(rename = "a")]
-     attempt_id: String,
- }
- 
- impl Display for OrderInfo {
-     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-         write!(
-             f,
-             "OrderInfo {{ popTime: {}, invisibleTime: {:?}, offsetList: {:?}, \
-              offsetNextVisibleTime: {:?}, offsetConsumedCount: {:?}, lastConsumeTimestamp: {}, \
-              commitOffsetBit: {}, attemptId: {} }}",
-             self.pop_time,
-             self.invisible_time,
-             self.offset_list,
-             self.offset_next_visible_time,
-             self.offset_consumed_count,
-             self.last_consume_timestamp,
-             self.commit_offset_bit,
-             self.attempt_id
-         )
-     }
- }
- 
- impl OrderInfo {
-     /// Builds a list of offsets from a given list of queue offsets.
-     /// If the list contains only one element, it returns the same list.
-     /// Otherwise, it returns a list where each element is the difference
-     /// between the current and the first element.
-     ///
-     /// # Arguments
-     ///
-     /// * `queue_offset_list` - A vector of queue offsets.
-     ///
-     /// # Returns
-     ///
-     /// A vector of offsets.
-     pub fn build_offset_list(queue_offset_list: Vec<u64>) -> Vec<u64> {
-         let mut simple = Vec::new();
-         if queue_offset_list.len() == 1 {
-             simple.extend(queue_offset_list);
-             return simple;
-         }
-         let first = queue_offset_list[0];
-         simple.push(first);
-         for item in queue_offset_list.iter().skip(1) {
-             simple.push(*item - first);
-         }
-         simple
-     }
- 
-     /// Determines if the current order info needs to be blocked based on the attempt ID
-     /// and the current invisible time.
-     ///
-     /// # Arguments
-     ///
-     /// * `attempt_id` - The attempt ID to check.
-     /// * `current_invisible_time` - The current invisible time.
-     ///
-     /// # Returns
-     ///
-     /// `true` if the order info needs to be blocked, `false` otherwise.
-     pub fn need_block(&mut self, attempt_id: &str, current_invisible_time: u64) -> bool {
-         if self.offset_list.is_empty() {
-             return false;
-         }
-         if self.attempt_id == attempt_id {
-             return false;
-         }
-         let num = self.offset_list.len();
-         if self.invisible_time.is_none() || self.invisible_time.unwrap_or(0) == 0 {
-             self.invisible_time = Some(current_invisible_time);
-         }
-         let current_time = get_current_millis();
-         for (i, _) in (0..num).enumerate() {
-             if self.is_not_ack(i) {
-                 let mut next_visible_time = self.pop_time + self.invisible_time.unwrap_or(0);
-                 if let Some(time) = self.offset_next_visible_time.get(&self.get_queue_offset(i)) {
-                     next_visible_time = *time;
-                 }
-                 if current_time < next_visible_time {
-                     return true;
-                 }
-             }
-         }
-         false
-     }
- 
-     /// Gets the lock-free timestamp for the current order info.
-     ///
-     /// # Returns
-     ///
-     /// An `Option<u64>` containing the lock-free timestamp if available, `None` otherwise.
-     pub fn get_lock_free_timestamp(&self) -> Option<u64> {
-         if self.offset_list.is_empty() {
-             return None;
-         }
-         let current_time = get_current_millis();
-         for i in 0..self.offset_list.len() {
-             if self.is_not_ack(i) {
-                 if self.invisible_time.is_none() || self.invisible_time.unwrap_or(0) == 0 {
-                     return None;
-                 }
-                 let mut next_visible_time = self.pop_time + self.invisible_time.unwrap_or(0);
-                 if let Some(time) = self.offset_next_visible_time.get(&self.get_queue_offset(i)) {
-                     next_visible_time = *time;
-                 }
-                 if current_time < next_visible_time {
-                     return Some(next_visible_time);
-                 }
-             }
-         }
-         Some(current_time)
-     }
- 
-     /// Updates the next visible time for a given queue offset.
-     ///
-     /// # Arguments
-     ///
-     /// * `queue_offset` - The queue offset to update.
-     /// * `next_visible_time` - The next visible time to set.
-     #[inline]
-     pub fn update_offset_next_visible_time(&mut self, queue_offset: u64, next_visible_time: u64) {
-         self.offset_next_visible_time
-             .insert(queue_offset, next_visible_time);
-     }
- 
-     /// Gets the next offset for the current order info.
-     ///
-     /// # Returns
-     ///
-     /// An `i64` representing the next offset. Returns -2 if the offset list is empty.
-     pub fn get_next_offset(&self) -> i64 {
-         if self.offset_list.is_empty() {
-             return -2;
-         }
-         let mut i = 0;
-         for j in 0..self.offset_list.len() {
-             if self.is_not_ack(j) {
-                 break;
-             }
-             i += 1;
-         }
-         if i == self.offset_list.len() {
-             self.get_queue_offset(self.offset_list.len() - 1) as i64 + 1
-         } else {
-             self.get_queue_offset(i) as i64
-         }
-     }
- 
-     /// Gets the queue offset for a given offset index.
-     ///
-     /// # Arguments
-     ///
-     /// * `offset_index` - The index of the offset to get.
-     ///
-     /// # Returns
-     ///
-     /// A `u64` representing the queue offset.
-     pub fn get_queue_offset(&self, offset_index: usize) -> u64 {
-         if offset_index == 0 {
-             return self.offset_list[0];
-         }
-         self.offset_list[0] + self.offset_list[offset_index]
-     }
- 
-     /// Checks if the offset at the given index is not acknowledged.
-     ///
-     /// # Arguments
-     ///
-     /// * `offset_index` - The index of the offset to check.
-     ///
-     /// # Returns
-     ///
-     /// `true` if the offset is not acknowledged, `false` otherwise.
-     pub fn is_not_ack(&self, offset_index: usize) -> bool {
-         if offset_index >= 64 {
-             return false;
-         }
-         (self.commit_offset_bit & (1 << offset_index)) == 0
-     }
- 
-     /// Merges the offset consumed count with the previous attempt ID and offset list.
-     ///
-     /// # Arguments
-     ///
-     /// * `pre_attempt_id` - The previous attempt ID.
-     /// * `pre_offset_list` - The previous offset list.
-     /// * `prev_offset_consumed_count` - The previous offset consumed count.
-     pub fn merge_offset_consumed_count(
-         &mut self,
-         pre_attempt_id: &str,
-         pre_offset_list: Vec<u64>,
-         prev_offset_consumed_count: HashMap<u64, i32>,
-     ) {
-         let mut offset_consumed_count = HashMap::new();
-         if pre_attempt_id == self.attempt_id {
-             self.offset_consumed_count = prev_offset_consumed_count;
-             return;
-         }
-         let mut pre_queue_offset_set = HashSet::new();
-         for (index, _) in pre_offset_list.iter().enumerate() {
-             pre_queue_offset_set.insert(Self::get_queue_offset_from_list(&pre_offset_list, index));
-         }
-         for i in 0..self.offset_list.len() {
-             let queue_offset = self.get_queue_offset(i);
-             if pre_queue_offset_set.contains(&queue_offset) {
-                 let mut count = 1;
-                 if let Some(pre_count) = prev_offset_consumed_count.get(&queue_offset) {
-                     count += pre_count;
-                 }
-                 offset_consumed_count.insert(queue_offset, count);
-             }
-         }
-         self.offset_consumed_count = offset_consumed_count;
-     }
- 
-     /// Gets the queue offset from a list of offsets for a given index.
-     ///
-     /// # Arguments
-     ///
-     /// * `pre_offset_list` - The list of previous offsets.
-     /// * `offset_index` - The index of the offset to get.
-     ///
-     /// # Returns
-     ///
-     /// A `u64` representing the queue offset.
-     fn get_queue_offset_from_list(pre_offset_list: &[u64], offset_index: usize) -> u64 {
-         if offset_index == 0 {
-             return pre_offset_list[0];
-         }
-         pre_offset_list[0] + pre_offset_list[offset_index]
-     }
- }
- 
- #[cfg(test)]
- mod tests {
-     use std::collections::HashMap;
- 
-     use super::*;
- 
-     #[test]
-     fn build_offset_list_with_single_element() {
-         let queue_offset_list = vec![10];
-         let expected = vec![10];
-         assert_eq!(OrderInfo::build_offset_list(queue_offset_list), expected);
-     }
- 
-     #[test]
-     fn need_block_returns_false_for_empty_offset_list() {
-         let mut order_info = OrderInfo {
-             pop_time: 1000,
-             invisible_time: Some(3000),
-             offset_list: vec![],
-             offset_next_visible_time: HashMap::new(),
-             offset_consumed_count: HashMap::new(),
-             last_consume_timestamp: 0,
-             commit_offset_bit: 0,
-             attempt_id: "test".to_string(),
-         };
-         assert!(!order_info.need_block("another_test", 2000));
-     }
- 
-     #[test]
-     fn get_lock_free_timestamp_returns_none_for_empty_offset_list() {
-         let order_info = OrderInfo {
-             pop_time: 1000,
-             invisible_time: Some(3000),
-             offset_list: vec![],
-             offset_next_visible_time: HashMap::new(),
-             offset_consumed_count: HashMap::new(),
-             last_consume_timestamp: 0,
-             commit_offset_bit: 0,
-             attempt_id: "test".to_string(),
-         };
-         assert_eq!(order_info.get_lock_free_timestamp(), None);
-     }
- 
-     #[test]
-     fn get_next_offset_returns_minus_two_for_empty_offset_list() {
-         let order_info = OrderInfo {
-             pop_time: 1000,
-             invisible_time: Some(3000),
-             offset_list: vec![],
-             offset_next_visible_time: HashMap::new(),
-             offset_consumed_count: HashMap::new(),
-             last_consume_timestamp: 0,
-             commit_offset_bit: 0,
-             attempt_id: "test".to_string(),
-         };
-         assert_eq!(order_info.get_next_offset(), -2);
-     }
- 
-     #[test]
-     fn merge_offset_consumed_count_with_same_attempt_id() {
-         let mut order_info = OrderInfo {
-             pop_time: 0,
-             invisible_time: None,
-             offset_list: vec![1, 2, 3],
-             offset_next_visible_time: HashMap::new(),
-             offset_consumed_count: HashMap::new(),
-             last_consume_timestamp: 0,
-             commit_offset_bit: 0,
-             attempt_id: "test".to_string(),
-         };
-         let pre_offset_list = vec![1, 2];
-         let prev_offset_consumed_count = HashMap::from([(1, 1), (2, 1)]);
-         order_info.merge_offset_consumed_count("test", pre_offset_list, prev_offset_consumed_count);
-         assert_eq!(order_info.offset_consumed_count.get(&1), Some(&1));
-         assert_eq!(order_info.offset_consumed_count.get(&2), Some(&1));
-     }
- }
- 
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fmt::Display;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_common::common::config_manager::ConfigManager;
+use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
+use rocketmq_common::TimeUtils::get_current_millis;
+use serde::Deserialize;
+use serde::Serialize;
+use tracing::info;
+use tracing::warn;
+
+use crate::broker_path_config_helper::get_consumer_order_info_path;
+use crate::offset::manager::consumer_order_info_lock_manager::ConsumerOrderInfoLockManager;
+use crate::subscription::manager::subscription_group_manager::SubscriptionGroupManager;
+use crate::topic::manager::topic_config_manager::TopicConfigManager;
+
+const TOPIC_GROUP_SEPARATOR: &str = "@";
+const CLEAN_SPAN_FROM_LAST: u64 = 24 * 3600 * 1000;
+
+pub(crate) struct ConsumerOrderInfoManager<MS> {
+    pub(crate) broker_config: Arc<BrokerConfig>,
+    pub(crate) consumer_order_info_wrapper: parking_lot::Mutex<ConsumerOrderInfoWrapper>,
+    pub(crate) consumer_order_info_lock_manager: Option<ConsumerOrderInfoLockManager>,
+    pub(crate) topic_config_manager: Arc<TopicConfigManager>,
+    pub(crate) subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
+}
+
+impl<MS> ConsumerOrderInfoManager<MS> {
+    pub fn new(
+        broker_config: Arc<BrokerConfig>,
+        topic_config_manager: Arc<TopicConfigManager>,
+        subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
+    ) -> ConsumerOrderInfoManager<MS> {
+        Self {
+            broker_config,
+            consumer_order_info_wrapper: parking_lot::Mutex::new(
+                ConsumerOrderInfoWrapper::default(),
+            ),
+            consumer_order_info_lock_manager: None,
+            topic_config_manager,
+            subscription_group_manager,
+        }
+    }
+}
+
+//Fully implemented will be removed
+#[allow(unused_variables)]
+impl<MS> ConfigManager for ConsumerOrderInfoManager<MS> {
+    fn config_file_path(&self) -> String {
+        get_consumer_order_info_path(self.broker_config.store_path_root_dir.as_str())
+    }
+
+    fn encode_pretty(&self, pretty_format: bool) -> String {
+        self.auto_clean();
+        let wrapper = self.consumer_order_info_wrapper.lock();
+        match pretty_format {
+            true => SerdeJsonUtils::to_json_pretty(&wrapper.table)
+                .expect("Failed to serialize consumer order info wrapper"),
+            false => serde_json::to_string(&wrapper.table)
+                .expect("Failed to serialize consumer order info wrapper"),
+        }
+    }
+
+    fn decode(&self, json_string: &str) {
+        if json_string.is_empty() {
+            return;
+        }
+        let wrapper =
+            serde_json::from_str::<ConsumerOrderInfoWrapper>(json_string).unwrap_or_default();
+        if !wrapper.table.is_empty() {
+            self.consumer_order_info_wrapper
+                .lock()
+                .table
+                .clone_from(&wrapper.table);
+            if self.consumer_order_info_lock_manager.is_some() {
+                self.consumer_order_info_lock_manager
+                    .as_ref()
+                    .unwrap()
+                    .recover(self.consumer_order_info_wrapper.lock().deref());
+            }
+        }
+    }
+}
+
+impl<MS> ConsumerOrderInfoManager<MS> {
+    pub fn auto_clean(&self) {
+        let mut consumer_order_info_wrapper = self.consumer_order_info_wrapper.lock();
+        let table = &mut consumer_order_info_wrapper.table;
+
+        // Iterate through the `table` entries (topic@group -> queueId -> OrderInfo)
+        let mut keys_to_remove = Vec::new(); // Temporary storage for keys to remove
+
+        for (topic_at_group, qs) in table.iter_mut() {
+            let arrays: Vec<&str> = topic_at_group.split('@').collect();
+            if arrays.len() != 2 {
+                continue;
+            }
+            let topic = arrays[0];
+            let group = arrays[1];
+
+            let topic_config = self
+                .topic_config_manager
+                .select_topic_config(&CheetahString::from(topic));
+            if topic_config.is_none() {
+                info!(
+                    "Topic not exist, Clean order info, {}:{:?}",
+                    topic_at_group, qs
+                );
+                keys_to_remove.push(topic_at_group.clone());
+                continue;
+            }
+            let subscription_group_wrapper = self
+                .subscription_group_manager
+                .subscription_group_wrapper()
+                .lock();
+            let subscription_group_config = subscription_group_wrapper
+                .subscription_group_table()
+                .get(&CheetahString::from(group));
+            if subscription_group_config.is_none() {
+                info!(
+                    "Group not exist, Clean order info, {}:{:?}",
+                    topic_at_group, qs
+                );
+                keys_to_remove.push(topic_at_group.clone());
+                continue;
+            }
+
+            if qs.is_empty() {
+                info!(
+                    "Order table is empty, Clean order info, {}:{:?}",
+                    topic_at_group, qs
+                );
+                keys_to_remove.push(topic_at_group.clone());
+                continue;
+            }
+            let topic_config = topic_config.unwrap();
+            // Clean individual queues in the current topic@group
+            let mut queues_to_remove = Vec::new();
+            for (queue_id, order_info) in qs.iter_mut() {
+                if *queue_id == topic_config.read_queue_nums as i32 {
+                    queues_to_remove.push(*queue_id);
+                    info!(
+                        "Queue not exist, Clean order info, {}:{}, {}",
+                        topic_at_group, order_info, topic_config
+                    );
+                    continue;
+                }
+            }
+
+            // Remove stale or invalid queues
+            for queue_id in queues_to_remove {
+                qs.remove(&queue_id);
+                info!(
+                    "Removed queue {} for topic@group {}",
+                    queue_id, topic_at_group
+                );
+            }
+
+            // If all queues are removed, mark topic@group for removal
+            if qs.is_empty() {
+                keys_to_remove.push(topic_at_group.clone());
+            }
+        }
+
+        // Now, remove all topics/groups from the table that need to be cleaned
+        for key in keys_to_remove {
+            table.remove(&key);
+            info!("Removed topic@group {}", key);
+        }
+    }
+
+    pub fn update_next_visible_time(
+        &self,
+        topic: &CheetahString,
+        group: &CheetahString,
+        queue_id: i32,
+        queue_offset: u64,
+        pop_time: u64,
+        next_visible_time: u64,
+    ) {
+        let key = CheetahString::from_string(build_key(topic, group));
+        let mut table = self.consumer_order_info_wrapper.lock();
+        let qs = table.table.get_mut(&key);
+        if qs.is_none() {
+            warn!(
+                "orderInfo of queueId is null. key: {}, queueOffset: {}, queueId: {}",
+                key, queue_offset, queue_id
+            );
+            return;
+        }
+        let qs = qs.unwrap();
+        let order_info = qs.get_mut(&queue_id);
+        if order_info.is_none() {
+            warn!(
+                "orderInfo of queueId is null. key: {}, queueOffset: {}, queueId: {}",
+                key, queue_offset, queue_id
+            );
+            return;
+        }
+        let order_info = order_info.unwrap();
+        if pop_time != order_info.pop_time {
+            warn!(
+                "popTime is not equal to orderInfo saved. key: {}, queueOffset: {}, orderInfo: \
+                 {}, popTime: {}",
+                key, queue_offset, queue_id, pop_time,
+            );
+            return;
+        }
+        order_info.update_offset_next_visible_time(queue_offset, next_visible_time);
+        self.update_lock_free_timestamp(topic, group, queue_id, order_info);
+    }
+
+    fn update_lock_free_timestamp(
+        &self,
+        _topic: &CheetahString,
+        _group: &CheetahString,
+        _queue_id: i32,
+        _order_info: &OrderInfo,
+    ) {
+        unimplemented!("")
+    }
+
+    pub fn commit_and_next(
+        &self,
+        topic: &CheetahString,
+        group: &CheetahString,
+        queue_id: i32,
+        queue_offset: u64,
+        pop_time: u64,
+    ) -> i64 {
+        unimplemented!()
+    }
+
+    pub fn check_block(
+        &self,
+        attempt_id: &CheetahString,
+        topic: &CheetahString,
+        group: &CheetahString,
+        queue_id: i32,
+        invisible_time: u64,
+    ) -> bool {
+        unimplemented!()
+    }
+
+    pub fn update(
+        &self,
+        attempt_id: CheetahString,
+        is_retry: bool,
+        topic: &CheetahString,
+        group: &CheetahString,
+        queue_id: i32,
+        pop_time: u64,
+        invisible_time: u64,
+        msg_queue_offset_list: Vec<u64>,
+        order_info_builder: &str,
+    ) -> bool {
+        unimplemented!()
+    }
+}
+
+#[inline]
+#[must_use]
+fn build_key(topic: &CheetahString, group: &CheetahString) -> String {
+    format!("{}{}{}", topic, TOPIC_GROUP_SEPARATOR, group)
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub(crate) struct ConsumerOrderInfoWrapper {
+    table: HashMap<CheetahString /* topic@group */, HashMap<i32, OrderInfo>>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub(crate) struct OrderInfo {
+    #[serde(rename = "popTime")]
+    pop_time: u64,
+    #[serde(rename = "i")]
+    invisible_time: Option<u64>,
+    #[serde(rename = "0")]
+    offset_list: Vec<u64>,
+    #[serde(rename = "ot")]
+    offset_next_visible_time: HashMap<u64, u64>,
+    #[serde(rename = "oc")]
+    offset_consumed_count: HashMap<u64, i32>,
+    #[serde(rename = "l")]
+    last_consume_timestamp: u64,
+    #[serde(rename = "cm")]
+    commit_offset_bit: u64,
+    #[serde(rename = "a")]
+    attempt_id: String,
+}
+
+impl Display for OrderInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "OrderInfo {{ popTime: {}, invisibleTime: {:?}, offsetList: {:?}, \
+             offsetNextVisibleTime: {:?}, offsetConsumedCount: {:?}, lastConsumeTimestamp: {}, \
+             commitOffsetBit: {}, attemptId: {} }}",
+            self.pop_time,
+            self.invisible_time,
+            self.offset_list,
+            self.offset_next_visible_time,
+            self.offset_consumed_count,
+            self.last_consume_timestamp,
+            self.commit_offset_bit,
+            self.attempt_id
+        )
+    }
+}
+
+impl OrderInfo {
+    /// Builds a list of offsets from a given list of queue offsets.
+    /// If the list contains only one element, it returns the same list.
+    /// Otherwise, it returns a list where each element is the difference
+    /// between the current and the first element.
+    ///
+    /// # Arguments
+    ///
+    /// * `queue_offset_list` - A vector of queue offsets.
+    ///
+    /// # Returns
+    ///
+    /// A vector of offsets.
+    pub fn build_offset_list(queue_offset_list: Vec<u64>) -> Vec<u64> {
+        let mut simple = Vec::new();
+        if queue_offset_list.len() == 1 {
+            simple.extend(queue_offset_list);
+            return simple;
+        }
+        let first = queue_offset_list[0];
+        simple.push(first);
+        for item in queue_offset_list.iter().skip(1) {
+            simple.push(*item - first);
+        }
+        simple
+    }
+
+    /// Determines if the current order info needs to be blocked based on the attempt ID
+    /// and the current invisible time.
+    ///
+    /// # Arguments
+    ///
+    /// * `attempt_id` - The attempt ID to check.
+    /// * `current_invisible_time` - The current invisible time.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the order info needs to be blocked, `false` otherwise.
+    pub fn need_block(&mut self, attempt_id: &str, current_invisible_time: u64) -> bool {
+        if self.offset_list.is_empty() {
+            return false;
+        }
+        if self.attempt_id == attempt_id {
+            return false;
+        }
+        let num = self.offset_list.len();
+        if self.invisible_time.is_none() || self.invisible_time.unwrap_or(0) == 0 {
+            self.invisible_time = Some(current_invisible_time);
+        }
+        let current_time = get_current_millis();
+        for (i, _) in (0..num).enumerate() {
+            if self.is_not_ack(i) {
+                let mut next_visible_time = self.pop_time + self.invisible_time.unwrap_or(0);
+                if let Some(time) = self.offset_next_visible_time.get(&self.get_queue_offset(i)) {
+                    next_visible_time = *time;
+                }
+                if current_time < next_visible_time {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Gets the lock-free timestamp for the current order info.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<u64>` containing the lock-free timestamp if available, `None` otherwise.
+    pub fn get_lock_free_timestamp(&self) -> Option<u64> {
+        if self.offset_list.is_empty() {
+            return None;
+        }
+        let current_time = get_current_millis();
+        for i in 0..self.offset_list.len() {
+            if self.is_not_ack(i) {
+                if self.invisible_time.is_none() || self.invisible_time.unwrap_or(0) == 0 {
+                    return None;
+                }
+                let mut next_visible_time = self.pop_time + self.invisible_time.unwrap_or(0);
+                if let Some(time) = self.offset_next_visible_time.get(&self.get_queue_offset(i)) {
+                    next_visible_time = *time;
+                }
+                if current_time < next_visible_time {
+                    return Some(next_visible_time);
+                }
+            }
+        }
+        Some(current_time)
+    }
+
+    /// Updates the next visible time for a given queue offset.
+    ///
+    /// # Arguments
+    ///
+    /// * `queue_offset` - The queue offset to update.
+    /// * `next_visible_time` - The next visible time to set.
+    #[inline]
+    pub fn update_offset_next_visible_time(&mut self, queue_offset: u64, next_visible_time: u64) {
+        self.offset_next_visible_time
+            .insert(queue_offset, next_visible_time);
+    }
+
+    /// Gets the next offset for the current order info.
+    ///
+    /// # Returns
+    ///
+    /// An `i64` representing the next offset. Returns -2 if the offset list is empty.
+    pub fn get_next_offset(&self) -> i64 {
+        if self.offset_list.is_empty() {
+            return -2;
+        }
+        let mut i = 0;
+        for j in 0..self.offset_list.len() {
+            if self.is_not_ack(j) {
+                break;
+            }
+            i += 1;
+        }
+        if i == self.offset_list.len() {
+            self.get_queue_offset(self.offset_list.len() - 1) as i64 + 1
+        } else {
+            self.get_queue_offset(i) as i64
+        }
+    }
+
+    /// Gets the queue offset for a given offset index.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset_index` - The index of the offset to get.
+    ///
+    /// # Returns
+    ///
+    /// A `u64` representing the queue offset.
+    pub fn get_queue_offset(&self, offset_index: usize) -> u64 {
+        if offset_index == 0 {
+            return self.offset_list[0];
+        }
+        self.offset_list[0] + self.offset_list[offset_index]
+    }
+
+    /// Checks if the offset at the given index is not acknowledged.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset_index` - The index of the offset to check.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the offset is not acknowledged, `false` otherwise.
+    pub fn is_not_ack(&self, offset_index: usize) -> bool {
+        if offset_index >= 64 {
+            return false;
+        }
+        (self.commit_offset_bit & (1 << offset_index)) == 0
+    }
+
+    /// Merges the offset consumed count with the previous attempt ID and offset list.
+    ///
+    /// # Arguments
+    ///
+    /// * `pre_attempt_id` - The previous attempt ID.
+    /// * `pre_offset_list` - The previous offset list.
+    /// * `prev_offset_consumed_count` - The previous offset consumed count.
+    pub fn merge_offset_consumed_count(
+        &mut self,
+        pre_attempt_id: &str,
+        pre_offset_list: Vec<u64>,
+        prev_offset_consumed_count: HashMap<u64, i32>,
+    ) {
+        let mut offset_consumed_count = HashMap::new();
+        if pre_attempt_id == self.attempt_id {
+            self.offset_consumed_count = prev_offset_consumed_count;
+            return;
+        }
+        let mut pre_queue_offset_set = HashSet::new();
+        for (index, _) in pre_offset_list.iter().enumerate() {
+            pre_queue_offset_set.insert(Self::get_queue_offset_from_list(&pre_offset_list, index));
+        }
+        for i in 0..self.offset_list.len() {
+            let queue_offset = self.get_queue_offset(i);
+            if pre_queue_offset_set.contains(&queue_offset) {
+                let mut count = 1;
+                if let Some(pre_count) = prev_offset_consumed_count.get(&queue_offset) {
+                    count += pre_count;
+                }
+                offset_consumed_count.insert(queue_offset, count);
+            }
+        }
+        self.offset_consumed_count = offset_consumed_count;
+    }
+
+    /// Gets the queue offset from a list of offsets for a given index.
+    ///
+    /// # Arguments
+    ///
+    /// * `pre_offset_list` - The list of previous offsets.
+    /// * `offset_index` - The index of the offset to get.
+    ///
+    /// # Returns
+    ///
+    /// A `u64` representing the queue offset.
+    fn get_queue_offset_from_list(pre_offset_list: &[u64], offset_index: usize) -> u64 {
+        if offset_index == 0 {
+            return pre_offset_list[0];
+        }
+        pre_offset_list[0] + pre_offset_list[offset_index]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn build_offset_list_with_single_element() {
+        let queue_offset_list = vec![10];
+        let expected = vec![10];
+        assert_eq!(OrderInfo::build_offset_list(queue_offset_list), expected);
+    }
+
+    #[test]
+    fn need_block_returns_false_for_empty_offset_list() {
+        let mut order_info = OrderInfo {
+            pop_time: 1000,
+            invisible_time: Some(3000),
+            offset_list: vec![],
+            offset_next_visible_time: HashMap::new(),
+            offset_consumed_count: HashMap::new(),
+            last_consume_timestamp: 0,
+            commit_offset_bit: 0,
+            attempt_id: "test".to_string(),
+        };
+        assert!(!order_info.need_block("another_test", 2000));
+    }
+
+    #[test]
+    fn get_lock_free_timestamp_returns_none_for_empty_offset_list() {
+        let order_info = OrderInfo {
+            pop_time: 1000,
+            invisible_time: Some(3000),
+            offset_list: vec![],
+            offset_next_visible_time: HashMap::new(),
+            offset_consumed_count: HashMap::new(),
+            last_consume_timestamp: 0,
+            commit_offset_bit: 0,
+            attempt_id: "test".to_string(),
+        };
+        assert_eq!(order_info.get_lock_free_timestamp(), None);
+    }
+
+    #[test]
+    fn get_next_offset_returns_minus_two_for_empty_offset_list() {
+        let order_info = OrderInfo {
+            pop_time: 1000,
+            invisible_time: Some(3000),
+            offset_list: vec![],
+            offset_next_visible_time: HashMap::new(),
+            offset_consumed_count: HashMap::new(),
+            last_consume_timestamp: 0,
+            commit_offset_bit: 0,
+            attempt_id: "test".to_string(),
+        };
+        assert_eq!(order_info.get_next_offset(), -2);
+    }
+
+    #[test]
+    fn merge_offset_consumed_count_with_same_attempt_id() {
+        let mut order_info = OrderInfo {
+            pop_time: 0,
+            invisible_time: None,
+            offset_list: vec![1, 2, 3],
+            offset_next_visible_time: HashMap::new(),
+            offset_consumed_count: HashMap::new(),
+            last_consume_timestamp: 0,
+            commit_offset_bit: 0,
+            attempt_id: "test".to_string(),
+        };
+        let pre_offset_list = vec![1, 2];
+        let prev_offset_consumed_count = HashMap::from([(1, 1), (2, 1)]);
+        order_info.merge_offset_consumed_count("test", pre_offset_list, prev_offset_consumed_count);
+        assert_eq!(order_info.offset_consumed_count.get(&1), Some(&1));
+        assert_eq!(order_info.offset_consumed_count.get(&2), Some(&1));
+    }
+}

--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -119,7 +119,7 @@ impl PullMessageResultHandler for DefaultPullMessageResultHandler {
         subscription_data: SubscriptionData,
         subscription_group_config: SubscriptionGroupConfig,
         broker_allow_suspend: bool,
-        message_filter: Box<dyn MessageFilter>,
+        message_filter: Arc<Box<dyn MessageFilter>>,
         mut response: RemotingCommand,
         mut mapping_context: TopicQueueMappingContext,
         _begin_time_mills: u64,
@@ -234,7 +234,7 @@ impl PullMessageResultHandler for DefaultPullMessageResultHandler {
                         get_current_millis(),
                         offset,
                         subscription_data,
-                        Arc::new(message_filter),
+                        message_filter,
                     );
                     self.pull_request_hold_service
                         .as_ref()

--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -15,17 +15,16 @@
  * limitations under the License.
  */
 
- use rocketmq_store::pop::AckMessage;
+use rocketmq_store::pop::AckMessage;
 
- pub(crate) struct PopBufferMergeService;
- 
- impl PopBufferMergeService {
-     pub fn add_ack(&mut self, _revive_qid: i32, _ack_msg: &dyn AckMessage) -> bool {
-         unimplemented!("Not implemented yet");
-     }
- 
-     pub fn get_latest_offset(&self, _lock_key: &str) -> i64 {
-         unimplemented!("Not implemented yet");
-     }
- }
- 
+pub(crate) struct PopBufferMergeService;
+
+impl PopBufferMergeService {
+    pub fn add_ack(&mut self, _revive_qid: i32, _ack_msg: &dyn AckMessage) -> bool {
+        unimplemented!("Not implemented yet");
+    }
+
+    pub fn get_latest_offset(&self, _lock_key: &str) -> i64 {
+        unimplemented!("Not implemented yet");
+    }
+}

--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -15,12 +15,17 @@
  * limitations under the License.
  */
 
-use rocketmq_store::pop::AckMessage;
+ use rocketmq_store::pop::AckMessage;
 
-pub(crate) struct PopBufferMergeService;
-
-impl PopBufferMergeService {
-    pub fn add_ack(&mut self, _revive_qid: i32, _ack_msg: &dyn AckMessage) -> bool {
-        unimplemented!("Not implemented yet");
-    }
-}
+ pub(crate) struct PopBufferMergeService;
+ 
+ impl PopBufferMergeService {
+     pub fn add_ack(&mut self, _revive_qid: i32, _ack_msg: &dyn AckMessage) -> bool {
+         unimplemented!("Not implemented yet");
+     }
+ 
+     pub fn get_latest_offset(&self, _lock_key: &str) -> i64 {
+         unimplemented!("Not implemented yet");
+     }
+ }
+ 

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -680,14 +680,15 @@ where
             );
         }
 
-        let message_filter: Box<dyn MessageFilter> = if self.broker_config.filter_support_retry {
-            Box::new(ExpressionForRetryMessageFilter)
+        let message_filter: Arc<Box<dyn MessageFilter>> = if self.broker_config.filter_support_retry
+        {
+            Arc::new(Box::new(ExpressionForRetryMessageFilter))
         } else {
-            Box::new(ExpressionMessageFilter::new(
+            Arc::new(Box::new(ExpressionMessageFilter::new(
                 Some(subscription_data.clone()),
                 consumer_filter_data,
                 self.consumer_filter_manager.clone(),
-            ))
+            )))
         };
 
         //ColdDataFlow not implement
@@ -740,7 +741,7 @@ where
                         request_header.queue_offset,
                         request_header.max_msg_nums,
                         MAX_PULL_MSG_SIZE,
-                        Some(message_filter.as_ref()),
+                        Some(message_filter.clone()),
                     )
                     .await;
                 if result.is_none() {

--- a/rocketmq-broker/src/processor/pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/pull_message_result_handler.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use std::any::Any;
+use std::sync::Arc;
 
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
@@ -67,7 +68,7 @@ pub trait PullMessageResultHandler: Sync + Send + Any + 'static {
         subscription_data: SubscriptionData,
         subscription_group_config: SubscriptionGroupConfig,
         broker_allow_suspend: bool,
-        message_filter: Box<dyn MessageFilter>,
+        message_filter: Arc<Box<dyn MessageFilter>>,
         response: RemotingCommand,
         mapping_context: TopicQueueMappingContext,
         begin_time_mills: u64,

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -15,586 +15,589 @@
  * limitations under the License.
  */
 
-use std::any::Any;
-use std::collections::HashMap;
-
-use cheetah_string::CheetahString;
-use lazy_static::lazy_static;
-use serde::Deserialize;
-use serde::Serialize;
-
-use crate::common::constant::PermName;
-use crate::common::message::message_enum::MessageRequestMode;
-use crate::common::mix_all;
-use crate::common::mix_all::NAMESRV_ADDR_PROPERTY;
-use crate::common::server::config::ServerConfig;
-use crate::common::topic::TopicValidator;
-
-const DEFAULT_CLUSTER_NAME: &str = "DefaultCluster";
-
-lazy_static! {
-    pub static ref LOCAL_HOST_NAME: Option<String> = match hostname::get() {
-        Ok(hostname) => {
-            Some(hostname.to_string_lossy().to_string())
-        }
-        Err(_) => {
-            None
-        }
-    };
-    pub static ref NAMESRV_ADDR: Option<String> =
-        std::env::var(NAMESRV_ADDR_PROPERTY).map_or(Some("127.0.0.1:9876".to_string()), Some);
-}
-
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct BrokerIdentity {
-    pub broker_name: CheetahString,
-    pub broker_cluster_name: CheetahString,
-    pub broker_id: u64,
-    pub is_broker_container: bool,
-    pub is_in_broker_container: bool,
-}
-
-impl BrokerIdentity {
-    pub fn new() -> Self {
-        let broker_name = default_broker_name();
-        let broker_cluster_name = String::from(DEFAULT_CLUSTER_NAME);
-        let broker_id = mix_all::MASTER_ID;
-        let is_broker_container = false;
-
-        BrokerIdentity {
-            broker_name: CheetahString::from_string(broker_name),
-            broker_cluster_name: CheetahString::from_string(broker_cluster_name),
-            broker_id,
-            is_broker_container,
-            is_in_broker_container: false,
-        }
-    }
-
-    fn new_with_container(is_broker_container: bool) -> Self {
-        let mut identity = BrokerIdentity::new();
-        identity.is_broker_container = is_broker_container;
-        identity
-    }
-
-    fn new_with_params(broker_cluster_name: String, broker_name: String, broker_id: u64) -> Self {
-        BrokerIdentity {
-            broker_name: CheetahString::from_string(broker_name),
-            broker_cluster_name: CheetahString::from_string(broker_cluster_name),
-            broker_id,
-            is_broker_container: false,
-            is_in_broker_container: false,
-        }
-    }
-
-    fn new_with_container_params(
-        broker_cluster_name: String,
-        broker_name: String,
-        broker_id: u64,
-        is_in_broker_container: bool,
-    ) -> Self {
-        BrokerIdentity {
-            broker_name: CheetahString::from_string(broker_name),
-            broker_cluster_name: CheetahString::from_string(broker_cluster_name),
-            broker_id,
-            is_broker_container: true,
-            is_in_broker_container,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct BrokerConfig {
-    pub broker_identity: BrokerIdentity,
-
-    pub topic_queue_config: TopicQueueConfig,
-
-    pub timer_wheel_config: TimerWheelConfig,
-
-    pub broker_server_config: ServerConfig,
-
-    pub broker_ip1: CheetahString,
-    pub broker_ip2: Option<CheetahString>,
-    pub listen_port: u32,
-    pub trace_topic_enable: bool,
-    pub msg_trace_topic_name: CheetahString,
-    pub enable_controller_mode: bool,
-    pub broker_name: CheetahString,
-    pub region_id: CheetahString,
-    pub trace_on: bool,
-    pub broker_permission: u32,
-    pub async_send_enable: bool,
-    pub store_path_root_dir: CheetahString,
-    pub enable_split_registration: bool,
-    pub split_registration_size: i32,
-    pub register_broker_timeout_mills: i32,
-    pub is_in_broker_container: bool,
-    pub commercial_size_per_msg: i32,
-    pub recover_concurrently: bool,
-    pub duplication_enable: bool,
-    pub start_accept_send_request_time_stamp: i64,
-    pub auto_create_topic_enable: bool,
-    pub enable_single_topic_register: bool,
-    pub broker_topic_enable: bool,
-    pub cluster_topic_enable: bool,
-    pub revive_queue_num: u32,
-    pub enable_slave_acting_master: bool,
-    pub reject_transaction_message: bool,
-    pub enable_detail_stat: bool,
-    pub flush_consumer_offset_interval: u64,
-    pub force_register: bool,
-    pub register_name_server_period: u64,
-    pub skip_pre_online: bool,
-    pub namesrv_addr: Option<CheetahString>,
-    pub fetch_name_srv_addr_by_dns_lookup: bool,
-    pub lite_pull_message_enable: bool,
-    pub auto_create_subscription_group: bool,
-    pub channel_expired_timeout: u64,
-    pub subscription_expired_timeout: u64,
-    pub enable_property_filter: bool,
-    pub filter_support_retry: bool,
-    pub use_server_side_reset_offset: bool,
-    pub slave_read_enable: bool,
-    pub commercial_base_count: i32,
-    pub reject_pull_consumer_enable: bool,
-    pub consumer_offset_update_version_step: i64,
-    pub enable_broadcast_offset_store: bool,
-    pub transfer_msg_by_heap: bool,
-    pub short_polling_time_mills: u64,
-    pub long_polling_enable: bool,
-    pub max_error_rate_of_bloom_filter: i32,
-    pub expect_consumer_num_use_filter: i32,
-    pub bit_map_length_consume_queue_ext: i32,
-    pub validate_system_topic_when_update_topic: bool,
-    pub enable_mixed_message_type: bool,
-    pub auto_delete_unused_stats: bool,
-    pub forward_timeout: u64,
-    pub store_reply_message_enable: bool,
-    pub lock_in_strict_mode: bool,
-    pub transaction_timeout: u64,
-    pub transaction_op_msg_max_size: i32,
-    pub default_message_request_mode: MessageRequestMode,
-    pub default_pop_share_queue_num: i32,
-    pub load_balance_poll_name_server_interval: u64,
-    pub server_load_balancer_enable: bool,
-    pub enable_remote_escape: bool,
-    pub enable_pop_log: bool,
-    pub enable_retry_topic_v2: bool,
-    // read message from pop retry topic v1, for the compatibility, will be removed in the future
-    // version
-    pub retrieve_message_from_pop_retry_topic_v1: bool,
-    pub pop_from_retry_probability: i32,
-}
-
-impl Default for BrokerConfig {
-    fn default() -> Self {
-        let broker_identity = BrokerIdentity::new();
-        let local_ip = local_ip_address::local_ip().unwrap();
-        let broker_ip1 = local_ip.to_string().into();
-        let broker_ip2 = Some(local_ip.to_string().into());
-        let listen_port = 10911;
-
-        BrokerConfig {
-            broker_identity,
-            topic_queue_config: TopicQueueConfig::default(),
-            timer_wheel_config: TimerWheelConfig::default(),
-            broker_server_config: Default::default(),
-            broker_ip1,
-            broker_ip2,
-            listen_port,
-            trace_topic_enable: false,
-            msg_trace_topic_name: CheetahString::from_static_str(
-                TopicValidator::RMQ_SYS_TRACE_TOPIC,
-            ),
-            enable_controller_mode: false,
-            broker_name: default_broker_name().into(),
-            region_id: CheetahString::from_static_str(mix_all::DEFAULT_TRACE_REGION_ID),
-            trace_on: true,
-            broker_permission: PermName::PERM_WRITE | PermName::PERM_READ,
-            async_send_enable: false,
-            store_path_root_dir: dirs::home_dir()
-                .unwrap()
-                .join("store")
-                .to_string_lossy()
-                .into_owned()
-                .into(),
-            enable_split_registration: false,
-            split_registration_size: 800,
-            register_broker_timeout_mills: 24000,
-            is_in_broker_container: false,
-            commercial_size_per_msg: 4 * 1024,
-            recover_concurrently: false,
-            duplication_enable: false,
-            start_accept_send_request_time_stamp: 0,
-            auto_create_topic_enable: true,
-            enable_single_topic_register: true,
-            broker_topic_enable: true,
-            cluster_topic_enable: true,
-            revive_queue_num: 8,
-            enable_slave_acting_master: false,
-            reject_transaction_message: false,
-            enable_detail_stat: true,
-            flush_consumer_offset_interval: 1000 * 5,
-            force_register: true,
-            register_name_server_period: 1000 * 30,
-            skip_pre_online: false,
-            namesrv_addr: NAMESRV_ADDR.clone().map(|addr| addr.into()),
-            fetch_name_srv_addr_by_dns_lookup: false,
-            lite_pull_message_enable: true,
-            auto_create_subscription_group: true,
-            channel_expired_timeout: 1000 * 120,
-            subscription_expired_timeout: 1000 * 60 * 10,
-            enable_property_filter: false,
-            filter_support_retry: false,
-            use_server_side_reset_offset: true,
-            slave_read_enable: false,
-            commercial_base_count: 1,
-            reject_pull_consumer_enable: false,
-            consumer_offset_update_version_step: 500,
-            enable_broadcast_offset_store: true,
-            transfer_msg_by_heap: true,
-            short_polling_time_mills: 1000,
-            long_polling_enable: true,
-            max_error_rate_of_bloom_filter: 20,
-            expect_consumer_num_use_filter: 32,
-            bit_map_length_consume_queue_ext: 64,
-            forward_timeout: 3 * 1000,
-            validate_system_topic_when_update_topic: true,
-            enable_mixed_message_type: false,
-            auto_delete_unused_stats: false,
-            store_reply_message_enable: true,
-            lock_in_strict_mode: false,
-            transaction_timeout: 6_000,
-            transaction_op_msg_max_size: 4096,
-            default_message_request_mode: MessageRequestMode::Pull,
-            default_pop_share_queue_num: -1,
-            load_balance_poll_name_server_interval: 30_000,
-            server_load_balancer_enable: true,
-            enable_remote_escape: false,
-            enable_pop_log: false,
-            enable_retry_topic_v2: false,
-            retrieve_message_from_pop_retry_topic_v1: true,
-            pop_from_retry_probability: 20,
-        }
-    }
-}
-
-impl BrokerConfig {
-    pub fn broker_name(&self) -> CheetahString {
-        self.broker_name.clone()
-    }
-
-    pub fn broker_ip1(&self) -> CheetahString {
-        self.broker_ip1.clone()
-    }
-
-    pub fn broker_ip2(&self) -> Option<CheetahString> {
-        self.broker_ip2.clone()
-    }
-
-    pub fn listen_port(&self) -> u32 {
-        self.listen_port
-    }
-
-    pub fn trace_topic_enable(&self) -> bool {
-        self.trace_topic_enable
-    }
-
-    pub fn broker_server_config(&self) -> &ServerConfig {
-        &self.broker_server_config
-    }
-
-    pub fn region_id(&self) -> &str {
-        self.region_id.as_str()
-    }
-
-    pub fn broker_permission(&self) -> u32 {
-        self.broker_permission
-    }
-
-    pub fn get_broker_addr(&self) -> String {
-        format!("{}:{}", self.broker_ip1, self.listen_port)
-    }
-
-    pub fn get_start_accept_send_request_time_stamp(&self) -> i64 {
-        self.start_accept_send_request_time_stamp
-    }
-
-    pub fn get_properties(&self) -> HashMap<CheetahString, CheetahString> {
-        let mut properties = HashMap::new();
-        properties.insert("brokerName".into(), self.broker_name.clone());
-        properties.insert(
-            "brokerClusterName".into(),
-            self.broker_identity.broker_cluster_name.clone(),
-        );
-        properties.insert(
-            "brokerId".into(),
-            self.broker_identity.broker_id.to_string().into(),
-        );
-        properties.insert(
-            "isBrokerContainer".into(),
-            self.broker_identity.is_broker_container.to_string().into(),
-        );
-        properties.insert(
-            "defaultTopicQueueNums".into(),
-            self.topic_queue_config
-                .default_topic_queue_nums
-                .to_string()
-                .into(),
-        );
-        properties.insert(
-            "timerWheelEnable".into(),
-            self.timer_wheel_config
-                .timer_wheel_enable
-                .to_string()
-                .into(),
-        );
-        properties.insert(
-            "bindAddress".into(),
-            self.broker_server_config
-                .bind_address
-                .clone()
-                .to_string()
-                .into(),
-        );
-        properties.insert(
-            "brokerIp1".into(),
-            self.broker_ip1.clone().to_string().into(),
-        );
-        properties.insert(
-            "brokerIp2".into(),
-            self.broker_ip2.clone().unwrap_or_default(),
-        );
-        properties.insert("listenPort".into(), self.listen_port.to_string().into());
-        properties.insert(
-            "traceTopicEnable".into(),
-            self.trace_topic_enable.to_string().into(),
-        );
-        properties.insert(
-            "msgTraceTopicName".into(),
-            self.msg_trace_topic_name.clone(),
-        );
-        properties.insert(
-            "enableControllerMode".into(),
-            self.enable_controller_mode.to_string().into(),
-        );
-        properties.insert("regionId".into(), self.region_id.clone());
-        properties.insert("brokerName".into(), self.broker_name.clone());
-        properties.insert("traceOn".into(), self.trace_on.to_string().into());
-        properties.insert(
-            "brokerPermission".into(),
-            self.broker_permission.to_string().into(),
-        );
-        properties.insert(
-            "asyncSendEnable".into(),
-            self.async_send_enable.to_string().into(),
-        );
-        properties.insert("storePathRootDir".into(), self.store_path_root_dir.clone());
-        properties.insert(
-            "enableSplitRegistration".into(),
-            self.enable_split_registration.to_string().into(),
-        );
-        properties.insert(
-            "splitRegistrationSize".into(),
-            self.split_registration_size.to_string().into(),
-        );
-        properties.insert(
-            "registerBrokerTimeoutMills".into(),
-            self.register_broker_timeout_mills.to_string().into(),
-        );
-        properties.insert(
-            "isInBrokerContainer".into(),
-            self.is_in_broker_container.to_string().into(),
-        );
-        properties.insert(
-            "commercialSizePerMsg".into(),
-            self.commercial_size_per_msg.to_string().into(),
-        );
-        properties.insert(
-            "recoverConcurrently".into(),
-            self.recover_concurrently.to_string().into(),
-        );
-        properties.insert(
-            "duplicationEnable".into(),
-            self.duplication_enable.to_string().into(),
-        );
-        properties.insert(
-            "startAcceptSendRequestTimeStamp".into(),
-            self.start_accept_send_request_time_stamp.to_string().into(),
-        );
-        properties.insert(
-            "autoCreateTopicEnable".into(),
-            self.auto_create_topic_enable.to_string().into(),
-        );
-        properties.insert(
-            "enableSingleTopicRegister".into(),
-            self.enable_single_topic_register.to_string().into(),
-        );
-        properties.insert(
-            "brokerTopicEnable".into(),
-            self.broker_topic_enable.to_string().into(),
-        );
-        properties.insert(
-            "clusterTopicEnable".into(),
-            self.cluster_topic_enable.to_string().into(),
-        );
-        properties.insert(
-            "reviveQueueNum".into(),
-            self.revive_queue_num.to_string().into(),
-        );
-        properties.insert(
-            "enableSlaveActingMaster".into(),
-            self.enable_slave_acting_master.to_string().into(),
-        );
-        properties.insert(
-            "rejectTransactionMessage".into(),
-            self.reject_transaction_message.to_string().into(),
-        );
-        properties.insert(
-            "enableDetailStat".into(),
-            self.enable_detail_stat.to_string().into(),
-        );
-        properties.insert(
-            "flushConsumerOffsetInterval".into(),
-            self.flush_consumer_offset_interval.to_string().into(),
-        );
-        properties.insert(
-            "forceRegister".into(),
-            self.force_register.to_string().into(),
-        );
-        properties.insert(
-            "registerNameServerPeriod".into(),
-            self.register_name_server_period.to_string().into(),
-        );
-        properties.insert(
-            "skipPreOnline".into(),
-            self.skip_pre_online.to_string().into(),
-        );
-        properties.insert(
-            "namesrvAddr".into(),
-            self.namesrv_addr.clone().unwrap_or_default(),
-        );
-        properties.insert(
-            "fetchNameSrvAddrByDnsLookup".into(),
-            self.fetch_name_srv_addr_by_dns_lookup.to_string().into(),
-        );
-        properties.insert(
-            "litePullMessageEnable".into(),
-            self.lite_pull_message_enable.to_string().into(),
-        );
-        properties.insert(
-            "autoCreateSubscriptionGroup".into(),
-            self.auto_create_subscription_group.to_string().into(),
-        );
-        properties.insert(
-            "channelExpiredTimeout".into(),
-            self.channel_expired_timeout.to_string().into(),
-        );
-        properties.insert(
-            "subscriptionExpiredTimeout".into(),
-            self.subscription_expired_timeout.to_string().into(),
-        );
-        properties.insert(
-            "enablePropertyFilter".into(),
-            self.enable_property_filter.to_string().into(),
-        );
-        properties.insert(
-            "filterSupportRetry".into(),
-            self.filter_support_retry.to_string().into(),
-        );
-        properties.insert(
-            "useServerSideResetOffset".into(),
-            self.use_server_side_reset_offset.to_string().into(),
-        );
-        properties.insert(
-            "slaveReadEnable".into(),
-            self.slave_read_enable.to_string().into(),
-        );
-        properties.insert(
-            "commercialBaseCount".into(),
-            self.commercial_base_count.to_string().into(),
-        );
-        properties.insert(
-            "rejectPullConsumerEnable".into(),
-            self.reject_pull_consumer_enable.to_string().into(),
-        );
-        properties.insert(
-            "consumerOffsetUpdateVersionStep".into(),
-            self.consumer_offset_update_version_step.to_string().into(),
-        );
-        properties.insert(
-            "enableBroadcastOffsetStore".into(),
-            self.enable_broadcast_offset_store.to_string().into(),
-        );
-        properties.insert(
-            "transferMsgByHeap".into(),
-            self.transfer_msg_by_heap.to_string().into(),
-        );
-        properties.insert(
-            "shortPollingTimeMills".into(),
-            self.short_polling_time_mills.to_string().into(),
-        );
-        properties.insert(
-            "longPollingEnable".into(),
-            self.long_polling_enable.to_string().into(),
-        );
-        properties.insert(
-            "maxErrorRateOfBloomFilter".into(),
-            self.max_error_rate_of_bloom_filter.to_string().into(),
-        );
-        properties.insert(
-            "expectConsumerNumUseFilter".into(),
-            self.expect_consumer_num_use_filter.to_string().into(),
-        );
-        properties.insert(
-            "bitMapLengthConsumeQueueExt".into(),
-            self.bit_map_length_consume_queue_ext.to_string().into(),
-        );
-        properties.insert(
-            "validateSystemTopicWhenUpdateTopic".into(),
-            self.validate_system_topic_when_update_topic
-                .to_string()
-                .into(),
-        );
-        properties.insert(
-            "enableMixedMessageType".into(),
-            self.enable_mixed_message_type.to_string().into(),
-        );
-        properties.insert(
-            "autoDeleteUnusedStats".into(),
-            self.auto_delete_unused_stats.to_string().into(),
-        );
-        properties.insert(
-            "forwardTimeout".into(),
-            self.forward_timeout.to_string().into(),
-        );
-        properties
-    }
-}
-
-pub fn default_broker_name() -> String {
-    LOCAL_HOST_NAME
-        .clone()
-        .unwrap_or_else(|| "DEFAULT_BROKER".to_string())
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct TopicQueueConfig {
-    pub default_topic_queue_nums: u32,
-}
-
-impl Default for TopicQueueConfig {
-    fn default() -> Self {
-        TopicQueueConfig {
-            default_topic_queue_nums: 8,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct TimerWheelConfig {
-    pub timer_wheel_enable: bool,
-}
+ use std::any::Any;
+ use std::collections::HashMap;
+ 
+ use cheetah_string::CheetahString;
+ use lazy_static::lazy_static;
+ use serde::Deserialize;
+ use serde::Serialize;
+ 
+ use crate::common::constant::PermName;
+ use crate::common::message::message_enum::MessageRequestMode;
+ use crate::common::mix_all;
+ use crate::common::mix_all::NAMESRV_ADDR_PROPERTY;
+ use crate::common::server::config::ServerConfig;
+ use crate::common::topic::TopicValidator;
+ 
+ const DEFAULT_CLUSTER_NAME: &str = "DefaultCluster";
+ 
+ lazy_static! {
+     pub static ref LOCAL_HOST_NAME: Option<String> = match hostname::get() {
+         Ok(hostname) => {
+             Some(hostname.to_string_lossy().to_string())
+         }
+         Err(_) => {
+             None
+         }
+     };
+     pub static ref NAMESRV_ADDR: Option<String> =
+         std::env::var(NAMESRV_ADDR_PROPERTY).map_or(Some("127.0.0.1:9876".to_string()), Some);
+ }
+ 
+ #[derive(Debug, Default, Serialize, Deserialize, Clone)]
+ #[serde(rename_all = "camelCase")]
+ pub struct BrokerIdentity {
+     pub broker_name: CheetahString,
+     pub broker_cluster_name: CheetahString,
+     pub broker_id: u64,
+     pub is_broker_container: bool,
+     pub is_in_broker_container: bool,
+ }
+ 
+ impl BrokerIdentity {
+     pub fn new() -> Self {
+         let broker_name = default_broker_name();
+         let broker_cluster_name = String::from(DEFAULT_CLUSTER_NAME);
+         let broker_id = mix_all::MASTER_ID;
+         let is_broker_container = false;
+ 
+         BrokerIdentity {
+             broker_name: CheetahString::from_string(broker_name),
+             broker_cluster_name: CheetahString::from_string(broker_cluster_name),
+             broker_id,
+             is_broker_container,
+             is_in_broker_container: false,
+         }
+     }
+ 
+     fn new_with_container(is_broker_container: bool) -> Self {
+         let mut identity = BrokerIdentity::new();
+         identity.is_broker_container = is_broker_container;
+         identity
+     }
+ 
+     fn new_with_params(broker_cluster_name: String, broker_name: String, broker_id: u64) -> Self {
+         BrokerIdentity {
+             broker_name: CheetahString::from_string(broker_name),
+             broker_cluster_name: CheetahString::from_string(broker_cluster_name),
+             broker_id,
+             is_broker_container: false,
+             is_in_broker_container: false,
+         }
+     }
+ 
+     fn new_with_container_params(
+         broker_cluster_name: String,
+         broker_name: String,
+         broker_id: u64,
+         is_in_broker_container: bool,
+     ) -> Self {
+         BrokerIdentity {
+             broker_name: CheetahString::from_string(broker_name),
+             broker_cluster_name: CheetahString::from_string(broker_cluster_name),
+             broker_id,
+             is_broker_container: true,
+             is_in_broker_container,
+         }
+     }
+ }
+ 
+ #[derive(Debug, Serialize, Deserialize, Clone)]
+ #[serde(rename_all = "camelCase")]
+ pub struct BrokerConfig {
+     pub broker_identity: BrokerIdentity,
+ 
+     pub topic_queue_config: TopicQueueConfig,
+ 
+     pub timer_wheel_config: TimerWheelConfig,
+ 
+     pub broker_server_config: ServerConfig,
+ 
+     pub broker_ip1: CheetahString,
+     pub broker_ip2: Option<CheetahString>,
+     pub listen_port: u32,
+     pub trace_topic_enable: bool,
+     pub msg_trace_topic_name: CheetahString,
+     pub enable_controller_mode: bool,
+     pub broker_name: CheetahString,
+     pub region_id: CheetahString,
+     pub trace_on: bool,
+     pub broker_permission: u32,
+     pub async_send_enable: bool,
+     pub store_path_root_dir: CheetahString,
+     pub enable_split_registration: bool,
+     pub split_registration_size: i32,
+     pub register_broker_timeout_mills: i32,
+     pub is_in_broker_container: bool,
+     pub commercial_size_per_msg: i32,
+     pub recover_concurrently: bool,
+     pub duplication_enable: bool,
+     pub start_accept_send_request_time_stamp: i64,
+     pub auto_create_topic_enable: bool,
+     pub enable_single_topic_register: bool,
+     pub broker_topic_enable: bool,
+     pub cluster_topic_enable: bool,
+     pub revive_queue_num: u32,
+     pub enable_slave_acting_master: bool,
+     pub reject_transaction_message: bool,
+     pub enable_detail_stat: bool,
+     pub flush_consumer_offset_interval: u64,
+     pub force_register: bool,
+     pub register_name_server_period: u64,
+     pub skip_pre_online: bool,
+     pub namesrv_addr: Option<CheetahString>,
+     pub fetch_name_srv_addr_by_dns_lookup: bool,
+     pub lite_pull_message_enable: bool,
+     pub auto_create_subscription_group: bool,
+     pub channel_expired_timeout: u64,
+     pub subscription_expired_timeout: u64,
+     pub enable_property_filter: bool,
+     pub filter_support_retry: bool,
+     pub use_server_side_reset_offset: bool,
+     pub slave_read_enable: bool,
+     pub commercial_base_count: i32,
+     pub reject_pull_consumer_enable: bool,
+     pub consumer_offset_update_version_step: i64,
+     pub enable_broadcast_offset_store: bool,
+     pub transfer_msg_by_heap: bool,
+     pub short_polling_time_mills: u64,
+     pub long_polling_enable: bool,
+     pub max_error_rate_of_bloom_filter: i32,
+     pub expect_consumer_num_use_filter: i32,
+     pub bit_map_length_consume_queue_ext: i32,
+     pub validate_system_topic_when_update_topic: bool,
+     pub enable_mixed_message_type: bool,
+     pub auto_delete_unused_stats: bool,
+     pub forward_timeout: u64,
+     pub store_reply_message_enable: bool,
+     pub lock_in_strict_mode: bool,
+     pub transaction_timeout: u64,
+     pub transaction_op_msg_max_size: i32,
+     pub default_message_request_mode: MessageRequestMode,
+     pub default_pop_share_queue_num: i32,
+     pub load_balance_poll_name_server_interval: u64,
+     pub server_load_balancer_enable: bool,
+     pub enable_remote_escape: bool,
+     pub enable_pop_log: bool,
+     pub enable_retry_topic_v2: bool,
+     // read message from pop retry topic v1, for the compatibility, will be removed in the future
+     // version
+     pub retrieve_message_from_pop_retry_topic_v1: bool,
+     pub pop_from_retry_probability: i32,
+     pub pop_response_return_actual_retry_topic: bool,
+ }
+ 
+ impl Default for BrokerConfig {
+     fn default() -> Self {
+         let broker_identity = BrokerIdentity::new();
+         let local_ip = local_ip_address::local_ip().unwrap();
+         let broker_ip1 = local_ip.to_string().into();
+         let broker_ip2 = Some(local_ip.to_string().into());
+         let listen_port = 10911;
+ 
+         BrokerConfig {
+             broker_identity,
+             topic_queue_config: TopicQueueConfig::default(),
+             timer_wheel_config: TimerWheelConfig::default(),
+             broker_server_config: Default::default(),
+             broker_ip1,
+             broker_ip2,
+             listen_port,
+             trace_topic_enable: false,
+             msg_trace_topic_name: CheetahString::from_static_str(
+                 TopicValidator::RMQ_SYS_TRACE_TOPIC,
+             ),
+             enable_controller_mode: false,
+             broker_name: default_broker_name().into(),
+             region_id: CheetahString::from_static_str(mix_all::DEFAULT_TRACE_REGION_ID),
+             trace_on: true,
+             broker_permission: PermName::PERM_WRITE | PermName::PERM_READ,
+             async_send_enable: false,
+             store_path_root_dir: dirs::home_dir()
+                 .unwrap()
+                 .join("store")
+                 .to_string_lossy()
+                 .into_owned()
+                 .into(),
+             enable_split_registration: false,
+             split_registration_size: 800,
+             register_broker_timeout_mills: 24000,
+             is_in_broker_container: false,
+             commercial_size_per_msg: 4 * 1024,
+             recover_concurrently: false,
+             duplication_enable: false,
+             start_accept_send_request_time_stamp: 0,
+             auto_create_topic_enable: true,
+             enable_single_topic_register: true,
+             broker_topic_enable: true,
+             cluster_topic_enable: true,
+             revive_queue_num: 8,
+             enable_slave_acting_master: false,
+             reject_transaction_message: false,
+             enable_detail_stat: true,
+             flush_consumer_offset_interval: 1000 * 5,
+             force_register: true,
+             register_name_server_period: 1000 * 30,
+             skip_pre_online: false,
+             namesrv_addr: NAMESRV_ADDR.clone().map(|addr| addr.into()),
+             fetch_name_srv_addr_by_dns_lookup: false,
+             lite_pull_message_enable: true,
+             auto_create_subscription_group: true,
+             channel_expired_timeout: 1000 * 120,
+             subscription_expired_timeout: 1000 * 60 * 10,
+             enable_property_filter: false,
+             filter_support_retry: false,
+             use_server_side_reset_offset: true,
+             slave_read_enable: false,
+             commercial_base_count: 1,
+             reject_pull_consumer_enable: false,
+             consumer_offset_update_version_step: 500,
+             enable_broadcast_offset_store: true,
+             transfer_msg_by_heap: true,
+             short_polling_time_mills: 1000,
+             long_polling_enable: true,
+             max_error_rate_of_bloom_filter: 20,
+             expect_consumer_num_use_filter: 32,
+             bit_map_length_consume_queue_ext: 64,
+             forward_timeout: 3 * 1000,
+             validate_system_topic_when_update_topic: true,
+             enable_mixed_message_type: false,
+             auto_delete_unused_stats: false,
+             store_reply_message_enable: true,
+             lock_in_strict_mode: false,
+             transaction_timeout: 6_000,
+             transaction_op_msg_max_size: 4096,
+             default_message_request_mode: MessageRequestMode::Pull,
+             default_pop_share_queue_num: -1,
+             load_balance_poll_name_server_interval: 30_000,
+             server_load_balancer_enable: true,
+             enable_remote_escape: false,
+             enable_pop_log: false,
+             enable_retry_topic_v2: false,
+             retrieve_message_from_pop_retry_topic_v1: true,
+             pop_from_retry_probability: 20,
+             pop_response_return_actual_retry_topic: false,
+         }
+     }
+ }
+ 
+ impl BrokerConfig {
+     pub fn broker_name(&self) -> CheetahString {
+         self.broker_name.clone()
+     }
+ 
+     pub fn broker_ip1(&self) -> CheetahString {
+         self.broker_ip1.clone()
+     }
+ 
+     pub fn broker_ip2(&self) -> Option<CheetahString> {
+         self.broker_ip2.clone()
+     }
+ 
+     pub fn listen_port(&self) -> u32 {
+         self.listen_port
+     }
+ 
+     pub fn trace_topic_enable(&self) -> bool {
+         self.trace_topic_enable
+     }
+ 
+     pub fn broker_server_config(&self) -> &ServerConfig {
+         &self.broker_server_config
+     }
+ 
+     pub fn region_id(&self) -> &str {
+         self.region_id.as_str()
+     }
+ 
+     pub fn broker_permission(&self) -> u32 {
+         self.broker_permission
+     }
+ 
+     pub fn get_broker_addr(&self) -> String {
+         format!("{}:{}", self.broker_ip1, self.listen_port)
+     }
+ 
+     pub fn get_start_accept_send_request_time_stamp(&self) -> i64 {
+         self.start_accept_send_request_time_stamp
+     }
+ 
+     pub fn get_properties(&self) -> HashMap<CheetahString, CheetahString> {
+         let mut properties = HashMap::new();
+         properties.insert("brokerName".into(), self.broker_name.clone());
+         properties.insert(
+             "brokerClusterName".into(),
+             self.broker_identity.broker_cluster_name.clone(),
+         );
+         properties.insert(
+             "brokerId".into(),
+             self.broker_identity.broker_id.to_string().into(),
+         );
+         properties.insert(
+             "isBrokerContainer".into(),
+             self.broker_identity.is_broker_container.to_string().into(),
+         );
+         properties.insert(
+             "defaultTopicQueueNums".into(),
+             self.topic_queue_config
+                 .default_topic_queue_nums
+                 .to_string()
+                 .into(),
+         );
+         properties.insert(
+             "timerWheelEnable".into(),
+             self.timer_wheel_config
+                 .timer_wheel_enable
+                 .to_string()
+                 .into(),
+         );
+         properties.insert(
+             "bindAddress".into(),
+             self.broker_server_config
+                 .bind_address
+                 .clone()
+                 .to_string()
+                 .into(),
+         );
+         properties.insert(
+             "brokerIp1".into(),
+             self.broker_ip1.clone().to_string().into(),
+         );
+         properties.insert(
+             "brokerIp2".into(),
+             self.broker_ip2.clone().unwrap_or_default(),
+         );
+         properties.insert("listenPort".into(), self.listen_port.to_string().into());
+         properties.insert(
+             "traceTopicEnable".into(),
+             self.trace_topic_enable.to_string().into(),
+         );
+         properties.insert(
+             "msgTraceTopicName".into(),
+             self.msg_trace_topic_name.clone(),
+         );
+         properties.insert(
+             "enableControllerMode".into(),
+             self.enable_controller_mode.to_string().into(),
+         );
+         properties.insert("regionId".into(), self.region_id.clone());
+         properties.insert("brokerName".into(), self.broker_name.clone());
+         properties.insert("traceOn".into(), self.trace_on.to_string().into());
+         properties.insert(
+             "brokerPermission".into(),
+             self.broker_permission.to_string().into(),
+         );
+         properties.insert(
+             "asyncSendEnable".into(),
+             self.async_send_enable.to_string().into(),
+         );
+         properties.insert("storePathRootDir".into(), self.store_path_root_dir.clone());
+         properties.insert(
+             "enableSplitRegistration".into(),
+             self.enable_split_registration.to_string().into(),
+         );
+         properties.insert(
+             "splitRegistrationSize".into(),
+             self.split_registration_size.to_string().into(),
+         );
+         properties.insert(
+             "registerBrokerTimeoutMills".into(),
+             self.register_broker_timeout_mills.to_string().into(),
+         );
+         properties.insert(
+             "isInBrokerContainer".into(),
+             self.is_in_broker_container.to_string().into(),
+         );
+         properties.insert(
+             "commercialSizePerMsg".into(),
+             self.commercial_size_per_msg.to_string().into(),
+         );
+         properties.insert(
+             "recoverConcurrently".into(),
+             self.recover_concurrently.to_string().into(),
+         );
+         properties.insert(
+             "duplicationEnable".into(),
+             self.duplication_enable.to_string().into(),
+         );
+         properties.insert(
+             "startAcceptSendRequestTimeStamp".into(),
+             self.start_accept_send_request_time_stamp.to_string().into(),
+         );
+         properties.insert(
+             "autoCreateTopicEnable".into(),
+             self.auto_create_topic_enable.to_string().into(),
+         );
+         properties.insert(
+             "enableSingleTopicRegister".into(),
+             self.enable_single_topic_register.to_string().into(),
+         );
+         properties.insert(
+             "brokerTopicEnable".into(),
+             self.broker_topic_enable.to_string().into(),
+         );
+         properties.insert(
+             "clusterTopicEnable".into(),
+             self.cluster_topic_enable.to_string().into(),
+         );
+         properties.insert(
+             "reviveQueueNum".into(),
+             self.revive_queue_num.to_string().into(),
+         );
+         properties.insert(
+             "enableSlaveActingMaster".into(),
+             self.enable_slave_acting_master.to_string().into(),
+         );
+         properties.insert(
+             "rejectTransactionMessage".into(),
+             self.reject_transaction_message.to_string().into(),
+         );
+         properties.insert(
+             "enableDetailStat".into(),
+             self.enable_detail_stat.to_string().into(),
+         );
+         properties.insert(
+             "flushConsumerOffsetInterval".into(),
+             self.flush_consumer_offset_interval.to_string().into(),
+         );
+         properties.insert(
+             "forceRegister".into(),
+             self.force_register.to_string().into(),
+         );
+         properties.insert(
+             "registerNameServerPeriod".into(),
+             self.register_name_server_period.to_string().into(),
+         );
+         properties.insert(
+             "skipPreOnline".into(),
+             self.skip_pre_online.to_string().into(),
+         );
+         properties.insert(
+             "namesrvAddr".into(),
+             self.namesrv_addr.clone().unwrap_or_default(),
+         );
+         properties.insert(
+             "fetchNameSrvAddrByDnsLookup".into(),
+             self.fetch_name_srv_addr_by_dns_lookup.to_string().into(),
+         );
+         properties.insert(
+             "litePullMessageEnable".into(),
+             self.lite_pull_message_enable.to_string().into(),
+         );
+         properties.insert(
+             "autoCreateSubscriptionGroup".into(),
+             self.auto_create_subscription_group.to_string().into(),
+         );
+         properties.insert(
+             "channelExpiredTimeout".into(),
+             self.channel_expired_timeout.to_string().into(),
+         );
+         properties.insert(
+             "subscriptionExpiredTimeout".into(),
+             self.subscription_expired_timeout.to_string().into(),
+         );
+         properties.insert(
+             "enablePropertyFilter".into(),
+             self.enable_property_filter.to_string().into(),
+         );
+         properties.insert(
+             "filterSupportRetry".into(),
+             self.filter_support_retry.to_string().into(),
+         );
+         properties.insert(
+             "useServerSideResetOffset".into(),
+             self.use_server_side_reset_offset.to_string().into(),
+         );
+         properties.insert(
+             "slaveReadEnable".into(),
+             self.slave_read_enable.to_string().into(),
+         );
+         properties.insert(
+             "commercialBaseCount".into(),
+             self.commercial_base_count.to_string().into(),
+         );
+         properties.insert(
+             "rejectPullConsumerEnable".into(),
+             self.reject_pull_consumer_enable.to_string().into(),
+         );
+         properties.insert(
+             "consumerOffsetUpdateVersionStep".into(),
+             self.consumer_offset_update_version_step.to_string().into(),
+         );
+         properties.insert(
+             "enableBroadcastOffsetStore".into(),
+             self.enable_broadcast_offset_store.to_string().into(),
+         );
+         properties.insert(
+             "transferMsgByHeap".into(),
+             self.transfer_msg_by_heap.to_string().into(),
+         );
+         properties.insert(
+             "shortPollingTimeMills".into(),
+             self.short_polling_time_mills.to_string().into(),
+         );
+         properties.insert(
+             "longPollingEnable".into(),
+             self.long_polling_enable.to_string().into(),
+         );
+         properties.insert(
+             "maxErrorRateOfBloomFilter".into(),
+             self.max_error_rate_of_bloom_filter.to_string().into(),
+         );
+         properties.insert(
+             "expectConsumerNumUseFilter".into(),
+             self.expect_consumer_num_use_filter.to_string().into(),
+         );
+         properties.insert(
+             "bitMapLengthConsumeQueueExt".into(),
+             self.bit_map_length_consume_queue_ext.to_string().into(),
+         );
+         properties.insert(
+             "validateSystemTopicWhenUpdateTopic".into(),
+             self.validate_system_topic_when_update_topic
+                 .to_string()
+                 .into(),
+         );
+         properties.insert(
+             "enableMixedMessageType".into(),
+             self.enable_mixed_message_type.to_string().into(),
+         );
+         properties.insert(
+             "autoDeleteUnusedStats".into(),
+             self.auto_delete_unused_stats.to_string().into(),
+         );
+         properties.insert(
+             "forwardTimeout".into(),
+             self.forward_timeout.to_string().into(),
+         );
+         properties
+     }
+ }
+ 
+ pub fn default_broker_name() -> String {
+     LOCAL_HOST_NAME
+         .clone()
+         .unwrap_or_else(|| "DEFAULT_BROKER".to_string())
+ }
+ 
+ #[derive(Debug, Serialize, Deserialize, Clone)]
+ #[serde(rename_all = "camelCase")]
+ pub struct TopicQueueConfig {
+     pub default_topic_queue_nums: u32,
+ }
+ 
+ impl Default for TopicQueueConfig {
+     fn default() -> Self {
+         TopicQueueConfig {
+             default_topic_queue_nums: 8,
+         }
+     }
+ }
+ 
+ #[derive(Debug, Serialize, Deserialize, Default, Clone)]
+ #[serde(rename_all = "camelCase")]
+ pub struct TimerWheelConfig {
+     pub timer_wheel_enable: bool,
+ }
+ 

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -15,589 +15,588 @@
  * limitations under the License.
  */
 
- use std::any::Any;
- use std::collections::HashMap;
- 
- use cheetah_string::CheetahString;
- use lazy_static::lazy_static;
- use serde::Deserialize;
- use serde::Serialize;
- 
- use crate::common::constant::PermName;
- use crate::common::message::message_enum::MessageRequestMode;
- use crate::common::mix_all;
- use crate::common::mix_all::NAMESRV_ADDR_PROPERTY;
- use crate::common::server::config::ServerConfig;
- use crate::common::topic::TopicValidator;
- 
- const DEFAULT_CLUSTER_NAME: &str = "DefaultCluster";
- 
- lazy_static! {
-     pub static ref LOCAL_HOST_NAME: Option<String> = match hostname::get() {
-         Ok(hostname) => {
-             Some(hostname.to_string_lossy().to_string())
-         }
-         Err(_) => {
-             None
-         }
-     };
-     pub static ref NAMESRV_ADDR: Option<String> =
-         std::env::var(NAMESRV_ADDR_PROPERTY).map_or(Some("127.0.0.1:9876".to_string()), Some);
- }
- 
- #[derive(Debug, Default, Serialize, Deserialize, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct BrokerIdentity {
-     pub broker_name: CheetahString,
-     pub broker_cluster_name: CheetahString,
-     pub broker_id: u64,
-     pub is_broker_container: bool,
-     pub is_in_broker_container: bool,
- }
- 
- impl BrokerIdentity {
-     pub fn new() -> Self {
-         let broker_name = default_broker_name();
-         let broker_cluster_name = String::from(DEFAULT_CLUSTER_NAME);
-         let broker_id = mix_all::MASTER_ID;
-         let is_broker_container = false;
- 
-         BrokerIdentity {
-             broker_name: CheetahString::from_string(broker_name),
-             broker_cluster_name: CheetahString::from_string(broker_cluster_name),
-             broker_id,
-             is_broker_container,
-             is_in_broker_container: false,
-         }
-     }
- 
-     fn new_with_container(is_broker_container: bool) -> Self {
-         let mut identity = BrokerIdentity::new();
-         identity.is_broker_container = is_broker_container;
-         identity
-     }
- 
-     fn new_with_params(broker_cluster_name: String, broker_name: String, broker_id: u64) -> Self {
-         BrokerIdentity {
-             broker_name: CheetahString::from_string(broker_name),
-             broker_cluster_name: CheetahString::from_string(broker_cluster_name),
-             broker_id,
-             is_broker_container: false,
-             is_in_broker_container: false,
-         }
-     }
- 
-     fn new_with_container_params(
-         broker_cluster_name: String,
-         broker_name: String,
-         broker_id: u64,
-         is_in_broker_container: bool,
-     ) -> Self {
-         BrokerIdentity {
-             broker_name: CheetahString::from_string(broker_name),
-             broker_cluster_name: CheetahString::from_string(broker_cluster_name),
-             broker_id,
-             is_broker_container: true,
-             is_in_broker_container,
-         }
-     }
- }
- 
- #[derive(Debug, Serialize, Deserialize, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct BrokerConfig {
-     pub broker_identity: BrokerIdentity,
- 
-     pub topic_queue_config: TopicQueueConfig,
- 
-     pub timer_wheel_config: TimerWheelConfig,
- 
-     pub broker_server_config: ServerConfig,
- 
-     pub broker_ip1: CheetahString,
-     pub broker_ip2: Option<CheetahString>,
-     pub listen_port: u32,
-     pub trace_topic_enable: bool,
-     pub msg_trace_topic_name: CheetahString,
-     pub enable_controller_mode: bool,
-     pub broker_name: CheetahString,
-     pub region_id: CheetahString,
-     pub trace_on: bool,
-     pub broker_permission: u32,
-     pub async_send_enable: bool,
-     pub store_path_root_dir: CheetahString,
-     pub enable_split_registration: bool,
-     pub split_registration_size: i32,
-     pub register_broker_timeout_mills: i32,
-     pub is_in_broker_container: bool,
-     pub commercial_size_per_msg: i32,
-     pub recover_concurrently: bool,
-     pub duplication_enable: bool,
-     pub start_accept_send_request_time_stamp: i64,
-     pub auto_create_topic_enable: bool,
-     pub enable_single_topic_register: bool,
-     pub broker_topic_enable: bool,
-     pub cluster_topic_enable: bool,
-     pub revive_queue_num: u32,
-     pub enable_slave_acting_master: bool,
-     pub reject_transaction_message: bool,
-     pub enable_detail_stat: bool,
-     pub flush_consumer_offset_interval: u64,
-     pub force_register: bool,
-     pub register_name_server_period: u64,
-     pub skip_pre_online: bool,
-     pub namesrv_addr: Option<CheetahString>,
-     pub fetch_name_srv_addr_by_dns_lookup: bool,
-     pub lite_pull_message_enable: bool,
-     pub auto_create_subscription_group: bool,
-     pub channel_expired_timeout: u64,
-     pub subscription_expired_timeout: u64,
-     pub enable_property_filter: bool,
-     pub filter_support_retry: bool,
-     pub use_server_side_reset_offset: bool,
-     pub slave_read_enable: bool,
-     pub commercial_base_count: i32,
-     pub reject_pull_consumer_enable: bool,
-     pub consumer_offset_update_version_step: i64,
-     pub enable_broadcast_offset_store: bool,
-     pub transfer_msg_by_heap: bool,
-     pub short_polling_time_mills: u64,
-     pub long_polling_enable: bool,
-     pub max_error_rate_of_bloom_filter: i32,
-     pub expect_consumer_num_use_filter: i32,
-     pub bit_map_length_consume_queue_ext: i32,
-     pub validate_system_topic_when_update_topic: bool,
-     pub enable_mixed_message_type: bool,
-     pub auto_delete_unused_stats: bool,
-     pub forward_timeout: u64,
-     pub store_reply_message_enable: bool,
-     pub lock_in_strict_mode: bool,
-     pub transaction_timeout: u64,
-     pub transaction_op_msg_max_size: i32,
-     pub default_message_request_mode: MessageRequestMode,
-     pub default_pop_share_queue_num: i32,
-     pub load_balance_poll_name_server_interval: u64,
-     pub server_load_balancer_enable: bool,
-     pub enable_remote_escape: bool,
-     pub enable_pop_log: bool,
-     pub enable_retry_topic_v2: bool,
-     // read message from pop retry topic v1, for the compatibility, will be removed in the future
-     // version
-     pub retrieve_message_from_pop_retry_topic_v1: bool,
-     pub pop_from_retry_probability: i32,
-     pub pop_response_return_actual_retry_topic: bool,
- }
- 
- impl Default for BrokerConfig {
-     fn default() -> Self {
-         let broker_identity = BrokerIdentity::new();
-         let local_ip = local_ip_address::local_ip().unwrap();
-         let broker_ip1 = local_ip.to_string().into();
-         let broker_ip2 = Some(local_ip.to_string().into());
-         let listen_port = 10911;
- 
-         BrokerConfig {
-             broker_identity,
-             topic_queue_config: TopicQueueConfig::default(),
-             timer_wheel_config: TimerWheelConfig::default(),
-             broker_server_config: Default::default(),
-             broker_ip1,
-             broker_ip2,
-             listen_port,
-             trace_topic_enable: false,
-             msg_trace_topic_name: CheetahString::from_static_str(
-                 TopicValidator::RMQ_SYS_TRACE_TOPIC,
-             ),
-             enable_controller_mode: false,
-             broker_name: default_broker_name().into(),
-             region_id: CheetahString::from_static_str(mix_all::DEFAULT_TRACE_REGION_ID),
-             trace_on: true,
-             broker_permission: PermName::PERM_WRITE | PermName::PERM_READ,
-             async_send_enable: false,
-             store_path_root_dir: dirs::home_dir()
-                 .unwrap()
-                 .join("store")
-                 .to_string_lossy()
-                 .into_owned()
-                 .into(),
-             enable_split_registration: false,
-             split_registration_size: 800,
-             register_broker_timeout_mills: 24000,
-             is_in_broker_container: false,
-             commercial_size_per_msg: 4 * 1024,
-             recover_concurrently: false,
-             duplication_enable: false,
-             start_accept_send_request_time_stamp: 0,
-             auto_create_topic_enable: true,
-             enable_single_topic_register: true,
-             broker_topic_enable: true,
-             cluster_topic_enable: true,
-             revive_queue_num: 8,
-             enable_slave_acting_master: false,
-             reject_transaction_message: false,
-             enable_detail_stat: true,
-             flush_consumer_offset_interval: 1000 * 5,
-             force_register: true,
-             register_name_server_period: 1000 * 30,
-             skip_pre_online: false,
-             namesrv_addr: NAMESRV_ADDR.clone().map(|addr| addr.into()),
-             fetch_name_srv_addr_by_dns_lookup: false,
-             lite_pull_message_enable: true,
-             auto_create_subscription_group: true,
-             channel_expired_timeout: 1000 * 120,
-             subscription_expired_timeout: 1000 * 60 * 10,
-             enable_property_filter: false,
-             filter_support_retry: false,
-             use_server_side_reset_offset: true,
-             slave_read_enable: false,
-             commercial_base_count: 1,
-             reject_pull_consumer_enable: false,
-             consumer_offset_update_version_step: 500,
-             enable_broadcast_offset_store: true,
-             transfer_msg_by_heap: true,
-             short_polling_time_mills: 1000,
-             long_polling_enable: true,
-             max_error_rate_of_bloom_filter: 20,
-             expect_consumer_num_use_filter: 32,
-             bit_map_length_consume_queue_ext: 64,
-             forward_timeout: 3 * 1000,
-             validate_system_topic_when_update_topic: true,
-             enable_mixed_message_type: false,
-             auto_delete_unused_stats: false,
-             store_reply_message_enable: true,
-             lock_in_strict_mode: false,
-             transaction_timeout: 6_000,
-             transaction_op_msg_max_size: 4096,
-             default_message_request_mode: MessageRequestMode::Pull,
-             default_pop_share_queue_num: -1,
-             load_balance_poll_name_server_interval: 30_000,
-             server_load_balancer_enable: true,
-             enable_remote_escape: false,
-             enable_pop_log: false,
-             enable_retry_topic_v2: false,
-             retrieve_message_from_pop_retry_topic_v1: true,
-             pop_from_retry_probability: 20,
-             pop_response_return_actual_retry_topic: false,
-         }
-     }
- }
- 
- impl BrokerConfig {
-     pub fn broker_name(&self) -> CheetahString {
-         self.broker_name.clone()
-     }
- 
-     pub fn broker_ip1(&self) -> CheetahString {
-         self.broker_ip1.clone()
-     }
- 
-     pub fn broker_ip2(&self) -> Option<CheetahString> {
-         self.broker_ip2.clone()
-     }
- 
-     pub fn listen_port(&self) -> u32 {
-         self.listen_port
-     }
- 
-     pub fn trace_topic_enable(&self) -> bool {
-         self.trace_topic_enable
-     }
- 
-     pub fn broker_server_config(&self) -> &ServerConfig {
-         &self.broker_server_config
-     }
- 
-     pub fn region_id(&self) -> &str {
-         self.region_id.as_str()
-     }
- 
-     pub fn broker_permission(&self) -> u32 {
-         self.broker_permission
-     }
- 
-     pub fn get_broker_addr(&self) -> String {
-         format!("{}:{}", self.broker_ip1, self.listen_port)
-     }
- 
-     pub fn get_start_accept_send_request_time_stamp(&self) -> i64 {
-         self.start_accept_send_request_time_stamp
-     }
- 
-     pub fn get_properties(&self) -> HashMap<CheetahString, CheetahString> {
-         let mut properties = HashMap::new();
-         properties.insert("brokerName".into(), self.broker_name.clone());
-         properties.insert(
-             "brokerClusterName".into(),
-             self.broker_identity.broker_cluster_name.clone(),
-         );
-         properties.insert(
-             "brokerId".into(),
-             self.broker_identity.broker_id.to_string().into(),
-         );
-         properties.insert(
-             "isBrokerContainer".into(),
-             self.broker_identity.is_broker_container.to_string().into(),
-         );
-         properties.insert(
-             "defaultTopicQueueNums".into(),
-             self.topic_queue_config
-                 .default_topic_queue_nums
-                 .to_string()
-                 .into(),
-         );
-         properties.insert(
-             "timerWheelEnable".into(),
-             self.timer_wheel_config
-                 .timer_wheel_enable
-                 .to_string()
-                 .into(),
-         );
-         properties.insert(
-             "bindAddress".into(),
-             self.broker_server_config
-                 .bind_address
-                 .clone()
-                 .to_string()
-                 .into(),
-         );
-         properties.insert(
-             "brokerIp1".into(),
-             self.broker_ip1.clone().to_string().into(),
-         );
-         properties.insert(
-             "brokerIp2".into(),
-             self.broker_ip2.clone().unwrap_or_default(),
-         );
-         properties.insert("listenPort".into(), self.listen_port.to_string().into());
-         properties.insert(
-             "traceTopicEnable".into(),
-             self.trace_topic_enable.to_string().into(),
-         );
-         properties.insert(
-             "msgTraceTopicName".into(),
-             self.msg_trace_topic_name.clone(),
-         );
-         properties.insert(
-             "enableControllerMode".into(),
-             self.enable_controller_mode.to_string().into(),
-         );
-         properties.insert("regionId".into(), self.region_id.clone());
-         properties.insert("brokerName".into(), self.broker_name.clone());
-         properties.insert("traceOn".into(), self.trace_on.to_string().into());
-         properties.insert(
-             "brokerPermission".into(),
-             self.broker_permission.to_string().into(),
-         );
-         properties.insert(
-             "asyncSendEnable".into(),
-             self.async_send_enable.to_string().into(),
-         );
-         properties.insert("storePathRootDir".into(), self.store_path_root_dir.clone());
-         properties.insert(
-             "enableSplitRegistration".into(),
-             self.enable_split_registration.to_string().into(),
-         );
-         properties.insert(
-             "splitRegistrationSize".into(),
-             self.split_registration_size.to_string().into(),
-         );
-         properties.insert(
-             "registerBrokerTimeoutMills".into(),
-             self.register_broker_timeout_mills.to_string().into(),
-         );
-         properties.insert(
-             "isInBrokerContainer".into(),
-             self.is_in_broker_container.to_string().into(),
-         );
-         properties.insert(
-             "commercialSizePerMsg".into(),
-             self.commercial_size_per_msg.to_string().into(),
-         );
-         properties.insert(
-             "recoverConcurrently".into(),
-             self.recover_concurrently.to_string().into(),
-         );
-         properties.insert(
-             "duplicationEnable".into(),
-             self.duplication_enable.to_string().into(),
-         );
-         properties.insert(
-             "startAcceptSendRequestTimeStamp".into(),
-             self.start_accept_send_request_time_stamp.to_string().into(),
-         );
-         properties.insert(
-             "autoCreateTopicEnable".into(),
-             self.auto_create_topic_enable.to_string().into(),
-         );
-         properties.insert(
-             "enableSingleTopicRegister".into(),
-             self.enable_single_topic_register.to_string().into(),
-         );
-         properties.insert(
-             "brokerTopicEnable".into(),
-             self.broker_topic_enable.to_string().into(),
-         );
-         properties.insert(
-             "clusterTopicEnable".into(),
-             self.cluster_topic_enable.to_string().into(),
-         );
-         properties.insert(
-             "reviveQueueNum".into(),
-             self.revive_queue_num.to_string().into(),
-         );
-         properties.insert(
-             "enableSlaveActingMaster".into(),
-             self.enable_slave_acting_master.to_string().into(),
-         );
-         properties.insert(
-             "rejectTransactionMessage".into(),
-             self.reject_transaction_message.to_string().into(),
-         );
-         properties.insert(
-             "enableDetailStat".into(),
-             self.enable_detail_stat.to_string().into(),
-         );
-         properties.insert(
-             "flushConsumerOffsetInterval".into(),
-             self.flush_consumer_offset_interval.to_string().into(),
-         );
-         properties.insert(
-             "forceRegister".into(),
-             self.force_register.to_string().into(),
-         );
-         properties.insert(
-             "registerNameServerPeriod".into(),
-             self.register_name_server_period.to_string().into(),
-         );
-         properties.insert(
-             "skipPreOnline".into(),
-             self.skip_pre_online.to_string().into(),
-         );
-         properties.insert(
-             "namesrvAddr".into(),
-             self.namesrv_addr.clone().unwrap_or_default(),
-         );
-         properties.insert(
-             "fetchNameSrvAddrByDnsLookup".into(),
-             self.fetch_name_srv_addr_by_dns_lookup.to_string().into(),
-         );
-         properties.insert(
-             "litePullMessageEnable".into(),
-             self.lite_pull_message_enable.to_string().into(),
-         );
-         properties.insert(
-             "autoCreateSubscriptionGroup".into(),
-             self.auto_create_subscription_group.to_string().into(),
-         );
-         properties.insert(
-             "channelExpiredTimeout".into(),
-             self.channel_expired_timeout.to_string().into(),
-         );
-         properties.insert(
-             "subscriptionExpiredTimeout".into(),
-             self.subscription_expired_timeout.to_string().into(),
-         );
-         properties.insert(
-             "enablePropertyFilter".into(),
-             self.enable_property_filter.to_string().into(),
-         );
-         properties.insert(
-             "filterSupportRetry".into(),
-             self.filter_support_retry.to_string().into(),
-         );
-         properties.insert(
-             "useServerSideResetOffset".into(),
-             self.use_server_side_reset_offset.to_string().into(),
-         );
-         properties.insert(
-             "slaveReadEnable".into(),
-             self.slave_read_enable.to_string().into(),
-         );
-         properties.insert(
-             "commercialBaseCount".into(),
-             self.commercial_base_count.to_string().into(),
-         );
-         properties.insert(
-             "rejectPullConsumerEnable".into(),
-             self.reject_pull_consumer_enable.to_string().into(),
-         );
-         properties.insert(
-             "consumerOffsetUpdateVersionStep".into(),
-             self.consumer_offset_update_version_step.to_string().into(),
-         );
-         properties.insert(
-             "enableBroadcastOffsetStore".into(),
-             self.enable_broadcast_offset_store.to_string().into(),
-         );
-         properties.insert(
-             "transferMsgByHeap".into(),
-             self.transfer_msg_by_heap.to_string().into(),
-         );
-         properties.insert(
-             "shortPollingTimeMills".into(),
-             self.short_polling_time_mills.to_string().into(),
-         );
-         properties.insert(
-             "longPollingEnable".into(),
-             self.long_polling_enable.to_string().into(),
-         );
-         properties.insert(
-             "maxErrorRateOfBloomFilter".into(),
-             self.max_error_rate_of_bloom_filter.to_string().into(),
-         );
-         properties.insert(
-             "expectConsumerNumUseFilter".into(),
-             self.expect_consumer_num_use_filter.to_string().into(),
-         );
-         properties.insert(
-             "bitMapLengthConsumeQueueExt".into(),
-             self.bit_map_length_consume_queue_ext.to_string().into(),
-         );
-         properties.insert(
-             "validateSystemTopicWhenUpdateTopic".into(),
-             self.validate_system_topic_when_update_topic
-                 .to_string()
-                 .into(),
-         );
-         properties.insert(
-             "enableMixedMessageType".into(),
-             self.enable_mixed_message_type.to_string().into(),
-         );
-         properties.insert(
-             "autoDeleteUnusedStats".into(),
-             self.auto_delete_unused_stats.to_string().into(),
-         );
-         properties.insert(
-             "forwardTimeout".into(),
-             self.forward_timeout.to_string().into(),
-         );
-         properties
-     }
- }
- 
- pub fn default_broker_name() -> String {
-     LOCAL_HOST_NAME
-         .clone()
-         .unwrap_or_else(|| "DEFAULT_BROKER".to_string())
- }
- 
- #[derive(Debug, Serialize, Deserialize, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct TopicQueueConfig {
-     pub default_topic_queue_nums: u32,
- }
- 
- impl Default for TopicQueueConfig {
-     fn default() -> Self {
-         TopicQueueConfig {
-             default_topic_queue_nums: 8,
-         }
-     }
- }
- 
- #[derive(Debug, Serialize, Deserialize, Default, Clone)]
- #[serde(rename_all = "camelCase")]
- pub struct TimerWheelConfig {
-     pub timer_wheel_enable: bool,
- }
- 
+use std::any::Any;
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+use lazy_static::lazy_static;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::common::constant::PermName;
+use crate::common::message::message_enum::MessageRequestMode;
+use crate::common::mix_all;
+use crate::common::mix_all::NAMESRV_ADDR_PROPERTY;
+use crate::common::server::config::ServerConfig;
+use crate::common::topic::TopicValidator;
+
+const DEFAULT_CLUSTER_NAME: &str = "DefaultCluster";
+
+lazy_static! {
+    pub static ref LOCAL_HOST_NAME: Option<String> = match hostname::get() {
+        Ok(hostname) => {
+            Some(hostname.to_string_lossy().to_string())
+        }
+        Err(_) => {
+            None
+        }
+    };
+    pub static ref NAMESRV_ADDR: Option<String> =
+        std::env::var(NAMESRV_ADDR_PROPERTY).map_or(Some("127.0.0.1:9876".to_string()), Some);
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BrokerIdentity {
+    pub broker_name: CheetahString,
+    pub broker_cluster_name: CheetahString,
+    pub broker_id: u64,
+    pub is_broker_container: bool,
+    pub is_in_broker_container: bool,
+}
+
+impl BrokerIdentity {
+    pub fn new() -> Self {
+        let broker_name = default_broker_name();
+        let broker_cluster_name = String::from(DEFAULT_CLUSTER_NAME);
+        let broker_id = mix_all::MASTER_ID;
+        let is_broker_container = false;
+
+        BrokerIdentity {
+            broker_name: CheetahString::from_string(broker_name),
+            broker_cluster_name: CheetahString::from_string(broker_cluster_name),
+            broker_id,
+            is_broker_container,
+            is_in_broker_container: false,
+        }
+    }
+
+    fn new_with_container(is_broker_container: bool) -> Self {
+        let mut identity = BrokerIdentity::new();
+        identity.is_broker_container = is_broker_container;
+        identity
+    }
+
+    fn new_with_params(broker_cluster_name: String, broker_name: String, broker_id: u64) -> Self {
+        BrokerIdentity {
+            broker_name: CheetahString::from_string(broker_name),
+            broker_cluster_name: CheetahString::from_string(broker_cluster_name),
+            broker_id,
+            is_broker_container: false,
+            is_in_broker_container: false,
+        }
+    }
+
+    fn new_with_container_params(
+        broker_cluster_name: String,
+        broker_name: String,
+        broker_id: u64,
+        is_in_broker_container: bool,
+    ) -> Self {
+        BrokerIdentity {
+            broker_name: CheetahString::from_string(broker_name),
+            broker_cluster_name: CheetahString::from_string(broker_cluster_name),
+            broker_id,
+            is_broker_container: true,
+            is_in_broker_container,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BrokerConfig {
+    pub broker_identity: BrokerIdentity,
+
+    pub topic_queue_config: TopicQueueConfig,
+
+    pub timer_wheel_config: TimerWheelConfig,
+
+    pub broker_server_config: ServerConfig,
+
+    pub broker_ip1: CheetahString,
+    pub broker_ip2: Option<CheetahString>,
+    pub listen_port: u32,
+    pub trace_topic_enable: bool,
+    pub msg_trace_topic_name: CheetahString,
+    pub enable_controller_mode: bool,
+    pub broker_name: CheetahString,
+    pub region_id: CheetahString,
+    pub trace_on: bool,
+    pub broker_permission: u32,
+    pub async_send_enable: bool,
+    pub store_path_root_dir: CheetahString,
+    pub enable_split_registration: bool,
+    pub split_registration_size: i32,
+    pub register_broker_timeout_mills: i32,
+    pub is_in_broker_container: bool,
+    pub commercial_size_per_msg: i32,
+    pub recover_concurrently: bool,
+    pub duplication_enable: bool,
+    pub start_accept_send_request_time_stamp: i64,
+    pub auto_create_topic_enable: bool,
+    pub enable_single_topic_register: bool,
+    pub broker_topic_enable: bool,
+    pub cluster_topic_enable: bool,
+    pub revive_queue_num: u32,
+    pub enable_slave_acting_master: bool,
+    pub reject_transaction_message: bool,
+    pub enable_detail_stat: bool,
+    pub flush_consumer_offset_interval: u64,
+    pub force_register: bool,
+    pub register_name_server_period: u64,
+    pub skip_pre_online: bool,
+    pub namesrv_addr: Option<CheetahString>,
+    pub fetch_name_srv_addr_by_dns_lookup: bool,
+    pub lite_pull_message_enable: bool,
+    pub auto_create_subscription_group: bool,
+    pub channel_expired_timeout: u64,
+    pub subscription_expired_timeout: u64,
+    pub enable_property_filter: bool,
+    pub filter_support_retry: bool,
+    pub use_server_side_reset_offset: bool,
+    pub slave_read_enable: bool,
+    pub commercial_base_count: i32,
+    pub reject_pull_consumer_enable: bool,
+    pub consumer_offset_update_version_step: i64,
+    pub enable_broadcast_offset_store: bool,
+    pub transfer_msg_by_heap: bool,
+    pub short_polling_time_mills: u64,
+    pub long_polling_enable: bool,
+    pub max_error_rate_of_bloom_filter: i32,
+    pub expect_consumer_num_use_filter: i32,
+    pub bit_map_length_consume_queue_ext: i32,
+    pub validate_system_topic_when_update_topic: bool,
+    pub enable_mixed_message_type: bool,
+    pub auto_delete_unused_stats: bool,
+    pub forward_timeout: u64,
+    pub store_reply_message_enable: bool,
+    pub lock_in_strict_mode: bool,
+    pub transaction_timeout: u64,
+    pub transaction_op_msg_max_size: i32,
+    pub default_message_request_mode: MessageRequestMode,
+    pub default_pop_share_queue_num: i32,
+    pub load_balance_poll_name_server_interval: u64,
+    pub server_load_balancer_enable: bool,
+    pub enable_remote_escape: bool,
+    pub enable_pop_log: bool,
+    pub enable_retry_topic_v2: bool,
+    // read message from pop retry topic v1, for the compatibility, will be removed in the future
+    // version
+    pub retrieve_message_from_pop_retry_topic_v1: bool,
+    pub pop_from_retry_probability: i32,
+    pub pop_response_return_actual_retry_topic: bool,
+}
+
+impl Default for BrokerConfig {
+    fn default() -> Self {
+        let broker_identity = BrokerIdentity::new();
+        let local_ip = local_ip_address::local_ip().unwrap();
+        let broker_ip1 = local_ip.to_string().into();
+        let broker_ip2 = Some(local_ip.to_string().into());
+        let listen_port = 10911;
+
+        BrokerConfig {
+            broker_identity,
+            topic_queue_config: TopicQueueConfig::default(),
+            timer_wheel_config: TimerWheelConfig::default(),
+            broker_server_config: Default::default(),
+            broker_ip1,
+            broker_ip2,
+            listen_port,
+            trace_topic_enable: false,
+            msg_trace_topic_name: CheetahString::from_static_str(
+                TopicValidator::RMQ_SYS_TRACE_TOPIC,
+            ),
+            enable_controller_mode: false,
+            broker_name: default_broker_name().into(),
+            region_id: CheetahString::from_static_str(mix_all::DEFAULT_TRACE_REGION_ID),
+            trace_on: true,
+            broker_permission: PermName::PERM_WRITE | PermName::PERM_READ,
+            async_send_enable: false,
+            store_path_root_dir: dirs::home_dir()
+                .unwrap()
+                .join("store")
+                .to_string_lossy()
+                .into_owned()
+                .into(),
+            enable_split_registration: false,
+            split_registration_size: 800,
+            register_broker_timeout_mills: 24000,
+            is_in_broker_container: false,
+            commercial_size_per_msg: 4 * 1024,
+            recover_concurrently: false,
+            duplication_enable: false,
+            start_accept_send_request_time_stamp: 0,
+            auto_create_topic_enable: true,
+            enable_single_topic_register: true,
+            broker_topic_enable: true,
+            cluster_topic_enable: true,
+            revive_queue_num: 8,
+            enable_slave_acting_master: false,
+            reject_transaction_message: false,
+            enable_detail_stat: true,
+            flush_consumer_offset_interval: 1000 * 5,
+            force_register: true,
+            register_name_server_period: 1000 * 30,
+            skip_pre_online: false,
+            namesrv_addr: NAMESRV_ADDR.clone().map(|addr| addr.into()),
+            fetch_name_srv_addr_by_dns_lookup: false,
+            lite_pull_message_enable: true,
+            auto_create_subscription_group: true,
+            channel_expired_timeout: 1000 * 120,
+            subscription_expired_timeout: 1000 * 60 * 10,
+            enable_property_filter: false,
+            filter_support_retry: false,
+            use_server_side_reset_offset: true,
+            slave_read_enable: false,
+            commercial_base_count: 1,
+            reject_pull_consumer_enable: false,
+            consumer_offset_update_version_step: 500,
+            enable_broadcast_offset_store: true,
+            transfer_msg_by_heap: true,
+            short_polling_time_mills: 1000,
+            long_polling_enable: true,
+            max_error_rate_of_bloom_filter: 20,
+            expect_consumer_num_use_filter: 32,
+            bit_map_length_consume_queue_ext: 64,
+            forward_timeout: 3 * 1000,
+            validate_system_topic_when_update_topic: true,
+            enable_mixed_message_type: false,
+            auto_delete_unused_stats: false,
+            store_reply_message_enable: true,
+            lock_in_strict_mode: false,
+            transaction_timeout: 6_000,
+            transaction_op_msg_max_size: 4096,
+            default_message_request_mode: MessageRequestMode::Pull,
+            default_pop_share_queue_num: -1,
+            load_balance_poll_name_server_interval: 30_000,
+            server_load_balancer_enable: true,
+            enable_remote_escape: false,
+            enable_pop_log: false,
+            enable_retry_topic_v2: false,
+            retrieve_message_from_pop_retry_topic_v1: true,
+            pop_from_retry_probability: 20,
+            pop_response_return_actual_retry_topic: false,
+        }
+    }
+}
+
+impl BrokerConfig {
+    pub fn broker_name(&self) -> CheetahString {
+        self.broker_name.clone()
+    }
+
+    pub fn broker_ip1(&self) -> CheetahString {
+        self.broker_ip1.clone()
+    }
+
+    pub fn broker_ip2(&self) -> Option<CheetahString> {
+        self.broker_ip2.clone()
+    }
+
+    pub fn listen_port(&self) -> u32 {
+        self.listen_port
+    }
+
+    pub fn trace_topic_enable(&self) -> bool {
+        self.trace_topic_enable
+    }
+
+    pub fn broker_server_config(&self) -> &ServerConfig {
+        &self.broker_server_config
+    }
+
+    pub fn region_id(&self) -> &str {
+        self.region_id.as_str()
+    }
+
+    pub fn broker_permission(&self) -> u32 {
+        self.broker_permission
+    }
+
+    pub fn get_broker_addr(&self) -> String {
+        format!("{}:{}", self.broker_ip1, self.listen_port)
+    }
+
+    pub fn get_start_accept_send_request_time_stamp(&self) -> i64 {
+        self.start_accept_send_request_time_stamp
+    }
+
+    pub fn get_properties(&self) -> HashMap<CheetahString, CheetahString> {
+        let mut properties = HashMap::new();
+        properties.insert("brokerName".into(), self.broker_name.clone());
+        properties.insert(
+            "brokerClusterName".into(),
+            self.broker_identity.broker_cluster_name.clone(),
+        );
+        properties.insert(
+            "brokerId".into(),
+            self.broker_identity.broker_id.to_string().into(),
+        );
+        properties.insert(
+            "isBrokerContainer".into(),
+            self.broker_identity.is_broker_container.to_string().into(),
+        );
+        properties.insert(
+            "defaultTopicQueueNums".into(),
+            self.topic_queue_config
+                .default_topic_queue_nums
+                .to_string()
+                .into(),
+        );
+        properties.insert(
+            "timerWheelEnable".into(),
+            self.timer_wheel_config
+                .timer_wheel_enable
+                .to_string()
+                .into(),
+        );
+        properties.insert(
+            "bindAddress".into(),
+            self.broker_server_config
+                .bind_address
+                .clone()
+                .to_string()
+                .into(),
+        );
+        properties.insert(
+            "brokerIp1".into(),
+            self.broker_ip1.clone().to_string().into(),
+        );
+        properties.insert(
+            "brokerIp2".into(),
+            self.broker_ip2.clone().unwrap_or_default(),
+        );
+        properties.insert("listenPort".into(), self.listen_port.to_string().into());
+        properties.insert(
+            "traceTopicEnable".into(),
+            self.trace_topic_enable.to_string().into(),
+        );
+        properties.insert(
+            "msgTraceTopicName".into(),
+            self.msg_trace_topic_name.clone(),
+        );
+        properties.insert(
+            "enableControllerMode".into(),
+            self.enable_controller_mode.to_string().into(),
+        );
+        properties.insert("regionId".into(), self.region_id.clone());
+        properties.insert("brokerName".into(), self.broker_name.clone());
+        properties.insert("traceOn".into(), self.trace_on.to_string().into());
+        properties.insert(
+            "brokerPermission".into(),
+            self.broker_permission.to_string().into(),
+        );
+        properties.insert(
+            "asyncSendEnable".into(),
+            self.async_send_enable.to_string().into(),
+        );
+        properties.insert("storePathRootDir".into(), self.store_path_root_dir.clone());
+        properties.insert(
+            "enableSplitRegistration".into(),
+            self.enable_split_registration.to_string().into(),
+        );
+        properties.insert(
+            "splitRegistrationSize".into(),
+            self.split_registration_size.to_string().into(),
+        );
+        properties.insert(
+            "registerBrokerTimeoutMills".into(),
+            self.register_broker_timeout_mills.to_string().into(),
+        );
+        properties.insert(
+            "isInBrokerContainer".into(),
+            self.is_in_broker_container.to_string().into(),
+        );
+        properties.insert(
+            "commercialSizePerMsg".into(),
+            self.commercial_size_per_msg.to_string().into(),
+        );
+        properties.insert(
+            "recoverConcurrently".into(),
+            self.recover_concurrently.to_string().into(),
+        );
+        properties.insert(
+            "duplicationEnable".into(),
+            self.duplication_enable.to_string().into(),
+        );
+        properties.insert(
+            "startAcceptSendRequestTimeStamp".into(),
+            self.start_accept_send_request_time_stamp.to_string().into(),
+        );
+        properties.insert(
+            "autoCreateTopicEnable".into(),
+            self.auto_create_topic_enable.to_string().into(),
+        );
+        properties.insert(
+            "enableSingleTopicRegister".into(),
+            self.enable_single_topic_register.to_string().into(),
+        );
+        properties.insert(
+            "brokerTopicEnable".into(),
+            self.broker_topic_enable.to_string().into(),
+        );
+        properties.insert(
+            "clusterTopicEnable".into(),
+            self.cluster_topic_enable.to_string().into(),
+        );
+        properties.insert(
+            "reviveQueueNum".into(),
+            self.revive_queue_num.to_string().into(),
+        );
+        properties.insert(
+            "enableSlaveActingMaster".into(),
+            self.enable_slave_acting_master.to_string().into(),
+        );
+        properties.insert(
+            "rejectTransactionMessage".into(),
+            self.reject_transaction_message.to_string().into(),
+        );
+        properties.insert(
+            "enableDetailStat".into(),
+            self.enable_detail_stat.to_string().into(),
+        );
+        properties.insert(
+            "flushConsumerOffsetInterval".into(),
+            self.flush_consumer_offset_interval.to_string().into(),
+        );
+        properties.insert(
+            "forceRegister".into(),
+            self.force_register.to_string().into(),
+        );
+        properties.insert(
+            "registerNameServerPeriod".into(),
+            self.register_name_server_period.to_string().into(),
+        );
+        properties.insert(
+            "skipPreOnline".into(),
+            self.skip_pre_online.to_string().into(),
+        );
+        properties.insert(
+            "namesrvAddr".into(),
+            self.namesrv_addr.clone().unwrap_or_default(),
+        );
+        properties.insert(
+            "fetchNameSrvAddrByDnsLookup".into(),
+            self.fetch_name_srv_addr_by_dns_lookup.to_string().into(),
+        );
+        properties.insert(
+            "litePullMessageEnable".into(),
+            self.lite_pull_message_enable.to_string().into(),
+        );
+        properties.insert(
+            "autoCreateSubscriptionGroup".into(),
+            self.auto_create_subscription_group.to_string().into(),
+        );
+        properties.insert(
+            "channelExpiredTimeout".into(),
+            self.channel_expired_timeout.to_string().into(),
+        );
+        properties.insert(
+            "subscriptionExpiredTimeout".into(),
+            self.subscription_expired_timeout.to_string().into(),
+        );
+        properties.insert(
+            "enablePropertyFilter".into(),
+            self.enable_property_filter.to_string().into(),
+        );
+        properties.insert(
+            "filterSupportRetry".into(),
+            self.filter_support_retry.to_string().into(),
+        );
+        properties.insert(
+            "useServerSideResetOffset".into(),
+            self.use_server_side_reset_offset.to_string().into(),
+        );
+        properties.insert(
+            "slaveReadEnable".into(),
+            self.slave_read_enable.to_string().into(),
+        );
+        properties.insert(
+            "commercialBaseCount".into(),
+            self.commercial_base_count.to_string().into(),
+        );
+        properties.insert(
+            "rejectPullConsumerEnable".into(),
+            self.reject_pull_consumer_enable.to_string().into(),
+        );
+        properties.insert(
+            "consumerOffsetUpdateVersionStep".into(),
+            self.consumer_offset_update_version_step.to_string().into(),
+        );
+        properties.insert(
+            "enableBroadcastOffsetStore".into(),
+            self.enable_broadcast_offset_store.to_string().into(),
+        );
+        properties.insert(
+            "transferMsgByHeap".into(),
+            self.transfer_msg_by_heap.to_string().into(),
+        );
+        properties.insert(
+            "shortPollingTimeMills".into(),
+            self.short_polling_time_mills.to_string().into(),
+        );
+        properties.insert(
+            "longPollingEnable".into(),
+            self.long_polling_enable.to_string().into(),
+        );
+        properties.insert(
+            "maxErrorRateOfBloomFilter".into(),
+            self.max_error_rate_of_bloom_filter.to_string().into(),
+        );
+        properties.insert(
+            "expectConsumerNumUseFilter".into(),
+            self.expect_consumer_num_use_filter.to_string().into(),
+        );
+        properties.insert(
+            "bitMapLengthConsumeQueueExt".into(),
+            self.bit_map_length_consume_queue_ext.to_string().into(),
+        );
+        properties.insert(
+            "validateSystemTopicWhenUpdateTopic".into(),
+            self.validate_system_topic_when_update_topic
+                .to_string()
+                .into(),
+        );
+        properties.insert(
+            "enableMixedMessageType".into(),
+            self.enable_mixed_message_type.to_string().into(),
+        );
+        properties.insert(
+            "autoDeleteUnusedStats".into(),
+            self.auto_delete_unused_stats.to_string().into(),
+        );
+        properties.insert(
+            "forwardTimeout".into(),
+            self.forward_timeout.to_string().into(),
+        );
+        properties
+    }
+}
+
+pub fn default_broker_name() -> String {
+    LOCAL_HOST_NAME
+        .clone()
+        .unwrap_or_else(|| "DEFAULT_BROKER".to_string())
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TopicQueueConfig {
+    pub default_topic_queue_nums: u32,
+}
+
+impl Default for TopicQueueConfig {
+    fn default() -> Self {
+        TopicQueueConfig {
+            default_topic_queue_nums: 8,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TimerWheelConfig {
+    pub timer_wheel_enable: bool,
+}

--- a/rocketmq-remoting/src/protocol/header/extra_info_util.rs
+++ b/rocketmq-remoting/src/protocol/header/extra_info_util.rs
@@ -15,890 +15,891 @@
  * limitations under the License.
  */
 
-use std::collections::HashMap;
-use std::vec::Vec;
-
-use rocketmq_common::common::key_builder::KeyBuilder;
-use rocketmq_common::common::key_builder::POP_ORDER_REVIVE_QUEUE;
-use rocketmq_common::common::message::MessageConst;
-use rocketmq_common::common::mix_all;
-
-use crate::remoting_error::RemotingError::IllegalArgument;
-
-pub struct ExtraInfoUtil;
-
-const NORMAL_TOPIC: &str = "0";
-const RETRY_TOPIC: &str = "1";
-const RETRY_TOPIC_V2: &str = "2";
-const QUEUE_OFFSET: &str = "qo";
-
-impl ExtraInfoUtil {
-    pub fn split(extra_info: &str) -> crate::Result<Vec<String>> {
-        if extra_info.is_empty() {
-            return Err(IllegalArgument("split extraInfo is empty".to_string()));
-        }
-        Ok(extra_info.split('|').map(String::from).collect())
-    }
-
-    pub fn get_ck_queue_offset(extra_info_strs: &[String]) -> crate::Result<i64> {
-        if extra_info_strs.is_empty() {
-            return Err(IllegalArgument(format!(
-                "getCkQueueOffset fail, extraInfoStrs length {}",
-                extra_info_strs.len()
-            )));
-        }
-        extra_info_strs[0]
-            .parse::<i64>()
-            .map_err(|_| IllegalArgument("parse ck_queue_offset error".to_string()))
-    }
-
-    pub fn get_pop_time(extra_info_strs: &[String]) -> crate::Result<i64> {
-        if extra_info_strs.len() < 2 {
-            return Err(IllegalArgument(format!(
-                "getPopTime fail, extraInfoStrs length {}",
-                extra_info_strs.len()
-            )));
-        }
-        extra_info_strs[1]
-            .parse::<i64>()
-            .map_err(|_| IllegalArgument("parse pop_time error".to_string()))
-    }
-
-    pub fn get_invisible_time(extra_info_strs: &[String]) -> crate::Result<i64> {
-        if extra_info_strs.len() < 3 {
-            return Err(IllegalArgument(format!(
-                "getInvisibleTime fail, extraInfoStrs length {}",
-                extra_info_strs.len()
-            )));
-        }
-        extra_info_strs[2]
-            .parse::<i64>()
-            .map_err(|_| IllegalArgument("parse invisible_time error".to_string()))
-    }
-
-    pub fn get_revive_qid(extra_info_strs: &[String]) -> crate::Result<i32> {
-        if extra_info_strs.len() < 4 {
-            return Err(IllegalArgument(format!(
-                "getReviveQid fail, extraInfoStrs length {}",
-                extra_info_strs.len()
-            )));
-        }
-        extra_info_strs[3]
-            .parse::<i32>()
-            .map_err(|_| IllegalArgument("parse revive_qid error".to_string()))
-    }
-
-    pub fn get_real_topic(
-        extra_info_strs: &[String],
-        topic: &str,
-        cid: &str,
-    ) -> crate::Result<String> {
-        if extra_info_strs.len() < 5 {
-            return Err(IllegalArgument(format!(
-                "getRealTopic fail, extraInfoStrs length {}",
-                extra_info_strs.len()
-            )));
-        }
-        match extra_info_strs[4].as_str() {
-            RETRY_TOPIC => Ok(KeyBuilder::build_pop_retry_topic_v1(topic, cid)),
-            RETRY_TOPIC_V2 => Ok(KeyBuilder::build_pop_retry_topic_v2(topic, cid)),
-            _ => Ok(topic.to_string()),
-        }
-    }
-
-    pub fn get_real_topic_with_retry(topic: &str, cid: &str, retry: &str) -> crate::Result<String> {
-        match retry {
-            NORMAL_TOPIC => Ok(topic.to_string()),
-            RETRY_TOPIC => Ok(KeyBuilder::build_pop_retry_topic_v1(topic, cid)),
-            RETRY_TOPIC_V2 => Ok(KeyBuilder::build_pop_retry_topic_v2(topic, cid)),
-            _ => Err(IllegalArgument(
-                "getRetry fail, format is wrong".to_string(),
-            )),
-        }
-    }
-
-    pub fn get_retry_slice(extra_info_strs: &[String]) -> crate::Result<String> {
-        if extra_info_strs.len() < 5 {
-            return Err(IllegalArgument(format!(
-                "getRetry fail, extraInfoStrs length {}",
-                extra_info_strs.len()
-            )));
-        }
-        Ok(extra_info_strs[4].clone())
-    }
-
-    pub fn get_broker_name(extra_info_strs: &[String]) -> crate::Result<String> {
-        if extra_info_strs.len() < 6 {
-            return Err(IllegalArgument(format!(
-                "getBrokerName fail, extraInfoStrs length {}",
-                extra_info_strs.len()
-            )));
-        }
-        Ok(extra_info_strs[5].clone())
-    }
-
-    pub fn get_queue_id(extra_info_strs: &[String]) -> crate::Result<i32> {
-        if extra_info_strs.len() < 7 {
-            return Err(IllegalArgument(format!(
-                "getQueueId fail, extraInfoStrs length {}",
-                extra_info_strs.len()
-            )));
-        }
-        extra_info_strs[6]
-            .parse::<i32>()
-            .map_err(|_| IllegalArgument("parse queue_id error".to_string()))
-    }
-
-    pub fn get_queue_offset(extra_info_strs: &[String]) -> crate::Result<i64> {
-        if extra_info_strs.len() < 8 {
-            return Err(IllegalArgument(format!(
-                "getQueueOffset fail, extraInfoStrs length {}",
-                extra_info_strs.len()
-            )));
-        }
-        extra_info_strs[7]
-            .parse::<i64>()
-            .map_err(|_| IllegalArgument("parse queue_offset error".to_string()))
-    }
-
-    pub fn build_extra_info(
-        ck_queue_offset: i64,
-        pop_time: i64,
-        invisible_time: i64,
-        revive_qid: i32,
-        topic: &str,
-        broker_name: &str,
-        queue_id: i32,
-    ) -> String {
-        let t = ExtraInfoUtil::get_retry(topic);
-        format!(
-            "{}{}{}{}{}{}{}{}{}{}{}{}{}",
-            ck_queue_offset,
-            MessageConst::KEY_SEPARATOR,
-            pop_time,
-            MessageConst::KEY_SEPARATOR,
-            invisible_time,
-            MessageConst::KEY_SEPARATOR,
-            revive_qid,
-            MessageConst::KEY_SEPARATOR,
-            t,
-            MessageConst::KEY_SEPARATOR,
-            broker_name,
-            MessageConst::KEY_SEPARATOR,
-            queue_id
-        )
-    }
-
-    pub fn build_extra_info_with_msg_queue_offset(
-        ck_queue_offset: i64,
-        pop_time: i64,
-        invisible_time: i64,
-        revive_qid: i32,
-        topic: &str,
-        broker_name: &str,
-        queue_id: i32,
-        msg_queue_offset: i64,
-    ) -> String {
-        let t = ExtraInfoUtil::get_retry(topic);
-        format!(
-            "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
-            ck_queue_offset,
-            MessageConst::KEY_SEPARATOR,
-            pop_time,
-            MessageConst::KEY_SEPARATOR,
-            invisible_time,
-            MessageConst::KEY_SEPARATOR,
-            revive_qid,
-            MessageConst::KEY_SEPARATOR,
-            t,
-            MessageConst::KEY_SEPARATOR,
-            broker_name,
-            MessageConst::KEY_SEPARATOR,
-            queue_id,
-            MessageConst::KEY_SEPARATOR,
-            msg_queue_offset
-        )
-    }
-
-    pub fn build_start_offset_info(
-        string_builder: &mut String,
-        topic: &str,
-        queue_id: i32,
-        start_offset: i64,
-    ) {
-        let retry = ExtraInfoUtil::get_retry(topic);
-        if !string_builder.is_empty() {
-            string_builder.push(';');
-        }
-        string_builder.push_str(&format!(
-            "{}{}{}{}{}",
-            retry,
-            MessageConst::KEY_SEPARATOR,
-            queue_id,
-            MessageConst::KEY_SEPARATOR,
-            start_offset
-        ));
-    }
-
-    pub fn build_queue_id_order_count_info(
-        string_builder: &mut String,
-        topic: &str,
-        queue_id: i32,
-        order_count: i32,
-    ) {
-        let retry = ExtraInfoUtil::get_retry(topic);
-        if !string_builder.is_empty() {
-            string_builder.push(';');
-        }
-        string_builder.push_str(&format!(
-            "{}{}{}{}{}",
-            retry,
-            MessageConst::KEY_SEPARATOR,
-            queue_id,
-            MessageConst::KEY_SEPARATOR,
-            order_count
-        ));
-    }
-
-    pub fn build_queue_offset_order_count_info(
-        string_builder: &mut String,
-        topic: &str,
-        queue_id: i64,
-        queue_offset: i64,
-        order_count: i32,
-    ) {
-        if !string_builder.is_empty() {
-            string_builder.push(';');
-        }
-        string_builder.push_str(&format!(
-            "{}{}{}{}{}",
-            ExtraInfoUtil::get_retry(topic),
-            MessageConst::KEY_SEPARATOR,
-            ExtraInfoUtil::get_queue_offset_key_value_key(queue_id, queue_offset),
-            MessageConst::KEY_SEPARATOR,
-            order_count
-        ));
-    }
-
-    pub fn build_msg_offset_info(
-        string_builder: &mut String,
-        topic: &str,
-        queue_id: i32,
-        msg_offsets: Vec<i64>,
-    ) {
-        let retry = ExtraInfoUtil::get_retry(topic);
-        if !string_builder.is_empty() {
-            string_builder.push(';');
-        }
-        string_builder.push_str(&format!(
-            "{}{}{}",
-            retry,
-            MessageConst::KEY_SEPARATOR,
-            queue_id
-        ));
-        for (i, msg_offset) in msg_offsets.iter().enumerate() {
-            string_builder.push_str(&msg_offset.to_string());
-            if i < msg_offsets.len() - 1 {
-                string_builder.push(',');
-            }
-        }
-    }
-
-    pub fn parse_msg_offset_info(
-        msg_offset_info: &str,
-    ) -> crate::Result<HashMap<String, Vec<i64>>> {
-        let mut msg_offset_map = HashMap::new();
-        let entries: Vec<&str> = msg_offset_info.split(';').collect();
-
-        for entry in entries {
-            let parts: Vec<&str> = entry.split(MessageConst::KEY_SEPARATOR).collect();
-            if parts.len() != 3 {
-                return Err(IllegalArgument("parse msgOffsetInfo error".to_string()));
-            }
-
-            let key = format!("{}@{}", parts[0], parts[1]);
-            let offsets: Vec<i64> = parts[2]
-                .split(',')
-                .map(|s| s.parse::<i64>().unwrap())
-                .collect();
-
-            msg_offset_map.insert(key, offsets);
-        }
-
-        Ok(msg_offset_map)
-    }
-
-    pub fn parse_start_offset_info(start_offset_info: &str) -> crate::Result<HashMap<String, i64>> {
-        let mut start_offset_map = HashMap::new();
-        let entries: Vec<&str> = start_offset_info.split(';').collect();
-
-        for entry in entries {
-            let parts: Vec<&str> = entry.split(MessageConst::KEY_SEPARATOR).collect();
-            if parts.len() != 3 {
-                return Err(IllegalArgument("parse startOffsetInfo error".to_string()));
-            }
-
-            let key = format!("{}@{}", parts[0], parts[1]);
-            let offset = parts[2]
-                .parse::<i64>()
-                .map_err(|_| IllegalArgument("Invalid start offset value".to_string()))?;
-            start_offset_map.insert(key, offset);
-        }
-
-        Ok(start_offset_map)
-    }
-
-    pub fn parse_order_count_info(order_count_info: &str) -> crate::Result<HashMap<String, i32>> {
-        let mut start_offset_map = HashMap::new();
-        if order_count_info.is_empty() {
-            return Ok(start_offset_map); // return None if the input is empty
-        }
-
-        // Split the input string by semicolon
-        let array: Vec<&str> = order_count_info.split(';').collect();
-
-        for one in array {
-            // Split each element by the separator
-            let split: Vec<&str> = one.split(MessageConst::KEY_SEPARATOR).collect();
-
-            if split.len() != 3 {
-                return Err(IllegalArgument(format!(
-                    "parse orderCountInfo error {}",
-                    order_count_info
-                ))); // Handle invalid split
-            }
-
-            // Construct the key as `split[0]@split[1]`
-            let key = format!("{}@{}", split[0], split[1]);
-
-            // Check for duplicate keys
-            if start_offset_map.contains_key(&key) {
-                return Err(IllegalArgument(format!(
-                    "parse orderCountInfo error, duplicate key, {}",
-                    order_count_info
-                )));
-            }
-
-            // Insert the key-value pair into the map
-            if let Ok(value) = split[2].parse::<i32>() {
-                start_offset_map.insert(key, value);
-            } else {
-                return Err(IllegalArgument(format!(
-                    "parse orderCountInfo error, duplicate key, {}",
-                    order_count_info
-                )));
-            }
-        }
-
-        Ok(start_offset_map) // Return the populated HashMap
-    }
-
-    pub fn get_retry_for_topic(topic: &str) -> String {
-        if topic.starts_with("RETRY_") {
-            RETRY_TOPIC.to_string()
-        } else {
-            NORMAL_TOPIC.to_string()
-        }
-    }
-
-    pub fn get_start_offset_info_map_key(topic: &str, key: i64) -> String {
-        format!("{}@{}", ExtraInfoUtil::get_retry(topic), key)
-    }
-
-    pub fn get_start_offset_info_map_key_with_pop_ck(
-        topic: &str,
-        pop_ck: &str,
-        key: i64,
-    ) -> String {
-        format!(
-            "{}@{}",
-            ExtraInfoUtil::get_retry_with_pop_ck(topic, pop_ck),
-            key
-        )
-    }
-
-    pub fn get_queue_offset_key_value_key(queue_id: i64, queue_offset: i64) -> String {
-        format!("{}{}%{}", QUEUE_OFFSET, queue_id, queue_offset)
-    }
-
-    pub fn get_queue_offset_map_key(topic: &str, queue_id: i64, queue_offset: i64) -> String {
-        format!(
-            "{}@{}",
-            ExtraInfoUtil::get_retry(topic),
-            ExtraInfoUtil::get_queue_offset_key_value_key(queue_id, queue_offset)
-        )
-    }
-
-    pub fn is_order(extra_info: &[String]) -> bool {
-        ExtraInfoUtil::get_revive_qid(extra_info).unwrap_or_default() == POP_ORDER_REVIVE_QUEUE
-    }
-
-    fn get_retry(topic: &str) -> String {
-        if KeyBuilder::is_pop_retry_topic_v2(topic) {
-            RETRY_TOPIC_V2.to_string()
-        } else if topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
-            RETRY_TOPIC.to_string()
-        } else {
-            NORMAL_TOPIC.to_string()
-        }
-    }
-
-    fn get_retry_with_pop_ck(topic: &str, pop_ck: &str) -> String {
-        if let Ok(split_info) = ExtraInfoUtil::split(pop_ck) {
-            return ExtraInfoUtil::get_retry_from_split(&split_info);
-        }
-        ExtraInfoUtil::get_retry(topic)
-    }
-
-    fn get_retry_from_split(split_info: &[String]) -> String {
-        if split_info.is_empty() {
-            return NORMAL_TOPIC.to_string();
-        }
-        ExtraInfoUtil::get_retry(split_info[0].as_str())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use rocketmq_common::common::key_builder::KeyBuilder;
-
-    use super::*;
-    use crate::remoting_error::RemotingError::IllegalArgument;
-
-    #[test]
-    fn split_with_valid_string() {
-        let result = ExtraInfoUtil::split("a|b|c").unwrap();
-        assert_eq!(result, vec!["a", "b", "c"]);
-    }
-
-    #[test]
-    fn split_with_empty_string() {
-        let result = ExtraInfoUtil::split("").unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("split extraInfo is empty".to_string()).to_string()
-        );
-    }
-
-    #[test]
-    fn get_ck_queue_offset_with_valid_string() {
-        let result = ExtraInfoUtil::get_ck_queue_offset(&vec!["123".to_string()]).unwrap();
-        assert_eq!(result, 123);
-    }
-
-    #[test]
-    fn get_ck_queue_offset_with_invalid_string() {
-        let result = ExtraInfoUtil::get_ck_queue_offset(&vec!["abc".to_string()]).unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("parse ck_queue_offset error".to_string()).to_string()
-        );
-    }
-
-    #[test]
-    fn get_pop_time_with_valid_string() {
-        let result =
-            ExtraInfoUtil::get_pop_time(&vec!["123".to_string(), "456".to_string()]).unwrap();
-        assert_eq!(result, 456);
-    }
-
-    #[test]
-    fn get_pop_time_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_pop_time(&vec!["123".to_string()]).unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("getPopTime fail, extraInfoStrs length 1".to_string()).to_string()
-        );
-    }
-
-    #[test]
-    fn get_invisible_time_with_valid_string() {
-        let result = ExtraInfoUtil::get_invisible_time(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-        ])
-        .unwrap();
-        assert_eq!(result, 789);
-    }
-
-    #[test]
-    fn get_invisible_time_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_invisible_time(&vec!["123".to_string(), "456".to_string()])
-            .unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("getInvisibleTime fail, extraInfoStrs length 2".to_string())
-                .to_string()
-        );
-    }
-
-    #[test]
-    fn get_revive_qid_with_valid_string() {
-        let result = ExtraInfoUtil::get_revive_qid(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "10".to_string(),
-        ])
-        .unwrap();
-        assert_eq!(result, 10);
-    }
-
-    #[test]
-    fn get_revive_qid_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_revive_qid(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-        ])
-        .unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("getReviveQid fail, extraInfoStrs length 3".to_string()).to_string()
-        );
-    }
-
-    #[test]
-    fn get_real_topic_with_retry_v1() {
-        let result = ExtraInfoUtil::get_real_topic(
-            &vec![
-                "123".to_string(),
-                "456".to_string(),
-                "789".to_string(),
-                "10".to_string(),
-                "1".to_string(),
-            ],
-            "topic",
-            "cid",
-        )
-        .unwrap();
-        assert_eq!(result, KeyBuilder::build_pop_retry_topic_v1("topic", "cid"));
-    }
-
-    #[test]
-    fn get_real_topic_with_retry_v2() {
-        let result = ExtraInfoUtil::get_real_topic(
-            &vec![
-                "123".to_string(),
-                "456".to_string(),
-                "789".to_string(),
-                "10".to_string(),
-                "2".to_string(),
-            ],
-            "topic",
-            "cid",
-        )
-        .unwrap();
-        assert_eq!(result, KeyBuilder::build_pop_retry_topic_v2("topic", "cid"));
-    }
-
-    #[test]
-    fn get_real_topic_with_normal_topic() {
-        let result = ExtraInfoUtil::get_real_topic(
-            &vec![
-                "123".to_string(),
-                "456".to_string(),
-                "789".to_string(),
-                "10".to_string(),
-                "0".to_string(),
-            ],
-            "topic",
-            "cid",
-        )
-        .unwrap();
-        assert_eq!(result, "topic".to_string());
-    }
-
-    #[test]
-    fn get_real_topic_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_real_topic(
-            &vec![
-                "123".to_string(),
-                "456".to_string(),
-                "789".to_string(),
-                "10".to_string(),
-            ],
-            "topic",
-            "cid",
-        )
-        .unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("getRealTopic fail, extraInfoStrs length 4".to_string()).to_string()
-        );
-    }
-
-    #[test]
-    fn get_real_topic_with_retry_invalid() {
-        let result = ExtraInfoUtil::get_real_topic_with_retry("topic", "cid", "3").unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("getRetry fail, format is wrong".to_string()).to_string()
-        );
-    }
-
-    #[test]
-    fn get_retry_slice_with_valid_string() {
-        let result = ExtraInfoUtil::get_retry_slice(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "10".to_string(),
-            "1".to_string(),
-        ])
-        .unwrap();
-        assert_eq!(result, "1".to_string());
-    }
-
-    #[test]
-    fn get_retry_slice_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_retry_slice(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "10".to_string(),
-        ])
-        .unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("getRetry fail, extraInfoStrs length 4".to_string()).to_string()
-        );
-    }
-
-    #[test]
-    fn get_broker_name_with_valid_string() {
-        let result = ExtraInfoUtil::get_broker_name(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "10".to_string(),
-            "1".to_string(),
-            "broker".to_string(),
-        ])
-        .unwrap();
-        assert_eq!(result, "broker".to_string());
-    }
-
-    #[test]
-    fn get_broker_name_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_broker_name(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "10".to_string(),
-            "1".to_string(),
-        ])
-        .unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("getBrokerName fail, extraInfoStrs length 5".to_string()).to_string()
-        );
-    }
-
-    #[test]
-    fn get_queue_id_with_valid_string() {
-        let result = ExtraInfoUtil::get_queue_id(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "10".to_string(),
-            "1".to_string(),
-            "broker".to_string(),
-            "7".to_string(),
-        ])
-        .unwrap();
-        assert_eq!(result, 7);
-    }
-
-    #[test]
-    fn get_queue_id_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_queue_id(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "10".to_string(),
-            "1".to_string(),
-            "broker".to_string(),
-        ])
-        .unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("getQueueId fail, extraInfoStrs length 6".to_string()).to_string()
-        );
-    }
-
-    #[test]
-    fn get_queue_offset_with_valid_string() {
-        let result = ExtraInfoUtil::get_queue_offset(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "10".to_string(),
-            "1".to_string(),
-            "broker".to_string(),
-            "7".to_string(),
-            "100".to_string(),
-        ])
-        .unwrap();
-        assert_eq!(result, 100);
-    }
-
-    #[test]
-    fn get_queue_offset_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_queue_offset(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "10".to_string(),
-            "1".to_string(),
-            "broker".to_string(),
-            "7".to_string(),
-        ])
-        .unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            IllegalArgument("getQueueOffset fail, extraInfoStrs length 7".to_string()).to_string()
-        );
-    }
-
-    #[test]
-    fn build_extra_info_creates_correct_string() {
-        let result = ExtraInfoUtil::build_extra_info(123, 456, 789, 10, "topic", "broker", 7);
-        assert_eq!(result, "123 456 789 10 0 broker 7");
-    }
-
-    #[test]
-    fn build_extra_info_with_msg_queue_offset_creates_correct_string() {
-        let result = ExtraInfoUtil::build_extra_info_with_msg_queue_offset(
-            123, 456, 789, 10, "topic", "broker", 7, 100,
-        );
-        assert_eq!(result, "123 456 789 10 0 broker 7 100");
-    }
-
-    #[test]
-    fn build_start_offset_info_creates_correct_string() {
-        let mut string_builder = String::new();
-        ExtraInfoUtil::build_start_offset_info(&mut string_builder, "topic", 7, 100);
-        assert_eq!(string_builder, "0 7 100");
-    }
-
-    #[test]
-    fn build_queue_id_order_count_info_creates_correct_string() {
-        let mut string_builder = String::new();
-        ExtraInfoUtil::build_queue_id_order_count_info(&mut string_builder, "topic", 7, 100);
-        assert_eq!(string_builder, "0 7 100");
-    }
-
-    #[test]
-    fn build_queue_offset_order_count_info_creates_correct_string() {
-        let mut string_builder = String::new();
-        ExtraInfoUtil::build_queue_offset_order_count_info(
-            &mut string_builder,
-            "topic",
-            7,
-            100,
-            100,
-        );
-        assert_eq!(string_builder, "0 qo7%100 100");
-    }
-
-    #[test]
-    fn build_msg_offset_info_creates_correct_string() {
-        let mut string_builder = String::new();
-        ExtraInfoUtil::build_msg_offset_info(&mut string_builder, "topic", 7, vec![100, 200, 300]);
-        assert_eq!(string_builder, "0 7100,200,300");
-    }
-
-    #[test]
-    fn parse_msg_offset_info_with_valid_string() {
-        let result = ExtraInfoUtil::parse_msg_offset_info("0 7 100,200,300").unwrap();
-        let mut expected = HashMap::new();
-        expected.insert("0@7".to_string(), vec![100, 200, 300]);
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn parse_start_offset_info_with_valid_string() {
-        let result = ExtraInfoUtil::parse_start_offset_info("0 7 100").unwrap();
-        let mut expected = HashMap::new();
-        expected.insert("0@7".to_string(), 100);
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn parse_order_count_info_with_valid_string() {
-        let result = ExtraInfoUtil::parse_order_count_info("0 7 100").unwrap();
-        let mut expected = HashMap::new();
-        expected.insert("0@7".to_string(), 100);
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn get_retry_for_topic_with_retry_topic() {
-        let result = ExtraInfoUtil::get_retry_for_topic("RETRY_topic");
-        assert_eq!(result, "1");
-    }
-
-    #[test]
-    fn get_retry_for_topic_with_normal_topic() {
-        let result = ExtraInfoUtil::get_retry_for_topic("topic");
-        assert_eq!(result, "0");
-    }
-
-    #[test]
-    fn get_start_offset_info_map_key_creates_correct_string() {
-        let result = ExtraInfoUtil::get_start_offset_info_map_key("topic", 7);
-        assert_eq!(result, "0@7");
-    }
-
-    #[test]
-    fn get_start_offset_info_map_key_with_pop_ck_creates_correct_string() {
-        let result = ExtraInfoUtil::get_start_offset_info_map_key_with_pop_ck("topic", "pop_ck", 7);
-        assert_eq!(result, "0@7");
-    }
-
-    #[test]
-    fn get_queue_offset_key_value_key_creates_correct_string() {
-        let result = ExtraInfoUtil::get_queue_offset_key_value_key(7, 100);
-        assert_eq!(result, "qo7%100");
-    }
-
-    #[test]
-    fn get_queue_offset_map_key_creates_correct_string() {
-        let result = ExtraInfoUtil::get_queue_offset_map_key("topic", 7, 100);
-        assert_eq!(result, "0@qo7%100");
-    }
-
-    #[test]
-    fn is_order_with_order_queue() {
-        let result = ExtraInfoUtil::is_order(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "999".to_string(),
-            "1".to_string(),
-            "broker".to_string(),
-            "7".to_string(),
-            "999".to_string(),
-            "0".to_string(),
-        ]);
-        assert!(result);
-    }
-
-    #[test]
-    fn is_order_with_non_order_queue() {
-        let result = ExtraInfoUtil::is_order(&vec![
-            "123".to_string(),
-            "456".to_string(),
-            "789".to_string(),
-            "10".to_string(),
-            "1".to_string(),
-            "broker".to_string(),
-            "7".to_string(),
-            "100".to_string(),
-            "1".to_string(),
-        ]);
-        assert!(!result);
-    }
-}
+ use std::collections::HashMap;
+ use std::vec::Vec;
+ 
+ use rocketmq_common::common::key_builder::KeyBuilder;
+ use rocketmq_common::common::key_builder::POP_ORDER_REVIVE_QUEUE;
+ use rocketmq_common::common::message::MessageConst;
+ use rocketmq_common::common::mix_all;
+ 
+ use crate::remoting_error::RemotingError::IllegalArgument;
+ 
+ pub struct ExtraInfoUtil;
+ 
+ const NORMAL_TOPIC: &str = "0";
+ const RETRY_TOPIC: &str = "1";
+ const RETRY_TOPIC_V2: &str = "2";
+ const QUEUE_OFFSET: &str = "qo";
+ 
+ impl ExtraInfoUtil {
+     pub fn split(extra_info: &str) -> crate::Result<Vec<String>> {
+         if extra_info.is_empty() {
+             return Err(IllegalArgument("split extraInfo is empty".to_string()));
+         }
+         Ok(extra_info.split('|').map(String::from).collect())
+     }
+ 
+     pub fn get_ck_queue_offset(extra_info_strs: &[String]) -> crate::Result<i64> {
+         if extra_info_strs.is_empty() {
+             return Err(IllegalArgument(format!(
+                 "getCkQueueOffset fail, extraInfoStrs length {}",
+                 extra_info_strs.len()
+             )));
+         }
+         extra_info_strs[0]
+             .parse::<i64>()
+             .map_err(|_| IllegalArgument("parse ck_queue_offset error".to_string()))
+     }
+ 
+     pub fn get_pop_time(extra_info_strs: &[String]) -> crate::Result<i64> {
+         if extra_info_strs.len() < 2 {
+             return Err(IllegalArgument(format!(
+                 "getPopTime fail, extraInfoStrs length {}",
+                 extra_info_strs.len()
+             )));
+         }
+         extra_info_strs[1]
+             .parse::<i64>()
+             .map_err(|_| IllegalArgument("parse pop_time error".to_string()))
+     }
+ 
+     pub fn get_invisible_time(extra_info_strs: &[String]) -> crate::Result<i64> {
+         if extra_info_strs.len() < 3 {
+             return Err(IllegalArgument(format!(
+                 "getInvisibleTime fail, extraInfoStrs length {}",
+                 extra_info_strs.len()
+             )));
+         }
+         extra_info_strs[2]
+             .parse::<i64>()
+             .map_err(|_| IllegalArgument("parse invisible_time error".to_string()))
+     }
+ 
+     pub fn get_revive_qid(extra_info_strs: &[String]) -> crate::Result<i32> {
+         if extra_info_strs.len() < 4 {
+             return Err(IllegalArgument(format!(
+                 "getReviveQid fail, extraInfoStrs length {}",
+                 extra_info_strs.len()
+             )));
+         }
+         extra_info_strs[3]
+             .parse::<i32>()
+             .map_err(|_| IllegalArgument("parse revive_qid error".to_string()))
+     }
+ 
+     pub fn get_real_topic(
+         extra_info_strs: &[String],
+         topic: &str,
+         cid: &str,
+     ) -> crate::Result<String> {
+         if extra_info_strs.len() < 5 {
+             return Err(IllegalArgument(format!(
+                 "getRealTopic fail, extraInfoStrs length {}",
+                 extra_info_strs.len()
+             )));
+         }
+         match extra_info_strs[4].as_str() {
+             RETRY_TOPIC => Ok(KeyBuilder::build_pop_retry_topic_v1(topic, cid)),
+             RETRY_TOPIC_V2 => Ok(KeyBuilder::build_pop_retry_topic_v2(topic, cid)),
+             _ => Ok(topic.to_string()),
+         }
+     }
+ 
+     pub fn get_real_topic_with_retry(topic: &str, cid: &str, retry: &str) -> crate::Result<String> {
+         match retry {
+             NORMAL_TOPIC => Ok(topic.to_string()),
+             RETRY_TOPIC => Ok(KeyBuilder::build_pop_retry_topic_v1(topic, cid)),
+             RETRY_TOPIC_V2 => Ok(KeyBuilder::build_pop_retry_topic_v2(topic, cid)),
+             _ => Err(IllegalArgument(
+                 "getRetry fail, format is wrong".to_string(),
+             )),
+         }
+     }
+ 
+     pub fn get_retry_slice(extra_info_strs: &[String]) -> crate::Result<String> {
+         if extra_info_strs.len() < 5 {
+             return Err(IllegalArgument(format!(
+                 "getRetry fail, extraInfoStrs length {}",
+                 extra_info_strs.len()
+             )));
+         }
+         Ok(extra_info_strs[4].clone())
+     }
+ 
+     pub fn get_broker_name(extra_info_strs: &[String]) -> crate::Result<String> {
+         if extra_info_strs.len() < 6 {
+             return Err(IllegalArgument(format!(
+                 "getBrokerName fail, extraInfoStrs length {}",
+                 extra_info_strs.len()
+             )));
+         }
+         Ok(extra_info_strs[5].clone())
+     }
+ 
+     pub fn get_queue_id(extra_info_strs: &[String]) -> crate::Result<i32> {
+         if extra_info_strs.len() < 7 {
+             return Err(IllegalArgument(format!(
+                 "getQueueId fail, extraInfoStrs length {}",
+                 extra_info_strs.len()
+             )));
+         }
+         extra_info_strs[6]
+             .parse::<i32>()
+             .map_err(|_| IllegalArgument("parse queue_id error".to_string()))
+     }
+ 
+     pub fn get_queue_offset(extra_info_strs: &[String]) -> crate::Result<i64> {
+         if extra_info_strs.len() < 8 {
+             return Err(IllegalArgument(format!(
+                 "getQueueOffset fail, extraInfoStrs length {}",
+                 extra_info_strs.len()
+             )));
+         }
+         extra_info_strs[7]
+             .parse::<i64>()
+             .map_err(|_| IllegalArgument("parse queue_offset error".to_string()))
+     }
+ 
+     pub fn build_extra_info(
+         ck_queue_offset: i64,
+         pop_time: i64,
+         invisible_time: i64,
+         revive_qid: i32,
+         topic: &str,
+         broker_name: &str,
+         queue_id: i32,
+     ) -> String {
+         let t = ExtraInfoUtil::get_retry(topic);
+         format!(
+             "{}{}{}{}{}{}{}{}{}{}{}{}{}",
+             ck_queue_offset,
+             MessageConst::KEY_SEPARATOR,
+             pop_time,
+             MessageConst::KEY_SEPARATOR,
+             invisible_time,
+             MessageConst::KEY_SEPARATOR,
+             revive_qid,
+             MessageConst::KEY_SEPARATOR,
+             t,
+             MessageConst::KEY_SEPARATOR,
+             broker_name,
+             MessageConst::KEY_SEPARATOR,
+             queue_id
+         )
+     }
+ 
+     pub fn build_extra_info_with_msg_queue_offset(
+         ck_queue_offset: i64,
+         pop_time: i64,
+         invisible_time: i64,
+         revive_qid: i32,
+         topic: &str,
+         broker_name: &str,
+         queue_id: i32,
+         msg_queue_offset: i64,
+     ) -> String {
+         let t = ExtraInfoUtil::get_retry(topic);
+         format!(
+             "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+             ck_queue_offset,
+             MessageConst::KEY_SEPARATOR,
+             pop_time,
+             MessageConst::KEY_SEPARATOR,
+             invisible_time,
+             MessageConst::KEY_SEPARATOR,
+             revive_qid,
+             MessageConst::KEY_SEPARATOR,
+             t,
+             MessageConst::KEY_SEPARATOR,
+             broker_name,
+             MessageConst::KEY_SEPARATOR,
+             queue_id,
+             MessageConst::KEY_SEPARATOR,
+             msg_queue_offset
+         )
+     }
+ 
+     pub fn build_start_offset_info(
+         string_builder: &mut String,
+         topic: &str,
+         queue_id: i32,
+         start_offset: i64,
+     ) {
+         let retry = ExtraInfoUtil::get_retry(topic);
+         if !string_builder.is_empty() {
+             string_builder.push(';');
+         }
+         string_builder.push_str(&format!(
+             "{}{}{}{}{}",
+             retry,
+             MessageConst::KEY_SEPARATOR,
+             queue_id,
+             MessageConst::KEY_SEPARATOR,
+             start_offset
+         ));
+     }
+ 
+     pub fn build_queue_id_order_count_info(
+         string_builder: &mut String,
+         topic: &str,
+         queue_id: i32,
+         order_count: i32,
+     ) {
+         let retry = ExtraInfoUtil::get_retry(topic);
+         if !string_builder.is_empty() {
+             string_builder.push(';');
+         }
+         string_builder.push_str(&format!(
+             "{}{}{}{}{}",
+             retry,
+             MessageConst::KEY_SEPARATOR,
+             queue_id,
+             MessageConst::KEY_SEPARATOR,
+             order_count
+         ));
+     }
+ 
+     pub fn build_queue_offset_order_count_info(
+         string_builder: &mut String,
+         topic: &str,
+         queue_id: i64,
+         queue_offset: i64,
+         order_count: i32,
+     ) {
+         if !string_builder.is_empty() {
+             string_builder.push(';');
+         }
+         string_builder.push_str(&format!(
+             "{}{}{}{}{}",
+             ExtraInfoUtil::get_retry(topic),
+             MessageConst::KEY_SEPARATOR,
+             ExtraInfoUtil::get_queue_offset_key_value_key(queue_id, queue_offset),
+             MessageConst::KEY_SEPARATOR,
+             order_count
+         ));
+     }
+ 
+     pub fn build_msg_offset_info(
+         string_builder: &mut String,
+         topic: &str,
+         queue_id: i32,
+         msg_offsets: Vec<u64>,
+     ) {
+         let retry = ExtraInfoUtil::get_retry(topic);
+         if !string_builder.is_empty() {
+             string_builder.push(';');
+         }
+         string_builder.push_str(&format!(
+             "{}{}{}",
+             retry,
+             MessageConst::KEY_SEPARATOR,
+             queue_id
+         ));
+         for (i, msg_offset) in msg_offsets.iter().enumerate() {
+             string_builder.push_str(&msg_offset.to_string());
+             if i < msg_offsets.len() - 1 {
+                 string_builder.push(',');
+             }
+         }
+     }
+ 
+     pub fn parse_msg_offset_info(
+         msg_offset_info: &str,
+     ) -> crate::Result<HashMap<String, Vec<i64>>> {
+         let mut msg_offset_map = HashMap::new();
+         let entries: Vec<&str> = msg_offset_info.split(';').collect();
+ 
+         for entry in entries {
+             let parts: Vec<&str> = entry.split(MessageConst::KEY_SEPARATOR).collect();
+             if parts.len() != 3 {
+                 return Err(IllegalArgument("parse msgOffsetInfo error".to_string()));
+             }
+ 
+             let key = format!("{}@{}", parts[0], parts[1]);
+             let offsets: Vec<i64> = parts[2]
+                 .split(',')
+                 .map(|s| s.parse::<i64>().unwrap())
+                 .collect();
+ 
+             msg_offset_map.insert(key, offsets);
+         }
+ 
+         Ok(msg_offset_map)
+     }
+ 
+     pub fn parse_start_offset_info(start_offset_info: &str) -> crate::Result<HashMap<String, i64>> {
+         let mut start_offset_map = HashMap::new();
+         let entries: Vec<&str> = start_offset_info.split(';').collect();
+ 
+         for entry in entries {
+             let parts: Vec<&str> = entry.split(MessageConst::KEY_SEPARATOR).collect();
+             if parts.len() != 3 {
+                 return Err(IllegalArgument("parse startOffsetInfo error".to_string()));
+             }
+ 
+             let key = format!("{}@{}", parts[0], parts[1]);
+             let offset = parts[2]
+                 .parse::<i64>()
+                 .map_err(|_| IllegalArgument("Invalid start offset value".to_string()))?;
+             start_offset_map.insert(key, offset);
+         }
+ 
+         Ok(start_offset_map)
+     }
+ 
+     pub fn parse_order_count_info(order_count_info: &str) -> crate::Result<HashMap<String, i32>> {
+         let mut start_offset_map = HashMap::new();
+         if order_count_info.is_empty() {
+             return Ok(start_offset_map); // return None if the input is empty
+         }
+ 
+         // Split the input string by semicolon
+         let array: Vec<&str> = order_count_info.split(';').collect();
+ 
+         for one in array {
+             // Split each element by the separator
+             let split: Vec<&str> = one.split(MessageConst::KEY_SEPARATOR).collect();
+ 
+             if split.len() != 3 {
+                 return Err(IllegalArgument(format!(
+                     "parse orderCountInfo error {}",
+                     order_count_info
+                 ))); // Handle invalid split
+             }
+ 
+             // Construct the key as `split[0]@split[1]`
+             let key = format!("{}@{}", split[0], split[1]);
+ 
+             // Check for duplicate keys
+             if start_offset_map.contains_key(&key) {
+                 return Err(IllegalArgument(format!(
+                     "parse orderCountInfo error, duplicate key, {}",
+                     order_count_info
+                 )));
+             }
+ 
+             // Insert the key-value pair into the map
+             if let Ok(value) = split[2].parse::<i32>() {
+                 start_offset_map.insert(key, value);
+             } else {
+                 return Err(IllegalArgument(format!(
+                     "parse orderCountInfo error, duplicate key, {}",
+                     order_count_info
+                 )));
+             }
+         }
+ 
+         Ok(start_offset_map) // Return the populated HashMap
+     }
+ 
+     pub fn get_retry_for_topic(topic: &str) -> String {
+         if topic.starts_with("RETRY_") {
+             RETRY_TOPIC.to_string()
+         } else {
+             NORMAL_TOPIC.to_string()
+         }
+     }
+ 
+     pub fn get_start_offset_info_map_key(topic: &str, key: i64) -> String {
+         format!("{}@{}", ExtraInfoUtil::get_retry(topic), key)
+     }
+ 
+     pub fn get_start_offset_info_map_key_with_pop_ck(
+         topic: &str,
+         pop_ck: &str,
+         key: i64,
+     ) -> String {
+         format!(
+             "{}@{}",
+             ExtraInfoUtil::get_retry_with_pop_ck(topic, pop_ck),
+             key
+         )
+     }
+ 
+     pub fn get_queue_offset_key_value_key(queue_id: i64, queue_offset: i64) -> String {
+         format!("{}{}%{}", QUEUE_OFFSET, queue_id, queue_offset)
+     }
+ 
+     pub fn get_queue_offset_map_key(topic: &str, queue_id: i64, queue_offset: i64) -> String {
+         format!(
+             "{}@{}",
+             ExtraInfoUtil::get_retry(topic),
+             ExtraInfoUtil::get_queue_offset_key_value_key(queue_id, queue_offset)
+         )
+     }
+ 
+     pub fn is_order(extra_info: &[String]) -> bool {
+         ExtraInfoUtil::get_revive_qid(extra_info).unwrap_or_default() == POP_ORDER_REVIVE_QUEUE
+     }
+ 
+     fn get_retry(topic: &str) -> String {
+         if KeyBuilder::is_pop_retry_topic_v2(topic) {
+             RETRY_TOPIC_V2.to_string()
+         } else if topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
+             RETRY_TOPIC.to_string()
+         } else {
+             NORMAL_TOPIC.to_string()
+         }
+     }
+ 
+     fn get_retry_with_pop_ck(topic: &str, pop_ck: &str) -> String {
+         if let Ok(split_info) = ExtraInfoUtil::split(pop_ck) {
+             return ExtraInfoUtil::get_retry_from_split(&split_info);
+         }
+         ExtraInfoUtil::get_retry(topic)
+     }
+ 
+     fn get_retry_from_split(split_info: &[String]) -> String {
+         if split_info.is_empty() {
+             return NORMAL_TOPIC.to_string();
+         }
+         ExtraInfoUtil::get_retry(split_info[0].as_str())
+     }
+ }
+ 
+ #[cfg(test)]
+ mod tests {
+     use rocketmq_common::common::key_builder::KeyBuilder;
+ 
+     use super::*;
+     use crate::remoting_error::RemotingError::IllegalArgument;
+ 
+     #[test]
+     fn split_with_valid_string() {
+         let result = ExtraInfoUtil::split("a|b|c").unwrap();
+         assert_eq!(result, vec!["a", "b", "c"]);
+     }
+ 
+     #[test]
+     fn split_with_empty_string() {
+         let result = ExtraInfoUtil::split("").unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("split extraInfo is empty".to_string()).to_string()
+         );
+     }
+ 
+     #[test]
+     fn get_ck_queue_offset_with_valid_string() {
+         let result = ExtraInfoUtil::get_ck_queue_offset(&vec!["123".to_string()]).unwrap();
+         assert_eq!(result, 123);
+     }
+ 
+     #[test]
+     fn get_ck_queue_offset_with_invalid_string() {
+         let result = ExtraInfoUtil::get_ck_queue_offset(&vec!["abc".to_string()]).unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("parse ck_queue_offset error".to_string()).to_string()
+         );
+     }
+ 
+     #[test]
+     fn get_pop_time_with_valid_string() {
+         let result =
+             ExtraInfoUtil::get_pop_time(&vec!["123".to_string(), "456".to_string()]).unwrap();
+         assert_eq!(result, 456);
+     }
+ 
+     #[test]
+     fn get_pop_time_with_insufficient_length() {
+         let result = ExtraInfoUtil::get_pop_time(&vec!["123".to_string()]).unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("getPopTime fail, extraInfoStrs length 1".to_string()).to_string()
+         );
+     }
+ 
+     #[test]
+     fn get_invisible_time_with_valid_string() {
+         let result = ExtraInfoUtil::get_invisible_time(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+         ])
+         .unwrap();
+         assert_eq!(result, 789);
+     }
+ 
+     #[test]
+     fn get_invisible_time_with_insufficient_length() {
+         let result = ExtraInfoUtil::get_invisible_time(&vec!["123".to_string(), "456".to_string()])
+             .unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("getInvisibleTime fail, extraInfoStrs length 2".to_string())
+                 .to_string()
+         );
+     }
+ 
+     #[test]
+     fn get_revive_qid_with_valid_string() {
+         let result = ExtraInfoUtil::get_revive_qid(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "10".to_string(),
+         ])
+         .unwrap();
+         assert_eq!(result, 10);
+     }
+ 
+     #[test]
+     fn get_revive_qid_with_insufficient_length() {
+         let result = ExtraInfoUtil::get_revive_qid(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+         ])
+         .unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("getReviveQid fail, extraInfoStrs length 3".to_string()).to_string()
+         );
+     }
+ 
+     #[test]
+     fn get_real_topic_with_retry_v1() {
+         let result = ExtraInfoUtil::get_real_topic(
+             &vec![
+                 "123".to_string(),
+                 "456".to_string(),
+                 "789".to_string(),
+                 "10".to_string(),
+                 "1".to_string(),
+             ],
+             "topic",
+             "cid",
+         )
+         .unwrap();
+         assert_eq!(result, KeyBuilder::build_pop_retry_topic_v1("topic", "cid"));
+     }
+ 
+     #[test]
+     fn get_real_topic_with_retry_v2() {
+         let result = ExtraInfoUtil::get_real_topic(
+             &vec![
+                 "123".to_string(),
+                 "456".to_string(),
+                 "789".to_string(),
+                 "10".to_string(),
+                 "2".to_string(),
+             ],
+             "topic",
+             "cid",
+         )
+         .unwrap();
+         assert_eq!(result, KeyBuilder::build_pop_retry_topic_v2("topic", "cid"));
+     }
+ 
+     #[test]
+     fn get_real_topic_with_normal_topic() {
+         let result = ExtraInfoUtil::get_real_topic(
+             &vec![
+                 "123".to_string(),
+                 "456".to_string(),
+                 "789".to_string(),
+                 "10".to_string(),
+                 "0".to_string(),
+             ],
+             "topic",
+             "cid",
+         )
+         .unwrap();
+         assert_eq!(result, "topic".to_string());
+     }
+ 
+     #[test]
+     fn get_real_topic_with_insufficient_length() {
+         let result = ExtraInfoUtil::get_real_topic(
+             &vec![
+                 "123".to_string(),
+                 "456".to_string(),
+                 "789".to_string(),
+                 "10".to_string(),
+             ],
+             "topic",
+             "cid",
+         )
+         .unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("getRealTopic fail, extraInfoStrs length 4".to_string()).to_string()
+         );
+     }
+ 
+     #[test]
+     fn get_real_topic_with_retry_invalid() {
+         let result = ExtraInfoUtil::get_real_topic_with_retry("topic", "cid", "3").unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("getRetry fail, format is wrong".to_string()).to_string()
+         );
+     }
+ 
+     #[test]
+     fn get_retry_slice_with_valid_string() {
+         let result = ExtraInfoUtil::get_retry_slice(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "10".to_string(),
+             "1".to_string(),
+         ])
+         .unwrap();
+         assert_eq!(result, "1".to_string());
+     }
+ 
+     #[test]
+     fn get_retry_slice_with_insufficient_length() {
+         let result = ExtraInfoUtil::get_retry_slice(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "10".to_string(),
+         ])
+         .unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("getRetry fail, extraInfoStrs length 4".to_string()).to_string()
+         );
+     }
+ 
+     #[test]
+     fn get_broker_name_with_valid_string() {
+         let result = ExtraInfoUtil::get_broker_name(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "10".to_string(),
+             "1".to_string(),
+             "broker".to_string(),
+         ])
+         .unwrap();
+         assert_eq!(result, "broker".to_string());
+     }
+ 
+     #[test]
+     fn get_broker_name_with_insufficient_length() {
+         let result = ExtraInfoUtil::get_broker_name(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "10".to_string(),
+             "1".to_string(),
+         ])
+         .unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("getBrokerName fail, extraInfoStrs length 5".to_string()).to_string()
+         );
+     }
+ 
+     #[test]
+     fn get_queue_id_with_valid_string() {
+         let result = ExtraInfoUtil::get_queue_id(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "10".to_string(),
+             "1".to_string(),
+             "broker".to_string(),
+             "7".to_string(),
+         ])
+         .unwrap();
+         assert_eq!(result, 7);
+     }
+ 
+     #[test]
+     fn get_queue_id_with_insufficient_length() {
+         let result = ExtraInfoUtil::get_queue_id(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "10".to_string(),
+             "1".to_string(),
+             "broker".to_string(),
+         ])
+         .unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("getQueueId fail, extraInfoStrs length 6".to_string()).to_string()
+         );
+     }
+ 
+     #[test]
+     fn get_queue_offset_with_valid_string() {
+         let result = ExtraInfoUtil::get_queue_offset(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "10".to_string(),
+             "1".to_string(),
+             "broker".to_string(),
+             "7".to_string(),
+             "100".to_string(),
+         ])
+         .unwrap();
+         assert_eq!(result, 100);
+     }
+ 
+     #[test]
+     fn get_queue_offset_with_insufficient_length() {
+         let result = ExtraInfoUtil::get_queue_offset(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "10".to_string(),
+             "1".to_string(),
+             "broker".to_string(),
+             "7".to_string(),
+         ])
+         .unwrap_err();
+         assert_eq!(
+             result.to_string(),
+             IllegalArgument("getQueueOffset fail, extraInfoStrs length 7".to_string()).to_string()
+         );
+     }
+ 
+     #[test]
+     fn build_extra_info_creates_correct_string() {
+         let result = ExtraInfoUtil::build_extra_info(123, 456, 789, 10, "topic", "broker", 7);
+         assert_eq!(result, "123 456 789 10 0 broker 7");
+     }
+ 
+     #[test]
+     fn build_extra_info_with_msg_queue_offset_creates_correct_string() {
+         let result = ExtraInfoUtil::build_extra_info_with_msg_queue_offset(
+             123, 456, 789, 10, "topic", "broker", 7, 100,
+         );
+         assert_eq!(result, "123 456 789 10 0 broker 7 100");
+     }
+ 
+     #[test]
+     fn build_start_offset_info_creates_correct_string() {
+         let mut string_builder = String::new();
+         ExtraInfoUtil::build_start_offset_info(&mut string_builder, "topic", 7, 100);
+         assert_eq!(string_builder, "0 7 100");
+     }
+ 
+     #[test]
+     fn build_queue_id_order_count_info_creates_correct_string() {
+         let mut string_builder = String::new();
+         ExtraInfoUtil::build_queue_id_order_count_info(&mut string_builder, "topic", 7, 100);
+         assert_eq!(string_builder, "0 7 100");
+     }
+ 
+     #[test]
+     fn build_queue_offset_order_count_info_creates_correct_string() {
+         let mut string_builder = String::new();
+         ExtraInfoUtil::build_queue_offset_order_count_info(
+             &mut string_builder,
+             "topic",
+             7,
+             100,
+             100,
+         );
+         assert_eq!(string_builder, "0 qo7%100 100");
+     }
+ 
+     #[test]
+     fn build_msg_offset_info_creates_correct_string() {
+         let mut string_builder = String::new();
+         ExtraInfoUtil::build_msg_offset_info(&mut string_builder, "topic", 7, vec![100, 200, 300]);
+         assert_eq!(string_builder, "0 7100,200,300");
+     }
+ 
+     #[test]
+     fn parse_msg_offset_info_with_valid_string() {
+         let result = ExtraInfoUtil::parse_msg_offset_info("0 7 100,200,300").unwrap();
+         let mut expected = HashMap::new();
+         expected.insert("0@7".to_string(), vec![100, 200, 300]);
+         assert_eq!(result, expected);
+     }
+ 
+     #[test]
+     fn parse_start_offset_info_with_valid_string() {
+         let result = ExtraInfoUtil::parse_start_offset_info("0 7 100").unwrap();
+         let mut expected = HashMap::new();
+         expected.insert("0@7".to_string(), 100);
+         assert_eq!(result, expected);
+     }
+ 
+     #[test]
+     fn parse_order_count_info_with_valid_string() {
+         let result = ExtraInfoUtil::parse_order_count_info("0 7 100").unwrap();
+         let mut expected = HashMap::new();
+         expected.insert("0@7".to_string(), 100);
+         assert_eq!(result, expected);
+     }
+ 
+     #[test]
+     fn get_retry_for_topic_with_retry_topic() {
+         let result = ExtraInfoUtil::get_retry_for_topic("RETRY_topic");
+         assert_eq!(result, "1");
+     }
+ 
+     #[test]
+     fn get_retry_for_topic_with_normal_topic() {
+         let result = ExtraInfoUtil::get_retry_for_topic("topic");
+         assert_eq!(result, "0");
+     }
+ 
+     #[test]
+     fn get_start_offset_info_map_key_creates_correct_string() {
+         let result = ExtraInfoUtil::get_start_offset_info_map_key("topic", 7);
+         assert_eq!(result, "0@7");
+     }
+ 
+     #[test]
+     fn get_start_offset_info_map_key_with_pop_ck_creates_correct_string() {
+         let result = ExtraInfoUtil::get_start_offset_info_map_key_with_pop_ck("topic", "pop_ck", 7);
+         assert_eq!(result, "0@7");
+     }
+ 
+     #[test]
+     fn get_queue_offset_key_value_key_creates_correct_string() {
+         let result = ExtraInfoUtil::get_queue_offset_key_value_key(7, 100);
+         assert_eq!(result, "qo7%100");
+     }
+ 
+     #[test]
+     fn get_queue_offset_map_key_creates_correct_string() {
+         let result = ExtraInfoUtil::get_queue_offset_map_key("topic", 7, 100);
+         assert_eq!(result, "0@qo7%100");
+     }
+ 
+     #[test]
+     fn is_order_with_order_queue() {
+         let result = ExtraInfoUtil::is_order(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "999".to_string(),
+             "1".to_string(),
+             "broker".to_string(),
+             "7".to_string(),
+             "999".to_string(),
+             "0".to_string(),
+         ]);
+         assert!(result);
+     }
+ 
+     #[test]
+     fn is_order_with_non_order_queue() {
+         let result = ExtraInfoUtil::is_order(&vec![
+             "123".to_string(),
+             "456".to_string(),
+             "789".to_string(),
+             "10".to_string(),
+             "1".to_string(),
+             "broker".to_string(),
+             "7".to_string(),
+             "100".to_string(),
+             "1".to_string(),
+         ]);
+         assert!(!result);
+     }
+ }
+ 

--- a/rocketmq-remoting/src/protocol/header/extra_info_util.rs
+++ b/rocketmq-remoting/src/protocol/header/extra_info_util.rs
@@ -15,891 +15,890 @@
  * limitations under the License.
  */
 
- use std::collections::HashMap;
- use std::vec::Vec;
- 
- use rocketmq_common::common::key_builder::KeyBuilder;
- use rocketmq_common::common::key_builder::POP_ORDER_REVIVE_QUEUE;
- use rocketmq_common::common::message::MessageConst;
- use rocketmq_common::common::mix_all;
- 
- use crate::remoting_error::RemotingError::IllegalArgument;
- 
- pub struct ExtraInfoUtil;
- 
- const NORMAL_TOPIC: &str = "0";
- const RETRY_TOPIC: &str = "1";
- const RETRY_TOPIC_V2: &str = "2";
- const QUEUE_OFFSET: &str = "qo";
- 
- impl ExtraInfoUtil {
-     pub fn split(extra_info: &str) -> crate::Result<Vec<String>> {
-         if extra_info.is_empty() {
-             return Err(IllegalArgument("split extraInfo is empty".to_string()));
-         }
-         Ok(extra_info.split('|').map(String::from).collect())
-     }
- 
-     pub fn get_ck_queue_offset(extra_info_strs: &[String]) -> crate::Result<i64> {
-         if extra_info_strs.is_empty() {
-             return Err(IllegalArgument(format!(
-                 "getCkQueueOffset fail, extraInfoStrs length {}",
-                 extra_info_strs.len()
-             )));
-         }
-         extra_info_strs[0]
-             .parse::<i64>()
-             .map_err(|_| IllegalArgument("parse ck_queue_offset error".to_string()))
-     }
- 
-     pub fn get_pop_time(extra_info_strs: &[String]) -> crate::Result<i64> {
-         if extra_info_strs.len() < 2 {
-             return Err(IllegalArgument(format!(
-                 "getPopTime fail, extraInfoStrs length {}",
-                 extra_info_strs.len()
-             )));
-         }
-         extra_info_strs[1]
-             .parse::<i64>()
-             .map_err(|_| IllegalArgument("parse pop_time error".to_string()))
-     }
- 
-     pub fn get_invisible_time(extra_info_strs: &[String]) -> crate::Result<i64> {
-         if extra_info_strs.len() < 3 {
-             return Err(IllegalArgument(format!(
-                 "getInvisibleTime fail, extraInfoStrs length {}",
-                 extra_info_strs.len()
-             )));
-         }
-         extra_info_strs[2]
-             .parse::<i64>()
-             .map_err(|_| IllegalArgument("parse invisible_time error".to_string()))
-     }
- 
-     pub fn get_revive_qid(extra_info_strs: &[String]) -> crate::Result<i32> {
-         if extra_info_strs.len() < 4 {
-             return Err(IllegalArgument(format!(
-                 "getReviveQid fail, extraInfoStrs length {}",
-                 extra_info_strs.len()
-             )));
-         }
-         extra_info_strs[3]
-             .parse::<i32>()
-             .map_err(|_| IllegalArgument("parse revive_qid error".to_string()))
-     }
- 
-     pub fn get_real_topic(
-         extra_info_strs: &[String],
-         topic: &str,
-         cid: &str,
-     ) -> crate::Result<String> {
-         if extra_info_strs.len() < 5 {
-             return Err(IllegalArgument(format!(
-                 "getRealTopic fail, extraInfoStrs length {}",
-                 extra_info_strs.len()
-             )));
-         }
-         match extra_info_strs[4].as_str() {
-             RETRY_TOPIC => Ok(KeyBuilder::build_pop_retry_topic_v1(topic, cid)),
-             RETRY_TOPIC_V2 => Ok(KeyBuilder::build_pop_retry_topic_v2(topic, cid)),
-             _ => Ok(topic.to_string()),
-         }
-     }
- 
-     pub fn get_real_topic_with_retry(topic: &str, cid: &str, retry: &str) -> crate::Result<String> {
-         match retry {
-             NORMAL_TOPIC => Ok(topic.to_string()),
-             RETRY_TOPIC => Ok(KeyBuilder::build_pop_retry_topic_v1(topic, cid)),
-             RETRY_TOPIC_V2 => Ok(KeyBuilder::build_pop_retry_topic_v2(topic, cid)),
-             _ => Err(IllegalArgument(
-                 "getRetry fail, format is wrong".to_string(),
-             )),
-         }
-     }
- 
-     pub fn get_retry_slice(extra_info_strs: &[String]) -> crate::Result<String> {
-         if extra_info_strs.len() < 5 {
-             return Err(IllegalArgument(format!(
-                 "getRetry fail, extraInfoStrs length {}",
-                 extra_info_strs.len()
-             )));
-         }
-         Ok(extra_info_strs[4].clone())
-     }
- 
-     pub fn get_broker_name(extra_info_strs: &[String]) -> crate::Result<String> {
-         if extra_info_strs.len() < 6 {
-             return Err(IllegalArgument(format!(
-                 "getBrokerName fail, extraInfoStrs length {}",
-                 extra_info_strs.len()
-             )));
-         }
-         Ok(extra_info_strs[5].clone())
-     }
- 
-     pub fn get_queue_id(extra_info_strs: &[String]) -> crate::Result<i32> {
-         if extra_info_strs.len() < 7 {
-             return Err(IllegalArgument(format!(
-                 "getQueueId fail, extraInfoStrs length {}",
-                 extra_info_strs.len()
-             )));
-         }
-         extra_info_strs[6]
-             .parse::<i32>()
-             .map_err(|_| IllegalArgument("parse queue_id error".to_string()))
-     }
- 
-     pub fn get_queue_offset(extra_info_strs: &[String]) -> crate::Result<i64> {
-         if extra_info_strs.len() < 8 {
-             return Err(IllegalArgument(format!(
-                 "getQueueOffset fail, extraInfoStrs length {}",
-                 extra_info_strs.len()
-             )));
-         }
-         extra_info_strs[7]
-             .parse::<i64>()
-             .map_err(|_| IllegalArgument("parse queue_offset error".to_string()))
-     }
- 
-     pub fn build_extra_info(
-         ck_queue_offset: i64,
-         pop_time: i64,
-         invisible_time: i64,
-         revive_qid: i32,
-         topic: &str,
-         broker_name: &str,
-         queue_id: i32,
-     ) -> String {
-         let t = ExtraInfoUtil::get_retry(topic);
-         format!(
-             "{}{}{}{}{}{}{}{}{}{}{}{}{}",
-             ck_queue_offset,
-             MessageConst::KEY_SEPARATOR,
-             pop_time,
-             MessageConst::KEY_SEPARATOR,
-             invisible_time,
-             MessageConst::KEY_SEPARATOR,
-             revive_qid,
-             MessageConst::KEY_SEPARATOR,
-             t,
-             MessageConst::KEY_SEPARATOR,
-             broker_name,
-             MessageConst::KEY_SEPARATOR,
-             queue_id
-         )
-     }
- 
-     pub fn build_extra_info_with_msg_queue_offset(
-         ck_queue_offset: i64,
-         pop_time: i64,
-         invisible_time: i64,
-         revive_qid: i32,
-         topic: &str,
-         broker_name: &str,
-         queue_id: i32,
-         msg_queue_offset: i64,
-     ) -> String {
-         let t = ExtraInfoUtil::get_retry(topic);
-         format!(
-             "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
-             ck_queue_offset,
-             MessageConst::KEY_SEPARATOR,
-             pop_time,
-             MessageConst::KEY_SEPARATOR,
-             invisible_time,
-             MessageConst::KEY_SEPARATOR,
-             revive_qid,
-             MessageConst::KEY_SEPARATOR,
-             t,
-             MessageConst::KEY_SEPARATOR,
-             broker_name,
-             MessageConst::KEY_SEPARATOR,
-             queue_id,
-             MessageConst::KEY_SEPARATOR,
-             msg_queue_offset
-         )
-     }
- 
-     pub fn build_start_offset_info(
-         string_builder: &mut String,
-         topic: &str,
-         queue_id: i32,
-         start_offset: i64,
-     ) {
-         let retry = ExtraInfoUtil::get_retry(topic);
-         if !string_builder.is_empty() {
-             string_builder.push(';');
-         }
-         string_builder.push_str(&format!(
-             "{}{}{}{}{}",
-             retry,
-             MessageConst::KEY_SEPARATOR,
-             queue_id,
-             MessageConst::KEY_SEPARATOR,
-             start_offset
-         ));
-     }
- 
-     pub fn build_queue_id_order_count_info(
-         string_builder: &mut String,
-         topic: &str,
-         queue_id: i32,
-         order_count: i32,
-     ) {
-         let retry = ExtraInfoUtil::get_retry(topic);
-         if !string_builder.is_empty() {
-             string_builder.push(';');
-         }
-         string_builder.push_str(&format!(
-             "{}{}{}{}{}",
-             retry,
-             MessageConst::KEY_SEPARATOR,
-             queue_id,
-             MessageConst::KEY_SEPARATOR,
-             order_count
-         ));
-     }
- 
-     pub fn build_queue_offset_order_count_info(
-         string_builder: &mut String,
-         topic: &str,
-         queue_id: i64,
-         queue_offset: i64,
-         order_count: i32,
-     ) {
-         if !string_builder.is_empty() {
-             string_builder.push(';');
-         }
-         string_builder.push_str(&format!(
-             "{}{}{}{}{}",
-             ExtraInfoUtil::get_retry(topic),
-             MessageConst::KEY_SEPARATOR,
-             ExtraInfoUtil::get_queue_offset_key_value_key(queue_id, queue_offset),
-             MessageConst::KEY_SEPARATOR,
-             order_count
-         ));
-     }
- 
-     pub fn build_msg_offset_info(
-         string_builder: &mut String,
-         topic: &str,
-         queue_id: i32,
-         msg_offsets: Vec<u64>,
-     ) {
-         let retry = ExtraInfoUtil::get_retry(topic);
-         if !string_builder.is_empty() {
-             string_builder.push(';');
-         }
-         string_builder.push_str(&format!(
-             "{}{}{}",
-             retry,
-             MessageConst::KEY_SEPARATOR,
-             queue_id
-         ));
-         for (i, msg_offset) in msg_offsets.iter().enumerate() {
-             string_builder.push_str(&msg_offset.to_string());
-             if i < msg_offsets.len() - 1 {
-                 string_builder.push(',');
-             }
-         }
-     }
- 
-     pub fn parse_msg_offset_info(
-         msg_offset_info: &str,
-     ) -> crate::Result<HashMap<String, Vec<i64>>> {
-         let mut msg_offset_map = HashMap::new();
-         let entries: Vec<&str> = msg_offset_info.split(';').collect();
- 
-         for entry in entries {
-             let parts: Vec<&str> = entry.split(MessageConst::KEY_SEPARATOR).collect();
-             if parts.len() != 3 {
-                 return Err(IllegalArgument("parse msgOffsetInfo error".to_string()));
-             }
- 
-             let key = format!("{}@{}", parts[0], parts[1]);
-             let offsets: Vec<i64> = parts[2]
-                 .split(',')
-                 .map(|s| s.parse::<i64>().unwrap())
-                 .collect();
- 
-             msg_offset_map.insert(key, offsets);
-         }
- 
-         Ok(msg_offset_map)
-     }
- 
-     pub fn parse_start_offset_info(start_offset_info: &str) -> crate::Result<HashMap<String, i64>> {
-         let mut start_offset_map = HashMap::new();
-         let entries: Vec<&str> = start_offset_info.split(';').collect();
- 
-         for entry in entries {
-             let parts: Vec<&str> = entry.split(MessageConst::KEY_SEPARATOR).collect();
-             if parts.len() != 3 {
-                 return Err(IllegalArgument("parse startOffsetInfo error".to_string()));
-             }
- 
-             let key = format!("{}@{}", parts[0], parts[1]);
-             let offset = parts[2]
-                 .parse::<i64>()
-                 .map_err(|_| IllegalArgument("Invalid start offset value".to_string()))?;
-             start_offset_map.insert(key, offset);
-         }
- 
-         Ok(start_offset_map)
-     }
- 
-     pub fn parse_order_count_info(order_count_info: &str) -> crate::Result<HashMap<String, i32>> {
-         let mut start_offset_map = HashMap::new();
-         if order_count_info.is_empty() {
-             return Ok(start_offset_map); // return None if the input is empty
-         }
- 
-         // Split the input string by semicolon
-         let array: Vec<&str> = order_count_info.split(';').collect();
- 
-         for one in array {
-             // Split each element by the separator
-             let split: Vec<&str> = one.split(MessageConst::KEY_SEPARATOR).collect();
- 
-             if split.len() != 3 {
-                 return Err(IllegalArgument(format!(
-                     "parse orderCountInfo error {}",
-                     order_count_info
-                 ))); // Handle invalid split
-             }
- 
-             // Construct the key as `split[0]@split[1]`
-             let key = format!("{}@{}", split[0], split[1]);
- 
-             // Check for duplicate keys
-             if start_offset_map.contains_key(&key) {
-                 return Err(IllegalArgument(format!(
-                     "parse orderCountInfo error, duplicate key, {}",
-                     order_count_info
-                 )));
-             }
- 
-             // Insert the key-value pair into the map
-             if let Ok(value) = split[2].parse::<i32>() {
-                 start_offset_map.insert(key, value);
-             } else {
-                 return Err(IllegalArgument(format!(
-                     "parse orderCountInfo error, duplicate key, {}",
-                     order_count_info
-                 )));
-             }
-         }
- 
-         Ok(start_offset_map) // Return the populated HashMap
-     }
- 
-     pub fn get_retry_for_topic(topic: &str) -> String {
-         if topic.starts_with("RETRY_") {
-             RETRY_TOPIC.to_string()
-         } else {
-             NORMAL_TOPIC.to_string()
-         }
-     }
- 
-     pub fn get_start_offset_info_map_key(topic: &str, key: i64) -> String {
-         format!("{}@{}", ExtraInfoUtil::get_retry(topic), key)
-     }
- 
-     pub fn get_start_offset_info_map_key_with_pop_ck(
-         topic: &str,
-         pop_ck: &str,
-         key: i64,
-     ) -> String {
-         format!(
-             "{}@{}",
-             ExtraInfoUtil::get_retry_with_pop_ck(topic, pop_ck),
-             key
-         )
-     }
- 
-     pub fn get_queue_offset_key_value_key(queue_id: i64, queue_offset: i64) -> String {
-         format!("{}{}%{}", QUEUE_OFFSET, queue_id, queue_offset)
-     }
- 
-     pub fn get_queue_offset_map_key(topic: &str, queue_id: i64, queue_offset: i64) -> String {
-         format!(
-             "{}@{}",
-             ExtraInfoUtil::get_retry(topic),
-             ExtraInfoUtil::get_queue_offset_key_value_key(queue_id, queue_offset)
-         )
-     }
- 
-     pub fn is_order(extra_info: &[String]) -> bool {
-         ExtraInfoUtil::get_revive_qid(extra_info).unwrap_or_default() == POP_ORDER_REVIVE_QUEUE
-     }
- 
-     fn get_retry(topic: &str) -> String {
-         if KeyBuilder::is_pop_retry_topic_v2(topic) {
-             RETRY_TOPIC_V2.to_string()
-         } else if topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
-             RETRY_TOPIC.to_string()
-         } else {
-             NORMAL_TOPIC.to_string()
-         }
-     }
- 
-     fn get_retry_with_pop_ck(topic: &str, pop_ck: &str) -> String {
-         if let Ok(split_info) = ExtraInfoUtil::split(pop_ck) {
-             return ExtraInfoUtil::get_retry_from_split(&split_info);
-         }
-         ExtraInfoUtil::get_retry(topic)
-     }
- 
-     fn get_retry_from_split(split_info: &[String]) -> String {
-         if split_info.is_empty() {
-             return NORMAL_TOPIC.to_string();
-         }
-         ExtraInfoUtil::get_retry(split_info[0].as_str())
-     }
- }
- 
- #[cfg(test)]
- mod tests {
-     use rocketmq_common::common::key_builder::KeyBuilder;
- 
-     use super::*;
-     use crate::remoting_error::RemotingError::IllegalArgument;
- 
-     #[test]
-     fn split_with_valid_string() {
-         let result = ExtraInfoUtil::split("a|b|c").unwrap();
-         assert_eq!(result, vec!["a", "b", "c"]);
-     }
- 
-     #[test]
-     fn split_with_empty_string() {
-         let result = ExtraInfoUtil::split("").unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("split extraInfo is empty".to_string()).to_string()
-         );
-     }
- 
-     #[test]
-     fn get_ck_queue_offset_with_valid_string() {
-         let result = ExtraInfoUtil::get_ck_queue_offset(&vec!["123".to_string()]).unwrap();
-         assert_eq!(result, 123);
-     }
- 
-     #[test]
-     fn get_ck_queue_offset_with_invalid_string() {
-         let result = ExtraInfoUtil::get_ck_queue_offset(&vec!["abc".to_string()]).unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("parse ck_queue_offset error".to_string()).to_string()
-         );
-     }
- 
-     #[test]
-     fn get_pop_time_with_valid_string() {
-         let result =
-             ExtraInfoUtil::get_pop_time(&vec!["123".to_string(), "456".to_string()]).unwrap();
-         assert_eq!(result, 456);
-     }
- 
-     #[test]
-     fn get_pop_time_with_insufficient_length() {
-         let result = ExtraInfoUtil::get_pop_time(&vec!["123".to_string()]).unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("getPopTime fail, extraInfoStrs length 1".to_string()).to_string()
-         );
-     }
- 
-     #[test]
-     fn get_invisible_time_with_valid_string() {
-         let result = ExtraInfoUtil::get_invisible_time(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-         ])
-         .unwrap();
-         assert_eq!(result, 789);
-     }
- 
-     #[test]
-     fn get_invisible_time_with_insufficient_length() {
-         let result = ExtraInfoUtil::get_invisible_time(&vec!["123".to_string(), "456".to_string()])
-             .unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("getInvisibleTime fail, extraInfoStrs length 2".to_string())
-                 .to_string()
-         );
-     }
- 
-     #[test]
-     fn get_revive_qid_with_valid_string() {
-         let result = ExtraInfoUtil::get_revive_qid(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "10".to_string(),
-         ])
-         .unwrap();
-         assert_eq!(result, 10);
-     }
- 
-     #[test]
-     fn get_revive_qid_with_insufficient_length() {
-         let result = ExtraInfoUtil::get_revive_qid(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-         ])
-         .unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("getReviveQid fail, extraInfoStrs length 3".to_string()).to_string()
-         );
-     }
- 
-     #[test]
-     fn get_real_topic_with_retry_v1() {
-         let result = ExtraInfoUtil::get_real_topic(
-             &vec![
-                 "123".to_string(),
-                 "456".to_string(),
-                 "789".to_string(),
-                 "10".to_string(),
-                 "1".to_string(),
-             ],
-             "topic",
-             "cid",
-         )
-         .unwrap();
-         assert_eq!(result, KeyBuilder::build_pop_retry_topic_v1("topic", "cid"));
-     }
- 
-     #[test]
-     fn get_real_topic_with_retry_v2() {
-         let result = ExtraInfoUtil::get_real_topic(
-             &vec![
-                 "123".to_string(),
-                 "456".to_string(),
-                 "789".to_string(),
-                 "10".to_string(),
-                 "2".to_string(),
-             ],
-             "topic",
-             "cid",
-         )
-         .unwrap();
-         assert_eq!(result, KeyBuilder::build_pop_retry_topic_v2("topic", "cid"));
-     }
- 
-     #[test]
-     fn get_real_topic_with_normal_topic() {
-         let result = ExtraInfoUtil::get_real_topic(
-             &vec![
-                 "123".to_string(),
-                 "456".to_string(),
-                 "789".to_string(),
-                 "10".to_string(),
-                 "0".to_string(),
-             ],
-             "topic",
-             "cid",
-         )
-         .unwrap();
-         assert_eq!(result, "topic".to_string());
-     }
- 
-     #[test]
-     fn get_real_topic_with_insufficient_length() {
-         let result = ExtraInfoUtil::get_real_topic(
-             &vec![
-                 "123".to_string(),
-                 "456".to_string(),
-                 "789".to_string(),
-                 "10".to_string(),
-             ],
-             "topic",
-             "cid",
-         )
-         .unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("getRealTopic fail, extraInfoStrs length 4".to_string()).to_string()
-         );
-     }
- 
-     #[test]
-     fn get_real_topic_with_retry_invalid() {
-         let result = ExtraInfoUtil::get_real_topic_with_retry("topic", "cid", "3").unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("getRetry fail, format is wrong".to_string()).to_string()
-         );
-     }
- 
-     #[test]
-     fn get_retry_slice_with_valid_string() {
-         let result = ExtraInfoUtil::get_retry_slice(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "10".to_string(),
-             "1".to_string(),
-         ])
-         .unwrap();
-         assert_eq!(result, "1".to_string());
-     }
- 
-     #[test]
-     fn get_retry_slice_with_insufficient_length() {
-         let result = ExtraInfoUtil::get_retry_slice(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "10".to_string(),
-         ])
-         .unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("getRetry fail, extraInfoStrs length 4".to_string()).to_string()
-         );
-     }
- 
-     #[test]
-     fn get_broker_name_with_valid_string() {
-         let result = ExtraInfoUtil::get_broker_name(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "10".to_string(),
-             "1".to_string(),
-             "broker".to_string(),
-         ])
-         .unwrap();
-         assert_eq!(result, "broker".to_string());
-     }
- 
-     #[test]
-     fn get_broker_name_with_insufficient_length() {
-         let result = ExtraInfoUtil::get_broker_name(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "10".to_string(),
-             "1".to_string(),
-         ])
-         .unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("getBrokerName fail, extraInfoStrs length 5".to_string()).to_string()
-         );
-     }
- 
-     #[test]
-     fn get_queue_id_with_valid_string() {
-         let result = ExtraInfoUtil::get_queue_id(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "10".to_string(),
-             "1".to_string(),
-             "broker".to_string(),
-             "7".to_string(),
-         ])
-         .unwrap();
-         assert_eq!(result, 7);
-     }
- 
-     #[test]
-     fn get_queue_id_with_insufficient_length() {
-         let result = ExtraInfoUtil::get_queue_id(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "10".to_string(),
-             "1".to_string(),
-             "broker".to_string(),
-         ])
-         .unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("getQueueId fail, extraInfoStrs length 6".to_string()).to_string()
-         );
-     }
- 
-     #[test]
-     fn get_queue_offset_with_valid_string() {
-         let result = ExtraInfoUtil::get_queue_offset(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "10".to_string(),
-             "1".to_string(),
-             "broker".to_string(),
-             "7".to_string(),
-             "100".to_string(),
-         ])
-         .unwrap();
-         assert_eq!(result, 100);
-     }
- 
-     #[test]
-     fn get_queue_offset_with_insufficient_length() {
-         let result = ExtraInfoUtil::get_queue_offset(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "10".to_string(),
-             "1".to_string(),
-             "broker".to_string(),
-             "7".to_string(),
-         ])
-         .unwrap_err();
-         assert_eq!(
-             result.to_string(),
-             IllegalArgument("getQueueOffset fail, extraInfoStrs length 7".to_string()).to_string()
-         );
-     }
- 
-     #[test]
-     fn build_extra_info_creates_correct_string() {
-         let result = ExtraInfoUtil::build_extra_info(123, 456, 789, 10, "topic", "broker", 7);
-         assert_eq!(result, "123 456 789 10 0 broker 7");
-     }
- 
-     #[test]
-     fn build_extra_info_with_msg_queue_offset_creates_correct_string() {
-         let result = ExtraInfoUtil::build_extra_info_with_msg_queue_offset(
-             123, 456, 789, 10, "topic", "broker", 7, 100,
-         );
-         assert_eq!(result, "123 456 789 10 0 broker 7 100");
-     }
- 
-     #[test]
-     fn build_start_offset_info_creates_correct_string() {
-         let mut string_builder = String::new();
-         ExtraInfoUtil::build_start_offset_info(&mut string_builder, "topic", 7, 100);
-         assert_eq!(string_builder, "0 7 100");
-     }
- 
-     #[test]
-     fn build_queue_id_order_count_info_creates_correct_string() {
-         let mut string_builder = String::new();
-         ExtraInfoUtil::build_queue_id_order_count_info(&mut string_builder, "topic", 7, 100);
-         assert_eq!(string_builder, "0 7 100");
-     }
- 
-     #[test]
-     fn build_queue_offset_order_count_info_creates_correct_string() {
-         let mut string_builder = String::new();
-         ExtraInfoUtil::build_queue_offset_order_count_info(
-             &mut string_builder,
-             "topic",
-             7,
-             100,
-             100,
-         );
-         assert_eq!(string_builder, "0 qo7%100 100");
-     }
- 
-     #[test]
-     fn build_msg_offset_info_creates_correct_string() {
-         let mut string_builder = String::new();
-         ExtraInfoUtil::build_msg_offset_info(&mut string_builder, "topic", 7, vec![100, 200, 300]);
-         assert_eq!(string_builder, "0 7100,200,300");
-     }
- 
-     #[test]
-     fn parse_msg_offset_info_with_valid_string() {
-         let result = ExtraInfoUtil::parse_msg_offset_info("0 7 100,200,300").unwrap();
-         let mut expected = HashMap::new();
-         expected.insert("0@7".to_string(), vec![100, 200, 300]);
-         assert_eq!(result, expected);
-     }
- 
-     #[test]
-     fn parse_start_offset_info_with_valid_string() {
-         let result = ExtraInfoUtil::parse_start_offset_info("0 7 100").unwrap();
-         let mut expected = HashMap::new();
-         expected.insert("0@7".to_string(), 100);
-         assert_eq!(result, expected);
-     }
- 
-     #[test]
-     fn parse_order_count_info_with_valid_string() {
-         let result = ExtraInfoUtil::parse_order_count_info("0 7 100").unwrap();
-         let mut expected = HashMap::new();
-         expected.insert("0@7".to_string(), 100);
-         assert_eq!(result, expected);
-     }
- 
-     #[test]
-     fn get_retry_for_topic_with_retry_topic() {
-         let result = ExtraInfoUtil::get_retry_for_topic("RETRY_topic");
-         assert_eq!(result, "1");
-     }
- 
-     #[test]
-     fn get_retry_for_topic_with_normal_topic() {
-         let result = ExtraInfoUtil::get_retry_for_topic("topic");
-         assert_eq!(result, "0");
-     }
- 
-     #[test]
-     fn get_start_offset_info_map_key_creates_correct_string() {
-         let result = ExtraInfoUtil::get_start_offset_info_map_key("topic", 7);
-         assert_eq!(result, "0@7");
-     }
- 
-     #[test]
-     fn get_start_offset_info_map_key_with_pop_ck_creates_correct_string() {
-         let result = ExtraInfoUtil::get_start_offset_info_map_key_with_pop_ck("topic", "pop_ck", 7);
-         assert_eq!(result, "0@7");
-     }
- 
-     #[test]
-     fn get_queue_offset_key_value_key_creates_correct_string() {
-         let result = ExtraInfoUtil::get_queue_offset_key_value_key(7, 100);
-         assert_eq!(result, "qo7%100");
-     }
- 
-     #[test]
-     fn get_queue_offset_map_key_creates_correct_string() {
-         let result = ExtraInfoUtil::get_queue_offset_map_key("topic", 7, 100);
-         assert_eq!(result, "0@qo7%100");
-     }
- 
-     #[test]
-     fn is_order_with_order_queue() {
-         let result = ExtraInfoUtil::is_order(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "999".to_string(),
-             "1".to_string(),
-             "broker".to_string(),
-             "7".to_string(),
-             "999".to_string(),
-             "0".to_string(),
-         ]);
-         assert!(result);
-     }
- 
-     #[test]
-     fn is_order_with_non_order_queue() {
-         let result = ExtraInfoUtil::is_order(&vec![
-             "123".to_string(),
-             "456".to_string(),
-             "789".to_string(),
-             "10".to_string(),
-             "1".to_string(),
-             "broker".to_string(),
-             "7".to_string(),
-             "100".to_string(),
-             "1".to_string(),
-         ]);
-         assert!(!result);
-     }
- }
- 
+use std::collections::HashMap;
+use std::vec::Vec;
+
+use rocketmq_common::common::key_builder::KeyBuilder;
+use rocketmq_common::common::key_builder::POP_ORDER_REVIVE_QUEUE;
+use rocketmq_common::common::message::MessageConst;
+use rocketmq_common::common::mix_all;
+
+use crate::remoting_error::RemotingError::IllegalArgument;
+
+pub struct ExtraInfoUtil;
+
+const NORMAL_TOPIC: &str = "0";
+const RETRY_TOPIC: &str = "1";
+const RETRY_TOPIC_V2: &str = "2";
+const QUEUE_OFFSET: &str = "qo";
+
+impl ExtraInfoUtil {
+    pub fn split(extra_info: &str) -> crate::Result<Vec<String>> {
+        if extra_info.is_empty() {
+            return Err(IllegalArgument("split extraInfo is empty".to_string()));
+        }
+        Ok(extra_info.split('|').map(String::from).collect())
+    }
+
+    pub fn get_ck_queue_offset(extra_info_strs: &[String]) -> crate::Result<i64> {
+        if extra_info_strs.is_empty() {
+            return Err(IllegalArgument(format!(
+                "getCkQueueOffset fail, extraInfoStrs length {}",
+                extra_info_strs.len()
+            )));
+        }
+        extra_info_strs[0]
+            .parse::<i64>()
+            .map_err(|_| IllegalArgument("parse ck_queue_offset error".to_string()))
+    }
+
+    pub fn get_pop_time(extra_info_strs: &[String]) -> crate::Result<i64> {
+        if extra_info_strs.len() < 2 {
+            return Err(IllegalArgument(format!(
+                "getPopTime fail, extraInfoStrs length {}",
+                extra_info_strs.len()
+            )));
+        }
+        extra_info_strs[1]
+            .parse::<i64>()
+            .map_err(|_| IllegalArgument("parse pop_time error".to_string()))
+    }
+
+    pub fn get_invisible_time(extra_info_strs: &[String]) -> crate::Result<i64> {
+        if extra_info_strs.len() < 3 {
+            return Err(IllegalArgument(format!(
+                "getInvisibleTime fail, extraInfoStrs length {}",
+                extra_info_strs.len()
+            )));
+        }
+        extra_info_strs[2]
+            .parse::<i64>()
+            .map_err(|_| IllegalArgument("parse invisible_time error".to_string()))
+    }
+
+    pub fn get_revive_qid(extra_info_strs: &[String]) -> crate::Result<i32> {
+        if extra_info_strs.len() < 4 {
+            return Err(IllegalArgument(format!(
+                "getReviveQid fail, extraInfoStrs length {}",
+                extra_info_strs.len()
+            )));
+        }
+        extra_info_strs[3]
+            .parse::<i32>()
+            .map_err(|_| IllegalArgument("parse revive_qid error".to_string()))
+    }
+
+    pub fn get_real_topic(
+        extra_info_strs: &[String],
+        topic: &str,
+        cid: &str,
+    ) -> crate::Result<String> {
+        if extra_info_strs.len() < 5 {
+            return Err(IllegalArgument(format!(
+                "getRealTopic fail, extraInfoStrs length {}",
+                extra_info_strs.len()
+            )));
+        }
+        match extra_info_strs[4].as_str() {
+            RETRY_TOPIC => Ok(KeyBuilder::build_pop_retry_topic_v1(topic, cid)),
+            RETRY_TOPIC_V2 => Ok(KeyBuilder::build_pop_retry_topic_v2(topic, cid)),
+            _ => Ok(topic.to_string()),
+        }
+    }
+
+    pub fn get_real_topic_with_retry(topic: &str, cid: &str, retry: &str) -> crate::Result<String> {
+        match retry {
+            NORMAL_TOPIC => Ok(topic.to_string()),
+            RETRY_TOPIC => Ok(KeyBuilder::build_pop_retry_topic_v1(topic, cid)),
+            RETRY_TOPIC_V2 => Ok(KeyBuilder::build_pop_retry_topic_v2(topic, cid)),
+            _ => Err(IllegalArgument(
+                "getRetry fail, format is wrong".to_string(),
+            )),
+        }
+    }
+
+    pub fn get_retry_slice(extra_info_strs: &[String]) -> crate::Result<String> {
+        if extra_info_strs.len() < 5 {
+            return Err(IllegalArgument(format!(
+                "getRetry fail, extraInfoStrs length {}",
+                extra_info_strs.len()
+            )));
+        }
+        Ok(extra_info_strs[4].clone())
+    }
+
+    pub fn get_broker_name(extra_info_strs: &[String]) -> crate::Result<String> {
+        if extra_info_strs.len() < 6 {
+            return Err(IllegalArgument(format!(
+                "getBrokerName fail, extraInfoStrs length {}",
+                extra_info_strs.len()
+            )));
+        }
+        Ok(extra_info_strs[5].clone())
+    }
+
+    pub fn get_queue_id(extra_info_strs: &[String]) -> crate::Result<i32> {
+        if extra_info_strs.len() < 7 {
+            return Err(IllegalArgument(format!(
+                "getQueueId fail, extraInfoStrs length {}",
+                extra_info_strs.len()
+            )));
+        }
+        extra_info_strs[6]
+            .parse::<i32>()
+            .map_err(|_| IllegalArgument("parse queue_id error".to_string()))
+    }
+
+    pub fn get_queue_offset(extra_info_strs: &[String]) -> crate::Result<i64> {
+        if extra_info_strs.len() < 8 {
+            return Err(IllegalArgument(format!(
+                "getQueueOffset fail, extraInfoStrs length {}",
+                extra_info_strs.len()
+            )));
+        }
+        extra_info_strs[7]
+            .parse::<i64>()
+            .map_err(|_| IllegalArgument("parse queue_offset error".to_string()))
+    }
+
+    pub fn build_extra_info(
+        ck_queue_offset: i64,
+        pop_time: i64,
+        invisible_time: i64,
+        revive_qid: i32,
+        topic: &str,
+        broker_name: &str,
+        queue_id: i32,
+    ) -> String {
+        let t = ExtraInfoUtil::get_retry(topic);
+        format!(
+            "{}{}{}{}{}{}{}{}{}{}{}{}{}",
+            ck_queue_offset,
+            MessageConst::KEY_SEPARATOR,
+            pop_time,
+            MessageConst::KEY_SEPARATOR,
+            invisible_time,
+            MessageConst::KEY_SEPARATOR,
+            revive_qid,
+            MessageConst::KEY_SEPARATOR,
+            t,
+            MessageConst::KEY_SEPARATOR,
+            broker_name,
+            MessageConst::KEY_SEPARATOR,
+            queue_id
+        )
+    }
+
+    pub fn build_extra_info_with_msg_queue_offset(
+        ck_queue_offset: i64,
+        pop_time: i64,
+        invisible_time: i64,
+        revive_qid: i32,
+        topic: &str,
+        broker_name: &str,
+        queue_id: i32,
+        msg_queue_offset: i64,
+    ) -> String {
+        let t = ExtraInfoUtil::get_retry(topic);
+        format!(
+            "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+            ck_queue_offset,
+            MessageConst::KEY_SEPARATOR,
+            pop_time,
+            MessageConst::KEY_SEPARATOR,
+            invisible_time,
+            MessageConst::KEY_SEPARATOR,
+            revive_qid,
+            MessageConst::KEY_SEPARATOR,
+            t,
+            MessageConst::KEY_SEPARATOR,
+            broker_name,
+            MessageConst::KEY_SEPARATOR,
+            queue_id,
+            MessageConst::KEY_SEPARATOR,
+            msg_queue_offset
+        )
+    }
+
+    pub fn build_start_offset_info(
+        string_builder: &mut String,
+        topic: &str,
+        queue_id: i32,
+        start_offset: i64,
+    ) {
+        let retry = ExtraInfoUtil::get_retry(topic);
+        if !string_builder.is_empty() {
+            string_builder.push(';');
+        }
+        string_builder.push_str(&format!(
+            "{}{}{}{}{}",
+            retry,
+            MessageConst::KEY_SEPARATOR,
+            queue_id,
+            MessageConst::KEY_SEPARATOR,
+            start_offset
+        ));
+    }
+
+    pub fn build_queue_id_order_count_info(
+        string_builder: &mut String,
+        topic: &str,
+        queue_id: i32,
+        order_count: i32,
+    ) {
+        let retry = ExtraInfoUtil::get_retry(topic);
+        if !string_builder.is_empty() {
+            string_builder.push(';');
+        }
+        string_builder.push_str(&format!(
+            "{}{}{}{}{}",
+            retry,
+            MessageConst::KEY_SEPARATOR,
+            queue_id,
+            MessageConst::KEY_SEPARATOR,
+            order_count
+        ));
+    }
+
+    pub fn build_queue_offset_order_count_info(
+        string_builder: &mut String,
+        topic: &str,
+        queue_id: i64,
+        queue_offset: i64,
+        order_count: i32,
+    ) {
+        if !string_builder.is_empty() {
+            string_builder.push(';');
+        }
+        string_builder.push_str(&format!(
+            "{}{}{}{}{}",
+            ExtraInfoUtil::get_retry(topic),
+            MessageConst::KEY_SEPARATOR,
+            ExtraInfoUtil::get_queue_offset_key_value_key(queue_id, queue_offset),
+            MessageConst::KEY_SEPARATOR,
+            order_count
+        ));
+    }
+
+    pub fn build_msg_offset_info(
+        string_builder: &mut String,
+        topic: &str,
+        queue_id: i32,
+        msg_offsets: Vec<u64>,
+    ) {
+        let retry = ExtraInfoUtil::get_retry(topic);
+        if !string_builder.is_empty() {
+            string_builder.push(';');
+        }
+        string_builder.push_str(&format!(
+            "{}{}{}",
+            retry,
+            MessageConst::KEY_SEPARATOR,
+            queue_id
+        ));
+        for (i, msg_offset) in msg_offsets.iter().enumerate() {
+            string_builder.push_str(&msg_offset.to_string());
+            if i < msg_offsets.len() - 1 {
+                string_builder.push(',');
+            }
+        }
+    }
+
+    pub fn parse_msg_offset_info(
+        msg_offset_info: &str,
+    ) -> crate::Result<HashMap<String, Vec<i64>>> {
+        let mut msg_offset_map = HashMap::new();
+        let entries: Vec<&str> = msg_offset_info.split(';').collect();
+
+        for entry in entries {
+            let parts: Vec<&str> = entry.split(MessageConst::KEY_SEPARATOR).collect();
+            if parts.len() != 3 {
+                return Err(IllegalArgument("parse msgOffsetInfo error".to_string()));
+            }
+
+            let key = format!("{}@{}", parts[0], parts[1]);
+            let offsets: Vec<i64> = parts[2]
+                .split(',')
+                .map(|s| s.parse::<i64>().unwrap())
+                .collect();
+
+            msg_offset_map.insert(key, offsets);
+        }
+
+        Ok(msg_offset_map)
+    }
+
+    pub fn parse_start_offset_info(start_offset_info: &str) -> crate::Result<HashMap<String, i64>> {
+        let mut start_offset_map = HashMap::new();
+        let entries: Vec<&str> = start_offset_info.split(';').collect();
+
+        for entry in entries {
+            let parts: Vec<&str> = entry.split(MessageConst::KEY_SEPARATOR).collect();
+            if parts.len() != 3 {
+                return Err(IllegalArgument("parse startOffsetInfo error".to_string()));
+            }
+
+            let key = format!("{}@{}", parts[0], parts[1]);
+            let offset = parts[2]
+                .parse::<i64>()
+                .map_err(|_| IllegalArgument("Invalid start offset value".to_string()))?;
+            start_offset_map.insert(key, offset);
+        }
+
+        Ok(start_offset_map)
+    }
+
+    pub fn parse_order_count_info(order_count_info: &str) -> crate::Result<HashMap<String, i32>> {
+        let mut start_offset_map = HashMap::new();
+        if order_count_info.is_empty() {
+            return Ok(start_offset_map); // return None if the input is empty
+        }
+
+        // Split the input string by semicolon
+        let array: Vec<&str> = order_count_info.split(';').collect();
+
+        for one in array {
+            // Split each element by the separator
+            let split: Vec<&str> = one.split(MessageConst::KEY_SEPARATOR).collect();
+
+            if split.len() != 3 {
+                return Err(IllegalArgument(format!(
+                    "parse orderCountInfo error {}",
+                    order_count_info
+                ))); // Handle invalid split
+            }
+
+            // Construct the key as `split[0]@split[1]`
+            let key = format!("{}@{}", split[0], split[1]);
+
+            // Check for duplicate keys
+            if start_offset_map.contains_key(&key) {
+                return Err(IllegalArgument(format!(
+                    "parse orderCountInfo error, duplicate key, {}",
+                    order_count_info
+                )));
+            }
+
+            // Insert the key-value pair into the map
+            if let Ok(value) = split[2].parse::<i32>() {
+                start_offset_map.insert(key, value);
+            } else {
+                return Err(IllegalArgument(format!(
+                    "parse orderCountInfo error, duplicate key, {}",
+                    order_count_info
+                )));
+            }
+        }
+
+        Ok(start_offset_map) // Return the populated HashMap
+    }
+
+    pub fn get_retry_for_topic(topic: &str) -> String {
+        if topic.starts_with("RETRY_") {
+            RETRY_TOPIC.to_string()
+        } else {
+            NORMAL_TOPIC.to_string()
+        }
+    }
+
+    pub fn get_start_offset_info_map_key(topic: &str, key: i64) -> String {
+        format!("{}@{}", ExtraInfoUtil::get_retry(topic), key)
+    }
+
+    pub fn get_start_offset_info_map_key_with_pop_ck(
+        topic: &str,
+        pop_ck: &str,
+        key: i64,
+    ) -> String {
+        format!(
+            "{}@{}",
+            ExtraInfoUtil::get_retry_with_pop_ck(topic, pop_ck),
+            key
+        )
+    }
+
+    pub fn get_queue_offset_key_value_key(queue_id: i64, queue_offset: i64) -> String {
+        format!("{}{}%{}", QUEUE_OFFSET, queue_id, queue_offset)
+    }
+
+    pub fn get_queue_offset_map_key(topic: &str, queue_id: i64, queue_offset: i64) -> String {
+        format!(
+            "{}@{}",
+            ExtraInfoUtil::get_retry(topic),
+            ExtraInfoUtil::get_queue_offset_key_value_key(queue_id, queue_offset)
+        )
+    }
+
+    pub fn is_order(extra_info: &[String]) -> bool {
+        ExtraInfoUtil::get_revive_qid(extra_info).unwrap_or_default() == POP_ORDER_REVIVE_QUEUE
+    }
+
+    fn get_retry(topic: &str) -> String {
+        if KeyBuilder::is_pop_retry_topic_v2(topic) {
+            RETRY_TOPIC_V2.to_string()
+        } else if topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
+            RETRY_TOPIC.to_string()
+        } else {
+            NORMAL_TOPIC.to_string()
+        }
+    }
+
+    fn get_retry_with_pop_ck(topic: &str, pop_ck: &str) -> String {
+        if let Ok(split_info) = ExtraInfoUtil::split(pop_ck) {
+            return ExtraInfoUtil::get_retry_from_split(&split_info);
+        }
+        ExtraInfoUtil::get_retry(topic)
+    }
+
+    fn get_retry_from_split(split_info: &[String]) -> String {
+        if split_info.is_empty() {
+            return NORMAL_TOPIC.to_string();
+        }
+        ExtraInfoUtil::get_retry(split_info[0].as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_common::common::key_builder::KeyBuilder;
+
+    use super::*;
+    use crate::remoting_error::RemotingError::IllegalArgument;
+
+    #[test]
+    fn split_with_valid_string() {
+        let result = ExtraInfoUtil::split("a|b|c").unwrap();
+        assert_eq!(result, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn split_with_empty_string() {
+        let result = ExtraInfoUtil::split("").unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("split extraInfo is empty".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn get_ck_queue_offset_with_valid_string() {
+        let result = ExtraInfoUtil::get_ck_queue_offset(&vec!["123".to_string()]).unwrap();
+        assert_eq!(result, 123);
+    }
+
+    #[test]
+    fn get_ck_queue_offset_with_invalid_string() {
+        let result = ExtraInfoUtil::get_ck_queue_offset(&vec!["abc".to_string()]).unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("parse ck_queue_offset error".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn get_pop_time_with_valid_string() {
+        let result =
+            ExtraInfoUtil::get_pop_time(&vec!["123".to_string(), "456".to_string()]).unwrap();
+        assert_eq!(result, 456);
+    }
+
+    #[test]
+    fn get_pop_time_with_insufficient_length() {
+        let result = ExtraInfoUtil::get_pop_time(&vec!["123".to_string()]).unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("getPopTime fail, extraInfoStrs length 1".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn get_invisible_time_with_valid_string() {
+        let result = ExtraInfoUtil::get_invisible_time(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(result, 789);
+    }
+
+    #[test]
+    fn get_invisible_time_with_insufficient_length() {
+        let result = ExtraInfoUtil::get_invisible_time(&vec!["123".to_string(), "456".to_string()])
+            .unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("getInvisibleTime fail, extraInfoStrs length 2".to_string())
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn get_revive_qid_with_valid_string() {
+        let result = ExtraInfoUtil::get_revive_qid(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "10".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(result, 10);
+    }
+
+    #[test]
+    fn get_revive_qid_with_insufficient_length() {
+        let result = ExtraInfoUtil::get_revive_qid(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+        ])
+        .unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("getReviveQid fail, extraInfoStrs length 3".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn get_real_topic_with_retry_v1() {
+        let result = ExtraInfoUtil::get_real_topic(
+            &vec![
+                "123".to_string(),
+                "456".to_string(),
+                "789".to_string(),
+                "10".to_string(),
+                "1".to_string(),
+            ],
+            "topic",
+            "cid",
+        )
+        .unwrap();
+        assert_eq!(result, KeyBuilder::build_pop_retry_topic_v1("topic", "cid"));
+    }
+
+    #[test]
+    fn get_real_topic_with_retry_v2() {
+        let result = ExtraInfoUtil::get_real_topic(
+            &vec![
+                "123".to_string(),
+                "456".to_string(),
+                "789".to_string(),
+                "10".to_string(),
+                "2".to_string(),
+            ],
+            "topic",
+            "cid",
+        )
+        .unwrap();
+        assert_eq!(result, KeyBuilder::build_pop_retry_topic_v2("topic", "cid"));
+    }
+
+    #[test]
+    fn get_real_topic_with_normal_topic() {
+        let result = ExtraInfoUtil::get_real_topic(
+            &vec![
+                "123".to_string(),
+                "456".to_string(),
+                "789".to_string(),
+                "10".to_string(),
+                "0".to_string(),
+            ],
+            "topic",
+            "cid",
+        )
+        .unwrap();
+        assert_eq!(result, "topic".to_string());
+    }
+
+    #[test]
+    fn get_real_topic_with_insufficient_length() {
+        let result = ExtraInfoUtil::get_real_topic(
+            &vec![
+                "123".to_string(),
+                "456".to_string(),
+                "789".to_string(),
+                "10".to_string(),
+            ],
+            "topic",
+            "cid",
+        )
+        .unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("getRealTopic fail, extraInfoStrs length 4".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn get_real_topic_with_retry_invalid() {
+        let result = ExtraInfoUtil::get_real_topic_with_retry("topic", "cid", "3").unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("getRetry fail, format is wrong".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn get_retry_slice_with_valid_string() {
+        let result = ExtraInfoUtil::get_retry_slice(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "10".to_string(),
+            "1".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(result, "1".to_string());
+    }
+
+    #[test]
+    fn get_retry_slice_with_insufficient_length() {
+        let result = ExtraInfoUtil::get_retry_slice(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "10".to_string(),
+        ])
+        .unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("getRetry fail, extraInfoStrs length 4".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn get_broker_name_with_valid_string() {
+        let result = ExtraInfoUtil::get_broker_name(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "10".to_string(),
+            "1".to_string(),
+            "broker".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(result, "broker".to_string());
+    }
+
+    #[test]
+    fn get_broker_name_with_insufficient_length() {
+        let result = ExtraInfoUtil::get_broker_name(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "10".to_string(),
+            "1".to_string(),
+        ])
+        .unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("getBrokerName fail, extraInfoStrs length 5".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn get_queue_id_with_valid_string() {
+        let result = ExtraInfoUtil::get_queue_id(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "10".to_string(),
+            "1".to_string(),
+            "broker".to_string(),
+            "7".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(result, 7);
+    }
+
+    #[test]
+    fn get_queue_id_with_insufficient_length() {
+        let result = ExtraInfoUtil::get_queue_id(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "10".to_string(),
+            "1".to_string(),
+            "broker".to_string(),
+        ])
+        .unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("getQueueId fail, extraInfoStrs length 6".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn get_queue_offset_with_valid_string() {
+        let result = ExtraInfoUtil::get_queue_offset(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "10".to_string(),
+            "1".to_string(),
+            "broker".to_string(),
+            "7".to_string(),
+            "100".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(result, 100);
+    }
+
+    #[test]
+    fn get_queue_offset_with_insufficient_length() {
+        let result = ExtraInfoUtil::get_queue_offset(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "10".to_string(),
+            "1".to_string(),
+            "broker".to_string(),
+            "7".to_string(),
+        ])
+        .unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            IllegalArgument("getQueueOffset fail, extraInfoStrs length 7".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn build_extra_info_creates_correct_string() {
+        let result = ExtraInfoUtil::build_extra_info(123, 456, 789, 10, "topic", "broker", 7);
+        assert_eq!(result, "123 456 789 10 0 broker 7");
+    }
+
+    #[test]
+    fn build_extra_info_with_msg_queue_offset_creates_correct_string() {
+        let result = ExtraInfoUtil::build_extra_info_with_msg_queue_offset(
+            123, 456, 789, 10, "topic", "broker", 7, 100,
+        );
+        assert_eq!(result, "123 456 789 10 0 broker 7 100");
+    }
+
+    #[test]
+    fn build_start_offset_info_creates_correct_string() {
+        let mut string_builder = String::new();
+        ExtraInfoUtil::build_start_offset_info(&mut string_builder, "topic", 7, 100);
+        assert_eq!(string_builder, "0 7 100");
+    }
+
+    #[test]
+    fn build_queue_id_order_count_info_creates_correct_string() {
+        let mut string_builder = String::new();
+        ExtraInfoUtil::build_queue_id_order_count_info(&mut string_builder, "topic", 7, 100);
+        assert_eq!(string_builder, "0 7 100");
+    }
+
+    #[test]
+    fn build_queue_offset_order_count_info_creates_correct_string() {
+        let mut string_builder = String::new();
+        ExtraInfoUtil::build_queue_offset_order_count_info(
+            &mut string_builder,
+            "topic",
+            7,
+            100,
+            100,
+        );
+        assert_eq!(string_builder, "0 qo7%100 100");
+    }
+
+    #[test]
+    fn build_msg_offset_info_creates_correct_string() {
+        let mut string_builder = String::new();
+        ExtraInfoUtil::build_msg_offset_info(&mut string_builder, "topic", 7, vec![100, 200, 300]);
+        assert_eq!(string_builder, "0 7100,200,300");
+    }
+
+    #[test]
+    fn parse_msg_offset_info_with_valid_string() {
+        let result = ExtraInfoUtil::parse_msg_offset_info("0 7 100,200,300").unwrap();
+        let mut expected = HashMap::new();
+        expected.insert("0@7".to_string(), vec![100, 200, 300]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_start_offset_info_with_valid_string() {
+        let result = ExtraInfoUtil::parse_start_offset_info("0 7 100").unwrap();
+        let mut expected = HashMap::new();
+        expected.insert("0@7".to_string(), 100);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_order_count_info_with_valid_string() {
+        let result = ExtraInfoUtil::parse_order_count_info("0 7 100").unwrap();
+        let mut expected = HashMap::new();
+        expected.insert("0@7".to_string(), 100);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn get_retry_for_topic_with_retry_topic() {
+        let result = ExtraInfoUtil::get_retry_for_topic("RETRY_topic");
+        assert_eq!(result, "1");
+    }
+
+    #[test]
+    fn get_retry_for_topic_with_normal_topic() {
+        let result = ExtraInfoUtil::get_retry_for_topic("topic");
+        assert_eq!(result, "0");
+    }
+
+    #[test]
+    fn get_start_offset_info_map_key_creates_correct_string() {
+        let result = ExtraInfoUtil::get_start_offset_info_map_key("topic", 7);
+        assert_eq!(result, "0@7");
+    }
+
+    #[test]
+    fn get_start_offset_info_map_key_with_pop_ck_creates_correct_string() {
+        let result = ExtraInfoUtil::get_start_offset_info_map_key_with_pop_ck("topic", "pop_ck", 7);
+        assert_eq!(result, "0@7");
+    }
+
+    #[test]
+    fn get_queue_offset_key_value_key_creates_correct_string() {
+        let result = ExtraInfoUtil::get_queue_offset_key_value_key(7, 100);
+        assert_eq!(result, "qo7%100");
+    }
+
+    #[test]
+    fn get_queue_offset_map_key_creates_correct_string() {
+        let result = ExtraInfoUtil::get_queue_offset_map_key("topic", 7, 100);
+        assert_eq!(result, "0@qo7%100");
+    }
+
+    #[test]
+    fn is_order_with_order_queue() {
+        let result = ExtraInfoUtil::is_order(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "999".to_string(),
+            "1".to_string(),
+            "broker".to_string(),
+            "7".to_string(),
+            "999".to_string(),
+            "0".to_string(),
+        ]);
+        assert!(result);
+    }
+
+    #[test]
+    fn is_order_with_non_order_queue() {
+        let result = ExtraInfoUtil::is_order(&vec![
+            "123".to_string(),
+            "456".to_string(),
+            "789".to_string(),
+            "10".to_string(),
+            "1".to_string(),
+            "broker".to_string(),
+            "7".to_string(),
+            "100".to_string(),
+            "1".to_string(),
+        ]);
+        assert!(!result);
+    }
+}

--- a/rocketmq-store/src/base/get_message_result.rs
+++ b/rocketmq-store/src/base/get_message_result.rs
@@ -225,6 +225,12 @@ impl GetMessageResult {
     pub fn message_mapped_list(&self) -> &[SelectMappedBufferResult] {
         self.message_mapped_list.as_slice()
     }
+
+    
+    #[inline]
+    pub fn message_queue_offset(&self) -> &Vec<u64> {
+        &self.message_queue_offset
+    }
 }
 
 #[cfg(test)]

--- a/rocketmq-store/src/base/get_message_result.rs
+++ b/rocketmq-store/src/base/get_message_result.rs
@@ -226,7 +226,6 @@ impl GetMessageResult {
         self.message_mapped_list.as_slice()
     }
 
-    
     #[inline]
     pub fn message_queue_offset(&self) -> &Vec<u64> {
         &self.message_queue_offset

--- a/rocketmq-store/src/log_file.rs
+++ b/rocketmq-store/src/log_file.rs
@@ -246,7 +246,7 @@ pub trait RocketMQMessageStore: Sync + 'static {
         offset: i64,
         max_msg_nums: i32,
         max_total_msg_size: i32,
-        message_filter: Option<&dyn MessageFilter>,
+        message_filter: Option<Arc<Box<dyn MessageFilter>>>,
     ) -> Option<GetMessageResult>;
 
     /// Check if messages are in memory by consume offset.


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1939

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced message processing capabilities with new parameters in message processors.
	- Introduced a new method to retrieve the latest offset in the PopBufferMergeService.
	- Added a method to access message queue offsets in GetMessageResult.
	- New configuration option for retry topic behavior in BrokerConfig.

- **Bug Fixes**
	- Improved memory management and concurrency for message filters across various components.

- **Documentation**
	- Updated method signatures and added comments for clarity in the broker configuration.

- **Refactor**
	- Simplified the handling of message filters in multiple processor methods.

- **Chores**
	- Restored and validated methods in the ExtraInfoUtil for processing extra information strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->