### PR TITLE
[ISSUE #2833]🐛Fix MessageStoreConfig flush_delay_offset_interval value is zero

### DIFF
--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -311,7 +311,7 @@ impl Default for MessageStoreConfig {
             slave_timeout: 0,
             message_delay_level: "1s 5s 10s 30s 1m 2m 3m 4m 5m 6m 7m 8m 9m 10m 20m 30m 1h 2h"
                 .to_string(),
-            flush_delay_offset_interval: 0,
+            flush_delay_offset_interval: 10_000,
             clean_file_forcibly_enable: false,
             warm_mapped_file_enable: false,
             offset_check_in_slave: false,


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2833

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the default delay for flush operations, introducing a controlled waiting period that enhances the efficiency of message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->