### PR TITLE
[ISSUE #2554]🚀Fix pop consumer can't start🔥

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -98,6 +98,7 @@ impl DefaultMQAdminExtImpl {
         rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
         timeout_millis: Duration,
         client_config: ArcMut<ClientConfig>,
+        admin_ext_group: CheetahString,
     ) -> Self {
         DefaultMQAdminExtImpl {
             service_state: ServiceState::CreateJust,
@@ -108,7 +109,7 @@ impl DefaultMQAdminExtImpl {
                 NAMESPACE_ORDER_TOPIC_CONFIG,
             )],
             client_config,
-            admin_ext_group: Default::default(),
+            admin_ext_group,
             inner: None,
         }
     }

--- a/rocketmq-example/examples/consumer/pop_consumer.rs
+++ b/rocketmq-example/examples/consumer/pop_consumer.rs
@@ -62,6 +62,8 @@ pub async fn main() -> Result<()> {
 
 async fn switch_pop_consumer() -> Result<()> {
     let mut mq_admin_ext = DefaultMQAdminExt::new();
+    mq_admin_ext.client_config_mut().namesrv_addr =
+        Some(CheetahString::from_static_str(DEFAULT_NAMESRVADDR));
     MQAdminExt::start(&mut mq_admin_ext).await.unwrap();
     let broker_datas =
         MQAdminExt::examine_topic_route_info(&mq_admin_ext, CheetahString::from_static_str(TOPIC))

--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -61,18 +61,20 @@ pub struct DefaultMQAdminExt {
 
 impl DefaultMQAdminExt {
     pub fn new() -> Self {
+        let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
         let client_config = ArcMut::new(ClientConfig::new());
         let mut default_mqadmin_ext_impl = ArcMut::new(DefaultMQAdminExtImpl::new(
             None,
             Duration::from_millis(5000),
             client_config.clone(),
+            admin_ext_group.clone(),
         ));
         let inner = default_mqadmin_ext_impl.clone();
         default_mqadmin_ext_impl.set_inner(inner);
         Self {
             client_config,
             default_mqadmin_ext_impl,
-            admin_ext_group: CheetahString::from_static_str(ADMIN_EXT_GROUP),
+            admin_ext_group,
             create_topic_key: CheetahString::from_static_str(
                 TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC,
             ),
@@ -81,6 +83,7 @@ impl DefaultMQAdminExt {
     }
 
     pub fn with_timeout(timeout_millis: Duration) -> Self {
+        let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
         let client_config = ArcMut::new(ClientConfig::new());
         Self {
             client_config: client_config.clone(),
@@ -88,8 +91,9 @@ impl DefaultMQAdminExt {
                 None,
                 timeout_millis,
                 client_config,
+                admin_ext_group.clone(),
             )),
-            admin_ext_group: CheetahString::from_static_str(ADMIN_EXT_GROUP),
+            admin_ext_group,
             create_topic_key: CheetahString::from_static_str(
                 TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC,
             ),
@@ -98,6 +102,7 @@ impl DefaultMQAdminExt {
     }
 
     pub fn with_rpc_hook(rpc_hook: impl RPCHook) -> Self {
+        let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
         let rpc_hook_inner: Box<dyn RPCHook> = Box::new(rpc_hook);
         let client_config = ArcMut::new(ClientConfig::new());
         Self {
@@ -106,8 +111,9 @@ impl DefaultMQAdminExt {
                 Some(Arc::new(rpc_hook_inner)),
                 Duration::from_millis(5000),
                 client_config,
+                admin_ext_group.clone(),
             )),
-            admin_ext_group: CheetahString::from_static_str(ADMIN_EXT_GROUP),
+            admin_ext_group,
             create_topic_key: CheetahString::from_static_str(
                 TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC,
             ),
@@ -116,6 +122,7 @@ impl DefaultMQAdminExt {
     }
 
     pub fn with_rpc_hook_and_timeout(rpc_hook: impl RPCHook, timeout_millis: Duration) -> Self {
+        let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
         let rpc_hook_inner: Box<dyn RPCHook> = Box::new(rpc_hook);
         let client_config = ArcMut::new(ClientConfig::new());
         Self {
@@ -124,8 +131,9 @@ impl DefaultMQAdminExt {
                 Some(Arc::new(rpc_hook_inner)),
                 timeout_millis,
                 client_config,
+                admin_ext_group.clone(),
             )),
-            admin_ext_group: CheetahString::from_static_str(ADMIN_EXT_GROUP),
+            admin_ext_group,
             create_topic_key: CheetahString::from_static_str(
                 TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC,
             ),
@@ -134,6 +142,7 @@ impl DefaultMQAdminExt {
     }
 
     pub fn with_admin_ext_group(admin_ext_group: impl Into<CheetahString>) -> Self {
+        let admin_ext_group = admin_ext_group.into();
         let client_config = ArcMut::new(ClientConfig::new());
         Self {
             client_config: client_config.clone(),
@@ -141,8 +150,9 @@ impl DefaultMQAdminExt {
                 None,
                 Duration::from_millis(5000),
                 client_config,
+                admin_ext_group.clone(),
             )),
-            admin_ext_group: admin_ext_group.into(),
+            admin_ext_group,
             create_topic_key: CheetahString::from_static_str(
                 TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC,
             ),
@@ -154,6 +164,7 @@ impl DefaultMQAdminExt {
         admin_ext_group: impl Into<CheetahString>,
         timeout_millis: Duration,
     ) -> Self {
+        let admin_ext_group = admin_ext_group.into();
         let client_config = ArcMut::new(ClientConfig::new());
         Self {
             client_config: client_config.clone(),
@@ -161,13 +172,24 @@ impl DefaultMQAdminExt {
                 None,
                 timeout_millis,
                 client_config,
+                admin_ext_group.clone(),
             )),
-            admin_ext_group: admin_ext_group.into(),
+            admin_ext_group,
             create_topic_key: CheetahString::from_static_str(
                 TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC,
             ),
             timeout_millis,
         }
+    }
+
+    #[inline]
+    pub fn client_config(&self) -> &ArcMut<ClientConfig> {
+        &self.client_config
+    }
+
+    #[inline]
+    pub fn client_config_mut(&mut self) -> &mut ArcMut<ClientConfig> {
+        &mut self.client_config
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2554

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Administration now supports explicit group configuration for more tailored setup.
  - The consumer now automatically assigns a default nameserver address for improved connectivity.
  - New interfaces allow flexible access to client configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->