### PR TITLE
[ISSUE #2128]💫Remove RouteInfoManager #[derive(Clone)]🧑‍💻

### DIFF
--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -113,7 +113,6 @@ type TopicQueueMappingInfoTable = ArcMut<
     >,
 >;
 
-#[derive(Clone)]
 pub struct RouteInfoManager {
     pub(crate) topic_queue_table: TopicQueueTable,
     pub(crate) broker_addr_table: BrokerAddrTable,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2128

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed automatic cloning capability for a specific system component
	- Adjusted struct behavior to prevent unintended object duplication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->