### PR TITLE
[ISSUE #2749]♻️Refactor LocalFileMessageStore shutdown method🍻

### DIFF
--- a/rocketmq-store/src/base/allocate_mapped_file_service.rs
+++ b/rocketmq-store/src/base/allocate_mapped_file_service.rs
@@ -63,6 +63,10 @@ impl AllocateMappedFileService {
     pub fn start(&self) {
         error!("AllocateMappedFileService start failed, not implement yet");
     }
+
+    pub fn shutdown(&self) {
+        error!("AllocateMappedFileService shutdown failed, not implement yet");
+    }
 }
 
 struct AllocateRequest {

--- a/rocketmq-store/src/base/store_stats_service.rs
+++ b/rocketmq-store/src/base/store_stats_service.rs
@@ -123,6 +123,10 @@ impl StoreStatsService {
         error!("StoreStatsService start not implemented");
     }
 
+    pub fn shutdown(&self) {
+        error!("StoreStatsService shutdown not implemented");
+    }
+
     #[inline]
     pub fn get_message_times_total_found(&self) -> &AtomicUsize {
         &self.get_message_times_total_found

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -207,6 +207,7 @@ pub struct MessageStoreConfig {
     pub topic_queue_lock_num: usize,
     pub max_filter_message_size: i32,
     pub enable_dleger_commit_log: bool,
+    pub rocksdb_cq_double_write_enable: bool,
 }
 
 impl Default for MessageStoreConfig {
@@ -395,6 +396,7 @@ impl Default for MessageStoreConfig {
             topic_queue_lock_num: 32,
             max_filter_message_size: 16000,
             enable_dleger_commit_log: false,
+            rocksdb_cq_double_write_enable: false,
         }
     }
 }

--- a/rocketmq-store/src/index/index_service.rs
+++ b/rocketmq-store/src/index/index_service.rs
@@ -69,6 +69,10 @@ impl IndexService {
         //nothing to do
     }
 
+    pub fn shutdown(&self) {
+        error!("StoreStatsService shutdown not implemented");
+    }
+
     #[inline]
     pub fn load(&mut self, last_exit_ok: bool) -> bool {
         let dir = Path::new(&self.store_path);

--- a/rocketmq-store/src/kv/compaction_service.rs
+++ b/rocketmq-store/src/kv/compaction_service.rs
@@ -14,15 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use tracing::error;
+
 #[derive(Default, Clone)]
 pub struct CompactionService {}
 
 impl CompactionService {
     pub fn load(&mut self, exit_ok: bool) -> bool {
-        println!(
+        error!(
             "[unimplemented]load compaction service, exit ok: {}",
             exit_ok
         );
         true
+    }
+
+    pub fn shutdown(&self) {
+        error!("[unimplemented]shutdown compaction service");
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2749

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shutdown interfaces across several services, setting the stage for future graceful termination.
  - Introduced a new configuration option to control a double-write feature for enhanced storage reliability (disabled by default).

- **Refactor**
  - Enhanced logging and refined the shutdown sequence in local storage operations, ensuring a more orderly cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->