### PR TITLE
[ISSUE #2651]🐛Request PopMessage return not response header🔥

### DIFF
--- a/rocketmq-remoting/src/protocol/header/extra_info_util.rs
+++ b/rocketmq-remoting/src/protocol/header/extra_info_util.rs
@@ -808,7 +808,7 @@ mod tests {
     fn build_msg_offset_info_creates_correct_string() {
         let mut string_builder = String::new();
         ExtraInfoUtil::build_msg_offset_info(&mut string_builder, "topic", 7, vec![100, 200, 300]);
-        assert_eq!(string_builder, "0 7100,200,300");
+        assert_eq!(string_builder, "0 7 100,200,300");
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/header/extra_info_util.rs
+++ b/rocketmq-remoting/src/protocol/header/extra_info_util.rs
@@ -291,10 +291,11 @@ impl ExtraInfoUtil {
             string_builder.push(';');
         }
         string_builder.push_str(&format!(
-            "{}{}{}",
+            "{}{}{}{}",
             retry,
             MessageConst::KEY_SEPARATOR,
-            queue_id
+            queue_id,
+            MessageConst::KEY_SEPARATOR,
         ));
         for (i, msg_offset) in msg_offsets.iter().enumerate() {
             string_builder.push_str(&msg_offset.to_string());


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2651

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined message retrieval and response processing, leading to more consistent handling and improved clarity.
- **Style**
  - Enhanced the formatting of message metadata by adding an extra separator for a uniform display.
- **Chores**
  - Removed obsolete comments and redundant code to improve overall maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->