### PR TITLE
[ISSUE #2364]🚀PopRequest implement get_channel and get_channel_mut method

### DIFF
--- a/rocketmq-broker/src/long_polling/pop_request.rs
+++ b/rocketmq-broker/src/long_polling/pop_request.rs
@@ -61,11 +61,11 @@ impl PopRequest {
     }
 
     pub fn get_channel(&self) -> &Channel {
-        self.ctx.upgrade().expect("ctx is none").channel()
+        self.ctx.channel()
     }
 
     pub fn get_channel_mut(&mut self) -> &mut Channel {
-        self.ctx.upgrade().expect("ctx is none").channel_mut()
+        self.ctx.channel_mut()
     }
 
     pub fn get_ctx(&self) -> &ConnectionHandlerContext {

--- a/rocketmq-broker/src/long_polling/pop_request.rs
+++ b/rocketmq-broker/src/long_polling/pop_request.rs
@@ -60,13 +60,12 @@ impl PopRequest {
         }
     }
 
-    //need to implement and optimize
     pub fn get_channel(&self) -> &Channel {
-        unimplemented!("PopRequest::get_channel")
+        self.ctx.upgrade().expect("ctx is none").channel()
     }
 
     pub fn get_channel_mut(&mut self) -> &mut Channel {
-        unimplemented!("PopRequest::get_channel")
+        self.ctx.upgrade().expect("ctx is none").channel_mut()
     }
 
     pub fn get_ctx(&self) -> &ConnectionHandlerContext {

--- a/rocketmq-remoting/src/runtime/connection_handler_context.rs
+++ b/rocketmq-remoting/src/runtime/connection_handler_context.rs
@@ -55,6 +55,10 @@ impl ConnectionHandlerContextWrapper {
     pub fn channel(&self) -> &Channel {
         &self.channel
     }
+
+    pub fn channel_mut(&mut self) -> &mut Channel {
+        &mut self.channel
+    }
 }
 
 impl AsRef<ConnectionHandlerContextWrapper> for ConnectionHandlerContextWrapper {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2364

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced channel access methods for better usability.
	- Introduced mutable channel retrieval functionality for improved internal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->