### PR TITLE
[ISSUE #3999]🐛NameServer runtime not shutting down in Drop (restored shutdown call)

### DIFF
--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -173,9 +173,9 @@ impl NameServerRuntime {
 impl Drop for NameServerRuntime {
     #[inline]
     fn drop(&mut self) {
-        // if let Some(runtime) = self.name_server_runtime.take() {
-        //     runtime.shutdown();
-        // }
+        if let Some(runtime) = self.name_server_runtime.take() {
+            runtime.shutdown();
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3999

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the NameServer runtime cleanly shuts down when its container is dropped, triggering internal shutdown and resource cleanup.
  * Prevents lingering background tasks, open sockets, or memory from persisting after shutdown, reducing hangs on exit and improving stability.
  * Improves reliability in shutdown scenarios and test environments without altering the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->