### PR TITLE
[ISSUE #3183]🚀Implement LocalFileMessageStore get_dispatcher_list and add_dispatcher methods

### DIFF
--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -400,10 +400,13 @@ pub trait MessageStoreInner: Sync + 'static {
     fn is_transient_store_pool_deficient(&self) -> bool;
 
     /// Get the dispatcher list.
-    fn get_dispatcher_list(&self) -> Vec<Arc<dyn CommitLogDispatcher>>;
+    fn get_dispatcher_list(&self) -> &[Arc<dyn CommitLogDispatcher>];
 
     /// Add dispatcher.
-    fn add_dispatcher(&self, dispatcher: Arc<dyn CommitLogDispatcher>);
+    fn add_dispatcher(&mut self, dispatcher: Arc<dyn CommitLogDispatcher>);
+
+    /// Add the first dispatcher.
+    fn add_first_dispatcher(&mut self, dispatcher: Arc<dyn CommitLogDispatcher>);
 
     /// Get consume queue of the topic/queue. If not exist, returns None.
     fn get_consume_queue(&self, topic: &CheetahString, queue_id: i32) -> Option<ArcConsumeQueue>;

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -191,7 +191,7 @@ pub struct CommitLog {
     broker_config: Arc<BrokerConfig>,
     enabled_append_prop_crc: bool,
     local_file_message_store: Option<ArcMut<LocalFileMessageStore>>,
-    dispatcher: CommitLogDispatcherDefault,
+    dispatcher: ArcMut<CommitLogDispatcherDefault>,
     confirm_offset: i64,
     store_checkpoint: Arc<StoreCheckpoint>,
     append_message_callback: Arc<DefaultAppendMessageCallback>,
@@ -208,7 +208,7 @@ impl CommitLog {
     pub fn new(
         message_store_config: Arc<MessageStoreConfig>,
         broker_config: Arc<BrokerConfig>,
-        dispatcher: &CommitLogDispatcherDefault,
+        dispatcher: ArcMut<CommitLogDispatcherDefault>,
         store_checkpoint: Arc<StoreCheckpoint>,
         topic_config_table: Arc<parking_lot::Mutex<HashMap<CheetahString, TopicConfig>>>,
         consume_queue_store: ConsumeQueueStore,
@@ -227,7 +227,7 @@ impl CommitLog {
             broker_config,
             enabled_append_prop_crc,
             local_file_message_store: None,
-            dispatcher: dispatcher.clone(),
+            dispatcher,
             confirm_offset: -1,
             store_checkpoint: store_checkpoint.clone(),
             append_message_callback: Arc::new(DefaultAppendMessageCallback::new(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3183

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to insert a dispatcher at the beginning of the dispatcher list.
  - Provided methods to add dispatchers dynamically to the message store.

- **Refactor**
  - Improved dispatcher management by introducing shared, mutable ownership for dispatchers.
  - Updated dispatcher lists for more efficient and flexible handling of message dispatching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->