### PR TITLE
[ISSUE #3794]✨Add fixed-rate and fixed-delay task scheduling methods to ScheduledTaskManager

### DIFF
--- a/rocketmq/src/schedule.rs
+++ b/rocketmq/src/schedule.rs
@@ -115,6 +115,92 @@ pub mod simple_scheduler {
             self.counter.fetch_add(1, Ordering::Relaxed)
         }
 
+        /// Adds a fixed-rate scheduled task to the task manager.
+        ///
+        /// # Arguments
+        /// * `initial_delay` - The delay before the first execution of the task.
+        /// * `period` - The interval between task executions.
+        /// * `task_fn` - A function that defines the task to be executed. It takes a
+        ///   `CancellationToken` as an argument and returns a `Future` that resolves to a
+        ///   `Result<()>`.
+        ///
+        /// # Returns
+        /// A `TaskId` representing the unique identifier of the scheduled task.
+        ///
+        /// # Notes
+        /// - Tasks are executed at fixed intervals, even if previous executions overlap.
+        pub fn add_fixed_rate_task<F, Fut>(
+            &self,
+            initial_delay: Duration,
+            period: Duration,
+            task_fn: F,
+        ) -> TaskId
+        where
+            F: FnMut(CancellationToken) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<()>> + Send + 'static,
+        {
+            self.add_scheduled_task(ScheduleMode::FixedRate, initial_delay, period, task_fn)
+        }
+
+        /// Adds a fixed-delay scheduled task to the task manager.
+        ///
+        /// # Arguments
+        /// * `initial_delay` - The delay before the first execution of the task.
+        /// * `period` - The interval between task executions.
+        /// * `task_fn` - A function that defines the task to be executed. It takes a
+        ///   `CancellationToken` as an argument and returns a `Future` that resolves to a
+        ///   `Result<()>`.
+        ///
+        /// # Returns
+        /// A `TaskId` representing the unique identifier of the scheduled task.
+        ///
+        /// # Notes
+        /// - Tasks are executed serially, with a delay after each task completes.
+        pub fn add_fixed_delay_task<F, Fut>(
+            &self,
+            initial_delay: Duration,
+            period: Duration,
+            task_fn: F,
+        ) -> TaskId
+        where
+            F: FnMut(CancellationToken) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<()>> + Send + 'static,
+        {
+            self.add_scheduled_task(ScheduleMode::FixedDelay, initial_delay, period, task_fn)
+        }
+
+        /// Adds a fixed-rate-no-overlap scheduled task to the task manager.
+        ///
+        /// # Arguments
+        /// * `initial_delay` - The delay before the first execution of the task.
+        /// * `period` - The interval between task executions.
+        /// * `task_fn` - A function that defines the task to be executed. It takes a
+        ///   `CancellationToken` as an argument and returns a `Future` that resolves to a
+        ///   `Result<()>`.
+        ///
+        /// # Returns
+        /// A `TaskId` representing the unique identifier of the scheduled task.
+        ///
+        /// # Notes
+        /// - Tasks are executed at fixed intervals, but overlapping executions are skipped.
+        pub fn add_fixed_rate_no_overlap_task<F, Fut>(
+            &self,
+            initial_delay: Duration,
+            period: Duration,
+            task_fn: F,
+        ) -> TaskId
+        where
+            F: FnMut(CancellationToken) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<()>> + Send + 'static,
+        {
+            self.add_scheduled_task(
+                ScheduleMode::FixedRateNoOverlap,
+                initial_delay,
+                period,
+                task_fn,
+            )
+        }
+
         /// Adds a scheduled task to the task manager.
         ///
         /// # Arguments


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3794

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added streamlined options to schedule recurring tasks by mode: fixed rate, fixed delay, and fixed rate without overlap.
  - Each mode supports configuring an initial delay and period, with tasks respecting cancellation.
  - “Fixed rate without overlap” ensures a new run won’t start if the previous one is still running.
  - Existing scheduling behavior remains unchanged; these options provide a more convenient, explicit way to set task timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->