### PR TITLE
[ISSUE #3613]♻️Convert HA service is_slave_ok method from sync to async

### DIFF
--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -114,7 +114,7 @@ impl HAService for AutoSwitchHAService {
         todo!()
     }
 
-    fn is_slave_ok(&self, master_put_where: i64) -> bool {
+    async fn is_slave_ok(&self, master_put_where: i64) -> bool {
         todo!()
     }
 }

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -298,8 +298,16 @@ impl HAService for DefaultHAService {
         todo!()
     }
 
-    fn is_slave_ok(&self, master_put_where: i64) -> bool {
-        todo!()
+    async fn is_slave_ok(&self, master_put_where: i64) -> bool {
+        !self.connections.lock().await.is_empty()
+            && (master_put_where
+                - self
+                    .push2_slave_max_offset
+                    .load(std::sync::atomic::Ordering::Relaxed) as i64)
+                < (self
+                    .default_message_store
+                    .message_store_config_ref()
+                    .ha_max_gap_not_in_sync as i64)
     }
 }
 

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -209,7 +209,16 @@ impl HAService for GeneralHAService {
         todo!()
     }
 
-    fn is_slave_ok(&self, master_put_where: i64) -> bool {
-        todo!()
+    async fn is_slave_ok(&self, master_put_where: i64) -> bool {
+        match (&self.default_ha_service, &self.auto_switch_ha_service) {
+            (Some(default_ha_service), _) => default_ha_service.is_slave_ok(master_put_where).await,
+            (_, Some(auto_switch_service)) => {
+                auto_switch_service.is_slave_ok(master_put_where).await
+            }
+            (None, None) => {
+                error!("No HA service initialized to check if slave is ok");
+                false
+            }
+        }
     }
 }

--- a/rocketmq-store/src/ha/ha_service.rs
+++ b/rocketmq-store/src/ha/ha_service.rs
@@ -185,5 +185,5 @@ pub trait RocketHAService: Sync {
     ///
     /// # Returns
     /// Whether the slave is keeping up
-    fn is_slave_ok(&self, master_put_where: i64) -> bool;
+    async fn is_slave_ok(&self, master_put_where: i64) -> bool;
 }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -271,6 +271,10 @@ impl LocalFileMessageStore {
         self.message_store_config.clone()
     }
 
+    pub fn message_store_config_ref(&self) -> &MessageStoreConfig {
+        self.message_store_config.as_ref()
+    }
+
     pub fn is_transient_store_pool_enable(&self) -> bool {
         self.message_store_config.transient_store_pool_enable
             && (self.broker_config.enable_controller_mode


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3613

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a method to provide direct access to message store configuration details.

* **Refactor**
  * Updated several methods related to high availability (HA) services to support asynchronous operations, improving responsiveness and scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->