### PR TITLE
[ISSUE #2396]🚀RocketMQMessageStore add get_message_with_total_size method🧑‍💻

### DIFF
--- a/rocketmq-broker/src/failover/escape_bridge.rs
+++ b/rocketmq-broker/src/failover/escape_bridge.rs
@@ -496,7 +496,7 @@ where
                         queue_id,
                         offset,
                         1,
-                        128 * 1024 * 1024,
+                        //    128 * 1024 * 1024,
                         None,
                     )
                     .await;

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -928,7 +928,7 @@ where
                 offset,
                 request_header.max_msg_nums as i32
                     - get_message_result.message_mapped_list().len() as i32,
-                1024 * 1024,
+                //   1024 * 1024,
                 message_filter.clone(),
             )
             .await;
@@ -978,7 +978,7 @@ where
                                     offset,
                                     request_header.max_msg_nums as i32
                                         - get_message_result.message_mapped_list().len() as i32,
-                                    1024 * 1024,
+                                    //     1024 * 1024,
                                     message_filter,
                                 )
                                 .await;

--- a/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
@@ -254,12 +254,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
         let get_message_result = self
             .message_store
             .get_message(
-                group,
-                topic,
-                queue_id,
-                offset,
-                nums,
-                128 * 1024 * 1024,
+                group, topic, queue_id, offset, nums, //    128 * 1024 * 1024,
                 None,
             )
             .await;

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -48,7 +48,6 @@ use rocketmq_store::base::get_message_result::GetMessageResult;
 use rocketmq_store::base::message_status_enum::GetMessageStatus;
 use rocketmq_store::filter::MessageFilter;
 use rocketmq_store::log_file::MessageStore;
-use rocketmq_store::log_file::MAX_PULL_MSG_SIZE;
 use tokio::sync::Mutex;
 use tracing::error;
 use tracing::warn;
@@ -752,7 +751,7 @@ where
                         queue_id,
                         request_header.queue_offset,
                         request_header.max_msg_nums,
-                        MAX_PULL_MSG_SIZE,
+                        //   MAX_PULL_MSG_SIZE,
                         Some(message_filter.clone()),
                     )
                     .await;

--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -44,7 +44,6 @@ use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_status_enum::GetMessageStatus;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::log_file::MessageStore;
-use rocketmq_store::log_file::MAX_PULL_MSG_SIZE;
 use tokio::sync::Mutex;
 use tracing::error;
 
@@ -190,12 +189,7 @@ where
             .as_ref()
             .unwrap()
             .get_message(
-                group,
-                topic,
-                queue_id,
-                offset,
-                nums,
-                MAX_PULL_MSG_SIZE,
+                group, topic, queue_id, offset, nums, //  MAX_PULL_MSG_SIZE,
                 None,
             )
             .await;

--- a/rocketmq-store/src/log_file.rs
+++ b/rocketmq-store/src/log_file.rs
@@ -246,6 +246,34 @@ pub trait RocketMQMessageStore: Sync + 'static {
         queue_id: i32,
         offset: i64,
         max_msg_nums: i32,
+        message_filter: Option<Arc<Box<dyn MessageFilter>>>,
+    ) -> Option<GetMessageResult>;
+
+    /// Get a message asynchronously with a total size limit.
+    ///
+    /// This function retrieves messages from a specified queue, considering the total size limit
+    /// for the messages. It supports optional message filtering.
+    ///
+    /// # Arguments
+    ///
+    /// * `group` - The consumer group name.
+    /// * `topic` - The topic name.
+    /// * `queue_id` - The queue identifier.
+    /// * `offset` - The offset of the message.
+    /// * `max_msg_nums` - The maximum number of messages to retrieve.
+    /// * `max_total_msg_size` - The maximum total size of the messages to retrieve.
+    /// * `message_filter` - An optional filter to apply to the messages.
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing the result of the message retrieval.
+    async fn get_message_with_total_size(
+        &self,
+        group: &CheetahString,
+        topic: &CheetahString,
+        queue_id: i32,
+        offset: i64,
+        max_msg_nums: i32,
         max_total_msg_size: i32,
         message_filter: Option<Arc<Box<dyn MessageFilter>>>,
     ) -> Option<GetMessageResult>;

--- a/rocketmq-store/src/message_store/default_message_store.rs
+++ b/rocketmq-store/src/message_store/default_message_store.rs
@@ -793,6 +793,27 @@ impl MessageStore for DefaultMessageStore {
         queue_id: i32,
         offset: i64,
         max_msg_nums: i32,
+        message_filter: Option<Arc<Box<dyn MessageFilter>>>,
+    ) -> Option<GetMessageResult> {
+        self.get_message_with_total_size(
+            group,
+            topic,
+            queue_id,
+            offset,
+            max_msg_nums,
+            MAX_PULL_MSG_SIZE,
+            message_filter,
+        )
+        .await
+    }
+
+    async fn get_message_with_total_size(
+        &self,
+        group: &CheetahString,
+        topic: &CheetahString,
+        queue_id: i32,
+        offset: i64,
+        max_msg_nums: i32,
         max_total_msg_size: i32,
         message_filter: Option<Arc<Box<dyn MessageFilter>>>,
     ) -> Option<GetMessageResult> {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2396

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Performance Optimization**
  - Enhanced message retrieval mechanisms across multiple components
  - Removed explicit message size limitations in various message processing methods
  - Added more flexible message filtering and retrieval capabilities

- **Message Store Improvements**
  - Introduced new asynchronous methods for advanced message retrieval
  - Added support for total message size constraints
  - Improved message filtering options

- **System Modifications**
  - Updated message processing logic in broker and store components
  - Simplified method signatures in transactional message handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->