### PR TITLE
[ISSUE #3096]🚀pub use anyhow::Result as RocketMQResult💫

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,7 @@ dependencies = [
 name = "rocketmq-rust"
 version = "0.5.0"
 dependencies = [
+ "anyhow",
  "tokio",
  "tracing",
 ]

--- a/rocketmq/Cargo.toml
+++ b/rocketmq/Cargo.toml
@@ -15,3 +15,4 @@ description.workspace = true
 [dependencies]
 tokio.workspace = true
 tracing.workspace = true
+anyhow = { workspace = true }

--- a/rocketmq/src/lib.rs
+++ b/rocketmq/src/lib.rs
@@ -25,6 +25,7 @@ pub use netty_rust::timer::Timer;
 pub mod rocketmq_tokio_lock;
 mod shutdown;
 
+pub use anyhow::Result as RocketMQResult;
 pub use arc_mut::ArcMut;
 pub use arc_mut::SyncUnsafeCellWrapper;
 pub use arc_mut::WeakArcMut;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3096

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release update includes enhancements to our public interface. The update introduces an additional dependency within the workspace and a new public type alias for result types. These changes expand the available API elements for users and further refine the overall integration options.

- **New Features**
  - Integrated an extra workspace dependency.
  - Added a new public alias for result types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->