### PR TITLE
[ISSUE #2265]🚀ScheduleMessageService and TopicRouteInfoManager  add shutdown method

### DIFF
--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_store::store_path_config_helper::get_delay_offset_store_path;
+use tracing::warn;
 
 #[derive(Default, Clone)]
 pub struct ScheduleMessageService {
@@ -38,6 +39,10 @@ impl ScheduleMessageService {
 
     pub fn get_max_delay_level(&self) -> i32 {
         0
+    }
+
+    pub fn shutdown(&mut self) {
+        warn!("ScheduleMessageService shutdown not implemented");
     }
 }
 

--- a/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
@@ -89,6 +89,9 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
         });
     }
 
+    pub fn shutdown(&mut self) {
+        warn!("TopicRouteInfoManager shutdown not implemented");
+    }
     async fn update_topic_route_info_from_name_server(&self) {
         let topic_set_for_pop_assignment = self
             .topic_subscribe_info_table


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2265

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added placeholder shutdown methods to `ScheduleMessageService` and `TopicRouteInfoManager`
- **Chores**
	- Implemented warning logs for unfinished shutdown functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->