### PR TITLE
[ISSUE #3993]📝Add configuration files for broker master and slave settings

### DIFF
--- a/distribution/config/broker/1m-1s-async-one-machine/broker-master.toml
+++ b/distribution/config/broker/1m-1s-async-one-machine/broker-master.toml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ======================
+# Core Broker Settings
+# ======================
+brokerRole = "ASYNC_MASTER"             # enum BrokerRole: ASYNC_MASTER/AsyncMaster|SYNC_MASTER/SyncMaster|SLAVE/Slave
+flushDiskType = "ASYNC_FLUSH"
+deleteWhen = 4
+fileReservedTime = 72
+listenPort = 10911
+haListenPort = 10912
+storePathRootDir="/opt/rocketmq/store"
+
+
+# ======================
+# Broker Identity
+# ======================
+[brokerIdentity]
+brokerName = "broker-mxsm-a"          # default_broker_name()
+brokerClusterName = "DefaultCluster-mxsm"
+brokerId = 0                           # MASTER_ID

--- a/distribution/config/broker/1m-1s-async-one-machine/broker-slave.toml
+++ b/distribution/config/broker/1m-1s-async-one-machine/broker-slave.toml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ======================
+# Core Broker Settings
+# ======================
+brokerRole = "SLAVE"             # enum BrokerRole: ASYNC_MASTER/AsyncMaster|SYNC_MASTER/SyncMaster|SLAVE/Slave
+flushDiskType = "ASYNC_FLUSH"
+deleteWhen = 4
+fileReservedTime = 72
+haListenPort = 10932
+storePathRootDir = '/opt/rocketmq/store/slave'
+haMasterAddress = "127.0.0.1:10912"  # For Slave to connect to Master
+
+[brokerServerConfig]
+listenPort = 10931
+bind_address = '127.0.0.1'
+
+# ======================
+# Broker Identity
+# ======================
+[brokerIdentity]
+brokerName = "broker-mxsm-a"          # default_broker_name()
+brokerClusterName = "DefaultCluster-mxsm"
+brokerId = 1                           # MASTER_ID


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3993

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ready-to-use configuration templates for a single-machine asynchronous master–slave broker setup, including master and slave roles, HA linkage, storage paths, and local bind options. Enables quick local deployment and testing.

- Documentation
  - Included license headers and in-file guidance on broker roles, identity, and core settings to aid configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->