### PR TITLE
[ISSUE #3688]Remove zerocopy and zerocopy-derive useless crate from rocketmq-store crate Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2463,8 +2463,6 @@ dependencies = [
  "trait-variant",
  "uuid",
  "windows",
- "zerocopy",
- "zerocopy-derive",
 ]
 
 [[package]]

--- a/rocketmq-store/Cargo.toml
+++ b/rocketmq-store/Cargo.toml
@@ -53,8 +53,6 @@ thiserror = { workspace = true }
 
 futures-util = "0.3.31"
 rand = { workspace = true }
-zerocopy = "0.8.26"
-zerocopy-derive = "0.8.26"
 uuid = { workspace = true }
 
 [target.'cfg(linux)'.dependencies]


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3688

### Brief Description
Remove useless crates from `Cargo.toml` file in `rocketmq-store` folder

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
Tested using commands given in `CONTRIBUTING.md`
<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to streamline the application. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->