### PR TITLE
[ISSUE #3099]🚀Add TokioEvent struct 💫

### DIFF
--- a/rocketmq-remoting/src/base.rs
+++ b/rocketmq-remoting/src/base.rs
@@ -19,3 +19,4 @@ pub mod connection_net_event;
 pub mod remoting_fn;
 pub mod request_task;
 pub mod response_future;
+pub mod tokio_event;

--- a/rocketmq-remoting/src/base/tokio_event.rs
+++ b/rocketmq-remoting/src/base/tokio_event.rs
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::fmt::Display;
+use std::net::SocketAddr;
+
+use crate::base::connection_net_event::ConnectionNetEvent;
+use crate::net::channel::Channel;
+
+#[derive(Debug, Clone)]
+pub struct TokioEvent {
+    type_: ConnectionNetEvent,
+    remote_addr: SocketAddr,
+    channel: Channel,
+}
+
+impl TokioEvent {
+    pub fn new(type_: ConnectionNetEvent, remote_addr: SocketAddr, channel: Channel) -> Self {
+        Self {
+            type_,
+            remote_addr,
+            channel,
+        }
+    }
+
+    #[inline]
+    pub fn type_(&self) -> &ConnectionNetEvent {
+        &self.type_
+    }
+
+    #[inline]
+    pub fn remote_addr(&self) -> &SocketAddr {
+        &self.remote_addr
+    }
+
+    #[inline]
+    pub fn channel(&self) -> &Channel {
+        &self.channel
+    }
+}
+
+impl Display for TokioEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TokioEvent {{ type_: {:?}, remote_addr: {:?}, channel: {:?} }}",
+            self.type_, self.remote_addr, self.channel
+        )
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3099

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced event handling capabilities that provide detailed, human-readable information about connection events, including event type, network address, and communication channel details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->