### PR TITLE
[ISSUE #3192]🚀Replace MessageStoreConfig and ServerConfig with Arc in BrokerRuntime

### DIFF
--- a/rocketmq-broker/src/broker_bootstrap.rs
+++ b/rocketmq-broker/src/broker_bootstrap.rs
@@ -94,8 +94,8 @@ impl Builder {
         BrokerBootstrap {
             broker_runtime: BrokerRuntime::new(
                 Arc::new(self.broker_config),
-                self.message_store_config,
-                self.server_config,
+                Arc::new(self.message_store_config),
+                Arc::new(self.server_config),
             ),
         }
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3192

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal handling of configuration data to use shared references, enhancing consistency and efficiency when accessing configuration settings within the broker runtime.
- **Chores**
  - Removed unnecessary mutable access to configuration settings, resulting in a cleaner and safer configuration management approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->