### PR TITLE
[ISSUE #3885]♻️Make RemotingCommand::body() ergonomic (Option<&Bytes>) and update call sites

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -267,11 +267,7 @@ where
             .set_properties(string_to_message_properties(
                 request_header.properties.as_ref(),
             ));
-        message_ext
-            .message_ext_inner
-            .message
-            .body
-            .clone_from(request.body());
+        message_ext.message_ext_inner.message.body = request.body().cloned();
         message_ext.message_ext_inner.born_timestamp = request_header.born_timestamp;
         message_ext.message_ext_inner.born_host = channel.remote_address();
         message_ext.message_ext_inner.store_host = self.store_host;
@@ -483,11 +479,7 @@ where
         ) {
             return Ok(Some(response));
         }
-        message_ext
-            .message_ext_inner
-            .message
-            .body
-            .clone_from(request.body());
+        message_ext.message_ext_inner.message.body = request.body().cloned();
         message_ext.message_ext_inner.message.flag = request_header.flag;
 
         let uniq_key = ori_props.get(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX);

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -437,7 +437,7 @@ impl DefaultRequestProcessor {
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<RegisterTopicRequestHeader>()?;
-        if let Some(ref body) = request.body() {
+        if let Some(body) = request.body() {
             let topic_route_data = TopicRouteData::decode(body).unwrap_or_default();
             if !topic_route_data.queue_datas.is_empty() {
                 self.name_server_runtime_inner

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -614,8 +614,8 @@ impl RemotingCommand {
     }
 
     #[inline]
-    pub fn body(&self) -> &Option<Bytes> {
-        &self.body
+    pub fn body(&self) -> Option<&Bytes> {
+        self.body.as_ref()
     }
 
     #[inline]

--- a/rocketmq-remoting/src/rpc/rpc_client_impl.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_impl.rs
@@ -102,7 +102,6 @@ impl RpcClientImpl {
                         response.decode_command_custom_header::<PullMessageResponseHeader>()?;
                     let body = response
                         .body()
-                        .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
                     let rpc_response =
                         RpcResponse::new(response.code(), Box::new(response_header), body);
@@ -138,7 +137,6 @@ impl RpcClientImpl {
                         response.decode_command_custom_header::<GetMinOffsetResponseHeader>()?;
                     let body = response
                         .body()
-                        .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
                     let rpc_response =
                         RpcResponse::new(response.code(), Box::new(response_header), body);
@@ -173,7 +171,6 @@ impl RpcClientImpl {
                         response.decode_command_custom_header::<GetMaxOffsetResponseHeader>()?;
                     let body = response
                         .body()
-                        .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
                     let rpc_response =
                         RpcResponse::new(response.code(), Box::new(response_header), body);
@@ -208,7 +205,6 @@ impl RpcClientImpl {
                         response.decode_command_custom_header::<SearchOffsetResponseHeader>()?;
                     let body = response
                         .body()
-                        .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
                     let rpc_response =
                         RpcResponse::new(response.code(), Box::new(response_header), body);
@@ -243,7 +239,6 @@ impl RpcClientImpl {
                         .decode_command_custom_header::<GetEarliestMsgStoretimeResponseHeader>()?;
                     let body = response
                         .body()
-                        .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
                     let rpc_response =
                         RpcResponse::new(response.code(), Box::new(response_header), body);
@@ -278,7 +273,6 @@ impl RpcClientImpl {
                         .decode_command_custom_header::<QueryConsumerOffsetResponseHeader>()?;
                     let body = response
                         .body()
-                        .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
                     let rpc_response =
                         RpcResponse::new(response.code(), Box::new(response_header), body);
@@ -317,7 +311,6 @@ impl RpcClientImpl {
                         .decode_command_custom_header::<UpdateConsumerOffsetResponseHeader>()?;
                     let body = response
                         .body()
-                        .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
                     let rpc_response =
                         RpcResponse::new(response.code(), Box::new(response_header), body);
@@ -350,7 +343,6 @@ impl RpcClientImpl {
                 ResponseCode::Success => {
                     let body = response
                         .body()
-                        .as_ref()
                         .map(|value| Box::new(value.clone()) as Box<dyn Any>);
                     let rpc_response = RpcResponse::new_option(response.code(), body);
                     Ok(rpc_response)


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3885

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined message body handling across messaging paths to reduce copying and improve memory efficiency.
  - Simplified response body processing in RPC flows for clearer and more consistent behavior.
  - Adjusted a command body accessor to return a more ergonomic optional reference, aligning usage across components.
  - Internal ownership updates in request processing to better reflect data flow.
  - No changes to user-facing behavior or configuration; existing operations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->