### PR TITLE
[ISSUE #1685] Add Channel's method #[inline]

### DIFF
--- a/rocketmq-remoting/src/net/channel.rs
+++ b/rocketmq-remoting/src/net/channel.rs
@@ -153,37 +153,53 @@ impl Channel {
 }
 
 impl Channel {
+
+    #[inline]
     pub fn set_local_address(&mut self, local_address: SocketAddr) {
         self.local_address = local_address;
     }
+    
+    #[inline]
     pub fn set_remote_address(&mut self, remote_address: SocketAddr) {
         self.remote_address = remote_address;
     }
+
+    #[inline]
     pub fn set_channel_id(&mut self, channel_id: String) {
         self.channel_id = channel_id;
     }
 
+    #[inline]
     pub fn local_address(&self) -> SocketAddr {
         self.local_address
     }
+
+    #[inline]
     pub fn remote_address(&self) -> SocketAddr {
         self.remote_address
     }
+
+    #[inline]
     pub fn channel_id(&self) -> &str {
         self.channel_id.as_str()
     }
 
+    #[inline]
     pub fn connection(&self) -> ArcMut<Connection> {
         self.connection.clone()
     }
+
+    #[inline]
     pub fn connection_ref(&self) -> &Connection {
         self.connection.as_ref()
     }
 
+    #[inline]
     pub fn connection_mut(&mut self) -> &mut Connection {
         self.connection.as_mut()
     }
 
+    #[inline]
     pub fn connection_mut_from_ref(&self) -> &mut Connection {
         self.connection.mut_from_ref()
     }

--- a/rocketmq-remoting/src/net/channel.rs
+++ b/rocketmq-remoting/src/net/channel.rs
@@ -153,12 +153,11 @@ impl Channel {
 }
 
 impl Channel {
-
     #[inline]
     pub fn set_local_address(&mut self, local_address: SocketAddr) {
         self.local_address = local_address;
     }
-    
+
     #[inline]
     pub fn set_remote_address(&mut self, remote_address: SocketAddr) {
         self.remote_address = remote_address;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1685

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `Channel` struct with new methods for managing network connection properties.
	- Added setters and getters for local/remote addresses and channel ID.
	- Introduced additional methods for accessing connection details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->