### PR TITLE
[ISSUE #2770]🚀Implement earlist message time

### DIFF
--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -49,7 +49,6 @@ use crate::log_file::commit_log::CommitLog;
 use crate::log_file::mapped_file::MappedFile;
 use crate::queue::ArcConsumeQueue;
 use crate::queue::ConsumeQueueStoreTrait;
-use crate::queue::ConsumeQueueTrait;
 use crate::stats::broker_stats_manager::BrokerStatsManager;
 use crate::store::running_flags::RunningFlags;
 use crate::store_error::StoreError;
@@ -254,22 +253,22 @@ pub trait MessageStoreInner {
     fn get_min_phy_offset(&self) -> i64;
 
     /// Get the store time of the earliest message in the given queue.
-    fn get_earliest_message_time(&self, topic: &str, queue_id: i32) -> i64;
+    fn get_earliest_message_time(&self, topic: &CheetahString, queue_id: i32) -> i64;
 
     /// Get the store time of the earliest message in this store.
     fn get_earliest_message_time_store(&self) -> i64;
 
-    /// Asynchronous get the store time of the earliest message in this store.
+    /*    /// Asynchronous get the store time of the earliest message in this store.
     async fn get_earliest_message_time_async(
         &self,
         topic: &str,
         queue_id: i32,
-    ) -> Result<i64, StoreError>;
+    ) -> Result<i64, StoreError>;*/
 
     /// Get the store time of the message specified.
     fn get_message_store_time_stamp(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         consume_queue_offset: i64,
     ) -> i64;
@@ -277,7 +276,7 @@ pub trait MessageStoreInner {
     /// Asynchronous get the store time of the message specified.
     async fn get_message_store_time_stamp_async(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         consume_queue_offset: i64,
     ) -> Result<i64, StoreError>;
@@ -397,10 +396,10 @@ pub trait MessageStoreInner {
     fn add_dispatcher(&self, dispatcher: Arc<dyn CommitLogDispatcher>);
 
     /// Get consume queue of the topic/queue. If not exist, returns None.
-    fn get_consume_queue(&self, topic: &str, queue_id: i32) -> Option<Arc<dyn ConsumeQueueTrait>>;
+    fn get_consume_queue(&self, topic: &CheetahString, queue_id: i32) -> Option<ArcConsumeQueue>;
 
     /// Get consume queue of the topic/queue. If not exist, creates one.
-    fn find_consume_queue(&self, topic: &str, queue_id: i32) -> Option<ArcConsumeQueue>;
+    fn find_consume_queue(&self, topic: &CheetahString, queue_id: i32) -> Option<ArcConsumeQueue>;
 
     /// Get BrokerStatsManager of the messageStore.
     fn get_broker_stats_manager(&self) -> Arc<BrokerStatsManager>;

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1490,11 +1490,11 @@ impl MessageStoreRefactor for LocalFileMessageStore {
         todo!()
     }
 
-    fn get_consume_queue(&self, topic: &str, queue_id: i32) -> Option<Arc<dyn ConsumeQueueTrait>> {
+    fn get_consume_queue(&self, topic: &CheetahString, queue_id: i32) -> Option<ArcConsumeQueue> {
         todo!()
     }
 
-    fn find_consume_queue(&self, topic: &str, queue_id: i32) -> Option<ArcConsumeQueue> {
+    fn find_consume_queue(&self, topic: &CheetahString, queue_id: i32) -> Option<ArcConsumeQueue> {
         todo!()
     }
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -22,6 +22,7 @@ use std::collections::HashSet;
 use std::error::Error;
 use std::fs;
 use std::future::Future;
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
@@ -1277,46 +1278,81 @@ impl MessageStoreRefactor for LocalFileMessageStore {
         result
     }
 
+    #[inline]
     fn get_max_phy_offset(&self) -> i64 {
-        todo!()
+        self.commit_log.get_max_offset()
     }
 
+    #[inline]
     fn get_min_phy_offset(&self) -> i64 {
-        todo!()
+        self.commit_log.get_min_offset()
     }
 
-    fn get_earliest_message_time(&self, topic: &str, queue_id: i32) -> i64 {
-        todo!()
+    fn get_earliest_message_time(&self, topic: &CheetahString, queue_id: i32) -> i64 {
+        if let Some(logic_queue) = self.get_consume_queue(topic, queue_id) {
+            if let Some(cq) = logic_queue.get_earliest_unit_and_store_time() {
+                return cq.1;
+            }
+        }
+        -1
     }
 
     fn get_earliest_message_time_store(&self) -> i64 {
-        todo!()
+        let min_phy_offset = self.get_min_phy_offset();
+
+        //Rust not support DLedgerCommitLog
+        /*if (this.getCommitLog() instanceof DLedgerCommitLog) {
+            minPhyOffset += DLedgerEntry.BODY_OFFSET;
+        }*/
+
+        let mut size = MessageDecoder::MESSAGE_STORE_TIMESTAMP_POSITION + 8;
+        let result = self
+            .broker_config
+            .broker_ip1
+            .to_string()
+            .parse::<IpAddr>()
+            .unwrap();
+        if result.is_ipv6() {
+            size = MessageDecoder::MESSAGE_STORE_TIMESTAMP_POSITION + 20;
+        }
+        self.commit_log
+            .pickup_store_timestamp(min_phy_offset, size as i32)
     }
 
-    async fn get_earliest_message_time_async(
+    /*    async fn get_earliest_message_time_async(
         &self,
         topic: &str,
         queue_id: i32,
     ) -> Result<i64, StoreError> {
-        todo!()
-    }
+
+    }*/
 
     fn get_message_store_time_stamp(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         consume_queue_offset: i64,
     ) -> i64 {
-        todo!()
+        if let Some(logic_queue) = self.get_consume_queue(topic, queue_id) {
+            if let Some(cq) = logic_queue.get_cq_unit_and_store_time(consume_queue_offset) {
+                return cq.1;
+            }
+        }
+        -1
     }
 
     async fn get_message_store_time_stamp_async(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         consume_queue_offset: i64,
     ) -> Result<i64, StoreError> {
-        todo!()
+        if let Some(logic_queue) = self.get_consume_queue(topic, queue_id) {
+            if let Some(cq) = logic_queue.get_cq_unit_and_store_time(consume_queue_offset) {
+                return Ok(cq.1);
+            }
+        }
+        Ok(-1)
     }
 
     fn get_message_total_in_queue(&self, topic: &str, queue_id: i32) -> i64 {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2770

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented methods to retrieve maximum and minimum message offsets.
  - Added functionality to retrieve the earliest message time and store timestamp based on the topic.

- **Refactor**
  - Updated parameter types for core messaging functions to improve type safety.
  - Removed deprecated asynchronous retrieval functionality from the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->