### PR TITLE
[ISSUE #2166]♻️Refactor DeleteTopicFromNamesrvRequestHeader and RegisterTopicRequestHeader with derive marco RequestHeaderCodec

### DIFF
--- a/rocketmq-remoting/src/protocol/header/namesrv/topic_operation_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/topic_operation_header.rs
@@ -18,6 +18,7 @@
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -25,17 +26,15 @@ use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteTopicFromNamesrvRequestHeader {
+    #[required]
     pub topic: CheetahString,
     pub cluster_name: Option<CheetahString>,
 }
 
 impl DeleteTopicFromNamesrvRequestHeader {
-    const CLUSTER_NAME: &'static str = "clusterName";
-    const TOPIC: &'static str = "topic";
-
     pub fn new(
         topic: impl Into<CheetahString>,
         cluster_name: Option<impl Into<CheetahString>>,
@@ -47,86 +46,21 @@ impl DeleteTopicFromNamesrvRequestHeader {
     }
 }
 
-impl CommandCustomHeader for DeleteTopicFromNamesrvRequestHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        let mut map = HashMap::from([(
-            CheetahString::from_static_str(Self::TOPIC),
-            self.topic.clone(),
-        )]);
-        if let Some(ref cluster_name) = self.cluster_name {
-            map.insert(
-                CheetahString::from_static_str(Self::CLUSTER_NAME),
-                cluster_name.clone(),
-            );
-        }
-        Some(map)
-    }
-}
-
-impl FromMap for DeleteTopicFromNamesrvRequestHeader {
-    type Error = crate::remoting_error::RemotingError;
-
-    type Target = Self;
-
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(DeleteTopicFromNamesrvRequestHeader {
-            topic: map
-                .get(&CheetahString::from_static_str(Self::TOPIC))
-                .cloned()
-                .unwrap_or_default(),
-            cluster_name: map
-                .get(&CheetahString::from_static_str(Self::CLUSTER_NAME))
-                .cloned(),
-        })
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterTopicRequestHeader {
+    #[required]
     pub topic: CheetahString,
     #[serde(flatten)]
     pub topic_request: Option<TopicRequestHeader>,
 }
 
 impl RegisterTopicRequestHeader {
-    const TOPIC: &'static str = "topic";
-
     pub fn new(topic: impl Into<CheetahString>) -> Self {
         Self {
             topic: topic.into(),
             topic_request: None,
         }
-    }
-}
-
-impl CommandCustomHeader for RegisterTopicRequestHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        let mut map = HashMap::from([(
-            CheetahString::from_static_str(Self::TOPIC),
-            self.topic.clone(),
-        )]);
-        if let Some(ref request) = self.topic_request {
-            if let Some(val) = request.to_map() {
-                map.extend(val);
-            }
-        }
-        Some(map)
-    }
-}
-impl FromMap for RegisterTopicRequestHeader {
-    type Error = crate::remoting_error::RemotingError;
-
-    type Target = Self;
-
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(RegisterTopicRequestHeader {
-            topic: map
-                .get(&CheetahString::from_static_str(Self::TOPIC))
-                .cloned()
-                .unwrap_or_default(),
-            topic_request: Some(<TopicRequestHeader as FromMap>::from(map)?),
-        })
     }
 }
 


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2166

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated topic operation header structs with new serialization and deserialization approach
	- Added mandatory requirement for topic field in delete and register topic request headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->