### PR TITLE
[ISSUE #4008]♻️Refactor: Add original request parameter to RPCHook::do_after_response for richer post-processing

### DIFF
--- a/rocketmq-remoting/src/remoting_server/server.rs
+++ b/rocketmq-remoting/src/remoting_server/server.rs
@@ -99,11 +99,12 @@ impl<RP> ConnectionHandler<RP> {
     pub fn do_after_rpc_hooks(
         &self,
         channel: &Channel,
+        request: &RemotingCommand,
         response: Option<&mut RemotingCommand>,
     ) -> rocketmq_error::RocketMQResult<()> {
         if let Some(response) = response {
             for hook in self.rpc_hooks.iter() {
-                hook.do_after_response(channel.remote_address(), response)?;
+                hook.do_after_response(channel.remote_address(), request, response)?;
             }
         }
         Ok(())
@@ -194,7 +195,7 @@ impl<RP: RequestProcessor + Sync + 'static> ConnectionHandler<RP> {
             };
 
             let exception = self
-                .do_after_rpc_hooks(&self.channel_inner.1, response.as_mut())
+                .do_after_rpc_hooks(&self.channel_inner.1, &cmd, response.as_mut())
                 .err();
 
             match self.handle_error(oneway_rpc, opaque, exception).await {

--- a/rocketmq-remoting/src/runtime.rs
+++ b/rocketmq-remoting/src/runtime.rs
@@ -52,24 +52,27 @@ pub trait RPCHook: Send + Sync + 'static {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<()>;
 
-    /// Executes custom logic after an RPC response has been prepared.
+    /// Executes custom logic after an RPC response is processed.
     ///
-    /// This method allows for actions such as logging, metrics collection, or cleanup activities
-    /// to be performed after a request has been processed and a response is ready to be sent back.
-    /// It takes a mutable reference to the `RemotingCommand` allowing for the response to be
-    /// modified before sending.
+    /// This method allows for actions such as logging, metrics collection, or
+    /// post-processing tasks to be performed after the response is generated.
+    /// It takes references to the remote caller's address, the original request,
+    /// and a mutable reference to the response, enabling modifications to the response
+    /// before it is sent back to the caller.
     ///
     /// # Arguments
     /// * `remote_addr` - The socket address of the remote caller.
+    /// * `request` - A reference to the `RemotingCommand` representing the original request.
     /// * `response` - A mutable reference to the `RemotingCommand` representing the response to be
-    ///   sent back.
+    ///   sent back to the caller.
     ///
     /// # Returns
     /// A `Result` indicating the outcome of the post-processing step. Returning an `Err`
-    /// value can be used to indicate an issue with the response preparation.
+    /// value can be used to signal a failure in the post-processing logic.
     fn do_after_response(
         &self,
         remote_addr: SocketAddr,
+        request: &RemotingCommand,
         response: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<()>;
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4008

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RPC post-response hooks now receive both the original request and the response, enabling richer post-processing and validation.

* **Documentation**
  * Updated guidance to reflect the additional request context provided to post-response hooks.

* **Refactor**
  * Unified hook handling to propagate request context through the RPC pipeline.

* **Chores**
  * This change requires updating existing hook implementations to accept the new request parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->