### PR TITLE
Exchange broker ha info

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -2063,7 +2063,7 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
-    pub fn set_master_addr(&mut self, master_addr: CheetahString) {
+    pub fn update_slave_master_addr(&mut self, master_addr: CheetahString) {
         if let Some(ref mut slave) = self.slave_synchronize {
             slave.set_master_addr(master_addr);
         };

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -2058,6 +2058,18 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
+    pub fn slave_synchronize(&self) -> &Option<SlaveSynchronize<MS>> {
+        &self.slave_synchronize
+    }
+
+    #[inline]
+    pub fn set_master_addr(&mut self, master_addr: CheetahString) {
+        if let Some(ref mut slave) = self.slave_synchronize {
+            slave.set_master_addr(master_addr);
+        };
+    }
+
+    #[inline]
     pub fn set_store_host(&mut self, store_host: SocketAddr) {
         self.store_host = store_host;
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -162,7 +162,7 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
         }
 
         //master online
-        if min_broker_id == MASTER_ID || !min_broker_addr.is_empty() {
+        if min_broker_id == MASTER_ID && !min_broker_addr.is_empty() {
             self.on_master_on_line(min_broker_addr, master_ha_addr)
                 .await;
         }

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -203,7 +203,7 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
     ) {
         let need_sync_master_flush_offset =
             if let Some(message_store) = self.broker_runtime_inner.message_store() {
-                message_store.get_master_flushed_offset() == 0x000
+                message_store.get_master_flushed_offset() == 0x0000
                     && self
                         .broker_runtime_inner
                         .message_store_config()

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -182,11 +182,8 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
         let broker_runtime_inner = self.broker_runtime_inner.mut_from_ref();
 
         if let Some(slave_synchronize) = broker_runtime_inner.slave_synchronize() {
-            match slave_synchronize.master_addr() {
-                Some(_master_addr) => {
-                    // Call the close client method
-                }
-                None => {}
+            if let Some(_master_addr) = slave_synchronize.master_addr() {
+                // Call the close client method
             }
         }
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -190,7 +190,7 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
             }
         }
 
-        broker_runtime_inner.set_master_addr(CheetahString::empty());
+        broker_runtime_inner.update_slave_master_addr(CheetahString::empty());
         if let Some(message_store) = broker_runtime_inner.message_store() {
             message_store.update_master_address(&CheetahString::empty());
         }

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -203,16 +203,11 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
     ) {
         let need_sync_master_flush_offset =
             if let Some(message_store) = self.broker_runtime_inner.message_store() {
-                if message_store.get_master_flushed_offset() == 0x000
+                message_store.get_master_flushed_offset() == 0x000
                     && self
                         .broker_runtime_inner
                         .message_store_config()
                         .sync_master_flush_offset_when_startup
-                {
-                    true
-                } else {
-                    false
-                }
             } else {
                 false
             };

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -180,7 +180,7 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
 
         if let Some(slave_synchronize) = broker_runtime_inner.slave_synchronize() {
             if let Some(_master_addr) = slave_synchronize.master_addr() {
-                // Call the close client method
+                unimplemented!("Call the close client method")
             }
         }
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -45,14 +45,14 @@ pub struct NotifyMinBrokerChangeIdHandler<MS: MessageStore> {
 #[derive(Clone)]
 struct MinBrokerIngroup {
     min_broker_id_in_group: Option<u64>,
-    min_broker_addr_in_group: CheetahString,
+    min_broker_addr_in_group: Arc<CheetahString>,
 }
 
 impl MinBrokerIngroup {
     fn new() -> Self {
         Self {
             min_broker_id_in_group: Some(MASTER_ID),
-            min_broker_addr_in_group: CheetahString::empty(),
+            min_broker_addr_in_group: Arc::new(CheetahString::empty()),
         }
     }
 }
@@ -109,16 +109,13 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
                 if let Some(min_broker_id) = change_header.min_broker_id {
                     if min_broker_id != self.broker_runtime_inner.get_min_broker_id_in_group() {
                         // on min broker change
-                        let min_broker_id = change_header.min_broker_id.unwrap();
                         let min_broker_addr = change_header.min_broker_addr.as_deref().unwrap();
-                        let offline_broker_addr = &change_header.offline_broker_addr;
-                        let master_ha_addr = &change_header.ha_broker_addr;
 
                         self.on_min_broker_change(
                             min_broker_id,
                             min_broker_addr,
-                            offline_broker_addr,
-                            master_ha_addr,
+                            &change_header.offline_broker_addr,
+                            &change_header.ha_broker_addr,
                         )
                         .await;
                     }
@@ -146,7 +143,7 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
 
         let mut lock_guard = self.lock.write().await;
         lock_guard.min_broker_id_in_group = Some(min_broker_id);
-        lock_guard.min_broker_addr_in_group = CheetahString::from_slice(min_broker_addr);
+        lock_guard.min_broker_addr_in_group = Arc::new(CheetahString::from_slice(min_broker_addr));
 
         let should_start = self.broker_runtime_inner.get_min_broker_id_in_group()
             == self.lock.read().await.min_broker_id_in_group.unwrap();
@@ -157,7 +154,7 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
         if let Some(offline_broker_addr) = offline_broker_addr {
             if let Some(slave_sync) = self.broker_runtime_inner.slave_synchronize() {
                 if let Some(master_addr) = slave_sync.master_addr() {
-                    if offline_broker_addr.eq(master_addr.deref()) {
+                    if !master_addr.is_empty() && offline_broker_addr.eq(master_addr.deref()) {
                         self.on_master_offline().await;
                     }
                 }
@@ -227,7 +224,7 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
         self.lock.read().await.min_broker_id_in_group
     }
 
-    pub async fn get_min_broker_addr_in_group(&self) -> CheetahString {
+    pub async fn get_min_broker_addr_in_group(&self) -> Arc<CheetahString> {
         self.lock.read().await.min_broker_addr_in_group.clone()
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::header::namesrv::brokerid_change_request_header::NotifyMinBrokerIdChangeRequestHeader;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+use tracing::warn;
+
+use crate::broker_runtime::BrokerRuntimeInner;
+
+#[derive(Clone)]
+pub struct NotifyMinBrokerChangeIdHandler<MS: MessageStore> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+}
+
+impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
+    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        Self {
+            broker_runtime_inner,
+        }
+    }
+
+    pub async fn notify_min_broker_id_change(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        let change_header = request
+            .decode_command_custom_header::<NotifyMinBrokerIdChangeRequestHeader>()
+            .unwrap();
+
+        let current_broker_id = self
+            .broker_runtime_inner
+            .broker_config()
+            .broker_identity
+            .broker_id;
+
+        warn!(
+            "min broker id changed, prev {}, new {}",
+            current_broker_id,
+            change_header
+                .min_broker_id
+                .expect("min broker id not must be present")
+        );
+
+        // TODO Implement update broker id method in the near future
+
+        let mut response = RemotingCommand::default();
+        response.set_code_ref(ResponseCode::Success);
+        Some(response)
+    }
+}

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -167,7 +167,7 @@ impl<MS: MessageStore> NotifyMinBrokerChangeIdHandler<MS> {
         }
 
         //master online
-        if min_broker_id == MASTER_ID {
+        if min_broker_id == MASTER_ID || !min_broker_addr.is_empty() {
             self.on_master_on_line(min_broker_addr, master_ha_addr)
                 .await;
         }

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
@@ -53,7 +53,7 @@ impl<MS: MessageStore> UpdateBrokerHaHandler<MS> {
 
         let mut response = RemotingCommand::default();
 
-        if let Some(master_ha_addr) = exchange_request_header.master_ha_address {
+        if let Some(master_ha_addr) = exchange_request_header.master_ha_address.as_ref() {
             if !master_ha_addr.is_empty() {
                 if let Some(message_store) = self.broker_runtime_inner.message_store() {
                     message_store
@@ -63,12 +63,12 @@ impl<MS: MessageStore> UpdateBrokerHaHandler<MS> {
                     let master_address = exchange_request_header.master_address.unwrap_or_default();
                     message_store.update_master_address(&master_address);
 
-                    let is_sync_master_flush_offset_when_startip = self
+                    let should_sync_master_flush_offset_on_startup = self
                         .broker_runtime_inner
                         .message_store_config()
                         .sync_master_flush_offset_when_startup;
-                    if message_store.get_master_flushed_offset() == 0x000
-                        && is_sync_master_flush_offset_when_startip
+                    if message_store.get_master_flushed_offset() == 0x0000
+                        && should_sync_master_flush_offset_on_startup
                     {
                         let master_flush_offset =
                             exchange_request_header.master_flush_offset.unwrap();

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use rocketmq_common::common::mix_all::MASTER_ID;
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::header::exchange_ha_info_request_header::ExchangeHAInfoRequestHeader;
+use rocketmq_remoting::protocol::header::exchange_ha_info_response_header::ExchangeHaInfoResponseHeader;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+use tracing::info;
+
+use crate::broker_runtime::BrokerRuntimeInner;
+
+pub struct UpdateBrokerHaHandler<MS: MessageStore> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+}
+
+impl<MS: MessageStore> UpdateBrokerHaHandler<MS> {
+    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        Self {
+            broker_runtime_inner,
+        }
+    }
+
+    pub async fn update_broker_ha_info(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: RemotingCommand,
+    ) -> Option<RemotingCommand> {
+        let exchange_request_header = request
+            .decode_command_custom_header::<ExchangeHAInfoRequestHeader>()
+            .unwrap();
+
+        let mut response = RemotingCommand::default();
+
+        if let Some(master_ha_addr) = exchange_request_header.master_ha_address {
+            if !master_ha_addr.is_empty() {
+                if let Some(message_store) = self.broker_runtime_inner.message_store() {
+                    message_store
+                        .update_ha_master_address(master_ha_addr.as_str())
+                        .await;
+
+                    let master_address = exchange_request_header.master_address.unwrap_or_default();
+                    message_store.update_master_address(&master_address);
+
+                    let is_sync_master_flush_offset_when_startip = self
+                        .broker_runtime_inner
+                        .message_store_config()
+                        .sync_master_flush_offset_when_startup;
+                    if message_store.get_master_flushed_offset() == 0x000
+                        && is_sync_master_flush_offset_when_startip
+                    {
+                        let master_flush_offset =
+                            exchange_request_header.master_flush_offset.unwrap();
+
+                        info!(
+                            "Set master flush offset in slave to {}",
+                            master_flush_offset
+                        );
+                        message_store.set_master_flushed_offset(master_flush_offset);
+                    }
+                }
+            } else if self
+                .broker_runtime_inner
+                .broker_config()
+                .broker_identity
+                .broker_id
+                == MASTER_ID
+            {
+                let response_header = response
+                    .read_custom_header_mut::<ExchangeHaInfoResponseHeader>()
+                    .unwrap();
+
+                response_header.master_ha_address =
+                    Some(self.broker_runtime_inner.get_ha_server_addr());
+
+                if let Some(message_store) = self.broker_runtime_inner.message_store() {
+                    response_header.master_flush_offset =
+                        Some(message_store.get_broker_init_max_offset());
+                }
+                response_header.master_address =
+                    Some(self.broker_runtime_inner.get_broker_addr().clone());
+            }
+        }
+
+        response.set_code_ref(ResponseCode::Success);
+        Some(response)
+    }
+}

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
@@ -45,7 +45,7 @@ impl<MS: MessageStore> UpdateBrokerHaHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        request: RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> Option<RemotingCommand> {
         let exchange_request_header = request
             .decode_command_custom_header::<ExchangeHAInfoRequestHeader>()

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
@@ -29,6 +29,7 @@ use tracing::info;
 
 use crate::broker_runtime::BrokerRuntimeInner;
 
+#[derive(Clone)]
 pub struct UpdateBrokerHaHandler<MS: MessageStore> {
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
 }

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -29,6 +29,7 @@ pub mod elect_master_response_header;
 pub mod empty_header;
 pub mod end_transaction_request_header;
 pub mod exchange_ha_info_request_header;
+pub mod exchange_ha_info_response_header;
 pub mod extra_info_util;
 pub mod get_all_topic_config_response_header;
 pub mod get_consume_stats_request_header;

--- a/rocketmq-remoting/src/protocol/header/exchange_ha_info_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/exchange_ha_info_response_header.rs
@@ -1,0 +1,52 @@
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodec;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodec)]
+#[serde(rename_all = "camelCase")]
+pub struct ExchangeHaInfoResponseHeader {
+    pub master_ha_address: Option<CheetahString>,
+    pub master_flush_offset: Option<i64>,
+    pub master_address: Option<CheetahString>,
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    fn create_cheetah_string(value: &str) -> Option<CheetahString> {
+        Some(CheetahString::from(value))
+    }
+
+    #[test]
+    fn serialize_with_all_fields_set() {
+        let header = ExchangeHaInfoResponseHeader {
+            master_ha_address: create_cheetah_string("127.0.0.1:10911"),
+            master_flush_offset: Some(1024),
+            master_address: create_cheetah_string("127.0.0.1"),
+        };
+
+        let serialized = serde_json::to_string(&header).unwrap();
+        assert!(serialized.contains("\"masterHaAddress\":\"127.0.0.1:10911\""));
+        assert!(serialized.contains("\"masterFlushOffset\":1024"));
+        assert!(serialized.contains("\"masterAddress\":\"127.0.0.1\""));
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4036 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Admin API: support exchanging broker HA info; responses can convey master HA address, master flush offset, and master address. Added runtime handling for HA info updates.
- Bug Fixes
  - Safer concurrent handling of min-broker state and addresses (shared ownership for address state).
  - Avoids master-offline actions when master address is empty and ensures proper state clearing and improved startup sync.
- Tests
  - Added serialization test for the HA info response header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->