### PR TITLE
[ISSUE #2539]🚀Replace DefaultMappedFile get_committed_position load with Ordering::Relaxed to Ordering::Acquire 🔥

### DIFF
--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -638,7 +638,7 @@ impl MappedFile for DefaultMappedFile {
     #[inline]
     fn get_wrote_position(&self) -> i32 {
         self.wrote_position
-            .load(std::sync::atomic::Ordering::Relaxed)
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     #[inline]
@@ -665,7 +665,7 @@ impl MappedFile for DefaultMappedFile {
 
     #[inline]
     fn get_committed_position(&self) -> i32 {
-        self.committed_position.load(Ordering::Relaxed)
+        self.committed_position.load(Ordering::Acquire)
     }
 
     #[inline]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2539

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved internal data synchronization to enhance reliability and consistency in multi-threaded operations. This update helps ensure that concurrent processes reflect the most up-to-date shared data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->