### PR TITLE
[ISSUE #3757]📝broker.toml sample updated to list mixed-case MessageRequestMode variants

### DIFF
--- a/distribution/config/broker/broker.toml
+++ b/distribution/config/broker/broker.toml
@@ -136,7 +136,7 @@ popPollingSizeInternal = 1024
 # Message / Transaction
 transactionOpMsgMaxSize = 4096
 transactionCheckMax = 15
-defaultMessageRequestMode = "Pull"    # enum MessageRequestMode: Pull|Pop
+defaultMessageRequestMode = "Pull"    # enum MessageRequestMode: Pull/PULL|Pop/POP
 
 # ======================
 # Statistics / Ack / Resume


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3757

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified the allowed values for the MessageRequestMode setting in the broker configuration comments, indicating both lowercase and uppercase forms (Pull/PULL, Pop/POP).
  - No functional changes were made; the default remains Pull.
  - Aims to reduce configuration ambiguity for administrators. No action required unless referencing the inline comments for guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->