### PR TITLE
[ISSUE #3422]🚀Add wakeup method to ServiceTask for improved notification handling

### DIFF
--- a/rocketmq/src/task/service_task.rs
+++ b/rocketmq/src/task/service_task.rs
@@ -80,6 +80,16 @@ impl ServiceContext {
         self.has_notified.store(false, Ordering::Release);
         true // Should call on_wait_end
     }
+
+    pub fn wakeup(&self) {
+        if self
+            .has_notified
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            self.wait_point.notify_one();
+        }
+    }
 }
 
 /*#[trait_variant::make(ServiceTask: Send)]


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3422 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to externally wake up or signal service contexts, enhancing responsiveness for waiting tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->