### PR TITLE
[ISSUE #2398]🐛Fix GetMessageStatus judgement not incorret

### DIFF
--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -1053,11 +1053,11 @@ where
                         queue_id,
                         result_inner.message_queue_offset().clone(),
                     );
-                } else if (result_inner.status().is_none()
-                    || result_inner.status().unwrap() == GetMessageStatus::NoMatchedMessage
-                    || result_inner.status().unwrap() == GetMessageStatus::OffsetFoundNull
-                    || result_inner.status().unwrap() == GetMessageStatus::MessageWasRemoving
-                    || result_inner.status().unwrap() == GetMessageStatus::NoMatchedLogicQueue)
+                } else if (result_inner.status().is_some()
+                    && (result_inner.status().unwrap() == GetMessageStatus::NoMatchedMessage
+                        || result_inner.status().unwrap() == GetMessageStatus::OffsetFoundNull
+                        || result_inner.status().unwrap() == GetMessageStatus::MessageWasRemoving
+                        || result_inner.status().unwrap() == GetMessageStatus::NoMatchedLogicQueue))
                     && result_inner.next_begin_offset() > -1
                 {
                     if is_order {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2398

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined message processing logic to improve status handling and message retrieval accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->