### PR TITLE
[ISSUE #2687]⚡️Remove PopBufferMergeService print debug log🍻

### DIFF
--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -627,27 +627,13 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
                     break;
                 }
                 let point_wrapper = point_wrapper.unwrap();
-
-                println!(
-                    "======{}={}={}={}===",
-                    point_wrapper.is_just_offset(),
-                    point_wrapper.is_ck_stored(),
-                    is_ck_done(point_wrapper),
-                    is_ck_done_for_finish(point_wrapper),
-                );
-
                 if point_wrapper.is_just_offset() && point_wrapper.is_ck_stored()
                     || is_ck_done(point_wrapper)
                     || is_ck_done_for_finish(point_wrapper) && point_wrapper.is_ck_stored()
                 {
                     if self.commit_offset(point_wrapper.as_ref()).await {
-                        let option = queue.pop_front();
-                        println!(
-                            "========================11111111111111111===================={:?}",
-                            option
-                        );
+                        queue.pop_front();
                     } else {
-                        println!("========================2222222222222222====================");
                         break;
                     }
                 } else {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2687

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed redundant debug output to streamline internal operations while keeping the end-user experience unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->