### PR TITLE
#3826: Refactor Make is_compaction take Option<&TopicConfig> instead …

### DIFF
--- a/rocketmq-common/src/utils/cleanup_policy_utils.rs
+++ b/rocketmq-common/src/utils/cleanup_policy_utils.rs
@@ -22,7 +22,7 @@ use crate::common::attribute::Attribute;
 use crate::common::config::TopicConfig;
 use crate::TopicAttributes::TopicAttributes;
 
-pub fn is_compaction(topic_config: &Option<TopicConfig>) -> bool {
+pub fn is_compaction(topic_config: Option<&TopicConfig>) -> bool {
     match topic_config {
         Some(config) => CleanupPolicy::COMPACTION == get_delete_policy(Some(config)),
         None => false,
@@ -61,7 +61,7 @@ mod tests {
             TopicAttributes::cleanup_policy_attribute().name().into(),
             CleanupPolicy::COMPACTION.to_string().into(),
         );
-        assert_eq!(is_compaction(&Some(topic_config)), true);
+        assert_eq!(is_compaction(Some(&topic_config)), true);
     }
 
     #[test]
@@ -74,12 +74,12 @@ mod tests {
                 .into(),
             CleanupPolicy::DELETE.to_string().into(),
         );
-        assert_eq!(is_compaction(&Some(topic_config)), false);
+        assert_eq!(is_compaction(Some(&topic_config)), false);
     }
 
     #[test]
     fn is_compaction_returns_false_when_topic_config_is_none() {
-        assert_eq!(is_compaction(&None), false);
+        assert_eq!(is_compaction(None), false);
     }
 
     #[test]


### PR DESCRIPTION
…of &Option<TopicConfig>

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3826

### Brief Description

#3826: Refactor Make is_compaction take Option<&TopicConfig> instead of &Option<TopicConfig>

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
Updated unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.

- Refactor
  - Streamlined configuration handling for cleanup policy checks to use more ergonomic references. Behavior remains unchanged.

- Tests
  - Updated test cases to align with the refined API, with identical pass/fail outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->