### PR TITLE
[ISSUE #3610]♻️Convert HA system shutdown methods from sync to async

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -332,7 +332,7 @@ impl BrokerRuntime {
         self.inner.broadcast_offset_manager.shutdown();
 
         if let Some(message_store) = self.inner.message_store.as_mut() {
-            message_store.shutdown();
+            message_store.shutdown().await;
         }
 
         if let Some(replicas_manager) = self.inner.replicas_manager.as_mut() {

--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -69,7 +69,7 @@ pub trait MessageStoreInner: Sync + 'static {
     async fn start(&mut self) -> Result<(), StoreError>;
 
     /// Shutdown this message store.
-    fn shutdown(&mut self);
+    async fn shutdown(&mut self);
 
     /// Destroy this message store.
     /// Generally, all persistent files should be removed after invocation.

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -38,7 +38,7 @@ impl HAService for AutoSwitchHAService {
         Ok(())
     }
 
-    fn shutdown(&self) {
+    async fn shutdown(&self) {
         todo!()
     }
 

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -198,6 +198,7 @@ impl HAService for DefaultHAService {
         if let Some(ref accept_socket_service) = self.accept_socket_service {
             accept_socket_service.shutdown();
         }
+        self.destroy_connections().await;
 
         if let Some(ref group_transfer_service) = self.group_transfer_service {
             group_transfer_service.shutdown().await;

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -156,6 +156,13 @@ impl DefaultHAService {
         let mut connections = self.connections.lock().await;
         connections.remove(connection.get_ha_connection_id());
     }
+
+    pub async fn destroy_connections(&self) {
+        let mut connections = self.connections.lock().await;
+        for (_, mut connection) in connections.drain() {
+            connection.shutdown().await;
+        }
+    }
 }
 
 impl HAService for DefaultHAService {
@@ -181,8 +188,26 @@ impl HAService for DefaultHAService {
         Ok(())
     }
 
-    fn shutdown(&self) {
-        todo!()
+    async fn shutdown(&self) {
+        info!("Shutting down DefaultHAService");
+
+        if let Some(ref ha_client) = self.ha_client {
+            ha_client.shutdown().await;
+        }
+
+        if let Some(ref accept_socket_service) = self.accept_socket_service {
+            accept_socket_service.shutdown();
+        }
+
+        if let Some(ref group_transfer_service) = self.group_transfer_service {
+            group_transfer_service.shutdown().await;
+        }
+
+        if let Some(ref ha_connection_state_notification_service) =
+            self.ha_connection_state_notification_service
+        {
+            ha_connection_state_notification_service.shutdown();
+        }
     }
 
     async fn change_to_master(&self, master_epoch: i32) -> HAResult<bool> {

--- a/rocketmq-store/src/ha/general_ha_client.rs
+++ b/rocketmq-store/src/ha/general_ha_client.rs
@@ -78,7 +78,13 @@ impl HAClient for GeneralHAClient {
     }
 
     async fn shutdown(&self) {
-        todo!()
+        if let Some(ref client) = self.default_ha_client {
+            client.shutdown().await;
+        } else if let Some(ref client) = self.auto_switch_ha_client {
+            client.shutdown().await;
+        } else {
+            panic!("No HA service is set for GeneralHAClient");
+        }
     }
 
     async fn wakeup(&self) {

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -86,8 +86,14 @@ impl HAService for GeneralHAService {
         Ok(())
     }
 
-    fn shutdown(&self) {
-        todo!()
+    async fn shutdown(&self) {
+        if let Some(ref service) = self.default_ha_service {
+            service.shutdown().await;
+        } else if let Some(ref service) = self.auto_switch_ha_service {
+            service.shutdown().await;
+        } else {
+            error!("No HA service initialized to shutdown");
+        }
     }
 
     async fn change_to_master(&self, master_epoch: i32) -> HAResult<bool> {

--- a/rocketmq-store/src/ha/group_transfer_service.rs
+++ b/rocketmq-store/src/ha/group_transfer_service.rs
@@ -58,6 +58,10 @@ impl GroupTransferService {
         })
     }
 
+    pub async fn shutdown(&self) {
+        let _ = self.service_manager.shutdown().await;
+    }
+
     pub async fn put_request(&self, request: ArcMut<GroupCommitRequest>) {
         self.inner.put_request(request).await
     }

--- a/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
+++ b/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
@@ -39,7 +39,10 @@ impl HAConnectionStateNotificationService {
     }
 
     pub fn shutdown(&self) {
-        error!("HAConnectionStateNotificationService shutdown is not implemented. This is a placeholder method.");
+        error!(
+            "HAConnectionStateNotificationService shutdown is not implemented. This is a \
+             placeholder method."
+        );
     }
 
     pub async fn start(&mut self) -> HAResult<()> {

--- a/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
+++ b/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
@@ -38,6 +38,10 @@ impl HAConnectionStateNotificationService {
         }
     }
 
+    pub fn shutdown(&self) {
+        error!("HAConnectionStateNotificationService is not implemented yet");
+    }
+
     pub async fn start(&mut self) -> HAResult<()> {
         error!("HAConnectionStateNotificationService is not implemented yet");
         Ok(())

--- a/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
+++ b/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
@@ -39,7 +39,7 @@ impl HAConnectionStateNotificationService {
     }
 
     pub fn shutdown(&self) {
-        error!("HAConnectionStateNotificationService is not implemented yet");
+        error!("HAConnectionStateNotificationService shutdown is not implemented. This is a placeholder method.");
     }
 
     pub async fn start(&mut self) -> HAResult<()> {

--- a/rocketmq-store/src/ha/ha_service.rs
+++ b/rocketmq-store/src/ha/ha_service.rs
@@ -39,7 +39,7 @@ pub trait RocketHAService: Sync {
     async fn start(&mut self) -> HAResult<()>;
 
     /// Shutdown the HA service
-    fn shutdown(&self);
+    async fn shutdown(&self);
 
     /// Change this node to master state
     ///

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -692,12 +692,12 @@ impl MessageStore for LocalFileMessageStore {
         Ok(())
     }
 
-    fn shutdown(&mut self) {
+    async fn shutdown(&mut self) {
         if !self.shutdown.load(Ordering::Acquire) {
             self.shutdown.store(true, Ordering::Release);
 
             if let Some(ha_service) = self.ha_service.as_ref() {
-                ha_service.shutdown();
+                ha_service.shutdown().await;
             }
 
             self.store_stats_service.shutdown();


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3610

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved shutdown procedures for high-availability and message store services, now supporting asynchronous operations for smoother and more reliable service termination.

* **Bug Fixes**
  * Replaced previously unimplemented shutdown methods with functional asynchronous logic in several high-availability service components.

* **Refactor**
  * Updated shutdown methods across message store and high-availability services to use asynchronous patterns, aligning with modern async lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->