### PR TITLE
#3884: Refactor zone_name method to return an Option reference

### DIFF
--- a/rocketmq-remoting/src/protocol/route/route_data_view.rs
+++ b/rocketmq-remoting/src/protocol/route/route_data_view.rs
@@ -127,8 +127,8 @@ impl BrokerData {
     }
 
     #[inline]
-    pub fn zone_name(&self) -> &Option<CheetahString> {
-        &self.zone_name
+    pub fn zone_name(&self) -> Option<&CheetahString> {
+        self.zone_name.as_ref()
     }
 
     #[inline]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3884

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
#3884: Refactor zone_name method to return an Option reference

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified the public API for accessing a broker’s zone name to return an optional reference rather than a reference to an optional, reducing boilerplate and clarifying null handling.
  - This is a minor breaking change for integrators; update any usages that expected the old shape (e.g., pattern matches or direct dereferencing).
  - No change to stored data or runtime behavior; only call-site adjustments may be needed to resolve compile-time errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->