### PR TITLE
[ISSUE #3815]♻️ Split MessageStore init from start and align BrokerRuntime initialization flow

### DIFF
--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -68,6 +68,9 @@ pub trait MessageStoreInner: Sync + 'static {
     /// Launch this message store.
     async fn start(&mut self) -> Result<(), StoreError>;
 
+    /// Initialize this message store.
+    async fn init(&mut self) -> Result<(), StoreError>;
+
     /// Shutdown this message store.
     async fn shutdown(&mut self);
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -647,23 +647,6 @@ impl MessageStore for LocalFileMessageStore {
     }
 
     async fn start(&mut self) -> Result<(), StoreError> {
-        if !self.message_store_config.enable_dleger_commit_log
-            && !self.message_store_config.duplication_enable
-        {
-            if let Some(ha_service) = self.ha_service.as_mut() {
-                ha_service
-                    .init(self.message_store_arc.clone().unwrap())
-                    .map_err(|e| {
-                        error!("HA service start failed: {:?}", e);
-                        StoreError::General(e.to_string())
-                    })?;
-            }
-        }
-
-        if self.is_transient_store_pool_enable() {
-            self.transient_store_pool.init();
-        }
-
         self.allocate_mapped_file_service.start();
 
         self.index_service.start();
@@ -693,6 +676,26 @@ impl MessageStore for LocalFileMessageStore {
         self.add_schedule_task();
         // self.perfs.start();
         self.shutdown.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    async fn init(&mut self) -> Result<(), StoreError> {
+        if !self.message_store_config.enable_dleger_commit_log
+            && !self.message_store_config.duplication_enable
+        {
+            if let Some(ha_service) = self.ha_service.as_mut() {
+                ha_service
+                    .init(self.message_store_arc.clone().unwrap())
+                    .map_err(|e| {
+                        error!("HA service start failed: {:?}", e);
+                        StoreError::General(e.to_string())
+                    })?;
+            }
+        }
+
+        if self.is_transient_store_pool_enable() {
+            self.transient_store_pool.init();
+        }
         Ok(())
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3815

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Startup now correctly detects and surfaces message store initialization failures, preventing partial or unstable launches.
  - Improved logging with clear success and warning messages during storage initialization.

- Refactor
  - Introduced a dedicated asynchronous initialization phase for storage components, separating init from start for more predictable lifecycle management.
  - Streamlined local file storage startup by moving one-time setup into the new initialization phase, improving reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->