### PR TITLE
[ISSUE #3839]♻️Refactor DefaultHAService initialization to accept GeneralHAService as a parameter

### DIFF
--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -48,10 +48,10 @@ impl GeneralHAService {
     }
 
     pub(crate) fn init(&mut self) -> HAResult<()> {
+        let ha_service = self.clone();
         match self {
             GeneralHAService::DefaultHAService(service) => {
-                let this = service.clone();
-                service.init(this)
+                DefaultHAService::init(service, ha_service)
             }
             GeneralHAService::AutoSwitchHAService(service) => {
                 unimplemented!("AutoSwitchHAService init is not implemented yet")


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3839

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined initialization of high availability (HA) services using dependency injection to reduce internal coupling and clarify ownership/mutability handling.
  * Consolidated service setup to reuse a shared HA service instance across components, improving consistency and maintainability.
  * Adjusted internal service wiring to provide safer handles to dependent services, enhancing stability under different broker roles.

* **Chores**
  * No user-facing behavior changes; internal improvements only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->