### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,5 +1,9 @@
 name: Auto Request Review
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request_target:
     types: [ opened, ready_for_review, reopened, synchronize ]


### PR DESCRIPTION
Potential fix for [https://github.com/mxsm/rocketmq-rust/security/code-scanning/2](https://github.com/mxsm/rocketmq-rust/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's purpose (auto-requesting reviews), it likely needs `contents: read` to access repository contents and `pull-requests: write` to manage pull request reviews. These permissions will be applied to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for the "Auto Request Review" automation. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->