### PR TITLE
refactor: Replace manual impls in GetMinOffsetRequestHeader with RequestHeaderCodec

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_min_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_min_offset_request_header.rs
@@ -14,18 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMinOffsetRequestHeader {
     pub topic: CheetahString,
@@ -36,54 +34,54 @@ pub struct GetMinOffsetRequestHeader {
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 
-impl GetMinOffsetRequestHeader {
-    pub const TOPIC: &'static str = "topic";
-    pub const QUEUE_ID: &'static str = "queueId";
-}
+// impl GetMinOffsetRequestHeader {
+//     pub const TOPIC: &'static str = "topic";
+//     pub const QUEUE_ID: &'static str = "queueId";
+// }
 
-impl CommandCustomHeader for GetMinOffsetRequestHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        let mut map = HashMap::new();
-        map.insert(
-            CheetahString::from_static_str(Self::TOPIC),
-            self.topic.clone(),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::QUEUE_ID),
-            CheetahString::from_string(self.queue_id.to_string()),
-        );
-        if let Some(topic_request_header) = &self.topic_request_header {
-            if let Some(topic_request_header_map) = topic_request_header.to_map() {
-                map.extend(topic_request_header_map);
-            }
-        }
-        Some(map)
-    }
-}
+// impl CommandCustomHeader for GetMinOffsetRequestHeader {
+//     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+//         let mut map = HashMap::new();
+//         map.insert(
+//             CheetahString::from_static_str(Self::TOPIC),
+//             self.topic.clone(),
+//         );
+//         map.insert(
+//             CheetahString::from_static_str(Self::QUEUE_ID),
+//             CheetahString::from_string(self.queue_id.to_string()),
+//         );
+//         if let Some(topic_request_header) = &self.topic_request_header {
+//             if let Some(topic_request_header_map) = topic_request_header.to_map() {
+//                 map.extend(topic_request_header_map);
+//             }
+//         }
+//         Some(map)
+//     }
+// }
 
-impl FromMap for GetMinOffsetRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
+// impl FromMap for GetMinOffsetRequestHeader {
+//     type Error = rocketmq_error::RocketmqError;
 
-    type Target = Self;
+//     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(GetMinOffsetRequestHeader {
-            topic: map
-                .get(&CheetahString::from_static_str(
-                    GetMinOffsetRequestHeader::TOPIC,
-                ))
-                .cloned()
-                .unwrap_or_default(),
-            queue_id: map
-                .get(&CheetahString::from_static_str(
-                    GetMinOffsetRequestHeader::QUEUE_ID,
-                ))
-                .map(|s| s.parse().unwrap())
-                .unwrap_or_default(),
-            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
-        })
-    }
-}
+//     fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+//         Ok(GetMinOffsetRequestHeader {
+//             topic: map
+//                 .get(&CheetahString::from_static_str(
+//                     GetMinOffsetRequestHeader::TOPIC,
+//                 ))
+//                 .cloned()
+//                 .unwrap_or_default(),
+//             queue_id: map
+//                 .get(&CheetahString::from_static_str(
+//                     GetMinOffsetRequestHeader::QUEUE_ID,
+//                 ))
+//                 .map(|s| s.parse().unwrap())
+//                 .unwrap_or_default(),
+//             topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
+//         })
+//     }
+// }
 
 impl TopicRequestHeaderTrait for GetMinOffsetRequestHeader {
     fn set_lo(&mut self, lo: Option<bool>) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3399 

### Brief Description

This PR refactors GetMinOffsetRequestHeader to use #[derive(RequestHeaderCodec)], following the same approach as SendMessageRequestHeader.

Added #[derive(RequestHeaderCodec)] to the struct

Commented out the manual impls (CommandCustomHeader, FromMap, etc.)
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined request header encoding/decoding using a standardized derive-based codec, removing manual map-based serialization.
  * Reduced complexity and improved maintainability with no expected changes to runtime behavior.
  * Removed deprecated constants and legacy integration hooks related to header handling, aligning with the new codec approach.
  * Developers integrating at the protocol layer may need minor updates due to the removal of legacy APIs; end-users should see no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->