### PR TITLE
[ISSUE #3412]♻️Refactor UnlockBatchMqRequestHeader with derive marco RequestHeaderCodec

### DIFF
--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -906,7 +906,7 @@ impl MQClientAPIImpl {
         client_id: &str,
         subscription_data: &SubscriptionData,
         timeout_millis: u64,
-    ) -> rocketmq_error::RocketMQResult<()> {
+    ) -> RocketMQResult<()> {
         let mut request = RemotingCommand::create_remoting_command(RequestCode::CheckClientConfig);
         let body = CheckClientRequestBody::new(
             client_id.to_string(),

--- a/rocketmq-remoting/src/protocol/header/unlock_batch_mq_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/unlock_batch_mq_request_header.rs
@@ -14,44 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
 
-use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct UnlockBatchMqRequestHeader {
     #[serde(flatten)]
     pub rpc_request_header: Option<RpcRequestHeader>,
-}
-
-impl CommandCustomHeader for UnlockBatchMqRequestHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        let mut map = HashMap::new();
-        if let Some(value) = self.rpc_request_header.as_ref() {
-            if let Some(value) = value.to_map() {
-                map.extend(value);
-            }
-        }
-        Some(map)
-    }
-}
-
-impl FromMap for UnlockBatchMqRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
-
-    type Target = Self;
-
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        let rpc_request_header = <RpcRequestHeader as FromMap>::from(map)?;
-        Ok(UnlockBatchMqRequestHeader {
-            rpc_request_header: Some(rpc_request_header),
-        })
-    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3412 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal code by replacing manual trait implementations with an automatic derive macro for request header handling.
  - Updated method return types for consistency and clarity; no impact on user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->