### PR TITLE
[ISSUE #2944]🚀Implement LocalFileMessageStore#remain_transient_store_buffer_numbs

### DIFF
--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1636,8 +1636,9 @@ impl MessageStore for LocalFileMessageStore {
         self.commit_log.lock_time_mills()
     }
 
+    #[inline]
     fn is_transient_store_pool_deficient(&self) -> bool {
-        todo!()
+        self.remain_transient_store_buffer_numbs() == 0
     }
 
     fn get_dispatcher_list(&self) -> Vec<Arc<dyn CommitLogDispatcher>> {
@@ -1844,17 +1845,22 @@ impl MessageStore for LocalFileMessageStore {
     ) -> DispatchRequest {
         todo!()
     }
-
+    #[inline]
     fn remain_transient_store_buffer_numbs(&self) -> i32 {
-        todo!()
+        if self.is_transient_store_pool_enable() {
+            return self.transient_store_pool.available_buffer_nums() as i32;
+        }
+        i32::MAX
     }
 
+    #[inline]
     fn remain_how_many_data_to_commit(&self) -> i64 {
-        todo!()
+        self.commit_log.remain_how_many_data_to_commit()
     }
 
+    #[inline]
     fn remain_how_many_data_to_flush(&self) -> i64 {
-        todo!()
+        self.commit_log.remain_how_many_data_to_flush()
     }
 
     fn is_shutdown(&self) -> bool {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2944

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented complete functionality for data buffering, commit, and flush operations in the message storage system.
  - Enhancements in the handling of available buffer counts and pending operations improve overall reliability and performance during message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->