### PR TITLE
[ISSUE #3315]🚀Implement GetNamesrvConfigCommand for name server tool💫

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,7 @@ version = "0.6.0"
 dependencies = [
  "cheetah-string",
  "clap",
+ "futures",
  "rocketmq-client-rust",
  "rocketmq-common",
  "rocketmq-error",

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -657,7 +657,16 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         name_servers: Vec<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<HashMap<CheetahString, HashMap<CheetahString, CheetahString>>>
     {
-        todo!()
+        Ok(self
+            .client_instance
+            .as_ref()
+            .unwrap()
+            .mq_client_api_impl
+            .as_ref()
+            .unwrap()
+            .get_name_server_config(Some(name_servers), self.timeout_millis)
+            .await?
+            .unwrap_or_default())
     }
 
     async fn resume_check_half_message(

--- a/rocketmq-tools/Cargo.toml
+++ b/rocketmq-tools/Cargo.toml
@@ -20,11 +20,12 @@ rocketmq-error = { workspace = true }
 
 serde.workspace = true
 serde_json.workspace = true
-tokio = {workspace = true}
+tokio = { workspace = true }
 
 cheetah-string = { workspace = true }
 clap = { version = "4.5.38", features = ["derive"] }
 tabled = { version = "0.19.0", features = ["derive"] }
+futures = "0.3.31"
 
 [[bin]]
 name = "rocketmq-admin-cli-rust"


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3315

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to fetch and display name server configurations in a user-friendly table format via the command-line tool.
- **Bug Fixes**
  - Improved error handling when retrieving name server configurations, with clear messages if configurations are missing.
- **Chores**
  - Updated dependencies to include the latest version of the futures crate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->