### PR TITLE
[ISSUE #3084]🚀Add ProducerGroupEvent enum

### DIFF
--- a/rocketmq-broker/src/client.rs
+++ b/rocketmq-broker/src/client.rs
@@ -23,4 +23,5 @@ pub(crate) mod consumer_ids_change_listener;
 pub(crate) mod default_consumer_ids_change_listener;
 pub(crate) mod manager;
 pub(crate) mod net;
+pub(crate) mod producer_group_event;
 pub(crate) mod rebalance;

--- a/rocketmq-broker/src/client/producer_group_event.rs
+++ b/rocketmq-broker/src/client/producer_group_event.rs
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::fmt::Display;
+
+/// Producer group events that occur when producers register or unregister.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProducerGroupEvent {
+    /// The group of producer is unregistered.
+    GroupUnregister,
+    /// The client of this producer is unregistered.
+    ClientUnregister,
+}
+
+impl Display for ProducerGroupEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProducerGroupEvent::GroupUnregister => write!(f, "GROUP_UNREGISTER"),
+            ProducerGroupEvent::ClientUnregister => write!(f, "CLIENT_UNREGISTER"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn producer_group_event_display_group_unregister() {
+        let event = ProducerGroupEvent::GroupUnregister;
+        assert_eq!(event.to_string(), "GROUP_UNREGISTER");
+    }
+
+    #[test]
+    fn producer_group_event_display_client_unregister() {
+        let event = ProducerGroupEvent::ClientUnregister;
+        assert_eq!(event.to_string(), "CLIENT_UNREGISTER");
+    }
+
+    #[test]
+    fn producer_group_event_equality_same_variant() {
+        let event1 = ProducerGroupEvent::GroupUnregister;
+        let event2 = ProducerGroupEvent::GroupUnregister;
+        assert_eq!(event1, event2);
+    }
+
+    #[test]
+    fn producer_group_event_equality_different_variants() {
+        let event1 = ProducerGroupEvent::GroupUnregister;
+        let event2 = ProducerGroupEvent::ClientUnregister;
+        assert_ne!(event1, event2);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3084

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced event tracking for messaging producer groups, including clear notifications for group and client unregistrations.
- **Tests**
	- Added comprehensive unit tests to ensure proper behavior and accurate event representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->