### PR TITLE
[ISSUE #2583] Optimize order_count_info String capacity 

### DIFF
--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -520,7 +520,11 @@ where
         }
         let mut start_offset_info = String::with_capacity(64);
         let mut msg_offset_info = String::with_capacity(64);
-        let mut order_count_info = String::with_capacity(64);
+        let mut order_count_info = if request_header.order.is_some() {
+            String::with_capacity(64)
+        } else {
+            String::new()
+        };
         let pop_time = get_current_millis();
 
         let message_filter = message_filter.map(Arc::new);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)
When request_header.order is order then string with capacity is instantiated else with no capacity.






<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2583 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

cargo test --all-features --workspace
cargo fmt --all -- --check
<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized message processing by dynamically adjusting resource allocation based on whether ordering details are provided, reducing unnecessary memory usage in scenarios without order information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->