### PR TITLE
[ISSUE #2205]🐛Fix stats_item.rs cargo clippy -- -D warnings error🍻

### DIFF
--- a/rocketmq-common/src/common/stats/stats_item.rs
+++ b/rocketmq-common/src/common/stats/stats_item.rs
@@ -56,7 +56,7 @@ impl StatsItem {
     pub fn compute_stats_data(cs_list: Arc<Mutex<LinkedList<CallSnapshot>>>) -> StatsSnapshot {
         let mut stats_snapshot = StatsSnapshot::new();
         let cs_list = cs_list.lock();
-        if cs_list.len() > 0 {
+        if !cs_list.is_empty() {
             let first = cs_list.front().unwrap();
             let last = cs_list.back().unwrap();
             let sum = last.get_value() - first.get_value();


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2205

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved code readability by updating emptiness check for list in stats computation methods
	- Replaced `cs_list.len() > 0` with more idiomatic `!cs_list.is_empty()`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->