### PR TITLE
[ISSUE #2134]🐛Fix get_kv_config return code not correct

### DIFF
--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -165,13 +165,11 @@ impl DefaultRequestProcessor {
                 .set_command_custom_header(GetKVConfigResponseHeader::new(value)));
         }
         Ok(
-            RemotingCommand::create_response_command_with_code(
-                RemotingSysResponseCode::SystemError,
-            )
-            .set_remark(format!(
-                "No config item, Namespace: {} Key: {}",
-                request_header.namespace, request_header.key
-            )),
+            RemotingCommand::create_response_command_with_code(ResponseCode::QueryNotFound)
+                .set_remark(format!(
+                    "No config item, Namespace: {} Key: {}",
+                    request_header.namespace, request_header.key
+                )),
         )
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2134

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for configuration retrieval operations
	- Enhanced error response codes when configuration items or namespaces are not found
	- Provided more specific error reporting for better debugging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->