### PR TITLE
[ISSUE #3589]♻️Simplify HA client initialization and remove unnecessary ArcMut wrappers

### DIFF
--- a/rocketmq-store/src/ha/default_ha_client.rs
+++ b/rocketmq-store/src/ha/default_ha_client.rs
@@ -112,14 +112,14 @@ impl DefaultHAClient {
     /// Create a new DefaultHAClient
     pub fn new(
         default_message_store: ArcMut<LocalFileMessageStore>,
-    ) -> Result<ArcMut<Self>, HAClientError> {
+    ) -> Result<Self, HAClientError> {
         let flow_monitor = Arc::new(FlowMonitor::new(
             default_message_store.message_store_config(),
         ));
 
         let now = get_current_millis() as i64;
 
-        Ok(ArcMut::new(Self {
+        Ok(Self {
             master_ha_address: Arc::new(AtomicPtr::default()),
             master_address: Arc::new(AtomicPtr::default()),
             socket_stream: Arc::new(RwLock::new(None)),
@@ -137,7 +137,7 @@ impl DefaultHAClient {
             flow_monitor,
             shutdown_notify: Arc::new(Notify::new()),
             service_handle: Arc::new(RwLock::new(None)),
-        }))
+        })
     }
 
     /// Get HA master address

--- a/rocketmq-store/src/ha/general_ha_client.rs
+++ b/rocketmq-store/src/ha/general_ha_client.rs
@@ -21,6 +21,7 @@ use crate::ha::default_ha_client::DefaultHAClient;
 use crate::ha::ha_client::HAClient;
 use crate::ha::ha_connection_state::HAConnectionState;
 
+#[derive(Clone)]
 pub struct GeneralHAClient {
     default_ha_client: Option<ArcMut<DefaultHAClient>>,
     auto_switch_ha_client: Option<ArcMut<AutoSwitchHAClient>>,
@@ -37,6 +38,20 @@ impl GeneralHAClient {
         GeneralHAClient {
             default_ha_client: None,
             auto_switch_ha_client: None,
+        }
+    }
+
+    pub fn new_with_default_ha_client(default_ha_client: DefaultHAClient) -> Self {
+        GeneralHAClient {
+            default_ha_client: Some(ArcMut::new(default_ha_client)),
+            auto_switch_ha_client: None,
+        }
+    }
+
+    pub fn new_with_auto_switch_ha_client(auto_switch_ha_client: AutoSwitchHAClient) -> Self {
+        GeneralHAClient {
+            default_ha_client: None,
+            auto_switch_ha_client: Some(ArcMut::new(auto_switch_ha_client)),
         }
     }
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -153,7 +153,7 @@ pub struct LocalFileMessageStore {
     timer_message_store: Option<Arc<TimerMessageStore>>,
     transient_store_pool: TransientStorePool,
     message_store_arc: Option<ArcMut<LocalFileMessageStore>>,
-    ha_service: Option<ArcMut<GeneralHAService>>,
+    ha_service: Option<GeneralHAService>,
     flush_consume_queue_service: FlushConsumeQueueService,
     delay_level_table: ArcMut<BTreeMap<i32 /* level */, i64 /* delay timeMillis */>>,
     max_delay_level: i32,
@@ -247,7 +247,7 @@ impl LocalFileMessageStore {
             timer_message_store: None,
             transient_store_pool,
             message_store_arc: None,
-            ha_service: None,
+            ha_service: Some(GeneralHAService::new()),
             flush_consume_queue_service: FlushConsumeQueueService,
             delay_level_table: ArcMut::new(delay_level_table),
             max_delay_level,
@@ -1908,7 +1908,7 @@ impl MessageStore for LocalFileMessageStore {
 
     fn get_ha_service(&self) -> &GeneralHAService {
         if let Some(ha_service) = self.ha_service.as_ref() {
-            ha_service.as_ref()
+            ha_service
         } else {
             panic!("HA service is not initialized");
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3589

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new constructors for high availability (HA) client management, allowing flexible initialization options.
  * Enhanced clone support for HA client structures.

* **Bug Fixes**
  * Improved safety and error handling when HA clients are not initialized, preventing potential runtime issues.

* **Refactor**
  * Simplified ownership and access patterns for HA services and clients, reducing unnecessary indirection and improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->