### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/mxsm/rocketmq-rust/security/code-scanning/5](https://github.com/mxsm/rocketmq-rust/security/code-scanning/5)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. For a typical CI workflow that only checks out code and runs tests, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). The best practice is to set it at the workflow level unless a specific job requires different permissions. The change should be made near the top of `.github/workflows/ci.yaml`, after the `name` and before `on` or after `on` (either is valid YAML). No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
