### PR TITLE
[ISSUE #3961]🚀Add constructor for BrokerPreOnlineService and integrate with BrokerRuntime

### DIFF
--- a/rocketmq-broker/src/broker/broker_pre_online_service.rs
+++ b/rocketmq-broker/src/broker/broker_pre_online_service.rs
@@ -36,6 +36,16 @@ pub struct BrokerPreOnlineService<MS: MessageStore> {
     service_manager: ServiceManager<BrokerPreOnlineServiceInner<MS>>,
 }
 
+impl<MS: MessageStore> BrokerPreOnlineService<MS> {
+    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        let inner = BrokerPreOnlineServiceInner {
+            broker_runtime_inner,
+        };
+        let service_manager = ServiceManager::new(inner);
+        BrokerPreOnlineService { service_manager }
+    }
+}
+
 struct BrokerPreOnlineServiceInner<MS: MessageStore> {
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
 }

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -256,6 +256,7 @@ impl BrokerRuntime {
         inner.client_housekeeping_service =
             Some(Arc::new(ClientHousekeepingService::new(inner.clone())));
         inner.slave_synchronize = Some(SlaveSynchronize::new(inner.clone()));
+        inner.broker_pre_online_service = Some(BrokerPreOnlineService::new(inner.clone()));
         Self {
             inner,
             broker_runtime: Some(runtime),


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3961

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The broker’s pre-online service now initializes automatically during startup and shuts down cleanly with existing lifecycle flows, improving reliability and reducing manual steps for operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->