### PR TITLE
[ISSUE #3957]🚀BrokerConfig: add compatible_with_old_name_srv flag with default true

### DIFF
--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -362,6 +362,10 @@ mod defaults {
     pub fn transaction_op_batch_interval() -> u64 {
         3000
     }
+
+    pub fn compatible_with_old_name_srv() -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -754,6 +758,9 @@ pub struct BrokerConfig {
 
     #[serde(default = "defaults::transaction_op_batch_interval")]
     pub transaction_op_batch_interval: u64,
+
+    #[serde(default = "defaults::compatible_with_old_name_srv")]
+    pub compatible_with_old_name_srv: bool,
 }
 
 impl Default for BrokerConfig {
@@ -873,6 +880,7 @@ impl Default for BrokerConfig {
             transaction_check_interval: 30_000,
             transaction_check_max: 15,
             transaction_op_batch_interval: 3_000,
+            compatible_with_old_name_srv: true,
         }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3957

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control legacy NameServer compatibility.
  * The option is enabled by default, preserving existing behavior after upgrade.
  * Users can adjust this setting in their broker configuration to match their deployment needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->