### PR TITLE
[ISSUE #1380]💫Add QueryConsumeQueueResponseBody

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -43,6 +43,7 @@ pub mod process_queue_info;
 pub mod producer_connection;
 pub mod query_assignment_request_body;
 pub mod query_assignment_response_body;
+pub mod query_consume_queue_response_body;
 pub mod queue_time_span;
 pub mod request;
 pub mod response;

--- a/rocketmq-remoting/src/protocol/body/query_consume_queue_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/query_consume_queue_response_body.rs
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::body::consume_queue_data::ConsumeQueueData;
+use crate::protocol::heartbeat::subscription_data::SubscriptionData;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryConsumeQueueResponseBody {
+    subscription_data: SubscriptionData,
+    filter_data: CheetahString,
+    queue_data: Vec<ConsumeQueueData>,
+    max_queue_index: i64,
+    min_queue_index: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_consume_queue_response_body_default_values() {
+        let response_body: QueryConsumeQueueResponseBody = Default::default();
+        assert_eq!(response_body.subscription_data, SubscriptionData::default());
+        assert_eq!(response_body.filter_data, "");
+        assert!(response_body.queue_data.is_empty());
+        assert_eq!(response_body.max_queue_index, 0);
+        assert_eq!(response_body.min_queue_index, 0);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1380

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new `QueryConsumeQueueResponseBody` struct for handling consume queue query responses
	- Implemented serialization and deserialization support for the new response body
	- Included fields for subscription data, filter data, queue data, and queue index tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->