### PR TITLE
[ISSUE #2548]🚀 DefaultMQAdminExt add create instance method🚧

### DIFF
--- a/rocketmq-tools/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext_impl.rs
@@ -19,6 +19,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use lazy_static::lazy_static;
@@ -72,13 +73,27 @@ lazy_static! {
 }
 
 const SOCKS_PROXY_JSON: &str = "socksProxyJson";
-
+const NAMESPACE_ORDER_TOPIC_CONFIG: &str = "ORDER_TOPIC_CONFIG";
 pub struct DefaultMQAdminExtImpl {
     service_state: ServiceState,
     client_instance: Option<ArcMut<MQClientInstance>>,
     rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
-    timeout_millis: u64,
+    timeout_millis: Duration,
     kv_namespace_to_delete_list: Vec<CheetahString>,
+}
+
+impl DefaultMQAdminExtImpl {
+    pub fn new(rpc_hook: Option<Arc<Box<dyn RPCHook>>>, timeout_millis: Duration) -> Self {
+        DefaultMQAdminExtImpl {
+            service_state: ServiceState::CreateJust,
+            client_instance: None,
+            rpc_hook,
+            timeout_millis,
+            kv_namespace_to_delete_list: vec![CheetahString::from_static_str(
+                NAMESPACE_ORDER_TOPIC_CONFIG,
+            )],
+        }
+    }
 }
 
 #[allow(unused_variables)]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2548

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced flexible configuration options for administrative operations, allowing users to tailor settings such as timeouts and integration hooks.
  - Enabled customized initialization with preset groups for a more intuitive setup.

- **Refactor**
  - Enhanced timeout management by shifting to a robust duration-based approach, improving precision.
  - Improved namespace configuration handling for a more reliable and seamless administration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->