### PR TITLE
[ISSUE #2031]🚀Implement PopBufferMergeService#clear_offset_queue💫

### DIFF
--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -1051,22 +1051,21 @@ where
         group: &CheetahString,
         queue_id: i32,
     ) -> Option<i64> {
-        let lock_key = format!(
+        let lock_key = CheetahString::from_string(format!(
             "{}{}{}{}{}",
             topic,
             PopAckConstants::SPLIT,
             group,
             PopAckConstants::SPLIT,
             queue_id
-        );
+        ));
         let reset_offset = self
             .consumer_offset_manager
             .query_then_erase_reset_offset(group, topic, queue_id);
         if let Some(value) = &reset_offset {
             self.consumer_order_info_manager
                 .clear_block(topic, group, queue_id);
-            self.pop_buffer_merge_service
-                .clear_offset_queue(lock_key.as_ref());
+            self.pop_buffer_merge_service.clear_offset_queue(&lock_key);
             self.consumer_offset_manager.commit_offset(
                 "ResetPopOffset".into(),
                 group,

--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -195,8 +195,8 @@ impl PopBufferMergeService {
         )))
     }
 
-    pub fn clear_offset_queue(&self, _lock_key: &str) {
-        unimplemented!("Not implemented yet");
+    pub fn clear_offset_queue(&self, lock_key: &CheetahString) {
+        self.commit_offsets.remove(lock_key);
     }
 
     fn mark_bit_cas(set_bits: &AtomicI32, index: usize) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2031

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal method signatures and implementations related to offset queue management
	- Modified type handling for lock keys from `String` to `CheetahString`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->