### PR TITLE
[ISSUE #2556]🚀Implement DefaultMQAdminExt examine_topic_route_info method🔥

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -348,8 +348,15 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
     async fn examine_topic_route_info(
         &self,
         topic: CheetahString,
-    ) -> crate::Result<TopicRouteData> {
-        todo!()
+    ) -> crate::Result<Option<TopicRouteData>> {
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .mq_client_api_impl
+            .as_ref()
+            .unwrap()
+            .get_topic_route_info_from_name_server(&topic, self.timeout_millis.as_millis() as u64)
+            .await
     }
 
     async fn examine_consumer_connection_info(

--- a/rocketmq-client/src/admin/mq_admin_ext_async.rs
+++ b/rocketmq-client/src/admin/mq_admin_ext_async.rs
@@ -159,7 +159,10 @@ pub trait MQAdminExtLocal: Sync {
 
     async fn examine_broker_cluster_info(&self) -> Result<ClusterInfo>;
 
-    async fn examine_topic_route_info(&self, topic: CheetahString) -> Result<TopicRouteData>;
+    async fn examine_topic_route_info(
+        &self,
+        topic: CheetahString,
+    ) -> Result<Option<TopicRouteData>>;
 
     async fn examine_consumer_connection_info(
         &self,

--- a/rocketmq-example/examples/consumer/pop_consumer.rs
+++ b/rocketmq-example/examples/consumer/pop_consumer.rs
@@ -68,6 +68,7 @@ async fn switch_pop_consumer() -> Result<()> {
     let broker_datas =
         MQAdminExt::examine_topic_route_info(&mq_admin_ext, CheetahString::from_static_str(TOPIC))
             .await
+            .unwrap()
             .unwrap();
     for broker_data in broker_datas.broker_datas {
         let broker_addrs = broker_data
@@ -90,6 +91,7 @@ async fn switch_pop_consumer() -> Result<()> {
             .unwrap();
         }
     }
+    mq_admin_ext.shutdown().await;
     Ok(())
 }
 

--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -366,8 +366,10 @@ impl MQAdminExt for DefaultMQAdminExt {
     async fn examine_topic_route_info(
         &self,
         topic: CheetahString,
-    ) -> rocketmq_client_rust::Result<TopicRouteData> {
-        todo!()
+    ) -> rocketmq_client_rust::Result<Option<TopicRouteData>> {
+        self.default_mqadmin_ext_impl
+            .examine_topic_route_info(topic)
+            .await
     }
 
     async fn examine_consumer_connection_info(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2556

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced topic routing information retrieval now supports cases where no routing data is available.
  - Improved asynchronous handling for retrieving topic information.
  - Added explicit shutdown in consumer operations to ensure proper resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->