### PR TITLE
[ISSUE #2331]🤡Remove PopBufferMergeService useless code🧑‍💻

### DIFF
--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -69,12 +69,7 @@ pub(crate) struct PopBufferMergeService<MS> {
     count_of_second30: u64,
     batch_ack_index_list: Vec<u8>,
     master: AtomicBool,
-    //broker_config: Arc<BrokerConfig>,
     shutdown: Arc<Notify>,
-    //store_host: SocketAddr,
-    //escape_bridge: ArcMut<EscapeBridge<MS>>,
-    //topic_config_manager: Arc<TopicConfigManager>,
-    // subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
 }
 
@@ -82,11 +77,6 @@ impl<MS> PopBufferMergeService<MS> {
     pub fn new(
         revive_topic: CheetahString,
         queue_lock_manager: QueueLockManager,
-        /*broker_config: Arc<BrokerConfig>,
-        store_host: SocketAddr,
-        escape_bridge: ArcMut<EscapeBridge<MS>>,
-        topic_config_manager: Arc<TopicConfigManager>,
-        subscription_group_manager: Arc<SubscriptionGroupManager<MS>>,*/
         broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     ) -> Self {
         let interval = 5;
@@ -105,12 +95,7 @@ impl<MS> PopBufferMergeService<MS> {
             count_of_second30: 30 * 1000 / interval,
             batch_ack_index_list: Vec::with_capacity(32),
             master: AtomicBool::new(false),
-            // broker_config,
             shutdown: Arc::new(Notify::new()),
-            //  store_host,
-            // escape_bridge,
-            // topic_config_manager,
-            //  subscription_group_manager,
             broker_runtime_inner,
         }
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2331

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified `PopBufferMergeService` struct by removing unused configuration fields
	- Updated constructor to remove unnecessary parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->