### PR TITLE
[ISSUE #3246]⚡️Optimize MessageExtEncoder performance

### DIFF
--- a/rocketmq-common/src/common/message/message_ext_broker_inner.rs
+++ b/rocketmq-common/src/common/message/message_ext_broker_inner.rs
@@ -39,7 +39,7 @@ pub struct MessageExtBrokerInner {
     pub message_ext_inner: MessageExt,
     pub properties_string: CheetahString,
     pub tags_code: i64,
-    pub encoded_buff: Option<ArcMut<bytes::BytesMut>>,
+    pub encoded_buff: Option<bytes::BytesMut>,
     pub encode_completed: bool,
     pub version: MessageVersion,
 }

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -107,7 +107,7 @@ thread_local! {
 fn encode_message_ext(
     message_ext: &MessageExtBrokerInner,
     message_store_config: &Arc<MessageStoreConfig>,
-) -> (Option<PutMessageResult>, ArcMut<BytesMut>) {
+) -> (Option<PutMessageResult>, BytesMut) {
     PUT_MESSAGE_THREAD_LOCAL.with(|thread_local| {
         if thread_local.encoder.borrow().is_none() {
             let encoder = MessageExtEncoder::new(Arc::clone(message_store_config));


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3246

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal buffer management by removing shared mutable wrappers and using direct mutable buffers for message encoding.
  - Updated method and field types to use more straightforward and idiomatic buffer handling, improving code clarity and maintainability for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->