### PR TITLE
[ISSUE #3515]🐛Memory Safety Issue in DefaultHAClient master_address Field Implementation

### DIFF
--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_client.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_client.rs
@@ -33,11 +33,11 @@ impl HAClient for AutoSwitchHAClient {
         todo!()
     }
 
-    async fn update_master_address(&self, new_address: &str) {
+    fn update_master_address(&self, new_address: &str) {
         todo!()
     }
 
-    async fn update_ha_master_address(&self, new_address: &str) {
+    fn update_ha_master_address(&self, new_address: &str) {
         todo!()
     }
 

--- a/rocketmq-store/src/ha/default_ha_client.rs
+++ b/rocketmq-store/src/ha/default_ha_client.rs
@@ -16,6 +16,7 @@
  */
 use std::io::Cursor;
 use std::sync::atomic::AtomicI64;
+use std::sync::atomic::AtomicPtr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -65,7 +66,7 @@ pub struct DefaultHAClient {
     master_ha_address: Arc<RwLock<Option<String>>>,
 
     /// Master address (atomic reference)
-    master_address: Arc<RwLock<Option<String>>>,
+    master_address: Arc<AtomicPtr<String>>,
 
     /// TCP connection to master
     socket_stream: Arc<RwLock<Option<TcpStream>>>,
@@ -120,7 +121,7 @@ impl DefaultHAClient {
 
         Ok(ArcMut::new(Self {
             master_ha_address: Arc::new(RwLock::new(None)),
-            master_address: Arc::new(RwLock::new(None)),
+            master_address: Arc::new(AtomicPtr::default()),
             socket_stream: Arc::new(RwLock::new(None)),
             last_read_timestamp: AtomicI64::new(now),
             last_write_timestamp: AtomicI64::new(now),
@@ -151,18 +152,6 @@ impl DefaultHAClient {
         );
     }
 
-    /// Update master address
-    pub async fn update_master_address(&self, new_addr: Option<String>) {
-        let mut current_addr = self.master_address.write().await;
-        let old_addr = current_addr.clone();
-        *current_addr = new_addr.clone();
-
-        info!(
-            "update master address, OLD: {:?} NEW: {:?}",
-            old_addr, new_addr
-        );
-    }
-
     /// Get HA master address
     pub async fn get_ha_master_address(&self) -> Option<String> {
         self.master_ha_address.read().await.clone()
@@ -170,7 +159,13 @@ impl DefaultHAClient {
 
     /// Get master address
     pub async fn get_master_address(&self) -> Option<String> {
-        self.master_address.read().await.clone()
+        let addr_ptr = self.master_address.load(Ordering::SeqCst);
+        if !addr_ptr.is_null() {
+            let address = unsafe { (*addr_ptr).clone() };
+            Some(address)
+        } else {
+            None
+        }
     }
 
     /// Check if it's time to report offset
@@ -677,11 +672,13 @@ impl HAClient for DefaultHAClient {
         todo!()
     }
 
-    async fn update_master_address(&self, new_address: &str) {
-        todo!()
+    /// Update master address
+    fn update_master_address(&self, new_address: &str) {
+        let addresss = Box::into_raw(Box::new(new_address.to_string()));
+        self.master_address.store(addresss, Ordering::SeqCst);
     }
 
-    async fn update_ha_master_address(&self, new_address: &str) {
+    fn update_ha_master_address(&self, new_address: &str) {
         todo!()
     }
 

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -195,7 +195,7 @@ impl HAService for DefaultHAService {
     }
 
     fn update_master_address(&self, new_addr: &str) {
-        todo!()
+        self.ha_client.update_master_address(new_addr);
     }
 
     fn update_ha_master_address(&self, new_addr: &str) {

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -115,7 +115,13 @@ impl HAService for GeneralHAService {
     }
 
     fn update_master_address(&self, new_addr: &str) {
-        todo!()
+        if let Some(ref service) = self.default_ha_service {
+            service.update_master_address(new_addr);
+        } else if let Some(ref service) = self.auto_switch_ha_service {
+            service.update_master_address(new_addr);
+        } else {
+            error!("No HA service initialized to update master address");
+        }
     }
 
     fn update_ha_master_address(&self, new_addr: &str) {

--- a/rocketmq-store/src/ha/ha_client.rs
+++ b/rocketmq-store/src/ha/ha_client.rs
@@ -38,13 +38,13 @@ pub trait RocketmqHAClient: Sync {
     ///
     /// # Parameters
     /// * `new_address` - The new address to connect to
-    async fn update_master_address(&self, new_address: &str);
+    fn update_master_address(&self, new_address: &str);
 
     /// Update the HA master address
     ///
     /// # Parameters
     /// * `new_address` - The new HA address to connect to
-    async fn update_ha_master_address(&self, new_address: &str);
+    fn update_ha_master_address(&self, new_address: &str);
 
     /// Get the current master address
     ///


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3515

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated several methods related to master address management to be synchronous instead of asynchronous, improving performance and simplifying usage.
  - Improved internal handling and delegation of master address updates within HA client and service components.
  - Enhanced error logging when no HA service is available for master address updates.

- **Bug Fixes**
  - Fixed unimplemented methods by providing actual logic for updating master addresses in relevant components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->