### PR TITLE
Refactor GeneralHAService to use enum for HA service

### DIFF
--- a/rocketmq-store/src/ha.rs
+++ b/rocketmq-store/src/ha.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-mod auto_switch;
+pub(crate) mod auto_switch;
 pub(crate) mod default_ha_client;
 mod default_ha_connection;
 pub(crate) mod default_ha_service;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

Fixes #3738

### Brief Description
Refactors `GeneralHAService` to use an enum-based design for managing HA service variants, improving type safety and code maintainability.

## Brief changelog

- Replace `Option`-based fields with a single enum variant
- Simplify service type management using Rust's enum pattern matching
- Remove unnecessary error handling for impossible states
- Add dedicated constructors for each service type
- Improve code readability and maintainability


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - HA now operates in a single explicit mode chosen at startup (controller vs standard), with routing delegated to the active HA implementation.
  - Initialization simplified to pick and activate the appropriate HA mode during startup; HA init failures no longer block service startup.

- Impact
  - More predictable HA behavior and streamlined failover routing.
  - Improved startup resilience — service starts even if HA initialization encounters issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->