### PR TITLE
[ISSUE #3887]✨Add ConsumerOffsetSerializeWrapper protocol and export module

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -35,6 +35,7 @@ pub mod connection;
 pub mod consume_message_directly_result;
 pub mod consume_queue_data;
 pub mod consume_status;
+pub mod consumer_offset_serialize_wrapper;
 pub mod epoch_entry_cache;
 pub mod group_list;
 pub mod ha_client_runtime_info;

--- a/rocketmq-remoting/src/protocol/body/consumer_offset_serialize_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/consumer_offset_serialize_wrapper.rs
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::DataVersion;
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct ConsumerOffsetSerializeWrapper {
+    data_version: DataVersion,
+    // Pop mode offset table
+    offset_table: HashMap<CheetahString /* topic@group */, HashMap<i32 /* queue id */, i64>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn test_consumer_offset_serialize_wrapper_insert_and_retrieve() {
+        let mut wrapper = ConsumerOffsetSerializeWrapper::default();
+
+        let topic_group = CheetahString::from("test_topic@test_group");
+        let mut queue_offsets = HashMap::new();
+        queue_offsets.insert(0, 100i64);
+        queue_offsets.insert(1, 200i64);
+
+        wrapper
+            .offset_table
+            .insert(topic_group.clone(), queue_offsets);
+
+        assert_eq!(wrapper.offset_table.len(), 1);
+        assert!(wrapper.offset_table.contains_key(&topic_group));
+
+        let retrieved_offsets = wrapper.offset_table.get(&topic_group).unwrap();
+        assert_eq!(retrieved_offsets.get(&0), Some(&100i64));
+        assert_eq!(retrieved_offsets.get(&1), Some(&200i64));
+    }
+}

--- a/rocketmq-remoting/src/protocol/body/consumer_offset_serialize_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/consumer_offset_serialize_wrapper.rs
@@ -29,6 +29,29 @@ pub struct ConsumerOffsetSerializeWrapper {
     offset_table: HashMap<CheetahString /* topic@group */, HashMap<i32 /* queue id */, i64>>,
 }
 
+impl ConsumerOffsetSerializeWrapper {
+    /// Returns a reference to the data_version field.
+    pub fn data_version(&self) -> &DataVersion {
+        &self.data_version
+    }
+    /// Sets the data_version field.
+    pub fn set_data_version(&mut self, data_version: DataVersion) {
+        self.data_version = data_version;
+    }
+    /// Returns a reference to the offset_table field.
+    pub fn offset_table(&self) -> &HashMap<CheetahString, HashMap<i32, i64>> {
+        &self.offset_table
+    }
+    /// Returns a mutable reference to the offset_table field.
+    pub fn offset_table_mut(&mut self) -> &mut HashMap<CheetahString, HashMap<i32, i64>> {
+        &mut self.offset_table
+    }
+    /// Sets the offset_table field.
+    pub fn set_offset_table(&mut self, offset_table: HashMap<CheetahString, HashMap<i32, i64>>) {
+        self.offset_table = offset_table;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3887

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces consumer offset serialization support, enabling consistent persistence and retrieval of offsets across topics and queues.
- Tests
  - Adds unit tests validating offset mapping behavior, including per-queue insertions and lookups to ensure correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->