### PR TITLE
[ISSUE #3033]🚀Connection add send_bytes and send_slice methods

### DIFF
--- a/rocketmq-remoting/src/connection.rs
+++ b/rocketmq-remoting/src/connection.rs
@@ -149,4 +149,47 @@ impl Connection {
         self.writer.send(self.buf.clone().freeze()).await?;
         Ok(())
     }
+
+    /// Sends a `Bytes` object over the connection.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - The `Bytes` object to send.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating success (`Ok(())`) or failure (`Err(RemotingError)`).
+    ///
+    /// # Errors
+    ///
+    /// This function returns a `RemotingError` if the underlying writer fails to send the data.
+    pub async fn send_bytes(&mut self, bytes: Bytes) -> Result<(), RemotingError> {
+        self.writer.send(bytes).await?;
+        Ok(())
+    }
+
+    /// Sends a static byte slice (`&'static [u8]`) over the connection.
+    ///
+    /// # Arguments
+    ///
+    /// * `slice` - A static byte slice to send.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating success (`Ok(())`) or failure (`Err(RemotingError)`).
+    ///
+    /// # Errors
+    ///
+    /// This function returns a `RemotingError` if the underlying writer fails to send the data.
+    ///
+    /// # Notes
+    ///
+    /// The static lifetime of the slice ensures that the data is valid for the entire duration
+    /// of the program, making it suitable for scenarios where the data does not need to be
+    /// dynamically allocated or modified.
+    pub async fn send_slice(&mut self, slice: &'static [u8]) -> Result<(), RemotingError> {
+        let bytes = slice.into();
+        self.writer.send(bytes).await?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3033

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced, asynchronous data sending capabilities that support both dynamic and static data formats.
  - Improved reliability through robust error handling during transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->