### PR TITLE
[ISSUE #3721]♻️Resilient topic route retrieval & decoding error handling in client

### DIFF
--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -458,7 +458,7 @@ impl MQClientAPIImpl {
                             if let Ok(data) = route_data {
                                 return Ok(Some(data));
                             } else {
-                                let error1 = route_data.err().unwrap();
+                            } else if let Err(error1) = route_data {
                                 error!(
                                     "get Topic [{}] RouteInfoFromNameServer decode error: {}",
                                     topic, error1

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -47,6 +47,7 @@ use rocketmq_error::ClientErr;
 use rocketmq_error::MQBrokerErr;
 use rocketmq_error::RocketMQResult;
 use rocketmq_error::RocketmqError;
+use rocketmq_error::RocketmqError::JsonError;
 use rocketmq_error::RocketmqError::MQClientBrokerError;
 use rocketmq_remoting::base::connection_net_event::ConnectionNetEvent;
 use rocketmq_remoting::clients::rocketmq_default_impl::RocketmqDefaultClient;
@@ -446,17 +447,23 @@ impl MQClientAPIImpl {
             .invoke_async(None, request, timeout_millis)
             .await;
         match response {
-            Ok(result) => {
+            Ok(mut result) => {
                 let code = result.code();
                 let response_code = ResponseCode::from(code);
                 match response_code {
                     ResponseCode::Success => {
-                        let body = result.body();
-                        if body.is_some() && !body.as_ref().unwrap().is_empty() {
-                            let route_data =
-                                TopicRouteData::decode(body.as_ref().unwrap().as_ref());
+                        let body = result.take_body();
+                        if let Some(body_inner) = body {
+                            let route_data = TopicRouteData::decode(body_inner.as_ref());
                             if let Ok(data) = route_data {
                                 return Ok(Some(data));
+                            } else {
+                                let error1 = route_data.err().unwrap();
+                                error!(
+                                    "get Topic [{}] RouteInfoFromNameServer decode error: {}",
+                                    topic, error1
+                                );
+                                return Err(JsonError(error1.to_string()));
                             }
                         }
                     }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -457,7 +457,6 @@ impl MQClientAPIImpl {
                             let route_data = TopicRouteData::decode(body_inner.as_ref());
                             if let Ok(data) = route_data {
                                 return Ok(Some(data));
-                            } else {
                             } else if let Err(error1) = route_data {
                                 error!(
                                     "get Topic [{}] RouteInfoFromNameServer decode error: {}",


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3721

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when fetching default topic route info from the name server, logging failures instead of silently dropping them.
  * Safer consumption of name server responses to ensure JSON decoding errors are surfaced and logged, reducing hidden failures and improving stability.
* **Chores**
  * Internal adjustments to response handling to support the above changes without altering public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->