### PR TITLE
refactor: Replace manual impls in GetMaxOffsetRequestHeader with RequestHeaderCodec

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_max_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_max_offset_request_header.rs
@@ -14,18 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMaxOffsetRequestHeader {
     pub topic: CheetahString,
@@ -38,76 +36,76 @@ pub struct GetMaxOffsetRequestHeader {
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 
-impl Default for GetMaxOffsetRequestHeader {
-    fn default() -> Self {
-        GetMaxOffsetRequestHeader {
-            topic: Default::default(),
-            queue_id: Default::default(),
-            committed: true,
-            topic_request_header: Default::default(),
-        }
-    }
-}
+// impl Default for GetMaxOffsetRequestHeader {
+//     fn default() -> Self {
+//         GetMaxOffsetRequestHeader {
+//             topic: Default::default(),
+//             queue_id: Default::default(),
+//             committed: true,
+//             topic_request_header: Default::default(),
+//         }
+//     }
+// }
 
-impl GetMaxOffsetRequestHeader {
-    pub const TOPIC: &'static str = "topic";
-    pub const QUEUE_ID: &'static str = "queueId";
-    pub const COMMITTED: &'static str = "committed";
-}
+// impl GetMaxOffsetRequestHeader {
+//     pub const TOPIC: &'static str = "topic";
+//     pub const QUEUE_ID: &'static str = "queueId";
+//     pub const COMMITTED: &'static str = "committed";
+// }
 
-impl CommandCustomHeader for GetMaxOffsetRequestHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        let mut map = HashMap::new();
-        map.insert(
-            CheetahString::from_static_str(Self::TOPIC),
-            self.topic.clone(),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::QUEUE_ID),
-            CheetahString::from_string(self.queue_id.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(Self::COMMITTED),
-            CheetahString::from_string(self.committed.to_string()),
-        );
-        if let Some(topic_request_header) = &self.topic_request_header {
-            if let Some(topic_request_header_map) = topic_request_header.to_map() {
-                map.extend(topic_request_header_map);
-            }
-        }
-        Some(map)
-    }
-}
+// impl CommandCustomHeader for GetMaxOffsetRequestHeader {
+//     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+//         let mut map = HashMap::new();
+//         map.insert(
+//             CheetahString::from_static_str(Self::TOPIC),
+//             self.topic.clone(),
+//         );
+//         map.insert(
+//             CheetahString::from_static_str(Self::QUEUE_ID),
+//             CheetahString::from_string(self.queue_id.to_string()),
+//         );
+//         map.insert(
+//             CheetahString::from_static_str(Self::COMMITTED),
+//             CheetahString::from_string(self.committed.to_string()),
+//         );
+//         if let Some(topic_request_header) = &self.topic_request_header {
+//             if let Some(topic_request_header_map) = topic_request_header.to_map() {
+//                 map.extend(topic_request_header_map);
+//             }
+//         }
+//         Some(map)
+//     }
+// }
 
-impl FromMap for GetMaxOffsetRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
+// impl FromMap for GetMaxOffsetRequestHeader {
+//     type Error = rocketmq_error::RocketmqError;
 
-    type Target = Self;
+//     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(GetMaxOffsetRequestHeader {
-            topic: map
-                .get(&CheetahString::from_static_str(
-                    GetMaxOffsetRequestHeader::TOPIC,
-                ))
-                .cloned()
-                .unwrap_or_default(),
-            queue_id: map
-                .get(&CheetahString::from_static_str(
-                    GetMaxOffsetRequestHeader::QUEUE_ID,
-                ))
-                .map(|s| s.parse().unwrap())
-                .unwrap_or_default(),
-            committed: map
-                .get(&CheetahString::from_static_str(
-                    GetMaxOffsetRequestHeader::COMMITTED,
-                ))
-                .map(|s| s.parse().unwrap())
-                .unwrap_or(true),
-            topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
-        })
-    }
-}
+//     fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+//         Ok(GetMaxOffsetRequestHeader {
+//             topic: map
+//                 .get(&CheetahString::from_static_str(
+//                     GetMaxOffsetRequestHeader::TOPIC,
+//                 ))
+//                 .cloned()
+//                 .unwrap_or_default(),
+//             queue_id: map
+//                 .get(&CheetahString::from_static_str(
+//                     GetMaxOffsetRequestHeader::QUEUE_ID,
+//                 ))
+//                 .map(|s| s.parse().unwrap())
+//                 .unwrap_or_default(),
+//             committed: map
+//                 .get(&CheetahString::from_static_str(
+//                     GetMaxOffsetRequestHeader::COMMITTED,
+//                 ))
+//                 .map(|s| s.parse().unwrap())
+//                 .unwrap_or(true),
+//             topic_request_header: Some(<TopicRequestHeader as FromMap>::from(map)?),
+//         })
+//     }
+//}
 
 impl TopicRequestHeaderTrait for GetMaxOffsetRequestHeader {
     fn set_lo(&mut self, lo: Option<bool>) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3397 

### Brief Description

This PR refactors GetMaxOffsetRequestHeader to use #[derive(RequestHeaderCodec)], following the same approach as SendMessageRequestHeader.

Added #[derive(RequestHeaderCodec)] to the struct

Commented out the manual impls (CommandCustomHeader, FromMap, etc.)
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Get Max Offset request header handling by adopting automatic encoding/decoding, removing manual mapping logic.
  * Improves reliability, consistency, and maintainability of request header serialization/deserialization.
  * Reduces potential edge-case errors and simplifies future changes without altering visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->