### PR TITLE
[ISSUE #3505]🚀Implement comprehensive HA service infrastructure with GroupTransfer and ConnectionState services✨

### DIFF
--- a/rocketmq-store/src/ha/general_ha_client.rs
+++ b/rocketmq-store/src/ha/general_ha_client.rs
@@ -22,3 +22,28 @@ pub struct GeneralHAClient {
     default_ha_service: Option<DefaultHAClient>,
     auto_switch_ha_service: Option<AutoSwitchHAClient>,
 }
+
+impl Default for GeneralHAClient {
+    fn default() -> Self {
+        GeneralHAClient::new()
+    }
+}
+
+impl GeneralHAClient {
+    pub fn new() -> Self {
+        GeneralHAClient {
+            default_ha_service: None,
+            auto_switch_ha_service: None,
+        }
+    }
+
+    pub fn set_default_ha_service(&mut self, service: DefaultHAClient) {
+        self.default_ha_service = Some(service);
+    }
+
+    pub fn set_auto_switch_ha_service(&mut self, service: AutoSwitchHAClient) {
+        self.auto_switch_ha_service = Some(service);
+    }
+
+    // Additional methods to interact with the HA services can be added here
+}

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -49,8 +49,8 @@ impl GeneralHAService {
         {
             self.auto_switch_ha_service = Some(AutoSwitchHAService)
         } else {
-            let mut default_ha_service = DefaultHAService::default();
-            default_ha_service.init(message_store)?;
+            let mut default_ha_service = DefaultHAService::new(message_store);
+            default_ha_service.init()?;
             self.default_ha_service = Some(default_ha_service);
         }
         Ok(())

--- a/rocketmq-store/src/ha/group_transfer_service.rs
+++ b/rocketmq-store/src/ha/group_transfer_service.rs
@@ -15,19 +15,4 @@
  * limitations under the License.
  */
 
-mod auto_switch;
-pub(crate) mod default_ha_client;
-mod default_ha_connection;
-pub(crate) mod default_ha_service;
-pub(crate) mod flow_monitor;
-pub(crate) mod general_ha_client;
-pub(crate) mod general_ha_connection;
-pub(crate) mod general_ha_service;
-mod group_transfer_service;
-pub(crate) mod ha_client;
-pub(crate) mod ha_connection;
-pub(crate) mod ha_connection_state;
-pub(crate) mod ha_connection_state_notification_request;
-mod ha_connection_state_notification_service;
-pub(crate) mod ha_service;
-pub(crate) mod wait_notify_object;
+pub struct GroupTransferService;

--- a/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
+++ b/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
@@ -15,19 +15,4 @@
  * limitations under the License.
  */
 
-mod auto_switch;
-pub(crate) mod default_ha_client;
-mod default_ha_connection;
-pub(crate) mod default_ha_service;
-pub(crate) mod flow_monitor;
-pub(crate) mod general_ha_client;
-pub(crate) mod general_ha_connection;
-pub(crate) mod general_ha_service;
-mod group_transfer_service;
-pub(crate) mod ha_client;
-pub(crate) mod ha_connection;
-pub(crate) mod ha_connection_state;
-pub(crate) mod ha_connection_state_notification_request;
-mod ha_connection_state_notification_service;
-pub(crate) mod ha_service;
-pub(crate) mod wait_notify_object;
+pub struct HAConnectionStateNotificationService;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3505

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new components for group transfer service and HA connection state notification service.
  - Expanded the default high-availability (HA) service with additional fields and initialization logic.
  - Added new constructors and setter methods for the general HA client.

- **Refactor**
  - Updated initialization flow for default HA service to streamline setup and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->