### PR TITLE
[ISSUE #3075]🚀ClientManageProcessor supports UnregisterClient(request code:35)

### DIFF
--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -107,8 +107,24 @@ where
                 .unregister_producer(group, &client_channel_info, &ctx);
         }
 
-        if let Some(ref _group) = request_header.consumer_group {
-            unimplemented!()
+        if let Some(ref group) = request_header.consumer_group {
+            let subscription_group_config = self
+                .broker_runtime_inner
+                .subscription_group_manager()
+                .find_subscription_group_config(group);
+            let is_notify_consumer_ids_changed_enable =
+                if let Some(ref subscription_group_config) = subscription_group_config {
+                    subscription_group_config.notify_consumer_ids_changed_enable()
+                } else {
+                    true
+                };
+            self.broker_runtime_inner
+                .consumer_manager()
+                .unregister_consumer(
+                    group,
+                    &client_channel_info,
+                    is_notify_consumer_ids_changed_enable,
+                );
         }
 
         Ok(Some(RemotingCommand::create_response_command()))

--- a/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
+++ b/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
@@ -171,7 +171,7 @@ where
         subscription_group_config
     }
 
-    pub fn find_subscription_group_config_inner(
+    fn find_subscription_group_config_inner(
         &self,
         group: &CheetahString,
     ) -> Option<SubscriptionGroupConfig> {


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3075

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced consumer unregistration to ensure that client removals are processed reliably and notifications are managed consistently.
  
- **Refactor**
	- Improved internal handling of subscription group configurations by restricting access to internal processes, thereby strengthening overall encapsulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->