### PR TITLE
[ISSUE #2209]🚸Implement DefaultMappedFile#get_mapped_byte_buffer🍻

### DIFF
--- a/rocketmq-store/src/log_file/mapped_file.rs
+++ b/rocketmq-store/src/log_file/mapped_file.rs
@@ -368,7 +368,7 @@ pub trait MappedFile {
     ///
     /// # Returns
     /// A `bytes::Bytes` instance containing the byte buffer of the entire mapped file.
-    fn get_mapped_byte_buffer(&self) -> bytes::Bytes;
+    fn get_mapped_byte_buffer(&self) -> &[u8];
 
     /// Creates a slice of the mapped byte buffer.
     ///
@@ -614,7 +614,6 @@ pub trait MappedFileRefactor {
         cb: &dyn CompactionAppendMsgCallback,
     ) -> AppendMessageResult;
 
-    fn get_mapped_byte_buffer(&self) -> &[u8];
     fn slice_byte_buffer(&self) -> &[u8];
     fn get_store_timestamp(&self) -> u64;
     fn get_last_modified_timestamp(&self) -> u64;

--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -524,8 +524,10 @@ impl MappedFile for DefaultMappedFile {
     }
 
     #[inline]
-    fn get_mapped_byte_buffer(&self) -> Bytes {
-        todo!()
+    fn get_mapped_byte_buffer(&self) -> &[u8] {
+        self.mapped_byte_buffer_access_count_since_last_swap
+            .fetch_add(1, Ordering::AcqRel);
+        self.mmapped_file.as_ref()
     }
 
     #[inline]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2209

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated memory-mapped file buffer access method to return a byte slice reference instead of an owned buffer
	- Simplified byte buffer retrieval mechanism
	- Removed redundant method from `MappedFileRefactor` trait

<!-- end of auto-generated comment: release notes by coderabbit.ai -->