### PR TITLE
[ISSUE  #3127]⚡️Set PopReviveService ShouldRunPopRevive on new

### DIFF
--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -25,6 +25,7 @@ use rocketmq_common::common::message::message_decoder;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::common::mix_all::MASTER_ID;
 use rocketmq_common::common::pop_ack_constants::PopAckConstants;
 use rocketmq_common::common::FAQUrl;
 use rocketmq_common::TimeUtils::get_current_millis;
@@ -75,10 +76,16 @@ where
                 .as_str(),
         ));
         let mut pop_revive_services = vec![];
+        let is_run_pop_revive = broker_runtime_inner
+            .broker_config()
+            .broker_identity
+            .broker_id
+            == MASTER_ID;
         for i in 0..broker_runtime_inner.broker_config().revive_queue_num {
             let revive_queue_id = POP_ORDER_REVIVE_QUEUE;
-            let pop_revive_service =
+            let mut pop_revive_service =
                 PopReviveService::new(revive_topic.clone(), i as i32, broker_runtime_inner.clone());
+            pop_revive_service.set_should_run_pop_revive(is_run_pop_revive);
             pop_revive_services.push(ArcMut::new(pop_revive_service));
         }
         AckMessageProcessor {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3127

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the initialization logic for certain background services to depend on the broker's identity, ensuring specific functionality runs only on designated brokers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->