### PR TITLE
[ISSUE #1675]Optimize MessageListenerOrderly#consume_message method signature

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -615,7 +615,7 @@ impl ConsumeRequest {
 
                 match consume_message_orderly_service_inner
                     .message_listener
-                    .consume_message(&vec, &mut context)
+                    .consume_message(vec, &mut context)
                 {
                     Ok(value) => {
                         status = Some(value);

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -410,7 +410,8 @@ impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
         let begin_timestamp = Instant::now();
 
         let status = self.message_listener.consume_message(
-            &msgs.iter()
+            &msgs
+                .iter()
                 .map(|msg| msg.as_ref())
                 .collect::<Vec<&MessageExt>>()[..],
             &mut context,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -410,10 +410,9 @@ impl ConsumeMessageServiceTrait for ConsumeMessageOrderlyService {
         let begin_timestamp = Instant::now();
 
         let status = self.message_listener.consume_message(
-            &msgs
-                .iter()
+            &msgs.iter()
                 .map(|msg| msg.as_ref())
-                .collect::<Vec<&MessageExt>>(),
+                .collect::<Vec<&MessageExt>>()[..],
             &mut context,
         );
         let mut result = ConsumeMessageDirectlyResult::default();
@@ -608,10 +607,10 @@ impl ConsumeRequest {
                     );
                     break;
                 }
-                let vec = msgs
+                let vec = &msgs
                     .iter()
                     .map(|msg| msg.as_ref())
-                    .collect::<Vec<&MessageExt>>();
+                    .collect::<Vec<&MessageExt>>()[..];
 
                 match consume_message_orderly_service_inner
                     .message_listener

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -136,7 +136,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
             &msgs
                 .iter()
                 .map(|msg| msg.as_ref())
-                .collect::<Vec<&MessageExt>>(),
+                .collect::<Vec<&MessageExt>>()[..],
             &mut context,
         );
         let mut result = ConsumeMessageDirectlyResult::default();


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

###  Optimize MessageListenerOrderly#consume_message method signature 

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #1675 

### I have updated the cosume_message method signature.

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### To test the changes, I had run `cargo build` command and no error occurred during this build.

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal message processing in orderly consumer components for consistent handling, ensuring smoother operation without affecting existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->