### PR TITLE
[ISSUE #2079]💫Add HAConnectionRuntimeInfo for rust🚀

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -33,6 +33,7 @@ pub mod cm_result;
 pub mod connection;
 pub mod consume_message_directly_result;
 pub mod group_list;
+pub mod ha_connection_runtime_info;
 pub mod kv_table;
 pub mod pop_process_queue_info;
 pub mod process_queue_info;

--- a/rocketmq-remoting/src/protocol/body/ha_connection_runtime_info.rs
+++ b/rocketmq-remoting/src/protocol/body/ha_connection_runtime_info.rs
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::fmt::Display;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HAConnectionRuntimeInfo {
+    pub addr: String,
+    pub slave_ack_offset: u64,
+    pub diff: i64,
+    pub in_sync: bool,
+    pub transferred_byte_in_second: u64,
+    pub transfer_from_where: u64,
+}
+
+impl Display for HAConnectionRuntimeInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "HAConnectionRuntimeInfo [addr={}, slaveAckOffset={}, diff={}, inSync={}, \
+             transferredBytesInSecond={}, transferFromWhere={}]",
+            self.addr,
+            self.slave_ack_offset,
+            self.diff,
+            self.in_sync,
+            self.transferred_byte_in_second,
+            self.transfer_from_where
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ha_connection_runtime_info_initializes_correctly() {
+        let info = HAConnectionRuntimeInfo {
+            addr: "127.0.0.1:10911".to_string(),
+            slave_ack_offset: 100,
+            diff: 50,
+            in_sync: true,
+            transferred_byte_in_second: 1024,
+            transfer_from_where: 200,
+        };
+        assert_eq!(info.addr, "127.0.0.1:10911");
+        assert_eq!(info.slave_ack_offset, 100);
+        assert_eq!(info.diff, 50);
+        assert!(info.in_sync);
+        assert_eq!(info.transferred_byte_in_second, 1024);
+        assert_eq!(info.transfer_from_where, 200);
+    }
+
+    #[test]
+    fn ha_connection_runtime_info_default_values() {
+        let info = HAConnectionRuntimeInfo::default();
+        assert_eq!(info.addr, "");
+        assert_eq!(info.slave_ack_offset, 0);
+        assert_eq!(info.diff, 0);
+        assert!(!info.in_sync);
+        assert_eq!(info.transferred_byte_in_second, 0);
+        assert_eq!(info.transfer_from_where, 0);
+    }
+
+    #[test]
+    fn ha_connection_runtime_info_display_formats_correctly() {
+        let info = HAConnectionRuntimeInfo {
+            addr: "127.0.0.1:10911".to_string(),
+            slave_ack_offset: 100,
+            diff: 50,
+            in_sync: true,
+            transferred_byte_in_second: 1024,
+            transfer_from_where: 200,
+        };
+        let display = format!("{}", info);
+        assert!(display.contains(
+            "HAConnectionRuntimeInfo [addr=127.0.0.1:10911, slaveAckOffset=100, diff=50, \
+             inSync=true, transferredBytesInSecond=1024, transferFromWhere=200]"
+        ));
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2079

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new module for High Availability (HA) connection runtime information tracking
	- Introduced a structured way to capture and represent connection runtime details

- **Tests**
	- Included unit tests to validate the new HA connection runtime information struct

<!-- end of auto-generated comment: release notes by coderabbit.ai -->