### PR TITLE
[ISSUE #3908]♻️Unify JSON error handling: replace JsonError with feature-gated SerdeJsonError and simplify conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,6 +2327,7 @@ name = "rocketmq-error"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "config",
  "serde_json",
  "thiserror 2.0.16",
 ]

--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 rocketmq-rust = { workspace = true }
-rocketmq-error = { workspace = true, features = ["serde_json"] }
+rocketmq-error = { workspace = true, features = ["with_serde", "with_config"] }
 
 anyhow.workspace = true
 tokio.workspace = true

--- a/rocketmq-common/src/utils/parse_config_file.rs
+++ b/rocketmq-common/src/utils/parse_config_file.rs
@@ -30,27 +30,9 @@ pub fn parse_config_file<'de, C>(config_file: PathBuf) -> crate::error::RocketMQ
 where
     C: Debug + Deserialize<'de>,
 {
-    let config_file = match Config::builder()
+    let cfg = Config::builder()
         .add_source(config::File::from(config_file.as_path()))
-        .build()
-    {
-        Ok(cfg) => match cfg.try_deserialize::<C>() {
-            Ok(value) => value,
-            Err(err) => {
-                error!(
-                    "Failed to load config file: {:?}, error: {:?}",
-                    config_file, err
-                );
-                return Err(CommonError::ConfigError(err));
-            }
-        },
-        Err(err) => {
-            error!(
-                "Failed to load config file: {:?}, error: {:?}",
-                config_file, err
-            );
-            return Err(CommonError::ConfigError(err));
-        }
-    };
+        .build()?;
+    let config_file = cfg.try_deserialize::<C>()?;
     Ok(config_file)
 }

--- a/rocketmq-error/Cargo.toml
+++ b/rocketmq-error/Cargo.toml
@@ -15,7 +15,9 @@ rust-version.workspace = true
 thiserror.workspace = true
 anyhow = { workspace = true }
 serde_json = { workspace = true, optional = true }
+config = { workspace = true, optional = true }
 
 [features]
 default = []
 with_serde = ["serde_json"] # alias for downstreams already using serde_json
+with_config = ["config"] # alias for downstreams already using config

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -42,6 +42,8 @@ mod tui_error;
 
 use std::io;
 
+use config::ConfigError;
+
 pub type RocketMQResult<T> = std::result::Result<T, RocketmqError>;
 
 pub type Result<T> = anyhow::Result<T>;
@@ -125,7 +127,7 @@ pub enum RocketmqError {
     IllegalArgumentError(String),
 
     #[error("{0}")]
-    #[cfg(feature = "serde_json")]
+    #[cfg(feature = "with_serde")]
     SerdeJsonError(#[from] serde_json::Error),
 
     #[error("{0}")]
@@ -146,8 +148,9 @@ pub enum RocketmqError {
     #[error("{0}")]
     TokioHandlerError(String),
 
-    #[error("{0}")]
-    ConfigError(String),
+    #[error("Config parse error: {0}")]
+    #[cfg(feature = "with_config")]
+    ConfigError(#[from] ConfigError),
 
     #[error("{0} command failed , {1}")]
     SubCommand(String, String),


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3908

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional config integration via a new with_config feature, enabling richer configuration error reporting.
- Refactor
  - Simplified configuration file parsing with idiomatic error propagation, reducing nested control flow and improving clarity.
  - Improved error messages for configuration parsing to be more descriptive.
- Chores
  - Standardized feature flags: migrated serde_json gating to with_serde and introduced with_config; dependency features updated accordingly.
  - Added optional config dependency behind a feature flag.
  - No changes to public function signatures; behavior remains consistent aside from feature-flag-driven error variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->