### PR TITLE
Refactor ReplyMessageRequestHeader with derive marco RequestHeaderCodec #3411

### DIFF
--- a/rocketmq-remoting/src/protocol/header/reply_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/reply_message_request_header.rs
@@ -14,42 +14,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
-
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
 /// Represents the header of a reply message request.
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct ReplyMessageRequestHeader {
     /// Producer group associated with the message.
+    #[required]
     pub producer_group: CheetahString,
 
     /// The topic of the message.
+    #[required]
     pub topic: CheetahString,
 
     /// Default topic used when the specified topic is not found.
+    #[required]
     pub default_topic: CheetahString,
 
     /// Number of queues in the default topic.
+    #[required]
     pub default_topic_queue_nums: i32,
 
     /// Queue ID of the message.
+    #[required]
     pub queue_id: i32,
 
     /// System flags associated with the message.
+    #[required]
     pub sys_flag: i32,
 
     /// Timestamp of when the message was born.
+    #[required]
     pub born_timestamp: i64,
 
     /// Flags associated with the message.
+    #[required]
     pub flag: i32,
 
     /// Properties of the message (nullable).
@@ -62,174 +67,133 @@ pub struct ReplyMessageRequestHeader {
     pub unit_mode: Option<bool>,
 
     /// Host where the message was born.
+    #[required]
     pub born_host: CheetahString,
 
     /// Host where the message is stored.
+    #[required]
     pub store_host: CheetahString,
 
     /// Timestamp of when the message was stored.
+    #[required]
     pub store_timestamp: i64,
 
     #[serde(flatten)]
     pub topic_request: Option<TopicRequestHeader>,
 }
 
-impl ReplyMessageRequestHeader {
-    pub const PRODUCER_GROUP: &'static str = "producerGroup";
-    pub const TOPIC: &'static str = "topic";
-    pub const DEFAULT_TOPIC: &'static str = "defaultTopic";
-    pub const DEFAULT_TOPIC_QUEUE_NUMS: &'static str = "defaultTopicQueueNums";
-    pub const QUEUE_ID: &'static str = "queueId";
-    pub const SYS_FLAG: &'static str = "sysFlag";
-    pub const BORN_TIMESTAMP: &'static str = "bornTimestamp";
-    pub const FLAG: &'static str = "flag";
-    pub const PROPERTIES: &'static str = "properties";
-    pub const RECONSUME_TIMES: &'static str = "reconsumeTimes";
-    pub const UNIT_MODE: &'static str = "unitMode";
-    pub const BORN_HOST: &'static str = "bornHost";
-    pub const STORE_HOST: &'static str = "storeHost";
-    pub const STORE_TIMESTAMP: &'static str = "storeTimestamp";
-}
+#[cfg(test)]
+mod reply_message_request_header_tests {
+    use std::collections::HashMap;
 
-impl CommandCustomHeader for ReplyMessageRequestHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        let mut map = HashMap::new();
-        map.insert(
-            CheetahString::from_static_str(Self::PRODUCER_GROUP),
-            self.producer_group.clone(),
-        );
+    use super::*;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::FromMap;
+    #[test]
+    fn deserialize_from_map_with_all_fields_populates_struct_correctly() {
+        let mut map: HashMap<CheetahString, CheetahString> = HashMap::new();
+        map.insert("producerGroup".into(), "test_producer_group".into());
+        map.insert("topic".into(), "test_topic".into());
+        map.insert("defaultTopic".into(), "test_default_topic".into());
+        map.insert("defaultTopicQueueNums".into(), "10".into());
+        map.insert("queueId".into(), "1".into());
+        map.insert("sysFlag".into(), "0".into());
+        map.insert("flag".into(), "0".into());
+        map.insert("bornTimestamp".into(), "1622547800".into());
+        map.insert("bornHost".into(), "test_born_host".into());
+        map.insert("storeHost".into(), "test_store_host".into());
+        map.insert("storeTimestamp".into(), "1622547800".into());
+        map.insert("unitMode".into(), "true".into());
 
-        map.insert(
-            CheetahString::from_static_str(Self::TOPIC),
-            self.topic.clone(),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::DEFAULT_TOPIC),
-            self.default_topic.clone(),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::DEFAULT_TOPIC_QUEUE_NUMS),
-            CheetahString::from_string(self.default_topic_queue_nums.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::QUEUE_ID),
-            CheetahString::from_string(self.queue_id.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::SYS_FLAG),
-            CheetahString::from_string(self.sys_flag.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::BORN_TIMESTAMP),
-            CheetahString::from_string(self.born_timestamp.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::FLAG),
-            CheetahString::from_string(self.flag.to_string()),
-        );
+        let header: ReplyMessageRequestHeader =
+            <ReplyMessageRequestHeader as FromMap>::from(&map).unwrap();
 
-        if let Some(value) = self.properties.as_ref() {
-            map.insert(
-                CheetahString::from_static_str(Self::PROPERTIES),
-                value.clone(),
-            );
-        }
-        if let Some(value) = self.reconsume_times.as_ref() {
-            map.insert(
-                CheetahString::from_static_str(Self::RECONSUME_TIMES),
-                CheetahString::from_string(value.to_string()),
-            );
-        }
-        if let Some(value) = self.unit_mode.as_ref() {
-            map.insert(
-                CheetahString::from_static_str(Self::UNIT_MODE),
-                CheetahString::from_string(value.to_string()),
-            );
-        }
-        map.insert(
-            CheetahString::from_static_str(Self::BORN_HOST),
-            self.born_host.clone(),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::STORE_HOST),
-            self.store_host.clone(),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::STORE_TIMESTAMP),
-            CheetahString::from_string(self.store_timestamp.to_string()),
-        );
-        if let Some(value) = self.topic_request.as_ref() {
-            if let Some(value) = value.to_map() {
-                map.extend(value);
-            }
-        }
-        Some(map)
+        assert_eq!(header.topic, "test_topic");
+        assert_eq!(header.producer_group, "test_producer_group");
+        assert_eq!(header.default_topic, "test_default_topic");
+        assert_eq!(header.default_topic_queue_nums, 10);
+        assert_eq!(header.queue_id, 1);
+        assert_eq!(header.sys_flag, 0);
+        assert_eq!(header.flag, 0);
+        assert_eq!(header.born_timestamp, 1622547800);
+        assert_eq!(header.born_host, "test_born_host");
+        assert_eq!(header.store_host, "test_store_host");
+        assert_eq!(header.store_timestamp, 1622547800);
+        assert_eq!(header.properties, None);
+        assert_eq!(header.reconsume_times, None);
+        assert_eq!(header.unit_mode, Some(true));
     }
-}
 
-impl FromMap for ReplyMessageRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
+    #[test]
+    fn deserialize_from_map_with_invalid_number_fields_returns_none() {
+        let mut map = HashMap::new();
+        map.insert("producerGroup".into(), "test_producer_group".into());
+        map.insert("topic".into(), "test_topic".into());
+        map.insert("defaultTopic".into(), "test_default_topic".into());
+        map.insert("defaultTopicQueueNums".into(), "invalid".into());
+        let header: Result<ReplyMessageRequestHeader, rocketmq_error::RocketmqError> =
+            <ReplyMessageRequestHeader as FromMap>::from(&map);
+        assert!(header.is_err());
+    }
 
-    type Target = Self;
+    #[test]
+    fn serialize_header_to_map() {
+        let header = ReplyMessageRequestHeader {
+            topic: "test_topic".into(),
+            producer_group: "test_producer_group".into(),
+            default_topic: "test_default_topic".into(),
+            default_topic_queue_nums: 10,
+            queue_id: 1,
+            flag: 2,
+            sys_flag: 0,
+            born_timestamp: 1622547800,
+            born_host: "test_born_host".into(),
+            store_host: "test_store_host".into(),
+            store_timestamp: 1622547800,
+            properties: Some("test_properties".into()),
+            reconsume_times: Some(1),
+            unit_mode: Some(true),
+            topic_request: None,
+        };
+        let map: HashMap<CheetahString, CheetahString> = header.to_map().unwrap();
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(ReplyMessageRequestHeader {
-            producer_group: map
-                .get(&CheetahString::from_static_str(Self::PRODUCER_GROUP))
-                .cloned()
-                .unwrap_or_default(),
-            topic: map
-                .get(&CheetahString::from_static_str(Self::TOPIC))
-                .cloned()
-                .unwrap_or_default(),
-            default_topic: map
-                .get(&CheetahString::from_static_str(Self::DEFAULT_TOPIC))
-                .cloned()
-                .unwrap_or_default(),
-            default_topic_queue_nums: map
-                .get(&CheetahString::from_static_str(
-                    Self::DEFAULT_TOPIC_QUEUE_NUMS,
-                ))
-                .and_then(|value| value.parse().ok())
-                .unwrap_or_default(),
-            queue_id: map
-                .get(&CheetahString::from_static_str(Self::QUEUE_ID))
-                .and_then(|value| value.parse().ok())
-                .unwrap_or_default(),
-            sys_flag: map
-                .get(&CheetahString::from_static_str(Self::SYS_FLAG))
-                .and_then(|value| value.parse().ok())
-                .unwrap_or_default(),
-            born_timestamp: map
-                .get(&CheetahString::from_static_str(Self::BORN_TIMESTAMP))
-                .and_then(|value| value.parse().ok())
-                .unwrap_or_default(),
-            flag: map
-                .get(&CheetahString::from_static_str(Self::FLAG))
-                .and_then(|value| value.parse().ok())
-                .unwrap_or_default(),
-            properties: map
-                .get(&CheetahString::from_static_str(Self::PROPERTIES))
-                .cloned(),
-            reconsume_times: map
-                .get(&CheetahString::from_static_str(Self::RECONSUME_TIMES))
-                .and_then(|value| value.parse().ok()),
-            unit_mode: map
-                .get(&CheetahString::from_static_str(Self::UNIT_MODE))
-                .and_then(|value| value.parse().ok()),
-            born_host: map
-                .get(&CheetahString::from_static_str(Self::BORN_HOST))
-                .cloned()
-                .unwrap_or_default(),
-            store_host: map
-                .get(&CheetahString::from_static_str(Self::STORE_HOST))
-                .cloned()
-                .unwrap_or_default(),
-            store_timestamp: map
-                .get(&CheetahString::from_static_str(Self::STORE_TIMESTAMP))
-                .and_then(|value| value.parse().ok())
-                .unwrap_or_default(),
-            topic_request: Some(<TopicRequestHeader as FromMap>::from(map)?),
-        })
+        assert_eq!(map.get("topic").unwrap(), "test_topic");
+        assert_eq!(map.get("producerGroup").unwrap(), "test_producer_group");
+        assert_eq!(map.get("defaultTopicQueueNums").unwrap(), "10");
+        assert_eq!(map.get("bornTimestamp").unwrap(), "1622547800");
+        assert_eq!(map.get("topicRequest").is_none(), true);
+        assert_eq!(map.get("queueId").unwrap(), "1");
+        assert_eq!(map.get("sysFlag").unwrap(), "0");
+        assert_eq!(map.get("bornHost").unwrap(), "test_born_host");
+        assert_eq!(map.get("storeHost").unwrap(), "test_store_host");
+        assert_eq!(map.get("storeTimestamp").unwrap(), "1622547800");
+        assert_eq!(map.get("flag").unwrap(), "2");
+        assert_eq!(map.get("properties").unwrap(), "test_properties");
+        assert_eq!(map.get("reconsumeTimes").unwrap(), "1");
+        assert_eq!(map.get("unitMode").unwrap(), "true");
+    }
+
+    #[test]
+    fn serialize_header_to_map_with_topic_request_header_includes_nested_fields() {
+        let topic_request_header = TopicRequestHeader::default();
+        let header = ReplyMessageRequestHeader {
+            topic: "test_topic".into(),
+            producer_group: "test_producer_group".into(),
+            default_topic: "test_default_topic".into(),
+            default_topic_queue_nums: 10,
+            queue_id: 1,
+            flag: 2,
+            sys_flag: 0,
+            born_timestamp: 1622547800,
+            born_host: "test_born_host".into(),
+            store_host: "test_store_host".into(),
+            store_timestamp: 1622547800,
+            properties: Some("test_properties".into()),
+            reconsume_times: Some(1),
+            unit_mode: Some(true),
+            topic_request: Some(topic_request_header),
+        };
+        let map: HashMap<CheetahString, CheetahString> = header.to_map().unwrap();
+        assert!(!map.contains_key("nestedField"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3411 

### Brief Description

Refactor ReplyMessageRequestHeader with derive marco RequestHeaderCodec 
### How Did You Test This Change?

run unit tests local


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests to verify correct serialization and deserialization of reply message request headers, including error handling for invalid input.

* **Refactor**
  * Improved the handling of reply message request headers by switching to a macro-based approach for serialization and deserialization, reducing manual code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->