### PR TITLE
#3912: Refactor ConfigManager::encode method

### DIFF
--- a/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
+++ b/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
@@ -78,10 +78,6 @@ impl ConfigManager for ConsumerFilterManager {
         get_consumer_filter_path(self.message_store_config.store_path_root_dir.as_str())
     }
 
-    fn encode(&mut self) -> String {
-        todo!()
-    }
-
     fn encode_pretty(&self, pretty_format: bool) -> String {
         "".to_string()
     }

--- a/rocketmq-common/src/common/config_manager.rs
+++ b/rocketmq-common/src/common/config_manager.rs
@@ -144,7 +144,7 @@ pub trait ConfigManager {
     ///
     /// # Returns
     /// A `String` representing the encoded configuration in a compact format.
-    fn encode(&mut self) -> String {
+    fn encode(&self) -> String {
         self.encode_pretty(false)
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3912

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Refactor ConfigManager::encode method, removed unnecessary mut

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration encoding to be non-mutating, improving safety and consistency across components.
  * Aligned implementations with the new immutable encoding approach.

* **Chores**
  * Removed an unused encoding method tied to the previous mutable pattern.

* **Notes**
  * No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->