### PR TITLE
[ISSUE #3866]⚡️Update message handling in content_show.rs for improved clarity and type safety

### DIFF
--- a/rocketmq-cli/src/content_show.rs
+++ b/rocketmq-cli/src/content_show.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 use bytes::Buf;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_decoder;
+use rocketmq_common::common::message::MessageConst;
 use rocketmq_store::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use rocketmq_store::log_file::mapped_file::MappedFile;
 use tabled::Table;
@@ -28,7 +29,7 @@ use tabled::Tabled;
 
 pub fn print_content(from: Option<u32>, to: Option<u32>, path: Option<PathBuf>) {
     if path.is_none() {
-        println!("path is none");
+        eprintln!("File path is none");
         return;
     }
     let path_buf = path.unwrap().into_os_string();
@@ -77,7 +78,13 @@ pub fn print_content(from: Option<u32>, to: Option<u32>, path: Option<PathBuf>) 
             None => {}
             Some(value) => {
                 table.push(MessagePrint {
-                    message_id: value.msg_id.to_string(),
+                    message_id: value.msg_id,
+                    client_message_id: value
+                        .message
+                        .get_property(&CheetahString::from_static_str(
+                            MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+                        ))
+                        .unwrap_or(CheetahString::empty()),
                 });
             }
         }
@@ -87,5 +94,6 @@ pub fn print_content(from: Option<u32>, to: Option<u32>, path: Option<PathBuf>) 
 
 #[derive(Tabled)]
 struct MessagePrint {
-    message_id: String,
+    message_id: CheetahString,
+    client_message_id: CheetahString,
 }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3866

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display of the unique client message ID alongside the message ID in the output. If unavailable, it shows as empty without errors.

* **Bug Fixes**
  * Error message for missing file path now goes to standard error (stderr) instead of standard output (stdout) for better tooling compatibility and scripting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->