### PR TITLE
[ISSUE #2455]💫Add print string for AckMessageProcessor handle code not supporting🥅

### DIFF
--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -102,15 +102,22 @@ where
             RequestCode::BatchAckMessage => {
                 self.process_batch_ack(channel, ctx, request, true).await
             }
-            _ => Ok(Some(
-                RemotingCommand::create_response_command_with_code_remark(
-                    ResponseCode::MessageIllegal,
-                    format!(
-                        "request code not supported, request code: {:?}",
-                        request_code
+            _ => {
+                error!(
+                    "AckMessageProcessor failed to process RequestCode: {}, consumer: {} ",
+                    request_code.to_i32(),
+                    channel.remote_address()
+                );
+                Ok(Some(
+                    RemotingCommand::create_response_command_with_code_remark(
+                        ResponseCode::MessageIllegal,
+                        format!(
+                            "AckMessageProcessor failed to process RequestCode: {:?}",
+                            request_code
+                        ),
                     ),
-                ),
-            )),
+                ))
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2455

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and logging for unsupported request codes in the message acknowledgment processor.
	- Enhanced debugging capabilities by adding more context to error logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->