### PR TITLE
[ISSUE #2618]🐛Fix PopMessageRequestHeader#is_timeout_too_much attempt to subtract with overflow🔥

### DIFF
--- a/rocketmq-remoting/src/protocol/header/pop_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pop_message_request_header.rs
@@ -54,7 +54,7 @@ pub struct PopMessageRequestHeader {
 
 impl PopMessageRequestHeader {
     pub fn is_timeout_too_much(&self) -> bool {
-        get_current_millis() - self.born_time - self.poll_time > 500
+        get_current_millis() as i64 - self.born_time as i64 - self.poll_time as i64 > 500
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2618

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the consistency of message timeout checks to ensure more reliable processing by addressing numeric handling discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->