### PR TITLE
[ISSUE #3897]✨Implement master→slave subscription group sync and add BrokerOuterAPI.get_all_subscription_group_config⚡️

### DIFF
--- a/rocketmq-remoting/src/protocol/body/subscription_group_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/subscription_group_wrapper.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use serde::Deserialize;
 use serde::Serialize;
@@ -24,7 +25,7 @@ use crate::protocol::DataVersion;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionGroupWrapper {
-    pub subscription_group_table: DashMap<String, SubscriptionGroupConfig>,
+    pub subscription_group_table: DashMap<CheetahString, SubscriptionGroupConfig>,
 
     pub data_version: DataVersion,
 }
@@ -43,18 +44,18 @@ impl SubscriptionGroupWrapper {
         }
     }
 
-    pub fn get_subscription_group_table(&self) -> &DashMap<String, SubscriptionGroupConfig> {
+    pub fn get_subscription_group_table(&self) -> &DashMap<CheetahString, SubscriptionGroupConfig> {
         &self.subscription_group_table
     }
 
     pub fn set_subscription_group_table(
         &mut self,
-        table: DashMap<String, SubscriptionGroupConfig>,
+        table: DashMap<CheetahString, SubscriptionGroupConfig>,
     ) {
         self.subscription_group_table = table;
     }
 
-    pub fn get_data_version(&self) -> &DataVersion {
+    pub fn data_version(&self) -> &DataVersion {
         &self.data_version
     }
 
@@ -80,7 +81,7 @@ mod tests {
         let wrapper = SubscriptionGroupWrapper::new();
         wrapper
             .subscription_group_table
-            .insert("test_group".to_string(), SubscriptionGroupConfig::default());
+            .insert("test_group".into(), SubscriptionGroupConfig::default());
 
         let table = wrapper.get_subscription_group_table();
         assert_eq!(table.len(), 1);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3897

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Slave brokers now automatically synchronize subscription group configurations from the master, ensuring more consistent cluster behavior.
  - Synchronization performs incremental merging and persists updates without removing existing entries.
  - Added remote retrieval of all subscription group configurations, enabling faster recovery and setup.
  - Improved logging for successful updates, empty responses, and errors to aid operations.

- Style
  - Minor naming and accessor adjustments for clarity (no user-facing behavior changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->