### PR TITLE
[ISSUE #3900]🚀Add MessageRequestModeSerializeWrapper protocol and export module

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -42,6 +42,7 @@ pub mod ha_client_runtime_info;
 pub mod ha_connection_runtime_info;
 pub mod ha_runtime_info;
 pub mod kv_table;
+pub mod message_request_mode_serialize_wrapper;
 pub mod pop_process_queue_info;
 pub mod process_queue_info;
 pub mod producer_connection;

--- a/rocketmq-remoting/src/protocol/body/message_request_mode_serialize_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/message_request_mode_serialize_wrapper.rs
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+
+use crate::protocol::body::set_message_request_mode_request_body::SetMessageRequestModeRequestBody;
+
+pub type MessageRequestModeMap = HashMap<
+    CheetahString, /* Topic */
+    HashMap<CheetahString /* Group */, SetMessageRequestModeRequestBody>,
+>;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageRequestModeSerializeWrapper {
+    message_request_mode_map: MessageRequestModeMap,
+}
+
+impl MessageRequestModeSerializeWrapper {
+    pub fn new(message_request_mode_map: MessageRequestModeMap) -> Self {
+        Self {
+            message_request_mode_map,
+        }
+    }
+
+    pub fn message_request_mode_map(&self) -> &MessageRequestModeMap {
+        &self.message_request_mode_map
+    }
+
+    pub fn into_inner(self) -> MessageRequestModeMap {
+        self.message_request_mode_map
+    }
+
+    pub fn from_inner(message_request_mode_map: MessageRequestModeMap) -> Self {
+        Self {
+            message_request_mode_map,
+        }
+    }
+
+    pub fn set_message_request_mode_map(&mut self, map: MessageRequestModeMap) {
+        self.message_request_mode_map = map;
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::body::set_message_request_mode_request_body::SetMessageRequestModeRequestBody;
+
+    #[test]
+    fn default_creates_wrapper_with_empty_map() {
+        let wrapper = MessageRequestModeSerializeWrapper::default();
+        assert!(wrapper.message_request_mode_map().is_empty());
+    }
+
+    #[test]
+    fn new_creates_wrapper_with_provided_map() {
+        let mut map = MessageRequestModeMap::new();
+        let mut group_map = HashMap::new();
+        group_map.insert(
+            CheetahString::from("group1"),
+            SetMessageRequestModeRequestBody::default(),
+        );
+        map.insert(CheetahString::from("topic1"), group_map);
+
+        let wrapper = MessageRequestModeSerializeWrapper::new(map);
+        assert_eq!(wrapper.message_request_mode_map().len(), 1);
+        assert!(wrapper
+            .message_request_mode_map()
+            .contains_key(&CheetahString::from("topic1")));
+    }
+
+    #[test]
+    fn new_creates_wrapper_with_empty_map() {
+        let map = MessageRequestModeMap::new();
+        let wrapper = MessageRequestModeSerializeWrapper::new(map);
+        assert!(wrapper.message_request_mode_map().is_empty());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3900

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a serializable wrapper for message request mode mappings, enabling easier import/export of configuration and smoother integration with tooling. This expands the public API for managing request modes across topics and groups.

- Tests
  - Added unit tests validating default (empty) construction and initialization with provided mappings to ensure reliability of the new wrapper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->