### PR TITLE
[ISSUE #2327]🤡SelectMappedBufferResult add bytes attribute🧑‍💻

### DIFF
--- a/rocketmq-store/src/base/select_result.rs
+++ b/rocketmq-store/src/base/select_result.rs
@@ -27,6 +27,9 @@ use crate::log_file::mapped_file::MappedFile;
 pub struct SelectMappedBufferResult {
     /// The start offset.
     pub start_offset: u64,
+
+    pub bytes: Option<Bytes>,
+
     /// The size.
     pub size: i32,
     /// The mapped file.
@@ -39,6 +42,7 @@ impl Default for SelectMappedBufferResult {
     fn default() -> Self {
         Self {
             start_offset: 0,
+            bytes: None,
             size: 0,
             mapped_file: None,
             is_in_cache: true,

--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -506,6 +506,7 @@ impl MappedFile for DefaultMappedFile {
                     size,
                     mapped_file: None,
                     is_in_cache: true,
+                    ..Default::default()
                 })
             } else {
                 warn!(
@@ -785,6 +786,7 @@ impl MappedFile for DefaultMappedFile {
                 size: read_position - pos,
                 mapped_file: None,
                 is_in_cache: true,
+                ..Default::default()
             })
         } else {
             None


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2327

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced buffer selection result handling by adding an optional byte representation.
	- Updated default initialization for buffer selection results to ensure all fields are properly initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->