### PR TITLE
[ISSUE #2485]📝Add Run RocketMQ with Kubernetes doc💫

### DIFF
--- a/rocketmq-doc/_data/navigation.yml
+++ b/rocketmq-doc/_data/navigation.yml
@@ -54,6 +54,8 @@ docs:
         url: /docs/run-rocketmq-rust-locally/
       - title: "Run RocketMQ Rust with Docker"
         url: /docs/run-rocketmq-rust-docker/
+      - title: "Run RocketMQ Rust with Kubernetes"
+        url: /docs/run-rocketmq-rust-k8s/
   #      - title: "Overriding Theme Defaults"
   #        url: /docs/overriding-theme-defaults/
   #      - title: "Navigation"

--- a/rocketmq-doc/_docs/01-run-rocketmq-rust-k8s.md
+++ b/rocketmq-doc/_docs/01-run-rocketmq-rust-k8s.md
@@ -1,0 +1,11 @@
+---
+title: "Run RocketMQ Rust with Kubernetes"
+permalink: /docs/run-rocketmq-rust-k8s/
+excerpt: "Run RocketMQ Rust with Kubernetes"
+last_modified_at: 2025-02-01T08:48:05-04:00
+redirect_from:
+  - /theme-setup/
+toc: true
+---
+
+WIP


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2485

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a new documentation page titled "Run RocketMQ Rust with Kubernetes" to guide users on running RocketMQ Rust in a Kubernetes environment.
  - Updated the navigation by adding a dedicated link under the "Getting Started" section for easier access to this new guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->