### PR TITLE
[ISSUE #4025]Introduce ChannelId type alias for improved clarity in channel struct

### DIFF
--- a/rocketmq-remoting/src/net/channel.rs
+++ b/rocketmq-remoting/src/net/channel.rs
@@ -35,12 +35,14 @@ use crate::base::response_future::ResponseFuture;
 use crate::connection::Connection;
 use crate::protocol::remoting_command::RemotingCommand;
 
+pub type ChannelId = CheetahString;
+
 #[derive(Clone)]
 pub struct Channel {
     inner: WeakArcMut<ChannelInner>,
     local_address: SocketAddr,
     remote_address: SocketAddr,
-    channel_id: CheetahString,
+    channel_id: ChannelId,
 }
 
 impl Channel {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4025

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channels now auto-generate unique identifiers on creation, improving traceability and diagnostics.
  * Added an API to update a channel’s identifier when needed.

* **Refactor**
  * Standardized the channel identifier type across the module for consistency and clearer semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->