### PR TITLE
Replace init_logger() with init_logger_with_level()

### DIFF
--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -34,7 +34,7 @@ use tracing::warn;
 #[rocketmq::main]
 async fn main() -> RocketMQResult<()> {
     // Initialize the logger
-    rocketmq_common::log::init_logger();
+    rocketmq_common::log::init_logger_with_level(rocketmq_common::log::Level::INFO);
     // parse command line arguments
     let args = Args::parse();
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2801 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
 
- Update logger init function to init_logger_wih_level for improved clarity
### How Did You Test This Change?
Using the commands mentioned in `CONTRIBUTING.md`
<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized logging for the NameServer to explicitly use INFO as the default level. Users will now see informational messages and above by default, reducing debug noise and improving readability during normal operations.
  * No functional changes to runtime behavior; only log verbosity is affected. Existing mechanisms to adjust log levels remain available for those who need more or less detail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->