### PR TITLE
enhancement: remove sync_unsafe_cell feature from rocketmq-namesrv

### DIFF
--- a/rocketmq-namesrv/src/lib.rs
+++ b/rocketmq-namesrv/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(sync_unsafe_cell)]
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3859 

### Brief Description

Removed the feature flag ```sync_unsafe_cell``` from file rocketmq-namesrv/src/lib.rs
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Removed reliance on a nightly-only Rust feature, enabling builds on stable Rust toolchains.
  - Improves portability and simplifies local setup and CI pipelines.
  - No functional changes or API modifications; existing integrations continue to work as before.
  - Users may experience easier installation with standard stable Rust environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->