### PR TITLE
[ISSUE #3891]✨Implement master→slave consumer offset sync and add BrokerOuterAPI.get_all_consumer_offset

### DIFF
--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -235,6 +235,16 @@ where
         }
         topics
     }
+
+    pub fn offset_table(
+        &self,
+    ) -> Arc<parking_lot::RwLock<HashMap<CheetahString, HashMap<i32, i64>>>> {
+        self.consumer_offset_wrapper.offset_table.clone()
+    }
+
+    pub fn data_version(&self) -> ArcMut<DataVersion> {
+        self.consumer_offset_wrapper.data_version.clone()
+    }
 }
 
 impl<MS> ConfigManager for ConsumerOffsetManager<MS>

--- a/rocketmq-remoting/src/protocol/body/consumer_offset_serialize_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/consumer_offset_serialize_wrapper.rs
@@ -40,8 +40,11 @@ impl ConsumerOffsetSerializeWrapper {
         self.data_version = data_version;
     }
     /// Returns a reference to the offset_table field.
-    pub fn offset_table(&self) -> &HashMap<CheetahString, HashMap<i32, i64>> {
+    pub fn offset_table_ref(&self) -> &HashMap<CheetahString, HashMap<i32, i64>> {
         &self.offset_table
+    }
+    pub fn offset_table(self) -> HashMap<CheetahString, HashMap<i32, i64>> {
+        self.offset_table
     }
     /// Returns a mutable reference to the offset_table field.
     pub fn offset_table_mut(&mut self) -> &mut HashMap<CheetahString, HashMap<i32, i64>> {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3891

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Slave nodes now automatically synchronize consumer offsets from the master, improving failover readiness and consistency.
  - Topic configuration synchronization is more robust, proceeding only when a valid, distinct master address is set.

- Bug Fixes
  - Prevents synchronization attempts when the master address is missing or equals the broker’s own address, reducing errors and noise.
  - Clearer success, warning, and error logs during synchronization to aid operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->