### PR TITLE
[ISSUE #2876]⚡️Add #[inline] to ArcMut methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- **perf(ArcMut):** Add the `#[inline]` attribute to the `mut_from_ref`, `downgrade`, and `get_inner` methods for `ArcMut`, improving performance ([#2876](https://github.com/mxsm/rocketmq-rust/pull/2876))

--- a/rocketmq/src/arc_mut.rs
+++ b/rocketmq/src/arc_mut.rs
@@ -101,17 +101,20 @@ impl<T: Hash> Hash for ArcMut<T> {
 impl<T: PartialEq> Eq for ArcMut<T> {}
 
 impl<T> ArcMut<T> {
+    #[inline]
     #[allow(clippy::mut_from_ref)]
     pub fn mut_from_ref(&self) -> &mut T {
         unsafe { &mut *self.inner.get() }
     }
 
+    #[inline]
     pub fn downgrade(this: &Self) -> WeakArcMut<T> {
         WeakArcMut {
             inner: Arc::downgrade(&this.inner),
         }
     }
 
+    #[inline]
     pub fn get_inner(&self) -> &Arc<SyncUnsafeCell<T>> {
         &self.inner
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

Fixes #2876

### Brief Description

Add `#[inline]` attributes to `ArcMut` methods (`mut_from_ref`, `downgrade`, and `get_inner`) to optimize performance by reducing function call overhead.

### How Did You Test This Change?

- Ran `cargo test --all-features --workspace` to verify all tests pass.
- Validated performance improvements through benchmark tests (if applicable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the public API for shared mutable resource management by introducing additional methods that improve mutable access, enable lightweight reference management, and provide direct access to underlying content. These changes also incorporate performance optimizations.

- **Documentation**
  - Updated release notes to reflect the latest performance improvements and newly available features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->