### PR TITLE
[ISSUE #1992]🍻Implement PopMessageProcessor#get_init_offset method logic🚀

### DIFF
--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -108,7 +108,7 @@ impl ConsumerOffsetManager {
 
     pub fn commit_offset(
         &self,
-        client_host: SocketAddr,
+        client_host: CheetahString,
         group: &CheetahString,
         topic: &CheetahString,
         queue_id: i32,

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -517,7 +517,7 @@ where
                     q_id,
                 ) {
                     self.consumer_offset_manager.commit_offset(
-                        channel.remote_address(),
+                        channel.remote_address().to_string().into(),
                         &consume_group,
                         &topic,
                         q_id,

--- a/rocketmq-broker/src/processor/consumer_manage_processor.rs
+++ b/rocketmq-broker/src/processor/consumer_manage_processor.rs
@@ -229,7 +229,7 @@ where
             return Some(response.set_remark("Offset has been previously reset"));
         }
         self.consumer_offset_manager.commit_offset(
-            channel.remote_address(),
+            channel.remote_address().to_string().into(),
             group,
             topic,
             queue_id,

--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -537,7 +537,7 @@ impl DefaultPullMessageResultHandler {
         store_offset_enable = store_offset_enable && has_commit_offset_flag;
         if store_offset_enable {
             self.consumer_offset_manager.commit_offset(
-                client_address,
+                client_address.to_string().into(),
                 request_header.consumer_group.as_ref(),
                 request_header.topic.as_ref(),
                 request_header.queue_id,

--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -121,7 +121,7 @@ where
 
     pub fn update_consume_offset(&self, mq: &MessageQueue, offset: i64) {
         self.consumer_offset_manager.commit_offset(
-            self.store_host,
+            self.store_host.to_string().into(),
             &CheetahString::from_static_str(TransactionalMessageUtil::build_consumer_group()),
             mq.get_topic_cs(),
             mq.get_queue_id(),

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -186,6 +186,7 @@ pub struct BrokerConfig {
     pub retrieve_message_from_pop_retry_topic_v1: bool,
     pub pop_from_retry_probability: i32,
     pub pop_response_return_actual_retry_topic: bool,
+    pub init_pop_offset_by_check_msg_in_mem: bool,
 }
 
 impl Default for BrokerConfig {
@@ -278,6 +279,7 @@ impl Default for BrokerConfig {
             retrieve_message_from_pop_retry_topic_v1: true,
             pop_from_retry_probability: 20,
             pop_response_return_actual_retry_topic: false,
+            init_pop_offset_by_check_msg_in_mem: true,
         }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1992

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configuration option `init_pop_offset_by_check_msg_in_mem` for broker settings
	- Enhanced message processing logic for offset initialization and retrieval

- **Bug Fixes**
	- Updated type handling for client and remote addresses in various message processing methods

- **Refactor**
	- Modified method signatures to improve type consistency across message processing components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->