### PR TITLE
[ISSUE #3250]⚡️Replace MessageIdSupplier Box with Arc

### DIFF
--- a/rocketmq-store/src/base/message_result.rs
+++ b/rocketmq-store/src/base/message_result.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use crate::base::message_status_enum::AppendMessageStatus;
 use crate::base::message_status_enum::PutMessageStatus;
 
-type MessageIdSupplier = Box<dyn Fn() -> String + Send + Sync>;
+type MessageIdSupplier = Arc<dyn Fn() -> String + Send + Sync>;
 
 /// Represents the result of an append message operation.
 #[derive(Clone)]
@@ -34,7 +34,7 @@ pub struct AppendMessageResult {
     /// Message ID.
     pub msg_id: Option<String>,
     /// Message ID supplier.
-    pub msg_id_supplier: Option<Arc<MessageIdSupplier>>,
+    pub msg_id_supplier: Option<MessageIdSupplier>,
     /// Message storage timestamp.
     pub store_timestamp: i64,
     /// Consume queue's offset (step by one).


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3250

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of transaction message flags and message ID supplier logic for better clarity and maintainability.
  - Simplified the ownership model for message ID suppliers to reduce redundancy.
- **Style**
  - Enhanced code readability by streamlining variable assignments and removing outdated comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->