### PR TITLE
[ISSUE #2805]📝Replace MessageStore methods &str parameters with &CheetahString🍻

### DIFF
--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -196,18 +196,23 @@ pub trait MessageStoreInner: Sync + 'static {
     /// Get the offset of the message in the commit log (physical offset).
     fn get_commit_log_offset_in_queue(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         consume_queue_offset: i64,
     ) -> i64;
 
     /// Look up the physical offset of the message by timestamp.
-    fn get_offset_in_queue_by_time(&self, topic: &str, queue_id: i32, timestamp: i64) -> i64;
+    fn get_offset_in_queue_by_time(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        timestamp: i64,
+    ) -> i64;
 
     /// Look up the physical offset of the message by timestamp with boundary type.
     fn get_offset_in_queue_by_time_with_boundary(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         timestamp: i64,
         boundary_type: BoundaryType,
@@ -328,10 +333,10 @@ pub trait MessageStoreInner: Sync + 'static {
     ) -> Result<QueryMessageResult, StoreError>;*/
 
     /// Update HA master address.
-    fn update_ha_master_address(&self, new_addr: &str);
+    fn update_ha_master_address(&self, new_addr: &CheetahString);
 
     /// Update master address.
-    fn update_master_address(&self, new_addr: &str);
+    fn update_master_address(&self, new_addr: &CheetahString);
 
     /// Return how much the slave falls behind.
     fn slave_fall_behind_much(&self) -> i64;
@@ -362,7 +367,7 @@ pub trait MessageStoreInner: Sync + 'static {
     /// Check if the given message is in store.
     fn check_in_store_by_consume_offset(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         consume_offset: i64,
     ) -> bool;
@@ -569,7 +574,7 @@ pub trait MessageStoreInner: Sync + 'static {
     /// Estimate number of messages, within [from, to], which match given filter
     fn estimate_message_count(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         from: i64,
         to: i64,

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -281,7 +281,7 @@ impl Drop for LocalFileMessageStore {
 
 impl LocalFileMessageStore {
     #[inline]
-    pub fn get_topic_config(&self, topic: &str) -> Option<TopicConfig> {
+    pub fn get_topic_config(&self, topic: &CheetahString) -> Option<TopicConfig> {
         if self.topic_config_table.lock().is_empty() {
             return None;
         }
@@ -1133,20 +1133,25 @@ impl MessageStore for LocalFileMessageStore {
 
     fn get_commit_log_offset_in_queue(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         consume_queue_offset: i64,
     ) -> i64 {
         todo!()
     }
 
-    fn get_offset_in_queue_by_time(&self, topic: &str, queue_id: i32, timestamp: i64) -> i64 {
+    fn get_offset_in_queue_by_time(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        timestamp: i64,
+    ) -> i64 {
         todo!()
     }
 
     fn get_offset_in_queue_by_time_with_boundary(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         timestamp: i64,
         boundary_type: BoundaryType,
@@ -1466,11 +1471,11 @@ impl MessageStore for LocalFileMessageStore {
 
     }*/
 
-    fn update_ha_master_address(&self, new_addr: &str) {
+    fn update_ha_master_address(&self, new_addr: &CheetahString) {
         todo!()
     }
 
-    fn update_master_address(&self, new_addr: &str) {
+    fn update_master_address(&self, new_addr: &CheetahString) {
         todo!()
     }
 
@@ -1565,7 +1570,7 @@ impl MessageStore for LocalFileMessageStore {
 
     fn check_in_store_by_consume_offset(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         consume_offset: i64,
     ) -> bool {
@@ -1831,7 +1836,7 @@ impl MessageStore for LocalFileMessageStore {
 
     fn estimate_message_count(
         &self,
-        topic: &str,
+        topic: &CheetahString,
         queue_id: i32,
         from: i64,
         to: i64,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2805

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal messaging processes to use an improved string handling approach for topics and addresses, ensuring greater consistency and potential performance benefits without impacting current user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->