### PR TITLE
[ISSUE #3140]⚡️Implement PopReviveService#revive_msg_from_ck method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,6 +2200,7 @@ dependencies = [
  "dashmap",
  "dirs",
  "dns-lookup",
+ "futures",
  "lazy_static",
  "mockall",
  "num_cpus",

--- a/rocketmq-broker/Cargo.toml
+++ b/rocketmq-broker/Cargo.toml
@@ -58,6 +58,8 @@ dashmap = { workspace = true }
 
 crossbeam-skiplist = "0.1"
 
+futures = "0.3.31"
+
 [dev-dependencies]
 mockall = "0.13.1"
 static_assertions = { version = "1" }

--- a/rocketmq-broker/src/failover/escape_bridge.rs
+++ b/rocketmq-broker/src/failover/escape_bridge.rs
@@ -45,7 +45,7 @@ use crate::transaction::queue::transactional_message_util::TransactionalMessageU
 
 const SEND_TIMEOUT: u64 = 3_000;
 const DEFAULT_PULL_TIMEOUT_MILLIS: u64 = 10_000;
-type FutureResult = Pin<Box<dyn Future<Output = (Option<MessageExt>, String, bool)>>>;
+type FutureResult = Pin<Box<dyn Future<Output = (Option<MessageExt>, String, bool)> + Send>>;
 
 ///### RocketMQ's EscapeBridge for Dead Letter Queue (DLQ) Mechanism
 ///


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3140

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented asynchronous processing for reviving messages, allowing concurrent retrieval and retry of business messages for improved efficiency.
  - Added a method to fetch business messages asynchronously.

- **Refactor**
  - Updated internal methods to use shared ownership, enabling safer and more flexible async operations.

- **Chores**
  - Updated dependencies to include the latest futures library for enhanced async support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->