### PR TITLE
[ISSUE #2991]⚡️Optimize ConsumeQueue#put_message_position_info💫

### DIFF
--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -264,7 +264,7 @@ impl<MS: MessageStore> ConsumeQueue<MS> {
                 && mapped_file.get_wrote_position() == 0
             {
                 self.min_logic_offset
-                    .store(expect_logic_offset, Ordering::Acquire);
+                    .store(expect_logic_offset, Ordering::Release);
                 self.mapped_file_queue
                     .set_flushed_where(expect_logic_offset);
                 self.mapped_file_queue

--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -249,10 +249,10 @@ impl<MS: MessageStore> ConsumeQueue<MS> {
             );
             return true;
         }
-        let mut bytes = BytesMut::with_capacity(CQ_STORE_UNIT_SIZE as usize);
-        bytes.put_i64(offset);
-        bytes.put_i32(size);
-        bytes.put_i64(tags_code);
+        self.byte_buffer_index.clear();
+        self.byte_buffer_index.put_i64(offset);
+        self.byte_buffer_index.put_i32(size);
+        self.byte_buffer_index.put_i64(tags_code);
 
         let expect_logic_offset = cq_offset * CQ_STORE_UNIT_SIZE as i64;
         if let Some(mapped_file) = self
@@ -264,7 +264,7 @@ impl<MS: MessageStore> ConsumeQueue<MS> {
                 && mapped_file.get_wrote_position() == 0
             {
                 self.min_logic_offset
-                    .store(expect_logic_offset, Ordering::SeqCst);
+                    .store(expect_logic_offset, Ordering::Acquire);
                 self.mapped_file_queue
                     .set_flushed_where(expect_logic_offset);
                 self.mapped_file_queue
@@ -307,7 +307,7 @@ impl<MS: MessageStore> ConsumeQueue<MS> {
                 }
             }
             self.set_max_physic_offset(offset + size as i64);
-            mapped_file.append_message_bytes(&bytes.freeze())
+            mapped_file.append_message_bytes(self.byte_buffer_index.as_ref())
         } else {
             false
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2991

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Implemented behind-the-scenes improvements to optimize messaging performance.
  - Streamlined resource reuse and reduced unnecessary memory allocations.
  - Enhanced concurrency operations for better stability and responsiveness.

Overall, these updates significantly bolster the efficiency, stability, and reliability of the messaging system, resulting in a more robust experience for users even during high load conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->