### PR TITLE
[ISSUE #1929] Optimize PutMessageStatus Display like Java PutMessageStatus toString

### DIFF
--- a/rocketmq-store/src/base/message_status_enum.rs
+++ b/rocketmq-store/src/base/message_status_enum.rs
@@ -75,7 +75,9 @@ impl std::fmt::Display for PutMessageStatus {
             PutMessageStatus::UnknownError => write!(f, "UNKNOWN_ERROR"),
             PutMessageStatus::InSyncReplicasNotEnough => write!(f, "IN_SYNC_REPLICAS_NOT_ENOUGH"),
             PutMessageStatus::PutToRemoteBrokerFail => write!(f, "PUT_TO_REMOTE_BROKER_FAIL"),
-            PutMessageStatus::LmqConsumeQueueNumExceeded => write!(f, "LMQ_CONSUME_QUEUE_NUM_EXCEEDED"),
+            PutMessageStatus::LmqConsumeQueueNumExceeded => {
+                write!(f, "LMQ_CONSUME_QUEUE_NUM_EXCEEDED")
+            }
             PutMessageStatus::WheelTimerFlowControl => write!(f, "WHEEL_TIMER_FLOW_CONTROL"),
             PutMessageStatus::WheelTimerMsgIllegal => write!(f, "WHEEL_TIMER_MSG_ILLEGAL"),
             PutMessageStatus::WheelTimerNotEnable => write!(f, "WHEEL_TIMER_NOT_ENABLE"),
@@ -156,17 +158,11 @@ mod tests {
 
     #[test]
     fn put_message_status_display_put_ok() {
-        assert_eq!(
-            PutMessageStatus::PutOk.to_string(),
-            "PUT_OK"
-        );
+        assert_eq!(PutMessageStatus::PutOk.to_string(), "PUT_OK");
     }
 
     #[test]
     fn get_message_status_display_found() {
-        assert_eq!(
-            GetMessageStatus::Found.to_string(),
-            "FOUND"
-        );
+        assert_eq!(GetMessageStatus::Found.to_string(), "FOUND");
     }
 }

--- a/rocketmq-store/src/base/message_status_enum.rs
+++ b/rocketmq-store/src/base/message_status_enum.rs
@@ -15,159 +15,158 @@
  * limitations under the License.
  */
 
- #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
- pub enum AppendMessageStatus {
-     #[default]
-     PutOk,
-     EndOfFile,
-     MessageSizeExceeded,
-     PropertiesSizeExceeded,
-     UnknownError,
- }
- 
- impl std::fmt::Display for AppendMessageStatus {
-     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-         // Compatible with Java enums
-         match self {
-             AppendMessageStatus::PutOk => write!(f, "PUT_OK"),
-             AppendMessageStatus::EndOfFile => write!(f, "END_OF_FILE"),
-             AppendMessageStatus::MessageSizeExceeded => write!(f, "MESSAGE_SIZE_EXCEEDED"),
-             AppendMessageStatus::PropertiesSizeExceeded => write!(f, "PROPERTIES_SIZE_EXCEEDED"),
-             AppendMessageStatus::UnknownError => write!(f, "UNKNOWN_ERROR"),
-         }
-     }
- }
- 
- #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
- pub enum PutMessageStatus {
-     #[default]
-     PutOk,
-     FlushDiskTimeout,
-     FlushSlaveTimeout,
-     SlaveNotAvailable,
-     ServiceNotAvailable,
-     CreateMappedFileFailed,
-     MessageIllegal,
-     PropertiesSizeExceeded,
-     OsPageCacheBusy,
-     UnknownError,
-     InSyncReplicasNotEnough,
-     PutToRemoteBrokerFail,
-     LmqConsumeQueueNumExceeded,
-     WheelTimerFlowControl,
-     WheelTimerMsgIllegal,
-     WheelTimerNotEnable,
- }
- 
- impl std::fmt::Display for PutMessageStatus {
-     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-         // Compatible with Java enums
-         match self {
-             PutMessageStatus::PutOk => write!(f, "PUT_OK"),
-             PutMessageStatus::FlushDiskTimeout => write!(f, "FLUSH_DISK_TIMEOUT"),
-             PutMessageStatus::FlushSlaveTimeout => write!(f, "FLUSH_SLAVE_TIMEOUT"),
-             PutMessageStatus::SlaveNotAvailable => write!(f, "SLAVE_NOT_AVAILABLE"),
-             PutMessageStatus::ServiceNotAvailable => write!(f, "SERVICE_NOT_AVAILABLE"),
-             PutMessageStatus::CreateMappedFileFailed => write!(f, "CREATE_MAPPED_FILE_FAILED"),
-             PutMessageStatus::MessageIllegal => write!(f, "MESSAGE_ILLEGAL"),
-             PutMessageStatus::PropertiesSizeExceeded => write!(f, "PROPERTIES_SIZE_EXCEEDED"),
-             PutMessageStatus::OsPageCacheBusy => write!(f, "OS_PAGE_CACHE_BUSY"),
-             PutMessageStatus::UnknownError => write!(f, "UNKNOWN_ERROR"),
-             PutMessageStatus::InSyncReplicasNotEnough => write!(f, "IN_SYNC_REPLICAS_NOT_ENOUGH"),
-             PutMessageStatus::PutToRemoteBrokerFail => write!(f, "PUT_TO_REMOTE_BROKER_FAIL"),
-             PutMessageStatus::LmqConsumeQueueNumExceeded => write!(f, "LMQ_CONSUME_QUEUE_NUM_EXCEEDED"),
-             PutMessageStatus::WheelTimerFlowControl => write!(f, "WHEEL_TIMER_FLOW_CONTROL"),
-             PutMessageStatus::WheelTimerMsgIllegal => write!(f, "WHEEL_TIMER_MSG_ILLEGAL"),
-             PutMessageStatus::WheelTimerNotEnable => write!(f, "WHEEL_TIMER_NOT_ENABLE"),
-         }
-     }
- }
- 
- #[derive(Debug, Default, PartialEq, Clone, Copy)]
- pub enum GetMessageStatus {
-     #[default]
-     Found,
-     NoMatchedMessage,
-     MessageWasRemoving,
-     OffsetFoundNull,
-     OffsetOverflowBadly,
-     OffsetOverflowOne,
-     OffsetTooSmall,
-     NoMatchedLogicQueue,
-     NoMessageInQueue,
-     OffsetReset,
- }
- 
- impl std::fmt::Display for GetMessageStatus {
-     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-         // Compatible with Java enums
-         match self {
-             GetMessageStatus::Found => write!(f, "FOUND"),
-             GetMessageStatus::NoMatchedMessage => write!(f, "NO_MATCHED_MESSAGE"),
-             GetMessageStatus::MessageWasRemoving => write!(f, "MESSAGE_WAS_REMOVING"),
-             GetMessageStatus::OffsetFoundNull => write!(f, "OFFSET_FOUND_NULL"),
-             GetMessageStatus::OffsetOverflowBadly => write!(f, "OFFSET_OVERFLOW_BADLY"),
-             GetMessageStatus::OffsetOverflowOne => write!(f, "OFFSET_OVERFLOW_ONE"),
-             GetMessageStatus::OffsetTooSmall => write!(f, "OFFSET_TOO_SMALL"),
-             GetMessageStatus::NoMatchedLogicQueue => write!(f, "NO_MATCHED_LOGIC_QUEUE"),
-             GetMessageStatus::NoMessageInQueue => write!(f, "NO_MESSAGE_IN_QUEUE"),
-             GetMessageStatus::OffsetReset => write!(f, "OFFSET_RESET"),
-         }
-     }
- }
- 
- #[cfg(test)]
- mod tests {
-     use super::*;
- 
-     #[test]
-     fn append_message_status_display_put_ok() {
-         assert_eq!(AppendMessageStatus::PutOk.to_string(), "PUT_OK");
-     }
- 
-     #[test]
-     fn append_message_status_display_end_of_file() {
-         assert_eq!(AppendMessageStatus::EndOfFile.to_string(), "END_OF_FILE");
-     }
- 
-     #[test]
-     fn append_message_status_display_message_size_exceeded() {
-         assert_eq!(
-             AppendMessageStatus::MessageSizeExceeded.to_string(),
-             "MESSAGE_SIZE_EXCEEDED"
-         );
-     }
- 
-     #[test]
-     fn append_message_status_display_properties_size_exceeded() {
-         assert_eq!(
-             AppendMessageStatus::PropertiesSizeExceeded.to_string(),
-             "PROPERTIES_SIZE_EXCEEDED"
-         );
-     }
- 
-     #[test]
-     fn append_message_status_display_unknown_error() {
-         assert_eq!(
-             AppendMessageStatus::UnknownError.to_string(),
-             "UNKNOWN_ERROR"
-         );
-     }
- 
-     #[test]
-     fn put_message_status_display_put_ok() {
-         assert_eq!(
-             PutMessageStatus::PutOk.to_string(),
-             "PUT_OK"
-         );
-     }
- 
-     #[test]
-     fn get_message_status_display_found() {
-         assert_eq!(
-             GetMessageStatus::Found.to_string(),
-             "FOUND"
-         );
-     }
- }
- 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum AppendMessageStatus {
+    #[default]
+    PutOk,
+    EndOfFile,
+    MessageSizeExceeded,
+    PropertiesSizeExceeded,
+    UnknownError,
+}
+
+impl std::fmt::Display for AppendMessageStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Compatible with Java enums
+        match self {
+            AppendMessageStatus::PutOk => write!(f, "PUT_OK"),
+            AppendMessageStatus::EndOfFile => write!(f, "END_OF_FILE"),
+            AppendMessageStatus::MessageSizeExceeded => write!(f, "MESSAGE_SIZE_EXCEEDED"),
+            AppendMessageStatus::PropertiesSizeExceeded => write!(f, "PROPERTIES_SIZE_EXCEEDED"),
+            AppendMessageStatus::UnknownError => write!(f, "UNKNOWN_ERROR"),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum PutMessageStatus {
+    #[default]
+    PutOk,
+    FlushDiskTimeout,
+    FlushSlaveTimeout,
+    SlaveNotAvailable,
+    ServiceNotAvailable,
+    CreateMappedFileFailed,
+    MessageIllegal,
+    PropertiesSizeExceeded,
+    OsPageCacheBusy,
+    UnknownError,
+    InSyncReplicasNotEnough,
+    PutToRemoteBrokerFail,
+    LmqConsumeQueueNumExceeded,
+    WheelTimerFlowControl,
+    WheelTimerMsgIllegal,
+    WheelTimerNotEnable,
+}
+
+impl std::fmt::Display for PutMessageStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Compatible with Java enums
+        match self {
+            PutMessageStatus::PutOk => write!(f, "PUT_OK"),
+            PutMessageStatus::FlushDiskTimeout => write!(f, "FLUSH_DISK_TIMEOUT"),
+            PutMessageStatus::FlushSlaveTimeout => write!(f, "FLUSH_SLAVE_TIMEOUT"),
+            PutMessageStatus::SlaveNotAvailable => write!(f, "SLAVE_NOT_AVAILABLE"),
+            PutMessageStatus::ServiceNotAvailable => write!(f, "SERVICE_NOT_AVAILABLE"),
+            PutMessageStatus::CreateMappedFileFailed => write!(f, "CREATE_MAPPED_FILE_FAILED"),
+            PutMessageStatus::MessageIllegal => write!(f, "MESSAGE_ILLEGAL"),
+            PutMessageStatus::PropertiesSizeExceeded => write!(f, "PROPERTIES_SIZE_EXCEEDED"),
+            PutMessageStatus::OsPageCacheBusy => write!(f, "OS_PAGE_CACHE_BUSY"),
+            PutMessageStatus::UnknownError => write!(f, "UNKNOWN_ERROR"),
+            PutMessageStatus::InSyncReplicasNotEnough => write!(f, "IN_SYNC_REPLICAS_NOT_ENOUGH"),
+            PutMessageStatus::PutToRemoteBrokerFail => write!(f, "PUT_TO_REMOTE_BROKER_FAIL"),
+            PutMessageStatus::LmqConsumeQueueNumExceeded => write!(f, "LMQ_CONSUME_QUEUE_NUM_EXCEEDED"),
+            PutMessageStatus::WheelTimerFlowControl => write!(f, "WHEEL_TIMER_FLOW_CONTROL"),
+            PutMessageStatus::WheelTimerMsgIllegal => write!(f, "WHEEL_TIMER_MSG_ILLEGAL"),
+            PutMessageStatus::WheelTimerNotEnable => write!(f, "WHEEL_TIMER_NOT_ENABLE"),
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
+pub enum GetMessageStatus {
+    #[default]
+    Found,
+    NoMatchedMessage,
+    MessageWasRemoving,
+    OffsetFoundNull,
+    OffsetOverflowBadly,
+    OffsetOverflowOne,
+    OffsetTooSmall,
+    NoMatchedLogicQueue,
+    NoMessageInQueue,
+    OffsetReset,
+}
+
+impl std::fmt::Display for GetMessageStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Compatible with Java enums
+        match self {
+            GetMessageStatus::Found => write!(f, "FOUND"),
+            GetMessageStatus::NoMatchedMessage => write!(f, "NO_MATCHED_MESSAGE"),
+            GetMessageStatus::MessageWasRemoving => write!(f, "MESSAGE_WAS_REMOVING"),
+            GetMessageStatus::OffsetFoundNull => write!(f, "OFFSET_FOUND_NULL"),
+            GetMessageStatus::OffsetOverflowBadly => write!(f, "OFFSET_OVERFLOW_BADLY"),
+            GetMessageStatus::OffsetOverflowOne => write!(f, "OFFSET_OVERFLOW_ONE"),
+            GetMessageStatus::OffsetTooSmall => write!(f, "OFFSET_TOO_SMALL"),
+            GetMessageStatus::NoMatchedLogicQueue => write!(f, "NO_MATCHED_LOGIC_QUEUE"),
+            GetMessageStatus::NoMessageInQueue => write!(f, "NO_MESSAGE_IN_QUEUE"),
+            GetMessageStatus::OffsetReset => write!(f, "OFFSET_RESET"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_message_status_display_put_ok() {
+        assert_eq!(AppendMessageStatus::PutOk.to_string(), "PUT_OK");
+    }
+
+    #[test]
+    fn append_message_status_display_end_of_file() {
+        assert_eq!(AppendMessageStatus::EndOfFile.to_string(), "END_OF_FILE");
+    }
+
+    #[test]
+    fn append_message_status_display_message_size_exceeded() {
+        assert_eq!(
+            AppendMessageStatus::MessageSizeExceeded.to_string(),
+            "MESSAGE_SIZE_EXCEEDED"
+        );
+    }
+
+    #[test]
+    fn append_message_status_display_properties_size_exceeded() {
+        assert_eq!(
+            AppendMessageStatus::PropertiesSizeExceeded.to_string(),
+            "PROPERTIES_SIZE_EXCEEDED"
+        );
+    }
+
+    #[test]
+    fn append_message_status_display_unknown_error() {
+        assert_eq!(
+            AppendMessageStatus::UnknownError.to_string(),
+            "UNKNOWN_ERROR"
+        );
+    }
+
+    #[test]
+    fn put_message_status_display_put_ok() {
+        assert_eq!(
+            PutMessageStatus::PutOk.to_string(),
+            "PUT_OK"
+        );
+    }
+
+    #[test]
+    fn get_message_status_display_found() {
+        assert_eq!(
+            GetMessageStatus::Found.to_string(),
+            "FOUND"
+        );
+    }
+}

--- a/rocketmq-store/src/base/message_status_enum.rs
+++ b/rocketmq-store/src/base/message_status_enum.rs
@@ -15,112 +15,159 @@
  * limitations under the License.
  */
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub enum AppendMessageStatus {
-    #[default]
-    PutOk,
-    EndOfFile,
-    MessageSizeExceeded,
-    PropertiesSizeExceeded,
-    UnknownError,
-}
-
-impl std::fmt::Display for AppendMessageStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Compatible with Java enums
-        match self {
-            AppendMessageStatus::PutOk => write!(f, "PUT_OK"),
-            AppendMessageStatus::EndOfFile => write!(f, "END_OF_FILE"),
-            AppendMessageStatus::MessageSizeExceeded => write!(f, "MESSAGE_SIZE_EXCEEDED"),
-            AppendMessageStatus::PropertiesSizeExceeded => write!(f, "PROPERTIES_SIZE_EXCEEDED"),
-            AppendMessageStatus::UnknownError => write!(f, "UNKNOWN_ERROR"),
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub enum PutMessageStatus {
-    #[default]
-    PutOk,
-    FlushDiskTimeout,
-    FlushSlaveTimeout,
-    SlaveNotAvailable,
-    ServiceNotAvailable,
-    CreateMappedFileFailed,
-    MessageIllegal,
-    PropertiesSizeExceeded,
-    OsPageCacheBusy,
-    UnknownError,
-    InSyncReplicasNotEnough,
-    PutToRemoteBrokerFail,
-    LmqConsumeQueueNumExceeded,
-    WheelTimerFlowControl,
-    WheelTimerMsgIllegal,
-    WheelTimerNotEnable,
-}
-
-impl std::fmt::Display for PutMessageStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-#[derive(Debug, Default, PartialEq, Clone, Copy)]
-pub enum GetMessageStatus {
-    #[default]
-    Found,
-    NoMatchedMessage,
-    MessageWasRemoving,
-    OffsetFoundNull,
-    OffsetOverflowBadly,
-    OffsetOverflowOne,
-    OffsetTooSmall,
-    NoMatchedLogicQueue,
-    NoMessageInQueue,
-    OffsetReset,
-}
-
-impl std::fmt::Display for GetMessageStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn append_message_status_display_put_ok() {
-        assert_eq!(AppendMessageStatus::PutOk.to_string(), "PUT_OK");
-    }
-
-    #[test]
-    fn append_message_status_display_end_of_file() {
-        assert_eq!(AppendMessageStatus::EndOfFile.to_string(), "END_OF_FILE");
-    }
-
-    #[test]
-    fn append_message_status_display_message_size_exceeded() {
-        assert_eq!(
-            AppendMessageStatus::MessageSizeExceeded.to_string(),
-            "MESSAGE_SIZE_EXCEEDED"
-        );
-    }
-
-    #[test]
-    fn append_message_status_display_properties_size_exceeded() {
-        assert_eq!(
-            AppendMessageStatus::PropertiesSizeExceeded.to_string(),
-            "PROPERTIES_SIZE_EXCEEDED"
-        );
-    }
-
-    #[test]
-    fn append_message_status_display_unknown_error() {
-        assert_eq!(
-            AppendMessageStatus::UnknownError.to_string(),
-            "UNKNOWN_ERROR"
-        );
-    }
-}
+ #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+ pub enum AppendMessageStatus {
+     #[default]
+     PutOk,
+     EndOfFile,
+     MessageSizeExceeded,
+     PropertiesSizeExceeded,
+     UnknownError,
+ }
+ 
+ impl std::fmt::Display for AppendMessageStatus {
+     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+         // Compatible with Java enums
+         match self {
+             AppendMessageStatus::PutOk => write!(f, "PUT_OK"),
+             AppendMessageStatus::EndOfFile => write!(f, "END_OF_FILE"),
+             AppendMessageStatus::MessageSizeExceeded => write!(f, "MESSAGE_SIZE_EXCEEDED"),
+             AppendMessageStatus::PropertiesSizeExceeded => write!(f, "PROPERTIES_SIZE_EXCEEDED"),
+             AppendMessageStatus::UnknownError => write!(f, "UNKNOWN_ERROR"),
+         }
+     }
+ }
+ 
+ #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+ pub enum PutMessageStatus {
+     #[default]
+     PutOk,
+     FlushDiskTimeout,
+     FlushSlaveTimeout,
+     SlaveNotAvailable,
+     ServiceNotAvailable,
+     CreateMappedFileFailed,
+     MessageIllegal,
+     PropertiesSizeExceeded,
+     OsPageCacheBusy,
+     UnknownError,
+     InSyncReplicasNotEnough,
+     PutToRemoteBrokerFail,
+     LmqConsumeQueueNumExceeded,
+     WheelTimerFlowControl,
+     WheelTimerMsgIllegal,
+     WheelTimerNotEnable,
+ }
+ 
+ impl std::fmt::Display for PutMessageStatus {
+     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+         // Compatible with Java enums
+         match self {
+             PutMessageStatus::PutOk => write!(f, "PUT_OK"),
+             PutMessageStatus::FlushDiskTimeout => write!(f, "FLUSH_DISK_TIMEOUT"),
+             PutMessageStatus::FlushSlaveTimeout => write!(f, "FLUSH_SLAVE_TIMEOUT"),
+             PutMessageStatus::SlaveNotAvailable => write!(f, "SLAVE_NOT_AVAILABLE"),
+             PutMessageStatus::ServiceNotAvailable => write!(f, "SERVICE_NOT_AVAILABLE"),
+             PutMessageStatus::CreateMappedFileFailed => write!(f, "CREATE_MAPPED_FILE_FAILED"),
+             PutMessageStatus::MessageIllegal => write!(f, "MESSAGE_ILLEGAL"),
+             PutMessageStatus::PropertiesSizeExceeded => write!(f, "PROPERTIES_SIZE_EXCEEDED"),
+             PutMessageStatus::OsPageCacheBusy => write!(f, "OS_PAGE_CACHE_BUSY"),
+             PutMessageStatus::UnknownError => write!(f, "UNKNOWN_ERROR"),
+             PutMessageStatus::InSyncReplicasNotEnough => write!(f, "IN_SYNC_REPLICAS_NOT_ENOUGH"),
+             PutMessageStatus::PutToRemoteBrokerFail => write!(f, "PUT_TO_REMOTE_BROKER_FAIL"),
+             PutMessageStatus::LmqConsumeQueueNumExceeded => write!(f, "LMQ_CONSUME_QUEUE_NUM_EXCEEDED"),
+             PutMessageStatus::WheelTimerFlowControl => write!(f, "WHEEL_TIMER_FLOW_CONTROL"),
+             PutMessageStatus::WheelTimerMsgIllegal => write!(f, "WHEEL_TIMER_MSG_ILLEGAL"),
+             PutMessageStatus::WheelTimerNotEnable => write!(f, "WHEEL_TIMER_NOT_ENABLE"),
+         }
+     }
+ }
+ 
+ #[derive(Debug, Default, PartialEq, Clone, Copy)]
+ pub enum GetMessageStatus {
+     #[default]
+     Found,
+     NoMatchedMessage,
+     MessageWasRemoving,
+     OffsetFoundNull,
+     OffsetOverflowBadly,
+     OffsetOverflowOne,
+     OffsetTooSmall,
+     NoMatchedLogicQueue,
+     NoMessageInQueue,
+     OffsetReset,
+ }
+ 
+ impl std::fmt::Display for GetMessageStatus {
+     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+         // Compatible with Java enums
+         match self {
+             GetMessageStatus::Found => write!(f, "FOUND"),
+             GetMessageStatus::NoMatchedMessage => write!(f, "NO_MATCHED_MESSAGE"),
+             GetMessageStatus::MessageWasRemoving => write!(f, "MESSAGE_WAS_REMOVING"),
+             GetMessageStatus::OffsetFoundNull => write!(f, "OFFSET_FOUND_NULL"),
+             GetMessageStatus::OffsetOverflowBadly => write!(f, "OFFSET_OVERFLOW_BADLY"),
+             GetMessageStatus::OffsetOverflowOne => write!(f, "OFFSET_OVERFLOW_ONE"),
+             GetMessageStatus::OffsetTooSmall => write!(f, "OFFSET_TOO_SMALL"),
+             GetMessageStatus::NoMatchedLogicQueue => write!(f, "NO_MATCHED_LOGIC_QUEUE"),
+             GetMessageStatus::NoMessageInQueue => write!(f, "NO_MESSAGE_IN_QUEUE"),
+             GetMessageStatus::OffsetReset => write!(f, "OFFSET_RESET"),
+         }
+     }
+ }
+ 
+ #[cfg(test)]
+ mod tests {
+     use super::*;
+ 
+     #[test]
+     fn append_message_status_display_put_ok() {
+         assert_eq!(AppendMessageStatus::PutOk.to_string(), "PUT_OK");
+     }
+ 
+     #[test]
+     fn append_message_status_display_end_of_file() {
+         assert_eq!(AppendMessageStatus::EndOfFile.to_string(), "END_OF_FILE");
+     }
+ 
+     #[test]
+     fn append_message_status_display_message_size_exceeded() {
+         assert_eq!(
+             AppendMessageStatus::MessageSizeExceeded.to_string(),
+             "MESSAGE_SIZE_EXCEEDED"
+         );
+     }
+ 
+     #[test]
+     fn append_message_status_display_properties_size_exceeded() {
+         assert_eq!(
+             AppendMessageStatus::PropertiesSizeExceeded.to_string(),
+             "PROPERTIES_SIZE_EXCEEDED"
+         );
+     }
+ 
+     #[test]
+     fn append_message_status_display_unknown_error() {
+         assert_eq!(
+             AppendMessageStatus::UnknownError.to_string(),
+             "UNKNOWN_ERROR"
+         );
+     }
+ 
+     #[test]
+     fn put_message_status_display_put_ok() {
+         assert_eq!(
+             PutMessageStatus::PutOk.to_string(),
+             "PUT_OK"
+         );
+     }
+ 
+     #[test]
+     fn get_message_status_display_found() {
+         assert_eq!(
+             GetMessageStatus::Found.to_string(),
+             "FOUND"
+         );
+     }
+ }
+ 


### PR DESCRIPTION
…tatus toString

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1929

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced string representations for `PutMessageStatus` and `GetMessageStatus` enums for better clarity and consistency.
- **Tests**
  - Added test cases to verify new string representations for the updated enums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->