### PR TITLE
[ISSUE #4006]♻️Refactor: Use &mut RemotingCommand in RequestProcessor API for in-place mutation & reduced cloning

### DIFF
--- a/rocketmq-broker/src/long_polling/pop_request.rs
+++ b/rocketmq-broker/src/long_polling/pop_request.rs
@@ -75,6 +75,10 @@ impl PopRequest {
         &self.remoting_command
     }
 
+    pub fn remoting_command_mut(&mut self) -> &mut RemotingCommand {
+        &mut self.remoting_command
+    }
+
     pub fn is_timeout(&self) -> bool {
         let now = get_current_millis();
         now > (self.expired - 50)

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -88,7 +88,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match self {
             BrokerProcessorType::Send(processor) => {
@@ -210,7 +210,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match self.process_table.get_mut(request.code_ref()) {
             Some(processor) => processor.process_request(channel, ctx, request).await,

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -68,7 +68,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -140,7 +140,7 @@ where
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match request_code {
             RequestCode::AckMessage => self.process_ack(channel, ctx, request, true).await,
@@ -186,7 +186,7 @@ where
         &mut self,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
         _broker_allow_suspend: bool,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<AckMessageRequestHeader>()?;
@@ -262,7 +262,7 @@ where
         &mut self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
         _broker_allow_suspend: bool,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         if request.get_body().is_none() {

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -63,7 +63,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         Ok(self
@@ -104,7 +104,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         match request_code {
             RequestCode::UpdateAndCreateTopic => {

--- a/rocketmq-broker/src/processor/admin_broker_processor/batch_mq_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/batch_mq_handler.rs
@@ -54,7 +54,7 @@ impl<MS: MessageStore> BatchMqHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut request_body = LockBatchRequestBody::decode(request.get_body().unwrap()).unwrap();
         let mut lock_ok_mqset = HashSet::new();
@@ -154,7 +154,7 @@ impl<MS: MessageStore> BatchMqHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut request_body = UnlockBatchRequestBody::decode(request.get_body().unwrap()).unwrap();
         if request_body.only_this_broker

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -49,7 +49,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         todo!()
     }
@@ -59,7 +59,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         // broker config => broker config
@@ -93,7 +93,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let runtime_info = self.prepare_runtime_info();

--- a/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
@@ -56,7 +56,7 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let request_header = request
@@ -109,7 +109,7 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let request_header = request
@@ -239,7 +239,7 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let content = self

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -44,7 +44,7 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let change_header = request
             .decode_command_custom_header::<NotifyMinBrokerIdChangeRequestHeader>()

--- a/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
@@ -54,7 +54,7 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let request_header = request
             .decode_command_custom_header::<GetMaxOffsetRequestHeader>()
@@ -89,7 +89,7 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let request_header = request
             .decode_command_custom_header::<GetMinOffsetRequestHeader>()
@@ -283,7 +283,7 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response_command = RemotingCommand::create_response_command();
         let content = self
@@ -306,7 +306,7 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response_command = RemotingCommand::create_response_command();
         let content = self

--- a/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
@@ -50,7 +50,7 @@ impl<MS: MessageStore> SubscriptionGroupHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let start_time = get_current_millis() as i64;
 
@@ -92,7 +92,7 @@ impl<MS: MessageStore> SubscriptionGroupHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut request_body = UnlockBatchRequestBody::decode(request.get_body().unwrap()).unwrap();
         if request_body.only_this_broker

--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -72,7 +72,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let response = RemotingCommand::create_response_command();
         let request_header = request
@@ -205,7 +205,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut request_body =
             CreateTopicListRequestBody::decode(request.body().as_ref().unwrap().as_ref()).unwrap();
@@ -308,7 +308,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let response = RemotingCommand::create_response_command();
         let request_header = request
@@ -379,7 +379,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let topic_config_and_mapping_serialize_wrapper = TopicConfigAndMappingSerializeWrapper {
@@ -425,7 +425,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let topics = TopicValidator::get_system_topic_set();
@@ -442,7 +442,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let request_header = request
@@ -521,7 +521,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let request_header = request
@@ -568,7 +568,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let request_header = request
@@ -594,7 +594,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let request_header = request

--- a/rocketmq-broker/src/processor/change_invisible_time_processor.rs
+++ b/rocketmq-broker/src/processor/change_invisible_time_processor.rs
@@ -61,7 +61,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -120,7 +120,7 @@ where
         channel: Channel,
         ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         self.process_request_inner(channel, ctx, request, true)
             .await
@@ -130,7 +130,7 @@ where
         &mut self,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
         _broker_allow_suspend: bool,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header =

--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -59,7 +59,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -112,7 +112,7 @@ where
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match request_code {
             RequestCode::HeartBeat => self.heart_beat(channel, ctx, request),
@@ -130,7 +130,7 @@ where
         &self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header =
             request.decode_command_custom_header::<UnregisterClientRequestHeader>()?;
@@ -175,7 +175,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let heartbeat_data = SerdeJsonUtils::decode::<HeartbeatData>(
             request.body().as_ref().map(|v| v.as_ref()).unwrap(),

--- a/rocketmq-broker/src/processor/consumer_manage_processor.rs
+++ b/rocketmq-broker/src/processor/consumer_manage_processor.rs
@@ -48,7 +48,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -100,7 +100,7 @@ where
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         match request_code {
             RequestCode::GetConsumerListByGroup => {
@@ -120,7 +120,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let response = RemotingCommand::create_response_command();
         let request_header = request
@@ -176,7 +176,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut request_header = request
             .decode_command_custom_header::<UpdateConsumerOffsetRequestHeader>()
@@ -268,7 +268,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut request_header = request
             .decode_command_custom_header::<QueryConsumerOffsetRequestHeader>()

--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -88,7 +88,7 @@ impl<MS: MessageStore> PullMessageResultHandler for DefaultPullMessageResultHand
     async fn handle(
         &self,
         mut get_message_result: GetMessageResult,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
         request_header: PullMessageRequestHeader,
         channel: Channel,
         ctx: ConnectionHandlerContext,
@@ -116,7 +116,7 @@ impl<MS: MessageStore> PullMessageResultHandler for DefaultPullMessageResultHand
         );
         let code = From::from(response.code());
         self.execute_consume_message_hook_before(
-            &request,
+            request,
             &request_header,
             &get_message_result,
             broker_allow_suspend,
@@ -232,7 +232,7 @@ impl<MS: MessageStore> PullMessageResultHandler for DefaultPullMessageResultHand
                     let offset = request_header.queue_offset;
 
                     let pull_request = PullRequest::new(
-                        request,
+                        request.clone(),
                         channel,
                         ctx,
                         polling_time_mills,

--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -59,7 +59,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -107,7 +107,7 @@ where
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let request_header = request
             .decode_command_custom_header::<EndTransactionRequestHeader>()

--- a/rocketmq-broker/src/processor/notification_processor.rs
+++ b/rocketmq-broker/src/processor/notification_processor.rs
@@ -205,7 +205,7 @@ where
         &mut self,
         _channel: Channel,
         ctx: ConnectionHandlerContext,
-        mut request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let now = get_current_millis();
         request.add_ext_field_if_not_exist(NotificationProcessor::<MS>::BORN_TIME, now.to_string());

--- a/rocketmq-broker/src/processor/peek_message_processor.rs
+++ b/rocketmq-broker/src/processor/peek_message_processor.rs
@@ -28,7 +28,7 @@ impl RequestProcessor for PeekMessageProcessor {
         &mut self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         unimplemented!("RequestProcessor.process_request for PeekMessageProcessor not implemented")
     }
@@ -40,7 +40,7 @@ impl PeekMessageProcessor {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         unimplemented!("PeekMessageProcessor.process_request")
     }

--- a/rocketmq-broker/src/processor/polling_info_processor.rs
+++ b/rocketmq-broker/src/processor/polling_info_processor.rs
@@ -28,7 +28,7 @@ impl RequestProcessor for PollingInfoProcessor {
         &mut self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         unimplemented!("RequestProcessor.process_request for PollingInfoProcessor not implemented")
     }
@@ -40,7 +40,7 @@ impl PollingInfoProcessor {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         todo!()
     }

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -168,7 +168,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         self._process_request(channel, ctx, request_code, request)
@@ -185,7 +185,7 @@ where
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
-        mut request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let begin_time_mills = get_current_millis();
         request.add_ext_field_if_not_exist(

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -82,7 +82,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -361,7 +361,7 @@ where
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         self.process_request_inner(request_code, channel, ctx, request, true, true)
             .await
@@ -372,7 +372,7 @@ where
         request_code: RequestCode,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
         broker_allow_suspend: bool,
         broker_allow_flow_ctr_suspend: bool,
     ) -> Option<RemotingCommand> {
@@ -888,7 +888,7 @@ where
         mut pull_message_processor: ArcMut<PullMessageProcessor<MS>>,
         channel: Channel,
         mut ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        mut request: RemotingCommand,
     ) {
         let lock = Arc::clone(&self.write_message_lock);
         self.write_message_runtime.get_handle().spawn(async move {
@@ -901,7 +901,7 @@ where
                     RequestCode::from(request.code()),
                     channel,
                     ctx.clone(),
-                    request,
+                    &mut request,
                     false,
                     broker_allow_flow_ctr_suspend,
                 )

--- a/rocketmq-broker/src/processor/pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/pull_message_result_handler.rs
@@ -61,7 +61,7 @@ pub trait PullMessageResultHandler: Sync + Send + Any + 'static {
     async fn handle(
         &self,
         get_message_result: GetMessageResult,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
         request_header: PullMessageRequestHeader,
         channel: Channel,
         ctx: ConnectionHandlerContext,

--- a/rocketmq-broker/src/processor/query_assignment_processor.rs
+++ b/rocketmq-broker/src/processor/query_assignment_processor.rs
@@ -76,7 +76,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -143,7 +143,7 @@ impl<MS: MessageStore> QueryAssignmentProcessor<MS> {
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match request_code {
             RequestCode::QueryAssignment => self.query_assignment(channel, ctx, request).await,
@@ -158,7 +158,7 @@ impl<MS: MessageStore> QueryAssignmentProcessor<MS> {
         &mut self,
         channel: Channel,
         _ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         if request.get_body().is_none() {
             return Ok(Some(
@@ -434,7 +434,7 @@ impl<MS: MessageStore> QueryAssignmentProcessor<MS> {
         &mut self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         if request.get_body().is_none() {
             return Ok(Some(

--- a/rocketmq-broker/src/processor/query_message_processor.rs
+++ b/rocketmq-broker/src/processor/query_message_processor.rs
@@ -45,7 +45,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -96,7 +96,7 @@ where
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         match request_code {
             RequestCode::QueryMessage => self.query_message(channel, ctx, request).await,
@@ -109,7 +109,7 @@ where
         &mut self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command_with_header(
             QueryMessageResponseHeader::default(),
@@ -165,7 +165,7 @@ where
         &mut self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let mut response = RemotingCommand::create_response_command();
         let request_header = request

--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -61,7 +61,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -120,13 +120,13 @@ where
         channel: Channel,
         ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
-        let request_header = parse_request_header(&request);
+        let request_header = parse_request_header(request);
         let mut request_header = request_header.unwrap(); //need to optimize
         let mut mqtrace_context =
             self.inner
-                .build_msg_context(&channel, &ctx, &mut request_header, &request);
+                .build_msg_context(&channel, &ctx, &mut request_header, request);
         self.inner
             .execute_send_message_hook_before(&mqtrace_context);
 
@@ -149,7 +149,7 @@ where
         &mut self,
         ctx: &ConnectionHandlerContext,
         channel: &Channel,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
         send_message_context: &mut SendMessageContext,
         request_header: SendMessageRequestHeader,
     ) -> RemotingCommand {
@@ -184,7 +184,7 @@ where
         }
         response.set_code_mut(-1);
         self.inner
-            .msg_check(channel, ctx, &request, &request_header, &mut response);
+            .msg_check(channel, ctx, request, &request_header, &mut response);
         if response.code() != -1 {
             return response;
         }
@@ -243,7 +243,7 @@ where
                 .await;
             self.handle_put_message_result(
                 put_message_result,
-                &request,
+                request,
                 &mut response_header,
                 send_message_context,
                 queue_id_int,

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -98,7 +98,7 @@ where
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -153,16 +153,16 @@ where
         channel: Channel,
         mut ctx: ConnectionHandlerContext,
         request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match request_code {
             RequestCode::ConsumerSendMsgBack => {
                 self.inner
-                    .consumer_send_msg_back(&channel, &ctx, &request)
+                    .consumer_send_msg_back(&channel, &ctx, request)
                     .await
             }
             _ => {
-                let mut request_header = parse_request_header(&request, request_code)?;
+                let mut request_header = parse_request_header(request, request_code)?;
                 let mapping_context = self
                     .inner
                     .broker_runtime_inner
@@ -178,7 +178,7 @@ where
 
                 let send_message_context =
                     self.inner
-                        .build_msg_context(&channel, &ctx, &mut request_header, &request);
+                        .build_msg_context(&channel, &ctx, &mut request_header, request);
                 self.inner
                     .execute_send_message_hook_before(&send_message_context);
                 SendMessageProcessor::<MS, TS>::clear_reserved_properties(&mut request_header);
@@ -243,7 +243,7 @@ where
         &mut self,
         channel: &Channel,
         ctx: &mut ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
         mut send_message_context: SendMessageContext,
         request_header: SendMessageRequestHeader,
         mut mapping_context: TopicQueueMappingContext,
@@ -414,7 +414,7 @@ where
                 .handle_put_message_result(
                     put_message_result,
                     &mut response,
-                    &request,
+                    request,
                     topic.as_ref(),
                     transaction_id,
                     &mut send_message_context,
@@ -451,7 +451,7 @@ where
                 .handle_put_message_result(
                     put_message_result,
                     &mut response,
-                    &request,
+                    request,
                     topic.as_str(),
                     transaction_id,
                     &mut send_message_context,
@@ -477,7 +477,7 @@ where
         &mut self,
         channel: &Channel,
         ctx: &mut ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
         mut send_message_context: SendMessageContext,
         request_header: SendMessageRequestHeader,
         mut mapping_context: TopicQueueMappingContext,
@@ -513,7 +513,7 @@ where
         if !self.handle_retry_and_dlq(
             &request_header,
             &mut response,
-            &request,
+            request,
             &mut message_ext.message_ext_inner,
             &mut topic_config,
             &mut ori_props,
@@ -636,7 +636,7 @@ where
                 .handle_put_message_result(
                     put_message_result,
                     &mut response,
-                    &request,
+                    request,
                     topic.as_str(),
                     transaction_id,
                     &mut send_message_context,
@@ -672,7 +672,7 @@ where
                 .handle_put_message_result(
                     put_message_result,
                     &mut response,
-                    &request,
+                    request,
                     topic.as_str(),
                     transaction_id,
                     &mut send_message_context,

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -62,7 +62,7 @@ impl RequestProcessor for ClientRemotingProcessor {
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!("process_request: {:?}", request_code);
@@ -100,7 +100,7 @@ impl ClientRemotingProcessor {
     async fn receive_reply_message(
         &mut self,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let receive_time = get_current_millis();
         let response = RemotingCommand::create_response_command();
@@ -197,7 +197,7 @@ impl ClientRemotingProcessor {
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request
             .decode_command_custom_header::<NotifyConsumerIdsChangedRequestHeader>()
@@ -219,7 +219,7 @@ impl ClientRemotingProcessor {
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        mut request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request
             .decode_command_custom_header::<CheckTransactionStateRequestHeader>()
@@ -276,7 +276,7 @@ impl ClientRemotingProcessor {
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        mut request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header =
             request.decode_command_custom_header::<ConsumeMessageDirectlyResultRequestHeader>()?;

--- a/rocketmq-namesrv/src/processor.rs
+++ b/rocketmq-namesrv/src/processor.rs
@@ -44,7 +44,7 @@ impl RequestProcessor for NameServerRequestProcessorWrapper {
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match self {
             NameServerRequestProcessorWrapper::ClientRequestProcessor(processor) => {
@@ -102,7 +102,7 @@ impl RequestProcessor for NameServerRequestProcessor {
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match self.processor_table.get_mut(request.code_ref()) {
             None => match self.default_request_processor.as_mut() {

--- a/rocketmq-namesrv/src/processor/client_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/client_request_processor.rs
@@ -49,7 +49,7 @@ impl RequestProcessor for ClientRequestProcessor {
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -75,14 +75,14 @@ impl ClientRequestProcessor {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         self.get_route_info_by_topic(request)
     }
 
     fn get_route_info_by_topic(
         &self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<GetRouteInfoRequestHeader>()?;
         let namesrv_ready = self.need_check_namesrv_ready.load(Ordering::Relaxed)

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -74,7 +74,7 @@ impl RequestProcessor for DefaultRequestProcessor {
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         info!(
@@ -91,7 +91,7 @@ impl DefaultRequestProcessor {
         channel: Channel,
         _ctx: ConnectionHandlerContext,
         request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let response = match request_code {
             RequestCode::PutKvConfig => self.put_kv_config(request),
@@ -136,7 +136,7 @@ impl DefaultRequestProcessor {
 impl DefaultRequestProcessor {
     fn put_kv_config(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header = request.decode_command_custom_header::<PutKVConfigRequestHeader>()?;
         //check namespace and key, need?
@@ -159,7 +159,7 @@ impl DefaultRequestProcessor {
 
     fn get_kv_config(
         &self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header = request.decode_command_custom_header::<GetKVConfigRequestHeader>()?;
 
@@ -183,7 +183,7 @@ impl DefaultRequestProcessor {
 
     fn delete_kv_config(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<DeleteKVConfigRequestHeader>()?;
@@ -196,7 +196,7 @@ impl DefaultRequestProcessor {
 
     fn query_broker_topic_config(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<QueryDataVersionRequestHeader>()?;
@@ -242,11 +242,11 @@ impl DefaultRequestProcessor {
     fn process_register_broker(
         &mut self,
         remote_addr: SocketAddr,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<RegisterBrokerRequestHeader>()?;
-        if !check_sum_crc32(&request, &request_header) {
+        if !check_sum_crc32(request, &request_header) {
             return Ok(RemotingCommand::create_response_command_with_code(
                 RemotingSysResponseCode::SystemError,
             )
@@ -260,11 +260,11 @@ impl DefaultRequestProcessor {
         let mut filter_server_list = Vec::new();
         if broker_version >= RocketMqVersion::V3_0_11 {
             let register_broker_body =
-                extract_register_broker_body_from_request(&request, &request_header);
+                extract_register_broker_body_from_request(request, &request_header);
             topic_config_wrapper = register_broker_body.topic_config_serialize_wrapper;
             filter_server_list = register_broker_body.filter_server_list;
         } else {
-            topic_config_wrapper = extract_register_topic_config_from_request(&request);
+            topic_config_wrapper = extract_register_topic_config_from_request(request);
         }
         let result = self
             .name_server_runtime_inner
@@ -315,7 +315,7 @@ impl DefaultRequestProcessor {
 
     fn process_unregister_broker(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<UnRegisterBrokerRequestHeader>()?;
@@ -339,7 +339,7 @@ impl DefaultRequestProcessor {
 impl DefaultRequestProcessor {
     fn process_broker_heartbeat(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<BrokerHeartbeatRequestHeader>()?;
@@ -354,7 +354,7 @@ impl DefaultRequestProcessor {
 
     fn get_broker_member_group(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<GetBrokerMemberGroupRequestHeader>()?;
@@ -372,7 +372,7 @@ impl DefaultRequestProcessor {
 
     fn get_broker_cluster_info(
         &self,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let vec = self
             .name_server_runtime_inner
@@ -387,7 +387,7 @@ impl DefaultRequestProcessor {
 
     fn wipe_write_perm_of_broker(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<WipeWritePermOfBrokerRequestHeader>()?;
@@ -401,7 +401,7 @@ impl DefaultRequestProcessor {
 
     fn add_write_perm_of_broker(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<AddWritePermOfBrokerRequestHeader>()?;
@@ -415,7 +415,7 @@ impl DefaultRequestProcessor {
 
     fn get_all_topic_list_from_nameserver(
         &self,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if self
             .name_server_runtime_inner
@@ -439,7 +439,7 @@ impl DefaultRequestProcessor {
 
     fn delete_topic_in_name_srv(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<DeleteTopicFromNamesrvRequestHeader>()?;
@@ -451,7 +451,7 @@ impl DefaultRequestProcessor {
 
     fn register_topic_to_name_srv(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<RegisterTopicRequestHeader>()?;
@@ -468,7 +468,7 @@ impl DefaultRequestProcessor {
 
     fn get_kv_list_by_namespace(
         &self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header =
             request.decode_command_custom_header::<GetKVListByNamespaceRequestHeader>()?;
@@ -490,7 +490,7 @@ impl DefaultRequestProcessor {
 
     fn get_topics_by_cluster(
         &self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if !self
             .name_server_runtime_inner
@@ -515,7 +515,7 @@ impl DefaultRequestProcessor {
 
     fn get_system_topic_list_from_ns(
         &self,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let topic_list = self
             .name_server_runtime_inner
@@ -527,7 +527,7 @@ impl DefaultRequestProcessor {
 
     fn get_unit_topic_list(
         &self,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if self
             .name_server_runtime_inner
@@ -551,7 +551,7 @@ impl DefaultRequestProcessor {
 
     fn get_has_unit_sub_topic_list(
         &self,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if self
             .name_server_runtime_inner
@@ -575,7 +575,7 @@ impl DefaultRequestProcessor {
 
     fn get_has_unit_sub_un_unit_topic_list(
         &self,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if self
             .name_server_runtime_inner
@@ -599,7 +599,7 @@ impl DefaultRequestProcessor {
 
     fn update_config(
         &mut self,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if let Some(body) = request.body() {
             let body_str = match str::from_utf8(body) {
@@ -654,7 +654,7 @@ impl DefaultRequestProcessor {
 
     fn get_config(
         &mut self,
-        _request: RemotingCommand,
+        _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let config = self.name_server_runtime_inner.name_server_config();
         let result = match config.get_all_configs_format_string() {

--- a/rocketmq-remoting/src/clients/client.rs
+++ b/rocketmq-remoting/src/clients/client.rs
@@ -73,12 +73,12 @@ async fn run_send(mut client: ArcMut<ClientInner>, mut rx: Receiver<SendMessage>
 async fn run_recv<PR: RequestProcessor>(mut client: ArcMut<ClientInner>, mut processor: PR) {
     while let Some(response) = client.channel.0.connection.receive_command().await {
         match response {
-            Ok(msg) => match msg.get_type() {
+            Ok(mut msg) => match msg.get_type() {
                 // handle request
                 RemotingCommandType::REQUEST => {
                     let opaque = msg.opaque();
                     let process_result = processor
-                        .process_request(client.channel.1.clone(), client.ctx.clone(), msg)
+                        .process_request(client.channel.1.clone(), client.ctx.clone(), &mut msg)
                         .await;
                     match process_result {
                         Ok(response) => {

--- a/rocketmq-remoting/src/remoting_server/server.rs
+++ b/rocketmq-remoting/src/remoting_server/server.rs
@@ -183,7 +183,7 @@ impl<RP: RequestProcessor + Sync + 'static> ConnectionHandler<RP> {
                 let ctx = self.connection_handler_context.clone();
                 let result = self
                     .request_processor
-                    .process_request(channel, ctx, cmd)
+                    .process_request(channel, ctx, &mut cmd)
                     .await
                     .unwrap_or_else(|_err| {
                         Some(RemotingCommand::create_response_command_with_code(

--- a/rocketmq-remoting/src/request_processor/default_request_processor.rs
+++ b/rocketmq-remoting/src/request_processor/default_request_processor.rs
@@ -29,8 +29,8 @@ impl RequestProcessor for DefaultRemotingRequestProcessor {
         &mut self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        Ok(Some(request))
+        Ok(Some(request.clone()))
     }
 }

--- a/rocketmq-remoting/src/runtime/processor.rs
+++ b/rocketmq-remoting/src/runtime/processor.rs
@@ -29,7 +29,7 @@ pub trait LocalRequestProcessor {
         &mut self,
         channel: Channel,
         ctx: ConnectionHandlerContext,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>>;
 
     fn reject_request(&self, _code: i32) -> RejectRequestResponse {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4006

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
