### PR TITLE
[ISSUE #3418]♻️Refactor end_message_transaction function to accept mutable reference and improve message handling

### DIFF
--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -423,8 +423,8 @@ mod tests {
 
     #[test]
     fn end_message_transaction_with_valid_message() {
-        let msg_ext = MessageExt::default();
-        let msg_inner = end_message_transaction(&msg_ext);
+        let mut msg_ext = MessageExt::default();
+        let msg_inner = end_message_transaction(&mut msg_ext);
         assert_eq!(
             msg_inner.get_topic(),
             &msg_ext
@@ -481,9 +481,9 @@ mod tests {
 
     #[test]
     fn end_message_transaction_with_empty_body() {
-        let msg_ext = MessageExt::default();
+        let mut msg_ext = MessageExt::default();
         //msg_ext.set_body(None);
-        let msg_inner = end_message_transaction(&msg_ext);
+        let msg_inner = end_message_transaction(&mut msg_ext);
         assert!(!msg_inner.get_body().is_some_and(|b| b.is_empty()));
     }
 
@@ -498,7 +498,7 @@ mod tests {
             CheetahString::from_static_str(MessageConst::PROPERTY_REAL_QUEUE_ID),
             CheetahString::empty(),
         );
-        let msg_inner = end_message_transaction(&msg_ext);
+        let msg_inner = end_message_transaction(&mut msg_ext);
         assert!(msg_inner.get_topic().is_empty());
         assert_eq!(msg_inner.message_ext_inner.queue_id, 0);
     }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3418

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved message processing reliability during transaction commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->