### PR TITLE
[ISSUE #3889]✨Normalize ConsumerOffsetSerializeWrapper JSON field casing and add accessors

### DIFF
--- a/rocketmq-remoting/src/protocol/body/consumer_offset_serialize_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/consumer_offset_serialize_wrapper.rs
@@ -23,6 +23,7 @@ use serde::Serialize;
 use crate::protocol::DataVersion;
 
 #[derive(Serialize, Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct ConsumerOffsetSerializeWrapper {
     data_version: DataVersion,
     // Pop mode offset table


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3889

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized JSON field naming for consumer offset payloads to camelCase, improving compatibility with common clients and tooling.
  * Fields now appear as dataVersion and offsetTable in serialized responses and accepted in requests, reducing parsing inconsistencies.
  * Integrations expecting snake_case may need minor updates to handle the new field casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->