### PR TITLE
[ISSUE #2552]🚀Implement DefaultMQAdminExt shutdown method🔥

### DIFF
--- a/rocketmq-client/src/admin/mq_admin_ext_async.rs
+++ b/rocketmq-client/src/admin/mq_admin_ext_async.rs
@@ -45,7 +45,7 @@ use crate::Result;
 #[trait_variant::make(MQAdminExt: Send)]
 pub trait MQAdminExtLocal: Sync {
     async fn start(&mut self) -> Result<()>;
-    async fn shutdown(&self);
+    async fn shutdown(&mut self);
     async fn add_broker_to_container(
         &self,
         broker_container_addr: CheetahString,

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -1118,6 +1118,10 @@ impl MQClientInstance {
         self.unregister_client(Some(group.into()), None).await;
     }
 
+    pub async fn unregister_admin_ext(&mut self, group: impl Into<CheetahString>) {
+        let mut write_guard = self.admin_ext_table.write().await;
+        let _ = write_guard.remove(&group.into());
+    }
     async fn unregister_client(
         &mut self,
         producer_group: Option<CheetahString>,

--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -184,8 +184,8 @@ impl MQAdminExt for DefaultMQAdminExt {
         MQAdminExt::start(self.default_mqadmin_ext_impl.as_mut()).await
     }
 
-    async fn shutdown(&self) {
-        todo!()
+    async fn shutdown(&mut self) {
+        MQAdminExt::shutdown(self.default_mqadmin_ext_impl.as_mut()).await
     }
 
     async fn add_broker_to_container(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2552

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled dynamic management of admin extensions by allowing their removal.
  
- **Bug Fixes / Improvements**
  - Improved error messaging during admin extension registration, offering clear guidance when conflicts occur.
  - Enhanced shutdown procedures to ensure reliable state transitions and smoother service operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->