### PR TITLE
 Refactor QueryTopicsByConsumerRequestHeader with derive macro RequestHeaderCodec

### DIFF
--- a/rocketmq-remoting/src/protocol/header/query_topics_by_consumer_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_topics_by_consumer_request_header.rs
@@ -15,63 +15,18 @@
  * limitations under the License.
  */
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodec)]
 pub struct QueryTopicsByConsumerRequestHeader {
+    #[required]
     #[serde(rename = "group")]
     pub group: CheetahString,
 
     #[serde(flatten)]
     pub rpc_request_header: Option<RpcRequestHeader>,
-}
-
-impl QueryTopicsByConsumerRequestHeader {
-    pub const GROUP: &'static str = "group";
-
-    pub fn get_group(&self) -> &CheetahString {
-        &self.group
-    }
-    pub fn set_group(&mut self, group: CheetahString) {
-        self.group = group;
-    }
-}
-
-impl CommandCustomHeader for QueryTopicsByConsumerRequestHeader {
-    fn to_map(&self) -> Option<std::collections::HashMap<CheetahString, CheetahString>> {
-        let mut map = std::collections::HashMap::new();
-        map.insert(
-            CheetahString::from_static_str(Self::GROUP),
-            self.group.clone(),
-        );
-        if let Some(value) = self.rpc_request_header.as_ref() {
-            if let Some(value) = value.to_map() {
-                map.extend(value);
-            }
-        }
-        Some(map)
-    }
-}
-
-impl FromMap for QueryTopicsByConsumerRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
-
-    type Target = Self;
-
-    fn from(
-        map: &std::collections::HashMap<CheetahString, CheetahString>,
-    ) -> Result<Self::Target, Self::Error> {
-        Ok(QueryTopicsByConsumerRequestHeader {
-            group: map
-                .get(&CheetahString::from_static_str(Self::GROUP))
-                .cloned()
-                .unwrap_or_default(),
-            rpc_request_header: Some(<RpcRequestHeader as FromMap>::from(map)?),
-        })
-    }
 }


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3410 

### Brief Description

- Refactored QueryTopicsByConsumerRequestHeader by removing the manual trait/static variables implementations and replaced it with derive macro RequestHeaderCodec. 

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

