### PR TITLE
[ISSUE #2257]🚀Add BrokerPreOnlineService struct for rust

### DIFF
--- a/rocketmq-broker/src/broker.rs
+++ b/rocketmq-broker/src/broker.rs
@@ -16,3 +16,4 @@
  */
 
 pub mod broker_hook;
+pub mod broker_pre_online_service;

--- a/rocketmq-broker/src/broker/broker_pre_online_service.rs
+++ b/rocketmq-broker/src/broker/broker_pre_online_service.rs
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+pub struct BrokerPreOnlineService;
+
+impl BrokerPreOnlineService {
+    pub fn shutdown(&mut self) {
+        unimplemented!("BrokerPreOnlineService shutdown not implemented");
+    }
+}

--- a/rocketmq-broker/src/broker/broker_pre_online_service.rs
+++ b/rocketmq-broker/src/broker/broker_pre_online_service.rs
@@ -14,10 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use tracing::warn;
+
 pub struct BrokerPreOnlineService;
 
 impl BrokerPreOnlineService {
     pub fn shutdown(&mut self) {
-        unimplemented!("BrokerPreOnlineService shutdown not implemented");
+        warn!("BrokerPreOnlineService shutdown not implemented");
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2257

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added a new module `broker_pre_online_service` to the broker system.
	- Introduced a placeholder `BrokerPreOnlineService` structure with an unimplemented shutdown method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->