### PR TITLE
[ISSUE #2349]🤡Connection supports send bytes 🧑‍💻

### DIFF
--- a/rocketmq-remoting/src/net/channel.rs
+++ b/rocketmq-remoting/src/net/channel.rs
@@ -23,7 +23,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures_util::SinkExt;
 use rocketmq_rust::ArcMut;
 use tokio::sync::mpsc::Receiver;
 use tokio::time::timeout;
@@ -67,7 +66,7 @@ pub(crate) async fn run_send(
                 ResponseFuture::new(opaque, timeout_millis.unwrap_or(0), true, tx),
             );
         }
-        match connection.writer.send(request).await {
+        match connection.send_command(request).await {
             Ok(_) => {}
             Err(error) => match error {
                 Io(error) => {

--- a/rocketmq-remoting/src/runtime/connection_handler_context.rs
+++ b/rocketmq-remoting/src/runtime/connection_handler_context.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use futures_util::SinkExt;
+
 use rocketmq_rust::WeakArcMut;
 use tracing::error;
 
@@ -44,7 +44,7 @@ impl ConnectionHandlerContextWrapper {
     }
 
     pub async fn write(&mut self, cmd: RemotingCommand) {
-        match self.channel.connection_mut().writer.send(cmd).await {
+        match self.channel.connection_mut().send_command(cmd).await {
             Ok(_) => {}
             Err(error) => {
                 error!("send response failed: {}", error);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2349

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
	- Updated command handling methods across multiple components
	- Introduced new methods for sending and receiving commands in network connections
	- Replaced existing command codec with a more flexible composite codec

- **Performance**
	- Improved command transmission and reception mechanisms
	- Enhanced network communication handling

- **Technical Improvements**
	- Streamlined asynchronous command processing
	- Updated error handling for network communication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->