### PR TITLE
[ISSUE #3595]⚡️Integrate HAConnectionId throughout HA connection system and optimize storage

### DIFF
--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_connection.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_connection.rs
@@ -20,6 +20,7 @@ use tokio::net::TcpStream;
 
 use crate::ha::general_ha_connection::GeneralHAConnection;
 use crate::ha::ha_connection::HAConnection;
+use crate::ha::ha_connection::HAConnectionId;
 use crate::ha::ha_connection_state::HAConnectionState;
 use crate::ha::HAConnectionError;
 
@@ -62,6 +63,10 @@ impl HAConnection for AutoSwitchHAConnection {
     }
 
     fn get_slave_ack_offset(&self) -> i64 {
+        todo!()
+    }
+
+    fn get_ha_connection_id(&self) -> &HAConnectionId {
         todo!()
     }
 }

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -50,6 +50,7 @@ use crate::ha::default_ha_service::DefaultHAService;
 use crate::ha::flow_monitor::FlowMonitor;
 use crate::ha::general_ha_connection::GeneralHAConnection;
 use crate::ha::ha_connection::HAConnection;
+use crate::ha::ha_connection::HAConnectionId;
 use crate::ha::ha_connection_state::HAConnectionState;
 use crate::ha::HAConnectionError;
 
@@ -70,6 +71,7 @@ pub struct DefaultHAConnection {
     shutdown_tx: Arc<Mutex<Option<mpsc::Sender<()>>>>,
     message_store_config: Arc<MessageStoreConfig>,
     next_transfer_from_where: Arc<AtomicI64>,
+    id: HAConnectionId,
 }
 
 impl DefaultHAConnection {
@@ -113,6 +115,7 @@ impl DefaultHAConnection {
             shutdown_tx: Arc::new(Mutex::new(None)),
             message_store_config,
             next_transfer_from_where: Arc::new(AtomicI64::new(-1)),
+            id: HAConnectionId::default(),
         })
     }
 
@@ -242,6 +245,10 @@ impl HAConnection for DefaultHAConnection {
 
     fn get_slave_ack_offset(&self) -> i64 {
         self.slave_ack_offset.load(Ordering::SeqCst)
+    }
+
+    fn get_ha_connection_id(&self) -> &HAConnectionId {
+        &self.id
     }
 }
 

--- a/rocketmq-store/src/ha/general_ha_connection.rs
+++ b/rocketmq-store/src/ha/general_ha_connection.rs
@@ -22,6 +22,7 @@ use tokio::net::TcpStream;
 use crate::ha::auto_switch::auto_switch_ha_connection::AutoSwitchHAConnection;
 use crate::ha::default_ha_connection::DefaultHAConnection;
 use crate::ha::ha_connection::HAConnection;
+use crate::ha::ha_connection::HAConnectionId;
 use crate::ha::ha_connection_state::HAConnectionState;
 use crate::ha::HAConnectionError;
 
@@ -162,6 +163,17 @@ impl HAConnection for GeneralHAConnection {
             (_, Some(connection)) => connection.get_slave_ack_offset(),
             (None, None) => {
                 tracing::warn!("No HA connection to get slave ack offset from");
+                panic!("No HA connection available");
+            }
+        }
+    }
+
+    fn get_ha_connection_id(&self) -> &HAConnectionId {
+        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
+            (Some(connection), _) => connection.get_ha_connection_id(),
+            (_, Some(connection)) => connection.get_ha_connection_id(),
+            (None, None) => {
+                tracing::warn!("No HA connection to get ID from");
                 panic!("No HA connection available");
             }
         }

--- a/rocketmq-store/src/ha/ha_connection.rs
+++ b/rocketmq-store/src/ha/ha_connection.rs
@@ -79,10 +79,19 @@ pub trait RocketmqHAConnection: Sync {
     /// # Returns
     /// The latest offset confirmed by the slave
     fn get_slave_ack_offset(&self) -> i64;
+
+    /// Get the unique identifier for the HA connection.
+    ///
+    /// This function returns a reference to the `HAConnectionId` instance,
+    /// which uniquely identifies the high availability connection.
+    ///
+    /// # Returns
+    /// A reference to the `HAConnectionId` instance.
+    fn get_ha_connection_id(&self) -> &HAConnectionId;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct HAConnectionId {
+pub(crate) struct HAConnectionId {
     id: String,
     random: u64,
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3595

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced unique identifiers for high-availability (HA) connections, allowing each connection to be referenced by a distinct ID.

* **Refactor**
  * Updated internal connection management to use a hash map keyed by connection IDs, improving organization and lookup of active HA connections.

* **Documentation**
  * Enhanced visibility of connection identifier types within the application for improved internal usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->