### PR TITLE
[ISSUE #3793]⚡️Remove unused trait-variant workspace dependency from Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,7 +2443,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "trait-variant",
  "uuid",
 ]
 

--- a/rocketmq/Cargo.toml
+++ b/rocketmq/Cargo.toml
@@ -17,7 +17,6 @@ rust-version.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-trait-variant = { workspace = true }
 rocketmq-error = { workspace = true }
 
 uuid = { version = "1", features = ["v4"] }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #3793 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Remove unused trait-variant workspace dependency from Cargo.toml

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
