### PR TITLE
[ISSUE #2733]🚀Add HAConnectionStateNotificationRequest

### DIFF
--- a/rocketmq-store/src/ha.rs
+++ b/rocketmq-store/src/ha.rs
@@ -16,4 +16,5 @@
  */
 
 pub(crate) mod ha_connection_state;
+pub(crate) mod ha_connection_state_notification_request;
 pub(crate) mod wait_notify_object;

--- a/rocketmq-store/src/ha/ha_connection_state_notification_request.rs
+++ b/rocketmq-store/src/ha/ha_connection_state_notification_request.rs
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use parking_lot::Mutex;
+use tokio::sync::oneshot;
+
+use crate::ha::ha_connection_state::HAConnectionState;
+
+/// Request to be notified when a connection reaches a specific state
+///
+/// This struct is used to register interest in a connection state change and
+/// receive notification when the expected state is reached.
+pub struct HAConnectionStateNotificationRequest {
+    /// Channel for receiving the notification result
+    notification_sender: Mutex<Option<oneshot::Sender<bool>>>,
+
+    /// The connection state we're waiting for
+    expect_state: HAConnectionState,
+
+    /// Remote address of the connection we're interested in
+    remote_addr: String,
+
+    /// Whether to notify when the connection is shut down, even if it doesn't reach the expected
+    /// state
+    notify_when_shutdown: bool,
+}
+
+impl HAConnectionStateNotificationRequest {
+    /// Create a new notification request
+    ///
+    /// # Parameters
+    /// * `expect_state` - The connection state we're waiting for
+    /// * `remote_addr` - Remote address of the connection we're interested in
+    /// * `notify_when_shutdown` - Whether to notify when the connection is shut down
+    pub fn new(
+        expect_state: HAConnectionState,
+        remote_addr: &str,
+        notify_when_shutdown: bool,
+    ) -> (Self, oneshot::Receiver<bool>) {
+        let (sender, receiver) = oneshot::channel();
+
+        (
+            Self {
+                notification_sender: Mutex::new(Some(sender)),
+                expect_state,
+                remote_addr: remote_addr.to_string(),
+                notify_when_shutdown,
+            },
+            receiver,
+        )
+    }
+
+    /// Get the expected state
+    pub fn expect_state(&self) -> HAConnectionState {
+        self.expect_state
+    }
+
+    /// Get the remote address
+    pub fn remote_addr(&self) -> &str {
+        &self.remote_addr
+    }
+
+    /// Check if notification should be sent when connection is shut down
+    pub fn notify_when_shutdown(&self) -> bool {
+        self.notify_when_shutdown
+    }
+
+    /// Complete the request with the given result
+    ///
+    /// This will send the notification to the waiting receiver.
+    ///
+    /// # Returns
+    /// `true` if the notification was successfully sent, `false` if the receiver was dropped
+    pub fn complete(&self, result: bool) -> bool {
+        let mut sender_guard = self.notification_sender.lock();
+        if let Some(sender) = sender_guard.take() {
+            sender.send(result).is_ok()
+        } else {
+            false // Sender was already consumed
+        }
+    }
+}
+
+// Example usage:
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ha::ha_connection_state::HAConnectionState;
+
+    #[tokio::test]
+    async fn test_notification_request() {
+        // Create a notification request
+        let (request, receiver) = HAConnectionStateNotificationRequest::new(
+            HAConnectionState::Transfer,
+            "127.0.0.1:9876",
+            true,
+        );
+
+        // Check getters
+        assert_eq!(request.expect_state(), HAConnectionState::Transfer);
+        assert_eq!(request.remote_addr(), "127.0.0.1:9876");
+        assert_eq!(request.notify_when_shutdown(), true);
+
+        // Complete the request
+        assert!(request.complete(true));
+
+        // Verify the result was received
+        assert_eq!(receiver.await.unwrap(), true);
+
+        // Completing again should fail
+        assert!(!request.complete(false));
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2733

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a connectivity notification feature that lets users register interest in connection state changes and receive timely alerts when a specific state is reached.

- **Tests**
  - Added validations to ensure the notification mechanism operates reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->