### PR TITLE
[ISSUE #2932]♻️Refactor WipeWritePermOfBrokerResponseHeader with derive marco RequestHeaderCodec

### DIFF
--- a/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
@@ -39,43 +39,15 @@ impl WipeWritePermOfBrokerRequestHeader {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct WipeWritePermOfBrokerResponseHeader {
     pub wipe_topic_count: i32,
 }
 
 impl WipeWritePermOfBrokerResponseHeader {
-    const WIPE_TOPIC_COUNT: &'static str = "wipeTopicCount";
-
     pub fn new(wipe_topic_count: i32) -> Self {
         Self { wipe_topic_count }
-    }
-}
-
-impl CommandCustomHeader for WipeWritePermOfBrokerResponseHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        Some(HashMap::from([(
-            CheetahString::from_static_str(Self::WIPE_TOPIC_COUNT),
-            CheetahString::from_string(self.wipe_topic_count.to_string()),
-        )]))
-    }
-}
-
-impl FromMap for WipeWritePermOfBrokerResponseHeader {
-    type Error = rocketmq_error::RocketmqError;
-
-    type Target = Self;
-
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(WipeWritePermOfBrokerResponseHeader {
-            wipe_topic_count: map
-                .get(&CheetahString::from_static_str(
-                    WipeWritePermOfBrokerResponseHeader::WIPE_TOPIC_COUNT,
-                ))
-                .and_then(|s| s.parse::<i32>().ok())
-                .unwrap_or(0),
-        })
     }
 }
 


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2932

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of broker response headers for write permission operations, resulting in more streamlined and maintainable code. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->