### PR TITLE
[ISSUE #3313]🚀Implement AddWritePermSubCommand for name server tool

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -377,7 +377,12 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
     }
 
     async fn get_name_server_address_list(&self) -> Vec<CheetahString> {
-        todo!()
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_name_server_address_list()
+            .to_vec()
     }
 
     async fn wipe_write_perm_of_broker(
@@ -393,7 +398,16 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         namesrv_addr: CheetahString,
         broker_name: CheetahString,
     ) -> rocketmq_error::RocketMQResult<i32> {
-        todo!()
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .add_write_perm_of_broker(
+                namesrv_addr,
+                broker_name,
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await
     }
 
     async fn put_kv_config(

--- a/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
@@ -79,6 +79,12 @@ impl AddWritePermOfBrokerResponseHeader {
     }
 }
 
+impl AddWritePermOfBrokerResponseHeader {
+    pub fn get_add_topic_count(&self) -> i32 {
+        self.add_topic_count
+    }
+}
+
 impl CommandCustomHeader for AddWritePermOfBrokerResponseHeader {
     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
         Some(HashMap::from([(

--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -396,7 +396,9 @@ impl MQAdminExt for DefaultMQAdminExt {
     }
 
     async fn get_name_server_address_list(&self) -> Vec<CheetahString> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .get_name_server_address_list()
+            .await
     }
 
     async fn wipe_write_perm_of_broker(
@@ -411,8 +413,10 @@ impl MQAdminExt for DefaultMQAdminExt {
         &self,
         namesrv_addr: CheetahString,
         broker_name: CheetahString,
-    ) -> rocketmq_error::RocketMQResult<i32> {
-        todo!()
+    ) -> RocketMQResult<i32> {
+        self.default_mqadmin_ext_impl
+            .add_write_perm_of_broker(namesrv_addr, broker_name)
+            .await
     }
 
     async fn put_kv_config(

--- a/rocketmq-tools/src/commands/namesrv_commands.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+mod add_write_perm_sub_command;
 mod delete_kv_config_command;
 mod get_namesrv_config_command;
 mod update_kv_config_command;
@@ -25,6 +26,7 @@ use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
+use crate::commands::namesrv_commands::add_write_perm_sub_command::AddWritePermSubCommand;
 use crate::commands::namesrv_commands::delete_kv_config_command::DeleteKvConfigCommand;
 use crate::commands::namesrv_commands::get_namesrv_config_command::GetNamesrvConfigCommand;
 use crate::commands::namesrv_commands::update_kv_config_command::UpdateKvConfigCommand;
@@ -55,11 +57,17 @@ pub enum NameServerCommands {
     UpdateKvConfigCommand(UpdateKvConfigCommand),
 
     #[command(
-        name = "UpdateNamesrvConfig",
+        name = "updateNamesrvConfig",
         about = "Update configs of name server.",
         long_about = None,
     )]
     UpdateNamesrvConfig(UpdateNamesrvConfig),
+    #[command(
+        name = "addWritePerm",
+        about = "Add write perm of broker in all name server you defined in the -n param.",
+        long_about = None,
+    )]
+    AddWritePermSubCommand(AddWritePermSubCommand),
 }
 
 impl CommandExecute for NameServerCommands {
@@ -69,6 +77,7 @@ impl CommandExecute for NameServerCommands {
             NameServerCommands::DeleteKvConfig(value) => value.execute(rpc_hook).await,
             NameServerCommands::UpdateKvConfigCommand(value) => value.execute(rpc_hook).await,
             NameServerCommands::UpdateNamesrvConfig(value) => value.execute(rpc_hook).await,
+            NameServerCommands::AddWritePermSubCommand(value) => value.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/src/commands/namesrv_commands/add_write_perm_sub_command.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands/add_write_perm_sub_command.rs
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::RocketmqError;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct AddWritePermSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(
+        short = 'b',
+        long = "brokerName",
+        required = true,
+        help = "broker name"
+    )]
+    broker_name: String,
+}
+
+impl CommandExecute for AddWritePermSubCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = DefaultMQAdminExt::new();
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext)
+                .await
+                .map_err(|e| {
+                    RocketmqError::SubCommand(
+                        "AddWritePermSubCommand".parse().unwrap(),
+                        e.to_string(),
+                    )
+                })?;
+            let broker_name = self.broker_name.trim();
+            for namesrv_addr in default_mqadmin_ext.get_name_server_address_list().await {
+                match default_mqadmin_ext
+                    .add_write_perm_of_broker(namesrv_addr.clone(), broker_name.into())
+                    .await
+                    .map_err(|e| {
+                        RocketmqError::SubCommand(
+                            "AddWritePermSubCommand".parse().unwrap(),
+                            e.to_string(),
+                        )
+                    }) {
+                    Ok(add_topic_count) => {
+                        println!(
+                            "add write perm of broker[{broker_name}] in name \
+                             server[{namesrv_addr}] OK, {add_topic_count}"
+                        );
+                    }
+                    Err(e) => {
+                        println!(
+                            "add write perm of broker[{broker_name}] in name \
+                             server[{namesrv_addr}] Failed",
+                        );
+                        println!("{e}")
+                    }
+                }
+            }
+            Ok(())
+        }
+        .await;
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
- 新增AddWritePermSubCommand结构体和相关实现
- 在NameServerCommands中添加AddWritePermSubCommand变体- 实现add_write_perm_of_broker方法以添加broker的写权限
- 更新相关模块以支持新功能

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3313

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line subcommand to add write permissions for a specified broker across all name servers.
  - Added the ability to retrieve the list of name server addresses via the admin interface.

- **Improvements**
  - Enhanced admin tools to support asynchronous operations for managing broker permissions.
  - Improved feedback and error reporting when updating broker write permissions through the command-line tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->