### PR TITLE
[ISSUE #2279]🚀BrokerFastFailure and BrokerPreOnlineService add start method

### DIFF
--- a/rocketmq-broker/src/broker/broker_pre_online_service.rs
+++ b/rocketmq-broker/src/broker/broker_pre_online_service.rs
@@ -19,6 +19,11 @@ use tracing::warn;
 pub struct BrokerPreOnlineService;
 
 impl BrokerPreOnlineService {
+
+    pub fn start(&mut self) {
+        warn!("BrokerPreOnlineService started not implemented");
+    }
+    
     pub fn shutdown(&mut self) {
         warn!("BrokerPreOnlineService shutdown not implemented");
     }

--- a/rocketmq-broker/src/broker/broker_pre_online_service.rs
+++ b/rocketmq-broker/src/broker/broker_pre_online_service.rs
@@ -19,11 +19,10 @@ use tracing::warn;
 pub struct BrokerPreOnlineService;
 
 impl BrokerPreOnlineService {
-
     pub fn start(&mut self) {
         warn!("BrokerPreOnlineService started not implemented");
     }
-    
+
     pub fn shutdown(&mut self) {
         warn!("BrokerPreOnlineService shutdown not implemented");
     }

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -19,7 +19,6 @@ use tracing::warn;
 pub struct BrokerFastFailure;
 
 impl BrokerFastFailure {
-    
     pub fn start(&mut self) {
         warn!("BrokerFastFailure started not implemented");
     }

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -19,6 +19,11 @@ use tracing::warn;
 pub struct BrokerFastFailure;
 
 impl BrokerFastFailure {
+    
+    pub fn start(&mut self) {
+        warn!("BrokerFastFailure started not implemented");
+    }
+
     pub fn shutdown(&mut self) {
         warn!("BrokerFastFailure shutdown not implemented");
     }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2279

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added placeholder `start` methods for `BrokerPreOnlineService` and `BrokerFastFailure` services
- **Chores**
	- Prepared service initialization methods with logging placeholders

<!-- end of auto-generated comment: release notes by coderabbit.ai -->