### PR TITLE
[ISSUE #3970]⚡️Broker pre-online HA handshake, HA metadata exchange, optional HA service, and remoting helper

### DIFF
--- a/rocketmq-store/src/ha.rs
+++ b/rocketmq-store/src/ha.rs
@@ -26,10 +26,10 @@ pub(crate) mod general_ha_service;
 mod group_transfer_service;
 pub(crate) mod ha_client;
 pub(crate) mod ha_connection;
-pub(crate) mod ha_connection_state;
-pub(crate) mod ha_connection_state_notification_request;
+pub mod ha_connection_state;
+pub mod ha_connection_state_notification_request;
 mod ha_connection_state_notification_service;
-pub(crate) mod ha_service;
+pub mod ha_service;
 pub(crate) mod wait_notify_object;
 
 /// Error types


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3970

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enables pre-online HA handshake, improving broker readiness in HA deployments.
  - Automatically starts slave services after successful HA synchronization.
  - Allows brokers to exchange HA metadata during startup for faster alignment.
  - Enhances handling of HA connection outcomes with clearer error reporting.

- Chores
  - Expands visibility of HA components to support the new HA flow without changing user-facing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->