### PR TITLE
[ISSUE #2126]💫Optimize RegisterBrokerBody filter_server_list Vec<String> with Vec<CheetahString>🍻

### DIFF
--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -181,7 +181,7 @@ impl BrokerOuterAPI {
         broker_id: u64,
         ha_server_addr: CheetahString,
         topic_config_wrapper: TopicConfigAndMappingSerializeWrapper,
-        filter_server_list: Vec<String>,
+        filter_server_list: Vec<CheetahString>,
         oneway: bool,
         timeout_mills: u64,
         enable_acting_master: bool,

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -265,7 +265,7 @@ impl DefaultRequestProcessor {
         let mut response_command = RemotingCommand::create_response_command();
         let broker_version = RocketMqVersion::try_from(request.version()).expect("invalid version");
         let topic_config_wrapper;
-        let mut filter_server_list = Vec::<String>::new();
+        let mut filter_server_list = Vec::new();
         if broker_version as usize >= RocketMqVersion::V3011 as usize {
             let register_broker_body =
                 extract_register_broker_body_from_request(&request, &request_header);

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -64,7 +64,7 @@ type ClusterAddrTable =
     ArcMut<HashMap<CheetahString /* clusterName */, HashSet<CheetahString /* brokerName */>>>;
 type BrokerLiveTable = ArcMut<HashMap<BrokerAddrInfo /* brokerAddr */, BrokerLiveInfo>>;
 type FilterServerTable =
-    ArcMut<HashMap<BrokerAddrInfo /* brokerAddr */, Vec<String> /* Filter Server */>>;
+    ArcMut<HashMap<BrokerAddrInfo /* brokerAddr */, Vec<CheetahString> /* Filter Server */>>;
 type TopicQueueMappingInfoTable = ArcMut<
     HashMap<
         CheetahString, /* topic */
@@ -113,7 +113,7 @@ impl RouteInfoManager {
         _timeout_millis: Option<i64>,
         enable_acting_master: Option<bool>,
         topic_config_serialize_wrapper: TopicConfigAndMappingSerializeWrapper,
-        filter_server_list: Vec<String>,
+        filter_server_list: Vec<CheetahString>,
         remote_addr: SocketAddr,
     ) -> Option<RegisterBrokerResult> {
         let mut result = RegisterBrokerResult::default();
@@ -405,14 +405,9 @@ impl RouteInfoManager {
                             if let Some(filter_server_list) =
                                 self.filter_server_table.get(&broker_addr_info)
                             {
-                                topic_route_data.filter_server_table.insert(
-                                    broker_addr.clone(),
-                                    filter_server_list
-                                        .clone()
-                                        .into_iter()
-                                        .map(CheetahString::from_string)
-                                        .collect(),
-                                );
+                                topic_route_data
+                                    .filter_server_table
+                                    .insert(broker_addr.clone(), filter_server_list.clone());
                             }
                         }
                     }

--- a/rocketmq-remoting/src/protocol/body/broker_body/register_broker_body.rs
+++ b/rocketmq-remoting/src/protocol/body/broker_body/register_broker_body.rs
@@ -21,6 +21,7 @@ use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
+use cheetah_string::CheetahString;
 use flate2::read::DeflateDecoder;
 use flate2::write::DeflateEncoder;
 use flate2::Compression;
@@ -41,13 +42,13 @@ pub struct RegisterBrokerBody {
     #[serde(rename = "topicConfigSerializeWrapper")]
     pub topic_config_serialize_wrapper: TopicConfigAndMappingSerializeWrapper,
     #[serde(rename = "filterServerList")]
-    pub filter_server_list: Vec<String>,
+    pub filter_server_list: Vec<CheetahString>,
 }
 
 impl RegisterBrokerBody {
     pub fn new(
         topic_config_serialize_wrapper: TopicConfigAndMappingSerializeWrapper,
-        filter_server_list: Vec<String>,
+        filter_server_list: Vec<CheetahString>,
     ) -> Self {
         RegisterBrokerBody {
             topic_config_serialize_wrapper,
@@ -59,7 +60,7 @@ impl RegisterBrokerBody {
         &self.topic_config_serialize_wrapper
     }
 
-    pub fn filter_server_list(&self) -> &Vec<String> {
+    pub fn filter_server_list(&self) -> &Vec<CheetahString> {
         &self.filter_server_list
     }
 
@@ -186,7 +187,7 @@ mod tests {
     #[test]
     fn encode_without_compression() {
         let wrapper = TopicConfigAndMappingSerializeWrapper::default();
-        let filter_list = vec!["filter1".to_string(), "filter2".to_string()];
+        let filter_list = vec!["filter1".into(), "filter2".into()];
         let body = RegisterBrokerBody::new(wrapper, filter_list);
         let encoded = body.encode(false);
         assert!(!encoded.is_empty());
@@ -195,7 +196,7 @@ mod tests {
     #[test]
     fn encode_with_compression() {
         let wrapper = TopicConfigAndMappingSerializeWrapper::default();
-        let filter_list = vec!["filter1".to_string(), "filter2".to_string()];
+        let filter_list = vec!["filter1".into(), "filter2".into()];
         let body = RegisterBrokerBody::new(wrapper, filter_list);
         let encoded = body.encode(true);
         assert!(!encoded.is_empty());
@@ -204,7 +205,7 @@ mod tests {
     #[test]
     fn decode_without_compression() {
         let wrapper = TopicConfigAndMappingSerializeWrapper::default();
-        let filter_list = vec!["filter1".to_string(), "filter2".to_string()];
+        let filter_list = vec!["filter1".into(), "filter2".into()];
         let body = RegisterBrokerBody::new(wrapper, filter_list);
         let encoded = body.encode(false);
         let decoded =


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2126

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Type Changes**
  - Updated filter server list type from `Vec<String>` to `Vec<CheetahString>` across multiple components
  - Modifications impact broker registration and route management processes

- **Compatibility**
  - Existing code may require updates to align with the new type definition
  - No functional changes to core logic or error handling

The changes primarily focus on standardizing the data type for filter servers throughout the RocketMQ system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->