### PR TITLE
[ISSUE #3909]🚀Feature flag mismatch: common enables rocketmq-error with serde_json, but error crate exposes with_serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,6 +2327,7 @@ name = "rocketmq-error"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "serde_json",
  "thiserror 2.0.16",
 ]
 

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -47,7 +47,6 @@ use rocketmq_error::ClientErr;
 use rocketmq_error::MQBrokerErr;
 use rocketmq_error::RocketMQResult;
 use rocketmq_error::RocketmqError;
-use rocketmq_error::RocketmqError::JsonError;
 use rocketmq_error::RocketmqError::MQClientBrokerError;
 use rocketmq_remoting::base::connection_net_event::ConnectionNetEvent;
 use rocketmq_remoting::clients::rocketmq_default_impl::RocketmqDefaultClient;
@@ -454,16 +453,8 @@ impl MQClientAPIImpl {
                     ResponseCode::Success => {
                         let body = result.take_body();
                         if let Some(body_inner) = body {
-                            let route_data = TopicRouteData::decode(body_inner.as_ref());
-                            if let Ok(data) = route_data {
-                                return Ok(Some(data));
-                            } else if let Err(error1) = route_data {
-                                error!(
-                                    "get Topic [{}] RouteInfoFromNameServer decode error: {}",
-                                    topic, error1
-                                );
-                                return Err(JsonError(error1.to_string()));
-                            }
+                            let route_data = TopicRouteData::decode(body_inner.as_ref())?;
+                            return Ok(Some(route_data));
                         }
                     }
                     ResponseCode::TopicNotExist => {

--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 rocketmq-rust = { workspace = true }
-rocketmq-error = { workspace = true }
+rocketmq-error = { workspace = true, features = ["serde_json"] }
 
 anyhow.workspace = true
 tokio.workspace = true

--- a/rocketmq-common/src/utils/serde_json_utils.rs
+++ b/rocketmq-common/src/utils/serde_json_utils.rs
@@ -22,56 +22,49 @@ impl SerdeJsonUtils {
     where
         T: serde::de::DeserializeOwned,
     {
-        serde_json::from_slice::<T>(bytes)
-            .map_err(|error| rocketmq_error::RocketmqError::JsonError(error.to_string()))
+        Ok(serde_json::from_slice::<T>(bytes)?)
     }
 
     pub fn from_json_str<T>(json: &str) -> rocketmq_error::RocketMQResult<T>
     where
         T: serde::de::DeserializeOwned,
     {
-        serde_json::from_str(json)
-            .map_err(|error| rocketmq_error::RocketmqError::JsonError(error.to_string()))
+        Ok(serde_json::from_str(json)?)
     }
 
     pub fn from_json_slice<T>(json: &[u8]) -> rocketmq_error::RocketMQResult<T>
     where
         T: serde::de::DeserializeOwned,
     {
-        serde_json::from_slice(json)
-            .map_err(|error| rocketmq_error::RocketmqError::JsonError(error.to_string()))
+        Ok(serde_json::from_slice(json)?)
     }
 
     pub fn to_json<T>(value: &T) -> rocketmq_error::RocketMQResult<String>
     where
         T: serde::Serialize,
     {
-        serde_json::to_string(value)
-            .map_err(|error| rocketmq_error::RocketmqError::JsonError(error.to_string()))
+        Ok(serde_json::to_string(value)?)
     }
 
     pub fn to_json_pretty<T>(value: &T) -> rocketmq_error::RocketMQResult<String>
     where
         T: serde::Serialize,
     {
-        serde_json::to_string_pretty(value)
-            .map_err(|error| rocketmq_error::RocketmqError::JsonError(error.to_string()))
+        Ok(serde_json::to_string_pretty(value)?)
     }
 
     pub fn to_json_vec<T>(value: &T) -> rocketmq_error::RocketMQResult<Vec<u8>>
     where
         T: serde::Serialize,
     {
-        serde_json::to_vec(value)
-            .map_err(|error| rocketmq_error::RocketmqError::JsonError(error.to_string()))
+        Ok(serde_json::to_vec(value)?)
     }
 
     pub fn to_json_vec_pretty<T>(value: &T) -> rocketmq_error::RocketMQResult<Vec<u8>>
     where
         T: serde::Serialize,
     {
-        serde_json::to_vec_pretty(value)
-            .map_err(|error| rocketmq_error::RocketmqError::JsonError(error.to_string()))
+        Ok(serde_json::to_vec_pretty(value)?)
     }
 }
 

--- a/rocketmq-error/Cargo.toml
+++ b/rocketmq-error/Cargo.toml
@@ -14,3 +14,8 @@ rust-version.workspace = true
 [dependencies]
 thiserror.workspace = true
 anyhow = { workspace = true }
+serde_json = { workspace = true, optional = true }
+
+[features]
+default = []
+with_serde = ["serde_json"] # alias for downstreams already using serde_json

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -124,8 +124,9 @@ pub enum RocketmqError {
     #[error("{0}")]
     IllegalArgumentError(String),
 
-    #[error("Serialization error: {0}")]
-    JsonError(String),
+    #[error("{0}")]
+    #[cfg(feature = "serde_json")]
+    SerdeJsonError(#[from] serde_json::Error),
 
     #[error("{0}")]
     UnsupportedOperationException(String),


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3909

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional JSON error support can be enabled via a feature flag, providing native integration with JSON serialization/deserialization errors.
- Bug Fixes
  - More accurate propagation of JSON decoding errors, improving clarity of error messages surfaced to users.
  - Reduced noisy/local logging for JSON decode failures, resulting in cleaner logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->