### PR TITLE
[ISSUE #2376]🚀Implement BrokerOuterAPI shutdown

### DIFF
--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -345,7 +345,9 @@ impl BrokerOuterAPI {
         }
     }
 
-    pub fn shutdown(&self) {}
+    pub fn shutdown(&mut self) {
+        self.remoting_client.shutdown();
+    }
 
     pub fn refresh_metadata(&self) {}
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2376

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the `shutdown` method in the `BrokerOuterAPI` to use a mutable reference
	- Added internal shutdown logic for the remoting client

<!-- end of auto-generated comment: release notes by coderabbit.ai -->