### PR TITLE
[ISSUE #3310]🚀Add the second-level command show

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "rocketmq-rust",
  "serde",
  "serde_json",
+ "tabled",
  "tokio",
 ]
 

--- a/rocketmq-tools/Cargo.toml
+++ b/rocketmq-tools/Cargo.toml
@@ -24,6 +24,7 @@ tokio = {workspace = true}
 
 cheetah-string = { workspace = true }
 clap = { version = "4.5.38", features = ["derive"] }
+tabled = { version = "0.19.0", features = ["derive"] }
 
 [[bin]]
 name = "rocketmq-admin-cli-rust"

--- a/rocketmq-tools/src/bin/rocketmq_admin_cli.rs
+++ b/rocketmq-tools/src/bin/rocketmq_admin_cli.rs
@@ -21,5 +21,6 @@ use rocketmq_tools::rocketmq_cli::RocketMQCli;
 async fn main() {
     // This is a placeholder for the main function.
     // The actual implementation will depend on the specific requirements of the RocketMQ admin CLI.
-    let _cli = RocketMQCli::parse();
+    let cli = RocketMQCli::parse();
+    cli.handle();
 }

--- a/rocketmq-tools/src/commands.rs
+++ b/rocketmq-tools/src/commands.rs
@@ -16,11 +16,46 @@
  */
 mod topic_commands;
 
+use clap::Parser;
 use clap::Subcommand;
+use tabled::settings::Style;
+use tabled::Table;
+use tabled::Tabled;
 
 #[derive(Subcommand)]
 pub enum Commands {
     #[command(subcommand)]
     #[command(about = "Topic commands")]
     Topic(topic_commands::TopicCommands),
+
+    #[command(about = "Category commands show")]
+    Show(ClassificationTablePrint),
+}
+
+#[derive(Tabled, Clone)]
+struct Command {
+    #[tabled(rename = "Category")]
+    category: &'static str,
+
+    #[tabled(rename = "Command")]
+    command: &'static str,
+
+    #[tabled(rename = "Remark")]
+    remark: &'static str,
+}
+
+#[derive(Parser)]
+pub(crate) struct ClassificationTablePrint;
+
+impl ClassificationTablePrint {
+    pub fn print(&self) {
+        let commands: Vec<Command> = vec![Command {
+            category: "Topic",
+            command: "allocateMQ",
+            remark: "Allocate MQ.",
+        }];
+        let mut table = Table::new(commands);
+        table.with(Style::extended());
+        print!("{table}");
+    }
 }

--- a/rocketmq-tools/src/rocketmq_cli.rs
+++ b/rocketmq-tools/src/rocketmq_cli.rs
@@ -20,8 +20,21 @@ use crate::commands::Commands;
 
 #[derive(Parser)]
 #[command(name = "rocketmq-admin-cli-rust")]
-#[command(about = "An example CLI application with subcommands in a group", long_about = None)]
+#[command(about = "Rocketmq Rust admin commands", long_about = None, author="mxsm")]
 pub struct RocketMQCli {
     #[command(subcommand)]
     commands: Commands,
+}
+
+impl RocketMQCli {
+    pub fn handle(&self) {
+        match &self.commands {
+            Commands::Topic(_) => {
+                unimplemented!("Topic command is not implemented yet");
+            }
+            Commands::Show(value) => {
+                value.print();
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3310

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "show" subcommand to the CLI that displays a formatted table of command categories and descriptions.
- **Improvements**
  - Enhanced CLI metadata with a more descriptive summary and author information.
  - The CLI now processes and handles subcommands, providing immediate feedback or output when commands are run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->