### PR TITLE
[ISSUE #3985]🍻Make HAConnection::remote_address return owned String and wire remote SocketAddr through HA layer

### DIFF
--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_connection.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_connection.rs
@@ -70,7 +70,7 @@ impl HAConnection for AutoSwitchHAConnection {
         todo!()
     }
 
-    fn remote_address(&self) -> &str {
+    fn remote_address(&self) -> String {
         todo!()
     }
 }

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::AtomicU64;
@@ -77,6 +77,7 @@ pub struct DefaultHAConnection {
     message_store_config: Arc<MessageStoreConfig>,
     next_transfer_from_where: Arc<AtomicI64>,
     id: HAConnectionId,
+    remote_addr: SocketAddr,
 }
 
 impl DefaultHAConnection {
@@ -85,6 +86,7 @@ impl DefaultHAConnection {
         ha_service: ArcMut<DefaultHAService>,
         socket_stream: TcpStream,
         message_store_config: Arc<MessageStoreConfig>,
+        remote_addr: SocketAddr,
     ) -> Result<Self, HAConnectionError> {
         // Configure socket options early
         socket_stream
@@ -126,6 +128,7 @@ impl DefaultHAConnection {
             message_store_config,
             next_transfer_from_where: Arc::new(AtomicI64::new(-1)),
             id: HAConnectionId::default(),
+            remote_addr,
         })
     }
 
@@ -269,8 +272,8 @@ impl HAConnection for DefaultHAConnection {
         &self.id
     }
 
-    fn remote_address(&self) -> &str {
-        todo!()
+    fn remote_address(&self) -> String {
+        self.remote_addr.to_string()
     }
 }
 

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -368,7 +368,7 @@ impl AcceptSocketService {
                                if is_auto_switch {
                                     unimplemented!("Auto-switching is not implemented yet");
                                 }else{
-                                    let default_conn = DefaultHAConnection::new(default_ha_service.clone(), stream,message_store_config.clone()).await.expect("Error creating HAConnection");
+                                    let default_conn = DefaultHAConnection::new(default_ha_service.clone(), stream,message_store_config.clone(),addr).await.expect("Error creating HAConnection");
                                     let mut general_conn = ArcMut::new(GeneralHAConnection::new_with_default_ha_connection(default_conn));
                                     let  conn_weak= ArcMut::downgrade(&general_conn);
                                     if  let Err(e) =  general_conn.start(conn_weak).await {

--- a/rocketmq-store/src/ha/general_ha_connection.rs
+++ b/rocketmq-store/src/ha/general_ha_connection.rs
@@ -179,7 +179,14 @@ impl HAConnection for GeneralHAConnection {
         }
     }
 
-    fn remote_address(&self) -> &str {
-        todo!()
+    fn remote_address(&self) -> String {
+        match (&self.default_ha_connection, &self.auto_switch_ha_connection) {
+            (Some(connection), _) => connection.remote_address(),
+            (_, Some(connection)) => connection.remote_address(),
+            (None, None) => {
+                tracing::warn!("No HA connection to get remote address from");
+                panic!("No HA connection available");
+            }
+        }
     }
 }

--- a/rocketmq-store/src/ha/ha_connection.rs
+++ b/rocketmq-store/src/ha/ha_connection.rs
@@ -93,7 +93,7 @@ pub trait RocketmqHAConnection: Sync {
     ///
     /// # Returns
     /// Remote socket address as a string
-    fn remote_address(&self) -> &str;
+    fn remote_address(&self) -> String;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3985

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
