### PR TITLE
[ISSUE #2953]🚀Implement ConsumeQueueStore#get_total_size method

### DIFF
--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -409,7 +409,13 @@ impl ConsumeQueueStoreTrait for ConsumeQueueStore {
 
     #[inline]
     fn get_total_size(&self) -> i64 {
-        todo!()
+        let mut total_size = 0;
+        for consume_queue_table in self.inner.consume_queue_table.lock().values() {
+            for consume_queue in consume_queue_table.values() {
+                total_size += consume_queue.get_total_size();
+            }
+        }
+        total_size
     }
 
     #[inline]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2953

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the total size calculation for consume queues. The method now iterates over all queues to accurately sum and return their combined sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->