### PR TITLE
[ISSUE #1514]♻️Refactor GetKVConfigResponseHeader with derive marco R…

### DIFF
--- a/rocketmq-remoting/src/protocol/header/namesrv/kv_config_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/kv_config_header.rs
@@ -76,44 +76,15 @@ impl GetKVConfigRequestHeader {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodec)]
 pub struct GetKVConfigResponseHeader {
+    #[required]
     pub value: Option<CheetahString>,
 }
 
 impl GetKVConfigResponseHeader {
-    const VALUE: &'static str = "value";
-
     pub fn new(value: Option<CheetahString>) -> Self {
         Self { value }
-    }
-}
-
-impl CommandCustomHeader for GetKVConfigResponseHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        if let Some(ref value) = self.value {
-            return Some(HashMap::from([(
-                CheetahString::from_static_str(GetKVConfigResponseHeader::VALUE),
-                value.clone(),
-            )]));
-        }
-        None
-    }
-}
-
-impl FromMap for GetKVConfigResponseHeader {
-    type Error = crate::remoting_error::RemotingError;
-
-    type Target = GetKVConfigResponseHeader;
-
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(GetKVConfigResponseHeader {
-            value: map
-                .get(&CheetahString::from_static_str(
-                    GetKVConfigResponseHeader::VALUE,
-                ))
-                .cloned(),
-        })
     }
 }
 


### PR DESCRIPTION
…equestHeaderCodec

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1514

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for request header encoding and decoding in `GetKVConfigResponseHeader`
  - Introduced a new optional `value` field to the response header

- **Refactor**
  - Removed previous map conversion methods from the header struct
  - Updated struct derivation to include `RequestHeaderCodec`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->