### PR TITLE
refactor: replace manual impls with derive(RequestHeaderCodec) in AddWritePermOfBrokerResponseHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
@@ -14,15 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodec;
 use serde::Deserialize;
 use serde::Serialize;
-
-use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
@@ -69,14 +65,14 @@ impl AddWritePermOfBrokerRequestHeader {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodec)]
 #[serde(rename_all = "camelCase")]
 pub struct AddWritePermOfBrokerResponseHeader {
     pub add_topic_count: i32,
 }
 
 impl AddWritePermOfBrokerResponseHeader {
-    const ADD_TOPIC_COUNT: &'static str = "addTopicCount";
+    //const ADD_TOPIC_COUNT: &'static str = "addTopicCount";
 
     pub fn new(add_topic_count: i32) -> Self {
         Self { add_topic_count }
@@ -89,28 +85,28 @@ impl AddWritePermOfBrokerResponseHeader {
     }
 }
 
-impl CommandCustomHeader for AddWritePermOfBrokerResponseHeader {
-    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        Some(HashMap::from([(
-            CheetahString::from_static_str(Self::ADD_TOPIC_COUNT),
-            CheetahString::from_string(self.add_topic_count.to_string()),
-        )]))
-    }
-}
+// impl CommandCustomHeader for AddWritePermOfBrokerResponseHeader {
+//     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+//         Some(HashMap::from([(
+//             CheetahString::from_static_str(Self::ADD_TOPIC_COUNT),
+//             CheetahString::from_string(self.add_topic_count.to_string()),
+//         )]))
+//     }
+// }
 
-impl FromMap for AddWritePermOfBrokerResponseHeader {
-    type Error = rocketmq_error::RocketmqError;
+// impl FromMap for AddWritePermOfBrokerResponseHeader {
+//     type Error = rocketmq_error::RocketmqError;
 
-    type Target = Self;
+//     type Target = Self;
 
-    fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-        Ok(AddWritePermOfBrokerResponseHeader {
-            add_topic_count: map
-                .get(&CheetahString::from_static_str(
-                    AddWritePermOfBrokerResponseHeader::ADD_TOPIC_COUNT,
-                ))
-                .and_then(|s| s.parse::<i32>().ok())
-                .unwrap_or(0),
-        })
-    }
-}
+//     fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
+//         Ok(AddWritePermOfBrokerResponseHeader {
+//             add_topic_count: map
+//                 .get(&CheetahString::from_static_str(
+//                     AddWritePermOfBrokerResponseHeader::ADD_TOPIC_COUNT,
+//                 ))
+//                 .and_then(|s| s.parse::<i32>().ok())
+//                 .unwrap_or(0),
+//         })
+//     }
+// }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #2934 

### Brief Description

This PR refactors AddWritePermOfBrokerResponseHeader to use #[derive(RequestHeaderCodec)], following the same approach as SendMessageRequestHeader.

Added #[derive(RequestHeaderCodec)] to the struct

Commented out the manual impls (CommandCustomHeader, FromMap, etc.)
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing features added.
- Bug Fixes
  - Improved reliability of request/response header handling, reducing possible serialization/deserialization issues.
- Refactor
  - Switched header encoding/decoding to a unified codec and removed legacy map-based serialization paths for clearer, more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->