### PR TITLE
[ISSUE #3323]🚀Change common arg namesrvAddr required to false💫

### DIFF
--- a/rocketmq-tools/src/commands.rs
+++ b/rocketmq-tools/src/commands.rs
@@ -47,10 +47,11 @@ pub struct CommonArgs {
     #[arg(
         short = 'n',
         long = "namesrvAddr",
-        required = true,
+        required = false,
+        default_value = None,
         help = "Name server address list, eg: '192.168.0.1:9876;192.168.0.2:9876'"
     )]
-    pub namesrv_addr: String,
+    pub namesrv_addr: Option<String>,
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3323

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The name server address argument is now optional when using the command-line tool, allowing users to run commands without specifying it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->