### PR TITLE
[ISSUE #3187]🚀Implement CommitLogDispatcherCalcBitMap

### DIFF
--- a/rocketmq-broker/src/filter.rs
+++ b/rocketmq-broker/src/filter.rs
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
+pub(crate) mod commit_log_dispatcher_calc_bit_map;
 pub(crate) mod consumer_filter_data;
 pub(crate) mod expression_for_retry_message_filter;
 pub(crate) mod expression_message_filter;
 pub(crate) mod manager;
-mod message_evaluation_context;
+pub(crate) mod message_evaluation_context;

--- a/rocketmq-broker/src/filter/commit_log_dispatcher_calc_bit_map.rs
+++ b/rocketmq-broker/src/filter/commit_log_dispatcher_calc_bit_map.rs
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::sync::Arc;
+use std::time::Instant;
+
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_filter::utils::bits_array::BitsArray;
+use rocketmq_store::base::commit_log_dispatcher::CommitLogDispatcher;
+use rocketmq_store::base::dispatch_request::DispatchRequest;
+use tracing::debug;
+use tracing::error;
+use tracing::warn;
+
+use crate::filter::manager::consumer_filter_manager::ConsumerFilterManager;
+use crate::filter::message_evaluation_context::MessageEvaluationContext;
+
+pub struct CommitLogDispatcherCalcBitMap {
+    broker_config: Arc<BrokerConfig>,
+    consumer_filter_manager: ConsumerFilterManager,
+}
+
+impl CommitLogDispatcherCalcBitMap {
+    pub fn new(
+        broker_config: Arc<BrokerConfig>,
+        consumer_filter_manager: ConsumerFilterManager,
+    ) -> Self {
+        Self {
+            broker_config,
+            consumer_filter_manager,
+        }
+    }
+}
+
+impl CommitLogDispatcher for CommitLogDispatcherCalcBitMap {
+    fn dispatch(&self, request: &mut DispatchRequest) {
+        if !self.broker_config.enable_calc_filter_bit_map {
+            return;
+        }
+
+        // Main logic
+        let filter_datas = self.consumer_filter_manager.get(&request.topic);
+        if filter_datas.is_none() || filter_datas.as_ref().unwrap().is_empty() {
+            return;
+        }
+        let filter_datas = filter_datas.unwrap();
+        let mut filter_bit_map =
+            BitsArray::create(self.consumer_filter_manager.bloom_filter().unwrap().m() as usize);
+
+        let start_time = Instant::now();
+        for filter_data in filter_datas.iter() {
+            if filter_data.compiled_expression().is_none() {
+                error!(
+                    "[BUG] Consumer in filter manager has no compiled expression! {:?}",
+                    filter_data
+                );
+                continue;
+            }
+            if filter_data.bloom_filter_data().is_none() {
+                error!(
+                    "[BUG] Consumer in filter manager has no bloom data! {:?}",
+                    filter_data
+                );
+                continue;
+            }
+
+            let context = MessageEvaluationContext::new(&request.properties_map);
+            let ret = filter_data
+                .compiled_expression()
+                .as_ref()
+                .unwrap()
+                .evaluate(&context);
+
+            debug!(
+                "Result of Calc bit map: ret={:?}, data={:?}, props={:?}, offset={}",
+                ret, filter_data, request.properties_map, request.commit_log_offset
+            );
+
+            // eval true
+            if let Ok(ret) = ret {
+                if let Some(b) = ret.downcast_ref::<bool>() {
+                    if *b {
+                        self.consumer_filter_manager
+                            .bloom_filter()
+                            .unwrap()
+                            .hash_to(
+                                filter_data.bloom_filter_data().unwrap(),
+                                &mut filter_bit_map,
+                            );
+                    }
+                }
+            }
+        }
+
+        request.bit_map = Some(filter_bit_map.bytes().to_vec());
+
+        let elapsed = start_time.elapsed().as_millis();
+        if elapsed >= 1 {
+            warn!(
+                "Spend {} ms to calc bit map, consumerNum={}, topic={}",
+                elapsed,
+                filter_datas.len(),
+                request.topic
+            );
+        }
+    }
+}

--- a/rocketmq-broker/src/filter/consumer_filter_data.rs
+++ b/rocketmq-broker/src/filter/consumer_filter_data.rs
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
@@ -104,5 +107,40 @@ impl ConsumerFilterData {
 
     pub fn compiled_expression(&self) -> &Option<Arc<Box<dyn Expression + Send + Sync + 'static>>> {
         &self.compiled_expression
+    }
+}
+
+impl Debug for ConsumerFilterData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConsumerFilterData")
+            .field("consumer_group", &self.consumer_group)
+            .field("topic", &self.topic)
+            .field("expression", &self.expression)
+            .field("expression_type", &self.expression_type)
+            .field("compiled_expression", &self.compiled_expression.is_some())
+            .field("born_time", &self.born_time)
+            .field("dead_time", &self.dead_time)
+            .field("bloom_filter_data", &self.bloom_filter_data)
+            .field("client_version", &self.client_version)
+            .finish()
+    }
+}
+
+impl Display for ConsumerFilterData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ConsumerFilterData {{ group: {}, topic: {}, expression: {:?}, type: {:?}, \
+             has_compiled: {}, born: {}, dead: {}, has_bloom: {}, client_ver: {} }}",
+            self.consumer_group,
+            self.topic,
+            self.expression,
+            self.expression_type,
+            self.compiled_expression.is_some(),
+            self.born_time,
+            self.dead_time,
+            self.bloom_filter_data.is_some(),
+            self.client_version
+        )
     }
 }

--- a/rocketmq-broker/src/filter/expression_message_filter.rs
+++ b/rocketmq-broker/src/filter/expression_message_filter.rs
@@ -44,7 +44,7 @@ impl ExpressionMessageFilter {
     ) -> Self {
         let bloom_data_valid = match consumer_filter_data {
             None => false,
-            Some(ref filter) => match consumer_filter_manager.get_bloom_filter() {
+            Some(ref filter) => match consumer_filter_manager.bloom_filter() {
                 None => false,
                 Some(bloom_filter) => bloom_filter.is_valid(filter.bloom_filter_data()),
             },
@@ -121,7 +121,7 @@ impl MessageFilter for ExpressionMessageFilter {
         } else {
             None
         };
-        let context = MessageEvaluationContext::new(temp_properties);
+        let context = MessageEvaluationContext::new(&temp_properties);
         if let Some(filter) = real_filter_data.compiled_expression() {
             match filter.evaluate(&context) {
                 Ok(value) => *value.downcast_ref::<bool>().unwrap_or(&false),

--- a/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
+++ b/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -130,7 +129,11 @@ impl ConsumerFilterManager {
         None
     }
 
-    pub fn get_bloom_filter(&self) -> Option<&BloomFilter> {
+    pub fn bloom_filter(&self) -> Option<&BloomFilter> {
         self.bloom_filter.as_ref()
+    }
+
+    pub fn get(&self, topic: &CheetahString) -> Option<Vec<ConsumerFilterData>> {
+        unimplemented!("get method not implemented");
     }
 }

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -223,6 +223,12 @@ pub struct BrokerConfig {
     pub pop_ck_offset_max_queue_size: u64,
     pub delay_offset_update_version_step: u64,
     pub revive_ack_wait_ms: u64,
+
+    // Switch of filter bit map calculation.
+    // If switch on:
+    // 1. Calculate filter bit map when construct queue.
+    // 2. Filter bit map will be saved to consume queue extend file if allowed.
+    pub enable_calc_filter_bit_map: bool,
 }
 
 impl Default for BrokerConfig {
@@ -338,6 +344,7 @@ impl Default for BrokerConfig {
             pop_ck_offset_max_queue_size: 20_000,
             delay_offset_update_version_step: 200,
             revive_ack_wait_ms: Duration::from_secs(3 * 60).as_millis() as u64,
+            enable_calc_filter_bit_map: false,
         }
     }
 }

--- a/rocketmq-filter/src/expression.rs
+++ b/rocketmq-filter/src/expression.rs
@@ -33,5 +33,8 @@ pub trait Expression {
     fn evaluate(
         &self,
         context: &dyn EvaluationContext,
-    ) -> Result<Box<dyn std::any::Any>, Box<dyn Error>>;
+    ) -> Result<
+        Box<dyn std::any::Any + Send + Sync + 'static>,
+        Box<dyn Error + Send + Sync + 'static>,
+    >;
 }

--- a/rocketmq-filter/src/utils.rs
+++ b/rocketmq-filter/src/utils.rs
@@ -14,5 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+pub mod bits_array;
 pub mod bloom_filter;
 pub mod bloom_filter_data;

--- a/rocketmq-filter/src/utils/bits_array.rs
+++ b/rocketmq-filter/src/utils/bits_array.rs
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#[derive(Clone, Debug)]
+pub struct BitsArray {
+    bytes: Vec<u8>,
+    bit_length: usize,
+}
+
+impl BitsArray {
+    pub fn create(bit_length: usize) -> Self {
+        let bytes = vec![0u8; bit_length.div_ceil(8)];
+        BitsArray { bytes, bit_length }
+    }
+
+    pub fn from_bytes(bytes: &[u8], bit_length: Option<usize>) -> Self {
+        if bytes.is_empty() {
+            panic!("Bytes is empty!");
+        }
+        let bit_length = bit_length.unwrap_or(bytes.len() * 8);
+        if bit_length < 1 {
+            panic!("Bit is less than 1.");
+        }
+        if bit_length < bytes.len() * 8 {
+            panic!("BitLength is less than bytes.len() * 8");
+        }
+        BitsArray {
+            bytes: bytes.to_vec(),
+            bit_length,
+        }
+    }
+
+    pub fn bit_length(&self) -> usize {
+        self.bit_length
+    }
+
+    pub fn byte_length(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn xor(&mut self, other: &BitsArray) {
+        self.check_initialized();
+        other.check_initialized();
+        let min_len = self.byte_length().min(other.byte_length());
+        for i in 0..min_len {
+            self.bytes[i] ^= other.get_byte(i);
+        }
+    }
+
+    pub fn xor_bit(&mut self, bit_pos: usize, set: bool) {
+        self.check_bit_position(bit_pos);
+        let value = self.get_bit(bit_pos);
+        self.set_bit(bit_pos, value ^ set);
+    }
+
+    pub fn or(&mut self, other: &BitsArray) {
+        self.check_initialized();
+        other.check_initialized();
+        let min_len = self.byte_length().min(other.byte_length());
+        for i in 0..min_len {
+            self.bytes[i] |= other.get_byte(i);
+        }
+    }
+
+    pub fn or_bit(&mut self, bit_pos: usize, set: bool) {
+        self.check_bit_position(bit_pos);
+        if set {
+            self.set_bit(bit_pos, true);
+        }
+    }
+
+    pub fn and(&mut self, other: &BitsArray) {
+        self.check_initialized();
+        other.check_initialized();
+        let min_len = self.byte_length().min(other.byte_length());
+        for i in 0..min_len {
+            self.bytes[i] &= other.get_byte(i);
+        }
+    }
+
+    pub fn and_bit(&mut self, bit_pos: usize, set: bool) {
+        self.check_bit_position(bit_pos);
+        if !set {
+            self.set_bit(bit_pos, false);
+        }
+    }
+
+    pub fn not(&mut self, bit_pos: usize) {
+        self.check_bit_position(bit_pos);
+        let value = self.get_bit(bit_pos);
+        self.set_bit(bit_pos, !value);
+    }
+
+    pub fn set_bit(&mut self, bit_pos: usize, set: bool) {
+        self.check_bit_position(bit_pos);
+        let sub = self.subscript(bit_pos);
+        let pos = self.position(bit_pos);
+        if set {
+            self.bytes[sub] |= pos;
+        } else {
+            self.bytes[sub] &= !pos;
+        }
+    }
+
+    pub fn set_byte(&mut self, byte_pos: usize, set: u8) {
+        self.check_byte_position(byte_pos);
+        self.bytes[byte_pos] = set;
+    }
+
+    pub fn get_bit(&self, bit_pos: usize) -> bool {
+        self.check_bit_position(bit_pos);
+        (self.bytes[self.subscript(bit_pos)] & self.position(bit_pos)) != 0
+    }
+
+    pub fn get_byte(&self, byte_pos: usize) -> u8 {
+        self.check_byte_position(byte_pos);
+        self.bytes[byte_pos]
+    }
+
+    fn subscript(&self, bit_pos: usize) -> usize {
+        bit_pos / 8
+    }
+
+    fn position(&self, bit_pos: usize) -> u8 {
+        1 << (bit_pos % 8)
+    }
+
+    fn check_byte_position(&self, byte_pos: usize) {
+        self.check_initialized();
+        if byte_pos >= self.byte_length() {
+            panic!("BytePos is greater than {}", self.bytes.len());
+        }
+    }
+
+    fn check_bit_position(&self, bit_pos: usize) {
+        self.check_initialized();
+        if bit_pos >= self.bit_length() {
+            panic!("BitPos is greater than {}", self.bit_length);
+        }
+    }
+
+    fn check_initialized(&self) {
+        if self.bytes.is_empty() {
+            panic!("Not initialized!");
+        }
+    }
+
+    pub fn clone_bits(&self) -> BitsArray {
+        BitsArray {
+            bytes: self.bytes.clone(),
+            bit_length: self.bit_length,
+        }
+    }
+}
+
+impl std::fmt::Display for BitsArray {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.bytes.is_empty() {
+            return write!(f, "null");
+        }
+        let mut s = String::with_capacity(self.bytes.len() * 8);
+        for i in (0..self.bytes.len()).rev() {
+            let mut j = 7;
+            if i == self.bytes.len() - 1 && self.bit_length % 8 > 0 {
+                j = self.bit_length % 8 - 1;
+            }
+            for k in (0..=j).rev() {
+                let mask = 1 << k;
+                if (self.bytes[i] & mask) == mask {
+                    s.push('1');
+                } else {
+                    s.push('0');
+                }
+            }
+            if i % 8 == 0 {
+                s.push('\n');
+            }
+        }
+        write!(f, "{s}")
+    }
+}

--- a/rocketmq-filter/src/utils/bloom_filter.rs
+++ b/rocketmq-filter/src/utils/bloom_filter.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use crate::utils::bits_array::BitsArray;
 use crate::utils::bloom_filter_data::BloomFilterData;
 
 #[derive(Clone, Copy)]
@@ -38,6 +39,8 @@ impl Default for BloomFilter {
     }
 }
 
+#[allow(unused_mut)]
+#[allow(unused_variables)]
 impl BloomFilter {
     pub fn new(f: i32, n: i32) -> Result<Self, &'static str> {
         if !(1..100).contains(&f) {
@@ -87,5 +90,25 @@ impl BloomFilter {
             }
             None => false,
         }
+    }
+
+    pub fn hash_to(&self, filter_data: &BloomFilterData, bits: &mut BitsArray) {
+        /* if !self.is_valid(filter_data) {
+            panic!(
+                "Bloom filter data may not belong to this filter! {:?}, {:?}",
+                filter_data, self
+            );
+        }
+        self.hash_to_positions(filter_data.bit_pos(), bits);*/
+        unimplemented!("hash_to");
+    }
+
+    // Helper method for setting bits at given positions
+    pub fn hash_to_positions(&self, bit_positions: &[usize], bits: &mut BitsArray) {
+        /*self.check(bits);
+        for &i in bit_positions {
+            bits.set_bit(i, true);
+        }*/
+        unimplemented!("hash_to_positions");
     }
 }

--- a/rocketmq-store/src/base.rs
+++ b/rocketmq-store/src/base.rs
@@ -21,7 +21,7 @@ pub mod allocate_mapped_file_service;
 pub mod append_message_callback;
 pub mod commit_log_dispatcher;
 pub mod compaction_append_msg_callback;
-pub(crate) mod dispatch_request;
+pub mod dispatch_request;
 pub mod flush_manager;
 pub mod get_message_result;
 pub mod message_arriving_listener;

--- a/rocketmq-store/src/base/commit_log_dispatcher.rs
+++ b/rocketmq-store/src/base/commit_log_dispatcher.rs
@@ -18,5 +18,5 @@
 use crate::base::dispatch_request::DispatchRequest;
 
 pub trait CommitLogDispatcher: Send + Sync + 'static {
-    fn dispatch(&self, dispatch_request: &DispatchRequest);
+    fn dispatch(&self, dispatch_request: &mut DispatchRequest);
 }

--- a/rocketmq-store/src/index/index_dispatch.rs
+++ b/rocketmq-store/src/index/index_dispatch.rs
@@ -38,7 +38,7 @@ impl CommitLogDispatcherBuildIndex {
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherBuildIndex {
-    fn dispatch(&self, dispatch_request: &DispatchRequest) {
+    fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         if self.message_store_config.message_index_enable {
             self.index_service.build_index(dispatch_request);
         }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -409,7 +409,7 @@ impl LocalFileMessageStore {
 
     pub fn on_commit_log_dispatch(
         &mut self,
-        dispatch_request: &DispatchRequest,
+        dispatch_request: &mut DispatchRequest,
         do_dispatch: bool,
         is_recover: bool,
         _is_file_end: bool,
@@ -419,7 +419,7 @@ impl LocalFileMessageStore {
         }
     }
 
-    pub fn do_dispatch(&mut self, dispatch_request: &DispatchRequest) {
+    pub fn do_dispatch(&mut self, dispatch_request: &mut DispatchRequest) {
         self.dispatcher.dispatch(dispatch_request)
     }
 
@@ -1954,7 +1954,7 @@ impl CommitLogDispatcherDefault {
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherDefault {
-    fn dispatch(&self, dispatch_request: &DispatchRequest) {
+    fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         for dispatcher in self.dispatcher_vec.iter() {
             dispatcher.dispatch(dispatch_request);
         }
@@ -2198,7 +2198,7 @@ impl ReputMessageServiceInner {
                 if dispatch_request.success {
                     match dispatch_request.msg_size.cmp(&0) {
                         std::cmp::Ordering::Greater => {
-                            self.dispatcher.dispatch(&dispatch_request);
+                            self.dispatcher.dispatch(&mut dispatch_request);
                             if !self.notify_message_arrive_in_batch {
                                 self.message_store
                                     .notify_message_arrive_if_necessary(&mut dispatch_request);

--- a/rocketmq-store/src/queue/build_consume_queue.rs
+++ b/rocketmq-store/src/queue/build_consume_queue.rs
@@ -34,7 +34,7 @@ impl CommitLogDispatcherBuildConsumeQueue {
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherBuildConsumeQueue {
-    fn dispatch(&self, dispatch_request: &DispatchRequest) {
+    fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         let tran_type = MessageSysFlag::get_transaction_value(dispatch_request.sys_flag);
         match tran_type {
             MessageSysFlag::TRANSACTION_NOT_TYPE | MessageSysFlag::TRANSACTION_COMMIT_TYPE => {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3187

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced filter bit map calculation capability, controlled by a new configuration option.
  - Added a BitsArray utility for efficient bit array operations.
  - Added a commit log dispatcher for filter bit map calculation.

- **Improvements**
  - Enhanced consumer filter data logging with custom debug and display formatting.
  - Improved evaluation context handling for message filtering.
  - Updated trait and method signatures to support mutability where needed.

- **Bug Fixes**
  - None.

- **Chores**
  - Refined module visibility and public API structure for better extensibility.
  - Added placeholder methods for future bloom filter enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->