### PR TITLE
[ISSUE #2411]💫Implement AckMessageProcessor shutdown method🥅

### DIFF
--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -46,7 +46,6 @@ use rocketmq_store::pop::ack_msg::AckMsg;
 use rocketmq_store::pop::batch_ack_msg::BatchAckMsg;
 use rocketmq_store::pop::AckMessage;
 use tracing::error;
-use tracing::warn;
 
 use crate::broker_error::BrokerError::BrokerCommonError;
 use crate::broker_error::BrokerError::BrokerRemotingError;
@@ -577,6 +576,8 @@ where
     }
 
     pub fn shutdown(&mut self) {
-        warn!("AckMessageProcessor shutdown unimplemented, need to be implemented");
+        for pop_revive_service in self.pop_revive_services.iter_mut() {
+            pop_revive_service.shutdown();
+        }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2411

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced shutdown mechanism for message processing services
	- Added controlled service termination capabilities
	- Implemented graceful service exit strategy

- **Improvements**
	- Improved resource management for message processing system
	- Added lifecycle management for background services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->