### PR TITLE
[ISSUE #2508]🔥Fix PopLongPollingService notify_message_arriving is none unwrap💫

### DIFF
--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -147,7 +147,7 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
                 let mut match_result = message_filter.is_matched_by_consume_queue(
                     tags_code,
                     Some(&CqExtUnit::new(
-                        tags_code.unwrap(),
+                        tags_code.unwrap_or_default(),
                         msg_store_time,
                         filter_bit_map,
                     )),
@@ -159,6 +159,7 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
                 }
                 if !match_result {
                     remoting_commands.value().insert(pop_request);
+                    self.total_polling_num.fetch_add(1, Ordering::AcqRel);
                     return false;
                 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2508

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured safe handling of missing tag information by applying a default value to prevent potential errors.
  - Refined polling tracking to accurately count operations when no matching message is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->