### PR TITLE
Improve GroupRetryPolicy accessors to return Option<&T> instead of &Option<T>

### DIFF
--- a/rocketmq-remoting/src/protocol/subscription/group_retry_policy.rs
+++ b/rocketmq-remoting/src/protocol/subscription/group_retry_policy.rs
@@ -47,12 +47,12 @@ impl GroupRetryPolicy {
         self.type_
     }
 
-    pub fn exponential_retry_policy(&self) -> &Option<ExponentialRetryPolicy> {
-        &self.exponential_retry_policy
+    pub fn exponential_retry_policy(&self) -> Option<&ExponentialRetryPolicy> {
+        self.exponential_retry_policy.as_ref()
     }
 
-    pub fn customized_retry_policy(&self) -> &Option<CustomizedRetryPolicy> {
-        &self.customized_retry_policy
+    pub fn customized_retry_policy(&self) -> Option<&CustomizedRetryPolicy> {
+        self.customized_retry_policy.as_ref()
     }
 
     pub fn set_type_(&mut self, type_: GroupRetryPolicyType) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3820 

### Brief Description

#3820  Improve GroupRetryPolicy accessors to return Option<&T> instead of &Option<T>

### How Did You Test This Change?

cargo test --all-features --workspace

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated retry policy getters to return optional references for both exponential and customized strategies.
  - No changes to default runtime behavior; existing configurations continue to work.
  - Integrations relying on previous return types may require minor adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->