### PR TITLE
[ISSUE #2339]🤡Add BrokerReplicasInfo for rust🧑‍💻

### DIFF
--- a/rocketmq-remoting/src/protocol/body/broker_replicas_info.rs
+++ b/rocketmq-remoting/src/protocol/body/broker_replicas_info.rs
@@ -21,6 +21,8 @@ use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
+#[derive(Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct BrokerReplicasInfo {
     replicas_info_table: HashMap<CheetahString, ReplicasInfo>,
 }

--- a/rocketmq-remoting/src/protocol/body/broker_replicas_info.rs
+++ b/rocketmq-remoting/src/protocol/body/broker_replicas_info.rs
@@ -14,12 +14,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+use std::collections::HashMap;
 use std::fmt;
 
 use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
+
+pub struct BrokerReplicasInfo {
+    replicas_info_table: HashMap<CheetahString, ReplicasInfo>,
+}
+
+impl BrokerReplicasInfo {
+    pub fn new() -> Self {
+        Self {
+            replicas_info_table: HashMap::new(),
+        }
+    }
+
+    pub fn add_replica_info(&mut self, broker_name: CheetahString, replicas_info: ReplicasInfo) {
+        self.replicas_info_table.insert(broker_name, replicas_info);
+    }
+
+    pub fn get_replicas_info_table(&self) -> &HashMap<CheetahString, ReplicasInfo> {
+        &self.replicas_info_table
+    }
+
+    pub fn set_replicas_info_table(
+        &mut self,
+        replicas_info_table: HashMap<CheetahString, ReplicasInfo>,
+    ) {
+        self.replicas_info_table = replicas_info_table;
+    }
+}
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2339

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `BrokerReplicasInfo` struct to manage broker replica information.
	- Added methods to create, modify, and retrieve replica information for brokers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->