### PR TITLE
[ISSUE #3117]🚀Implement ProducerManager get_producer_table and call_producer_change_listener

### DIFF
--- a/rocketmq-broker/src/client/producer_group_event.rs
+++ b/rocketmq-broker/src/client/producer_group_event.rs
@@ -17,7 +17,7 @@
 use std::fmt::Display;
 
 /// Producer group events that occur when producers register or unregister.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProducerGroupEvent {
     /// The group of producer is unregistered.
     GroupUnregister,


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3117

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to view a snapshot of all connected producer clients grouped by their producer group.
- **Other Improvements**
  - Enhanced internal handling of producer group events for improved notification and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->