### PR TITLE
[ISSUE #3696]error[E0275]: overflow evaluating the requirement

### DIFF
--- a/rocketmq-client/src/admin/mq_admin_ext_async.rs
+++ b/rocketmq-client/src/admin/mq_admin_ext_async.rs
@@ -41,8 +41,8 @@ use rocketmq_remoting::protocol::subscription::subscription_group_config::Subscr
 use crate::common::admin_tool_result::AdminToolResult;
 
 #[allow(dead_code)]
-#[trait_variant::make(MQAdminExt: Send)]
-pub trait MQAdminExtLocal: Sync {
+#[allow(async_fn_in_trait)]
+pub trait MQAdminExt: Send {
     async fn start(&mut self) -> rocketmq_error::RocketMQResult<()>;
     async fn shutdown(&mut self);
     async fn add_broker_to_container(

--- a/rocketmq-client/src/consumer/mq_consumer.rs
+++ b/rocketmq-client/src/consumer/mq_consumer.rs
@@ -19,8 +19,8 @@ use rocketmq_common::common::message::message_queue::MessageQueue;
 
 use crate::base::mq_admin::MQAdmin;
 
-#[trait_variant::make(MQConsumer: Send)]
-pub trait MQConsumerLocal: MQAdmin {
+#[allow(async_fn_in_trait)]
+pub trait MQConsumer: MQAdmin {
     async fn send_message_back(
         &mut self,
         msg: MessageExt,

--- a/rocketmq-client/src/consumer/mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/mq_push_consumer.rs
@@ -28,8 +28,8 @@ use crate::consumer::mq_consumer::MQConsumer;
 /// The `MQPushConsumer` trait defines the interface for a push consumer in RocketMQ.
 /// A push consumer receives messages from the broker and processes them using registered listeners.
 
-#[trait_variant::make(MQPushConsumer: Send)]
-pub trait MQPushConsumerLocal: MQConsumer {
+#[allow(async_fn_in_trait)]
+pub trait MQPushConsumer: MQConsumer {
     /// Starts the push consumer.
     ///
     /// # Returns

--- a/rocketmq-client/src/consumer/mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/mq_push_consumer.rs
@@ -27,7 +27,6 @@ use crate::consumer::mq_consumer::MQConsumer;
 
 /// The `MQPushConsumer` trait defines the interface for a push consumer in RocketMQ.
 /// A push consumer receives messages from the broker and processes them using registered listeners.
-
 #[allow(async_fn_in_trait)]
 pub trait MQPushConsumer: MQConsumer {
     /// Starts the push consumer.

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -318,6 +318,7 @@ impl MQClientInstance {
                 // Start rebalance service
                 self.rebalance_service.start(this).await;
                 // Start push service
+
                 self.default_producer
                     .default_mqproducer_impl
                     .as_mut()

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -643,7 +643,7 @@ impl MQClientAPIImpl {
         self.process_send_response(broker_name, msg, &response, addr)
     }
 
-    async fn send_message_async<T: MessageTrait>(
+    /*    async fn send_message_async<T: MessageTrait>(
         &mut self,
         addr: &CheetahString,
         broker_name: &CheetahString,
@@ -721,6 +721,183 @@ impl MQClientAPIImpl {
             }
             Err(err) => {
                 error!("send message async error: {:?}", err);
+            }
+        }
+    }*/
+
+    async fn send_message_async<T: MessageTrait>(
+        &mut self,
+        addr: &CheetahString,
+        broker_name: &CheetahString,
+        msg: &T,
+        timeout_millis: u64,
+        request: RemotingCommand,
+        send_callback: Option<SendMessageCallback>,
+        topic_publish_info: Option<&TopicPublishInfo>,
+        instance: Option<ArcMut<MQClientInstance>>,
+        retry_times_when_send_failed: u32,
+        times: &AtomicU32,
+        context: &mut Option<SendMessageContext<'_>>,
+        producer: &DefaultMQProducerImpl,
+    ) {
+        let mut current_addr = addr.clone();
+        let mut current_broker_name = broker_name.clone();
+        let mut current_request = request;
+
+        loop {
+            let begin_start_time = Instant::now();
+            let result = self
+                .remoting_client
+                .invoke_async(Some(&current_addr), current_request.clone(), timeout_millis)
+                .await;
+
+            match result {
+                Ok(response) => {
+                    let cost_time = (Instant::now() - begin_start_time).as_millis() as u64;
+                    if send_callback.is_none() {
+                        let send_result = self.process_send_response(
+                            &current_broker_name,
+                            msg,
+                            &response,
+                            &current_addr,
+                        );
+                        if let Ok(result) = send_result {
+                            if context.is_some() {
+                                let inner = context.as_mut().unwrap();
+                                inner.send_result = Some(result.clone());
+                                producer.execute_send_message_hook_after(context);
+                            }
+                        }
+                        let duration = (Instant::now() - begin_start_time).as_millis() as u64;
+                        producer
+                            .update_fault_item(current_broker_name.clone(), duration, false, true)
+                            .await;
+                        return;
+                    }
+
+                    let send_result = self.process_send_response(
+                        &current_broker_name,
+                        msg,
+                        &response,
+                        &current_addr,
+                    );
+                    match send_result {
+                        Ok(result) => {
+                            if context.is_some() {
+                                let inner = context.as_mut().unwrap();
+                                inner.send_result = Some(result.clone());
+                                producer.execute_send_message_hook_after(context);
+                            }
+                            let duration = (Instant::now() - begin_start_time).as_millis() as u64;
+                            send_callback.as_ref().unwrap()(Some(&result), None);
+                            producer
+                                .update_fault_item(
+                                    current_broker_name.clone(),
+                                    duration,
+                                    false,
+                                    true,
+                                )
+                                .await;
+                            return; // success, return loop
+                        }
+                        Err(err) => {
+                            let duration = (Instant::now() - begin_start_time).as_millis() as u64;
+                            producer
+                                .update_fault_item(
+                                    current_broker_name.clone(),
+                                    duration,
+                                    true,
+                                    true,
+                                )
+                                .await;
+
+                            // Check if a retry is needed
+                            let current_times =
+                                times.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+                            if current_times < retry_times_when_send_failed {
+                                // Prepare to retry: Select a new broker
+                                match self
+                                    .prepare_retry(
+                                        &current_broker_name,
+                                        msg,
+                                        &mut current_request,
+                                        topic_publish_info,
+                                        instance.as_ref(),
+                                        producer,
+                                    )
+                                    .await
+                                {
+                                    Some((new_addr, new_broker_name)) => {
+                                        current_addr = new_addr;
+                                        current_broker_name = new_broker_name;
+                                        warn!(
+                                            "async send msg by retry {} times. topic={}, \
+                                             brokerAddr={}, brokerName={}",
+                                            current_times + 1,
+                                            msg.get_topic(),
+                                            current_addr,
+                                            current_broker_name
+                                        );
+                                        current_request.set_opaque_mut(
+                                            RemotingCommand::create_new_request_id(),
+                                        );
+                                        continue; // continue to retry
+                                    }
+                                    None => {
+                                        // can not choose new broker, fail
+                                        if let Some(callback) = send_callback {
+                                            callback(None, Some(&err));
+                                        }
+                                        return;
+                                    }
+                                }
+                            } else {
+                                // The maximum number of retries has been reached
+                                if let Some(callback) = send_callback {
+                                    callback(None, Some(&err));
+                                }
+                                return;
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    error!("send message async error: {:?}", err);
+                    let current_times = times.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+                    if current_times < retry_times_when_send_failed {
+                        // Try to retry even if there is a network error.
+                        match self
+                            .prepare_retry(
+                                &current_broker_name,
+                                msg,
+                                &mut current_request,
+                                topic_publish_info,
+                                instance.as_ref(),
+                                producer,
+                            )
+                            .await
+                        {
+                            Some((new_addr, new_broker_name)) => {
+                                current_addr = new_addr;
+                                current_broker_name = new_broker_name;
+                                current_request
+                                    .set_opaque_mut(RemotingCommand::create_new_request_id());
+                                continue;
+                            }
+                            None => {
+                                if let Some(callback) = send_callback {
+                                    callback(None, Some(&err));
+                                }
+                                return;
+                            }
+                        }
+                    } else {
+                        if let Some(callback) = send_callback {
+                            callback(None, Some(&err));
+                        }
+                        return;
+                    }
+                }
             }
         }
     }
@@ -803,7 +980,7 @@ impl MQClientAPIImpl {
         Ok(send_result)
     }
 
-    async fn on_exception_impl<T: MessageTrait>(
+    /*async fn on_exception_impl<T: MessageTrait>(
         &mut self,
         broker_name: &CheetahString,
         msg: &T,
@@ -848,7 +1025,7 @@ impl MQClientAPIImpl {
                 retry_broker_name
             );
             request.set_opaque_mut(RemotingCommand::create_new_request_id());
-             Box::pin(self.send_message_async(
+            Box::pin(self.send_message_async(
                 &addr,
                 &retry_broker_name,
                 msg,
@@ -863,12 +1040,47 @@ impl MQClientAPIImpl {
                 producer,
             ))
             .await;
-
         } else if context.is_some() {
             let inner = context.as_mut().unwrap();
             inner.exception = Some(Arc::new(Box::new(e)));
             producer.execute_send_message_hook_after(context);
         }
+    }*/
+
+    async fn prepare_retry<T: MessageTrait>(
+        &self,
+        broker_name: &CheetahString,
+        msg: &T,
+        request: &mut RemotingCommand,
+        topic_publish_info: Option<&TopicPublishInfo>,
+        instance: Option<&ArcMut<MQClientInstance>>,
+        producer: &DefaultMQProducerImpl,
+    ) -> Option<(CheetahString, CheetahString)> {
+        let mut retry_broker_name = broker_name.clone();
+
+        if let Some(topic_publish_info) = topic_publish_info {
+            let mq_chosen = producer.select_one_message_queue(
+                topic_publish_info,
+                Some(&retry_broker_name),
+                false,
+            );
+            if let Some(instance) = instance {
+                retry_broker_name = instance
+                    .get_broker_name_from_message_queue(mq_chosen.as_ref().unwrap())
+                    .await;
+            }
+        }
+
+        if let Some(instance) = instance {
+            if let Some(addr) = instance
+                .find_broker_address_in_publish(retry_broker_name.as_ref())
+                .await
+            {
+                return Some((addr, retry_broker_name));
+            }
+        }
+
+        None
     }
 
     pub async fn send_heartbeat(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -848,7 +848,7 @@ impl MQClientAPIImpl {
                 retry_broker_name
             );
             request.set_opaque_mut(RemotingCommand::create_new_request_id());
-            Box::pin(self.send_message_async(
+             Box::pin(self.send_message_async(
                 &addr,
                 &retry_broker_name,
                 msg,
@@ -863,6 +863,7 @@ impl MQClientAPIImpl {
                 producer,
             ))
             .await;
+
         } else if context.is_some() {
             let inner = context.as_mut().unwrap();
             inner.exception = Some(Arc::new(Box::new(e)));

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -16,7 +16,6 @@
  */
 #![allow(dead_code)]
 #![allow(unused_variables)]
-#![recursion_limit = "256"]
 #![allow(clippy::result_large_err)]
 
 extern crate core;

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -24,8 +24,8 @@ use crate::producer::send_callback::SendMessageCallback;
 use crate::producer::send_result::SendResult;
 use crate::producer::transaction_send_result::TransactionSendResult;
 
-#[trait_variant::make(MQProducer: Send)]
-pub trait MQProducerLocal {
+#[allow(async_fn_in_trait)]
+pub trait MQProducer {
     /// Starts the producer.
     ///
     /// # Returns


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3696

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More robust async message sending with automatic broker failover and retry across brokers.
  - Optional callbacks to receive success/failure notifications on async sends.
  - Improved logging and metrics around send attempts and outcomes.

- Refactor
  - Public API trait names simplified; update your code to new names:
    - MQAdminExtLocal → MQAdminExt
    - MQConsumerLocal → MQConsumer
    - MQPushConsumerLocal → MQPushConsumer
    - MQProducerLocal → MQProducer
  - Async traits are now exposed directly without macro wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->