### PR TITLE
Remove unused queue_id generation code from default_transactional_mes…

### DIFF
--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
@@ -210,8 +210,6 @@ fn to_message_ext_broker_inner(
     topic_config: &TopicConfig,
     msg_ext: &MessageExt,
 ) -> MessageExtBrokerInner {
-    // TODO
-    //let queue_id = rand::thread_rng().gen_range(0..=99999999) % TCMT_QUEUE_NUMS;
     let mut inner = MessageExtBrokerInner::default();
     if let Some(topic_name) = &topic_config.topic_name {
         inner.set_topic(topic_name.clone());


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3463

### Brief Description
Removes unused queue_id generation code from default_transactional_message_check_listener.rs.
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
