### PR TITLE
[ISSUE #3741]📝Add configuration files for nameserver settings in RocketMQ

### DIFF
--- a/distribution/config/nameserver/namesrv.conf
+++ b/distribution/config/nameserver/namesrv.conf
@@ -1,73 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # RocketMQ home installation directory
-rocketmqHome = "${user.home}/rocketmq"
+rocketmqHome=${user.home}/rocketmq
 
 # Storage path for KV configuration file
-kvConfigPath = "${user.home}/namesrv/kvConfig.json"
+kvConfigPath=${user.home}/namesrv/kvConfig.json
 
 # Storage path for nameserver configuration file
-configStorePath = "${user.home}/namesrv/namesrv.properties"
+configStorePath=${user.home}/namesrv/namesrv.properties
 
 # Product environment name
-productEnvName = "center"
+productEnvName=center
 
 # Whether to enable cluster test mode
-clusterTest = false
+clusterTest=false
 
 # Whether to enable order message feature
-orderMessageEnable = false
+orderMessageEnable=false
 
 # Whether to return order topic configuration to broker
-returnOrderTopicConfigToBroker = true
+returnOrderTopicConfigToBroker=true
 
 # Number of threads to handle client requests, like GET_ROUTEINTO_BY_TOPIC
-clientRequestThreadPoolNums = 8
+clientRequestThreadPoolNums=8
 
 # Number of threads to handle broker or operation requests, like REGISTER_BROKER
-defaultThreadPoolNums = 16
+defaultThreadPoolNums=16
 
 # Capacity of queue to hold client requests
-clientRequestThreadPoolQueueCapacity = 50000
+clientRequestThreadPoolQueueCapacity=50000
 
 # Capacity of queue to hold broker or operation requests
-defaultThreadPoolQueueCapacity = 10000
+defaultThreadPoolQueueCapacity=10000
 
 # Interval of periodic scanning for non-active broker (milliseconds)
-scanNotActiveBrokerInterval = 5000
+scanNotActiveBrokerInterval=5000
 
 # Capacity of queue for unregister broker operations
-unRegisterBrokerQueueCapacity = 3000
+unRegisterBrokerQueueCapacity=3000
 
 # Whether to support acting master functionality
 # The slave can act as master when master node is down to support:
 # 1. Lock/unlock message queue operations
 # 2. SearchOffset, query maxOffset/minOffset operations
 # 3. Query earliest message store time
-supportActingMaster = false
+supportActingMaster=false
 
 # Whether to enable all topic list functionality
-enableAllTopicList = true
+enableAllTopicList=true
 
 # Whether to enable topic list functionality
-enableTopicList = true
+enableTopicList=true
 
 # Whether to notify when minimum broker ID changes
-notifyMinBrokerIdChanged = false
+notifyMinBrokerIdChanged=false
 
 # Whether to enable controller in name server
-enableControllerInNamesrv = false
+enableControllerInNamesrv=false
 
 # Whether service needs to wait before starting
-needWaitForService = false
+needWaitForService=false
 
 # Number of seconds to wait for service
-waitSecondsForService = 45
+waitSecondsForService=45
 
 # If enabled, topics not in broker registration payload will be deleted from name server
 # WARNING:
 # 1. Enable this and "enableSingleTopicRegister" in broker config to avoid losing topic route info
 # 2. This flag does not support static topics currently
-deleteTopicWithBrokerRegistration = false
+deleteTopicWithBrokerRegistration=false
 
 # Configurations in this black list will not be allowed to update by command
 # Try to update these configurations by restarting the process
-configBlackList = "configBlackList;configStorePath;kvConfigPath"
+configBlackList="configBlackList;configStorePath;kvConfigPath"

--- a/distribution/config/nameserver/namesrv.toml
+++ b/distribution/config/nameserver/namesrv.toml
@@ -1,73 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # RocketMQ home installation directory
-rocketmqHome=${user.home}/rocketmq
+rocketmqHome = "${user.home}/rocketmq"
 
 # Storage path for KV configuration file
-kvConfigPath=${user.home}/namesrv/kvConfig.json
+kvConfigPath = "${user.home}/namesrv/kvConfig.json"
 
 # Storage path for nameserver configuration file
-configStorePath=${user.home}/namesrv/namesrv.properties
+configStorePath = "${user.home}/namesrv/namesrv.properties"
 
 # Product environment name
-productEnvName=center
+productEnvName = "center"
 
 # Whether to enable cluster test mode
-clusterTest=false
+clusterTest = false
 
 # Whether to enable order message feature
-orderMessageEnable=false
+orderMessageEnable = false
 
 # Whether to return order topic configuration to broker
-returnOrderTopicConfigToBroker=true
+returnOrderTopicConfigToBroker = true
 
 # Number of threads to handle client requests, like GET_ROUTEINTO_BY_TOPIC
-clientRequestThreadPoolNums=8
+clientRequestThreadPoolNums = 8
 
 # Number of threads to handle broker or operation requests, like REGISTER_BROKER
-defaultThreadPoolNums=16
+defaultThreadPoolNums = 16
 
 # Capacity of queue to hold client requests
-clientRequestThreadPoolQueueCapacity=50000
+clientRequestThreadPoolQueueCapacity = 50000
 
 # Capacity of queue to hold broker or operation requests
-defaultThreadPoolQueueCapacity=10000
+defaultThreadPoolQueueCapacity = 10000
 
 # Interval of periodic scanning for non-active broker (milliseconds)
-scanNotActiveBrokerInterval=5000
+scanNotActiveBrokerInterval = 5000
 
 # Capacity of queue for unregister broker operations
-unRegisterBrokerQueueCapacity=3000
+unRegisterBrokerQueueCapacity = 3000
 
 # Whether to support acting master functionality
 # The slave can act as master when master node is down to support:
 # 1. Lock/unlock message queue operations
 # 2. SearchOffset, query maxOffset/minOffset operations
 # 3. Query earliest message store time
-supportActingMaster=false
+supportActingMaster = false
 
 # Whether to enable all topic list functionality
-enableAllTopicList=true
+enableAllTopicList = true
 
 # Whether to enable topic list functionality
-enableTopicList=true
+enableTopicList = true
 
 # Whether to notify when minimum broker ID changes
-notifyMinBrokerIdChanged=false
+notifyMinBrokerIdChanged = false
 
 # Whether to enable controller in name server
-enableControllerInNamesrv=false
+enableControllerInNamesrv = false
 
 # Whether service needs to wait before starting
-needWaitForService=false
+needWaitForService = false
 
 # Number of seconds to wait for service
-waitSecondsForService=45
+waitSecondsForService = 45
 
 # If enabled, topics not in broker registration payload will be deleted from name server
 # WARNING:
 # 1. Enable this and "enableSingleTopicRegister" in broker config to avoid losing topic route info
 # 2. This flag does not support static topics currently
-deleteTopicWithBrokerRegistration=false
+deleteTopicWithBrokerRegistration = false
 
 # Configurations in this black list will not be allowed to update by command
 # Try to update these configurations by restarting the process
-configBlackList="configBlackList;configStorePath;kvConfigPath"
+configBlackList = "configBlackList;configStorePath;kvConfigPath"


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3741

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Apache license headers to nameserver configuration files (conf and toml).
  * Clarifies licensing and improves consistency across configuration formats.
* **Chores**
  * Standardized comment headers and minor formatting (e.g., added leading blank line) in configuration files.
  * No functional changes; existing configuration values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->