### PR TITLE
[ISSUE #3416]🚀Add methods for managing message body in message structures

### DIFF
--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -387,9 +387,29 @@ pub trait MessageTrait: Any + Display + Debug {
         .unwrap_or(0)
     }
 
+    /// Retrieves a mutable reference to the compressed body of the message.
+    ///
+    /// # Returns
+    /// A mutable reference to an `Option<Bytes>` containing the compressed body, if it exists.
     fn get_compressed_body_mut(&mut self) -> &mut Option<Bytes>;
+
+    /// Retrieves an immutable reference to the compressed body of the message.
+    ///
+    /// # Returns
+    /// An `Option<&Bytes>` containing the compressed body, if it exists.
     fn get_compressed_body(&self) -> Option<&Bytes>;
+
+    /// Sets the compressed body of the message.
+    ///
+    /// # Arguments
+    /// * `compressed_body` - A `Bytes` object representing the compressed body to set.
     fn set_compressed_body_mut(&mut self, compressed_body: Bytes);
+
+    /// Takes ownership of the message body, leaving it empty.
+    ///
+    /// # Returns
+    /// An `Option<Bytes>` containing the message body if it exists, otherwise `None`.
+    fn take_body(&mut self) -> Option<Bytes>;
 
     /// Converts the message into a dynamic `Any` type.
     ///

--- a/rocketmq-common/src/common/message/message_batch.rs
+++ b/rocketmq-common/src/common/message/message_batch.rs
@@ -203,6 +203,11 @@ impl MessageTrait for MessageBatch {
         self.final_message.compressed_body = Some(compressed_body);
     }
 
+    #[inline]
+    fn take_body(&mut self) -> Option<Bytes> {
+        self.final_message.body.take()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/rocketmq-common/src/common/message/message_batch.rs
+++ b/rocketmq-common/src/common/message/message_batch.rs
@@ -205,7 +205,7 @@ impl MessageTrait for MessageBatch {
 
     #[inline]
     fn take_body(&mut self) -> Option<Bytes> {
-        self.final_message.body.take()
+        self.final_message.take_body()
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/rocketmq-common/src/common/message/message_client_ext.rs
+++ b/rocketmq-common/src/common/message/message_client_ext.rs
@@ -149,6 +149,11 @@ impl MessageTrait for MessageClientExt {
     }
 
     #[inline]
+    fn take_body(&mut self) -> Option<Bytes> {
+        self.message_ext_inner.take_body()
+    }
+
+    #[inline]
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/rocketmq-common/src/common/message/message_ext.rs
+++ b/rocketmq-common/src/common/message/message_ext.rs
@@ -341,6 +341,11 @@ impl MessageTrait for MessageExt {
         self.message.set_compressed_body_mut(compressed_body);
     }
 
+    #[inline]
+    fn take_body(&mut self) -> Option<Bytes> {
+        self.message.take_body()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/rocketmq-common/src/common/message/message_ext_broker_inner.rs
+++ b/rocketmq-common/src/common/message/message_ext_broker_inner.rs
@@ -332,6 +332,11 @@ impl MessageTrait for MessageExtBrokerInner {
     }
 
     #[inline]
+    fn take_body(&mut self) -> Option<Bytes> {
+        self.message_ext_inner.take_body()
+    }
+
+    #[inline]
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/rocketmq-common/src/common/message/message_single.rs
+++ b/rocketmq-common/src/common/message/message_single.rs
@@ -390,6 +390,11 @@ impl MessageTrait for Message {
     }
 
     #[inline]
+    fn take_body(&mut self) -> Option<Bytes> {
+        self.body.take()
+    }
+
+    #[inline]
     fn as_any(&self) -> &dyn Any {
         self
     }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3416

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new methods for managing compressed message bodies and transferring message body ownership, enabling more flexible handling of message data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->