### PR TITLE
[ISSUE #3950]♻️Derive Default for MessageVersion and mark V1 as default

### DIFF
--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -429,16 +429,11 @@ pub trait MessageTrait: Any + Display + Debug {
 pub const MESSAGE_MAGIC_CODE_V1: i32 = -626843481;
 pub const MESSAGE_MAGIC_CODE_V2: i32 = -626843477;
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Default)]
 pub enum MessageVersion {
+    #[default]
     V1,
     V2,
-}
-
-impl Default for MessageVersion {
-    fn default() -> Self {
-        Self::V1
-    }
 }
 
 impl fmt::Display for MessageVersion {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3950

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized default behavior for message handling using language-level defaults, reducing custom logic while preserving existing behavior.
- Chores
  - Simplified internal implementation by replacing manual default logic with an auto-derived approach.
- Notes
  - Backward-compatible; no changes required for users.
  - No impact on runtime behavior or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->