### PR TITLE
[ISSUE #3316]🚀Implement UpdateKvConfigCommand for name server tool

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -460,7 +460,17 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         key: CheetahString,
         value: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .put_kvconfig_value(
+                namespace,
+                key,
+                value,
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await
     }
 
     async fn delete_kv_config(

--- a/rocketmq-client/src/base/client_config.rs
+++ b/rocketmq-client/src/base/client_config.rs
@@ -194,6 +194,11 @@ impl ClientConfig {
     pub fn set_instance_name(&mut self, instance_name: CheetahString) {
         self.instance_name = instance_name;
     }
+    #[inline]
+    pub fn set_namesrv_addr(&mut self, namesrv_addr: CheetahString) {
+        self.namesrv_addr = Some(namesrv_addr);
+        self.namespace_initialized.store(false, Ordering::Release); //todo 看下不同顺序的表现
+    }
 
     #[inline]
     pub fn build_mq_client_id(&self) -> String {

--- a/rocketmq-client/src/base/client_config.rs
+++ b/rocketmq-client/src/base/client_config.rs
@@ -197,7 +197,7 @@ impl ClientConfig {
     #[inline]
     pub fn set_namesrv_addr(&mut self, namesrv_addr: CheetahString) {
         self.namesrv_addr = Some(namesrv_addr);
-        self.namespace_initialized.store(false, Ordering::Release); //todo 看下不同顺序的表现
+        self.namespace_initialized.store(false, Ordering::Release);
     }
 
     #[inline]

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -76,6 +76,7 @@ use rocketmq_remoting::protocol::header::message_operation_header::send_message_
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::DeleteKVConfigRequestHeader;
+use rocketmq_remoting::protocol::header::namesrv::kv_config_header::PutKVConfigRequestHeader;
 use rocketmq_remoting::protocol::header::pop_message_request_header::PopMessageRequestHeader;
 use rocketmq_remoting::protocol::header::pop_message_response_header::PopMessageResponseHeader;
 use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
@@ -148,6 +149,41 @@ impl MQClientAPIImpl {
         let request_header = DeleteKVConfigRequestHeader::new(namespace, key);
         let request =
             RemotingCommand::create_request_command(RequestCode::DeleteKvConfig, request_header);
+
+        let name_server_address_list = self.remoting_client.get_name_server_address_list();
+        let mut err_response = None;
+        for name_srv_addr in name_server_address_list {
+            let response = self
+                .remoting_client
+                .invoke_async(Some(name_srv_addr), request.clone(), timeout_millis)
+                .await?;
+            match ResponseCode::from(response.code()) {
+                ResponseCode::Success => break,
+                _ => err_response = Some(response),
+            }
+        }
+
+        if let Some(err_response) = err_response {
+            return mq_client_err!(
+                err_response.code(),
+                err_response
+                    .remark()
+                    .map_or("".to_string(), |s| s.to_string())
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn put_kvconfig_value(
+        &self,
+        namespace: CheetahString,
+        key: CheetahString,
+        value: CheetahString,
+        timeout_millis: u64,
+    ) -> RocketMQResult<()> {
+        let request_header = PutKVConfigRequestHeader::new(namespace, key, value);
+        let request =
+            RemotingCommand::create_request_command(RequestCode::PutKvConfig, request_header);
 
         let name_server_address_list = self.remoting_client.get_name_server_address_list();
         let mut err_response = None;

--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -60,6 +60,12 @@ pub struct DefaultMQAdminExt {
 }
 
 impl DefaultMQAdminExt {
+    pub(crate) fn set_namesrv_addr(&mut self, name_serv_addr: &str) {
+        self.client_config.set_namesrv_addr(name_serv_addr.into());
+    }
+}
+
+impl DefaultMQAdminExt {
     pub fn new() -> Self {
         let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
         let client_config = ArcMut::new(ClientConfig::new());
@@ -472,7 +478,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         key: CheetahString,
         value: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .create_and_update_kv_config(namespace, key, value)
+            .await
     }
 
     async fn delete_kv_config(

--- a/rocketmq-tools/src/commands/namesrv_commands.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands.rs
@@ -16,6 +16,7 @@
  */
 mod delete_kv_config_command;
 mod get_namesrv_config_command;
+mod update_kv_config_command;
 
 use std::sync::Arc;
 
@@ -25,6 +26,7 @@ use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::namesrv_commands::delete_kv_config_command::DeleteKvConfigCommand;
 use crate::commands::namesrv_commands::get_namesrv_config_command::GetNamesrvConfigCommand;
+use crate::commands::namesrv_commands::update_kv_config_command::UpdateKvConfigCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
@@ -42,6 +44,13 @@ pub enum NameServerCommands {
         long_about = None,
     )]
     DeleteKvConfig(DeleteKvConfigCommand),
+
+    #[command(
+        name = "updateKvConfig",
+        about = "Create or update KV config.",
+        long_about = None,
+    )]
+    UpdateKvConfigCommand(UpdateKvConfigCommand),
 }
 
 impl CommandExecute for NameServerCommands {
@@ -49,6 +58,7 @@ impl CommandExecute for NameServerCommands {
         match self {
             NameServerCommands::GetNamesrvConfig(value) => value.execute(rpc_hook).await,
             NameServerCommands::DeleteKvConfig(value) => value.execute(rpc_hook).await,
+            NameServerCommands::UpdateKvConfigCommand(value) => value.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/src/commands/namesrv_commands/update_kv_config_command.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands/update_kv_config_command.rs
@@ -87,7 +87,7 @@ impl CommandExecute for UpdateKvConfigCommand {
                     )
                 })?;
 
-            println!("delete kv config from namespace success.");
+            println!("update kv config in namespace success.");
             Ok(())
         }
         .await;

--- a/rocketmq-tools/src/commands/namesrv_commands/update_kv_config_command.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands/update_kv_config_command.rs
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::RocketmqError;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct UpdateKvConfigCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(
+        short = 's',
+        long = "namespace",
+        required = true,
+        help = "set the namespace"
+    )]
+    namespace: String,
+
+    #[arg(short = 'k', long = "key", required = true, help = "set the key name")]
+    key: String,
+
+    #[arg(
+        short = 'v',
+        long = "value",
+        required = true,
+        help = "set the key value"
+    )]
+    value: String,
+}
+
+impl CommandExecute for UpdateKvConfigCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = DefaultMQAdminExt::new();
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let operation_result = async {
+            if let Some(addr) = &self.common_args.namesrv_addr {
+                default_mqadmin_ext.set_namesrv_addr(addr.trim());
+            }
+
+            MQAdminExt::start(&mut default_mqadmin_ext)
+                .await
+                .map_err(|e| {
+                    RocketmqError::SubCommand(
+                        "UpdateKvConfigCommand".parse().unwrap(),
+                        e.to_string(),
+                    )
+                })?;
+
+            default_mqadmin_ext
+                .create_and_update_kv_config(
+                    self.namespace.parse().unwrap(),
+                    self.key.parse().unwrap(),
+                    self.value.parse().unwrap(),
+                )
+                .await
+                .map_err(|e| {
+                    RocketmqError::SubCommand(
+                        "UpdateKvConfigCommand".parse().unwrap(),
+                        e.to_string(),
+                    )
+                })?;
+
+            println!("delete kv config from namespace success.");
+            Ok(())
+        }
+        .await;
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
- 在 DefaultMQAdminExt 中实现 set_namesrv_addr 方法
- 在 DefaultMQAdminExt 和 MQClientAPIImpl 中实现 put_kvconfig_value 方法
- 新增 UpdateKvConfigCommand 命令处理 KV 配置更新- 更新 NameServerCommands 以包含新的更新 KV 配置命令

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3316 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for updating key-value configurations in RocketMQ's nameserver via a new CLI command.
  - Introduced the ability to set the nameserver address through the admin client.
- **Improvements**
  - Enhanced admin client with asynchronous methods for creating and updating key-value configurations.
  - Improved error handling and feedback for configuration update operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->