### PR TITLE
[ISSUE #2774]🚀Implement append_to_commit_log and execute_delete_files_manually methods

### DIFF
--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -77,6 +77,7 @@ use crate::message_store::default_message_store::CommitLogDispatcherDefault;
 use crate::message_store::default_message_store::DefaultMessageStore;
 use crate::queue::local_file_consume_queue_store::ConsumeQueueStore;
 use crate::queue::ConsumeQueueStoreTrait;
+use crate::store_error::StoreError;
 
 // Message's MAGIC CODE daa320a7
 pub const MESSAGE_MAGIC_CODE: i32 = -626843481;
@@ -1178,6 +1179,16 @@ impl CommitLog {
 
     pub fn pickup_store_timestamp(&self, offset: i64, size: i32) -> i64 {
         unimplemented!("pickupStoreTimestamp not implemented")
+    }
+
+    pub fn append_data(
+        &self,
+        start_offset: i64,
+        data: &[u8],
+        data_start: i32,
+        data_length: i32,
+    ) -> Result<bool, StoreError> {
+        unimplemented!("append_data not implemented")
     }
 }
 


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2774

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new mechanism for appending data to the log system, enhancing commit operations.
  - Improved message storage by adding safeguards for shutdown scenarios with appropriate notifications.
  - Enhanced manual maintenance of log files with better error reporting during deletion attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->