### PR TITLE
[ISSUE #3512]🚀Async High Availability (HA) Service Architecture Enhancement ✨

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -779,10 +779,11 @@ impl BrokerRuntime {
 
     fn initial_request_pipeline(&mut self) {}
 
-    fn start_basic_service(&mut self) {
+    async fn start_basic_service(&mut self) {
         if let Some(ref mut message_store) = self.inner.message_store {
             message_store
                 .start()
+                .await
                 .unwrap_or_else(|e| panic!("Failed to start message store: {e}"));
         } else {
             panic!("Message store is not initialized");
@@ -890,7 +891,7 @@ impl BrokerRuntime {
         }
 
         self.inner.broker_outer_api.start().await;
-        self.start_basic_service();
+        self.start_basic_service().await;
 
         if !self.inner.is_isolated.load(Ordering::Acquire)
             && !self.inner.message_store_config.enable_dledger_commit_log

--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -65,7 +65,7 @@ pub trait MessageStoreInner: Sync + 'static {
     async fn load(&mut self) -> bool;
 
     /// Launch this message store.
-    fn start(&mut self) -> Result<(), StoreError>;
+    async fn start(&mut self) -> Result<(), StoreError>;
 
     /// Shutdown this message store.
     fn shutdown(&mut self);

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -277,6 +277,9 @@ mod defaults {
     pub fn ha_send_heartbeat_interval() -> u64 {
         1000 * 5
     }
+    pub fn ha_listen_port() -> usize {
+        10912
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -510,7 +513,7 @@ pub struct MessageStoreConfig {
     #[serde(default)]
     pub message_index_safe: bool,
 
-    #[serde(default)]
+    #[serde(default = "defaults::ha_listen_port")]
     pub ha_listen_port: usize,
 
     #[serde(default = "defaults::ha_send_heartbeat_interval")]
@@ -899,7 +902,7 @@ impl Default for MessageStoreConfig {
             max_index_num: 5000000 * 4,
             max_msgs_num_batch: 64,
             message_index_safe: false,
-            ha_listen_port: 0,
+            ha_listen_port: 10912,
             ha_send_heartbeat_interval: 1000 * 5,
             ha_housekeeping_interval: 1000 * 20,
             ha_transfer_batch_size: 0,

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -33,7 +33,7 @@ use crate::store_error::HAResult;
 pub struct AutoSwitchHAService;
 
 impl HAService for AutoSwitchHAService {
-    fn start(&mut self) -> HAResult<()> {
+    async fn start(&mut self) -> HAResult<()> {
         error!("DefaultHAService start not implemented");
         Ok(())
     }

--- a/rocketmq-store/src/ha/default_ha_client.rs
+++ b/rocketmq-store/src/ha/default_ha_client.rs
@@ -39,6 +39,7 @@ use tracing::warn;
 
 use crate::base::message_store::MessageStore;
 use crate::ha::flow_monitor::FlowMonitor;
+use crate::ha::ha_client::HAClient;
 use crate::ha::ha_connection_state::HAConnectionState;
 use crate::message_store::local_file_message_store::LocalFileMessageStore;
 
@@ -609,9 +610,9 @@ impl DefaultHAClient {
         sleep(Duration::from_secs(5)).await;
     }
 
-    /// Start the HA client service
-    pub async fn start(self: Arc<Self>) -> Result<(), HAClientError> {
-        let self_clone = Arc::clone(&self);
+    // Start the HA client service
+    /*    pub async fn start(self: ArcMut<Self>) -> Result<(), HAClientError> {
+        let self_clone = ArcMut::clone(&self);
         let handle = tokio::spawn(async move {
             self_clone.run_service().await;
         });
@@ -620,7 +621,7 @@ impl DefaultHAClient {
         *service_handle = Some(handle);
 
         Ok(())
-    }
+    }*/
 
     /// Shutdown the HA client
     pub async fn shutdown(self: Arc<Self>) {
@@ -663,6 +664,59 @@ impl DefaultHAClient {
     }
 }
 
+impl HAClient for DefaultHAClient {
+    async fn start(&self) {
+        error!("GeneralHAService does not implement start directly, use specific service");
+    }
+
+    async fn shutdown(&self) {
+        todo!()
+    }
+
+    async fn wakeup(&self) {
+        todo!()
+    }
+
+    async fn update_master_address(&self, new_address: &str) {
+        todo!()
+    }
+
+    async fn update_ha_master_address(&self, new_address: &str) {
+        todo!()
+    }
+
+    fn get_master_address(&self) -> String {
+        todo!()
+    }
+
+    fn get_ha_master_address(&self) -> String {
+        todo!()
+    }
+
+    fn get_last_read_timestamp(&self) -> i64 {
+        todo!()
+    }
+
+    fn get_last_write_timestamp(&self) -> i64 {
+        todo!()
+    }
+
+    fn get_current_state(&self) -> HAConnectionState {
+        todo!()
+    }
+
+    fn change_current_state(&self, ha_connection_state: HAConnectionState) {
+        todo!()
+    }
+
+    async fn close_master(&self) {
+        todo!()
+    }
+
+    fn get_transferred_byte_in_second(&self) -> i64 {
+        todo!()
+    }
+}
 /// Error types
 #[derive(Debug, thiserror::Error)]
 pub enum HAClientError {

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -30,18 +30,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+use std::net::SocketAddr;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
+use std::time::Duration;
 
 use rocketmq_common::common::broker::broker_role::BrokerRole;
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_rust::ArcMut;
+use tokio::net::TcpListener;
+use tokio::select;
+use tokio::sync::Mutex;
+use tokio::sync::Notify;
+use tokio::time::sleep;
 use tracing::error;
+use tracing::info;
 
+use crate::config::message_store_config::MessageStoreConfig;
 use crate::ha::default_ha_client::DefaultHAClient;
+use crate::ha::default_ha_connection::DefaultHAConnection;
 use crate::ha::general_ha_client::GeneralHAClient;
 use crate::ha::general_ha_connection::GeneralHAConnection;
 use crate::ha::general_ha_service::GeneralHAService;
@@ -59,8 +68,8 @@ use crate::store_error::HAResult;
 
 pub struct DefaultHAService {
     connection_count: Arc<AtomicU64>,
-    connection_list: Vec<GeneralHAConnection>,
-    accept_socket_service: AcceptSocketService,
+    connection_list: Arc<Mutex<Vec<GeneralHAConnection>>>,
+    accept_socket_service: Option<AcceptSocketService>,
     default_message_store: ArcMut<LocalFileMessageStore>,
     wait_notify_object: Arc<WaitNotifyObject>,
     push2_slave_max_offset: Arc<AtomicU64>,
@@ -73,8 +82,8 @@ impl DefaultHAService {
     pub fn new(message_store: ArcMut<LocalFileMessageStore>) -> Self {
         DefaultHAService {
             connection_count: Arc::new(AtomicU64::new(0)),
-            connection_list: Vec::new(),
-            accept_socket_service: AcceptSocketService,
+            connection_list: Arc::new(Mutex::new(Vec::new())),
+            accept_socket_service: None,
             default_message_store: message_store,
             wait_notify_object: Arc::new(WaitNotifyObject),
             push2_slave_max_offset: Arc::new(AtomicU64::new(0)),
@@ -86,7 +95,7 @@ impl DefaultHAService {
 
     // Add any necessary fields here
     pub fn get_default_message_store(&self) -> &LocalFileMessageStore {
-        unimplemented!(" get_default_message_store method is not implemented");
+        self.default_message_store.as_ref()
     }
 
     pub async fn notify_transfer_some(&self, _offset: i64) {
@@ -99,6 +108,7 @@ impl DefaultHAService {
         // Initialize the DefaultHAService with the provided message store.
         let config = self.default_message_store.get_message_store_config();
         let service = GeneralHAService::new_with_default_ha_service(this.clone());
+
         let group_transfer_service = GroupTransferService::new(config.clone(), service.clone());
         self.group_transfer_service = Some(group_transfer_service);
 
@@ -108,16 +118,50 @@ impl DefaultHAService {
                 .map_err(|e| HAError::Service(format!("Failed to create DefaultHAClient: {e}")))?;
             self.ha_client.set_default_ha_service(client)
         }
+
         let state_notification_service =
             HAConnectionStateNotificationService::new(service, self.default_message_store.clone());
         self.ha_connection_state_notification_service = Some(state_notification_service);
+
+        self.accept_socket_service = Some(AcceptSocketService::new(
+            self.default_message_store
+                .get_message_store_config()
+                .clone(),
+            this,
+            false,
+        ));
         Ok(())
+    }
+
+    pub async fn add_connection(&self, connection: GeneralHAConnection) {
+        // Add a new connection to the service
+        let mut vec = self.connection_list.lock().await;
+        vec.push(connection);
+    }
+
+    pub fn get_connection_count(&self) -> &AtomicU64 {
+        &self.connection_count
     }
 }
 
 impl HAService for DefaultHAService {
-    fn start(&mut self) -> HAResult<()> {
-        error!("DefaultHAService start not implemented");
+    async fn start(&mut self) -> HAResult<()> {
+        self.accept_socket_service
+            .as_mut()
+            .expect("AcceptSocketService not initialized")
+            .start()
+            .await?;
+        self.group_transfer_service
+            .as_mut()
+            .expect("GroupTransferService not initialized")
+            .start()
+            .await?;
+        self.ha_connection_state_notification_service
+            .as_mut()
+            .expect("HAConnectionStateNotificationService not initialized")
+            .start()
+            .await?;
+        self.ha_client.start().await;
         Ok(())
     }
 
@@ -199,4 +243,76 @@ impl HAService for DefaultHAService {
     }
 }
 
-struct AcceptSocketService;
+struct AcceptSocketService {
+    socket_address_listen: SocketAddr,
+    message_store_config: Arc<MessageStoreConfig>,
+    is_auto_switch: bool,
+    shutdown_notify: Arc<Notify>,
+    default_ha_service: ArcMut<DefaultHAService>,
+}
+
+impl AcceptSocketService {
+    pub fn new(
+        message_store_config: Arc<MessageStoreConfig>,
+        default_ha_service: ArcMut<DefaultHAService>,
+        is_auto_switch: bool,
+    ) -> Self {
+        let ha_listen_port = message_store_config.ha_listen_port;
+        let socket_address_listen = SocketAddr::from(([0u8, 0u8, 0u8, 0u8], ha_listen_port as u16));
+        AcceptSocketService {
+            socket_address_listen,
+            message_store_config,
+            is_auto_switch,
+            shutdown_notify: Arc::new(Notify::new()),
+            default_ha_service,
+        }
+    }
+
+    pub async fn start(&mut self) -> HAResult<()> {
+        let listener = TcpListener::bind(self.socket_address_listen)
+            .await
+            .map_err(HAError::Io)?;
+        let shutdown_notify = self.shutdown_notify.clone();
+        let is_auto_switch = self.is_auto_switch;
+        let message_store_config = self.message_store_config.clone();
+        let default_ha_service = self.default_ha_service.clone();
+        tokio::spawn(async move {
+            let message_store_config = message_store_config;
+            let default_ha_service = default_ha_service;
+            loop {
+                select! {
+                    _ = shutdown_notify.notified() => {
+                        info!("AcceptSocketService is shutting down");
+                        break;
+                    }
+                // Accept new connections
+                    accept_result = listener.accept() => {
+                        match accept_result {
+                            Ok((stream, addr)) => {
+                                info!("HAService receive new connection, {}", addr);
+                               if is_auto_switch {
+                                    unimplemented!("Auto-switching is not implemented yet");
+                                }else{
+                                    let default_conn = DefaultHAConnection::new(default_ha_service.clone(), stream,message_store_config.clone()).await.expect("Error creating HAConnection");
+                                    let general_conn = GeneralHAConnection::new_with_default_ha_connection(default_conn);
+                                    default_ha_service.add_connection(general_conn).await;
+                                };
+                            }
+                            Err(e) => {
+                                error!("Failed to accept connection: {}", e);
+                                // Add a small delay to prevent busy-waiting on persistent errors
+                                sleep(Duration::from_millis(100)).await;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    pub fn shutdown(&self) {
+        info!("Shutting down AcceptSocketService");
+        self.shutdown_notify.notify_waiters();
+    }
+}

--- a/rocketmq-store/src/ha/general_ha_client.rs
+++ b/rocketmq-store/src/ha/general_ha_client.rs
@@ -18,6 +18,8 @@ use rocketmq_rust::ArcMut;
 
 use crate::ha::auto_switch::auto_switch_ha_client::AutoSwitchHAClient;
 use crate::ha::default_ha_client::DefaultHAClient;
+use crate::ha::ha_client::HAClient;
+use crate::ha::ha_connection_state::HAConnectionState;
 
 pub struct GeneralHAClient {
     default_ha_service: Option<ArcMut<DefaultHAClient>>,
@@ -47,4 +49,64 @@ impl GeneralHAClient {
     }
 
     // Additional methods to interact with the HA services can be added here
+}
+
+impl HAClient for GeneralHAClient {
+    async fn start(&self) {
+        if let Some(ref service) = self.default_ha_service {
+            service.start().await;
+        } else if let Some(ref service) = self.auto_switch_ha_service {
+            service.start().await;
+        } else {
+            panic!("No HA service is set for GeneralHAClient");
+        }
+    }
+
+    async fn shutdown(&self) {
+        todo!()
+    }
+
+    async fn wakeup(&self) {
+        todo!()
+    }
+
+    async fn update_master_address(&self, new_address: &str) {
+        todo!()
+    }
+
+    async fn update_ha_master_address(&self, new_address: &str) {
+        todo!()
+    }
+
+    fn get_master_address(&self) -> String {
+        todo!()
+    }
+
+    fn get_ha_master_address(&self) -> String {
+        todo!()
+    }
+
+    fn get_last_read_timestamp(&self) -> i64 {
+        todo!()
+    }
+
+    fn get_last_write_timestamp(&self) -> i64 {
+        todo!()
+    }
+
+    fn get_current_state(&self) -> HAConnectionState {
+        todo!()
+    }
+
+    fn change_current_state(&self, ha_connection_state: HAConnectionState) {
+        todo!()
+    }
+
+    async fn close_master(&self) {
+        todo!()
+    }
+
+    fn get_transferred_byte_in_second(&self) -> i64 {
+        todo!()
+    }
 }

--- a/rocketmq-store/src/ha/general_ha_connection.rs
+++ b/rocketmq-store/src/ha/general_ha_connection.rs
@@ -22,3 +22,36 @@ pub struct GeneralHAConnection {
     default_ha_connection: Option<DefaultHAConnection>,
     auto_switch_ha_connection: Option<AutoSwitchHAConnection>,
 }
+
+impl GeneralHAConnection {
+    pub fn new() -> Self {
+        GeneralHAConnection {
+            default_ha_connection: None,
+            auto_switch_ha_connection: None,
+        }
+    }
+
+    pub fn new_with_default_ha_connection(default_ha_connection: DefaultHAConnection) -> Self {
+        GeneralHAConnection {
+            default_ha_connection: Some(default_ha_connection),
+            auto_switch_ha_connection: None,
+        }
+    }
+
+    pub fn new_with_auto_switch_ha_connection(
+        auto_switch_ha_connection: AutoSwitchHAConnection,
+    ) -> Self {
+        GeneralHAConnection {
+            default_ha_connection: None,
+            auto_switch_ha_connection: Some(auto_switch_ha_connection),
+        }
+    }
+
+    pub fn set_default_ha_connection(&mut self, connection: DefaultHAConnection) {
+        self.default_ha_connection = Some(connection);
+    }
+
+    pub fn set_auto_switch_ha_connection(&mut self, connection: AutoSwitchHAConnection) {
+        self.auto_switch_ha_connection = Some(connection);
+    }
+}

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -73,11 +73,11 @@ impl GeneralHAService {
 }
 
 impl HAService for GeneralHAService {
-    fn start(&mut self) -> HAResult<()> {
+    async fn start(&mut self) -> HAResult<()> {
         if let Some(ref mut service) = self.default_ha_service {
-            service.start()?;
+            service.start().await?;
         } else if let Some(ref mut service) = self.auto_switch_ha_service {
-            service.start()?;
+            service.start().await?;
         } else {
             error!("No HA service initialized");
             return Err(HAError::Service("No HA service initialized".to_string()));

--- a/rocketmq-store/src/ha/group_transfer_service.rs
+++ b/rocketmq-store/src/ha/group_transfer_service.rs
@@ -16,8 +16,11 @@
  */
 use std::sync::Arc;
 
+use tracing::error;
+
 use crate::config::message_store_config::MessageStoreConfig;
 use crate::ha::general_ha_service::GeneralHAService;
+use crate::store_error::HAResult;
 
 pub struct GroupTransferService {
     message_store_config: Arc<MessageStoreConfig>,
@@ -33,5 +36,10 @@ impl GroupTransferService {
             message_store_config,
             ha_service,
         }
+    }
+
+    pub async fn start(&mut self) -> HAResult<()> {
+        error!("GroupTransferService is not implemented yet");
+        Ok(())
     }
 }

--- a/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
+++ b/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 use rocketmq_rust::ArcMut;
+use tracing::error;
 
 use crate::ha::general_ha_service::GeneralHAService;
 use crate::message_store::local_file_message_store::LocalFileMessageStore;
+use crate::store_error::HAResult;
 
 pub struct HAConnectionStateNotificationService {
     ha_service: GeneralHAService,
@@ -33,5 +35,10 @@ impl HAConnectionStateNotificationService {
             ha_service,
             default_message_store,
         }
+    }
+
+    pub async fn start(&mut self) -> HAResult<()> {
+        error!("HAConnectionStateNotificationService is not implemented yet");
+        Ok(())
     }
 }

--- a/rocketmq-store/src/ha/ha_service.rs
+++ b/rocketmq-store/src/ha/ha_service.rs
@@ -35,7 +35,7 @@ pub trait RocketHAService: Sync {
     ///
     /// # Returns
     /// Result indicating success or failure
-    fn start(&mut self) -> HAResult<()>;
+    async fn start(&mut self) -> HAResult<()>;
 
     /// Shutdown the HA service
     fn shutdown(&self);

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -642,7 +642,7 @@ impl MessageStore for LocalFileMessageStore {
         result
     }
 
-    fn start(&mut self) -> Result<(), StoreError> {
+    async fn start(&mut self) -> Result<(), StoreError> {
         if !self.message_store_config.enable_dleger_commit_log
             && !self.message_store_config.duplication_enable
         {
@@ -680,7 +680,7 @@ impl MessageStore for LocalFileMessageStore {
         self.store_stats_service.start();
 
         if let Some(ha_service) = self.ha_service.as_mut() {
-            ha_service.start().map_err(|e| {
+            ha_service.start().await.map_err(|e| {
                 error!("HA service start failed: {:?}", e);
                 StoreError::General(e.to_string())
             })?;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3512

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added asynchronous startup for high availability (HA) services, including socket acceptance and connection management.
  - Introduced default values for HA listen port configuration.
  - Provided new methods for managing HA connections and services.

- **Refactor**
  - Converted multiple service and trait methods from synchronous to asynchronous to improve scalability and responsiveness.
  - Updated internal service references to support asynchronous and concurrent access.

- **Bug Fixes**
  - Ensured consistent default values for HA listen ports during configuration and deserialization.

- **Documentation**
  - Added error logging for unimplemented HA service features and startup methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->