### PR TITLE
[ISSUE #2394]🐛Fix PopBufferMergeService get_latest_offset queue back None

### DIFF
--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -206,13 +206,12 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
     pub fn get_latest_offset(&self, lock_key: &CheetahString) -> i64 {
         let queue = self.commit_offsets.get(lock_key);
         if let Some(queue) = queue {
-            let queue = queue.value();
             let queue = queue.get().lock();
-            if queue.is_empty() {
-                return -1;
+            if let Some(queue) = queue.back() {
+                queue.get_next_begin_offset()
+            } else {
+                -1
             }
-            let point = queue.back().unwrap();
-            point.get_next_begin_offset()
         } else {
             -1
         }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2394

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
