### PR TITLE
[ISSUE #3267]♻️Refactor PutMessageHook trait

### DIFF
--- a/rocketmq-broker/src/hook/batch_check_before_put_message.rs
+++ b/rocketmq-broker/src/hook/batch_check_before_put_message.rs
@@ -48,8 +48,12 @@ impl PutMessageHook for BatchCheckBeforePutMessageHook {
         if let Some(msg) = msg.as_any_mut().downcast_mut::<MessageExtBrokerInner>() {
             HookUtils::check_inner_batch(&self.topic_config_table, &msg.message_ext_inner)
         } else {
-            // This should not happen, but just in case
-            warn!("Message is not of type MessageExtBrokerInner");
+            // This fallback case exists as a safeguard against unexpected message types.
+            // If this warning is logged, it indicates a potential issue with the message type conversion.
+            warn!(
+                "Message is not of type MessageExtBrokerInner. Actual type: {}",
+                msg.type_name()
+            );
             None
         }
     }

--- a/rocketmq-broker/src/hook/batch_check_before_put_message.rs
+++ b/rocketmq-broker/src/hook/batch_check_before_put_message.rs
@@ -48,12 +48,8 @@ impl PutMessageHook for BatchCheckBeforePutMessageHook {
         if let Some(msg) = msg.as_any_mut().downcast_mut::<MessageExtBrokerInner>() {
             HookUtils::check_inner_batch(&self.topic_config_table, &msg.message_ext_inner)
         } else {
-            // This fallback case exists as a safeguard against unexpected message types.
-            // If this warning is logged, it indicates a potential issue with the message type conversion.
-            warn!(
-                "Message is not of type MessageExtBrokerInner. Actual type: {}",
-                msg.type_name()
-            );
+            // This should not happen, but just in case
+            warn!("Message is not of type MessageExtBrokerInner");
             None
         }
     }

--- a/rocketmq-broker/src/hook/check_before_put_message.rs
+++ b/rocketmq-broker/src/hook/check_before_put_message.rs
@@ -17,7 +17,7 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_common::common::message::MessageTrait;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_store::MessageStore;
@@ -45,14 +45,11 @@ impl<MS: MessageStore> PutMessageHook for CheckBeforePutMessageHook<MS> {
         "checkBeforePutMessage".to_string()
     }
 
-    fn execute_before_put_message(
-        &self,
-        msg: &mut MessageExtBrokerInner,
-    ) -> Option<PutMessageResult> {
+    fn execute_before_put_message(&self, msg: &mut dyn MessageTrait) -> Option<PutMessageResult> {
         HookUtils::check_before_put_message(
             self.message_store.deref(),
             &self.message_store_config,
-            &msg.message_ext_inner,
+            msg,
         )
     }
 }

--- a/rocketmq-broker/src/hook/schedule_message_hook.rs
+++ b/rocketmq-broker/src/hook/schedule_message_hook.rs
@@ -43,6 +43,12 @@ impl<MS: MessageStore> PutMessageHook for ScheduleMessageHook<MS> {
     }
 
     fn execute_before_put_message(&self, msg: &mut dyn MessageTrait) -> Option<PutMessageResult> {
+        // Attempt to downcast the generic MessageTrait to MessageExtBrokerInner.
+        // This is necessary because the schedule message handling logic requires
+        // specific fields and methods available only in MessageExtBrokerInner.
+        // If the downcast fails, it means the message is not of the expected type,
+        // so we log a warning and return None to indicate that no further processing
+        // can be performed for this message.
         if let Some(msg) = msg.as_any_mut().downcast_mut::<MessageExtBrokerInner>() {
             HookUtils::handle_schedule_message(&self.broker_runtime_inner, msg)
         } else {

--- a/rocketmq-store/src/hook/put_message_hook.rs
+++ b/rocketmq-store/src/hook/put_message_hook.rs
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+
+use rocketmq_common::common::message::MessageTrait;
 
 use crate::base::message_result::PutMessageResult;
 
@@ -33,10 +34,7 @@ pub trait PutMessageHook {
     /// # Returns
     ///
     /// The result of putting the message
-    fn execute_before_put_message(
-        &self,
-        msg: &mut MessageExtBrokerInner,
-    ) -> Option<PutMessageResult>;
+    fn execute_before_put_message(&self, msg: &mut dyn MessageTrait) -> Option<PutMessageResult>;
 }
 
 /// Alias for `Arc<dyn PutMessageHook>`.


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3267

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved flexibility of message processing by allowing hooks to handle any message type implementing the required interface, rather than a specific message structure.
  - Enhanced runtime type checking and added warnings for unexpected message types during message processing.
  - Streamlined internal hook utility functions for broader compatibility with different message implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->