### PR TITLE
refactor: ClientRequestProcessor#process_request

### DIFF
--- a/rocketmq-namesrv/src/processor/client_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/client_request_processor.rs
@@ -46,8 +46,8 @@ impl RequestProcessor for ClientRequestProcessor {
     #[inline]
     async fn process_request(
         &mut self,
-        channel: Channel,
-        ctx: ConnectionHandlerContext,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
@@ -55,7 +55,8 @@ impl RequestProcessor for ClientRequestProcessor {
             "Name server ClientRequestProcessor Received request code: {:?}",
             request_code
         );
-        self.process_request_inner(channel, ctx, request_code, request)
+
+        self.get_route_info_by_topic(request)
     }
 }
 
@@ -66,17 +67,6 @@ impl ClientRequestProcessor {
             startup_time_millis: TimeUtils::get_current_millis(),
             name_server_runtime_inner,
         }
-    }
-
-    #[inline]
-    fn process_request_inner(
-        &mut self,
-        _channel: Channel,
-        _ctx: ConnectionHandlerContext,
-        _request_code: RequestCode,
-        request: &mut RemotingCommand,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        self.get_route_info_by_topic(request)
     }
 
     fn get_route_info_by_topic(


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4022 
### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Functional call is refactored to call function get_route_info_by_topic directly


### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined client request processing in the name server, reducing internal indirection and clarifying unused parameters. This simplifies the call path, improves readability, and may marginally reduce overhead under load. There are no changes to request/response behavior, configuration, or public interfaces. Existing clients and integrations continue to work without modification. No action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->