### PR TITLE
[ISSUE #2390]🤡Implement PopMessageProcessor is_pop_should_stop method🚀

### DIFF
--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -1164,7 +1164,13 @@ where
         group: &CheetahString,
         queue_id: i32,
     ) -> bool {
-        unimplemented!("PopMessageProcessor is_pop_should_stop")
+        let broker_config = self.broker_runtime_inner.broker_config();
+        broker_config.enable_pop_message_threshold
+            && self
+                .broker_runtime_inner
+                .pop_inflight_message_counter()
+                .get_group_pop_in_flight_message_num(topic, group, queue_id)
+                > broker_config.pop_inflight_message_threshold
     }
 
     fn get_pop_offset(

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -203,6 +203,8 @@ pub struct BrokerConfig {
     pub pop_polling_map_size: usize,
     pub max_pop_polling_size: u64,
     pub pop_polling_size: usize,
+    pub enable_pop_message_threshold: bool,
+    pub pop_inflight_message_threshold: i64,
 }
 
 impl Default for BrokerConfig {
@@ -311,6 +313,8 @@ impl Default for BrokerConfig {
             pop_polling_map_size: 100000,
             max_pop_polling_size: 100000,
             pop_polling_size: 1024,
+            enable_pop_message_threshold: false,
+            pop_inflight_message_threshold: 10000,
         }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2390

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configuration options to control message processing thresholds
	- Implemented dynamic message popping mechanism based on in-flight message count

- **Improvements**
	- Enhanced broker configuration with new threshold settings
	- Added ability to stop message popping when system load exceeds specified limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->