### PR TITLE
[ISSUE #3968]🍻 Make HAService::put_group_connection_state_request async and awaitable; update broker pre-online handshake flow

### DIFF
--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -86,7 +86,10 @@ impl HAService for AutoSwitchHAService {
         todo!()
     }
 
-    fn put_group_connection_state_request(&self, request: HAConnectionStateNotificationRequest) {
+    async fn put_group_connection_state_request(
+        &self,
+        request: HAConnectionStateNotificationRequest,
+    ) {
         todo!()
     }
 

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -275,8 +275,19 @@ impl HAService for DefaultHAService {
         }
     }
 
-    fn put_group_connection_state_request(&self, request: HAConnectionStateNotificationRequest) {
-        todo!()
+    async fn put_group_connection_state_request(
+        &self,
+        request: HAConnectionStateNotificationRequest,
+    ) {
+        if let Some(ref ha_connection_state_notification_service) =
+            self.ha_connection_state_notification_service
+        {
+            ha_connection_state_notification_service
+                .set_request(request)
+                .await;
+        } else {
+            error!("No HAConnectionStateNotificationService initialized to put state request");
+        }
     }
 
     async fn get_connection_list(&self) -> Vec<ArcMut<GeneralHAConnection>> {

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -192,13 +192,16 @@ impl HAService for GeneralHAService {
         }
     }
 
-    fn put_group_connection_state_request(&self, request: HAConnectionStateNotificationRequest) {
+    async fn put_group_connection_state_request(
+        &self,
+        request: HAConnectionStateNotificationRequest,
+    ) {
         match self {
             GeneralHAService::DefaultHAService(service) => {
-                service.put_group_connection_state_request(request)
+                service.put_group_connection_state_request(request).await
             }
             GeneralHAService::AutoSwitchHAService(service) => {
-                service.put_group_connection_state_request(request)
+                service.put_group_connection_state_request(request).await
             }
         }
     }

--- a/rocketmq-store/src/ha/ha_service.rs
+++ b/rocketmq-store/src/ha/ha_service.rs
@@ -128,7 +128,10 @@ pub trait RocketHAService: Sync {
     ///
     /// # Parameters
     /// * `request` - The connection state request
-    fn put_group_connection_state_request(&self, request: HAConnectionStateNotificationRequest);
+    async fn put_group_connection_state_request(
+        &self,
+        request: HAConnectionStateNotificationRequest,
+    );
 
     /// Get the list of HA connections
     ///


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3987 
Fix #3968

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Implemented previously unimplemented HA state update, preventing potential crashes.
  - Improved error handling when HA services are unavailable, reducing startup failures.

- Refactor
  - Migrated HA handshake and state update flows to async/await for more reliable, responsive broker startup.
  - Simplified control flow and removed legacy future boxing to reduce complexity and improve maintainability.

- Chores
  - Updated internal interfaces to async, aligning implementations and call sites across HA services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->