### PR TITLE
[ISSUE #3295]add updateAndSubscripGroup func

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use bytes::Bytes;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+use rocketmq_remoting::protocol::RemotingDeserializable;
+use rocketmq_remoting::protocol::RemotingSerializable;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+use tracing::info;
+use tracing::warn;
+
+use crate::broker_runtime::BrokerRuntimeInner;
+
+#[derive(Clone)]
+pub(super) struct SubscriptionGroupHandler<MS> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+}
+
+impl<MS: MessageStore> SubscriptionGroupHandler<MS> {
+    pub(super) fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        Self {
+            broker_runtime_inner,
+        }
+    }
+
+    pub async fn update_and_create_subscription_group(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        let start_time = get_current_millis() as i64;
+
+        let mut response = RemotingCommand::create_response_command();
+
+        info!(
+            "AdminBrokerProcessor#updateAndCreateSubscriptionGroup called by {}",
+            _channel.remote_address()
+        );
+        let mut config = SubscriptionGroupConfig::decode(request.get_body().unwrap());
+        if let Ok(config) = config.as_mut() {
+            self.broker_runtime_inner
+                .subscription_group_manager()
+                .update_subscription_group_config(config);
+        }
+        response.set_code_ref(ResponseCode::Success);
+        let execution_time = get_current_millis() as i64 - start_time;
+
+        if let Ok(config) = config.as_ref() {
+            info!(
+                "executionTime of create subscriptionGroup:{} is {} ms",
+                config.group_name(),
+                execution_time
+            );
+        }
+
+        // todo
+        // InvocationStatus status =
+        // response.getCode() == ResponseCode.SUCCESS ? InvocationStatus.SUCCESS :
+        // InvocationStatus.FAILURE; Attributes attributes =
+        // BrokerMetricsManager.newAttributesBuilder()     .put(LABEL_INVOCATION_STATUS,
+        // status.getName())     .build();
+        // BrokerMetricsManager.consumerGroupCreateExecuteTime.record(executionTime, attributes);
+        Some(response)
+    }
+
+    pub async fn unlock_batch_mq(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        let mut request_body = UnlockBatchRequestBody::decode(request.get_body().unwrap()).unwrap();
+        if request_body.only_this_broker
+            || !self
+                .broker_runtime_inner
+                .broker_config()
+                .lock_in_strict_mode
+        {
+            self.broker_runtime_inner
+                .rebalance_lock_manager()
+                .unlock_batch(
+                    request_body.consumer_group.as_ref().unwrap(),
+                    &request_body.mq_set,
+                    request_body.client_id.as_ref().unwrap(),
+                );
+        } else {
+            request_body.only_this_broker = true;
+            let request_body =
+                Bytes::from(request_body.encode().expect("unlockBatchMQ encode error"));
+            for broker_addr in self
+                .broker_runtime_inner
+                .broker_member_group()
+                .broker_addrs
+                .values()
+            {
+                match self
+                    .broker_runtime_inner
+                    .broker_outer_api()
+                    .unlock_batch_mq_async(broker_addr, request_body.clone(), 1000)
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(e) => {
+                        warn!("unlockBatchMQ exception on {}, {}", broker_addr, e);
+                    }
+                }
+            }
+        }
+        Some(RemotingCommand::create_response_command())
+    }
+}

--- a/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
@@ -63,8 +63,8 @@ impl<MS: MessageStore> SubscriptionGroupHandler<MS> {
         let mut config = SubscriptionGroupConfig::decode(request.get_body().unwrap());
         if let Ok(config) = config.as_mut() {
             self.broker_runtime_inner
-                .subscription_group_manager()
-                .update_subscription_group_config(config);
+                .subscription_group_manager_mut()
+                .update_subscription_group_config(config)
         }
         response.set_code_ref(ResponseCode::Success);
         let execution_time = get_current_millis() as i64 - start_time;

--- a/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
+++ b/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
@@ -83,8 +83,7 @@ where
                 .as_ref()
                 .lock()
                 .subscription_group_table
-                .get(config.group_name())
-                .is_none(),
+                .contains_key(config.group_name()),
             SubscriptionGroupAttributes::all(),
             &current_attributes,
             &new_attributes,

--- a/rocketmq-common/src/common/attribute.rs
+++ b/rocketmq-common/src/common/attribute.rs
@@ -23,6 +23,7 @@ pub mod cleanup_policy;
 pub mod cq_type;
 pub mod enum_attribute;
 pub mod long_range_attribute;
+pub mod subscription_group_attributes;
 pub mod topic_attributes;
 pub mod topic_message_type;
 

--- a/rocketmq-common/src/common/attribute/subscription_group_attributes.rs
+++ b/rocketmq-common/src/common/attribute/subscription_group_attributes.rs
@@ -11,6 +11,6 @@ pub struct SubscriptionGroupAttributes {}
 impl SubscriptionGroupAttributes {
     pub fn all() -> &'static HashMap<CheetahString, Arc<dyn Attribute>> {
         static ALL: OnceLock<HashMap<CheetahString, Arc<dyn Attribute>>> = OnceLock::new();
-        ALL.get_or_init(HashMap::new())
+        ALL.get_or_init(|| HashMap::new())
     }
 }

--- a/rocketmq-common/src/common/attribute/subscription_group_attributes.rs
+++ b/rocketmq-common/src/common/attribute/subscription_group_attributes.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use cheetah_string::CheetahString;
+
+use crate::common::attribute::Attribute;
+
+pub struct SubscriptionGroupAttributes {}
+
+impl SubscriptionGroupAttributes {
+    pub fn all() -> &'static HashMap<CheetahString, Arc<dyn Attribute>> {
+        static ALL: OnceLock<HashMap<CheetahString, Arc<dyn Attribute>>> = OnceLock::new();
+        ALL.get_or_init(|| HashMap::new())
+    }
+}

--- a/rocketmq-common/src/common/attribute/subscription_group_attributes.rs
+++ b/rocketmq-common/src/common/attribute/subscription_group_attributes.rs
@@ -9,6 +9,7 @@ use crate::common::attribute::Attribute;
 pub struct SubscriptionGroupAttributes {}
 
 impl SubscriptionGroupAttributes {
+    #[allow(clippy::redundant_closure)]
     pub fn all() -> &'static HashMap<CheetahString, Arc<dyn Attribute>> {
         static ALL: OnceLock<HashMap<CheetahString, Arc<dyn Attribute>>> = OnceLock::new();
         ALL.get_or_init(|| HashMap::new())

--- a/rocketmq-common/src/common/attribute/subscription_group_attributes.rs
+++ b/rocketmq-common/src/common/attribute/subscription_group_attributes.rs
@@ -11,6 +11,6 @@ pub struct SubscriptionGroupAttributes {}
 impl SubscriptionGroupAttributes {
     pub fn all() -> &'static HashMap<CheetahString, Arc<dyn Attribute>> {
         static ALL: OnceLock<HashMap<CheetahString, Arc<dyn Attribute>>> = OnceLock::new();
-        ALL.get_or_init(|| HashMap::new())
+        ALL.get_or_init(HashMap::new())
     }
 }

--- a/rocketmq-common/src/common/config_manager.rs
+++ b/rocketmq-common/src/common/config_manager.rs
@@ -25,7 +25,6 @@ use crate::FileUtils;
 
 // Define the trait ConfigManager
 pub trait ConfigManager {
-    
     /// Loads the configuration from a file.
     ///
     /// This method attempts to load the configuration from a file whose path is returned by

--- a/rocketmq-common/src/common/config_manager.rs
+++ b/rocketmq-common/src/common/config_manager.rs
@@ -25,6 +25,7 @@ use crate::FileUtils;
 
 // Define the trait ConfigManager
 pub trait ConfigManager {
+    
     /// Loads the configuration from a file.
     ///
     /// This method attempts to load the configuration from a file whose path is returned by

--- a/rocketmq-common/src/utils/file_utils.rs
+++ b/rocketmq-common/src/utils/file_utils.rs
@@ -51,7 +51,7 @@ pub fn file_to_string_impl(file: &File) -> Result<String, io::Error> {
 }
 
 pub fn string_to_file(str_content: &str, file_name: &str) -> io::Result<()> {
-    let lock = LOCK.lock();
+    let lock = LOCK.lock(); //todo enhancement: not use global lock
 
     let bak_file = format!("{file_name}.bak");
 

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -32,7 +32,7 @@
  */
 use std::io;
 
-pub type RocketMQResult<T> = std::result::Result<T, RocketmqError>;
+pub type RocketMQResult<T> = Result<T, RocketmqError>;
 
 use thiserror::Error;
 


### PR DESCRIPTION
- 新增 SubscriptionGroupHandler 处理订阅组相关请求
- 实现 update_and_create_subscription_group 方法处理更新和创建订阅组
- 添加 SubscriptionGroupAttributes 和相关属性处理
- 修改 SubscriptionGroupManager 支持更新订阅组配置

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3295

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for updating and creating subscription group configurations.
  - Introduced batch unlocking of message queues for improved subscription group management.
- **Enhancements**
  - Subscription group updates now merge attributes and track versioning for better configuration management.
- **Documentation**
  - Added comments and module documentation for new features and future improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->