### PR TITLE
[ISSUE #3827]♻️Consolidate server config: use BrokerConfig.broker_server_config across BrokerRuntime/Bootstrap

### DIFF
--- a/rocketmq-broker/src/broker_bootstrap.rs
+++ b/rocketmq-broker/src/broker_bootstrap.rs
@@ -17,7 +17,6 @@
 use std::sync::Arc;
 
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
-use rocketmq_common::common::server::config::ServerConfig;
 use rocketmq_rust::wait_for_signal;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
 use tracing::error;
@@ -63,7 +62,7 @@ async fn wait_for_signal_inner(shutdown_tx: tokio::sync::broadcast::Sender<()>) 
 pub struct Builder {
     broker_config: BrokerConfig,
     message_store_config: MessageStoreConfig,
-    server_config: ServerConfig,
+    //server_config: ServerConfig,
 }
 
 impl Builder {
@@ -72,7 +71,7 @@ impl Builder {
         Builder {
             broker_config: Default::default(),
             message_store_config: MessageStoreConfig::default(),
-            server_config: Default::default(),
+            //server_config: Default::default(),
         }
     }
     #[inline]
@@ -85,18 +84,18 @@ impl Builder {
         self.message_store_config = message_store_config;
         self
     }
-    #[inline]
+    /*    #[inline]
     pub fn set_server_config(mut self, server_config: ServerConfig) -> Self {
         self.server_config = server_config;
         self
-    }
+    }*/
     #[inline]
     pub fn build(self) -> BrokerBootstrap {
         BrokerBootstrap {
             broker_runtime: BrokerRuntime::new(
                 Arc::new(self.broker_config),
                 Arc::new(self.message_store_config),
-                Arc::new(self.server_config),
+                //Arc::new(self.server_config),
             ),
         }
     }

--- a/rocketmq-remoting/src/remoting_server/server.rs
+++ b/rocketmq-remoting/src/remoting_server/server.rs
@@ -439,16 +439,9 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> RocketMQServer<RP> {
         request_processor: RP,
         channel_event_listener: Option<Arc<dyn ChannelEventListener>>,
     ) {
-        let listener = TcpListener::bind(&format!(
-            "{}:{}",
-            self.config.bind_address, self.config.listen_port
-        ))
-        .await
-        .unwrap();
-        info!(
-            "Bind local address: {}",
-            format!("{}:{}", self.config.bind_address, self.config.listen_port)
-        );
+        let addr = format!("{}:{}", self.config.bind_address, self.config.listen_port);
+        let listener = TcpListener::bind(&addr).await.unwrap();
+        info!("Starting remoting_server at: {}", addr);
         let (notify_conn_disconnect, _) = broadcast::channel::<SocketAddr>(100);
         run(
             listener,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3827

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated server settings into the broker configuration; separate server configuration is no longer supported.
  - All ports and addresses now derive from the broker’s server configuration, including the fast server port (main port minus 2).
- Style
  - Improved startup logging to clearly display the remoting server address on launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->