### PR TITLE
[ISSUE #3855]🐛HA GroupTransferService ack threshold and lock handling cause unnecessary timeouts

### DIFF
--- a/rocketmq-store/src/ha/group_transfer_service.rs
+++ b/rocketmq-store/src/ha/group_transfer_service.rs
@@ -119,6 +119,7 @@ impl GroupTransferServiceInner {
     async fn do_wait_transfer(&self) {
         let mut read_requests = self.requests_read.lock().await;
         if read_requests.is_empty() {
+            drop(read_requests);
             return;
         }
 
@@ -142,7 +143,8 @@ impl GroupTransferServiceInner {
                     );
                 }
                 index += 1;
-                if !all_ack_in_sync_state_set && request.get_ack_nums() <= 1 {
+                //handle only one slave ack, ackNums <= 2 means master + 1 slave
+                if !all_ack_in_sync_state_set && request.get_ack_nums() <= 2 {
                     transfer_ok =
                         self.ha_service.get_push_to_slave_max_offset() >= request.get_next_offset();
                     continue;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3855

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Optimized HA replication to release locks promptly when queues are empty, reducing contention and improving responsiveness.
  * Refined acknowledgment handling to correctly treat master + one replica confirmations in non-strict sync scenarios, improving throughput without sacrificing safety.

* **Bug Fixes**
  * Addressed potential stalls caused by holding a lock longer than necessary during transfer waits.

* **Chores**
  * Internal comments updated for clarity.

* **Compatibility**
  * No public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->