### PR TITLE
[ISSUE #3325]⚡️Change CommandExecute#execute as async

### DIFF
--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -669,7 +669,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         name_servers: Vec<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<HashMap<CheetahString, HashMap<CheetahString, CheetahString>>>
     {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .get_name_server_config(name_servers)
+            .await
     }
 
     async fn resume_check_half_message(

--- a/rocketmq-tools/src/bin/rocketmq_admin_cli.rs
+++ b/rocketmq-tools/src/bin/rocketmq_admin_cli.rs
@@ -22,5 +22,5 @@ async fn main() {
     // This is a placeholder for the main function.
     // The actual implementation will depend on the specific requirements of the RocketMQ admin CLI.
     let cli = RocketMQCli::parse();
-    cli.handle();
+    cli.handle().await;
 }

--- a/rocketmq-tools/src/commands.rs
+++ b/rocketmq-tools/src/commands.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 use tabled::settings::Style;
 use tabled::Table;
@@ -38,7 +39,7 @@ pub trait CommandExecute {
     /// - `rpcHook`: An `Arc` containing a reference to a type that implements the `RPCHook` trait.
     ///   This hook is used to customize the behavior of remote procedure calls during command
     ///   execution.
-    fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>);
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()>;
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -70,11 +71,11 @@ pub enum Commands {
 }
 
 impl CommandExecute for Commands {
-    fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
-            Commands::NameServer(value) => value.execute(rpc_hook),
-            Commands::Topic(value) => value.execute(rpc_hook),
-            Commands::Show(value) => value.execute(rpc_hook),
+            Commands::NameServer(value) => value.execute(rpc_hook).await,
+            Commands::Topic(value) => value.execute(rpc_hook).await,
+            Commands::Show(value) => value.execute(rpc_hook).await,
         }
     }
 }
@@ -96,7 +97,7 @@ struct Command {
 pub(crate) struct ClassificationTablePrint;
 
 impl CommandExecute for ClassificationTablePrint {
-    fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         let commands: Vec<Command> = vec![
             Command {
                 category: "Topic",
@@ -112,5 +113,6 @@ impl CommandExecute for ClassificationTablePrint {
         let mut table = Table::new(commands);
         table.with(Style::extended());
         print!("{table}");
+        Ok(())
     }
 }

--- a/rocketmq-tools/src/commands/namesrv_commands.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands.rs
@@ -19,6 +19,7 @@ mod get_namesrv_config_command;
 use std::sync::Arc;
 
 use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::namesrv_commands::get_namesrv_config_command::GetNamesrvConfigCommand;
@@ -35,11 +36,9 @@ pub enum NameServerCommands {
 }
 
 impl CommandExecute for NameServerCommands {
-    fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
-            NameServerCommands::GetNamesrvConfig(value) => {
-                value.execute(rpc_hook);
-            }
+            NameServerCommands::GetNamesrvConfig(value) => value.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/src/commands/namesrv_commands/get_namesrv_config_command.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands/get_namesrv_config_command.rs
@@ -16,9 +16,14 @@
  */
 use std::sync::Arc;
 
+use cheetah_string::CheetahString;
 use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::commands::CommandExecute;
 use crate::commands::CommonArgs;
 
@@ -28,8 +33,47 @@ pub struct GetNamesrvConfigCommand {
     common: CommonArgs,
 }
 
+impl GetNamesrvConfigCommand {
+    fn parse_server_list(&self) -> Option<Vec<CheetahString>> {
+        self.common.namesrv_addr.as_ref().and_then(|servers| {
+            if servers.trim().is_empty() {
+                None
+            } else {
+                let server_array = servers
+                    .trim()
+                    .split(';')
+                    .filter(|s| !s.trim().is_empty())
+                    .map(|s| s.trim().to_string().into())
+                    .collect::<Vec<CheetahString>>();
+
+                if server_array.is_empty() {
+                    None
+                } else {
+                    Some(server_array)
+                }
+            }
+        })
+    }
+}
+
 impl CommandExecute for GetNamesrvConfigCommand {
-    fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        if self.common.namesrv_addr.is_none() {
+            eprintln!("Please set the namesrvAddr parameter");
+            return Ok(());
+        }
+        let mut admin = DefaultMQAdminExt::new();
+        admin.client_config_mut().instance_name = get_current_millis().to_string().into();
+
+        let server_list = self.parse_server_list();
+        if let Some(server_list) = server_list {
+            admin.start().await?;
+            let _ = admin.get_name_server_config(server_list).await;
+        } else {
+            eprintln!("Please set the namesrvAddr parameter");
+            return Ok(());
+        }
+
         unimplemented!("GetNamesrvConfigCommand is not implemented yet");
     }
 }

--- a/rocketmq-tools/src/commands/topic_commands.rs
+++ b/rocketmq-tools/src/commands/topic_commands.rs
@@ -19,6 +19,7 @@ mod allocate_mq_sub_command;
 use std::sync::Arc;
 
 use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::CommandExecute;
@@ -36,9 +37,9 @@ more memory space, you can use this command to allocate it."#
 }
 
 impl CommandExecute for TopicCommands {
-    fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
-            TopicCommands::AllocateMQ(cmd) => cmd.execute(rpc_hook),
+            TopicCommands::AllocateMQ(cmd) => cmd.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/src/commands/topic_commands/allocate_mq_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/allocate_mq_sub_command.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use clap::Parser;
+use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::CommandExecute;
@@ -33,7 +34,7 @@ pub struct AllocateMQSubCommand {
 }
 
 impl CommandExecute for AllocateMQSubCommand {
-    fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         unimplemented!("AllocateMQSubCommand is not implemented yet");
     }
 }

--- a/rocketmq-tools/src/rocketmq_cli.rs
+++ b/rocketmq-tools/src/rocketmq_cli.rs
@@ -28,7 +28,9 @@ pub struct RocketMQCli {
 }
 
 impl RocketMQCli {
-    pub fn handle(&self) {
-        self.commands.execute(None)
+    pub async fn handle(&self) {
+        if let Err(e) = self.commands.execute(None).await {
+            eprintln!("Error: {e}");
+        }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3325

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving name server configuration in the command-line tool.
  - Improved error handling for command execution, with clear error messages displayed to users.

- **Refactor**
  - Updated command execution to be fully asynchronous, resulting in a more responsive and reliable CLI experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->