### PR TITLE
[ISSUE #2170]🐛Fix BatchUnregistrationService not started when Name server start

### DIFF
--- a/rocketmq-namesrv/src/route/batch_unregistration_service.rs
+++ b/rocketmq-namesrv/src/route/batch_unregistration_service.rs
@@ -16,6 +16,7 @@
  */
 use rocketmq_remoting::protocol::header::namesrv::broker_request::UnRegisterBrokerRequestHeader;
 use rocketmq_rust::ArcMut;
+use tracing::info;
 use tracing::warn;
 
 use crate::bootstrap::NameServerRuntimeInner;
@@ -53,6 +54,7 @@ impl BatchUnregistrationService {
         let mut rx = self.rx.take().expect("rx is None");
         let limit = 10;
         tokio::spawn(async move {
+            info!(">>>>>>>>BatchUnregistrationService started<<<<<<<<<<<<<<<<<<<");
             loop {
                 let mut unregistration_requests = Vec::with_capacity(limit);
                 tokio::select! {

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -1207,6 +1207,7 @@ impl RouteInfoManager {
     //! start client connection disconnected listener
     pub fn start(&self, receiver: broadcast::Receiver<SocketAddr>) {
         let mut inner = self.name_server_runtime_inner.clone();
+        self.un_register_service.mut_from_ref().start();
         let mut receiver = receiver;
         tokio::spawn(async move {
             while let Ok(socket_addr) = receiver.recv().await {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2170

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging for service startup in batch unregistration service
	- Activated unregistration service during route info manager initialization

- **Chores**
	- Added tracing log for service startup process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->