### PR TITLE
[ISSUE #3829]⚡️Add brokerServerConfig section to broker-simple-slave.toml and move listenPort under it

### DIFF
--- a/distribution/config/broker/broker-simple-slave.toml
+++ b/distribution/config/broker/broker-simple-slave.toml
@@ -20,11 +20,13 @@ brokerRole = "ASYNC_MASTER"             # enum BrokerRole: ASYNC_MASTER/AsyncMas
 flushDiskType = "ASYNC_FLUSH"
 deleteWhen = 4
 fileReservedTime = 72
-listenPort = 10911
 haListenPort = 10912
 storePathRootDir = '/opt/rocketmq/store'
 haMasterAddress = "127.0.0.1:10912"  # For Slave to connect to Master
 
+[brokerServerConfig]
+listenPort = 10931
+bind_address = '127.0.0.1'
 
 # ======================
 # Broker Identity


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3829

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated broker configuration: the listen port is now 10931 and is configured under the broker server section.
  * Added a bind address option for the broker server (default: 127.0.0.1).
  * No other defaults changed.
  * Note: If you relied on the previous listen port or configuration path for overrides, update your settings to match the new section and values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->