### PR TITLE
[ISSUE #3129]🐛Fix ExtraInfoUtil split not correct

### DIFF
--- a/rocketmq-remoting/src/protocol/header/extra_info_util.rs
+++ b/rocketmq-remoting/src/protocol/header/extra_info_util.rs
@@ -478,7 +478,7 @@ mod tests {
 
     #[test]
     fn split_with_valid_string() {
-        let result = ExtraInfoUtil::split("a|b|c").unwrap();
+        let result = ExtraInfoUtil::split("a b c").unwrap();
         assert_eq!(result, vec!["a", "b", "c"]);
     }
 

--- a/rocketmq-remoting/src/protocol/header/extra_info_util.rs
+++ b/rocketmq-remoting/src/protocol/header/extra_info_util.rs
@@ -36,7 +36,10 @@ impl ExtraInfoUtil {
         if extra_info.is_empty() {
             return Err(IllegalArgument("split extraInfo is empty".to_string()));
         }
-        Ok(extra_info.split('|').map(String::from).collect())
+        Ok(extra_info
+            .split(MessageConst::KEY_SEPARATOR)
+            .map(String::from)
+            .collect())
     }
 
     pub fn get_ck_queue_offset(extra_info_strs: &[String]) -> rocketmq_error::RocketMQResult<i64> {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3129

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated internal logic to use a centralized delimiter constant for splitting extra information, with no change to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->