### PR TITLE
[ISSUE #3943]📚 Update permalink for Broker Naming documentation to Chinese version

### DIFF
--- a/rocketmq-doc/_docs/zh/07-01-broker-naming.md
+++ b/rocketmq-doc/_docs/zh/07-01-broker-naming.md
@@ -1,6 +1,6 @@
 ---
 title: "Understanding Broker Naming in RocketMQ-Rust"
-permalink: /docs/broker-naming/
+permalink: /zh/docs/broker-naming/
 excerpt: "Understanding Broker Naming in RocketMQ-Rust"
 last_modified_at: 2025-09-05T21:43:05-04:00
 redirect_from:


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3943

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Chinese “Broker Naming” documentation URL to use a locale-specific path (/zh/docs/broker-naming/), improving consistency and clarity for language-specific navigation.
  * Enhances discoverability of the Chinese content and aligns permalink structure with other localized pages.
  * Users accessing bookmarks or external links may need to update them to the new URL if redirects are not in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->