### PR TITLE
[ISSUE #2753]🚀Implement LocalFileMessageStore destroy method🍻

### DIFF
--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -70,7 +70,7 @@ pub trait MessageStoreInner {
 
     /// Destroy this message store.
     /// Generally, all persistent files should be removed after invocation.
-    fn destroy(&self);
+    fn destroy(&mut self);
 
     /// Store a message into the store in async manner.
     ///

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -265,9 +265,13 @@ impl CommitLog {
         });
     }
 
-    pub fn shutdown(&mut self) {}
+    pub fn shutdown(&mut self) {
+        error!("shutdown commit log unimplemented");
+    }
 
-    pub fn destroy(&mut self) {}
+    pub fn destroy(&mut self) {
+        error!("destroy commit log unimplemented");
+    }
 
     pub fn get_message(&self, offset: i64, size: i32) -> Option<SelectMappedBufferResult> {
         let mapped_file_size = self.message_store_config.mapped_file_size_commit_log;

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -706,8 +706,16 @@ impl MessageStoreRefactor for LocalFileMessageStore {
         self.transient_store_pool.destroy();
     }
 
-    fn destroy(&self) {
-        todo!()
+    fn destroy(&mut self) {
+        self.consume_queue_store.destroy();
+        self.commit_log.destroy();
+        self.index_service.destroy();
+        self.delete_file(get_abort_file(
+            self.message_store_config.store_path_root_dir.as_str(),
+        ));
+        self.delete_file(get_store_checkpoint(
+            self.message_store_config.store_path_root_dir.as_str(),
+        ));
     }
 
     async fn async_put_message(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2753

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated cleanup procedures to enable in-place state modifications during resource destruction.
- **Chores**
	- Introduced error logging in shutdown and destroy operations for improved operational feedback.
	- Enhanced local file message store cleanup by fully invoking related component shutdown and removing associated resource files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->