### PR TITLE
[ISSUE #2207]🚸Add Default trait for SelectMappedBufferResult🍻

### DIFF
--- a/rocketmq-store/src/base/select_result.rs
+++ b/rocketmq-store/src/base/select_result.rs
@@ -35,6 +35,17 @@ pub struct SelectMappedBufferResult {
     pub is_in_cache: bool,
 }
 
+impl Default for SelectMappedBufferResult {
+    fn default() -> Self {
+        Self {
+            start_offset: 0,
+            size: 0,
+            mapped_file: None,
+            is_in_cache: true,
+        }
+    }
+}
+
 impl SelectMappedBufferResult {
     /// Returns the buffer.
     pub fn get_buffer(&self) -> &[u8] {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2207

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a default constructor for a specific result type to improve code initialization flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->