### PR TITLE
[ISSUE #3227]♻️Refactor SendMessageProcessor handle_put_message_result

### DIFF
--- a/rocketmq-remoting/src/connection.rs
+++ b/rocketmq-remoting/src/connection.rs
@@ -151,6 +151,28 @@ impl Connection {
         Ok(())
     }
 
+    /// Sends a `RemotingCommand` over the connection.
+    ///
+    /// # Arguments
+    ///
+    /// * `command` - The `RemotingCommand` to send.
+    ///
+    /// # Returns
+    ///
+    /// A result indicating success or failure.
+    pub async fn send_command_ref(
+        &mut self,
+        command: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.buf.clear();
+        command.fast_header_encode(&mut self.buf);
+        if let Some(body_inner) = command.take_body() {
+            self.buf.put(body_inner);
+        }
+        self.writer.send(self.buf.clone().freeze()).await?;
+        Ok(())
+    }
+
     /// Sends a `Bytes` object over the connection.
     ///
     /// # Arguments

--- a/rocketmq-remoting/src/runtime/connection_handler_context.rs
+++ b/rocketmq-remoting/src/runtime/connection_handler_context.rs
@@ -60,6 +60,19 @@ impl ConnectionHandlerContextWrapper {
             }
         }
     }
+    pub async fn write_ref(&mut self, cmd: &mut RemotingCommand) {
+        match self.channel.upgrade() {
+            Some(mut channel) => match channel.connection_mut().send_command_ref(cmd).await {
+                Ok(_) => {}
+                Err(error) => {
+                    error!("send response failed: {}", error);
+                }
+            },
+            None => {
+                error!("channel is closed");
+            }
+        }
+    }
 
     pub fn channel(&self) -> &Channel {
         &self.channel


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3227

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for invoking a callback after sending messages, allowing more flexible response handling.
  - Introduced new methods for sending and writing messages using mutable references, improving performance and memory usage.

- **Improvements**
  - Enhanced control flow for message sending operations, enabling better handling of success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->