### PR TITLE
[ISSUE #2962]🚀Add get_bytes_readable_checked method and remove some useless methods

### DIFF
--- a/rocketmq-store/src/log_file/mapped_file.rs
+++ b/rocketmq-store/src/log_file/mapped_file.rs
@@ -219,6 +219,23 @@ pub trait MappedFile {
     /// requested slice goes beyond the file boundaries or the file is not available.
     fn get_bytes(&self, pos: usize, size: usize) -> Option<bytes::Bytes>;
 
+    /// Retrieves a byte slice from the mapped file with readable bounds checking.
+    ///
+    /// This method returns a byte slice starting from the specified position and of the specified
+    /// size. It performs bounds checking to ensure the requested slice is within the file
+    /// boundaries.
+    ///
+    /// # Arguments
+    ///
+    /// * `pos` - The starting position from where bytes should be read.
+    /// * `size` - The number of bytes to read from the starting position.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<bytes::Bytes>` containing the requested byte slice if available, or `None` if the
+    /// requested slice goes beyond the file boundaries or the file is not available.
+    fn get_bytes_readable_checked(&self, pos: usize, size: usize) -> Option<bytes::Bytes>;
+
     /// Appends a byte array to the mapped file without updating the write position.
     ///
     /// This method appends the given byte array to the mapped file without updating the internal
@@ -261,40 +278,6 @@ pub trait MappedFile {
     /// # Returns
     /// `true` if the append operation was successful, `false` otherwise.
     fn append_message_no_position_update(&self, data: &[u8], offset: usize, length: usize) -> bool;
-
-    /// Appends a byte array to the mapped file without updating the write position.
-    ///
-    /// This method appends a specified portion of the given byte array to the mapped file without
-    /// updating the internal write position. It allows for more controlled appending by specifying
-    /// an offset and length.
-    ///
-    /// # Arguments
-    /// * `data` - A reference to the byte array to be appended.
-    /// * `offset` - The starting offset in the byte array from where bytes should be appended.
-    /// * `length` - The number of bytes to append starting from the offset.
-    ///
-    /// # Returns
-    /// `true` if the append operation was successful, `false` otherwise.
-    fn append_message_offset_no_position_update(
-        &self,
-        data: &[u8],
-        offset: usize,
-        length: usize,
-    ) -> bool;
-
-    /// Appends a byte array to the mapped file without updating the write position.
-    ///
-    /// This method appends the given byte array to the mapped file without updating the internal
-    /// write position. It is useful for scenarios where the write position should remain unchanged.
-    ///
-    /// # Arguments
-    /// * `data` - A reference to the byte array to be appended.
-    ///
-    /// # Returns
-    /// `true` if the append operation was successful, `false` otherwise.
-    fn append_message_ref_no_position_update(&self, data: &[u8]) -> bool {
-        self.append_message_offset_no_position_update(data, 0, data.len())
-    }
 
     /// Writes a segment of bytes to the mapped file.
     ///
@@ -587,12 +570,12 @@ pub trait MappedFile {
     /// Retrieves the timestamp of the last flush operation.
     ///
     /// This method returns the time at which the last flush operation was completed for the mapped
-    /// file. The timestamp is represented as an `i64`, measuring milliseconds since the Unix
+    /// file. The timestamp is represented as an `u64`, measuring milliseconds since the Unix
     /// epoch.
     ///
     /// # Returns
-    /// An `i64` representing the timestamp of the last flush operation.
-    fn get_last_flush_time(&self) -> i64;
+    /// An `u64` representing the timestamp of the last flush operation.
+    fn get_last_flush_time(&self) -> u64;
 
     /// Checks if a specific portion of the mapped file is loaded into memory.
     ///


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2957
Fixes #2962

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced file reading with bounds checking for improved data safety.
  - Improved file initialization to ensure proper setup during creation.

- **Refactor**
  - Updated the flush timestamp to a more robust numeric representation.
  - Removed redundant message appending operations to simplify functionality.
  - Refined error reporting for features pending future implementation.

- **Documentation**
  - Expanded inline documentation to clarify the updated file handling and initialization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->