### PR TITLE
[ISSUE #3716]♻️Type-safe RocketMqVersion comparisons & accessor (rocketmq_version) across remoting, broker, namesrv, client

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -977,7 +977,7 @@ where
             let subscription_group_config = subscription_group_config.unwrap();
 
             let mut max_reconsume_times = subscription_group_config.retry_max_times();
-            if request.version() >= RocketMqVersion::V3_4_9 as i32
+            if request.rocketmq_version() >= RocketMqVersion::V3_4_9
                 && request_header.max_reconsume_times.is_some()
             {
                 max_reconsume_times = request_header.max_reconsume_times.unwrap();
@@ -1237,7 +1237,7 @@ where
         msg_ext.set_wait_store_msg_ok(false);
         let mut delay_level = request_header.delay_level;
         let mut max_reconsume_times = subscription_group_config.retry_max_times();
-        if request.version() >= RocketMqVersion::V3_4_9 as i32 {
+        if request.rocketmq_version() >= RocketMqVersion::V3_4_9 {
             if let Some(num) = request_header.max_reconsume_times {
                 max_reconsume_times = num;
             }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -137,7 +137,7 @@ lazy_static! {
         .unwrap_or("false".to_string())
         .parse()
         .unwrap_or(false);
-    static ref INIT: () = {
+    static ref INIT_REMOTING_VERSION: () = {
         EnvUtils::put_property(
             remoting_command::REMOTING_VERSION_KEY,
             (CURRENT_VERSION as u32).to_string(),
@@ -342,6 +342,8 @@ impl MQClientAPIImpl {
         client_config: ClientConfig,
         tx: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
     ) -> Self {
+        lazy_static::initialize(&INIT_REMOTING_VERSION);
+
         let mut default_client =
             RocketmqDefaultClient::new_with_cl(tokio_client_config, client_remoting_processor, tx);
         if let Some(hook) = rpc_hook {

--- a/rocketmq-common/src/common/mq_version.rs
+++ b/rocketmq-common/src/common/mq_version.rs
@@ -16,10 +16,12 @@
  */
 #![allow(non_camel_case_types)]
 
+use std::cmp::Ordering;
+
 pub const CURRENT_VERSION: RocketMqVersion = RocketMqVersion::V5_3_1_SNAPSHOT;
 
 #[repr(u32)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug)]
 pub enum RocketMqVersion {
     V3_0_0_SNAPSHOT,
     V3_0_0_ALPHA1,
@@ -637,6 +639,7 @@ pub enum RocketMqVersion {
 }
 
 impl RocketMqVersion {
+    #[inline]
     pub fn from_ordinal(mut value: u32) -> RocketMqVersion {
         let max = RocketMqVersion::HIGHER_VERSION as u32;
         if value > max {
@@ -644,6 +647,12 @@ impl RocketMqVersion {
         }
         unsafe { std::mem::transmute::<u32, RocketMqVersion>(value) }
     }
+
+    #[inline]
+    pub fn ordinal(&self) -> u32 {
+        *self as u32
+    }
+
     pub fn name(&self) -> &'static str {
         match self {
             RocketMqVersion::V3_0_0_SNAPSHOT => "V3_0_0_SNAPSHOT",
@@ -1268,6 +1277,25 @@ impl TryFrom<u32> for RocketMqVersion {
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Ok(RocketMqVersion::from_ordinal(value))
+    }
+}
+
+impl PartialEq for RocketMqVersion {
+    fn eq(&self, other: &Self) -> bool {
+        self.ordinal() == other.ordinal()
+    }
+}
+impl Eq for RocketMqVersion {}
+
+impl PartialOrd for RocketMqVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RocketMqVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.ordinal().cmp(&other.ordinal())
     }
 }
 

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -240,7 +240,7 @@ impl DefaultRequestProcessor {
             RocketMqVersion::try_from(request.version() as u32).expect("invalid version");
         let topic_config_wrapper;
         let mut filter_server_list = Vec::new();
-        if broker_version as usize >= RocketMqVersion::V3_0_11 as usize {
+        if broker_version >= RocketMqVersion::V3_0_11 {
             let register_broker_body =
                 extract_register_broker_body_from_request(&request, &request_header);
             topic_config_wrapper = register_broker_body.topic_config_serialize_wrapper;
@@ -679,7 +679,7 @@ fn extract_register_broker_body_from_request(
         if body_inner.is_empty() {
             return RegisterBrokerBody::default();
         }
-        let version = RocketMqVersion::try_from(request.version() as u32).unwrap();
+        let version = request.rocketmq_version();
         return RegisterBrokerBody::decode(body_inner, request_header.compressed, version);
     }
     RegisterBrokerBody::default()

--- a/rocketmq-remoting/src/protocol/body/broker_body/register_broker_body.rs
+++ b/rocketmq-remoting/src/protocol/body/broker_body/register_broker_body.rs
@@ -158,7 +158,7 @@ impl RegisterBrokerBody {
         register_broker_body.filter_server_list =
             SerdeJsonUtils::from_json_slice(filter_server_list_json.as_ref()).unwrap();
 
-        if broker_version as i32 >= RocketMqVersion::V5_0_0 as i32 {
+        if broker_version >= RocketMqVersion::V5_0_0 {
             let topic_queue_mapping_num = bytes.get_i32();
             let mut topic_queue_mapping_info_map = HashMap::new();
             for _ in 0..topic_queue_mapping_num {

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -29,6 +29,7 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use lazy_static::lazy_static;
+use rocketmq_common::common::mq_version::RocketMqVersion;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_common::EnvUtils::EnvUtils;
 use rocketmq_error::RocketmqError;
@@ -586,6 +587,10 @@ impl RemotingCommand {
     #[inline]
     pub fn version(&self) -> i32 {
         self.version
+    }
+
+    pub fn rocketmq_version(&self) -> RocketMqVersion {
+        RocketMqVersion::from_ordinal(self.version as u32)
     }
 
     #[inline]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3716

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
