### PR TITLE
[ISSUE #4020]⚡️Improve name server readiness checks and update log messages for clarity

### DIFF
--- a/rocketmq-namesrv/src/processor/client_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/client_request_processor.rs
@@ -16,7 +16,6 @@
  */
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::FAQUrl;
@@ -85,29 +84,26 @@ impl ClientRequestProcessor {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<GetRouteInfoRequestHeader>()?;
-        let namesrv_ready = self.need_check_namesrv_ready.load(Ordering::Relaxed)
-            && TimeUtils::get_current_millis() - self.startup_time_millis
-                >= Duration::from_secs(
-                    self.name_server_runtime_inner
-                        .name_server_config()
-                        .wait_seconds_for_service as u64,
-                )
-                .as_millis() as u64;
-        if self
+        let wait_seconds = self
             .name_server_runtime_inner
             .name_server_config()
-            .need_wait_for_service
-            && !namesrv_ready
-        {
-            warn!(
-                "name remoting_server not ready. request code {} ",
-                request.code()
-            );
+            .wait_seconds_for_service as u64;
+        let elapsed_millis =
+            TimeUtils::get_current_millis().saturating_sub(self.startup_time_millis);
+        let namesrv_ready = self.need_check_namesrv_ready.load(Ordering::Relaxed)
+            && elapsed_millis >= wait_seconds * 1000;
+
+        let need_wait_for_service = self
+            .name_server_runtime_inner
+            .name_server_config()
+            .need_wait_for_service;
+        if need_wait_for_service && !namesrv_ready {
+            warn!("name server not ready. request code {} ", request.code());
             return Ok(Some(
                 RemotingCommand::create_response_command_with_code(
                     RemotingSysResponseCode::SystemError,
                 )
-                .set_remark("name remoting_server not ready"),
+                .set_remark("name server not ready"),
             ));
         }
         match self
@@ -118,7 +114,7 @@ impl ClientRequestProcessor {
             None => Ok(Some(
                 RemotingCommand::create_response_command_with_code(ResponseCode::TopicNotExist)
                     .set_remark(format!(
-                        "No topic route info in name remoting_server for the topic:{}{}",
+                        "No topic route info in name server for the topic:{}{}",
                         request_header.topic,
                         FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
                     )),
@@ -143,15 +139,7 @@ impl ClientRequestProcessor {
                         );
                     topic_route_data.order_topic_conf = order_topic_config;
                 };
-                /*let standard_json_only = request_header.accept_standard_json_only.unwrap_or(false);
-                let content = if request.version() >= RocketMqVersion::into(RocketMqVersion::V494)
-                    || standard_json_only
-                {
-                    //topic_route_data.encode()
-                    topic_route_data.encode()
-                } else {
-                    topic_route_data.encode()
-                };*/
+                //Rust only support standard JSON serialization
                 let content = topic_route_data.encode()?;
                 Ok(Some(
                     RemotingCommand::create_response_command_with_code(ResponseCode::Success)


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4020

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - More reliable startup readiness handling that honors configured wait time, reducing premature “not ready” errors.
  - Standardized error messages to “name server not ready” and clearer “No topic route info…” wording.

- Refactor
  - Simplified topic route data encoding for consistent, predictable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->