### PR TITLE
[ISSUE #3402]Refactor HeartbeatRequestHeader with derive marco RequestHeaderCodec

### DIFF
--- a/rocketmq-remoting/src/protocol/header/heartbeat_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/heartbeat_request_header.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
-use rocketmq_macros::RequestHeaderCodec;
+
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
-
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 

--- a/rocketmq-remoting/src/protocol/header/heartbeat_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/heartbeat_request_header.rs
@@ -15,42 +15,17 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
-
+use rocketmq_macros::RequestHeaderCodec;
 use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
+
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct HeartbeatRequestHeader {
     #[serde(flatten)]
     pub rpc_request: Option<RpcRequestHeader>,
-}
-
-impl CommandCustomHeader for HeartbeatRequestHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        let mut map = HashMap::new();
-        if let Some(value) = self.rpc_request.as_ref() {
-            if let Some(value) = value.to_map() {
-                map.extend(value);
-            }
-        }
-        Some(map)
-    }
-}
-
-impl FromMap for HeartbeatRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
-
-    type Target = Self;
-
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(HeartbeatRequestHeader {
-            rpc_request: Some(<RpcRequestHeader as FromMap>::from(map)?),
-        })
-    }
 }

--- a/rocketmq-remoting/src/protocol/header/heartbeat_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/heartbeat_request_header.rs
@@ -14,9 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
-
-use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3402 

### Brief Description

- Refactored HeartbeatRequestHeader by removing the manual trait/static variables implementations and replaced it with derive macro RequestHeaderCodec.

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
- By running Cargo commands mentioned in `CONTRIBUTING.md` file
<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of heartbeat request headers for better maintainability and consistency. No changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->