### PR TITLE
[Issue:3531] Define constant for framed connection capacity in HAConnection start method 

### DIFF
--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -118,13 +118,14 @@ impl DefaultHAConnection {
 
 impl HAConnection for DefaultHAConnection {
     async fn start(&mut self) -> Result<(), HAConnectionError> {
+        const CAPACITY: usize = 1024 * 4;
         self.change_current_state(HAConnectionState::Transfer).await;
 
         // Start flow monitor
         self.flow_monitor.start().await;
 
         let tcp_stream = self.socket_stream.take().unwrap();
-        let framed = Framed::with_capacity(tcp_stream, BytesCodec::new(), 1024 * 4);
+        let framed = Framed::with_capacity(tcp_stream, BytesCodec::new(), CAPACITY);
         let (writer, reader) = framed.split();
 
         // Create and start read service


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

https://github.com/mxsm/rocketmq-rust/issues/3531

Fixes #issue_id

### Brief Description

Defined a constant instead of just computing on fly

### How Did You Test This Change?

If CI build, then we're fine for this change