### PR TITLE
[ISSUE #3939]📚 Added Chinese and en documentation on best practices for Broker naming

### DIFF
--- a/rocketmq-doc/_data/navigation.yml
+++ b/rocketmq-doc/_data/navigation.yml
@@ -107,7 +107,9 @@ docs:
   #      - title: "Terms &amp; Privacy Policy"
   #        url: /terms/
   - title: Best practice
-
+    children:
+      - title: "Broker Naming"
+        url: /docs/broker-naming/
   - title: Contribution Guide
     children:
       - title: "Contribute Guide"

--- a/rocketmq-doc/_docs/07-01-broker-naming.md
+++ b/rocketmq-doc/_docs/07-01-broker-naming.md
@@ -1,0 +1,194 @@
+---
+title: "Understanding Broker Naming in RocketMQ-Rust"
+permalink: /docs/broker-naming/
+excerpt: "Understanding Broker Naming in RocketMQ-Rust"
+last_modified_at: 2025-09-05T21:43:05-04:00
+redirect_from:
+  - /theme-setup/
+toc: false
+classes: wide
+---
+
+In **RocketMQ-Rust**, the way you name Brokers is not just a matter of convenience—it forms the foundation for **cluster
+management, routing discovery, and high availability**. A well-structured naming convention is critical for operations,
+monitoring, and troubleshooting.
+
+This article explains the **hierarchical naming structure** RocketMQ-Rust uses for Brokers, how it influences
+Master–Slave roles, and best practices for production environments.
+
+------
+
+## 1. The Core Identifier: `brokerName`
+
+In RocketMQ-Rust, a Broker is identified by its **`brokerName`**, rather than by its IP address or port.
+
+### Recommended Format
+
+Although multiple formats are technically supported, the recommended structure is:
+
+```
+{brokerClusterName}-{brokerId}
+```
+
+Optionally, an `instanceId` may be included for additional differentiation:
+
+```
+{brokerClusterName}-{brokerId}-{instanceId}
+```
+
+### Field Definitions
+
+| Field               | Description                                | Example              |
+|---------------------|--------------------------------------------|----------------------|
+| `brokerClusterName` | Name of the cluster the Broker belongs to  | `RocketMQ-Cluster-A` |
+| `brokerId`          | Unique ID of the Broker within the cluster | `0`, `1`, `2`, `100` |
+| `instanceId`        | Optional instance marker (rarely used)     |                      |
+
+------
+
+## 2. The Role of `brokerId`
+
+The value of `brokerId` determines the **role** of the Broker within the cluster:
+
+| brokerId   | Role                 | Description                                                 |
+|------------|----------------------|-------------------------------------------------------------|
+| `0`        | **Master**           | Handles both reads and writes; multiple Masters are allowed |
+| `> 0`      | **Slave**            | Read-only, replicates data from a Master                    |
+| `> 100000` | **Dledger Follower** | Used in Raft-based Dledger mode                             |
+
+> 🔎 **Important:** All nodes under the same `brokerName` (Master + Slaves) must share that `brokerName`, while their *
+*roles are distinguished by `brokerId`**.
+
+### Example
+
+```properties
+# Master node
+brokerClusterName=DefaultCluster
+brokerName=broker-a
+brokerId=0
+
+# Slave node (replicating broker-a)
+brokerClusterName=DefaultCluster
+brokerName=broker-a
+brokerId=1
+```
+
+Here, `broker-a` is a master–slave group, where `brokerId=0` is the Master and `brokerId=1` is the Slave.
+
+------
+
+## 3. Configuring Brokers (`broker.conf`)
+
+A typical Broker configuration file (`broker.conf`) might look like this:
+
+```conf
+# Cluster name (multiple Brokers may share this cluster)
+brokerClusterName=rocketmq-cluster
+
+# Logical name of the Broker
+brokerName=broker-a
+
+# Role-defining ID (0 = Master, >0 = Slave)
+brokerId=0
+
+# Physical address of the Broker (usually auto-registered)
+# brokerIP1=192.168.0.1
+```
+
+When deploying multiple Brokers, adjust only `brokerName` and `brokerId`:
+
+| Node     | brokerName | brokerId | Role   |
+|----------|------------|----------|--------|
+| A-Master | broker-a   | 0        | Master |
+| A-Slave  | broker-a   | 1        | Slave  |
+| B-Master | broker-b   | 0        | Master |
+| B-Slave  | broker-b   | 1        | Slave  |
+
+This results in a **multi-master, multi-slave cluster**.
+
+------
+
+## 4. Best Practices for Naming
+
+To ensure stability and maintainability:
+
+- 🔤 **Use meaningful names**
+  Example: `broker-prod-01`, `broker-order`, `broker-log`
+- 🔢 **Reserve `brokerId=0` for Masters**
+  Slaves should use incremental IDs: `1, 2, …`
+- 🌐 **Avoid duplicate `brokerName`s across clusters**
+  Otherwise, routing conflicts may occur
+- 📁 **Use separate config files**
+  Each Broker should maintain its own `broker.conf`
+- 🧩 **Include environment or purpose in naming**
+  Example: `broker-a-prod`, `broker-a-test`
+
+------
+
+## 5. How to Check Broker Names
+
+You can verify Broker names in two common ways:
+
+### From logs
+
+```log
+The broker[broker-a, 192.168.0.1:10911] registered successfully.
+```
+
+### From CLI
+
+```bash
+mqadmin clusterList -n 127.0.0.1:9876
+```
+
+Example output:
+
+```
+Broker Name: broker-a
+    Addr: 192.168.0.1:10911 (brokerId: 0) -> MASTER
+    Addr: 192.168.0.2:10911 (brokerId: 1) -> SLAVE
+```
+
+------
+
+## 6. Broker Naming in Dledger Mode
+
+In **Dledger mode** (Raft-based high availability), naming rules differ slightly:
+
+- `brokerId=0` no longer strictly indicates Master.
+- All nodes in the same Dledger group share the same `brokerName` and `brokerId=0`.
+- Roles (Leader/Follower) are determined dynamically through the Raft election process.
+
+Example configuration:
+
+```conf
+brokerName=broker-a
+brokerId=0
+enableDLegerCommitLog=true
+dLegerGroup=broker-a
+dLegerPeers=n1-192.168.0.1:40911;n2-192.168.0.2:40911;n3-192.168.0.3:40911
+```
+
+Here, `brokerName` represents the Dledger group, and individual nodes are identified as `n1`, `n2`, `n3`, etc.
+
+------
+
+## 7. Key Takeaways
+
+| Key Point                             | Explanation                          |
+|---------------------------------------|--------------------------------------|
+| 🎯 `brokerName` + `brokerId`          | Together define a Broker’s identity  |
+| 🔄 `brokerId=0` = Master              | `>0` = Slave (traditional setup)     |
+| 🏗️ Use clear, descriptive names      | Simplifies ops and monitoring        |
+| 🌐 Keep `brokerName` unique           | Prevents routing conflicts           |
+| 📈 Supports multi-master, multi-slave | Improves throughput and availability |
+
+------
+
+## Conclusion
+
+Broker naming in RocketMQ-Rust is **not arbitrary**. It follows a **structured `brokerName-brokerId` scheme** that
+underpins replication, cluster routing, and failover mechanisms.
+
+By adopting a clear and consistent naming strategy, you set the stage for a more **resilient, scalable, and maintainable
+RocketMQ-Rust cluster**.

--- a/rocketmq-doc/_docs/zh/07-01-broker-naming.md
+++ b/rocketmq-doc/_docs/zh/07-01-broker-naming.md
@@ -1,0 +1,171 @@
+---
+title: "Understanding Broker Naming in RocketMQ-Rust"
+permalink: /docs/broker-naming/
+excerpt: "Understanding Broker Naming in RocketMQ-Rust"
+last_modified_at: 2025-09-05T21:43:05-04:00
+redirect_from:
+  - /theme-setup/
+toc: false
+classes: wide
+---
+
+在 Apache RocketMQ 中，**Broker 的命名方式**是集群管理、路由发现和高可用机制的基础。合理的命名对于运维、监控和故障排查至关重要。
+RocketMQ 的 Broker 命名遵循一套**分层结构**，主要由两个核心部分构成：
+
+---
+
+### ✅ 1. Broker 的完整标识：`brokerName`
+
+在 RocketMQ 中，真正用于标识一个 Broker 身份的是 **`brokerName`**，而不是 IP 或端口。
+
+#### 📌 `brokerName` 的命名规范（推荐格式）：
+
+```
+{brokerClusterName}-{brokerId}-{instanceId}
+```
+
+但实际上，最常见和推荐的格式是：
+
+```
+{brokerClusterName}-{brokerId}
+```
+
+#### 各部分含义：
+
+| 字段                  | 说明                | 示例                   |
+|---------------------|-------------------|----------------------|
+| `brokerClusterName` | Broker 所属的集群名称    | `RocketMQ-Cluster-A` |
+| `brokerId`          | Broker 在集群中的唯一 ID | `0`, `1`, `2`, `100` |
+| `instanceId`        | 可选，实例标识（一般不用）     |                      |
+
+---
+
+### ✅ 2.`brokerId` 的特殊含义
+
+`brokerId` 不只是一个编号，它决定了 Broker 的角色：
+
+| brokerId       | 角色                        | 说明                         |
+|----------------|---------------------------|----------------------------|
+| `0`            | **Master (主节点)**          | 负责读写，可有多个（多主）              |
+| `> 0` 且 `!= 0` | **Slave (从节点)**           | 只读，复制 Master 数据            |
+| `> 100000`     | **Dledger 模式下的 Follower** | 在基于 Raft 协议的 Dledger 架构中使用 |
+
+> 📝 注意：**同一个 `brokerName` 下的所有节点（Master + Slave）必须共享相同的 `brokerName`，但通过 `brokerId` 区分角色**。
+
+#### 示例：
+
+```properties
+# Master 节点
+brokerClusterName=DefaultCluster
+brokerName=broker-a
+brokerId=0
+
+# Slave 节点（复制 broker-a）
+brokerClusterName=DefaultCluster
+brokerName=broker-a
+brokerId=1
+```
+
+这表示：`broker-a` 是一个主从组，`brokerId=0` 是主，`brokerId=1` 是从。
+
+---
+
+### ✅ 3. 实际配置方式（`broker.conf` 文件）
+
+```conf
+# 集群名称（多个 Broker 可属于同一集群）
+brokerClusterName=rocketmq-cluster
+
+# 当前 Broker 的名称（逻辑名）
+brokerName=broker-a
+
+# 当前 Broker 的 ID（决定主从角色）
+brokerId=0
+
+# Broker 物理地址（自动注册，通常不需手动设置）
+# brokerIP1=192.168.0.1
+```
+
+部署多个 Broker 时，只需修改 `brokerName` 和 `brokerId`：
+
+| 节点       | brokerName | brokerId | 角色     |
+|----------|------------|----------|--------|
+| A-Master | broker-a   | 0        | Master |
+| A-Slave  | broker-a   | 1        | Slave  |
+| B-Master | broker-b   | 0        | Master |
+| B-Slave  | broker-b   | 1        | Slave  |
+
+> 这样就构成了一个 **多主多从** 的集群。
+
+---
+
+### ✅ 4. 命名最佳实践
+
+| 建议                            | 说明                                                      |
+|-------------------------------|---------------------------------------------------------|
+| 🔤 **使用有意义的 `brokerName`**    | 如 `broker-prod-01`, `broker-order`, `broker-log`，便于识别用途 |
+| 🔢 **`brokerId=0` 表示 Master** | 所有主节点都用 0，从节点用 1, 2, ...                                |
+| 🌐 **避免重复 `brokerName` 跨集群**  | 否则路由会混乱                                                 |
+| 📁 **配置文件分离**                 | 每个 Broker 使用独立的 `broker.conf`                           |
+| 🧩 **结合环境命名**                 | 如 `broker-a-prod`, `broker-a-test`                      |
+
+---
+
+### ✅ 5. 查看 Broker Name 的方式
+
+#### 1. 通过日志查看：
+
+```log
+The broker[broker-a, 192.168.0.1:10911] registered successfully.
+```
+
+#### 2. 通过命令行查看集群状态：
+
+```bash
+mqadmin clusterList -n 127.0.0.1:9876
+```
+
+输出示例：
+
+```
+Broker Name: broker-a
+    Addr: 192.168.0.1:10911 (brokerId: 0) -> MASTER
+    Addr: 192.168.0.2:10911 (brokerId: 1) -> SLAVE
+```
+
+---
+
+### ✅ 6. Dledger 模式下的命名差异
+
+在 Dledger 模式（基于 Raft 实现高可用）中：
+
+- 不再使用 `brokerId=0` 表示 Master
+- 多个节点使用相同的 `brokerName` 和 `brokerId=0`
+- 角色由 Dledger 协议动态选举（Leader/Follower）
+
+```conf
+brokerName=broker-a
+brokerId=0
+enableDLegerCommitLog=true
+dLegerGroup=broker-a
+dLegerPeers=n1-192.168.0.1:40911;n2-192.168.0.2:40911;n3-192.168.0.3:40911
+```
+
+> 此时 `brokerName` 代表一个 Dledger 组，节点通过 `n1`, `n2` 等标识。
+
+---
+
+### ✅ 总结：Broker 命名要点
+
+| 要点                               | 说明                 |
+|----------------------------------|--------------------|
+| 🎯 核心是 `brokerName` + `brokerId` | 共同构成 Broker 的逻辑身份  |
+| 🔄 `brokerId=0` 是 Master         | `>0` 是 Slave（传统主从） |
+| 🏗️ 命名应清晰、可读                     | 便于运维和监控            |
+| 🌐 集群内 `brokerName` 唯一           | 避免冲突               |
+| 📈 支持多主多从                        | 提升吞吐和可用性           |
+
+---
+
+✅ **结论**：RocketMQ 的 Broker 命名不是随意的，而是**基于 `brokerName-brokerId` 的结构化设计**
+，支撑了主从复制、集群路由、故障转移等核心功能。合理命名是构建稳定 RocketMQ 集群的第一步。


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3939

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Broker Naming” guide covering naming structure, roles (Master/Slave/DLedger), configuration examples, and best practices.
  * Provided methods to verify broker names via logs and CLI, with sample outputs.
  * Published both English and Chinese versions of the guide.
  * Updated the docs navigation to nest “Broker Naming” under the “Best practice” section for easier discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->