### PR TITLE
[ISSUE #2948]🐛Fix can't delete topic from rocketmq dashboard

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -375,8 +375,8 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
             {
                 self.delete_topic_in_broker(pop_retry_topic_v1.as_ref());
             }
-            self.delete_topic_in_broker(topic);
         }
+        self.delete_topic_in_broker(topic);
         Some(response.set_code(ResponseCode::Success))
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2948

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the topic deletion process for improved reliability. The removal sequence was adjusted so that all related topics are processed properly before the main topic is removed. This update enhances the consistency of operations by ensuring that all necessary checks are completed before deletion occurs. The change is internal and does not affect external behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->