### PR TITLE
[ISSUE #2211]🚨Implement DefaultMappedFile get_last_modified_timestamp and slice_byte_buffer🍻

### DIFF
--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -406,7 +406,7 @@ impl MappedFileQueue {
             result = whered == self.get_flushed_where() as u64;
             self.set_flushed_where(whered as i64);
             if flush_least_pages == 0 {
-                self.set_store_timestamp(tmp_time_stamp as u64);
+                self.set_store_timestamp(tmp_time_stamp);
             }
         }
         result

--- a/rocketmq-store/src/log_file/mapped_file.rs
+++ b/rocketmq-store/src/log_file/mapped_file.rs
@@ -377,19 +377,19 @@ pub trait MappedFile {
     ///
     /// # Returns
     /// A `bytes::Bytes` instance representing a slice of the mapped byte buffer.
-    fn slice_byte_buffer(&self) -> bytes::Bytes;
+    fn slice_byte_buffer(&self) -> &[u8];
 
     /// Returns the timestamp when the store was created.
     ///
     /// # Returns
     /// A `i64` representing the timestamp of the store creation.
-    fn get_store_timestamp(&self) -> i64;
+    fn get_store_timestamp(&self) -> u64;
 
     /// Returns the timestamp of the last modification to the store.
     ///
     /// # Returns
     /// A `i64` representing the timestamp of the last modification.
-    fn get_last_modified_timestamp(&self) -> i64;
+    fn get_last_modified_timestamp(&self) -> u64;
 
     /// Retrieves data from the store starting at the specified position and of the specified size.
     ///


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2211

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Type Safety Improvements**
	- Updated multiple methods and fields to use unsigned integer types for timestamps and positions
	- Converted timestamp-related methods from signed to unsigned integer return types
	- Modified buffer access methods to improve type safety and consistency

- **Performance Optimizations**
	- Simplified type conversions in timestamp handling
	- Refined method signatures for more precise data representation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->