### PR TITLE
[ISSUE #2384]🚀Implement PopMessageProcessor shutdown🤡

### DIFF
--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -1322,7 +1322,7 @@ where
     }
 
     pub fn shutdown(&mut self) {
-        warn!("PopMessageProcessor shutdown unimplemented, need to implement");
+        self.pop_long_polling_service.shutdown();
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2384

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a `shutdown` method to `PopLongPollingService` to improve service graceful shutdown capabilities
	- Enhanced `PopMessageProcessor` shutdown logic to properly handle service termination

- **Improvements**
	- Implemented more responsive notification handling in long polling service
	- Replaced warning log with actual shutdown mechanism in message processor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->