### PR TITLE
[ISSUE #1379] Add ConsumeStatsList

### DIFF
--- a/rocketmq-remoting/src/protocol/admin.rs
+++ b/rocketmq-remoting/src/protocol/admin.rs
@@ -16,6 +16,7 @@
  */
 
 pub mod consume_stats;
+pub mod consume_stats_list;
 pub mod offset_wrapper;
 pub mod rollback_stats;
 pub mod topic_offset;

--- a/rocketmq-remoting/src/protocol/admin/consume_stats.rs
+++ b/rocketmq-remoting/src/protocol/admin/consume_stats.rs
@@ -27,8 +27,8 @@ use crate::protocol::admin::offset_wrapper::OffsetWrapper;
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ConsumeStats {
     #[serde(with = "any_key_map")]
-    offset_table: HashMap<MessageQueue, OffsetWrapper>,
-    consume_tps: f64,
+    pub offset_table: HashMap<MessageQueue, OffsetWrapper>,
+    pub consume_tps: f64,
 }
 
 impl ConsumeStats {

--- a/rocketmq-remoting/src/protocol/admin/consume_stats_list.rs
+++ b/rocketmq-remoting/src/protocol/admin/consume_stats_list.rs
@@ -1,0 +1,74 @@
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::consume_stats::ConsumeStats;
+
+#[derive(Serialize, Deserialize)]
+pub struct ConsumeStatsList {
+    #[serde(rename = "consume_stats_list")]
+    pub consume_stats_list: Vec<HashMap<CheetahString, Vec<ConsumeStats>>>,
+
+    #[serde(rename = "brokerAddr")]
+    pub broker_addr: Option<CheetahString>,
+
+    #[serde(rename = "total_diff")]
+    pub total_diff: i64,
+
+    #[serde(rename = "total_inflight_diff")]
+    pub total_inflight_diff: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn consume_status_list_serialization() {
+        let mut map = HashMap::new();
+        let consume_stats_list = vec![ConsumeStats {
+            offset_table: HashMap::new(),
+            consume_tps: 1.2,
+        }];
+        map.insert(CheetahString::from("group1"), consume_stats_list);
+        let consume_status_list = ConsumeStatsList {
+            consume_stats_list: vec![map],
+            broker_addr: Some(CheetahString::from("addr")),
+            total_diff: 2,
+            total_inflight_diff: 1,
+        };
+        let serialized = serde_json::to_string(&consume_status_list).unwrap();
+        println!("{}", serialized);
+        let deserialized: ConsumeStatsList = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(
+            deserialized.broker_addr.unwrap(),
+            CheetahString::from("addr")
+        );
+        assert_eq!(deserialized.total_diff, 2);
+        assert_eq!(deserialized.total_inflight_diff, 1);
+        let a = deserialized.consume_stats_list[0]
+            .get(&CheetahString::from("group1"))
+            .unwrap();
+        assert_eq!(a[0].consume_tps, 1.2);
+    }
+}

--- a/rocketmq-remoting/src/protocol/admin/consume_stats_list.rs
+++ b/rocketmq-remoting/src/protocol/admin/consume_stats_list.rs
@@ -1,6 +1,3 @@
-use std::collections::HashMap;
-
-use cheetah_string::CheetahString;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,6 +14,9 @@ use cheetah_string::CheetahString;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -34,7 +34,7 @@ pub mod cm_result;
 pub mod connection;
 pub mod consume_message_directly_result;
 pub mod consume_queue_data;
-pub mod consumer_status;
+pub mod consume_status;
 pub mod group_list;
 pub mod ha_client_runtime_info;
 pub mod ha_connection_runtime_info;

--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -34,6 +34,7 @@ pub mod cm_result;
 pub mod connection;
 pub mod consume_message_directly_result;
 pub mod consume_queue_data;
+pub mod consumer_status;
 pub mod group_list;
 pub mod ha_client_runtime_info;
 pub mod ha_connection_runtime_info;

--- a/rocketmq-remoting/src/protocol/body/consume_status.rs
+++ b/rocketmq-remoting/src/protocol/body/consume_status.rs
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ConsumeStatus {
+    #[serde(rename = "pullRT")]
+    pub pull_rt: f64,
+
+    #[serde(rename = "pullTPS")]
+    pub pull_tps: f64,
+
+    #[serde(rename = "consumeRT")]
+    pub consume_rt: f64,
+
+    #[serde(rename = "consumeOKTPS")]
+    pub consume_ok_tps: f64,
+
+    #[serde(rename = "consumeFailedTPS")]
+    pub consume_failed_tps: f64,
+
+    #[serde(rename = "consumeFailedMsgs")]
+    pub consume_failed_msgs: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn consume_status_serialization() {
+        let consume_status = ConsumeStatus {
+            pull_rt: 1.1,
+            pull_tps: 1.2,
+            consume_rt: 1.3,
+            consume_ok_tps: 1.4,
+            consume_failed_tps: 1.5,
+            consume_failed_msgs: 6,
+        };
+        let serialized = serde_json::to_string(&consume_status).unwrap();
+        let deserialized: ConsumeStatus = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.pull_rt, 1.1);
+        assert_eq!(deserialized.pull_tps, 1.2);
+        assert_eq!(deserialized.consume_rt, 1.3);
+        assert_eq!(deserialized.consume_ok_tps, 1.4);
+        assert_eq!(deserialized.consume_failed_tps, 1.5);
+        assert_eq!(deserialized.consume_failed_msgs, 6);
+    }
+
+    #[test]
+    fn consume_status_deserialization() {
+        let serialized = r#"{"pullRT":1.1,"pullTPS":1.2,"consumeRT":1.3,"consumeOKTPS":1.4,"consumeFailedTPS":1.5,"consumeFailedMsgs":6}"#;
+        let deserialized: ConsumeStatus = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.pull_rt, 1.1);
+        assert_eq!(deserialized.pull_tps, 1.2);
+        assert_eq!(deserialized.consume_rt, 1.3);
+        assert_eq!(deserialized.consume_ok_tps, 1.4);
+        assert_eq!(deserialized.consume_failed_tps, 1.5);
+        assert_eq!(deserialized.consume_failed_msgs, 6);
+    }
+
+}

--- a/rocketmq-remoting/src/protocol/body/consume_status.rs
+++ b/rocketmq-remoting/src/protocol/body/consume_status.rs
@@ -75,5 +75,4 @@ mod tests {
         assert_eq!(deserialized.consume_failed_tps, 1.5);
         assert_eq!(deserialized.consume_failed_msgs, 6);
     }
-
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1379

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new modules for consumption statistics management in the RocketMQ remoting protocol.
	- Introduced `ConsumeStatsList` and `ConsumeStatus` structs for tracking message consumption metrics.
	- Enhanced data serialization and deserialization capabilities for consumption-related data.

- **Improvements**
	- Updated visibility of `ConsumeStats` struct fields to improve accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->