### PR TITLE
[ISSUE #3563]Add missing semicolon in default HA service client initialization

### DIFF
--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -116,7 +116,7 @@ impl DefaultHAService {
             let default_message_store = self.default_message_store.clone();
             let client = DefaultHAClient::new(default_message_store)
                 .map_err(|e| HAError::Service(format!("Failed to create DefaultHAClient: {e}")))?;
-            self.ha_client.set_default_ha_service(client)
+            self.ha_client.set_default_ha_service(client);
         }
 
         let state_notification_service =


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3563

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a minor syntax issue to improve code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->