### PR TITLE
[ISSUE #2270]Adding #[inline] for ClientConfig methods.

### DIFF
--- a/rocketmq-client/src/base/client_config.rs
+++ b/rocketmq-client/src/base/client_config.rs
@@ -83,7 +83,6 @@ impl Default for ClientConfig {
 
 impl ClientConfig {
     pub fn new() -> Self {
-    pub fn new() -> Self {
         ClientConfig {
             namesrv_addr: NameServerAddressUtils::get_name_server_addresses()
                 .map(|addr| addr.into()),

--- a/rocketmq-client/src/base/client_config.rs
+++ b/rocketmq-client/src/base/client_config.rs
@@ -82,6 +82,7 @@ impl Default for ClientConfig {
 }
 
 impl ClientConfig {
+    #[inline]
     pub fn new() -> Self {
         ClientConfig {
             namesrv_addr: NameServerAddressUtils::get_name_server_addresses()
@@ -140,11 +141,13 @@ impl ClientConfig {
 }
 
 impl ClientConfig {
+    #[inline]
     pub fn with_namespace(&mut self, resource: &str) -> CheetahString {
         NamespaceUtil::wrap_namespace(self.get_namespace().unwrap_or_default().as_str(), resource)
             .into()
     }
 
+    #[inline]
     pub fn queue_with_namespace(&mut self, mut queue: MessageQueue) -> MessageQueue {
         if let Some(namespace) = self.get_namespace() {
             if !namespace.is_empty() {
@@ -159,6 +162,7 @@ impl ClientConfig {
         queue
     }
 
+    #[inline]
     pub fn get_namespace(&mut self) -> Option<CheetahString> {
         let namespace_initialized = self.namespace_initialized.load(Ordering::Acquire);
         if namespace_initialized {
@@ -180,12 +184,14 @@ impl ClientConfig {
         self.namespace.clone()
     }
 
+    #[inline]
     pub fn change_instance_name_to_pid(&mut self) {
         if self.instance_name == "DEFAULT" {
             self.instance_name = format!("{}#{}", std::process::id(), get_current_nano()).into();
         }
     }
 
+    #[inline]
     pub fn build_mq_client_id(&self) -> String {
         let mut sb = String::new();
         sb.push_str(self.client_ip.as_ref().unwrap());
@@ -207,6 +213,7 @@ impl ClientConfig {
         sb
     }
 
+    #[inline]
     pub fn get_namesrv_addr(&self) -> Option<CheetahString> {
         if StringUtils::is_not_empty_str(self.namesrv_addr.as_deref())
             && NAMESRV_ENDPOINT_PATTERN.is_match(self.namesrv_addr.as_ref().unwrap().as_str())

--- a/rocketmq-client/src/base/client_config.rs
+++ b/rocketmq-client/src/base/client_config.rs
@@ -82,7 +82,7 @@ impl Default for ClientConfig {
 }
 
 impl ClientConfig {
-    #[inline]
+    pub fn new() -> Self {
     pub fn new() -> Self {
         ClientConfig {
             namesrv_addr: NameServerAddressUtils::get_name_server_addresses()


### PR DESCRIPTION


### Which Issue(s) This PR Fixes(Closes)

Add #[inline] for ClientConfig methods.

Fixes #2270 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Optimization**
	- Added inline hints to several methods in the ClientConfig struct to potentially improve performance. 
	- Updated method signatures to include `#[inline]` attribute for compiler optimization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->