### PR TITLE
[ISSUE #2808]⚡️Replace PutResultProcess attributes String with CheetahString🍻

### DIFF
--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -844,12 +844,12 @@ impl<MS: MessageStore> DeliverDelayedMessageTimerTask<MS> {
 
 /// Process for handling the result of putting a message
 pub struct PutResultProcess<MS> {
-    topic: String,
+    topic: CheetahString,
     offset: i64,
     physic_offset: i64,
     physic_size: i32,
     delay_level: i32,
-    msg_id: String,
+    msg_id: CheetahString,
     auto_resend: bool,
     future: Option<oneshot::Receiver<PutMessageResult>>,
     result_sender: Option<oneshot::Sender<PutMessageResult>>,
@@ -864,12 +864,12 @@ impl<MS: MessageStore> PutResultProcess<MS> {
     pub fn new(broker_controller: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
         let (tx, rx) = oneshot::channel();
         Self {
-            topic: String::new(),
+            topic: CheetahString::empty(),
             offset: 0,
             physic_offset: 0,
             physic_size: 0,
             delay_level: 0,
-            msg_id: String::new(),
+            msg_id: CheetahString::empty(),
             auto_resend: false,
             future: Some(rx),
             result_sender: Some(tx),
@@ -880,7 +880,7 @@ impl<MS: MessageStore> PutResultProcess<MS> {
     }
 
     /// Set the topic for this process
-    pub fn set_topic(mut self, topic: impl Into<String>) -> Self {
+    pub fn set_topic(mut self, topic: impl Into<CheetahString>) -> Self {
         self.topic = topic.into();
         self
     }
@@ -910,7 +910,7 @@ impl<MS: MessageStore> PutResultProcess<MS> {
     }
 
     /// Set the message ID for this process
-    pub fn set_msg_id(mut self, msg_id: impl Into<String>) -> Self {
+    pub fn set_msg_id(mut self, msg_id: impl Into<CheetahString>) -> Self {
         self.msg_id = msg_id.into();
         self
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2808

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Upgraded internal string handling for topics and message IDs in the scheduling process, standardizing operations for improved efficiency and consistency.
	- These behind-the-scenes enhancements aim to streamline message processing and support smoother, more reliable scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->