### PR TITLE
[ISSUE #2794]Improve KVConfigManager perfermance with DashHashp 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,7 @@ dependencies = [
  "cheetah-string",
  "clap",
  "config",
+ "dashmap",
  "parking_lot",
  "rocketmq-common",
  "rocketmq-error",

--- a/rocketmq-namesrv/Cargo.toml
+++ b/rocketmq-namesrv/Cargo.toml
@@ -33,7 +33,7 @@ serde_json.workspace = true
 
 config.workspace = true
 parking_lot.workspace = true
-dashmap = "6.1.0"
+dashmap = { version = "6.1.0", features = ["serde"] }
 
 clap = { version = "4.5.37", features = ["derive"] }
 cheetah-string = { workspace = true }

--- a/rocketmq-namesrv/Cargo.toml
+++ b/rocketmq-namesrv/Cargo.toml
@@ -33,6 +33,7 @@ serde_json.workspace = true
 
 config.workspace = true
 parking_lot.workspace = true
+dashmap = "6.1.0"
 
 clap = { version = "4.5.37", features = ["derive"] }
 cheetah-string = { workspace = true }

--- a/rocketmq-namesrv/src/kvconfig.rs
+++ b/rocketmq-namesrv/src/kvconfig.rs
@@ -27,7 +27,7 @@ pub mod kvconfig_mananger;
 pub struct KVConfigSerializeWrapper {
     #[serde(rename = "configTable")]
     pub config_table: Option<
-        HashMap<
+        dashmap::DashMap<
             CheetahString, /* Namespace */
             HashMap<CheetahString /* Key */, CheetahString /* Value */>,
         >,
@@ -36,7 +36,7 @@ pub struct KVConfigSerializeWrapper {
 
 impl KVConfigSerializeWrapper {
     pub fn new_with_config_table(
-        config_table: HashMap<CheetahString, HashMap<CheetahString, CheetahString>>,
+        config_table: dashmap::DashMap<CheetahString, HashMap<CheetahString, CheetahString>>,
     ) -> KVConfigSerializeWrapper {
         KVConfigSerializeWrapper {
             config_table: Some(config_table),
@@ -45,7 +45,7 @@ impl KVConfigSerializeWrapper {
 
     pub fn new() -> KVConfigSerializeWrapper {
         KVConfigSerializeWrapper {
-            config_table: Some(HashMap::new()),
+            config_table: Some(dashmap::DashMap::new()),
         }
     }
 }

--- a/rocketmq-namesrv/src/kvconfig/kvconfig_mananger.rs
+++ b/rocketmq-namesrv/src/kvconfig/kvconfig_mananger.rs
@@ -160,11 +160,10 @@ impl KVConfigManager {
 
     /// Deletes a key-value configuration.
     pub fn delete_kv_config(&mut self, namespace: &CheetahString, key: &CheetahString) {
-        if !self.config_table.contains_key(namespace) {
-            return;
-        }
-
-        let pre_value = self.config_table.get_mut(namespace).unwrap().remove(key);
+        let pre_value = match self.config_table.get_mut(namespace) {
+            None => return,
+            Some(mut table) => table.remove(key),
+        };
         match pre_value {
             None => {}
             Some(value) => {


### PR DESCRIPTION
- 引入 dashmap crate 以使用并发安全的 dashmap- 重构 KVConfigManager 结构，将 config_table 替换为 dashmap
- 更新相关方法以适应新的数据结构
- 优化并发访问和修改配置表的逻辑

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fix #2794

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved performance and concurrency for configuration management by updating internal data structures to use a concurrent map.
- **Chores**
  - Updated dependencies to include a new library for enhanced concurrent data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->