### PR TITLE
[ISSUE #2678]🐛Fix PopBufferMergeService#put_offset_queue logic not correct

### DIFF
--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -734,12 +734,12 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
 
         self.put_offset_queue(ArcMut::new(point_wrapper)).await;
     }
-
     async fn put_offset_queue(&self, point_wrapper: ArcMut<PopCheckPointWrapper>) -> bool {
-        let queue = self
+        let mut queue = self
             .commit_offsets
             .entry(point_wrapper.lock_key.clone())
             .or_insert(QueueWithTime::new());
+        queue.set_time(point_wrapper.get_ck().pop_time as u64);
         let mut guard = queue.get().lock().await;
         guard.push_back(point_wrapper);
         true


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2678

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message processing reliability by ensuring that checkpoint timestamps are updated consistently during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->