### PR TITLE
[ISSUE #2115]Allow unused imports in ordermessage_consumer file

### DIFF
--- a/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
@@ -17,9 +17,9 @@
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 
+use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
 #[allow(unused_imports)]
 use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
-use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
 use rocketmq_client_rust::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
 use rocketmq_client_rust::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
 use rocketmq_client_rust::consumer::listener::message_listener_orderly::MessageListenerOrderly;

--- a/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
@@ -17,8 +17,9 @@
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 
-use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
+#[allow(unused_imports)]
 use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
+use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
 use rocketmq_client_rust::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
 use rocketmq_client_rust::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
 use rocketmq_client_rust::consumer::listener::message_listener_orderly::MessageListenerOrderly;


### PR DESCRIPTION

### Which Issue(s) This PR Fixes(Closes)

- [Bug🐛] Allow unused imports in ordermessage_consumer.rs

- Fixes #2115 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Reorganized import statements in the order message consumer example.
	- Added an unused import with a suppression attribute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->