### PR TITLE
[ISSUE #3058]🚀Add ChannelEventListener trait for Remoting

### DIFF
--- a/rocketmq-remoting/src/base/channel_event_listener.rs
+++ b/rocketmq-remoting/src/base/channel_event_listener.rs
@@ -14,8 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-pub mod channel_event_listener;
-pub mod connection_net_event;
-pub mod remoting_fn;
-pub mod request_task;
-pub mod response_future;
+use crate::net::channel::Channel;
+
+pub trait ChannelEventListener {
+    fn on_channel_connect(&self, remote_addr: &str, channel: &Channel);
+
+    fn on_channel_close(&self, remote_addr: &str, channel: &Channel);
+
+    fn on_channel_exception(&self, remote_addr: &str, channel: &Channel);
+
+    fn on_channel_idle(&self, remote_addr: &str, channel: &Channel);
+
+    fn on_channel_active(&self, remote_addr: &str, channel: &Channel);
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3058

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new interface for monitoring channel events, including connection, disconnection, error handling, idle state, and activation notifications.
	- Enhances the system's event management capabilities, providing a more standardized approach to handling channel interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->