### PR TITLE
[ISSUE #4004]📝Update doc website url to https://rocketmqrust.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ language.
 
 ### Document
 
-- **`Manual official documentation`**：[Rocketmq-rust website](https://rocketmq-rust.ljbmxsm.com/)
+- **`Manual official documentation`**：[Rocketmq-rust website](https://rocketmqrust.com)
 - **`AI documentation`**: [Rocketmq-rust Deepwiki](https://deepwiki.com/mxsm/rocketmq-rust)
 
 ## Getting Started
@@ -179,7 +179,7 @@ will be carried out sequentially in the following order.
 
 Contributions to code, issue reporting, and suggestions are welcome. The development of RocketMQ-Rust relies on the
 support of developers. Let's collaborate to advance Rust in the message middleware
-domain. [**`Contribute Guide`**](https://rocketmq-rust.ljbmxsm.com/docs/contribute-guide/)
+domain. [**`Contribute Guide`**](https://rocketmqrust.com/docs/contribute-guide/)
 
 ![](https://repobeats.axiom.co/api/embed/6ca125de92b36e1f78c6681d0a1296b8958adea1.svg "Repobeats analytics image")
 


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4004

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external documentation links in the README to the current official site, ensuring accurate destinations and consistent formatting.
  * Adjusted the Contribute Guide link to the correct domain and path.
  * No functional changes; application behavior and APIs remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->