### PR TITLE
[ISSUE #2213]🚨Refactor DefaultMappedFile#get_data🍻

### DIFF
--- a/rocketmq-store/src/log_file/mapped_file.rs
+++ b/rocketmq-store/src/log_file/mapped_file.rs
@@ -614,10 +614,6 @@ pub trait MappedFileRefactor {
         cb: &dyn CompactionAppendMsgCallback,
     ) -> AppendMessageResult;
 
-    fn slice_byte_buffer(&self) -> &[u8];
-    fn get_store_timestamp(&self) -> u64;
-    fn get_last_modified_timestamp(&self) -> u64;
-    fn get_data(&self, pos: usize, size: usize, byte_buffer: &mut [u8]) -> bool;
     fn destroy(&self, interval_forcibly: u64) -> bool;
     fn shutdown(&self, interval_forcibly: u64);
     fn release(&self);

--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -560,7 +560,7 @@ impl MappedFile for DefaultMappedFile {
         let read_end_position = pos + size;
         if read_end_position <= read_position as usize {
             if MappedFile::hold(self) {
-                let buffer = BytesMut::from(self.mmapped_file.as_ref()[pos..read_end_position]);
+                let buffer = BytesMut::from(&self.mmapped_file.as_ref()[pos..read_end_position]);
                 MappedFile::release(self);
                 Some(buffer.freeze())
             } else {

--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -560,7 +560,8 @@ impl MappedFile for DefaultMappedFile {
         let read_end_position = pos + size;
         if read_end_position <= read_position as usize {
             if MappedFile::hold(self) {
-                let buffer = BytesMut::from(&self.get_mapped_file()[pos..read_end_position]);
+                let buffer = BytesMut::from(self.mmapped_file.as_ref()[pos..read_end_position]);
+                MappedFile::release(self);
                 Some(buffer.freeze())
             } else {
                 debug!(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2213

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified `MappedFileRefactor` trait by removing several methods
	- Updated method signatures to use `usize` and `u64` types instead of `i32` and `i64`
	- Modified internal data access logic for mapped file buffers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->