### PR TITLE
[ISSUE #2718]Fix PopRequest#complete return value not correct

### DIFF
--- a/rocketmq-broker/src/long_polling/pop_request.rs
+++ b/rocketmq-broker/src/long_polling/pop_request.rs
@@ -82,8 +82,8 @@ impl PopRequest {
 
     pub fn complete(&self) -> bool {
         self.complete
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .unwrap_or_default()
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
+            .is_ok()
     }
 
     pub fn get_expired(&self) -> u64 {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2718

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the mechanism for confirming the completion of asynchronous operations. This update ensures that successes are accurately detected, eliminating reliance on default fallback values, which leads to more consistent and reliable behavior in long-polling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->