### PR TITLE
[ISSUE #2174]♻️Refactor remoting graceful shutdown

### DIFF
--- a/rocketmq-remoting/src/remoting_server/server.rs
+++ b/rocketmq-remoting/src/remoting_server/server.rs
@@ -22,7 +22,8 @@ use std::time::Duration;
 
 use futures::SinkExt;
 use rocketmq_common::common::server::config::ServerConfig;
-use rocketmq_rust::{wait_for_signal, ArcMut};
+use rocketmq_rust::wait_for_signal;
+use rocketmq_rust::ArcMut;
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::broadcast;

--- a/rocketmq-remoting/src/remoting_server/server.rs
+++ b/rocketmq-remoting/src/remoting_server/server.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use futures::SinkExt;
 use rocketmq_common::common::server::config::ServerConfig;
-use rocketmq_rust::ArcMut;
+use rocketmq_rust::{wait_for_signal, ArcMut};
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::broadcast;
@@ -115,6 +115,7 @@ impl<RP: RequestProcessor + Sync + 'static> ConnectionHandler<RP> {
                 res = self.connection_handler_context.channel.connection.reader.next() => res,
                 _ = self.shutdown.recv() =>{
                     //If a shutdown signal is received, return from `handle`.
+                    self.channel.connection_mut().ok = false;
                     return Ok(());
                 }
             };
@@ -404,7 +405,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> RocketMQServer<RP> {
         let (notify_conn_disconnect, _) = broadcast::channel::<SocketAddr>(100);
         run(
             listener,
-            tokio::signal::ctrl_c(),
+            wait_for_signal(),
             request_processor,
             Some(notify_conn_disconnect),
             vec![],


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2174

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced server shutdown signal handling mechanism
	- Updated connection state management during server shutdown
	- Introduced a new method for listening to shutdown signals
<!-- end of auto-generated comment: release notes by coderabbit.ai -->