### PR TITLE
[ISSUE #3523]⚡️Increase buffer size to 8 KB in Connection implementation

### DIFF
--- a/rocketmq-remoting/src/connection.rs
+++ b/rocketmq-remoting/src/connection.rs
@@ -99,13 +99,14 @@ impl Connection {
     /// A new `Connection` instance.
     pub fn new(tcp_stream: TcpStream) -> Connection {
         const CAPACITY: usize = 1024 * 1024; // 1 MB
+        const BUFFER_SIZE: usize = 8 * 1024; // 8 KB
         let framed = Framed::with_capacity(tcp_stream, CompositeCodec::new(), CAPACITY);
         let (writer, reader) = framed.split();
         Self {
             writer,
             reader,
             ok: true,
-            buf: BytesMut::with_capacity(4096),
+            buf: BytesMut::with_capacity(BUFFER_SIZE),
         }
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3523

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Increased the internal buffer size for connections, potentially improving performance when handling larger data streams. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->