### PR TITLE
[ISSUE #3521]⚡️Increase buffer capacity for Framed connection to 1 MB in new Connection implementation

### DIFF
--- a/rocketmq-remoting/src/connection.rs
+++ b/rocketmq-remoting/src/connection.rs
@@ -98,7 +98,8 @@ impl Connection {
     ///
     /// A new `Connection` instance.
     pub fn new(tcp_stream: TcpStream) -> Connection {
-        let framed = Framed::with_capacity(tcp_stream, CompositeCodec::new(), 1024 * 4);
+        const CAPACITY: usize = 1024 * 1024; // 1 MB
+        let framed = Framed::with_capacity(tcp_stream, CompositeCodec::new(), CAPACITY);
         let (writer, reader) = framed.split();
         Self {
             writer,


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3521

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Increased the internal buffer size for connections to improve data handling performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->