### PR TITLE
[Issue 2117] Fix unused warnings in RocketMQ examples

### DIFF
--- a/rocketmq-client/examples/transaction/transaction_producer.rs
+++ b/rocketmq-client/examples/transaction/transaction_producer.rs
@@ -85,7 +85,7 @@ impl TransactionListener for TransactionListenerImpl {
     fn execute_local_transaction(
         &self,
         msg: &Message,
-        arg: Option<&(dyn Any + Send + Sync)>,
+        _arg: Option<&(dyn Any + Send + Sync)>,
     ) -> LocalTransactionState {
         let value = self
             .transaction_index
@@ -100,7 +100,7 @@ impl TransactionListener for TransactionListenerImpl {
     }
 
     fn check_local_transaction(&self, msg: &MessageExt) -> LocalTransactionState {
-        let mut guard = self.local_trans.lock();
+        let guard = self.local_trans.lock();
         let status = guard
             .get(&msg.get_transaction_id().cloned().unwrap_or_default())
             .unwrap_or(&-1);

--- a/rocketmq-common/src/common/message/message_client_id_setter.rs
+++ b/rocketmq-common/src/common/message/message_client_id_setter.rs
@@ -171,7 +171,7 @@ mod tests {
     fn create_fake_ip_generates_valid_ip() {
         let fake_ip = create_fake_ip();
         assert_eq!(fake_ip.len(), 4);
-        assert!(fake_ip.iter().all(|&byte| byte >= 0 && byte <= 255));
+        assert!(fake_ip.iter().all(|&byte| true));
     }
 
     #[test]


### PR DESCRIPTION

### Description:
This PR addresses several compiler warnings related to unused imports, variables, and redundant mutability in the RocketMQ examples. The changes clean up the code without altering functionality:

  - Removed unused imports and redundant comparisons.
  -  Prefixed unused variables with _ to suppress warnings.
   - Removed unnecessary mut in variable declarations.

- Fixes #2117 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Code Clarity**
  - Updated transaction producer method parameter naming to indicate unused arguments
  - Modified locking mechanism in transaction listener to clarify read-only access

- **Testing**
  - Simplified IP address generation test validation (potential reduction in test rigor)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->