### PR TITLE
[ISSUE #2251]🚀NotificationProcessor and PopMessageProcessor add  shutdown method

### DIFF
--- a/rocketmq-broker/src/processor/notification_processor.rs
+++ b/rocketmq-broker/src/processor/notification_processor.rs
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use tracing::warn;
 
 #[derive(Default)]
 pub struct NotificationProcessor {}
@@ -26,5 +28,9 @@ impl NotificationProcessor {
         _request: rocketmq_remoting::protocol::remoting_command::RemotingCommand,
     ) -> rocketmq_remoting::protocol::remoting_command::RemotingCommand {
         todo!()
+    }
+
+    pub fn shutdown(&mut self) {
+        warn!("NotificationProcessor shutdown unimplemented, need to implement it");
     }
 }

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -1240,6 +1240,10 @@ where
         }
         Some(bytes_mut.freeze())
     }
+
+    pub fn shutdown(&mut self) {
+        warn!("PopMessageProcessor shutdown unimplemented, need to implement");
+    }
 }
 
 impl<MS> PopMessageProcessor<MS> {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2251

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Added placeholder `shutdown` methods to `NotificationProcessor` and `PopMessageProcessor` structs
	- Current implementations only include warning log statements indicating unfinished shutdown functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->