### PR TITLE
[ISSUE #3328]🐛Fix MQClientInstance start fetch_name_server_addr error💫

### DIFF
--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -59,7 +59,7 @@ hostname = "0.4"
 regex = "1.11.1"
 thiserror = { workspace = true }
 
-reqwest = { version = "0.12", features = ["blocking"] }
+reqwest = { version = "0.12", features = ["blocking", "json"] }
 url = "2.5.2"
 form_urlencoded = "1.2.1"
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3328

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for custom name server addressing implementations, allowing greater extensibility.
  - Improved URL construction and response parsing for name server address fetching.

- **Bug Fixes**
  - Improved handling of trailing newline characters in server address responses.
  - More robust error handling and response content capture for HTTP requests.

- **Refactor**
  - Unified and streamlined HTTP client parameter and header handling.
  - Updated HTTP result structure for richer feedback and compatibility.
  - Improved thread safety and asynchronous handling for name server address fetching.

- **Chores**
  - Enabled JSON support in the HTTP client dependency for future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->