### PR TITLE
[ISSUE #3755]✨Accept mixed-case variants for MessageRequestMode ("Pull"/"Pop") & add tests

### DIFF
--- a/rocketmq-common/src/common/message/message_enum.rs
+++ b/rocketmq-common/src/common/message/message_enum.rs
@@ -102,9 +102,9 @@ impl<'de> Deserialize<'de> for MessageRequestMode {
                 E: de::Error,
             {
                 match value {
-                    "PULL" => Ok(MessageRequestMode::Pull),
-                    "POP" => Ok(MessageRequestMode::Pop),
-                    _ => Err(de::Error::unknown_variant(value, &["PULL", "POP"])),
+                    "PULL" | "Pull" => Ok(MessageRequestMode::Pull),
+                    "POP" | "Pop" => Ok(MessageRequestMode::Pop),
+                    _ => Err(de::Error::unknown_variant(value, &["PULL/Pull", "POP/Pop"])),
                 }
             }
         }
@@ -179,11 +179,19 @@ mod tests {
         let json = "\"PULL\"";
         let deserialized: MessageRequestMode = serde_json::from_str(json).unwrap();
         assert_eq!(deserialized, MessageRequestMode::Pull);
+
+        let json = "\"Pull\"";
+        let deserialized: MessageRequestMode = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, MessageRequestMode::Pull);
     }
 
     #[test]
     fn deserialize_message_request_mode_pop() {
         let json = "\"POP\"";
+        let deserialized: MessageRequestMode = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, MessageRequestMode::Pop);
+
+        let json = "\"Pop\"";
         let deserialized: MessageRequestMode = serde_json::from_str(json).unwrap();
         assert_eq!(deserialized, MessageRequestMode::Pop);
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3755

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input handling for message request mode: deserialization now accepts both uppercase and title-case values (“PULL”/“Pull” and “POP”/“Pop”), preventing failures with mixed casing.
  * Updated error messages to clearly list accepted forms.
  * No changes to serialization behavior.
  * Enhances compatibility with varied client inputs and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->