### PR TITLE
[ISSUE #3789]📝Enhance documentation for `WeakArcMut` and `ArcMut` structs with safety notes

### DIFF
--- a/rocketmq/src/arc_mut.rs
+++ b/rocketmq/src/arc_mut.rs
@@ -28,6 +28,11 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 use std::sync::Weak;
 
+/// A weak version of `ArcMut` that doesn't prevent the inner value from being dropped.
+///
+/// # Safety
+/// This type uses `SyncUnsafeCell` which is not thread-safe by default.
+/// You must ensure that no data races occur when using this type across threads.
 pub struct WeakArcMut<T: ?Sized> {
     inner: Weak<SyncUnsafeCell<T>>,
 }
@@ -71,6 +76,11 @@ impl<T: ?Sized> WeakArcMut<T> {
     }
 }
 
+/// A mutable reference-counted pointer with interior mutability.
+///
+/// # Safety
+/// This type uses `SyncUnsafeCell` which is not thread-safe by default.
+/// You must ensure that no data races occur when using this type across threads.
 #[derive(Default)]
 pub struct ArcMut<T: ?Sized> {
     inner: Arc<SyncUnsafeCell<T>>,
@@ -101,6 +111,11 @@ impl<T> ArcMut<T> {
         }
     }
 
+    /// Returns a mutable reference to the inner value
+    ///
+    /// # Safety
+    /// This is safe as long as no other mutable references exist
+    /// and the caller ensures proper synchronization.
     #[inline]
     #[allow(clippy::mut_from_ref)]
     pub fn mut_from_ref(&self) -> &mut T {


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3789

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
