### PR TITLE
[ISSUE #2263]🚀DefaultTransactionalMessageService and EscapeBridge add shutdown method

### DIFF
--- a/rocketmq-broker/src/failover/escape_bridge.rs
+++ b/rocketmq-broker/src/failover/escape_bridge.rs
@@ -140,6 +140,10 @@ impl<MS: MessageStore> EscapeBridge<MS> {
             //self.message_store = message_store;
         }
     }
+
+    pub fn shutdown(&mut self) {
+        warn!("EscapeBridge shutdown not implemented");
+    }
 }
 
 impl<MS> EscapeBridge<MS>

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
@@ -141,6 +141,10 @@ where
             sb.as_bytes(),
         ))
     }
+
+    pub fn shutdown(&mut self) {
+        warn!("DefaultTransactionalMessageService shutdown unimplemented, need to implement");
+    }
 }
 
 impl<MS> TransactionalMessageService for DefaultTransactionalMessageService<MS>


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2263

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added placeholder `shutdown` methods to `EscapeBridge` and `DefaultTransactionalMessageService` structs
	- Prepared infrastructure for future graceful shutdown functionality in message processing components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->