### PR TITLE
Add startup  logo

### DIFF
--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -35,7 +35,17 @@ use tracing::warn;
 async fn main() -> Result<()> {
     // Initialize the logger
     rocketmq_common::log::init_logger_with_level(rocketmq_common::log::Level::INFO);
+    let logo = r#"
+        _____            _        _     _    __  __     _    ____            _
+       |  __ \          | |      | |   | |  |  \/  |   | |  |  _ \          | |
+       | |__) |___   ___| | _____| |_  | |  | \  / | __| |  | |_) | ___  ___| |_
+       |  _  // _ \ / __| |/ / _ \ __| | |  | |\/| |/ _` |  |  _ < / _ \/ __| __|
+       | | \ \ (_) | (__|   <  __/ |_  | |__| |  | | (_| |  | |_) |  __/\__ \ |_
+       |_|  \_\___/ \___|_|\_\___|\__|  \____/|_|  |_|\__,_|  |____/ \___||___/\__|
 
+
+        "#;
+    info!("            {}", logo);
     EnvUtils::put_property(
         remoting_command::REMOTING_VERSION_KEY,
         (CURRENT_VERSION as u32).to_string(),


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3833

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Displays an ASCII art banner on startup in the server logs, providing a clear visual indicator when the NameServer boots.
- Style
  - Cosmetic enhancement to startup output; no functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->