### PR TITLE
[ISSUE #3759]✨Accept mixed-case BrokerRole variants (AsyncMaster/SyncMaster/Slave) & tests added

### DIFF
--- a/rocketmq-common/src/common/broker/broker_role.rs
+++ b/rocketmq-common/src/common/broker/broker_role.rs
@@ -57,12 +57,16 @@ impl<'de> Deserialize<'de> for BrokerRole {
                 E: serde::de::Error,
             {
                 match value {
-                    "ASYNC_MASTER" => Ok(BrokerRole::AsyncMaster),
-                    "SYNC_MASTER" => Ok(BrokerRole::SyncMaster),
-                    "SLAVE" => Ok(BrokerRole::Slave),
+                    "ASYNC_MASTER" | "AsyncMaster" => Ok(BrokerRole::AsyncMaster),
+                    "SYNC_MASTER" | "SyncMaster" => Ok(BrokerRole::SyncMaster),
+                    "SLAVE" | "Slave" => Ok(BrokerRole::Slave),
                     _ => Err(serde::de::Error::unknown_variant(
                         value,
-                        &["AsyncMaster", "SyncMaster", "Slave"],
+                        &[
+                            "ASYNC_MASTER/AsyncMaster",
+                            "SYNC_MASTER/SyncMaster",
+                            "SLAVE/Slave",
+                        ],
                     )),
                 }
             }
@@ -113,6 +117,10 @@ mod tests {
         let json = "\"ASYNC_MASTER\"";
         let deserialized: BrokerRole = serde_json::from_str(json).unwrap();
         assert_eq!(deserialized, BrokerRole::AsyncMaster);
+
+        let json = "\"AsyncMaster\"";
+        let deserialized: BrokerRole = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, BrokerRole::AsyncMaster);
     }
 
     #[test]
@@ -120,11 +128,19 @@ mod tests {
         let json = "\"SYNC_MASTER\"";
         let deserialized: BrokerRole = serde_json::from_str(json).unwrap();
         assert_eq!(deserialized, BrokerRole::SyncMaster);
+
+        let json = "\"SyncMaster\"";
+        let deserialized: BrokerRole = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, BrokerRole::SyncMaster);
     }
 
     #[test]
     fn broker_role_slave_deserialization() {
         let json = "\"SLAVE\"";
+        let deserialized: BrokerRole = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, BrokerRole::Slave);
+
+        let json = "\"Slave\"";
         let deserialized: BrokerRole = serde_json::from_str(json).unwrap();
         assert_eq!(deserialized, BrokerRole::Slave);
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3759

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Broker role values are now accepted in both uppercase and PascalCase (e.g., ASYNC_MASTER/AsyncMaster, SYNC_MASTER/SyncMaster, SLAVE/Slave) when parsing inputs.
  * Error messages for unknown roles now list the accepted formats for easier troubleshooting.
* **Tests**
  * Added coverage to verify deserialization of the new role aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->