### PR TITLE
[ISSUE #3922]🚀Add RejectRequestResponse type and default reject_request implementation in LocalRequestProcessor

### DIFF
--- a/rocketmq-remoting/src/runtime/processor.rs
+++ b/rocketmq-remoting/src/runtime/processor.rs
@@ -19,6 +19,8 @@ use crate::net::channel::Channel;
 use crate::protocol::remoting_command::RemotingCommand;
 use crate::runtime::connection_handler_context::ConnectionHandlerContext;
 
+pub type RejectRequestResponse = (bool, Option<RemotingCommand>);
+
 /// Trait for processing requests.
 #[trait_variant::make(RequestProcessor: Send )]
 pub trait LocalRequestProcessor {
@@ -29,4 +31,8 @@ pub trait LocalRequestProcessor {
         ctx: ConnectionHandlerContext,
         request: RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>>;
+
+    fn reject_request(&self) -> RejectRequestResponse {
+        (false, None)
+    }
 }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3922

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces standardized request rejection, allowing components to decline processing when appropriate.
  - Provides optional explanatory responses on rejection for clearer client feedback.
  - Improves consistency and predictability of request handling across the system, especially under load or unsupported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->