### PR TITLE
[ISSUE #2901]🧪Add test case for time_millis_to_human_string3

### DIFF
--- a/rocketmq-common/src/utils/util_all.rs
+++ b/rocketmq-common/src/utils/util_all.rs
@@ -392,10 +392,16 @@ mod tests {
     }
 
     #[test]
-    // fn time_millis_to_human_string_formats_correctly() {
-    //     let timestamp = 1743239631601;
-    //     assert_eq!(time_millis_to_human_string(timestamp), "20250329171351601");
-    // }
+    fn time_millis_to_human_string_formats_correctly() {
+        let timestamp = 1743239631601;
+        let expected = Local
+            .timestamp_millis_opt(timestamp as i64)
+            .unwrap()
+            .format("%Y%m%d%H%M%S%3f")
+            .to_string();
+        assert_eq!(time_millis_to_human_string(timestamp), expected);
+    }
+
     #[test]
     fn is_path_exists_returns_true_for_existing_path() {
         assert_eq!(is_path_exists("."), true);
@@ -446,21 +452,28 @@ mod tests {
             .and_hms(0, 0, 0)
             .timestamp_millis();
         assert_eq!(next_morning, expected_next_morning as u64);
-    }
+    }*/
     #[test]
     fn time_millis_to_human_string2_formats_correctly_with_valid_timestamp() {
+        use chrono::TimeZone;
+        use chrono::Utc;
         let timestamp = 1625140800000;
-        assert_eq!(
-            time_millis_to_human_string2(timestamp),
-            "2021-07-01 20:00:00,000"
-        );
+        let expected = Local
+            .timestamp_millis_opt(timestamp as i64)
+            .unwrap()
+            .format("%Y-%m-%d %H:%M:%S,%3f")
+            .to_string();
+        assert_eq!(time_millis_to_human_string2(timestamp), expected);
     }
 
     #[test]
     fn time_millis_to_human_string3_formats_correctly_with_valid_timestamp() {
         let timestamp = 1625140800000;
-        assert_eq!(time_millis_to_human_string3(timestamp), "20210701200000");
+        let expect = Local
+            .timestamp_millis_opt(timestamp)
+            .unwrap()
+            .format("%Y%m%d%H%M%S")
+            .to_string();
+        assert_eq!(time_millis_to_human_string3(timestamp), expect);
     }
-
-    */
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2901

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced tests for timestamp formatting by reactivating and updating validations to generate expected outputs dynamically for improved accuracy and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->