### PR TITLE
[ISSUE #2680]🐛Fix set PopRequest message_filter some times is none

### DIFF
--- a/rocketmq-broker/src/long_polling/pop_request.rs
+++ b/rocketmq-broker/src/long_polling/pop_request.rs
@@ -34,7 +34,7 @@ pub struct PopRequest {
     op: i64,
     expired: u64,
     subscription_data: SubscriptionData,
-    message_filter: Arc<Box<dyn MessageFilter>>,
+    message_filter: Option<Arc<Box<dyn MessageFilter>>>,
 }
 
 impl PopRequest {
@@ -43,7 +43,7 @@ impl PopRequest {
         ctx: ConnectionHandlerContext,
         expired: u64,
         subscription_data: SubscriptionData,
-        message_filter: Arc<Box<dyn MessageFilter>>,
+        message_filter: Option<Arc<Box<dyn MessageFilter>>>,
     ) -> Self {
         static COUNTER: AtomicI64 = AtomicI64::new(i64::MIN);
         let op = COUNTER.fetch_add(1, Ordering::SeqCst);
@@ -94,8 +94,8 @@ impl PopRequest {
         &self.subscription_data
     }
 
-    pub fn get_message_filter(&self) -> &Arc<Box<dyn MessageFilter>> {
-        &self.message_filter
+    pub fn get_message_filter(&self) -> Option<&Arc<Box<dyn MessageFilter>>> {
+        self.message_filter.as_ref()
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2680

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved potential issues during message retrieval by checking filter availability before processing, reducing the risk of unexpected interruptions.
  
- **Refactor**
  - Streamlined the handling of message filters for long polling, now gracefully accommodating scenarios where filters may be absent, leading to improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->