### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-comment-pr.yml
+++ b/.github/workflows/auto-comment-pr.yml
@@ -1,5 +1,9 @@
 name: Auto Comment on PR
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request_target:
     types: [ opened, synchronize ]


### PR DESCRIPTION
Potential fix for [https://github.com/mxsm/rocketmq-rust/security/code-scanning/3](https://github.com/mxsm/rocketmq-rust/security/code-scanning/3)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the permissions of the `GITHUB_TOKEN` to the minimum required. Since the workflow only needs to comment on and label pull requests, it requires `contents: read` (to read repository contents) and `pull-requests: write` (to comment and add labels). The `permissions` block can be added at the workflow root (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to add it at the workflow root unless different jobs require different permissions.  
**Change:**  
- Add the following block after the `name` field and before the `on` field in `.github/workflows/auto-comment-pr.yml`:
  ```yaml
  permissions:
    contents: read
    pull-requests: write
  ```
No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
