### PR TITLE
[ISSUE #2249]🚀AckMessageProcessor and BrokerStatsManager add shutdown method

### DIFF
--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -46,6 +46,7 @@ use rocketmq_store::pop::ack_msg::AckMsg;
 use rocketmq_store::pop::batch_ack_msg::BatchAckMsg;
 use rocketmq_store::pop::AckMessage;
 use tracing::error;
+use tracing::warn;
 
 use crate::broker_error::BrokerError::BrokerCommonError;
 use crate::broker_error::BrokerError::BrokerRemotingError;
@@ -572,5 +573,9 @@ where
         self.broker_runtime_inner
             .pop_inflight_message_counter()
             .decrement_in_flight_message_num(&topic, &consume_group, pop_time, q_id, 1);
+    }
+
+    pub fn shutdown(&mut self) {
+        warn!("AckMessageProcessor shutdown unimplemented, need to be implemented");
     }
 }

--- a/rocketmq-store/src/stats/broker_stats_manager.rs
+++ b/rocketmq-store/src/stats/broker_stats_manager.rs
@@ -30,6 +30,7 @@ use rocketmq_common::common::statistics::statistics_manager::StatisticsManager;
 use rocketmq_common::common::stats::moment_stats_item_set::MomentStatsItemSet;
 use rocketmq_common::common::stats::stats_item_set::StatsItemSet;
 use rocketmq_common::common::stats::Stats;
+use tracing::warn;
 
 pub struct BrokerStatsManager {
     stats_table: Arc<parking_lot::RwLock<HashMap<String, StatsItemSet>>>,
@@ -533,6 +534,10 @@ impl BrokerStatsManager {
 
     #[inline]
     pub fn inc_broker_ack_nums(&self, inc_value: i32) {}
+
+    pub fn shutdown(&self) {
+        warn!("BrokerStatsManager shutdown unimplemented");
+    }
 }
 
 #[inline]


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2249

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added placeholder `shutdown` methods to `AckMessageProcessor` and `BrokerStatsManager` with warning logs
	- Prepared infrastructure for future shutdown functionality in broker and store components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->