### PR TITLE
[ISSUE #3384]♻️Refactor service task structures and rename for clarity

### DIFF
--- a/rocketmq-broker/src/transaction/transactional_message_check_service.rs
+++ b/rocketmq-broker/src/transaction/transactional_message_check_service.rs
@@ -18,9 +18,9 @@
 use std::time::Duration;
 use std::time::Instant;
 
+use rocketmq_rust::task::service_task::ServiceContext;
 use rocketmq_rust::task::service_task::ServiceTask;
-use rocketmq_rust::task::service_task::ServiceTaskContext;
-use rocketmq_rust::task::ServiceTaskImpl;
+use rocketmq_rust::task::ServiceManager;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use tracing::info;
@@ -29,7 +29,7 @@ use crate::broker_runtime::BrokerRuntimeInner;
 use crate::transaction::transactional_message_service::TransactionalMessageService;
 
 pub struct TransactionalMessageCheckService<MS: MessageStore> {
-    task_impl: ServiceTaskImpl<TransactionalMessageCheckServiceInner<MS>>,
+    task_impl: ServiceManager<TransactionalMessageCheckServiceInner<MS>>,
 }
 
 struct TransactionalMessageCheckServiceInner<MS: MessageStore> {
@@ -41,7 +41,7 @@ impl<MS: MessageStore> ServiceTask for TransactionalMessageCheckServiceInner<MS>
         "TransactionalMessageCheckService".into()
     }
 
-    async fn run(&self, context: &ServiceTaskContext) {
+    async fn run(&self, context: &ServiceContext) {
         info!("Starting transactional check service");
 
         while !context.is_stopped() {
@@ -93,7 +93,7 @@ impl<MS: MessageStore> ServiceTask for TransactionalMessageCheckServiceInner<MS>
 
 impl<MS: MessageStore> TransactionalMessageCheckService<MS> {
     pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        let task_impl = ServiceTaskImpl::new(TransactionalMessageCheckServiceInner {
+        let task_impl = ServiceManager::new(TransactionalMessageCheckServiceInner {
             broker_runtime_inner,
         });
         TransactionalMessageCheckService { task_impl }

--- a/rocketmq/src/task.rs
+++ b/rocketmq/src/task.rs
@@ -16,15 +16,15 @@
  */
 pub mod service_task;
 
-pub use service_task::ServiceTaskImpl;
+pub use service_task::ServiceManager;
 
 /// Helper macro to create a service thread implementation
 #[macro_export]
-macro_rules! service_task {
+macro_rules! service_manager {
     ($service_type:ty) => {
         impl $service_type {
-            pub fn create_service_task(self) -> $crate::task::service_task::ServiceTaskImpl<Self> {
-                $crate::task::service_task::ServiceTaskImpl::new(self)
+            pub fn create_service_task(self) -> $crate::task::service_task::ServiceManager<Self> {
+                $crate::task::service_task::ServiceManager::new(self)
             }
         }
     };


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3384

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed several service management components for improved clarity and consistency, including updates to service context, manager, and lifecycle naming across the application.
  - Updated related method names and macro invocations to reflect the new naming conventions.
  - No changes to application logic or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->