### PR TITLE
refactor: reference parameters for MessageListenerOrderlyFn

### DIFF
--- a/rocketmq-client/src/consumer/listener/message_listener_orderly.rs
+++ b/rocketmq-client/src/consumer/listener/message_listener_orderly.rs
@@ -33,5 +33,5 @@ pub trait MessageListenerOrderly: Sync + Send {
 pub type ArcBoxMessageListenerOrderly = Arc<Box<dyn MessageListenerOrderly>>;
 
 pub type MessageListenerOrderlyFn = Arc<
-    dyn Fn(Vec<MessageExt>, ConsumeOrderlyContext) -> Result<ConsumeOrderlyStatus> + Send + Sync,
+    dyn Fn(&[MessageExt], &ConsumeOrderlyContext) -> Result<ConsumeOrderlyStatus> + Send + Sync,
 >;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)
Close #1677 

### Brief Description

### How Did You Test This Change?
cargo test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated message listener function signature to use borrowing instead of ownership for improved memory efficiency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->