### PR TITLE
[ISSUE #3487] Optimize connection buffer handling to use split method

### DIFF
--- a/rocketmq-remoting/src/connection.rs
+++ b/rocketmq-remoting/src/connection.rs
@@ -149,7 +149,7 @@ impl Connection {
         if let Some(body_inner) = command.take_body() {
             self.buf.put(body_inner);
         }
-        self.writer.send(self.buf.clone().freeze()).await?;
+        self.writer.send(self.buf.split().freeze()).await?;
         Ok(())
     }
 
@@ -171,7 +171,7 @@ impl Connection {
         if let Some(body_inner) = command.take_body() {
             self.buf.put(body_inner);
         }
-        self.writer.send(self.buf.clone().freeze()).await?;
+        self.writer.send(self.buf.split().freeze()).await?;
         Ok(())
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

fixes: https://github.com/mxsm/rocketmq-rust/issues/3487

### Brief Description

Use split method instead of creating clones

### How Did You Test This Change?

cargo builds fine


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved buffer handling during command sending to enhance efficiency and reduce unnecessary data copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->