### PR TITLE
[ISSUE ##3318]🚀Implement WipeWritePermSubCommand for name server tool 

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -390,7 +390,16 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         namesrv_addr: CheetahString,
         broker_name: CheetahString,
     ) -> rocketmq_error::RocketMQResult<i32> {
-        todo!()
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .wipe_write_perm_of_broker(
+                namesrv_addr,
+                broker_name,
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await
     }
 
     async fn add_write_perm_of_broker(

--- a/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
@@ -49,6 +49,10 @@ impl WipeWritePermOfBrokerResponseHeader {
     pub fn new(wipe_topic_count: i32) -> Self {
         Self { wipe_topic_count }
     }
+
+    pub fn get_wipe_topic_count(&self) -> i32 {
+        self.wipe_topic_count
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodec)]

--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -405,8 +405,10 @@ impl MQAdminExt for DefaultMQAdminExt {
         &self,
         namesrv_addr: CheetahString,
         broker_name: CheetahString,
-    ) -> rocketmq_error::RocketMQResult<i32> {
-        todo!()
+    ) -> RocketMQResult<i32> {
+        self.default_mqadmin_ext_impl
+            .wipe_write_perm_of_broker(namesrv_addr, broker_name)
+            .await
     }
 
     async fn add_write_perm_of_broker(

--- a/rocketmq-tools/src/commands/namesrv_commands.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands.rs
@@ -32,8 +32,8 @@ use crate::commands::namesrv_commands::delete_kv_config_command::DeleteKvConfigC
 use crate::commands::namesrv_commands::get_namesrv_config_command::GetNamesrvConfigCommand;
 use crate::commands::namesrv_commands::update_kv_config_command::UpdateKvConfigCommand;
 use crate::commands::namesrv_commands::update_namesrv_config::UpdateNamesrvConfig;
-use crate::commands::CommandExecute;
 use crate::commands::namesrv_commands::wipe_write_perm_sub_command::WipeWritePermSubCommand;
+use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
 pub enum NameServerCommands {

--- a/rocketmq-tools/src/commands/namesrv_commands.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands.rs
@@ -19,6 +19,7 @@ mod delete_kv_config_command;
 mod get_namesrv_config_command;
 mod update_kv_config_command;
 mod update_namesrv_config;
+mod wipe_write_perm_sub_command;
 
 use std::sync::Arc;
 
@@ -32,6 +33,7 @@ use crate::commands::namesrv_commands::get_namesrv_config_command::GetNamesrvCon
 use crate::commands::namesrv_commands::update_kv_config_command::UpdateKvConfigCommand;
 use crate::commands::namesrv_commands::update_namesrv_config::UpdateNamesrvConfig;
 use crate::commands::CommandExecute;
+use crate::commands::namesrv_commands::wipe_write_perm_sub_command::WipeWritePermSubCommand;
 
 #[derive(Subcommand)]
 pub enum NameServerCommands {
@@ -68,6 +70,13 @@ pub enum NameServerCommands {
         long_about = None,
     )]
     AddWritePermSubCommand(AddWritePermSubCommand),
+
+    #[command(
+        name = "wipeWritePerm",
+        about = "Wipe write perm of broker in all name server you defined in the -n param.",
+        long_about = None,
+    )]
+    WipeWritePermSubCommand(WipeWritePermSubCommand),
 }
 
 impl CommandExecute for NameServerCommands {
@@ -78,6 +87,7 @@ impl CommandExecute for NameServerCommands {
             NameServerCommands::UpdateKvConfigCommand(value) => value.execute(rpc_hook).await,
             NameServerCommands::UpdateNamesrvConfig(value) => value.execute(rpc_hook).await,
             NameServerCommands::AddWritePermSubCommand(value) => value.execute(rpc_hook).await,
+            NameServerCommands::WipeWritePermSubCommand(value) => value.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/src/commands/namesrv_commands/wipe_write_perm_sub_command.rs
+++ b/rocketmq-tools/src/commands/namesrv_commands/wipe_write_perm_sub_command.rs
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::RocketmqError;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct WipeWritePermSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(
+        short = 'b',
+        long = "brokerName",
+        required = true,
+        help = "broker name"
+    )]
+    broker_name: String,
+}
+
+impl CommandExecute for WipeWritePermSubCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = DefaultMQAdminExt::new();
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext)
+                .await
+                .map_err(|e| {
+                    RocketmqError::SubCommand(
+                        "WipeWritePermSubCommand".parse().unwrap(),
+                        e.to_string(),
+                    )
+                })?;
+            let broker_name = self.broker_name.trim();
+            for namesrv_addr in default_mqadmin_ext.get_name_server_address_list().await {
+                match default_mqadmin_ext
+                    .wipe_write_perm_of_broker(namesrv_addr.clone(), broker_name.into())
+                    .await
+                    .map_err(|e| {
+                        RocketmqError::SubCommand(
+                            "WipeWritePermSubCommand".parse().unwrap(),
+                            e.to_string(),
+                        )
+                    }) {
+                    Ok(add_topic_count) => {
+                        println!(
+                            "wipe write perm of broker[{broker_name}] in name \
+                             server[{namesrv_addr}] OK, {add_topic_count}"
+                        );
+                    }
+                    Err(e) => {
+                        println!(
+                            "wipe write perm of broker[{broker_name}] in name \
+                             server[{namesrv_addr}] Failed",
+                        );
+                        println!("{e}")
+                    }
+                }
+            }
+            Ok(())
+        }
+        .await;
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
- 在 DefaultMQAdminExt 中添加 wipe_write_perm_of_broker 方法
- 在 DefaultMQAdminExtImpl 中实现 wipe_write_perm_of_broker 方法
- 在 MQClientAPIImpl 中添加 wipe_write_perm_of_broker 方法
- 新增 WipeWritePermSubCommand用于命令行清除 Broker 写权限
- 更新 NameServerCommands 以包含新的 WipeWritePermSubCommand

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3318

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line subcommand to wipe the write permission of a broker across all specified name servers.
  - Users can now execute this operation via the CLI by providing the broker name and name server addresses.
  - Success and failure messages are displayed for each name server after the operation.

- **Bug Fixes**
  - Previously unimplemented methods related to wiping broker write permissions are now fully functional and integrated into the toolset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->