### PR TITLE
[ISSUE #3880]♻️Simplify DataVersion counter from Arc<AtomicI64> to AtomicI64 in remoting protocol

### DIFF
--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -297,7 +297,7 @@ impl Clone for DataVersion {
         DataVersion {
             state_version: self.state_version,
             timestamp: self.timestamp,
-            counter: AtomicI64::new(self.counter.load(Ordering::Relaxed)),
+            counter: AtomicI64::new(self.counter.load(Ordering::SeqCst)),
         }
     }
 }

--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -20,7 +20,6 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 use std::time::SystemTime;
 
 use cheetah_string::CheetahString;
@@ -255,7 +254,7 @@ impl SerializeType {
 pub struct DataVersion {
     state_version: i64,
     timestamp: i64,
-    counter: Arc<AtomicI64>,
+    counter: AtomicI64,
 }
 
 impl Serialize for DataVersion {
@@ -288,7 +287,7 @@ impl<'de> Deserialize<'de> for DataVersion {
         Ok(DataVersion {
             state_version: helper.state_version,
             timestamp: helper.timestamp,
-            counter: Arc::new(AtomicI64::new(helper.counter)),
+            counter: AtomicI64::new(helper.counter),
         })
     }
 }
@@ -298,7 +297,7 @@ impl Clone for DataVersion {
         DataVersion {
             state_version: self.state_version,
             timestamp: self.timestamp,
-            counter: self.counter.clone(),
+            counter: AtomicI64::new(self.counter.load(Ordering::Relaxed)),
         }
     }
 }
@@ -327,14 +326,14 @@ impl DataVersion {
         DataVersion {
             state_version: 0,
             timestamp,
-            counter: Arc::new(AtomicI64::new(0)),
+            counter: AtomicI64::new(0),
         }
     }
 
     pub fn assign_new_one(&mut self, data_version: &DataVersion) {
         self.timestamp = data_version.timestamp;
         self.state_version = data_version.state_version;
-        self.counter = Arc::new(AtomicI64::new(data_version.counter.load(Ordering::SeqCst)));
+        self.counter = AtomicI64::new(data_version.counter.load(Ordering::SeqCst));
     }
 
     pub fn get_state_version(&self) -> i64 {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3880

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified internal version counter handling to remove unnecessary indirection, lowering memory overhead and making cloning/initialization more efficient.
  - Serialization/deserialization streamlined to use the simpler counter representation without changing observable behavior.
- Chores
  - Minor internal cleanup; no changes to public APIs or external behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->