### PR TITLE
[ISSUE #3622]Fix broken unimplemented! macro in recover_initialize_service function

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -464,7 +464,7 @@ impl BrokerRuntime {
 
         if self.inner.broker_config().enable_controller_mode {
             info!("Start controller mode(Support for future versions)");
-            unimplemented!("Start controller mode(Support for future versions");
+            unimplemented!("Start controller mode(Support for future versions)");
         }
         if self.inner.message_store.is_some() {
             self.register_message_store_hook();

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -464,7 +464,7 @@ impl BrokerRuntime {
 
         if self.inner.broker_config().enable_controller_mode {
             info!("Start controller mode(Support for future versions)");
-            unimplemented!("Start controller mode(Support for future versions")
+            unimplemented!("Start controller mode(Support for future versions");
         }
         if self.inner.message_store.is_some() {
             self.register_message_store_hook();

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -464,7 +464,7 @@ impl BrokerRuntime {
 
         if self.inner.broker_config().enable_controller_mode {
             info!("Start controller mode(Support for future versions)");
-            unimplemented!("tart controller mode(Support for future versions")
+            unimplemented!("Start controller mode(Support for future versions")
         }
         if self.inner.message_store.is_some() {
             self.register_message_store_hook();


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

Fixes #3622

### Brief Description

This PR fixes a syntax error in the `unimplemented!` macro inside the `recover_initialize_service` function by adding the missing closing parenthesis and semicolon, which prevents compilation errors.

### How Did You Test This Change?

- Verified the code compiles successfully without errors.  
- Ran existing tests to ensure no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in an error message related to controller mode support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->