### PR TITLE
[ISSUE  #3317]🚀Implement UpdateNamesrvConfigCommand for name server tool 

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -662,9 +662,18 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
     async fn update_name_server_config(
         &self,
         properties: HashMap<CheetahString, CheetahString>,
-        name_servers: Vec<CheetahString>,
+        name_servers: Option<Vec<CheetahString>>,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .update_name_server_config(
+                properties,
+                name_servers,
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await
     }
 
     async fn get_name_server_config(

--- a/rocketmq-client/src/admin/mq_admin_ext_async.rs
+++ b/rocketmq-client/src/admin/mq_admin_ext_async.rs
@@ -462,7 +462,7 @@ pub trait MQAdminExtLocal: Sync {
     async fn update_name_server_config(
         &self,
         properties: HashMap<CheetahString, CheetahString>,
-        name_servers: Vec<CheetahString>,
+        name_servers: Option<Vec<CheetahString>>,
     ) -> rocketmq_error::RocketMQResult<()>;
 
     async fn get_name_server_config(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -217,7 +217,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
         let body = mix_all::properties_to_string(&properties);
-        if body.len() < 1 {
+        if body.is_empty() {
             return Ok(());
         }
         let invoke_name_servers;

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -65,6 +65,7 @@ use rocketmq_remoting::protocol::header::change_invisible_time_request_header::C
 use rocketmq_remoting::protocol::header::change_invisible_time_response_header::ChangeInvisibleTimeResponseHeader;
 use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequestHeader;
 use rocketmq_remoting::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
+use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
 use rocketmq_remoting::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
 use rocketmq_remoting::protocol::header::extra_info_util::ExtraInfoUtil;
 use rocketmq_remoting::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
@@ -158,7 +159,7 @@ impl MQClientAPIImpl {
                 .invoke_async(Some(name_srv_addr), request.clone(), timeout_millis)
                 .await?;
             match ResponseCode::from(response.code()) {
-                ResponseCode::Success => break,
+                ResponseCode::Success => {}
                 _ => err_response = Some(response),
             }
         }
@@ -193,7 +194,56 @@ impl MQClientAPIImpl {
                 .invoke_async(Some(name_srv_addr), request.clone(), timeout_millis)
                 .await?;
             match ResponseCode::from(response.code()) {
-                ResponseCode::Success => break,
+                ResponseCode::Success => {}
+                _ => err_response = Some(response),
+            }
+        }
+
+        if let Some(err_response) = err_response {
+            return mq_client_err!(
+                err_response.code(),
+                err_response
+                    .remark()
+                    .map_or("".to_string(), |s| s.to_string())
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn update_name_server_config(
+        &self,
+        properties: HashMap<CheetahString, CheetahString>,
+        special_name_servers: Option<Vec<CheetahString>>,
+        timeout_millis: u64,
+    ) -> RocketMQResult<()> {
+        let body = mix_all::properties_to_string(&properties);
+        if body.len() < 1 {
+            return Ok(());
+        }
+        let invoke_name_servers;
+        if let Some(name_servers) = special_name_servers
+            && !name_servers.is_empty()
+        {
+            invoke_name_servers = name_servers;
+        } else {
+            invoke_name_servers = Vec::from(self.get_name_server_address_list());
+        }
+        if invoke_name_servers.is_empty() {
+            return Ok(());
+        }
+        let empty_header = EmptyHeader {};
+        let mut request =
+            RemotingCommand::create_request_command(RequestCode::UpdateNamesrvConfig, empty_header);
+
+        request = request.set_body(body.to_string());
+        let mut err_response = None;
+        for name_srv_addr in invoke_name_servers {
+            let response = self
+                .remoting_client
+                .invoke_async(Some(&name_srv_addr), request.clone(), timeout_millis)
+                .await?;
+            match ResponseCode::from(response.code()) {
+                ResponseCode::Success => {}
                 _ => err_response = Some(response),
             }
         }
@@ -1828,9 +1878,7 @@ impl MQClientAPIImpl {
         &self,
         name_servers: Option<Vec<CheetahString>>,
         timeout_millis: Duration,
-    ) -> rocketmq_error::RocketMQResult<
-        Option<HashMap<CheetahString, HashMap<CheetahString, CheetahString>>>,
-    > {
+    ) -> RocketMQResult<Option<HashMap<CheetahString, HashMap<CheetahString, CheetahString>>>> {
         // Determine which name servers to invoke
         let invoke_name_servers = match name_servers {
             Some(servers) if !servers.is_empty() => servers,

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(let_chains)]
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/rocketmq-common/src/common/mix_all.rs
+++ b/rocketmq-common/src/common/mix_all.rs
@@ -180,6 +180,15 @@ pub fn string_to_properties(input: &str) -> Option<HashMap<CheetahString, Cheeta
     Some(properties)
 }
 
+pub fn properties_to_string(properties: &HashMap<CheetahString, CheetahString>) -> CheetahString {
+    properties
+        .iter()
+        .map(|(key, value)| format!("{}={}", key.as_str(), value.as_str()))
+        .collect::<Vec<String>>()
+        .join("\n")
+        .into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rocketmq-remoting/src/protocol/body/ha_runtime_info.rs
+++ b/rocketmq-remoting/src/protocol/body/ha_runtime_info.rs
@@ -100,7 +100,7 @@ mod tests {
                 is_activated: true,
             },
         };
-        let display = format!("{:?}", info);
+        let display = format!("{info:?}");
         assert!(display.contains("HARuntimeInfo"));
         assert!(display.contains("master: true"));
         assert!(display.contains("master_commit_log_max_offset: 1000"));

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -26,6 +26,7 @@ pub mod create_topic_request_header;
 pub mod delete_subscription_group_request_header;
 pub mod delete_topic_request_header;
 pub mod elect_master_response_header;
+pub mod empty_header;
 pub mod end_transaction_request_header;
 pub mod extra_info_util;
 pub mod get_all_topic_config_response_header;

--- a/rocketmq-remoting/src/protocol/header/empty_header.rs
+++ b/rocketmq-remoting/src/protocol/header/empty_header.rs
@@ -1,0 +1,13 @@
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+
+use crate::protocol::command_custom_header::CommandCustomHeader;
+
+pub struct EmptyHeader {}
+
+impl CommandCustomHeader for EmptyHeader {
+    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+        None
+    }
+}

--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -31,6 +31,7 @@ use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::topic::TopicValidator;
+use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats;
 use rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
@@ -487,7 +488,7 @@ impl MQAdminExt for DefaultMQAdminExt {
         &self,
         namespace: CheetahString,
         key: CheetahString,
-    ) -> rocketmq_error::RocketMQResult<()> {
+    ) -> RocketMQResult<()> {
         self.default_mqadmin_ext_impl
             .delete_kv_config(namespace, key)
             .await
@@ -669,9 +670,11 @@ impl MQAdminExt for DefaultMQAdminExt {
     async fn update_name_server_config(
         &self,
         properties: HashMap<CheetahString, CheetahString>,
-        name_servers: Vec<CheetahString>,
-    ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        special_server_list: Option<Vec<CheetahString>>,
+    ) -> RocketMQResult<()> {
+        self.default_mqadmin_ext_impl
+            .update_name_server_config(properties, special_server_list)
+            .await
     }
 
     async fn get_name_server_config(

--- a/rocketmq-tools/src/commands/namesrv_commands.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands.rs
@@ -17,6 +17,7 @@
 mod delete_kv_config_command;
 mod get_namesrv_config_command;
 mod update_kv_config_command;
+mod update_namesrv_config;
 
 use std::sync::Arc;
 
@@ -27,6 +28,7 @@ use rocketmq_remoting::runtime::RPCHook;
 use crate::commands::namesrv_commands::delete_kv_config_command::DeleteKvConfigCommand;
 use crate::commands::namesrv_commands::get_namesrv_config_command::GetNamesrvConfigCommand;
 use crate::commands::namesrv_commands::update_kv_config_command::UpdateKvConfigCommand;
+use crate::commands::namesrv_commands::update_namesrv_config::UpdateNamesrvConfig;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
@@ -51,6 +53,13 @@ pub enum NameServerCommands {
         long_about = None,
     )]
     UpdateKvConfigCommand(UpdateKvConfigCommand),
+
+    #[command(
+        name = "UpdateNamesrvConfig",
+        about = "Update configs of name server.",
+        long_about = None,
+    )]
+    UpdateNamesrvConfig(UpdateNamesrvConfig),
 }
 
 impl CommandExecute for NameServerCommands {
@@ -59,6 +68,7 @@ impl CommandExecute for NameServerCommands {
             NameServerCommands::GetNamesrvConfig(value) => value.execute(rpc_hook).await,
             NameServerCommands::DeleteKvConfig(value) => value.execute(rpc_hook).await,
             NameServerCommands::UpdateKvConfigCommand(value) => value.execute(rpc_hook).await,
+            NameServerCommands::UpdateNamesrvConfig(value) => value.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/src/commands/namesrv_commands/update_namesrv_config.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands/update_namesrv_config.rs
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::RocketmqError;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct UpdateNamesrvConfig {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(short = 'k', long = "key", required = true, help = "config key")]
+    key: String,
+
+    #[arg(short = 'v', long = "value", required = true, help = "config value")]
+    value: String,
+}
+
+impl CommandExecute for UpdateNamesrvConfig {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        //         try {
+
+        //             defaultMQAdminExt.start();
+        //
+        //             defaultMQAdminExt.update_name_server_config(properties, serverList);
+        //
+        //             System.out.printf("update name server config success!%s\n%s : %s\n",
+        //                 serverList == null ? "" : serverList, key, value);
+        //         } catch (Exception e) {
+        //             throw new SubCommandException(this.getClass().getSimpleName() + " command
+        // failed", e);         } finally {
+        //             defaultMQAdminExt.shutdown();
+        //         }
+        let mut default_mqadmin_ext = DefaultMQAdminExt::new();
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let operation_result = async {
+            // key name
+            let key: CheetahString = self.key.trim().into();
+
+            // key name
+            let value: CheetahString = self.value.trim().into();
+            let mut properties = HashMap::with_capacity(1);
+            properties.insert(key.clone(), value.clone());
+
+            let mut server_list = None;
+            if let Some(servers) = &self.common_args.namesrv_addr
+                && servers.len() > 0
+            {
+                let servers_split: Vec<&str> = servers.split(';').collect();
+                if !servers_split.is_empty() {
+                    let mut vec = Vec::with_capacity(servers_split.len());
+                    for server in servers_split {
+                        vec.push(server.into());
+                    }
+                    server_list = Some(vec);
+                }
+            }
+
+            MQAdminExt::start(&mut default_mqadmin_ext)
+                .await
+                .map_err(|e| {
+                    RocketmqError::SubCommand("UpdateNamesrvConfig".parse().unwrap(), e.to_string())
+                })?;
+
+            default_mqadmin_ext
+                .update_name_server_config(properties, server_list.clone())
+                .await
+                .map_err(|e| {
+                    RocketmqError::SubCommand("UpdateNamesrvConfig".parse().unwrap(), e.to_string())
+                })?;
+
+            println!(
+                "update name server config success!{}\n{} : {}\n",
+                server_list.unwrap_or_default().join(";"),
+                key,
+                value
+            );
+            Ok(())
+        }
+        .await;
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}

--- a/rocketmq-tools/src/commands/namesrv_commands/update_namesrv_config.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands/update_namesrv_config.rs
@@ -58,16 +58,16 @@ impl CommandExecute for UpdateNamesrvConfig {
             properties.insert(key.clone(), value.clone());
 
             let mut server_list = None;
-            if let Some(servers) = &self.common_args.namesrv_addr
-                && servers.len() > 0
-            {
-                let servers_split: Vec<&str> = servers.split(';').collect();
-                if !servers_split.is_empty() {
-                    let mut vec = Vec::with_capacity(servers_split.len());
-                    for server in servers_split {
-                        vec.push(server.into());
+            if let Some(servers) = &self.common_args.namesrv_addr {
+                if !servers.is_empty() {
+                    let servers_split: Vec<&str> = servers.split(';').collect();
+                    if !servers_split.is_empty() {
+                        let mut vec = Vec::with_capacity(servers_split.len());
+                        for server in servers_split {
+                            vec.push(server.into());
+                        }
+                        server_list = Some(vec);
                     }
-                    server_list = Some(vec);
                 }
             }
 

--- a/rocketmq-tools/src/commands/namesrv_commands/update_namesrv_config.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands/update_namesrv_config.rs
@@ -43,19 +43,6 @@ pub struct UpdateNamesrvConfig {
 
 impl CommandExecute for UpdateNamesrvConfig {
     async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
-        //         try {
-
-        //             defaultMQAdminExt.start();
-        //
-        //             defaultMQAdminExt.update_name_server_config(properties, serverList);
-        //
-        //             System.out.printf("update name server config success!%s\n%s : %s\n",
-        //                 serverList == null ? "" : serverList, key, value);
-        //         } catch (Exception e) {
-        //             throw new SubCommandException(this.getClass().getSimpleName() + " command
-        // failed", e);         } finally {
-        //             defaultMQAdminExt.shutdown();
-        //         }
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()

--- a/rocketmq-tools/src/lib.rs
+++ b/rocketmq-tools/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(let_chains)]
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/rocketmq-tools/src/lib.rs
+++ b/rocketmq-tools/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(let_chains)]
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3317

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a command-line tool to update RocketMQ name server configurations directly, supporting custom key-value pairs and optional server targeting.
  - Introduced a new command for updating name server configurations via the admin interface.

- **Improvements**
  - Enhanced flexibility for updating name server configurations by allowing optional specification of target servers.
  - Improved formatting and usability in command-line output messages.

- **Bug Fixes**
  - Ensured that configuration updates are applied to all specified name servers, with proper error handling for failed updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->