### PR TITLE
[ISSUE #1515]♻️Refactor DeleteKVConfigRequestHeader with derive marco RequestHeaderCodec

### DIFF
--- a/rocketmq-remoting/src/protocol/header/namesrv/kv_config_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/kv_config_header.rs
@@ -88,63 +88,21 @@ impl GetKVConfigResponseHeader {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodec)]
 pub struct DeleteKVConfigRequestHeader {
+    #[required]
     pub namespace: CheetahString,
+
+    #[required]
     pub key: CheetahString,
 }
 
 impl DeleteKVConfigRequestHeader {
-    const KEY: &'static str = "key";
-    const NAMESPACE: &'static str = "namespace";
-
     pub fn new(namespace: impl Into<CheetahString>, key: impl Into<CheetahString>) -> Self {
         Self {
             namespace: namespace.into(),
             key: key.into(),
         }
-    }
-}
-
-impl CommandCustomHeader for DeleteKVConfigRequestHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        Some(HashMap::from([
-            (
-                CheetahString::from_static_str(DeleteKVConfigRequestHeader::NAMESPACE),
-                self.namespace.clone(),
-            ),
-            (
-                CheetahString::from_static_str(DeleteKVConfigRequestHeader::KEY),
-                self.key.clone(),
-            ),
-        ]))
-    }
-}
-
-impl FromMap for DeleteKVConfigRequestHeader {
-    type Error = crate::remoting_error::RemotingError;
-
-    type Target = DeleteKVConfigRequestHeader;
-
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(DeleteKVConfigRequestHeader {
-            namespace: map
-                .get(&CheetahString::from_static_str(
-                    DeleteKVConfigRequestHeader::NAMESPACE,
-                ))
-                .cloned()
-                .ok_or(Self::Error::RemotingCommandError(
-                    "Miss namespace field".to_string(),
-                ))?,
-            key: map
-                .get(&CheetahString::from_static_str(
-                    DeleteKVConfigRequestHeader::KEY,
-                ))
-                .cloned()
-                .ok_or(Self::Error::RemotingCommandError(
-                    "Miss key field".to_string(),
-                ))?,
-        })
     }
 }
 


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1515

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated `DeleteKVConfigRequestHeader` structure to support request header serialization
	- Added required `namespace` and `key` fields to the header
	- Removed previous mapping and custom header trait implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->