### PR TITLE
[ISSUE #4018]⚡️Enhance RocketMQServer to support RPC hooks and improve initialization logic

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -1025,7 +1025,7 @@ impl BrokerRuntime {
 
         let (request_processor, fast_request_processor) = self.init_processor();
 
-        let server = RocketMQServer::new(Arc::new(
+        let mut server = RocketMQServer::new(Arc::new(
             self.inner.broker_config.broker_server_config.clone(),
         ));
         //start nomarl broker remoting_server
@@ -1044,7 +1044,7 @@ impl BrokerRuntime {
         let mut fast_server_config = self.inner.broker_config.broker_server_config.clone();
         fast_server_config.listen_port =
             self.inner.broker_config.broker_server_config.listen_port - 2;
-        let fast_server = RocketMQServer::new(Arc::new(fast_server_config));
+        let mut fast_server = RocketMQServer::new(Arc::new(fast_server_config));
         tokio::spawn(async move {
             fast_server
                 .run(fast_request_processor, client_housekeeping_service_fast)

--- a/rocketmq-namesrv/src/kvconfig/kvconfig_mananger.rs
+++ b/rocketmq-namesrv/src/kvconfig/kvconfig_mananger.rs
@@ -91,6 +91,9 @@ impl KVConfigManager {
                 .as_str(),
         );
         if let Ok(content) = result {
+            if content.is_empty() {
+                return Ok(());
+            }
             let wrapper = KVConfigSerializeWrapper::decode(content.as_bytes())?;
             if let Some(config_table) = wrapper.config_table {
                 for (key, value) in config_table {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4018

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added RPC hook support to the server, enabling extensible request interception.
  * Integrated a zone-based routing hook in NameServer to improve routing behavior out of the box.
* Bug Fixes
  * KV configuration now loads gracefully when the config file is empty, avoiding unnecessary errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->