### PR TITLE
[ISSUE  #4038]🚀Add page_size dependency and enhance memory management in TransientStorePool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,9 +2461,11 @@ dependencies = [
  "libc",
  "memmap2",
  "once_cell",
+ "page_size",
  "parking_lot",
  "rand",
  "rocketmq-common",
+ "rocketmq-error",
  "rocketmq-remoting",
  "rocketmq-rust",
  "serde",

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -155,6 +155,9 @@ pub enum RocketmqError {
 
     #[error("{0}")]
     ServiceTaskError(#[from] ServiceError),
+
+    #[error("{0}")]
+    StoreCustomError(String),
 }
 
 #[derive(Error, Debug)]

--- a/rocketmq-store/Cargo.toml
+++ b/rocketmq-store/Cargo.toml
@@ -22,6 +22,7 @@ data_store = ["local_file_store"]
 rocketmq-common = { workspace = true }
 rocketmq-rust = { workspace = true }
 rocketmq-remoting = { workspace = true }
+rocketmq-error = {workspace = true}
 
 #tools
 dirs.workspace = true
@@ -55,9 +56,9 @@ futures-util = "0.3.31"
 rand = { workspace = true }
 uuid = { workspace = true }
 anyhow = { workspace = true }
+page_size = "0.6.0"
 
-
-[target.'cfg(linux)'.dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2.175"
 
 [target.'cfg(windows)'.dependencies]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -66,6 +66,7 @@ use rocketmq_common::FileUtils::string_to_file;
 use rocketmq_common::MessageDecoder;
 use rocketmq_common::TimeUtils::get_current_millis;
 use rocketmq_common::UtilAll::ensure_dir_ok;
+use rocketmq_error::RocketMQResult;
 use rocketmq_rust::ArcMut;
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
@@ -702,7 +703,10 @@ impl MessageStore for LocalFileMessageStore {
         }
 
         if self.is_transient_store_pool_enable() {
-            self.transient_store_pool.init();
+            match self.transient_store_pool.init() {
+                Ok(_) => {}
+                Err(e) => return Err(StoreError::General(e.to_string())),
+            }
         }
         Ok(())
     }
@@ -744,7 +748,7 @@ impl MessageStore for LocalFileMessageStore {
             }
         }
 
-        self.transient_store_pool.destroy();
+        let _ = self.transient_store_pool.destroy();
     }
 
     fn destroy(&mut self) {

--- a/rocketmq-store/src/utils.rs
+++ b/rocketmq-store/src/utils.rs
@@ -15,4 +15,5 @@
  * limitations under the License.
  */
 
+pub(crate) mod ffi;
 pub(crate) mod store_util;

--- a/rocketmq-store/src/utils/ffi.rs
+++ b/rocketmq-store/src/utils/ffi.rs
@@ -1,0 +1,71 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+use std::ffi::c_void;
+
+use libc::c_uchar;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::RocketmqError;
+
+pub(crate) const MADV_NORMAL: i32 = 0;
+pub(crate) const MADV_RANDOM: i32 = 1;
+pub(crate) const MADV_WILLNEED: i32 = 3;
+pub(crate) const MADV_DONTNEED: i32 = 4;
+
+#[inline]
+pub fn get_page_size() -> usize {
+    page_size::get()
+}
+
+#[inline]
+pub fn mlock(addr: *const u8, len: usize) -> RocketMQResult<()> {
+    #[cfg(unix)]
+    {
+        let result = unsafe { libc::mlock(addr as *const c_void, len) };
+        if result != 0 {
+            return Err(RocketmqError::StoreCustomError("mlock failed".to_string()));
+        }
+        Ok(())
+    }
+}
+
+#[inline]
+pub fn munlock(addr: *const u8, len: usize) -> RocketMQResult<()> {
+    #[cfg(unix)]
+    {
+        let result = unsafe { libc::munlock(addr as *const c_void, len) };
+        if result != 0 {
+            return Err(RocketmqError::StoreCustomError(
+                "munlock failed".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub fn madvise(addr: *const u8, len: usize, advice: i32) -> i32 {
+    #[cfg(unix)]
+    {
+        unsafe { libc::madvise(addr as *mut c_void, len, advice) }
+    }
+}
+
+pub fn mincore(addr: *const u8, len: usize, vec: *const u8) -> i32 {
+    #[cfg(unix)]
+    {
+        unsafe { libc::mincore(addr as *mut c_void, len, vec as *mut c_uchar) }
+    }
+}


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4038

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved transient storage reliability by locking buffers in memory on Unix systems to reduce paging.
  - More descriptive store error surfaced to users in failure scenarios.

- Performance
  - Faster, more efficient synchronization in transient storage operations, improving throughput under load.

- Refactor
  - Streamlined initialization and shutdown flows to propagate errors consistently from storage components.

- Chores
  - Updated dependencies and platform targeting to support Unix environments more broadly, preparing for advanced memory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->