### PR TITLE
[ISSUE #2255]🚀Add BrokerFastFailure struct for rust

### DIFF
--- a/rocketmq-broker/src/latency.rs
+++ b/rocketmq-broker/src/latency.rs
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+pub(crate) mod broker_fast_failure;

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use tracing::warn;
+
+pub struct BrokerFastFailure;
+
+impl BrokerFastFailure {
+    pub fn shutdown(&mut self) {
+        warn!("BrokerFastFailure shutdown not implemented");
+    }
+}

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -37,6 +37,7 @@ pub(crate) mod controller;
 pub(crate) mod failover;
 pub(crate) mod filter;
 pub(crate) mod hook;
+pub(crate) mod latency;
 pub(crate) mod load_balance;
 pub(crate) mod long_polling;
 pub(crate) mod mqtrace;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2255

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `BrokerFastFailure` structure with a shutdown method in the broker's latency module
	- Added internal module for handling broker-related latency operations

- **Chores**
	- Updated project structure to include new latency-related module
	- Added licensing information to new files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->