### PR TITLE
[ISSUE #3747]♻️Introduce common error module & strict config parsing across broker/namesrv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,6 +2333,7 @@ dependencies = [
 name = "rocketmq-error"
 version = "0.6.0"
 dependencies = [
+ "anyhow",
  "thiserror 2.0.14",
 ]
 

--- a/rocketmq-common/src/error.rs
+++ b/rocketmq-common/src/error.rs
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use config::ConfigError;
+
+pub type RocketMQResult<T> = Result<T, CommonError>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum CommonError {
+    #[error("Config error: {0}")]
+    ConfigError(#[from] ConfigError),
+}

--- a/rocketmq-common/src/lib.rs
+++ b/rocketmq-common/src/lib.rs
@@ -47,6 +47,7 @@ pub use crate::utils::time_utils as TimeUtils;
 pub use crate::utils::util_all as UtilAll;
 
 pub mod common;
+pub mod error;
 pub mod log;
 mod thread_pool;
 pub mod utils;

--- a/rocketmq-error/Cargo.toml
+++ b/rocketmq-error/Cargo.toml
@@ -13,3 +13,4 @@ description = "Rocketmq rust error module"
 rust-version.workspace = true
 [dependencies]
 thiserror.workspace = true
+anyhow = { workspace = true }

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -32,7 +32,9 @@
  */
 use std::io;
 
-pub type RocketMQResult<T> = Result<T, RocketmqError>;
+pub type RocketMQResult<T> = std::result::Result<T, RocketmqError>;
+
+pub type Result<T> = anyhow::Result<T>;
 
 use thiserror::Error;
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3747

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Centralized config parsing for broker and name server with clear logs of the selected config file.
  - Broker now applies both broker and message store configurations during startup.

- Bug Fixes
  - Broker no longer fails when the default config is missing; it starts with safe defaults.

- Refactor
  - Unified result/error handling for clearer, more descriptive startup errors.
  - Name server exits with a proper error when an invalid custom config path is provided.
  - Consistent logging of home directory and listen address during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->