### PR TITLE
[ISSUE #3587]⚡️Standardize HA client access with concrete types and comprehensive documentation

### DIFF
--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -23,7 +23,6 @@ use rocketmq_rust::ArcMut;
 use tracing::error;
 
 use crate::ha::general_ha_connection::GeneralHAConnection;
-use crate::ha::ha_client::HAClient;
 use crate::ha::ha_connection_state_notification_request::HAConnectionStateNotificationRequest;
 use crate::ha::ha_service::HAService;
 use crate::ha::wait_notify_object::WaitNotifyObject;
@@ -95,10 +94,13 @@ impl HAService for AutoSwitchHAService {
         todo!()
     }
 
-    fn get_ha_client<CL: HAClient>(&self) -> Arc<CL> {
+    fn get_ha_client(&self) -> &GeneralHAConnection {
         todo!()
     }
 
+    fn get_ha_client_mut(&mut self) -> &mut GeneralHAConnection {
+        todo!()
+    }
     fn get_push_to_slave_max_offset(&self) -> i64 {
         todo!()
     }

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -230,7 +230,11 @@ impl HAService for DefaultHAService {
         connection_list.iter().cloned().collect()
     }
 
-    fn get_ha_client<CL: HAClient>(&self) -> Arc<CL> {
+    fn get_ha_client(&self) -> &GeneralHAConnection {
+        todo!()
+    }
+
+    fn get_ha_client_mut(&mut self) -> &mut GeneralHAConnection {
         todo!()
     }
 

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -25,7 +25,6 @@ use tracing::error;
 use crate::ha::auto_switch::auto_switch_ha_service::AutoSwitchHAService;
 use crate::ha::default_ha_service::DefaultHAService;
 use crate::ha::general_ha_connection::GeneralHAConnection;
-use crate::ha::ha_client::HAClient;
 use crate::ha::ha_connection_state_notification_request::HAConnectionStateNotificationRequest;
 use crate::ha::ha_service::HAService;
 use crate::ha::wait_notify_object::WaitNotifyObject;
@@ -166,7 +165,11 @@ impl HAService for GeneralHAService {
         }
     }
 
-    fn get_ha_client<CL: HAClient>(&self) -> Arc<CL> {
+    fn get_ha_client(&self) -> &GeneralHAConnection {
+        todo!()
+    }
+
+    fn get_ha_client_mut(&mut self) -> &mut GeneralHAConnection {
         todo!()
     }
 

--- a/rocketmq-store/src/ha/ha_service.rs
+++ b/rocketmq-store/src/ha/ha_service.rs
@@ -21,7 +21,6 @@ use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_rust::ArcMut;
 
 use crate::ha::general_ha_connection::GeneralHAConnection;
-use crate::ha::ha_client::HAClient;
 use crate::ha::ha_connection_state_notification_request::HAConnectionStateNotificationRequest;
 use crate::ha::wait_notify_object::WaitNotifyObject;
 use crate::log_file::group_commit_request::GroupCommitRequest;
@@ -136,11 +135,23 @@ pub trait RocketHAService: Sync {
     /// List of HA connections
     async fn get_connection_list(&self) -> Vec<ArcMut<GeneralHAConnection>>;
 
-    /// Get the HA client
+    /// Get the HA client connection.
+    ///
+    /// This function provides a reference to the `GeneralHAConnection` instance,
+    /// which represents the connection used for high availability communication.
     ///
     /// # Returns
-    /// Reference to the HA client
-    fn get_ha_client<CL: HAClient>(&self) -> Arc<CL>;
+    /// A reference to the `GeneralHAConnection` instance.
+    fn get_ha_client(&self) -> &GeneralHAConnection;
+
+    /// Get a mutable reference to the HA client connection.
+    ///
+    /// This function provides a mutable reference to the `GeneralHAConnection` instance,
+    /// allowing modifications to the high availability connection.
+    ///
+    /// # Returns
+    /// A mutable reference to the `GeneralHAConnection` instance.
+    fn get_ha_client_mut(&mut self) -> &mut GeneralHAConnection;
 
     /// Get the maximum offset across all slaves
     ///


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3587

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the interface for accessing HA client connections to provide direct references instead of generic abstractions.
  * Introduced separate methods for immutable and mutable access to HA client connections.
  * Improved documentation for the updated methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->