### PR TITLE
[ISSUE #3952]🚀Implement BrokerPreOnlineService and integrate with BrokerRuntime lifecycle

### DIFF
--- a/rocketmq-broker/src/broker/broker_pre_online_service.rs
+++ b/rocketmq-broker/src/broker/broker_pre_online_service.rs
@@ -14,16 +14,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use tracing::warn;
+use rocketmq_error::RocketMQResult;
+use rocketmq_rust::task::service_task::ServiceContext;
+use rocketmq_rust::task::service_task::ServiceTask;
+use rocketmq_rust::task::ServiceManager;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
 
-pub struct BrokerPreOnlineService;
+use crate::broker_runtime::BrokerRuntimeInner;
 
-impl BrokerPreOnlineService {
-    pub fn start(&mut self) {
-        warn!("BrokerPreOnlineService started not implemented");
+pub struct BrokerPreOnlineService<MS: MessageStore> {
+    service_manager: ServiceManager<BrokerPreOnlineServiceInner<MS>>,
+}
+
+struct BrokerPreOnlineServiceInner<MS: MessageStore> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+}
+
+impl<MS> ServiceTask for BrokerPreOnlineServiceInner<MS>
+where
+    MS: MessageStore,
+{
+    fn get_service_name(&self) -> String {
+        "BrokerPreOnlineService".to_string()
     }
 
-    pub fn shutdown(&mut self) {
-        warn!("BrokerPreOnlineService shutdown not implemented");
+    async fn run(&self, context: &ServiceContext) {
+        while !context.is_stopped() {}
+    }
+}
+
+impl<MS> BrokerPreOnlineServiceInner<MS>
+where
+    MS: MessageStore,
+{
+    fn prepare_for_broker_online(&self) -> RocketMQResult<bool> {
+        unimplemented!()
+    }
+}
+
+impl<MS> BrokerPreOnlineService<MS>
+where
+    MS: MessageStore,
+{
+    pub async fn start(&mut self) {
+        self.service_manager.start().await.unwrap();
+    }
+
+    pub async fn shutdown(&mut self) {
+        self.service_manager.shutdown().await.unwrap();
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3952

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated broker pre-online handling to a managed, asynchronous service for smoother startup and shutdown.
  - Reorganized runtime to host the pre-online service internally and enable optional activation.
- Chores
  - Updated lifecycle APIs to async start/shutdown to improve non-blocking operations.
  - Added foundational hooks for future pre-online preparation steps to enhance readiness and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->