### PR TITLE
[ISSUE #3869]♻️Make SlaveSynchronize generic and optional; integrate safely into BrokerRuntime

### DIFF
--- a/rocketmq-broker/src/slave/slave_synchronize.rs
+++ b/rocketmq-broker/src/slave/slave_synchronize.rs
@@ -14,11 +14,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
 use tracing::error;
+use tracing::info;
 
-pub(crate) struct SlaveSynchronize;
+use crate::broker_runtime::BrokerRuntimeInner;
 
-impl SlaveSynchronize {
+pub(crate) struct SlaveSynchronize<MS: MessageStore> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+    master_addr: Option<String>,
+}
+
+impl<MS> SlaveSynchronize<MS>
+where
+    MS: MessageStore,
+{
+    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        Self {
+            broker_runtime_inner,
+            master_addr: None,
+        }
+    }
+
+    pub fn master_addr(&self) -> Option<&String> {
+        self.master_addr.as_ref()
+    }
+
+    pub fn set_master_addr(&mut self, addr: String) {
+        if let Some(current_addr) = &self.master_addr {
+            if current_addr == &addr {
+                return;
+            }
+        }
+        info!(
+            "Update master address from {} to {}",
+            self.master_addr.as_deref().unwrap_or("None"),
+            addr
+        );
+        self.master_addr = Some(addr);
+    }
+
     pub async fn sync_all(&self) {
         error!("SlaveSynchronize::sync_all is not implemented yet");
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3869

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes during startup and runtime by safely handling cases where slave synchronization isn’t initialized.
  * Improves reliability of periodic sync tasks under changing broker states.

* **New Features**
  * Logs master address changes for slave synchronization, improving operational visibility.

* **Refactor**
  * Modularizes slave synchronization to be optionally enabled and more adaptable to different storage backends, enhancing flexibility without affecting existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->