### PR TITLE
[ISSUE #2772]🚀Implement LocalFileMessageStore get commit log data

### DIFF
--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -282,13 +282,17 @@ pub trait MessageStoreInner {
     ) -> Result<i64, StoreError>;
 
     /// Get the total number of the messages in the specified queue.
-    fn get_message_total_in_queue(&self, topic: &str, queue_id: i32) -> i64;
+    fn get_message_total_in_queue(&self, topic: &CheetahString, queue_id: i32) -> i64;
 
     /// Get the raw commit log data starting from the given offset.
-    fn get_commit_log_data(&self, offset: i64) -> Result<SelectMappedBufferResult, StoreError>;
+    fn get_commit_log_data(&self, offset: i64) -> Option<SelectMappedBufferResult>;
 
     /// Get the raw commit log data starting from the given offset, across multiple mapped files.
-    fn get_bulk_commit_log_data(&self, offset: i64, size: i32) -> Vec<SelectMappedBufferResult>;
+    fn get_bulk_commit_log_data(
+        &self,
+        offset: i64,
+        size: i32,
+    ) -> Option<Vec<SelectMappedBufferResult>>;
 
     /// Append data to commit log.
     fn append_to_commit_log(

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -1124,6 +1124,10 @@ impl CommitLog {
         self.get_data_with_option(offset, offset == 0)
     }
 
+    pub fn get_bulk_data(&self, offset: i64, size: i32) -> Option<Vec<SelectMappedBufferResult>> {
+        unimplemented!("get_bulk_data not implemented")
+    }
+
     pub fn get_data_with_option(
         &self,
         offset: i64,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2772

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new interface for bulk retrieval of log data, opening the door for extended data access.

- **Refactor**
  - Updated message retrieval methods for more streamlined data handling and improved management when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->