### PR TITLE
[ISSUE #2238]💫Change the default value of total_replicas from 0 to 1 in the message_store_config🧑‍💻

### DIFF
--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -58,12 +58,6 @@ pub struct MessageStoreConfig {
     pub timer_intercept_delay_level: bool,
     pub timer_max_delay_sec: u64,
     pub timer_wheel_enable: bool,
-    /**
-     * 1. Register to broker after (startTime + disappearTimeAfterStart)
-     * 2. Internal msg exchange will start after (startTime + disappearTimeAfterStart)
-     * A. PopReviveService
-     * B. TimerDequeueGetService
-     */
     pub disappear_time_after_start: i64,
     pub timer_stop_enqueue: bool,
     pub timer_check_metrics_when: String,

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -58,6 +58,12 @@ pub struct MessageStoreConfig {
     pub timer_intercept_delay_level: bool,
     pub timer_max_delay_sec: u64,
     pub timer_wheel_enable: bool,
+    /**
+     * 1. Register to broker after (startTime + disappearTimeAfterStart)
+     * 2. Internal msg exchange will start after (startTime + disappearTimeAfterStart)
+     * A. PopReviveService
+     * B. TimerDequeueGetService
+     */
     pub disappear_time_after_start: i64,
     pub timer_stop_enqueue: bool,
     pub timer_check_metrics_when: String,
@@ -360,7 +366,7 @@ impl Default for MessageStoreConfig {
             enable_clean_expired_offset: false,
             max_async_put_message_requests: 0,
             pull_batch_max_message_count: 0,
-            total_replicas: 0,
+            total_replicas: 1,
             in_sync_replicas: 1,
             min_in_sync_replicas: 0,
             all_ack_in_sync_state_set: false,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2238

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
  - Added a new configuration parameter for message disappearance timing
  - Updated default total replicas from 0 to 1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->