### PR TITLE
Refactor GetTopicConfigRequestHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_topic_config_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_topic_config_request_header.rs
@@ -15,15 +15,15 @@
  * limitations under the License.
  */
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodec)]
 pub struct GetTopicConfigRequestHeader {
+    #[required]
     #[serde(rename = "topic")]
     pub topic: CheetahString,
 
@@ -32,46 +32,10 @@ pub struct GetTopicConfigRequestHeader {
 }
 
 impl GetTopicConfigRequestHeader {
-    pub const TOPIC: &'static str = "topic";
-
     pub fn get_topic(&self) -> &CheetahString {
         &self.topic
     }
     pub fn set_topic(&mut self, topic: CheetahString) {
         self.topic = topic;
-    }
-}
-
-impl CommandCustomHeader for GetTopicConfigRequestHeader {
-    fn to_map(&self) -> Option<std::collections::HashMap<CheetahString, CheetahString>> {
-        let mut map = std::collections::HashMap::new();
-        map.insert(
-            CheetahString::from_static_str(Self::TOPIC),
-            self.topic.clone(),
-        );
-        if let Some(value) = self.topic_request_header.as_ref() {
-            if let Some(value) = value.to_map() {
-                map.extend(value);
-            }
-        }
-        Some(map)
-    }
-}
-
-impl FromMap for GetTopicConfigRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
-
-    type Target = Self;
-
-    fn from(
-        map: &std::collections::HashMap<CheetahString, CheetahString>,
-    ) -> Result<Self::Target, Self::Error> {
-        Ok(GetTopicConfigRequestHeader {
-            topic: map
-                .get(&CheetahString::from_static_str(Self::TOPIC))
-                .cloned()
-                .unwrap_or_default(),
-            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
-        })
     }
 }


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3400 

### Brief Description

- Remove static implementations and refactored the header with derive macro RequestHeaderCodec

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

Tested with the commands mentioned in `CONTRIBUTING.md`
<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Extended topic configuration requests to accept optional topic-related parameters.
- Refactor
  - Switched to a standardized codec for request header encoding/decoding to improve consistency and interoperability.
- Chores
  - Enforced validation by marking the topic field as required.
  - Removed deprecated low-level constants and legacy header interfaces; advanced integrations referencing them may require minor updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->