### PR TITLE
[ISSUE #2155]♻️Refactor WipeWritePermOfBrokerRequestHeader with derive marco RequestHeaderCodec

### DIFF
--- a/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
@@ -17,51 +17,25 @@
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct WipeWritePermOfBrokerRequestHeader {
+    #[required]
     pub broker_name: CheetahString,
 }
 
 impl WipeWritePermOfBrokerRequestHeader {
-    const BROKER_NAME: &'static str = "brokerName";
-
     pub fn new(broker_name: impl Into<CheetahString>) -> Self {
         Self {
             broker_name: broker_name.into(),
         }
-    }
-}
-
-impl CommandCustomHeader for WipeWritePermOfBrokerRequestHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        Some(HashMap::from([(
-            CheetahString::from_static_str(Self::BROKER_NAME),
-            self.broker_name.clone(),
-        )]))
-    }
-}
-
-impl FromMap for WipeWritePermOfBrokerRequestHeader {
-    type Error = crate::remoting_error::RemotingError;
-
-    type Target = Self;
-
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(WipeWritePermOfBrokerRequestHeader {
-            broker_name: map
-                .get(&CheetahString::from_static_str(
-                    WipeWritePermOfBrokerRequestHeader::BROKER_NAME,
-                ))
-                .cloned()
-                .unwrap_or_default(),
-        })
     }
 }
 


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2155

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced request header handling for broker permissions
	- Simplified header encoding and decoding process
	- Added required `broker_name` field to request header
	- Removed manual mapping and parsing logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->