### PR TITLE
refactor: make ConsumeMessageDirectlyResult::remark return Option<&CheetahString>

### DIFF
--- a/rocketmq-remoting/src/protocol/body/consume_message_directly_result.rs
+++ b/rocketmq-remoting/src/protocol/body/consume_message_directly_result.rs
@@ -103,8 +103,8 @@ impl ConsumeMessageDirectlyResult {
     }
 
     #[inline]
-    pub fn remark(&self) -> &Option<CheetahString> {
-        &self.remark
+    pub fn remark(&self) -> Option<&CheetahString> {
+        self.remark.as_ref()
     }
 
     #[inline]
@@ -154,7 +154,7 @@ mod tests {
         assert!(result.order());
         assert!(!result.auto_commit());
         assert_eq!(result.consume_result().as_ref().unwrap(), &consume_result);
-        assert_eq!(result.remark().as_ref().unwrap(), &remark);
+        assert_eq!(result.remark(), Some(&remark));
         assert_eq!(result.spent_time_mills(), 12345);
     }
 
@@ -172,7 +172,7 @@ mod tests {
         assert!(result.order());
         assert!(!result.auto_commit());
         assert_eq!(result.consume_result().as_ref().unwrap(), &consume_result);
-        assert_eq!(result.remark().as_ref().unwrap(), &remark);
+        assert_eq!(result.remark(), Some(&remark));
         assert_eq!(result.spent_time_mills(), 67890);
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3822 

### Brief Description

Refactor ConsumeMessageDirectlyResult::remark to return Option<&CheetahString> and fix the corresponding tests.
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?
```cargo build --workspace``` 
```Run local tests in the file```
<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the remark accessor to return an optional reference directly, improving ergonomics and reducing the need for manual unwrapping. This may require minor adjustments in integrations using the previous signature.
* **Tests**
  * Updated tests to align with the streamlined API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->