### PR TITLE
[ISSUE #1512]♻️Refactor PutKVConfigRequestHeader with derive marco RequestHeaderCodec

### DIFF
--- a/rocketmq-remoting/src/protocol/header/namesrv/kv_config_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/kv_config_header.rs
@@ -18,6 +18,7 @@
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/rocketmq-remoting/src/protocol/header/namesrv/kv_config_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/kv_config_header.rs
@@ -24,18 +24,19 @@ use serde::Serialize;
 use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodec)]
 pub struct PutKVConfigRequestHeader {
+    #[required]
     pub namespace: CheetahString,
+
+    #[required]
     pub key: CheetahString,
+
+    #[required]
     pub value: CheetahString,
 }
 
 impl PutKVConfigRequestHeader {
-    const KEY: &'static str = "key";
-    const NAMESPACE: &'static str = "namespace";
-    const VALUE: &'static str = "value";
-
     /// Creates a new instance of `PutKVConfigRequestHeader`.
     ///
     /// # Arguments
@@ -53,60 +54,6 @@ impl PutKVConfigRequestHeader {
             key: key.into(),
             value: value.into(),
         }
-    }
-}
-
-impl CommandCustomHeader for PutKVConfigRequestHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        Some(HashMap::from([
-            (
-                CheetahString::from_static_str(PutKVConfigRequestHeader::NAMESPACE),
-                self.namespace.clone(),
-            ),
-            (
-                CheetahString::from_static_str(PutKVConfigRequestHeader::KEY),
-                self.key.clone(),
-            ),
-            (
-                CheetahString::from_static_str(PutKVConfigRequestHeader::VALUE),
-                self.value.clone(),
-            ),
-        ]))
-    }
-}
-
-impl FromMap for PutKVConfigRequestHeader {
-    type Error = crate::remoting_error::RemotingError;
-
-    type Target = PutKVConfigRequestHeader;
-
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(PutKVConfigRequestHeader {
-            namespace: map
-                .get(&CheetahString::from_static_str(
-                    PutKVConfigRequestHeader::NAMESPACE,
-                ))
-                .cloned()
-                .ok_or(Self::Error::RemotingCommandError(
-                    "Miss namespace field".to_string(),
-                ))?,
-            key: map
-                .get(&CheetahString::from_static_str(
-                    PutKVConfigRequestHeader::KEY,
-                ))
-                .cloned()
-                .ok_or(Self::Error::RemotingCommandError(
-                    "Miss key field".to_string(),
-                ))?,
-            value: map
-                .get(&CheetahString::from_static_str(
-                    PutKVConfigRequestHeader::VALUE,
-                ))
-                .cloned()
-                .ok_or(Self::Error::RemotingCommandError(
-                    "Miss value field".to_string(),
-                ))?,
-        })
     }
 }
 


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1512

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added mandatory field validation for namespace, key, and value in configuration request headers.
	- Enhanced header processing with `RequestHeaderCodec` trait.

- **Refactor**
	- Simplified configuration header implementation by removing map conversion methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->