### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,8 @@
 name: Codecov
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/mxsm/rocketmq-rust/security/code-scanning/6](https://github.com/mxsm/rocketmq-rust/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/codecov.yml`. The block should be placed at the top level (before `jobs:`) to apply to all jobs, unless a job requires different permissions. For this workflow, the jobs only check out code, build, test, and upload coverage, none of which require write access to repository contents. Therefore, the minimal required permission is `contents: read`. If in the future a job needs more permissions, you can override the permissions at the job level. The change should be made by inserting the following block after the `name:` and before `env:` or `jobs:`:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
