### PR TITLE
[ISSUE #2026]♿️AckMessage extends std::fmt::Display

### DIFF
--- a/rocketmq-store/src/pop.rs
+++ b/rocketmq-store/src/pop.rs
@@ -21,7 +21,7 @@ pub mod batch_ack_msg;
 pub mod pop_check_point;
 
 /// A trait representing an acknowledgment message that can be converted to and from `Any`.
-pub trait AckMessage {
+pub trait AckMessage: std::fmt::Display {
     fn ack_offset(&self) -> i64;
     fn set_ack_offset(&mut self, ack_offset: i64);
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2026

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `AckMessage` trait to require `Display` implementation for types implementing the trait.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->