### PR TITLE
[ISSUE #4048]🚀Add broker heartbeat interval configuration and scheduling

### DIFF
--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -366,6 +366,11 @@ mod defaults {
     pub fn compatible_with_old_name_srv() -> bool {
         true
     }
+
+    #[inline]
+    pub fn broker_heartbeat_interval() -> u64 {
+        1000
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -761,6 +766,9 @@ pub struct BrokerConfig {
 
     #[serde(default = "defaults::compatible_with_old_name_srv")]
     pub compatible_with_old_name_srv: bool,
+
+    #[serde(default = "defaults::broker_heartbeat_interval")]
+    pub broker_heartbeat_interval: u64,
 }
 
 impl Default for BrokerConfig {
@@ -881,6 +889,7 @@ impl Default for BrokerConfig {
             transaction_check_max: 15,
             transaction_op_batch_interval: 3_000,
             compatible_with_old_name_srv: true,
+            broker_heartbeat_interval: 1000,
         }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4048

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced periodic broker heartbeat scheduling in slave-acting-master and controller modes, enabling automated liveness updates without manual intervention on supported deployments.
  * Added a new broker configuration option to set the heartbeat interval (default: 1000 ms), allowing operators to fine-tune frequency based on deployment needs. The setting is applied on startup when the above modes are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->