### PR TITLE
[ISSUE #3598]⚡️Standardize connection count type to AtomicU32 across HA services

### DIFF
--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::sync::atomic::AtomicI32;
+use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
@@ -78,7 +78,7 @@ impl HAService for AutoSwitchHAService {
         todo!()
     }
 
-    fn get_connection_count(&self) -> &AtomicI32 {
+    fn get_connection_count(&self) -> &AtomicU32 {
         todo!()
     }
 

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -52,6 +52,7 @@ use crate::ha::general_ha_connection::GeneralHAConnection;
 use crate::ha::ha_connection::HAConnection;
 use crate::ha::ha_connection::HAConnectionId;
 use crate::ha::ha_connection_state::HAConnectionState;
+use crate::ha::ha_service::HAService;
 use crate::ha::HAConnectionError;
 
 /// Transfer Header buffer size. Schema: physic offset and body size.

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -32,7 +32,7 @@
  */
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::atomic::AtomicI32;
+use std::sync::atomic::AtomicU32;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
@@ -68,7 +68,7 @@ use crate::store_error::HAError;
 use crate::store_error::HAResult;
 
 pub struct DefaultHAService {
-    connection_count: Arc<AtomicU64>,
+    connection_count: Arc<AtomicU32>,
     //connection_list: Arc<Mutex<Vec<ArcMut<GeneralHAConnection>>>>,
     connections: Arc<Mutex<HashMap<HAConnectionId, ArcMut<GeneralHAConnection>>>>,
     accept_socket_service: Option<AcceptSocketService>,
@@ -83,7 +83,7 @@ pub struct DefaultHAService {
 impl DefaultHAService {
     pub fn new(message_store: ArcMut<LocalFileMessageStore>) -> Self {
         DefaultHAService {
-            connection_count: Arc::new(AtomicU64::new(0)),
+            connection_count: Arc::new(AtomicU32::new(0)),
             connections: Arc::new(Mutex::new(HashMap::new())),
             accept_socket_service: None,
             default_message_store: message_store,
@@ -142,10 +142,6 @@ impl DefaultHAService {
         // Add a new connection to the service
         let mut connections = self.connections.lock().await;
         connections.insert(connection.get_ha_connection_id().clone(), connection);
-    }
-
-    pub fn get_connection_count(&self) -> &AtomicU64 {
-        &self.connection_count
     }
 
     pub async fn remove_connection(&self, connection: ArcMut<GeneralHAConnection>) {
@@ -225,8 +221,8 @@ impl HAService for DefaultHAService {
         todo!()
     }
 
-    fn get_connection_count(&self) -> &AtomicI32 {
-        todo!()
+    fn get_connection_count(&self) -> &AtomicU32 {
+        self.connection_count.as_ref()
     }
 
     async fn put_request(&self, request: ArcMut<GroupCommitRequest>) {

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::sync::atomic::AtomicI32;
+use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
@@ -132,7 +132,7 @@ impl HAService for GeneralHAService {
         todo!()
     }
 
-    fn get_connection_count(&self) -> &AtomicI32 {
+    fn get_connection_count(&self) -> &AtomicU32 {
         todo!()
     }
 

--- a/rocketmq-store/src/ha/ha_service.rs
+++ b/rocketmq-store/src/ha/ha_service.rs
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::sync::atomic::AtomicI32;
+
+use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
@@ -115,7 +116,7 @@ pub trait RocketHAService: Sync {
     ///
     /// # Returns
     /// Atomic reference to connection count
-    fn get_connection_count(&self) -> &AtomicI32;
+    fn get_connection_count(&self) -> &AtomicU32;
 
     /// Put a group commit request to handle HA
     ///


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3598

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
