### PR TITLE
[ISSUE #2199]💫Implement MappedFile append_message_bytes and append_message_with_offset🍻

### DIFF
--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -339,13 +339,12 @@ impl MappedFile for DefaultMappedFile {
     }
 
     #[inline]
-    fn append_message_offset_length(&self, data: &Bytes, offset: usize, length: usize) -> bool {
-        let current_pos = self.wrote_position.load(Ordering::Relaxed) as usize;
+    fn append_message_offset_length(&self, data: &[u8], offset: usize, length: usize) -> bool {
+        let current_pos = self.wrote_position.load(Ordering::Acquire) as usize;
 
         if current_pos + length <= self.file_size as usize {
             let mut mapped_file =
                 &mut self.get_mapped_file_mut()[current_pos..current_pos + length];
-
             if let Some(data_slice) = data.get(offset..offset + length) {
                 if mapped_file.write_all(data_slice).is_ok() {
                     self.wrote_position


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2199

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated method signatures to use more generic byte array types
	- Removed several methods from `MappedFile` and `MappedFileRefactor` traits
	- Modified memory ordering semantics for atomic operations

- **Bug Fixes**
	- Improved flexibility in handling byte data appending and retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->