### PR TITLE
[ISSUE #3643]Removed unnecessary code from DefaultHAService

### DIFF
--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -69,7 +69,6 @@ use crate::store_error::HAResult;
 
 pub struct DefaultHAService {
     connection_count: Arc<AtomicU32>,
-    //connection_list: Arc<Mutex<Vec<ArcMut<GeneralHAConnection>>>>,
     connections: Arc<Mutex<HashMap<HAConnectionId, ArcMut<GeneralHAConnection>>>>,
     accept_socket_service: Option<AcceptSocketService>,
     default_message_store: ArcMut<LocalFileMessageStore>,


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)


<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3643 

### Brief Description
- Cleaned up unnecessary code from DefaultHAService in the default_ha_service.rs file.
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an unused field from the high availability service, streamlining internal data management. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->