### PR TITLE
[ISSUE #2815]🚀Implement BrokerRuntime changeScheduleServiceStatus method

### DIFF
--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -20,6 +20,7 @@ use cheetah_string::CheetahString;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::system_clock::SystemClock;
 use rocketmq_rust::ArcMut;
+use tracing::error;
 use tracing::warn;
 
 use crate::base::message_store::MessageStore;
@@ -158,5 +159,12 @@ impl TimerMessageStore {
 
     pub fn shutdown(&mut self) {
         warn!("TimerMessageStore shutdown unimplemented, do nothing");
+    }
+
+    pub fn sync_last_read_time_ms(&mut self) {
+        error!("sync_last_read_time_ms unimplemented");
+    }
+    pub fn set_should_running_dequeue(&mut self, _should_start: bool) {
+        error!("set_should_running_dequeue unimplemented");
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2815

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the scheduling service to now accurately start and stop in response to changes, ensuring dependable service state transitions.
  - Added foundational support for synchronizing message timing and managing queue processing, laying the groundwork for upcoming improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->