### PR TITLE
[ISSUE #3802]♻️Refactor QueueTypeUtils to accept Option references directly for improved clarity and performance

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -302,7 +302,7 @@ where
                 .message_ext_inner
                 .message,
         );
-        if batch_uniq_id.is_some() && QueueTypeUtils::is_batch_cq(&Some(topic_config)) {
+        if batch_uniq_id.is_some() && QueueTypeUtils::is_batch_cq(Some(topic_config).as_ref()) {
             let sys_flag = batch_message
                 .message_ext_broker_inner
                 .message_ext_inner

--- a/rocketmq-broker/src/util/hook_utils.rs
+++ b/rocketmq-broker/src/util/hook_utils.rs
@@ -156,8 +156,9 @@ impl HookUtils {
         }
 
         if MessageSysFlag::check(msg.sys_flag(), MessageSysFlag::INNER_BATCH_FLAG) {
-            let topic_config = topic_config_table.lock().get(msg.topic()).cloned();
-            if !QueueTypeUtils::is_batch_cq(&topic_config) {
+            let topic_config_table_guard = topic_config_table.lock();
+            let topic_config = topic_config_table_guard.get(msg.topic());
+            if !QueueTypeUtils::is_batch_cq(topic_config) {
                 error!("[BUG]The message is an inner batch but cq type is not batch cq");
                 return Some(PutMessageResult::new_default(
                     PutMessageStatus::MessageIllegal,

--- a/rocketmq-common/src/utils/queue_type_utils.rs
+++ b/rocketmq-common/src/utils/queue_type_utils.rs
@@ -8,11 +8,11 @@ use crate::TopicAttributes::TopicAttributes;
 pub struct QueueTypeUtils;
 
 impl QueueTypeUtils {
-    pub fn is_batch_cq(topic_config: &Option<TopicConfig>) -> bool {
+    pub fn is_batch_cq(topic_config: Option<&TopicConfig>) -> bool {
         Self::get_cq_type(topic_config) == CQType::BatchCQ
     }
 
-    pub fn get_cq_type(topic_config: &Option<TopicConfig>) -> CQType {
+    pub fn get_cq_type(topic_config: Option<&TopicConfig>) -> CQType {
         match topic_config {
             Some(config) => {
                 let default_value = TopicAttributes::queue_type_attribute().default_value();
@@ -40,13 +40,13 @@ mod tests {
     #[test]
     fn test_is_batch_cq() {
         let topic_config = None;
-        assert_eq!(QueueTypeUtils::is_batch_cq(&topic_config), false);
+        assert_eq!(QueueTypeUtils::is_batch_cq(topic_config), false);
 
         let topic_config = Some(TopicConfig {
             attributes: HashMap::new(),
             ..TopicConfig::default()
         });
-        assert_eq!(QueueTypeUtils::is_batch_cq(&topic_config), false);
+        assert_eq!(QueueTypeUtils::is_batch_cq(topic_config.as_ref()), false);
 
         let topic_config = Some(TopicConfig {
             attributes: HashMap::from_iter([(
@@ -58,7 +58,7 @@ mod tests {
             )]),
             ..TopicConfig::default()
         });
-        assert_eq!(QueueTypeUtils::is_batch_cq(&topic_config), true);
+        assert_eq!(QueueTypeUtils::is_batch_cq(topic_config.as_ref()), true);
 
         let topic_config = Some(TopicConfig {
             attributes: HashMap::from_iter([(
@@ -70,19 +70,22 @@ mod tests {
             )]),
             ..TopicConfig::default()
         });
-        assert_eq!(QueueTypeUtils::is_batch_cq(&topic_config), false);
+        assert_eq!(QueueTypeUtils::is_batch_cq(topic_config.as_ref()), false);
     }
 
     #[test]
     fn test_get_cq_type() {
         let topic_config = None;
-        assert_eq!(QueueTypeUtils::get_cq_type(&topic_config), CQType::SimpleCQ);
+        assert_eq!(QueueTypeUtils::get_cq_type(topic_config), CQType::SimpleCQ);
 
         let topic_config = Some(TopicConfig {
             attributes: HashMap::new(),
             ..TopicConfig::default()
         });
-        assert_eq!(QueueTypeUtils::get_cq_type(&topic_config), CQType::SimpleCQ);
+        assert_eq!(
+            QueueTypeUtils::get_cq_type(topic_config.as_ref()),
+            CQType::SimpleCQ
+        );
 
         let topic_config = Some(TopicConfig {
             attributes: HashMap::from_iter([(
@@ -94,7 +97,10 @@ mod tests {
             )]),
             ..TopicConfig::default()
         });
-        assert_eq!(QueueTypeUtils::get_cq_type(&topic_config), CQType::BatchCQ);
+        assert_eq!(
+            QueueTypeUtils::get_cq_type(topic_config.as_ref()),
+            CQType::BatchCQ
+        );
 
         let topic_config = Some(TopicConfig {
             attributes: HashMap::from_iter([(
@@ -106,6 +112,9 @@ mod tests {
             )]),
             ..TopicConfig::default()
         });
-        assert_eq!(QueueTypeUtils::get_cq_type(&topic_config), CQType::SimpleCQ);
+        assert_eq!(
+            QueueTypeUtils::get_cq_type(topic_config.as_ref()),
+            CQType::SimpleCQ
+        );
     }
 }

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -155,8 +155,9 @@ pub fn get_cq_type(
     topic_config_table: &Arc<parking_lot::Mutex<HashMap<CheetahString, TopicConfig>>>,
     msg_inner: &MessageExtBrokerInner,
 ) -> CQType {
-    let option = topic_config_table.lock().get(msg_inner.topic()).cloned();
-    QueueTypeUtils::get_cq_type(&option)
+    let topic_config_table_guard = topic_config_table.lock();
+    let option = topic_config_table_guard.get(msg_inner.topic());
+    QueueTypeUtils::get_cq_type(option)
 }
 
 pub fn get_message_num(

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -770,7 +770,7 @@ impl MessageStore for LocalFileMessageStore {
 
         if MessageSysFlag::check(msg.sys_flag(), MessageSysFlag::INNER_BATCH_FLAG) {
             let topic_config = self.get_topic_config(msg.topic());
-            if !QueueTypeUtils::is_batch_cq(&topic_config) {
+            if !QueueTypeUtils::is_batch_cq(topic_config.as_ref()) {
                 error!("[BUG]The message is an inner batch but cq type is not batch cq");
                 return PutMessageResult::new_default(PutMessageStatus::MessageIllegal);
             }

--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -427,7 +427,7 @@ impl ConsumeQueueStoreTrait for ConsumeQueueStore {
         let consume_queue = topic_map.entry(queue_id).or_insert_with(|| {
             let message_store = self.inner.message_store.as_ref().unwrap();
             let option = message_store.get_topic_config(topic);
-            match QueueTypeUtils::get_cq_type(&option) {
+            match QueueTypeUtils::get_cq_type(option.as_ref()) {
                 CQType::SimpleCQ | CQType::RocksDBCQ => ArcMut::new(Box::new(ConsumeQueue::new(
                     topic.clone(),
                     queue_id,
@@ -633,7 +633,7 @@ impl ConsumeQueueStore {
             .as_ref()
             .unwrap()
             .get_topic_config(topic);
-        let act = QueueTypeUtils::get_cq_type(&topic_config);
+        let act = QueueTypeUtils::get_cq_type(topic_config.as_ref());
         if act != cq_type {
             panic!("The queue type of topic: {topic} should be {cq_type:?}, but is {act:?}",);
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3802

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Optimized configuration handling across message processing and storage, borrowing data instead of cloning to reduce allocations and improve efficiency.
  - Unified queue-type evaluation to use lightweight references, aligning all call sites for consistency.

- Tests
  - Updated tests to reflect the refined configuration passing approach.

- Chores
  - Minor internal cleanups to improve maintainability and performance without changing behavior.

No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->