### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-issue-labels.yml
+++ b/.github/workflows/sync-issue-labels.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       # Checkout the repository


### PR DESCRIPTION
Potential fix for [https://github.com/mxsm/rocketmq-rust/security/code-scanning/7](https://github.com/mxsm/rocketmq-rust/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow or the specific job to restrict the `GITHUB_TOKEN` to the minimum required permissions. Since the job only needs to read repository contents (for checkout) and write to issues (to add labels), set `contents: read` and `issues: write` at the job level (under `sync-labels:`). This ensures the job cannot perform unnecessary actions with the `GITHUB_TOKEN`. No changes to the logic or functionality are required.

- Edit `.github/workflows/sync-issue-labels.yml`
- Under `sync-labels:`, add:
  ```yaml
  permissions:
    contents: read
    issues: write
  ```
- No new imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to improve access control for syncing issue labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->