### PR TITLE
[ISSUE #4016]♻️Refactor: Simplify kv_config_path and config_store_path methods for improved readability

### DIFF
--- a/rocketmq-common/src/common/namesrv/namesrv_config.rs
+++ b/rocketmq-common/src/common/namesrv/namesrv_config.rs
@@ -37,25 +37,17 @@ mod defaults {
     }
 
     pub fn kv_config_path() -> String {
-        format!(
-            "{}{}{}{}{}",
-            dirs::home_dir().unwrap().to_str().unwrap(),
-            MAIN_SEPARATOR,
-            "rocketmq-namesrv",
-            MAIN_SEPARATOR,
-            "kvConfig.json"
-        )
+        let mut kv_config_path = dirs::home_dir().unwrap_or_default();
+        kv_config_path.push("namesrv");
+        kv_config_path.push("kvConfig.json");
+        kv_config_path.to_str().unwrap_or_default().to_string()
     }
 
     pub fn config_store_path() -> String {
-        format!(
-            "{}{}{}{}{}",
-            dirs::home_dir().unwrap().to_str().unwrap(),
-            MAIN_SEPARATOR,
-            "rocketmq-namesrv",
-            MAIN_SEPARATOR,
-            "rocketmq-namesrv.properties"
-        )
+        let mut kv_config_path = dirs::home_dir().unwrap_or_default();
+        kv_config_path.push("namesrv");
+        kv_config_path.push("namesrv.properties");
+        kv_config_path.to_str().unwrap_or_default().to_string()
     }
 
     pub fn product_env_name() -> String {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4016

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved robustness when resolving the user home directory and converting paths, reducing chances of startup failures.
- Refactor
  - Updated default locations for NameServer configuration files to use a more consistent directory structure. Existing environments relying on previous default paths may need to adjust their configuration or migrate files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->