### PR TITLE
[ISSUE #3913]⚡️Expose GetAllSubscriptionGroupConfig via admin broker processor

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -189,6 +189,11 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .get_all_delay_offset(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::GetAllSubscriptionGroupConfig => {
+                self.offset_request_handler
+                    .get_all_subscription_group_config(channel, ctx, request_code, request)
+                    .await
+            }
             _ => Some(get_unknown_cmd_response(request_code)),
         }
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3913

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to retrieve all subscription group configurations via the admin interface.
  - Responses include the encoded configuration content for easy inspection and export.
  - When no configuration exists, the broker returns a clear system error to the client.
  - Enhanced observability: logs include the requesting client’s address when a configuration is missing, aiding troubleshooting and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->