### PR TITLE
[ISSUE #3965]🚀Add ExchangeHAInfoRequestHeader to remoting protocol

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -28,6 +28,7 @@ pub mod delete_topic_request_header;
 pub mod elect_master_response_header;
 pub mod empty_header;
 pub mod end_transaction_request_header;
+pub mod exchange_ha_info_request_header;
 pub mod extra_info_util;
 pub mod get_all_topic_config_response_header;
 pub mod get_consume_stats_request_header;

--- a/rocketmq-remoting/src/protocol/header/exchange_ha_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/exchange_ha_info_request_header.rs
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodec)]
+#[serde(rename_all = "camelCase")]
+pub struct ExchangeHAInfoRequestHeader {
+    pub master_ha_address: Option<CheetahString>,
+    pub master_flush_offset: Option<i64>,
+    pub master_address: Option<CheetahString>,
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    fn create_cheetah_string(value: &str) -> Option<CheetahString> {
+        Some(CheetahString::from(value))
+    }
+
+    #[test]
+    fn serialize_with_all_fields_set() {
+        let header = ExchangeHAInfoRequestHeader {
+            master_ha_address: create_cheetah_string("127.0.0.1:10911"),
+            master_flush_offset: Some(1024),
+            master_address: create_cheetah_string("127.0.0.1"),
+        };
+
+        let serialized = serde_json::to_string(&header).unwrap();
+        assert!(serialized.contains("\"masterHaAddress\":\"127.0.0.1:10911\""));
+        assert!(serialized.contains("\"masterFlushOffset\":1024"));
+        assert!(serialized.contains("\"masterAddress\":\"127.0.0.1\""));
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3965

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for High Availability (HA) info exchange in the remoting protocol via a new request header, enabling clients and brokers to share master address and flush offset details for improved HA coordination.
* **Tests**
  * Introduced unit tests to validate correct JSON serialization (camelCase) of the new HA request header fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->