### PR TITLE
[ISSUE #2306]⚡️Remove useless set_cmd_version from RemotingCommand

### DIFF
--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -202,10 +202,6 @@ impl RemotingCommand {
         requestId.fetch_add(1, Ordering::AcqRel)
     }
 
-    pub fn set_cmd_version(self) -> Self {
-        self
-    }
-
     pub fn create_response_command_with_code(code: impl Into<i32>) -> Self {
         Self::default().set_code(code).mark_response_type()
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2306

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
