### PR TITLE
[ISSUE #2657] 🐛PopMessageProcessor#pop_msg_from_queue's atomic_rest_n…

### DIFF
--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -963,18 +963,7 @@ where
         let final_offset = offset;
 
         let result = match get_message_result_inner {
-            None => {
-                let num = self
-                    .broker_runtime_inner
-                    .message_store()
-                    .as_ref()
-                    .unwrap()
-                    .get_max_offset_in_queue(topic, queue_id)
-                    - atomic_offset.load(Ordering::Acquire)
-                    + atomic_rest_num.load(Ordering::Acquire);
-                atomic_rest_num.store(num, Ordering::Release);
-                None
-            }
+            None => None,
             Some(value) => {
                 if value.status().is_none() {
                     Some(value)


### PR DESCRIPTION
…um repeatedly store value

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2657

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the message processing flow so that when no message is available, it now returns immediately without extra computations.
  - Maintained existing behavior for valid messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->