### PR TITLE
[ISSUE #2762]♻️Refactor LocalFileMessageStore get queue offset

### DIFF
--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -174,20 +174,24 @@ pub trait MessageStoreInner {
     ) -> Result<GetMessageResult, StoreError>;*/
 
     /// Get maximum offset of the topic queue.
-    fn get_max_offset_in_queue(&self, topic: &str, queue_id: i32) -> i64;
+    fn get_max_offset_in_queue(&self, topic: &CheetahString, queue_id: i32) -> i64;
 
     /// Get maximum offset of the topic queue.
-    fn get_max_offset_in_queue_committed(&self, topic: &str, queue_id: i32, committed: bool)
-        -> i64;
+    fn get_max_offset_in_queue_committed(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        committed: bool,
+    ) -> i64;
 
     /// Get the minimum offset of the topic queue.
-    fn get_min_offset_in_queue(&self, topic: &str, queue_id: i32) -> i64;
+    fn get_min_offset_in_queue(&self, topic: &CheetahString, queue_id: i32) -> i64;
 
     /// Get the timer message store.
-    fn get_timer_message_store(&self) -> Option<Arc<TimerMessageStore>>;
+    fn get_timer_message_store(&self) -> &Arc<TimerMessageStore>;
 
     /// Set the timer message store.
-    fn set_timer_message_store(&self, timer_message_store: Arc<TimerMessageStore>);
+    fn set_timer_message_store(&mut self, timer_message_store: Arc<TimerMessageStore>);
 
     /// Get the offset of the message in the commit log (physical offset).
     fn get_commit_log_offset_in_queue(

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1097,29 +1097,43 @@ impl MessageStoreRefactor for LocalFileMessageStore {
 
     }*/
 
-    fn get_max_offset_in_queue(&self, topic: &str, queue_id: i32) -> i64 {
-        todo!()
+    fn get_max_offset_in_queue(&self, topic: &CheetahString, queue_id: i32) -> i64 {
+        self.get_max_offset_in_queue_committed(topic, queue_id, true)
     }
 
     fn get_max_offset_in_queue_committed(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         committed: bool,
     ) -> i64 {
-        todo!()
+        if committed {
+            let queue = self
+                .consume_queue_store
+                .find_or_create_consume_queue(topic, queue_id);
+
+            queue.get_max_offset_in_queue()
+        } else {
+            self.consume_queue_store
+                .get_max_offset(topic, queue_id)
+                .unwrap_or_default()
+        }
     }
 
-    fn get_min_offset_in_queue(&self, topic: &str, queue_id: i32) -> i64 {
-        todo!()
+    #[inline]
+    fn get_min_offset_in_queue(&self, topic: &CheetahString, queue_id: i32) -> i64 {
+        self.consume_queue_store
+            .get_min_offset_in_queue(topic, queue_id)
     }
 
-    fn get_timer_message_store(&self) -> Option<Arc<TimerMessageStore>> {
-        todo!()
+    #[inline]
+    fn get_timer_message_store(&self) -> &Arc<TimerMessageStore> {
+        &self.timer_message_store
     }
 
-    fn set_timer_message_store(&self, timer_message_store: Arc<TimerMessageStore>) {
-        todo!()
+    #[inline]
+    fn set_timer_message_store(&mut self, timer_message_store: Arc<TimerMessageStore>) {
+        self.timer_message_store = timer_message_store;
     }
 
     fn get_commit_log_offset_in_queue(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2762

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Finalized implementations for offset retrieval and timer management, eliminating previously incomplete behaviors.
- **Refactor**
	- Enhanced type consistency and refined method interfaces for improved reliability and performance in message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->