### PR TITLE
[ISSUE #2357]🤡Use RemotingCommand take_body method for performance🧑‍💻

### DIFF
--- a/rocketmq-remoting/src/codec/remoting_command_codec.rs
+++ b/rocketmq-remoting/src/codec/remoting_command_codec.rs
@@ -121,8 +121,8 @@ impl Encoder<RemotingCommand> for RemotingCommandCodec {
     fn encode(&mut self, item: RemotingCommand, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let mut item = item;
         item.fast_header_encode(dst);
-        if let Some(body_inner) = item.get_body() {
-            dst.put(body_inner.as_ref());
+        if let Some(body_inner) = item.take_body() {
+            dst.put(body_inner);
         }
         Ok(())
     }

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -599,6 +599,7 @@ impl RemotingCommand {
         &self.body
     }
 
+    #[inline]
     pub fn take_body(&mut self) -> Option<Bytes> {
         self.body.take()
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2357

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `take_body()` method to `RemotingCommand` struct, enabling ownership transfer of command body
- **Refactor**
	- Updated encoding process to use `take_body()` instead of `get_body()`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->