### PR TITLE
[ISSUE #1851]Adding #[inline] for QueryResult methods

### DIFF
--- a/rocketmq-client/src/base/query_result.rs
+++ b/rocketmq-client/src/base/query_result.rs
@@ -26,6 +26,7 @@ pub struct QueryResult {
 
 impl QueryResult {
     // Constructor equivalent
+    #[inline]
     pub fn new(index_last_update_timestamp: u64, message_list: Vec<MessageExt>) -> Self {
         QueryResult {
             index_last_update_timestamp,
@@ -34,10 +35,12 @@ impl QueryResult {
     }
 
     // Getter methods equivalent
+    #[inline]
     pub fn index_last_update_timestamp(&self) -> u64 {
         self.index_last_update_timestamp
     }
 
+    #[inline]
     pub fn message_list(&self) -> &Vec<MessageExt> {
         &self.message_list
     }
@@ -45,6 +48,7 @@ impl QueryResult {
 
 // Implementing the Display trait for pretty printing, similar to Java's toString method
 impl fmt::Display for QueryResult {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

Add #[inline] for QueryResult struct method 

Fixes #1851 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added constructor and getter methods for `QueryResult` struct
	- Enhanced performance with inline annotations for methods

- **Refactor**
	- Updated `fmt::Display` implementation for `QueryResult`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->