### PR TITLE
refactor: return Option<&String>> on consumer_group

### DIFF
--- a/rocketmq-client/src/hook/filter_message_context.rs
+++ b/rocketmq-client/src/hook/filter_message_context.rs
@@ -45,8 +45,8 @@ impl<'a> FilterMessageContext<'a> {
         }
     }
 
-    pub fn consumer_group(&self) -> &Option<String> {
-        &self.consumer_group
+    pub fn consumer_group(&self) -> Option<&String> {
+        self.consumer_group.as_ref()
     }
 
     pub fn msg_list(&self) -> &'a [MessageExt] {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3821 

### Brief Description
Refactor consumer_group in FilterMessageContext to return Option<&String> instead of &Option<String>
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated an internal SDK accessor’s return type. This may require minor code adjustments for developers integrating with the client library, but there is no change to runtime behavior.
  * No user-facing functionality is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->