### PR TITLE
[ISSUE #3981]🔧Update test for SubscriptionGroupWrapper to validate data_version timestamp

### DIFF
--- a/rocketmq-remoting/src/protocol/body/subscription_group_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/subscription_group_wrapper.rs
@@ -72,8 +72,9 @@ mod tests {
     #[test]
     fn new_creates_wrapper_with_default_values() {
         let wrapper = SubscriptionGroupWrapper::new();
+
         assert_eq!(wrapper.subscription_group_table.len(), 0);
-        assert_eq!(wrapper.data_version, DataVersion::default());
+        assert!(wrapper.data_version.timestamp >= DataVersion::default().timestamp);
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3981

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Relaxed timestamp comparison in subscription group wrapper tests to improve stability and reduce flakiness.
  * No changes to production behavior or public APIs.

* **Style**
  * Minor formatting cleanup (added a blank line) with no functional impact.

No user-facing changes in this release; functionality and interfaces remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->