### PR TITLE
Refactor EndTransactionRequestHeader with derive marco RequestHeaderCodec

### DIFF
--- a/rocketmq-remoting/src/protocol/header/end_transaction_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/end_transaction_request_header.rs
@@ -14,168 +14,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use anyhow::anyhow;
-use anyhow::Error;
+
 use cheetah_string::CheetahString;
-use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct EndTransactionRequestHeader {
+    #[required]
     pub topic: CheetahString,
 
+    #[required]
     pub producer_group: CheetahString,
 
     //ConsumeQueue Offset
+    #[required]
     pub tran_state_table_offset: u64,
 
     // Offset of the message in the CommitLog
+    #[required]
     pub commit_log_offset: u64,
+
     //TRANSACTION_COMMIT_TYPE,TRANSACTION_ROLLBACK_TYPE,TRANSACTION_NOT_TYPE
+    #[required]
     pub commit_or_rollback: i32,
 
     //Whether the check-back is initiated by the Broker
+    #[required]
     pub from_transaction_check: bool,
 
+    #[required]
     pub msg_id: CheetahString,
+
     pub transaction_id: Option<CheetahString>,
+
     #[serde(flatten)]
     pub rpc_request_header: RpcRequestHeader,
-}
-
-impl EndTransactionRequestHeader {
-    pub const TOPIC: &'static str = "topic";
-    pub const PRODUCER_GROUP: &'static str = "producerGroup";
-    pub const TRAN_STATE_TABLE_OFFSET: &'static str = "tranStateTableOffset";
-    pub const COMMIT_LOG_OFFSET: &'static str = "commitLogOffset";
-    pub const COMMIT_OR_ROLLBACK: &'static str = "commitOrRollback";
-    pub const FROM_TRANSACTION_CHECK: &'static str = "fromTransactionCheck";
-    pub const MSG_ID: &'static str = "msgId";
-    pub const TRANSACTION_ID: &'static str = "transactionId";
-}
-
-impl CommandCustomHeader for EndTransactionRequestHeader {
-    fn to_map(&self) -> Option<std::collections::HashMap<CheetahString, CheetahString>> {
-        let mut map = std::collections::HashMap::new();
-        map.insert(
-            CheetahString::from_static_str(Self::TOPIC),
-            self.topic.clone(),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::PRODUCER_GROUP),
-            self.producer_group.clone(),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::TRAN_STATE_TABLE_OFFSET),
-            CheetahString::from_string(self.tran_state_table_offset.to_string()),
-        );
-
-        map.insert(
-            CheetahString::from_static_str(Self::COMMIT_LOG_OFFSET),
-            CheetahString::from_string(self.commit_log_offset.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::COMMIT_OR_ROLLBACK),
-            CheetahString::from_string(self.commit_or_rollback.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::FROM_TRANSACTION_CHECK),
-            CheetahString::from_string(self.from_transaction_check.to_string()),
-        );
-
-        map.insert(
-            CheetahString::from_static_str(Self::MSG_ID),
-            self.msg_id.clone(),
-        );
-        if let Some(value) = self.transaction_id.as_ref() {
-            map.insert(
-                CheetahString::from_static_str(Self::TRANSACTION_ID),
-                value.clone(),
-            );
-        }
-        if let Some(value) = self.rpc_request_header.to_map() {
-            map.extend(value);
-        }
-        Some(map)
-    }
-
-    fn check_fields(&self) -> anyhow::Result<(), Error> {
-        if MessageSysFlag::TRANSACTION_NOT_TYPE == self.commit_or_rollback {
-            return Ok(());
-        }
-        if MessageSysFlag::TRANSACTION_COMMIT_TYPE == self.commit_or_rollback {
-            return Ok(());
-        }
-        if MessageSysFlag::TRANSACTION_ROLLBACK_TYPE == self.commit_or_rollback {
-            return Ok(());
-        }
-        Err(anyhow!("commitOrRollback field wrong"))
-    }
-}
-
-impl FromMap for EndTransactionRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
-
-    type Target = Self;
-
-    fn from(
-        map: &std::collections::HashMap<CheetahString, CheetahString>,
-    ) -> Result<Self::Target, Self::Error> {
-        Ok(EndTransactionRequestHeader {
-            topic: map
-                .get(&CheetahString::from_static_str(
-                    EndTransactionRequestHeader::TOPIC,
-                ))
-                .cloned()
-                .unwrap_or_default(),
-            producer_group: map
-                .get(&CheetahString::from_static_str(
-                    EndTransactionRequestHeader::PRODUCER_GROUP,
-                ))
-                .cloned()
-                .unwrap_or_default(),
-            tran_state_table_offset: map
-                .get(&CheetahString::from_static_str(
-                    EndTransactionRequestHeader::TRAN_STATE_TABLE_OFFSET,
-                ))
-                .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or_default(),
-            commit_log_offset: map
-                .get(&CheetahString::from_static_str(
-                    EndTransactionRequestHeader::COMMIT_LOG_OFFSET,
-                ))
-                .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or_default(),
-            commit_or_rollback: map
-                .get(&CheetahString::from_static_str(
-                    EndTransactionRequestHeader::COMMIT_OR_ROLLBACK,
-                ))
-                .and_then(|s| s.parse::<i32>().ok())
-                .unwrap_or_default(),
-            from_transaction_check: map
-                .get(&CheetahString::from_static_str(
-                    EndTransactionRequestHeader::FROM_TRANSACTION_CHECK,
-                ))
-                .and_then(|s| s.parse::<bool>().ok())
-                .unwrap_or_default(),
-            msg_id: map
-                .get(&CheetahString::from_static_str(
-                    EndTransactionRequestHeader::MSG_ID,
-                ))
-                .cloned()
-                .unwrap_or_default(),
-            transaction_id: map
-                .get(&CheetahString::from_static_str(
-                    EndTransactionRequestHeader::TRANSACTION_ID,
-                ))
-                .cloned(),
-            rpc_request_header: <RpcRequestHeader as FromMap>::from(map).unwrap_or_default(),
-        })
-    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3388 

### Brief Description

- Removed static implementation and refactored the EndTransactionRequestHeader with derive macro RequestHeaderCodec.
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

Using cargo commands mentioned in `CONTRIBUTING.md`
<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the handling of transaction request headers to use automated code generation for serialization, deserialization, and validation.
  * Improved clarity by explicitly marking required fields in the transaction request header structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->