### PR TITLE
[ISSUE #3472]🚀Add FlowMonitor for tracking data transfer metrics and flow control management✨

### DIFF
--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -264,6 +264,10 @@ mod defaults {
         32
     }
 
+    pub const fn max_ha_transfer_byte_in_second() -> usize {
+        100 * 1024 * 1024
+    }
+
     pub fn max_filter_message_size() -> i32 {
         16000
     }
@@ -710,7 +714,7 @@ pub struct MessageStoreConfig {
     #[serde(default)]
     pub ha_flow_control_enable: bool,
 
-    #[serde(default)]
+    #[serde(default = "defaults::topic_queue_lock_num")]
     pub max_ha_transfer_byte_in_second: usize,
 
     #[serde(default)]
@@ -957,7 +961,7 @@ impl Default for MessageStoreConfig {
             all_ack_in_sync_state_set: false,
             enable_auto_in_sync_replicas: false,
             ha_flow_control_enable: false,
-            max_ha_transfer_byte_in_second: 0,
+            max_ha_transfer_byte_in_second: 100 * 1024 * 1024,
             ha_max_time_slave_not_catchup: 0,
             sync_master_flush_offset_when_startup: false,
             max_checksum_range: 0,

--- a/rocketmq-store/src/ha.rs
+++ b/rocketmq-store/src/ha.rs
@@ -16,6 +16,7 @@
  */
 
 pub(crate) mod default_ha_service;
+pub(crate) mod flow_monitor;
 pub(crate) mod general_ha_service;
 pub(crate) mod ha_client;
 pub(crate) mod ha_connection;

--- a/rocketmq-store/src/ha/flow_monitor.rs
+++ b/rocketmq-store/src/ha/flow_monitor.rs
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_rust::task::service_task::ServiceContext;
+use rocketmq_rust::task::service_task::ServiceTask;
+use rocketmq_rust::task::ServiceManager;
+
+use crate::config::message_store_config::MessageStoreConfig;
+
+pub struct FlowMonitor {
+    server_manager: ServiceManager<FlowMonitorInner>,
+}
+
+impl FlowMonitor {
+    pub fn new(message_store_config: Arc<MessageStoreConfig>) -> Self {
+        let inner = FlowMonitorInner::new(message_store_config);
+        let server_manager = ServiceManager::new(inner);
+        FlowMonitor { server_manager }
+    }
+
+    pub async fn start(&self) {
+        self.server_manager.start().await.unwrap();
+    }
+
+    pub async fn shutdown(&self) {
+        self.server_manager.shutdown().await.unwrap();
+    }
+}
+
+struct FlowMonitorInner {
+    transferred_byte: AtomicI64,
+    transferred_byte_in_second: AtomicI64,
+    message_store_config: Arc<MessageStoreConfig>,
+}
+
+impl FlowMonitorInner {
+    pub fn new(message_store_config: Arc<MessageStoreConfig>) -> Self {
+        FlowMonitorInner {
+            transferred_byte: AtomicI64::new(0),
+            transferred_byte_in_second: AtomicI64::new(0),
+            message_store_config,
+        }
+    }
+
+    pub fn calculate_speed(&self) {
+        let current_transferred = self.transferred_byte.load(Ordering::Relaxed);
+        self.transferred_byte_in_second
+            .store(current_transferred, Ordering::Relaxed);
+        self.transferred_byte.store(0, Ordering::Relaxed);
+    }
+
+    pub fn can_transfer_max_byte_num(&self) -> i32 {
+        if self.is_flow_control_enable() {
+            let max_bytes = self.max_transfer_byte_in_second() as i64;
+            let current_transferred = self.transferred_byte.load(Ordering::Relaxed);
+            let res = std::cmp::max(max_bytes - current_transferred, 0);
+
+            if res > i32::MAX as i64 {
+                i32::MAX
+            } else {
+                res as i32
+            }
+        } else {
+            i32::MAX
+        }
+    }
+
+    pub fn add_byte_count_transferred(&self, count: i64) {
+        self.transferred_byte.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn get_transferred_byte_in_second(&self) -> i64 {
+        self.transferred_byte_in_second.load(Ordering::Relaxed)
+    }
+
+    fn is_flow_control_enable(&self) -> bool {
+        self.message_store_config.ha_flow_control_enable
+    }
+
+    fn max_transfer_byte_in_second(&self) -> usize {
+        self.message_store_config.max_ha_transfer_byte_in_second
+    }
+}
+
+impl ServiceTask for FlowMonitorInner {
+    fn get_service_name(&self) -> String {
+        String::from("FlowMonitor")
+    }
+
+    async fn run(&self, context: &ServiceContext) {
+        while !context.is_stopped() {
+            context.wait_for_running(Duration::from_millis(1000)).await;
+            self.calculate_speed();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn flow_monitor_starts_successfully() {
+        let config = Arc::new(MessageStoreConfig::default());
+        let monitor = FlowMonitor::new(config);
+        monitor.start().await;
+    }
+
+    #[tokio::test]
+    async fn flow_monitor_shuts_down_successfully() {
+        let config = Arc::new(MessageStoreConfig::default());
+        let monitor = FlowMonitor::new(config);
+        monitor.start().await;
+        monitor.shutdown().await;
+    }
+
+    #[test]
+    fn calculate_speed_updates_transferred_byte_in_second() {
+        let config = Arc::new(MessageStoreConfig::default());
+        let inner = FlowMonitorInner::new(config);
+        inner.add_byte_count_transferred(100);
+        inner.calculate_speed();
+        assert_eq!(inner.get_transferred_byte_in_second(), 100);
+    }
+
+    #[test]
+    fn can_transfer_max_byte_num_returns_correct_value_when_flow_control_enabled() {
+        let mut config = MessageStoreConfig::default();
+        config.ha_flow_control_enable = true;
+        config.max_ha_transfer_byte_in_second = 200;
+        let inner = FlowMonitorInner::new(Arc::new(config));
+        inner.add_byte_count_transferred(150);
+        assert_eq!(inner.can_transfer_max_byte_num(), 50);
+    }
+
+    #[test]
+    fn can_transfer_max_byte_num_returns_max_value_when_flow_control_disabled() {
+        let mut config = MessageStoreConfig::default();
+        config.ha_flow_control_enable = false;
+        let inner = FlowMonitorInner::new(Arc::new(config));
+        assert_eq!(inner.can_transfer_max_byte_num(), i32::MAX);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3472

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a flow monitoring feature to track and control message transfer rates.
  - Added the ability to configure a maximum transfer rate for high availability (HA) message transfers, with a default limit set to 100 MB per second.

- **Bug Fixes**
  - Ensured the default transfer rate limit is consistently applied during configuration and deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->