### PR TITLE
Raft log : According to Rocketmq's Java version AdminBrokerProcessor#notifyMinBrokerIdChange implemented

### DIFF
--- a/rocketmq-broker/src/broker_controller.rs
+++ b/rocketmq-broker/src/broker_controller.rs
@@ -67,7 +67,7 @@ impl BrokerController {
     pub fn update_min_broker(
         &self,
         _min_broker_id: &Option<u64>,
-        _min_broket_addr: &Option<CheetahString>,
+        _min_broker_addr: &Option<CheetahString>,
         _offline_broker_addr: &Option<CheetahString>,
         _master_ha_addr: &Option<CheetahString>,
     ) {

--- a/rocketmq-broker/src/broker_controller.rs
+++ b/rocketmq-broker/src/broker_controller.rs
@@ -39,7 +39,7 @@ impl Error for BrokerControllerError {}
 
 type BrokerControllerResult<T> = Result<T, BrokerControllerError>;
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct BrokerController {
     broker_config: Option<BrokerConfig>,
 
@@ -56,7 +56,7 @@ impl BrokerController {
     }
 
     #[inline]
-    pub fn get_min_broker_in_group(&self) -> BrokerControllerResult<u64> {
+    pub fn get_current_broker_id(&self) -> BrokerControllerResult<u64> {
         if let Some(id) = &self.broker_config {
             Ok(id.broker_identity.broker_id)
         } else {
@@ -71,7 +71,14 @@ impl BrokerController {
         _offline_broker_addr: &Option<CheetahString>,
         _master_ha_addr: &Option<CheetahString>,
     ) {
-        // Missing update min broker implementation
-        todo!("");
+        // TODO(mx): implement min-broker state update/persist.
+        // Temporary no-op to avoid panics in production.
+        tracing::debug!(
+            ?_min_broker_id,
+            ?_min_broker_addr,
+            ?_offline_broker_addr,
+            ?_master_ha_addr,
+            "notifyMinBrokerIdChange received"
+        );
     }
 }

--- a/rocketmq-broker/src/broker_controller.rs
+++ b/rocketmq-broker/src/broker_controller.rs
@@ -71,6 +71,7 @@ impl BrokerController {
         _offline_broker_addr: &Option<CheetahString>,
         _master_ha_addr: &Option<CheetahString>,
     ) {
+        // Missing update min broker implementation
         todo!("");
     }
 }

--- a/rocketmq-broker/src/broker_controller.rs
+++ b/rocketmq-broker/src/broker_controller.rs
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::error::Error;
+use std::fmt;
+
+use cheetah_string::CheetahString;
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_store::config::message_store_config::MessageStoreConfig;
+
+#[derive(Debug)]
+pub enum BrokerControllerError {
+    MinBrokerIdNotExists,
+}
+
+impl fmt::Display for BrokerControllerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BrokerControllerError::MinBrokerIdNotExists => write!(f, "min broker id not exists"),
+        }
+    }
+}
+
+impl Error for BrokerControllerError {}
+
+type BrokerControllerResult<T> = Result<T, BrokerControllerError>;
+
+#[derive(Default, Clone)]
+pub struct BrokerController {
+    broker_config: Option<BrokerConfig>,
+
+    message_store_config: Option<MessageStoreConfig>,
+}
+
+impl BrokerController {
+    #[inline]
+    pub fn new(broker_config: BrokerConfig, message_store_config: MessageStoreConfig) -> Self {
+        Self {
+            broker_config: Some(broker_config),
+            message_store_config: Some(message_store_config),
+        }
+    }
+
+    #[inline]
+    pub fn get_min_broker_in_group(&self) -> BrokerControllerResult<u64> {
+        if let Some(id) = &self.broker_config {
+            Ok(id.broker_identity.broker_id)
+        } else {
+            Err(BrokerControllerError::MinBrokerIdNotExists)
+        }
+    }
+
+    pub fn update_min_broker(
+        &self,
+        _min_broker_id: &Option<u64>,
+        _min_broket_addr: &Option<CheetahString>,
+        _offline_broker_addr: &Option<CheetahString>,
+        _master_ha_addr: &Option<CheetahString>,
+    ) {
+        todo!("");
+    }
+}

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -59,6 +59,7 @@ use tracing::warn;
 
 use crate::broker::broker_hook::BrokerShutdownHook;
 use crate::broker::broker_pre_online_service::BrokerPreOnlineService;
+use crate::broker_controller::BrokerController;
 use crate::client::client_housekeeping_service::ClientHousekeepingService;
 use crate::client::consumer_ids_change_listener::ConsumerIdsChangeListener;
 use crate::client::default_consumer_ids_change_listener::DefaultConsumerIdsChangeListener;
@@ -91,6 +92,7 @@ use crate::processor::consumer_manage_processor::ConsumerManageProcessor;
 use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
 use crate::processor::end_transaction_processor::EndTransactionProcessor;
 use crate::processor::notification_processor::NotificationProcessor;
+use crate::processor::notify_min_broker_change_id_processor::NotifyMinBrokerChangeIdProcessor;
 use crate::processor::pop_inflight_message_counter::PopInflightMessageCounter;
 use crate::processor::pop_message_processor::PopMessageProcessor;
 use crate::processor::pull_message_processor::PullMessageProcessor;
@@ -123,6 +125,7 @@ pub(crate) struct BrokerRuntime {
     // receiver for shutdown signal
     pub(crate) shutdown_rx: Option<tokio::sync::broadcast::Receiver<()>>,
     scheduled_task_manager: ScheduledTaskManager,
+    broker_controller: BrokerController,
 }
 
 impl BrokerRuntime {
@@ -252,6 +255,7 @@ impl BrokerRuntime {
             broker_pre_online_service: BrokerPreOnlineService,
             shutdown_rx: None,
             scheduled_task_manager: Default::default(),
+            broker_controller: Default::default(),
         }
     }
 
@@ -519,6 +523,7 @@ impl BrokerRuntime {
         if result {
             self.initialize_remoting_server();
             self.initialize_resources();
+            self.register_processor();
             self.initialize_scheduled_tasks().await;
             self.initial_transaction().await;
             self.initial_acl();
@@ -551,6 +556,15 @@ impl BrokerRuntime {
 
     fn initialize_resources(&mut self) {
         self.inner.topic_queue_mapping_clean_service = Some(TopicQueueMappingCleanService);
+    }
+
+    fn register_processor(&mut self) {
+        // build broker controller
+        let broker_controller = BrokerController::new(
+            self.broker_config().clone(),
+            self.message_store_config().clone(),
+        );
+        self.broker_controller = broker_controller;
     }
 
     fn init_processor(
@@ -611,6 +625,9 @@ impl BrokerRuntime {
         self.inner.ack_message_processor = Some(ack_message_processor.clone());
 
         let notification_processor = NotificationProcessor::new(self.inner.clone());
+
+        let broker_controller = self.broker_controller.clone();
+
         self.inner.notification_processor = Some(notification_processor.clone());
         BrokerRequestProcessor {
             send_message_processor: ArcMut::new(send_message_processor),
@@ -640,7 +657,10 @@ impl BrokerRuntime {
                     .clone(),
                 self.inner.clone(),
             )),
-            notify_min_broker_id_processor: Default::default(),
+
+            notify_min_broker_id_processor: ArcMut::new(NotifyMinBrokerChangeIdProcessor::new(
+                broker_controller,
+            )),
         }
     }
 

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -640,6 +640,7 @@ impl BrokerRuntime {
                     .clone(),
                 self.inner.clone(),
             )),
+            notify_min_broker_id_processor: Default::default(),
         }
     }
 

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -125,7 +125,7 @@ pub(crate) struct BrokerRuntime {
     // receiver for shutdown signal
     pub(crate) shutdown_rx: Option<tokio::sync::broadcast::Receiver<()>>,
     scheduled_task_manager: ScheduledTaskManager,
-    broker_controller: BrokerController,
+    broker_controller: Option<BrokerController>,
 }
 
 impl BrokerRuntime {
@@ -255,7 +255,7 @@ impl BrokerRuntime {
             broker_pre_online_service: BrokerPreOnlineService,
             shutdown_rx: None,
             scheduled_task_manager: Default::default(),
-            broker_controller: Default::default(),
+            broker_controller: None,
         }
     }
 
@@ -564,7 +564,7 @@ impl BrokerRuntime {
             self.broker_config().clone(),
             self.message_store_config().clone(),
         );
-        self.broker_controller = broker_controller;
+        self.broker_controller = Some(broker_controller);
     }
 
     fn init_processor(

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -27,6 +27,7 @@ pub mod command;
 
 pub(crate) mod broker;
 pub(crate) mod broker_bootstrap;
+pub(crate) mod broker_controller;
 pub(crate) mod broker_path_config_helper;
 pub(crate) mod broker_runtime;
 pub(crate) mod client;

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -30,6 +30,7 @@ use crate::processor::change_invisible_time_processor::ChangeInvisibleTimeProces
 use crate::processor::consumer_manage_processor::ConsumerManageProcessor;
 use crate::processor::end_transaction_processor::EndTransactionProcessor;
 use crate::processor::notification_processor::NotificationProcessor;
+use crate::processor::notify_min_broker_change_id_processor::NotifyMinBrokerChangeIdProcessor;
 use crate::processor::peek_message_processor::PeekMessageProcessor;
 use crate::processor::polling_info_processor::PollingInfoProcessor;
 use crate::processor::pop_message_processor::PopMessageProcessor;
@@ -48,6 +49,7 @@ pub(crate) mod consumer_manage_processor;
 pub(crate) mod default_pull_message_result_handler;
 pub(crate) mod end_transaction_processor;
 pub(crate) mod notification_processor;
+pub(crate) mod notify_min_broker_change_id_processor;
 pub(crate) mod peek_message_processor;
 pub(crate) mod polling_info_processor;
 pub(crate) mod pop_inflight_message_counter;
@@ -76,6 +78,7 @@ pub struct BrokerRequestProcessor<MS: MessageStore, TS> {
     pub(crate) query_assignment_processor: ArcMut<QueryAssignmentProcessor<MS>>,
     pub(crate) end_transaction_processor: ArcMut<EndTransactionProcessor<TS, MS>>,
     pub(crate) admin_broker_processor: ArcMut<AdminBrokerProcessor<MS>>,
+    pub(crate) notify_min_broker_id_processor: ArcMut<NotifyMinBrokerChangeIdProcessor>,
 }
 impl<MS: MessageStore, TS> Clone for BrokerRequestProcessor<MS, TS> {
     fn clone(&self) -> Self {
@@ -95,6 +98,7 @@ impl<MS: MessageStore, TS> Clone for BrokerRequestProcessor<MS, TS> {
             query_assignment_processor: self.query_assignment_processor.clone(),
             query_message_processor: self.query_message_processor.clone(),
             end_transaction_processor: self.end_transaction_processor.clone(),
+            notify_min_broker_id_processor: self.notify_min_broker_id_processor.clone(),
         }
     }
 }
@@ -191,6 +195,12 @@ where
                 .map_err(Into::into);*/
                 return self
                     .pop_message_processor
+                    .process_request(channel, ctx, request)
+                    .await;
+            }
+            RequestCode::NotifyMinBrokerIdChange => {
+                return self
+                    .notify_min_broker_id_processor
                     .process_request(channel, ctx, request)
                     .await;
             }

--- a/rocketmq-broker/src/processor/notify_min_broker_change_id_processor.rs
+++ b/rocketmq-broker/src/processor/notify_min_broker_change_id_processor.rs
@@ -60,10 +60,10 @@ impl NotifyMinBrokerChangeIdProcessor {
         }
 
         self.broker_controller.update_min_broker(
-            &change_header.min_broker_id,
-            &change_header.min_broker_addr,
-            &change_header.offline_broker_addr,
-            &change_header.ha_broker_addr,
+            &change_header.get_min_broker_id(),
+            &change_header.get_broker_name(),
+            &change_header.get_offline_broker_addr(),
+            &change_header.get_ha_broker_addr(),
         );
 
         let mut response = RemotingCommand::default();

--- a/rocketmq-broker/src/processor/notify_min_broker_change_id_processor.rs
+++ b/rocketmq-broker/src/processor/notify_min_broker_change_id_processor.rs
@@ -1,0 +1,16 @@
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+#[derive(Default)]
+pub struct NotifyMinBrokerChangeIdProcessor {}
+
+impl NotifyMinBrokerChangeIdProcessor {
+    pub async fn process_request(
+        &mut self,
+        _channel: Channel,
+        ctx: ConnectionHandlerContext,
+        mut request: RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        unimplemented!("CheckClientConfig")
+    }
+}

--- a/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_machine_room_nearby.rs
+++ b/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_machine_room_nearby.rs
@@ -352,10 +352,10 @@ mod tests {
     fn test_run_10_random_case() {
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
         for _ in 0..10 {
-            let consumer_size = rng.gen_range(1..=200);
-            let queue_size = rng.gen_range(1..=100);
-            let broker_idc_size = rng.gen_range(1..=10);
-            let consumer_idc_size = rng.gen_range(1..=10);
+            let consumer_size = rng.random_range(1..=200);
+            let queue_size = rng.random_range(1..=100);
+            let broker_idc_size = rng.random_range(1..=10);
+            let consumer_idc_size = rng.random_range(1..=10);
 
             if broker_idc_size == consumer_idc_size {
                 test_when_idc_size_equals(broker_idc_size, queue_size, consumer_size);

--- a/rocketmq-remoting/src/protocol/body/request/register_broker_body.rs
+++ b/rocketmq-remoting/src/protocol/body/request/register_broker_body.rs
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+use std::io::prelude::*;
+
+use bytes::Buf;
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use cheetah_string::CheetahString;
+use flate2::read::DeflateDecoder;
+use flate2::write::DeflateEncoder;
+use flate2::Compression;
+use rocketmq_common::common::config::TopicConfig;
+use rocketmq_common::common::mq_version::RocketMqVersion;
+use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
+use crate::protocol::static_topic::topic_queue_info::TopicQueueMappingInfo;
+use crate::protocol::DataVersion;
+use crate::protocol::RemotingDeserializable;
+use crate::protocol::RemotingSerializable;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct RegisterBrokerBody {
+    #[serde(rename = "topicConfigSerializeWrapper")]
+    pub topic_config_serialize_wrapper: TopicConfigAndMappingSerializeWrapper,
+    #[serde(rename = "filterServerList")]
+    pub filter_server_list: Vec<CheetahString>,
+}
+
+impl RegisterBrokerBody {
+    pub fn new(
+        topic_config_serialize_wrapper: TopicConfigAndMappingSerializeWrapper,
+        filter_server_list: Vec<CheetahString>,
+    ) -> Self {
+        RegisterBrokerBody {
+            topic_config_serialize_wrapper,
+            filter_server_list,
+        }
+    }
+
+    pub fn topic_config_serialize_wrapper(&self) -> &TopicConfigAndMappingSerializeWrapper {
+        &self.topic_config_serialize_wrapper
+    }
+
+    pub fn filter_server_list(&self) -> &Vec<CheetahString> {
+        &self.filter_server_list
+    }
+
+    pub fn encode(&self, compress: bool) -> Vec<u8> {
+        if !compress {
+            return <Self as RemotingSerializable>::encode(self)
+                .expect("Encode RegisterBrokerBody failed");
+        }
+        let mut bytes_mut = BytesMut::new();
+        {
+            let buffer = self
+                .topic_config_serialize_wrapper
+                .mapping_data_version
+                .encode()
+                .expect("Encode DataVersion failed");
+            let topic_config_table = self
+                .topic_config_serialize_wrapper
+                .topic_config_serialize_wrapper
+                .topic_config_table
+                .clone();
+
+            bytes_mut.put_i32(buffer.len() as i32);
+            bytes_mut.put(buffer.as_ref());
+            let topic_number = topic_config_table.len();
+            bytes_mut.put_i32(topic_number as i32);
+            for (_topic, topic_config) in topic_config_table {
+                let topic_config_bytes = topic_config.encode();
+                bytes_mut.put_i32(topic_config_bytes.len() as i32);
+                bytes_mut.put(topic_config_bytes.as_bytes());
+            }
+            let buffer = SerdeJsonUtils::to_json(&self.filter_server_list).unwrap();
+            bytes_mut.put_i32(buffer.len() as i32);
+            bytes_mut.put(buffer.as_bytes());
+            let topic_queue_mapping_info_map = self
+                .topic_config_serialize_wrapper
+                .topic_queue_mapping_info_map
+                .clone();
+            bytes_mut.put_i32(topic_queue_mapping_info_map.len() as i32);
+            for (_, queue_mapping) in topic_queue_mapping_info_map {
+                let queue_mapping_bytes =
+                    queue_mapping.encode().expect("Encode queue mapping failed");
+                bytes_mut.put_i32(queue_mapping_bytes.len() as i32);
+                bytes_mut.put(queue_mapping_bytes.as_slice());
+            }
+        }
+        let bytes = bytes_mut.freeze();
+
+        let mut encoder = DeflateEncoder::new(Vec::new(), Compression::best());
+        encoder.write_all(bytes.as_ref()).unwrap();
+        encoder.finish().unwrap()
+    }
+}
+
+impl RegisterBrokerBody {
+    pub fn decode(
+        bytes: &Bytes,
+        compressed: bool,
+        broker_version: RocketMqVersion,
+    ) -> RegisterBrokerBody {
+        if !compressed {
+            return SerdeJsonUtils::decode::<RegisterBrokerBody>(bytes.iter().as_slice()).unwrap();
+        }
+        let mut decoder = DeflateDecoder::new(bytes.as_ref());
+        let mut vec = Vec::new();
+        let result = decoder.read_to_end(&mut vec);
+        let mut register_broker_body = RegisterBrokerBody::default();
+        if result.is_err() {
+            return register_broker_body;
+        }
+        let mut bytes = Bytes::from(vec);
+        let data_version_length = bytes.get_i32();
+        let data_version_bytes = bytes.copy_to_bytes(data_version_length as usize);
+        let data_version = DataVersion::decode(data_version_bytes.as_ref()).unwrap();
+        register_broker_body
+            .topic_config_serialize_wrapper
+            .mapping_data_version = data_version;
+
+        let topic_config_number = bytes.get_i32();
+        for _ in 0..topic_config_number {
+            let topic_config_length = bytes.get_i32();
+            let topic_config_bytes = bytes.copy_to_bytes(topic_config_length as usize);
+            let cow = String::from_utf8_lossy(topic_config_bytes.as_ref()).to_string();
+            let mut topic_config = TopicConfig::default();
+            topic_config.decode(cow.as_str());
+            let topic = topic_config.topic_name.clone().unwrap_or_default();
+            register_broker_body
+                .topic_config_serialize_wrapper
+                .topic_config_serialize_wrapper
+                .topic_config_table
+                .insert(topic, topic_config);
+        }
+
+        let filter_server_list_json_length = bytes.get_i32();
+        let filter_server_list_json = bytes.copy_to_bytes(filter_server_list_json_length as usize);
+        register_broker_body.filter_server_list =
+            SerdeJsonUtils::from_json_slice(filter_server_list_json.as_ref()).unwrap();
+
+        if broker_version >= RocketMqVersion::V5_0_0 {
+            let topic_queue_mapping_num = bytes.get_i32();
+            let mut topic_queue_mapping_info_map = HashMap::new();
+            for _ in 0..topic_queue_mapping_num {
+                let queue_mapping_length = bytes.get_i32();
+                let buffer = bytes.copy_to_bytes(queue_mapping_length as usize);
+                let info = TopicQueueMappingInfo::decode(buffer.as_ref()).unwrap();
+                topic_queue_mapping_info_map.insert(info.topic.clone().unwrap_or_default(), info);
+            }
+            register_broker_body
+                .topic_config_serialize_wrapper
+                .topic_queue_mapping_info_map = topic_queue_mapping_info_map;
+        }
+        register_broker_body
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_common::common::mq_version::RocketMqVersion;
+
+    use super::*;
+
+    #[test]
+    fn encode_without_compression() {
+        let wrapper = TopicConfigAndMappingSerializeWrapper::default();
+        let filter_list = vec!["filter1".into(), "filter2".into()];
+        let body = RegisterBrokerBody::new(wrapper, filter_list);
+        let encoded = body.encode(false);
+        assert!(!encoded.is_empty());
+    }
+
+    #[test]
+    fn encode_with_compression() {
+        let wrapper = TopicConfigAndMappingSerializeWrapper::default();
+        let filter_list = vec!["filter1".into(), "filter2".into()];
+        let body = RegisterBrokerBody::new(wrapper, filter_list);
+        let encoded = body.encode(true);
+        assert!(!encoded.is_empty());
+    }
+
+    #[test]
+    fn decode_without_compression() {
+        let wrapper = TopicConfigAndMappingSerializeWrapper::default();
+        let filter_list = vec!["filter1".into(), "filter2".into()];
+        let body = RegisterBrokerBody::new(wrapper, filter_list);
+        let encoded = body.encode(false);
+        let decoded =
+            RegisterBrokerBody::decode(&Bytes::from(encoded), false, RocketMqVersion::V5_0_0);
+        assert_eq!(decoded.filter_server_list, body.filter_server_list);
+    }
+
+    #[test]
+    fn test_encode() {
+        let mut register_broker_body = RegisterBrokerBody::default();
+        let mut topic_config_table = HashMap::new();
+        for i in 0..1 {
+            topic_config_table.insert(
+                CheetahString::from_string(i.to_string()),
+                TopicConfig::new(CheetahString::from_string(i.to_string())),
+            );
+        }
+        register_broker_body
+            .topic_config_serialize_wrapper
+            .topic_config_serialize_wrapper
+            .topic_config_table = topic_config_table;
+        let compare_encode = register_broker_body.encode(true);
+        let compare_decode =
+            RegisterBrokerBody::decode(&Bytes::from(compare_encode), true, RocketMqVersion::V5_0_0);
+        assert_eq!(
+            register_broker_body
+                .topic_config_serialize_wrapper
+                .topic_config_serialize_wrapper
+                .topic_config_table
+                .get("1"),
+            compare_decode
+                .topic_config_serialize_wrapper
+                .topic_config_serialize_wrapper
+                .topic_config_table
+                .get("1")
+        );
+    }
+}

--- a/rocketmq-remoting/src/protocol/header/namesrv/brokerid_change_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/brokerid_change_request_header.rs
@@ -21,20 +21,16 @@ use serde::Deserialize;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodec)]
+#[serde(rename_all = "camelCase")]
 pub struct NotifyMinBrokerIdChangeRequestHeader {
-    #[serde(rename = "minBrokerId")]
     pub min_broker_id: Option<u64>,
 
-    #[serde(rename = "brokerName")]
     pub broker_name: Option<CheetahString>,
 
-    #[serde(rename = "minBrokerAddr")]
     pub min_broker_addr: Option<CheetahString>,
 
-    #[serde(rename = "offlineBrokerAddr")]
     pub offline_broker_addr: Option<CheetahString>,
 
-    #[serde(rename = "haBrokerAddr")]
     pub ha_broker_addr: Option<CheetahString>,
 }
 

--- a/rocketmq-remoting/src/protocol/header/namesrv/brokerid_change_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/brokerid_change_request_header.rs
@@ -50,6 +50,31 @@ impl NotifyMinBrokerIdChangeRequestHeader {
             ha_broker_addr,
         }
     }
+
+    #[inline]
+    pub fn get_min_broker_id(&self) -> &Option<u64> {
+        &self.min_broker_id
+    }
+
+    #[inline]
+    pub fn get_broker_name(&self) -> &Option<CheetahString> {
+        &self.broker_name
+    }
+
+    #[inline]
+    pub fn get_min_broker_addr(&self) -> &Option<CheetahString> {
+        &self.min_broker_addr
+    }
+
+    #[inline]
+    pub fn get_offline_broker_addr(&self) -> &Option<CheetahString> {
+        &self.offline_broker_addr
+    }
+
+    #[inline]
+    pub fn get_ha_broker_addr(&self) -> &Option<CheetahString> {
+        &self.ha_broker_addr
+    }
 }
 
 #[cfg(test)]

--- a/rocketmq-remoting/src/runtime/config.rs
+++ b/rocketmq-remoting/src/runtime/config.rs
@@ -17,4 +17,4 @@
 
 pub mod client_config;
 mod net_system_config;
-mod server_config;
+pub mod server_config;

--- a/rocketmq-remoting/src/runtime/config/server_config.rs
+++ b/rocketmq-remoting/src/runtime/config/server_config.rs
@@ -17,7 +17,7 @@
 use crate::runtime::config::net_system_config::NetSystemConfig;
 
 #[derive(Debug, Clone)]
-struct NettyServerConfig {
+pub struct NettyServerConfig {
     bind_address: String,
     listen_port: i32,
     server_worker_threads: i32,

--- a/rocketmq/examples/advanced_usage.rs
+++ b/rocketmq/examples/advanced_usage.rs
@@ -30,7 +30,6 @@ use rocketmq_rust::TaskScheduler;
 use tokio::time::sleep;
 use tracing::error;
 use tracing::info;
-use tracing::warn;
 use tracing::Level;
 
 #[tokio::main]
@@ -122,7 +121,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let counter_c = counter.clone();
     // 4. Report generation task
     let report_task = Arc::new(
-        Task::new("report_generator", "Report Generator", move |ctx| {
+        Task::new("report_generator", "Report Generator", move |_| {
             let value = counter_c.clone();
             async move {
                 let count = value.load(Ordering::Relaxed);

--- a/rocketmq/examples/basic_usage_more.rs
+++ b/rocketmq/examples/basic_usage_more.rs
@@ -20,7 +20,6 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
-use rocketmq_rust::DelayTrigger;
 use rocketmq_rust::DelayedIntervalTrigger;
 use rocketmq_rust::IntervalTrigger;
 use rocketmq_rust::SchedulerConfig;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3931

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Broker now handles min-broker-ID change notifications.
  - Broker registration payload supports compressed and uncompressed encoding/decoding.

- Improvements
  - Header serialization standardized to camelCase for interoperability.
  - Server runtime configuration types are now publicly accessible.
  - Request routing extended to support min-broker-ID notifications.

- Chores
  - Removed unused imports in examples.
  - Minor test RNG API updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->