### PR TITLE
[ISSUE #2668]🐛PopBufferMergeService start wait time incorrect🍻

### DIFF
--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -595,7 +595,7 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
                         if this.scan_times % this.count_of_second30 == 0 {
                             this.mut_from_ref().scan_garbage();
                         }
-                        tokio::time::sleep(tokio::time::Duration::from_millis(interval)).await;
+                        tokio::time::sleep(tokio::time::Duration::from_millis(this.interval)).await;
                         if !this.serving.load(Ordering::Acquire) && this.buffer.is_empty()  && this.get_offset_total_size() == 0 {
                             this.serving.store(true,Ordering::Release);
                         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2668

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the scheduling of background operations to use a dynamic interval, enhancing the consistency and responsiveness of continuous background tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->