### PR TITLE
[ISSUE #2764]♻️Refactor LocalFileMessageStore look message by offset

### DIFF
--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -214,27 +214,27 @@ pub trait MessageStoreInner {
     ) -> i64;
 
     /// Look up the message by given commit log offset.
-    fn look_message_by_offset(&self, commit_log_offset: i64) -> Result<MessageExt, StoreError>;
+    fn look_message_by_offset(&self, commit_log_offset: i64) -> Option<MessageExt>;
 
     /// Look up the message by given commit log offset and size.
-    fn look_message_by_offset_and_size(
+    fn look_message_by_offset_with_size(
         &self,
         commit_log_offset: i64,
         size: i32,
-    ) -> Result<MessageExt, StoreError>;
+    ) -> Option<MessageExt>;
 
     /// Get one message from the specified commit log offset.
     fn select_one_message_by_offset(
         &self,
         commit_log_offset: i64,
-    ) -> Result<SelectMappedBufferResult, StoreError>;
+    ) -> Option<SelectMappedBufferResult>;
 
     /// Get one message from the specified commit log offset and message size.
-    fn select_one_message_by_offset_and_size(
+    fn select_one_message_by_offset_with_size(
         &self,
         commit_log_offset: i64,
         msg_size: i32,
-    ) -> Result<SelectMappedBufferResult, StoreError>;
+    ) -> Option<SelectMappedBufferResult>;
 
     /// Get the running information of this store.
     fn get_running_data_info(&self) -> String;

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1159,31 +1159,51 @@ impl MessageStoreRefactor for LocalFileMessageStore {
         todo!()
     }
 
-    fn look_message_by_offset(&self, commit_log_offset: i64) -> Result<MessageExt, StoreError> {
-        todo!()
+    fn look_message_by_offset(&self, commit_log_offset: i64) -> Option<MessageExt> {
+        if let Some(sbr) = self.commit_log.get_message(commit_log_offset, 4) {
+            let size = sbr.get_buffer().get_i32();
+            self.look_message_by_offset_with_size(commit_log_offset, size)
+        } else {
+            None
+        }
     }
 
-    fn look_message_by_offset_and_size(
+    fn look_message_by_offset_with_size(
         &self,
         commit_log_offset: i64,
         size: i32,
-    ) -> Result<MessageExt, StoreError> {
-        todo!()
+    ) -> Option<MessageExt> {
+        let sbr = self.commit_log.get_message(commit_log_offset, size);
+        if let Some(sbr) = sbr {
+            if let Some(mut value) = sbr.get_bytes() {
+                MessageDecoder::decode(&mut value, true, false, false, false, false)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
     }
 
     fn select_one_message_by_offset(
         &self,
         commit_log_offset: i64,
-    ) -> Result<SelectMappedBufferResult, StoreError> {
-        todo!()
+    ) -> Option<SelectMappedBufferResult> {
+        let sbr = self.commit_log.get_message(commit_log_offset, 4);
+        if let Some(sbr) = sbr {
+            let size = sbr.get_buffer().get_i32();
+            self.commit_log.get_message(commit_log_offset, size)
+        } else {
+            None
+        }
     }
 
-    fn select_one_message_by_offset_and_size(
+    fn select_one_message_by_offset_with_size(
         &self,
         commit_log_offset: i64,
         msg_size: i32,
-    ) -> Result<SelectMappedBufferResult, StoreError> {
-        todo!()
+    ) -> Option<SelectMappedBufferResult> {
+        self.commit_log.get_message(commit_log_offset, msg_size)
     }
 
     fn get_running_data_info(&self) -> String {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2764

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified message retrieval operations by replacing error-prone responses with direct absence indicators.
  - Updated lookup and selection methods to return a direct indicator when a message is not found.
  - Streamlined the message access workflow for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->