### PR TITLE
refactor: Simplying default configuration in NamesrvConfig

### DIFF
--- a/rocketmq-common/src/common/namesrv/namesrv_config.rs
+++ b/rocketmq-common/src/common/namesrv/namesrv_config.rs
@@ -38,15 +38,15 @@ mod defaults {
 
     pub fn kv_config_path() -> String {
         let mut kv_config_path = dirs::home_dir().unwrap_or_default();
-        kv_config_path.push("namesrv");
+        kv_config_path.push("rocketmq-namesrv");
         kv_config_path.push("kvConfig.json");
         kv_config_path.to_str().unwrap_or_default().to_string()
     }
 
     pub fn config_store_path() -> String {
         let mut kv_config_path = dirs::home_dir().unwrap_or_default();
-        kv_config_path.push("namesrv");
-        kv_config_path.push("namesrv.properties");
+        kv_config_path.push("rocketmq-namesrv");
+        kv_config_path.push("rocketmq-namesrv.properties");
         kv_config_path.to_str().unwrap_or_default().to_string()
     }
 
@@ -197,30 +197,10 @@ pub struct NamesrvConfig {
 
 impl Default for NamesrvConfig {
     fn default() -> Self {
-        let rocketmq_home = env::var(ROCKETMQ_HOME_PROPERTY)
-            .unwrap_or_else(|_| env::var(ROCKETMQ_HOME_ENV).unwrap_or_default());
-        let kv_config_path = format!(
-            "{}{}{}{}{}",
-            dirs::home_dir().unwrap().to_str().unwrap(),
-            std::path::MAIN_SEPARATOR,
-            "rocketmq-namesrv",
-            std::path::MAIN_SEPARATOR,
-            "kvConfig.json"
-        );
-
-        let config_store_path = format!(
-            "{}{}{}{}{}",
-            dirs::home_dir().unwrap().to_str().unwrap(),
-            std::path::MAIN_SEPARATOR,
-            "rocketmq-namesrv",
-            std::path::MAIN_SEPARATOR,
-            "rocketmq-namesrv.properties"
-        );
-
         NamesrvConfig {
-            rocketmq_home,
-            kv_config_path,
-            config_store_path,
+            rocketmq_home: defaults::rocketmq_home(),
+            kv_config_path: defaults::kv_config_path(),
+            config_store_path: defaults::config_store_path(),
             product_env_name: "center".to_string(),
             cluster_test: false,
             order_message_enable: false,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4037 
### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->

The Refactoring was tested against the test cases present in the file.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated default configuration and data file locations to use the rocketmq-namesrv directory and filenames.
- Refactor
  - Simplified how default paths are initialized internally without changing public interfaces.
- Chores
  - Aligned default file naming and directories for consistency across NameServer components.

Note: If you rely on default paths, ensure your existing configuration/data files are moved to the new rocketmq-namesrv locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->