### PR TITLE
[ISSUE #3997]⚡️Improve logging for commit log loading with distinct success and failure messages

### DIFF
--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -255,7 +255,11 @@ impl CommitLog {
     pub fn load(&mut self) -> bool {
         let result = self.mapped_file_queue.load();
         self.mapped_file_queue.check_self();
-        info!("load commit log {}", if result { "OK" } else { "Failed" });
+        if result {
+            info!("load commit log Ok");
+        } else {
+            error!("load commit log failed");
+        }
         result
     }
 


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3997

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging for commit log loading: successful loads now log an info message (“load commit log Ok”), while failures log an error (“load commit log failed”).
  * Enhances clarity and troubleshooting by distinguishing success and failure explicitly in logs.
  * No changes to behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->