### PR TITLE
[ISSUE #3808]📝Add configuration files for broker roles and settings

### DIFF
--- a/distribution/config/broker/2m-2s-async/broker-a-master.toml
+++ b/distribution/config/broker/2m-2s-async/broker-a-master.toml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ======================
+# Core Broker Settings
+# ======================
+brokerRole = "ASYNC_MASTER"             # enum BrokerRole: ASYNC_MASTER/AsyncMaster|SYNC_MASTER/SyncMaster|SLAVE/Slave
+flushDiskType = "ASYNC_FLUSH"
+deleteWhen = 4
+fileReservedTime = 72
+listenPort = 10911
+haListenPort = 10912
+storePathRootDir="/opt/rocketmq/store"
+haMasterAddress="127.0.0.1:10912"
+
+
+# ======================
+# Broker Identity
+# ======================
+[brokerIdentity]
+brokerName = "broker-mxsm-a"          # default_broker_name()
+brokerClusterName = "DefaultCluster-mxsm"
+brokerId = 0                           # MASTER_ID

--- a/distribution/config/broker/2m-2s-async/broker-a-slave.toml
+++ b/distribution/config/broker/2m-2s-async/broker-a-slave.toml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ======================
+# Core Broker Settings
+# ======================
+brokerRole = "SLAVE"             # enum BrokerRole: ASYNC_MASTER/AsyncMaster|SYNC_MASTER/SyncMaster|SLAVE/Slave
+flushDiskType = "ASYNC_FLUSH"
+deleteWhen = 4
+fileReservedTime = 72
+listenPort = 10911
+haListenPort = 10912
+storePathRootDir="/opt/rocketmq/store"
+haMasterAddress="127.0.0.1:10912"
+
+
+# ======================
+# Broker Identity
+# ======================
+[brokerIdentity]
+brokerName = "broker-mxsm-a"          # default_broker_name()
+brokerClusterName = "DefaultCluster-mxsm"
+brokerId = 1                          # MASTER_ID

--- a/distribution/config/broker/2m-2s-async/broker-b-master.toml
+++ b/distribution/config/broker/2m-2s-async/broker-b-master.toml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ======================
+# Core Broker Settings
+# ======================
+brokerRole = "ASYNC_MASTER"             # enum BrokerRole: ASYNC_MASTER/AsyncMaster|SYNC_MASTER/SyncMaster|SLAVE/Slave
+flushDiskType = "ASYNC_FLUSH"
+deleteWhen = 4
+fileReservedTime = 72
+listenPort = 10911
+haListenPort = 10912
+storePathRootDir="/opt/rocketmq/store"
+haMasterAddress="127.0.0.1:10912"
+
+
+# ======================
+# Broker Identity
+# ======================
+[brokerIdentity]
+brokerName = "broker-mxsm-b"          # default_broker_name()
+brokerClusterName = "DefaultCluster-mxsm"
+brokerId = 0                           # MASTER_ID

--- a/distribution/config/broker/2m-2s-async/broker-b-slave.toml
+++ b/distribution/config/broker/2m-2s-async/broker-b-slave.toml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ======================
+# Core Broker Settings
+# ======================
+brokerRole = "SLAVE"             # enum BrokerRole: ASYNC_MASTER/AsyncMaster|SYNC_MASTER/SyncMaster|SLAVE/Slave
+flushDiskType = "ASYNC_FLUSH"
+deleteWhen = 4
+fileReservedTime = 72
+listenPort = 10911
+haListenPort = 10912
+storePathRootDir="/opt/rocketmq/store"
+haMasterAddress="127.0.0.1:10912"
+
+
+# ======================
+# Broker Identity
+# ======================
+[brokerIdentity]
+brokerName = "broker-mxsm-b"          # default_broker_name()
+brokerClusterName = "DefaultCluster-mxsm"
+brokerId = 1                          # MASTER_ID


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3808

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ready-to-use configurations for a 2 masters, 2 slaves (async) broker cluster, covering both master and slave roles for two broker pairs.
  * Defaults include async flush, scheduled log deletion, 72-hour file retention, standard listen/HA ports, local store path, and predefined broker identities.
  * Helps users quickly bootstrap an asynchronous high-availability setup with consistent settings across brokers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->