### PR TITLE
[ISSUE #3204]⚡️Remove use lazy_static::lazy_static in TopicAttributes

### DIFF
--- a/rocketmq-common/src/common/attribute/topic_attributes.rs
+++ b/rocketmq-common/src/common/attribute/topic_attributes.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 
 use cheetah_string::CheetahString;
-use lazy_static::lazy_static;
 
 use crate::common::attribute::enum_attribute::EnumAttribute;
 use crate::common::attribute::long_range_attribute::LongRangeAttribute;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3204

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an unused dependency to improve code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->