### PR TITLE
[ISSUE #3305]🚀CommitLog put messages add unlockMappedFile logic

### DIFF
--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -470,7 +470,8 @@ pub trait MessageStoreInner: Sync + 'static {
     fn get_allocate_mapped_file_service(&self) -> Arc<AllocateMappedFileService>;
 
     /// Truncate dirty logic files
-    fn truncate_dirty_logic_files(&self, phy_offset: i64) -> Result<(), StoreError>;
+    // fn truncate_dirty_logic_files(&self, phy_offset: i64) -> Result<(), StoreError>;
+    fn truncate_dirty_logic_files(&self, phy_offset: i64);
 
     /// Unlock mappedFile
     fn unlock_mapped_file<MF: MappedFile>(&self, unlock_mapped_file: &MF);

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -63,6 +63,7 @@ use crate::base::message_result::AppendMessageResult;
 use crate::base::message_result::PutMessageResult;
 use crate::base::message_status_enum::AppendMessageStatus;
 use crate::base::message_status_enum::PutMessageStatus;
+use crate::base::message_store::MessageStore;
 use crate::base::put_message_context::PutMessageContext;
 use crate::base::select_result::SelectMappedBufferResult;
 use crate::base::store_checkpoint::StoreCheckpoint;
@@ -332,7 +333,7 @@ impl CommitLog {
             msg_batch.message_ext_broker_inner.with_store_host_v6_flag();
         }
 
-        let mut _unlock_mapped_file = None;
+        let mut unlock_mapped_file = None;
         let mut mapped_file = self.mapped_file_queue.get_last_mapped_file();
         let curr_offset = if let Some(ref mapped_file_inner) = mapped_file {
             mapped_file_inner.get_wrote_position() as u64 + mapped_file_inner.get_file_from_offset()
@@ -410,7 +411,7 @@ impl CommitLog {
             }
             AppendMessageStatus::EndOfFile => {
                 //onCommitLogAppend(msg, result, mappedFile); in java not support this version
-                _unlock_mapped_file = mapped_file;
+                unlock_mapped_file = mapped_file;
                 mapped_file = self
                     .mapped_file_queue
                     .get_last_mapped_file_mut_start_offset(0, true);
@@ -467,7 +468,15 @@ impl CommitLog {
                 put_message_result.append_message_result().as_ref().unwrap(),
             );
         }
-
+        if let (Some(unlock_mf), true) = (
+            unlock_mapped_file,
+            self.message_store_config.warm_mapped_file_enable,
+        ) {
+            self.local_file_message_store
+                .as_ref()
+                .unwrap()
+                .unlock_mapped_file(unlock_mf.as_ref());
+        }
         if put_message_result.put_message_status() == PutMessageStatus::PutOk {
             self.increase_offset(
                 &msg_batch.message_ext_broker_inner,
@@ -527,7 +536,7 @@ impl CommitLog {
 
         let topic_queue_key = generate_key(&msg);
 
-        let mut _unlock_mapped_file = None;
+        let mut unlock_mapped_file = None;
 
         //get last mapped file from mapped file queue
         let mut mapped_file = self.mapped_file_queue.get_last_mapped_file();
@@ -601,7 +610,7 @@ impl CommitLog {
             }
             AppendMessageStatus::EndOfFile => {
                 //onCommitLogAppend(msg, result, mappedFile); in java not support this version
-                _unlock_mapped_file = mapped_file;
+                unlock_mapped_file = mapped_file;
                 mapped_file = self
                     .mapped_file_queue
                     .get_last_mapped_file_mut_start_offset(0, true);
@@ -656,6 +665,16 @@ impl CommitLog {
                 msg.body_len(),
                 put_message_result.append_message_result().as_ref().unwrap(),
             );
+        }
+
+        if let (Some(unlock_mf), true) = (
+            unlock_mapped_file,
+            self.message_store_config.warm_mapped_file_enable,
+        ) {
+            self.local_file_message_store
+                .as_ref()
+                .unwrap()
+                .unlock_mapped_file(unlock_mf.as_ref());
         }
 
         if put_message_result.put_message_status() == PutMessageStatus::PutOk {

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -424,9 +424,9 @@ impl LocalFileMessageStore {
         self.dispatcher.dispatch(dispatch_request)
     }
 
-    pub fn truncate_dirty_logic_files(&mut self, phy_offset: i64) {
+    /*    pub fn truncate_dirty_logic_files(&mut self, phy_offset: i64) {
         self.consume_queue_store.truncate_dirty(phy_offset);
-    }
+    }*/
 
     pub fn consume_queue_store_mut(&mut self) -> &mut ConsumeQueueStore {
         &mut self.consume_queue_store
@@ -1716,12 +1716,12 @@ impl MessageStore for LocalFileMessageStore {
         todo!()
     }
 
-    fn truncate_dirty_logic_files(&self, phy_offset: i64) -> Result<(), StoreError> {
-        todo!()
+    fn truncate_dirty_logic_files(&self, phy_offset: i64) {
+        self.consume_queue_store.truncate_dirty(phy_offset);
     }
 
     fn unlock_mapped_file<MF: MappedFile>(&self, unlock_mapped_file: &MF) {
-        todo!()
+        warn!("unlock_mapped_file: not implemented");
     }
 
     fn get_queue_store(&self) -> &dyn Any {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3305

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message file handling to ensure mapped files are properly unlocked after appending messages when certain configurations are enabled.
  - Added warning logs for unimplemented mapped file unlocking functionality.

- **Refactor**
  - Simplified internal error handling for file truncation operations, removing error returns from related methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->