### PR TITLE
[ISSUE #3818]♻️ Refactor MessageStore commit log getters to return refs and add mutable variants

### DIFF
--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -458,7 +458,13 @@ pub trait MessageStoreInner: Sync + 'static {
     fn get_system_clock(&self) -> Arc<SystemClock>;
 
     /// Get the commit log
-    fn get_commit_log(&self) -> Arc<CommitLog>;
+    fn get_commit_log(&self) -> &CommitLog;
+
+    /// Get mutable commit log
+    #[allow(clippy::mut_from_ref)]
+    fn get_commit_log_mut_from_ref(&self) -> &mut CommitLog;
+
+    fn get_commit_log_mut(&mut self) -> &mut CommitLog;
 
     /// Get running flags
     fn get_running_flags(&self) -> &RunningFlags;

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1710,8 +1710,16 @@ impl MessageStore for LocalFileMessageStore {
         todo!()
     }
 
-    fn get_commit_log(&self) -> Arc<CommitLog> {
-        todo!()
+    fn get_commit_log(&self) -> &CommitLog {
+        self.commit_log.as_ref()
+    }
+
+    fn get_commit_log_mut_from_ref(&self) -> &mut CommitLog {
+        self.commit_log.mut_from_ref()
+    }
+
+    fn get_commit_log_mut(&mut self) -> &mut CommitLog {
+        self.commit_log.as_mut()
     }
 
     fn get_running_flags(&self) -> &RunningFlags {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3818

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined message storage access to reduce overhead when interacting with commit logs, improving efficiency under load.
* **Performance**
  * Lower memory overhead and faster access paths for message persistence, resulting in smoother throughput.
* **Chores**
  * Internal API adjustments to support more efficient mutation patterns without altering end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->