### PR TITLE
[ISSUE #3420]♻️Refactor make_op_message_inner function to accept ownership of Message and simplify message handling

### DIFF
--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -370,19 +370,20 @@ where
 
     fn make_op_message_inner(
         &self,
-        message: &Message,
+        message: Message,
         message_queue: &MessageQueue,
     ) -> MessageExtBrokerInner {
         let mut msg_inner = MessageExtBrokerInner::default();
-        msg_inner.set_topic(message.get_topic().to_owned());
-        msg_inner.set_body(message.get_body().expect("message body is empty").clone());
+        msg_inner.message_ext_inner.message = message;
+        //msg_inner.set_topic(message.get_topic().to_owned());
+        //msg_inner.set_body(message.get_body().expect("message body is empty").clone());
         msg_inner.message_ext_inner.queue_id = message_queue.get_queue_id();
-        msg_inner.set_tags(message.get_tags().unwrap_or_default());
+        //msg_inner.set_tags(message.get_tags().unwrap_or_default());
         msg_inner.tags_code = MessageExtBrokerInner::tags_string_to_tags_code(
-            message.get_tags().unwrap_or_default().as_str(),
+            msg_inner.get_tags().unwrap_or_default().as_str(),
         );
         msg_inner.message_ext_inner.sys_flag = 0;
-        MessageAccessor::set_properties(&mut msg_inner, message.get_properties().clone());
+        //MessageAccessor::set_properties(&mut msg_inner, message.get_properties().clone());
         msg_inner.properties_string =
             MessageDecoder::message_properties_to_string(msg_inner.get_properties());
 
@@ -413,7 +414,7 @@ where
                     .clone(),
             )
         });
-        let inner = self.make_op_message_inner(&message, op_queue);
+        let inner = self.make_op_message_inner(message, op_queue);
         let result = self.put_message_return_result(inner).await;
         result.put_message_status() == PutMessageStatus::PutOk
     }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3420

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal message handling for transactional messages to optimize performance and reliability. No changes to user-facing features or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->