### PR TITLE
[ISSUE #3124]🐛Broker not config file started fail

### DIFF
--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -32,7 +32,7 @@ use tracing::info;
 async fn main() -> RocketMQResult<()> {
     // init logger
     rocketmq_common::log::init_logger();
-    let (broker_config, message_store_config) = parse_config_file()?;
+    let (broker_config, message_store_config) = parse_config_file().unwrap_or_default();
     // boot strap broker
     Builder::new()
         .set_broker_config(broker_config)
@@ -46,6 +46,7 @@ async fn main() -> RocketMQResult<()> {
 fn parse_config_file() -> RocketMQResult<(BrokerConfig, MessageStoreConfig)> {
     let args = Args::parse();
     let home = EnvUtils::get_rocketmq_home();
+    info!("Rocketmq(Rust) home: {}", home);
     let config = if let Some(ref config_file) = args.config_file {
         let config_file = PathBuf::from(config_file);
         Ok((
@@ -61,6 +62,5 @@ fn parse_config_file() -> RocketMQResult<(BrokerConfig, MessageStoreConfig)> {
             ParseConfigFile::parse_config_file::<MessageStoreConfig>(path_buf)?,
         ))
     };
-    info!("Rocketmq(Rust) home: {}", home);
     config
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3124

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when loading configuration files by falling back to default settings if parsing fails, preventing unexpected program exits.
  - Adjusted logging to display the RocketMQ home directory earlier during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->