### PR TITLE
[ISSUE #3983]Use fully qualified config::ConfigError and remove redundant import in rocketmq-error

### DIFF
--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -42,8 +42,6 @@ mod tui_error;
 
 use std::io;
 
-use config::ConfigError;
-
 pub type RocketMQResult<T> = std::result::Result<T, RocketmqError>;
 
 pub type Result<T> = anyhow::Result<T>;
@@ -150,7 +148,7 @@ pub enum RocketmqError {
 
     #[error("Config parse error: {0}")]
     #[cfg(feature = "with_config")]
-    ConfigError(#[from] ConfigError),
+    ConfigError(#[from] config::ConfigError),
 
     #[error("{0} command failed , {1}")]
     SubCommand(String, String),


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3983

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal error handling by using a fully qualified configuration error type for improved consistency.
  * No changes to runtime behavior or functionality.

* **Chores**
  * Minor internal cleanup with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->