### PR TITLE
[ISSUE #2163]⚡️Nameserver supports batch broker unregistration

### DIFF
--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -331,9 +331,19 @@ impl DefaultRequestProcessor {
                     "decode UnRegisterBrokerRequestHeader fail".to_string(),
                 )
             })?;
-        self.name_server_runtime_inner
-            .route_info_manager_mut()
-            .un_register_broker(vec![request_header]);
+        /*self.name_server_runtime_inner
+        .route_info_manager_mut()
+        .un_register_broker(vec![request_header]);*/
+        if !self
+            .name_server_runtime_inner
+            .route_info_manager()
+            .submit_unregister_broker_request(request_header)
+        {
+            warn!("Couldn't submit the unregister broker request to handler");
+            return Ok(RemotingCommand::create_response_command_with_code(
+                ResponseCode::SystemError,
+            ));
+        }
         Ok(RemotingCommand::create_response_command())
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2163

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced broker unregistration process with batch processing capabilities
	- Added new method to submit unregistration requests with improved error handling

- **Improvements**
	- Refined broker management logic in route information system
	- Improved request processing with more robust error detection and logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->