### PR TITLE
[ISSUE #3974]🚀Implement PartialOrd and Ord traits for DataVersion; enhance equality comparison logic

### DIFF
--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -314,12 +314,7 @@ impl Eq for DataVersion {}
 
 impl PartialOrd for DataVersion {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(
-            self.state_version
-                .cmp(&other.state_version)
-                .then_with(|| self.timestamp.cmp(&other.timestamp))
-                .then_with(|| self.get_counter().cmp(&other.get_counter())),
-        )
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3974

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic ordering for version objects, enabling predictable comparisons system-wide.

* **Bug Fixes**
  * Aligned version equality with the public API to remove inconsistency when comparing versions.
  * Improved comparison logic to produce consistent results across state changes and timestamps.

* **Tests**
  * Added unit tests covering equality and ordering scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->