### PR TITLE
Refactor ElectMasterResponseHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/elect_master_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/elect_master_response_header.rs
@@ -17,13 +17,11 @@
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
-
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct ElectMasterResponseHeader {
     pub master_broker_id: Option<i64>,
@@ -32,79 +30,11 @@ pub struct ElectMasterResponseHeader {
     pub sync_state_set_epoch: Option<i32>,
 }
 
-impl ElectMasterResponseHeader {
-    pub const MASTER_BROKER_ID: &'static str = "masterBrokerId";
-    pub const MASTER_ADDRESS: &'static str = "masterAddress";
-    pub const MASTER_EPOCH: &'static str = "masterEpoch";
-    pub const SYNC_STATE_SET_EPOCH: &'static str = "syncStateSetEpoch";
-}
-
-impl CommandCustomHeader for ElectMasterResponseHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        let mut map = std::collections::HashMap::new();
-        if let Some(value) = self.master_broker_id.as_ref() {
-            map.insert(
-                CheetahString::from_static_str(Self::MASTER_BROKER_ID),
-                CheetahString::from(value.to_string()),
-            );
-        }
-        if let Some(value) = self.master_address.as_ref() {
-            map.insert(
-                CheetahString::from_static_str(Self::MASTER_ADDRESS),
-                value.clone(),
-            );
-        }
-        if let Some(value) = self.master_epoch.as_ref() {
-            map.insert(
-                CheetahString::from_static_str(Self::MASTER_EPOCH),
-                CheetahString::from(value.to_string()),
-            );
-        }
-        if let Some(value) = self.sync_state_set_epoch.as_ref() {
-            map.insert(
-                CheetahString::from_static_str(Self::SYNC_STATE_SET_EPOCH),
-                CheetahString::from(value.to_string()),
-            );
-        }
-        Some(map)
-    }
-}
-
-impl FromMap for ElectMasterResponseHeader {
-    type Error = rocketmq_error::RocketmqError;
-
-    type Target = Self;
-    fn from(
-        map: &std::collections::HashMap<CheetahString, CheetahString>,
-    ) -> Result<Self::Target, Self::Error> {
-        Ok(ElectMasterResponseHeader {
-            master_broker_id: map
-                .get(&CheetahString::from_static_str(
-                    ElectMasterResponseHeader::MASTER_BROKER_ID,
-                ))
-                .and_then(|s| s.parse::<i64>().ok()),
-            master_address: map
-                .get(&CheetahString::from_static_str(
-                    ElectMasterResponseHeader::MASTER_ADDRESS,
-                ))
-                .cloned(),
-            master_epoch: map
-                .get(&CheetahString::from_static_str(
-                    ElectMasterResponseHeader::MASTER_EPOCH,
-                ))
-                .and_then(|s| s.parse::<i32>().ok()),
-            sync_state_set_epoch: map
-                .get(&CheetahString::from_static_str(
-                    ElectMasterResponseHeader::SYNC_STATE_SET_EPOCH,
-                ))
-                .and_then(|s| s.parse::<i32>().ok()),
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::FromMap;
 
     #[test]
     fn elect_master_response_header_serializes_correctly() {

--- a/rocketmq-remoting/src/protocol/header/elect_master_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/elect_master_response_header.rs
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
-
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
@@ -32,6 +30,8 @@ pub struct ElectMasterResponseHeader {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::protocol::command_custom_header::CommandCustomHeader;
     use crate::protocol::command_custom_header::FromMap;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3393

### Brief Description

Removed static implementations and refatored the ElectMasterResponseHeader with RequestHeaderCodec derive macro

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

Tested utilizing the commands mentioned in `CONTRIBUITING.md`
<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined response header handling with a derived encoding/decoding approach to reduce boilerplate and improve maintainability. No user-facing behavior changes.
- **Tests**
  - Updated tests to align with the refactored header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->