### PR TITLE
refactor: replace manual impls with derive(RequestHeaderCodec) in GetAllTopicConfigResponseHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_all_topic_config_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_all_topic_config_response_header.rs
@@ -14,29 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
-
-use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
-
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
 pub struct GetAllTopicConfigResponseHeader;
 
-impl CommandCustomHeader for GetAllTopicConfigResponseHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        None
-    }
-}
-impl FromMap for GetAllTopicConfigResponseHeader {
-    type Error = rocketmq_error::RocketmqError;
+// impl CommandCustomHeader for GetAllTopicConfigResponseHeader {
+//     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+//         None
+//     }
+// }
+// impl FromMap for GetAllTopicConfigResponseHeader {
+//     type Error = rocketmq_error::RocketmqError;
 
-    type Target = Self;
+//     type Target = Self;
 
-    fn from(_map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(Self {})
-    }
-}
+//     fn from(_map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+//         Ok(Self {})
+//     }
+// }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3394 

### Brief Description

This PR refactors GetAllTopicConfigResponseHeader to use #[derive(RequestHeaderCodec)], following the same approach as SendMessageRequestHeader.

Added #[derive(RequestHeaderCodec)] to the struct

Commented out the manual impls (CommandCustomHeader, FromMap, etc.)

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated to a derive-based header codec for topic configuration responses, reducing boilerplate and aligning with existing patterns.
  - Improves consistency and reliability of header encoding/decoding.
  - No user-facing behavior changes; public APIs remain stable.
  - Internal implementation simplified for easier maintenance and fewer edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->