### PR TITLE
[ISSUE #3436]⚡️Improve message handling to simplify topic length retrieval and improve clarity

### DIFF
--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -475,7 +475,7 @@ impl MessageVersion {
 
     pub fn get_topic_length(&self, buffer: &mut Bytes) -> usize {
         match self {
-            MessageVersion::V1 => i32::from(buffer.get_u8()) as usize,
+            MessageVersion::V1 => buffer.get_u8() as usize,
             MessageVersion::V2 => buffer.get_i16() as usize,
         }
     }

--- a/rocketmq-common/src/common/message/message_decoder.rs
+++ b/rocketmq-common/src/common/message/message_decoder.rs
@@ -564,8 +564,8 @@ pub fn encode(
     need_compress: bool,
 ) -> rocketmq_error::RocketMQResult<Bytes> {
     let body = message_ext.get_body().unwrap();
-    let topics = message_ext.get_topic().as_bytes();
-    let topic_len = topics.len();
+    let topic = message_ext.get_topic().as_bytes();
+    let topic_len = topic.len();
     let properties = message_properties_to_string(message_ext.get_properties());
     let properties_bytes = properties.as_bytes();
     let properties_length = properties_bytes.len();
@@ -680,8 +680,8 @@ pub fn encode(
     }
 
     // 16 TOPIC
-    byte_buffer.put_i16(topic_len as i16);
-    byte_buffer.put_slice(topics);
+    byte_buffer.put_u8(topic_len as u8);
+    byte_buffer.put_slice(topic);
 
     // 17 properties
     byte_buffer.put_i16(properties_length as i16);


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3436

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of topic length encoding for messages, resulting in more efficient storage and clearer variable naming. No changes to user-facing features or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->