### PR TITLE
[ISSUE #2747]♻️Refactor LocalFileMessageStore start method🍻

### DIFF
--- a/rocketmq-store/src/base/allocate_mapped_file_service.rs
+++ b/rocketmq-store/src/base/allocate_mapped_file_service.rs
@@ -23,6 +23,7 @@ use std::sync::mpsc::Sender;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
+use tracing::error;
 
 use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 
@@ -58,51 +59,11 @@ impl AllocateMappedFileService {
     ) -> DefaultMappedFile {
         unimplemented!()
     }
+
+    pub fn start(&self) {
+        error!("AllocateMappedFileService start failed, not implement yet");
+    }
 }
-
-/*impl ThreadService for AllocateMappedFileService {
-    fn start(&self) {
-        let service_name = self.get_service_name();
-        let builder = std::thread::Builder::new().name(service_name);
-        let rx = self.rx.clone();
-        let request_table = self.request_table.clone();
-        let _ = builder
-            .spawn(move || loop {
-                match rx.lock().recv() {
-                    Ok(ref req) => {
-                        let guard = request_table.lock();
-                        let expected_request = guard.get(&req.file_path);
-                        if expected_request.is_none() {
-                            warn!(
-                                "this mmap request expired, maybe cause timeout {} {}",
-                                req.file_path, req.file_size,
-                            );
-                            continue;
-                        }
-                        if expected_request.unwrap() != req {
-                            warn!(
-                                "this mmap request expired, maybe cause timeout {} {}",
-                                req.file_path, req.file_size,
-                            );
-                            continue;
-                        }
-                        if req.mapped_file.is_none() {}
-                    }
-                    Err(err) => {
-                        error!("{}", err)
-                    }
-                }
-            })
-            .unwrap()
-            .join();
-    }
-
-    fn shutdown(&self) {}
-
-    fn get_service_name(&self) -> String {
-        "AllocateMappedFileService".to_string()
-    }
-}*/
 
 struct AllocateRequest {
     file_path: String,

--- a/rocketmq-store/src/base/store_stats_service.rs
+++ b/rocketmq-store/src/base/store_stats_service.rs
@@ -27,6 +27,7 @@ use parking_lot::RwLock;
 use rocketmq_common::common::broker::broker_config::BrokerIdentity;
 use rocketmq_common::common::system_clock::SystemClock;
 use rocketmq_common::TimeUtils::get_current_millis;
+use tracing::error;
 
 const FREQUENCY_OF_SAMPLING: u64 = 1000;
 const MAX_RECORDS_OF_SAMPLING: usize = 60 * 10;
@@ -118,6 +119,10 @@ impl StoreStatsService {
 }
 
 impl StoreStatsService {
+    pub fn start(&self) {
+        error!("StoreStatsService start not implemented");
+    }
+
     #[inline]
     pub fn get_message_times_total_found(&self) -> &AtomicUsize {
         &self.get_message_times_total_found

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -206,6 +206,7 @@ pub struct MessageStoreConfig {
     pub enable_rocksdb_log: bool,
     pub topic_queue_lock_num: usize,
     pub max_filter_message_size: i32,
+    pub enable_dleger_commit_log: bool,
 }
 
 impl Default for MessageStoreConfig {
@@ -393,6 +394,7 @@ impl Default for MessageStoreConfig {
             enable_rocksdb_log: false,
             topic_queue_lock_num: 32,
             max_filter_message_size: 16000,
+            enable_dleger_commit_log: false,
         }
     }
 }

--- a/rocketmq-store/src/index/index_service.rs
+++ b/rocketmq-store/src/index/index_service.rs
@@ -65,6 +65,10 @@ impl IndexService {
         }
     }
 
+    pub fn start(&self) {
+        //nothing to do
+    }
+
     #[inline]
     pub fn load(&mut self, last_exit_ok: bool) -> bool {
         let dir = Path::new(&self.store_path);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2747

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to enable commit logging.
  - Added placeholder methods to initialize statistics and indexing services.
  - Integrated high-availability checks and a consume queue flush mechanism in the messaging store.

- **Refactor**
  - Streamlined the file allocation component by removing redundant thread management routines and replacing core operations with error notifications.
  - Updated public interfaces to consolidate service operations and reduce legacy functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->