### PR TITLE
[ISSUE #1996]🍻Implement PopMessageProcessor#reset_pop_offset method logic🚀

### DIFF
--- a/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
@@ -106,6 +106,10 @@ impl<MS> ConfigManager for ConsumerOrderInfoManager<MS> {
 }
 
 impl<MS> ConsumerOrderInfoManager<MS> {
+    pub fn clear_block(&self, topic: &CheetahString, group: &CheetahString, queue_id: i32) {
+        unimplemented!()
+    }
+
     pub fn auto_clean(&self) {
         let mut consumer_order_info_wrapper = self.consumer_order_info_wrapper.lock();
         let table = &mut consumer_order_info_wrapper.table;

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -1050,7 +1050,7 @@ where
         let reset_offset = self
             .consumer_offset_manager
             .query_then_erase_reset_offset(group, topic, queue_id);
-        if reset_offset.is_some() {
+        if let Some(value) = &reset_offset {
             self.consumer_order_info_manager
                 .clear_block(topic, group, queue_id);
             self.pop_buffer_merge_service
@@ -1060,7 +1060,7 @@ where
                 group,
                 topic,
                 queue_id,
-                *reset_offset.as_ref().unwrap(),
+                *value,
             )
         }
         reset_offset

--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -27,4 +27,8 @@ impl PopBufferMergeService {
     pub fn get_latest_offset(&self, _lock_key: &str) -> i64 {
         unimplemented!("Not implemented yet");
     }
+
+    pub fn clear_offset_queue(&self, _lock_key: &str) {
+        unimplemented!("Not implemented yet");
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1996

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new `clear_block` method to `ConsumerOrderInfoManager`
	- Introduced a new `clear_offset_queue` method in `PopBufferMergeService`

- **Improvements**
	- Updated `reset_pop_offset` method signature in `PopMessageProcessor`
	- Enhanced offset management and concurrency control mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->