### PR TITLE
[ISSUE #4092]♻️Clean up existing clippy warnings of bool_assert_comparison and assertions_on_constant

### DIFF
--- a/rocketmq-broker/src/client/consumer_group_event.rs
+++ b/rocketmq-broker/src/client/consumer_group_event.rs
@@ -39,29 +39,16 @@ mod tests {
         let client_register = ConsumerGroupEvent::ClientRegister;
         let client_unregister = ConsumerGroupEvent::ClientUnregister;
 
-        match change {
-            ConsumerGroupEvent::Change => assert!(true),
-            _ => assert!(false),
-        }
-
-        match unregister {
-            ConsumerGroupEvent::Unregister => assert!(true),
-            _ => assert!(false),
-        }
-
-        match register {
-            ConsumerGroupEvent::Register => assert!(true),
-            _ => assert!(false),
-        }
-
-        match client_register {
-            ConsumerGroupEvent::ClientRegister => assert!(true),
-            _ => assert!(false),
-        }
-
-        match client_unregister {
-            ConsumerGroupEvent::ClientUnregister => assert!(true),
-            _ => assert!(false),
-        }
+        assert!(matches!(change, ConsumerGroupEvent::Change));
+        assert!(matches!(unregister, ConsumerGroupEvent::Unregister));
+        assert!(matches!(register, ConsumerGroupEvent::Register));
+        assert!(matches!(
+            client_register,
+            ConsumerGroupEvent::ClientRegister
+        ));
+        assert!(matches!(
+            client_unregister,
+            ConsumerGroupEvent::ClientUnregister
+        ));
     }
 }

--- a/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
@@ -266,7 +266,7 @@ mod tests {
         let broker_config = Arc::new(BrokerConfig::default());
         let manager = TopicQueueMappingManager::new(broker_config.clone());
 
-        assert_eq!(Arc::ptr_eq(&manager.broker_config, &broker_config), true);
+        assert!(Arc::ptr_eq(&manager.broker_config, &broker_config));
         assert_eq!(manager.data_version.lock().get_state_version(), 0);
         assert_eq!(manager.topic_queue_mapping_table.lock().len(), 0);
     }

--- a/rocketmq-common/src/common/attribute/bool_attribute.rs
+++ b/rocketmq-common/src/common/attribute/bool_attribute.rs
@@ -127,14 +127,14 @@ mod tests {
     fn parse_bool_true() {
         let result = BooleanAttribute::parse_bool("true");
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
     }
 
     #[test]
     fn parse_bool_false() {
         let result = BooleanAttribute::parse_bool("false");
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), false);
+        assert!(!result.unwrap());
     }
 
     #[test]

--- a/rocketmq-common/src/common/config.rs
+++ b/rocketmq-common/src/common/config.rs
@@ -210,7 +210,7 @@ mod tests {
         assert_eq!(config.perm, PermName::PERM_READ | PermName::PERM_WRITE);
         assert_eq!(config.topic_filter_type, TopicFilterType::SingleTag);
         assert_eq!(config.topic_sys_flag, 0);
-        assert_eq!(config.order, false);
+        assert!(!config.order);
         assert!(config.attributes.is_empty());
     }
 

--- a/rocketmq-common/src/common/namesrv/namesrv_config.rs
+++ b/rocketmq-common/src/common/namesrv/namesrv_config.rs
@@ -478,23 +478,23 @@ mod tests {
             )
         );
         assert_eq!(config.product_env_name, "center");
-        assert_eq!(config.cluster_test, false);
-        assert_eq!(config.order_message_enable, false);
-        assert_eq!(config.return_order_topic_config_to_broker, true);
+        assert!(!config.cluster_test);
+        assert!(!config.order_message_enable);
+        assert!(config.return_order_topic_config_to_broker);
         assert_eq!(config.client_request_thread_pool_nums, 8);
         assert_eq!(config.default_thread_pool_nums, 16);
         assert_eq!(config.client_request_thread_pool_queue_capacity, 50000);
         assert_eq!(config.default_thread_pool_queue_capacity, 10000);
         assert_eq!(config.scan_not_active_broker_interval, 5 * 1000);
         assert_eq!(config.unregister_broker_queue_capacity, 3000);
-        assert_eq!(config.support_acting_master, false);
-        assert_eq!(config.enable_all_topic_list, true);
-        assert_eq!(config.enable_topic_list, true);
-        assert_eq!(config.notify_min_broker_id_changed, false);
-        assert_eq!(config.enable_controller_in_namesrv, false);
-        assert_eq!(config.need_wait_for_service, false);
+        assert!(!config.support_acting_master);
+        assert!(config.enable_all_topic_list);
+        assert!(config.enable_topic_list);
+        assert!(!config.notify_min_broker_id_changed);
+        assert!(!config.enable_controller_in_namesrv);
+        assert!(!config.need_wait_for_service);
         assert_eq!(config.wait_seconds_for_service, 45);
-        assert_eq!(config.delete_topic_with_broker_registration, false);
+        assert!(!config.delete_topic_with_broker_registration);
         assert_eq!(
             config.config_black_list,
             "configBlackList;configStorePath;kvConfigPath".to_string()
@@ -598,22 +598,22 @@ mod tests {
         assert_eq!(config.kv_config_path, "/new/kvConfigPath");
         assert_eq!(config.config_store_path, "/new/configStorePath");
         assert_eq!(config.product_env_name, "new_env");
-        assert_eq!(config.cluster_test, true);
-        assert_eq!(config.order_message_enable, true);
+        assert!(config.cluster_test);
+        assert!(config.order_message_enable);
         assert_eq!(config.client_request_thread_pool_nums, 10);
         assert_eq!(config.default_thread_pool_nums, 20);
         assert_eq!(config.client_request_thread_pool_queue_capacity, 10000);
         assert_eq!(config.default_thread_pool_queue_capacity, 20000);
         assert_eq!(config.scan_not_active_broker_interval, 15000);
         assert_eq!(config.unregister_broker_queue_capacity, 4000);
-        assert_eq!(config.support_acting_master, true);
-        assert_eq!(config.enable_all_topic_list, false);
-        assert_eq!(config.enable_topic_list, false);
-        assert_eq!(config.notify_min_broker_id_changed, true);
-        assert_eq!(config.enable_controller_in_namesrv, true);
-        assert_eq!(config.need_wait_for_service, true);
+        assert!(config.support_acting_master);
+        assert!(!config.enable_all_topic_list);
+        assert!(!config.enable_topic_list);
+        assert!(config.notify_min_broker_id_changed);
+        assert!(config.enable_controller_in_namesrv);
+        assert!(config.need_wait_for_service);
         assert_eq!(config.wait_seconds_for_service, 30);
-        assert_eq!(config.delete_topic_with_broker_registration, true);
+        assert!(config.delete_topic_with_broker_registration);
         assert_eq!(config.config_black_list, "newBlackList");
     }
 

--- a/rocketmq-common/src/utils/cleanup_policy_utils.rs
+++ b/rocketmq-common/src/utils/cleanup_policy_utils.rs
@@ -61,7 +61,7 @@ mod tests {
             TopicAttributes::cleanup_policy_attribute().name().into(),
             CleanupPolicy::COMPACTION.to_string().into(),
         );
-        assert_eq!(is_compaction(Some(&topic_config)), true);
+        assert!(is_compaction(Some(&topic_config)));
     }
 
     #[test]
@@ -74,12 +74,12 @@ mod tests {
                 .into(),
             CleanupPolicy::DELETE.to_string().into(),
         );
-        assert_eq!(is_compaction(Some(&topic_config)), false);
+        assert!(!is_compaction(Some(&topic_config)));
     }
 
     #[test]
     fn is_compaction_returns_false_when_topic_config_is_none() {
-        assert_eq!(is_compaction(None), false);
+        assert!(!is_compaction(None));
     }
 
     #[test]

--- a/rocketmq-common/src/utils/queue_type_utils.rs
+++ b/rocketmq-common/src/utils/queue_type_utils.rs
@@ -40,13 +40,13 @@ mod tests {
     #[test]
     fn test_is_batch_cq() {
         let topic_config = None;
-        assert_eq!(QueueTypeUtils::is_batch_cq(topic_config), false);
+        assert!(!QueueTypeUtils::is_batch_cq(topic_config));
 
         let topic_config = Some(TopicConfig {
             attributes: HashMap::new(),
             ..TopicConfig::default()
         });
-        assert_eq!(QueueTypeUtils::is_batch_cq(topic_config.as_ref()), false);
+        assert!(!QueueTypeUtils::is_batch_cq(topic_config.as_ref()));
 
         let topic_config = Some(TopicConfig {
             attributes: HashMap::from_iter([(
@@ -58,7 +58,7 @@ mod tests {
             )]),
             ..TopicConfig::default()
         });
-        assert_eq!(QueueTypeUtils::is_batch_cq(topic_config.as_ref()), true);
+        assert!(QueueTypeUtils::is_batch_cq(topic_config.as_ref()));
 
         let topic_config = Some(TopicConfig {
             attributes: HashMap::from_iter([(
@@ -70,7 +70,7 @@ mod tests {
             )]),
             ..TopicConfig::default()
         });
-        assert_eq!(QueueTypeUtils::is_batch_cq(topic_config.as_ref()), false);
+        assert!(!QueueTypeUtils::is_batch_cq(topic_config.as_ref()));
     }
 
     #[test]

--- a/rocketmq-common/src/utils/util_all.rs
+++ b/rocketmq-common/src/utils/util_all.rs
@@ -412,13 +412,13 @@ mod tests {
     #[test]
     fn is_it_time_to_do_returns_true_when_current_hour_is_in_input() {
         let current_hour = Local::now().hour();
-        assert_eq!(is_it_time_to_do(&current_hour.to_string()), true);
+        assert!(is_it_time_to_do(&current_hour.to_string()));
     }
 
     #[test]
     fn is_it_time_to_do_returns_false_when_current_hour_is_not_in_input() {
         let current_hour = (Local::now().hour() + 1) % 24;
-        assert_eq!(is_it_time_to_do(&current_hour.to_string()), false);
+        assert!(!is_it_time_to_do(&current_hour.to_string()));
     }
 
     #[test]
@@ -434,12 +434,12 @@ mod tests {
 
     #[test]
     fn is_path_exists_returns_true_for_existing_path() {
-        assert_eq!(is_path_exists("."), true);
+        assert!(is_path_exists("."));
     }
 
     #[test]
     fn is_path_exists_returns_false_for_non_existing_path() {
-        assert_eq!(is_path_exists("./non_existing_path"), false);
+        assert!(!is_path_exists("./non_existing_path"));
     }
 
     #[test]
@@ -457,7 +457,7 @@ mod tests {
     fn ensure_dir_ok_creates_directory_if_not_exists() {
         let dir_name = "./test_dir";
         ensure_dir_ok(dir_name);
-        assert_eq!(is_path_exists(dir_name), true);
+        assert!(is_path_exists(dir_name));
         std::fs::remove_dir(dir_name).unwrap();
     }
 

--- a/rocketmq-remoting/src/protocol/body/topic_info_wrapper/topic_config_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/topic_info_wrapper/topic_config_wrapper.rs
@@ -91,13 +91,10 @@ mod tests {
         assert!(wrapper.topic_queue_mapping_info_map.is_empty());
         assert!(wrapper.topic_queue_mapping_detail_map.is_empty());
         //assert_eq!(wrapper.mapping_data_version, DataVersion::new());
-        assert_eq!(
-            wrapper
-                .topic_config_serialize_wrapper()
-                .topic_config_table()
-                .is_empty(),
-            true
-        );
+        assert!(wrapper
+            .topic_config_serialize_wrapper()
+            .topic_config_table()
+            .is_empty());
         // assert_eq!(
         //     wrapper.topic_config_serialize_wrapper().data_version(),
         //     &DataVersion::new()

--- a/rocketmq-remoting/src/protocol/header/create_topic_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/create_topic_request_header.rs
@@ -213,7 +213,7 @@ mod tests {
         assert_eq!(header.perm, 6);
         assert_eq!(header.topic_filter_type, CheetahString::from("filter_type"));
         assert_eq!(header.topic_sys_flag, Some(1));
-        assert_eq!(header.order, true);
+        assert!(header.order);
         assert_eq!(header.attributes, Some(CheetahString::from("attributes")));
         assert_eq!(header.force, Some(true));
     }
@@ -258,7 +258,7 @@ mod tests {
         assert_eq!(header.perm, 6);
         assert_eq!(header.topic_filter_type, CheetahString::from("filter_type"));
         assert_eq!(header.topic_sys_flag, None);
-        assert_eq!(header.order, true);
+        assert!(header.order);
         assert_eq!(header.attributes, None);
         assert_eq!(header.force, None);
     }

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
@@ -576,8 +576,8 @@ mod tests {
         assert_eq!(header.flag, 0);
         assert_eq!(header.properties.unwrap(), "test_properties");
         assert_eq!(header.reconsume_times.unwrap(), 3);
-        assert_eq!(header.unit_mode.unwrap(), true);
-        assert_eq!(header.batch.unwrap(), false);
+        assert!(header.unit_mode.unwrap());
+        assert!(!header.batch.unwrap());
         assert_eq!(header.max_reconsume_times.unwrap(), 5);
     }
 

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -614,9 +614,9 @@ mod tests {
         assert_eq!(header.h, 0);
         assert_eq!(header.i.unwrap(), "test_properties");
         assert_eq!(header.j.unwrap(), 3);
-        assert_eq!(header.k.unwrap(), true);
+        assert!(header.k.unwrap());
         assert_eq!(header.l.unwrap(), 5);
-        assert_eq!(header.m.unwrap(), false);
+        assert!(!header.m.unwrap());
         assert_eq!(header.n.unwrap(), "test_broker_name");
     }
 

--- a/rocketmq-remoting/src/protocol/header/reply_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/reply_message_request_header.rs
@@ -161,7 +161,7 @@ mod reply_message_request_header_tests {
         assert_eq!(map.get("producerGroup").unwrap(), "test_producer_group");
         assert_eq!(map.get("defaultTopicQueueNums").unwrap(), "10");
         assert_eq!(map.get("bornTimestamp").unwrap(), "1622547800");
-        assert_eq!(map.get("topicRequest").is_none(), true);
+        assert!(map.get("topicRequest").is_none());
         assert_eq!(map.get("queueId").unwrap(), "1");
         assert_eq!(map.get("sysFlag").unwrap(), "0");
         assert_eq!(map.get("bornHost").unwrap(), "test_born_host");

--- a/rocketmq-remoting/src/protocol/namespace_util.rs
+++ b/rocketmq-remoting/src/protocol/namespace_util.rs
@@ -229,18 +229,18 @@ mod tests {
 
     #[test]
     fn is_already_with_namespace_returns_false_when_empty() {
-        assert_eq!(
-            NamespaceUtil::is_already_with_namespace("", "my_namespace"),
-            false
-        );
+        assert!(!NamespaceUtil::is_already_with_namespace(
+            "",
+            "my_namespace"
+        ));
     }
 
     #[test]
     fn is_already_with_namespace_returns_true_when_with_namespace() {
-        assert_eq!(
-            NamespaceUtil::is_already_with_namespace("my_namespace%my_resource", "my_namespace"),
-            true
-        );
+        assert!(NamespaceUtil::is_already_with_namespace(
+            "my_namespace%my_resource",
+            "my_namespace"
+        ));
     }
 
     #[test]
@@ -291,46 +291,42 @@ mod tests {
 
     #[test]
     fn is_system_resource_returns_false_when_empty() {
-        assert_eq!(NamespaceUtil::is_system_resource(""), false);
+        assert!(!NamespaceUtil::is_system_resource(""));
     }
 
     #[test]
     fn is_system_resource_returns_true_when_system_resource() {
-        assert_eq!(NamespaceUtil::is_system_resource("CID_RMQ_SYS_"), true);
-        assert_eq!(NamespaceUtil::is_system_resource("TBW102"), true);
+        assert!(NamespaceUtil::is_system_resource("CID_RMQ_SYS_"));
+        assert!(NamespaceUtil::is_system_resource("TBW102"));
     }
 
     #[test]
     fn is_retry_topic_returns_false_when_empty() {
-        assert_eq!(NamespaceUtil::is_retry_topic(""), false);
+        assert!(!NamespaceUtil::is_retry_topic(""));
     }
 
     #[test]
     fn is_retry_topic_returns_true_when_retry_topic() {
-        assert_eq!(
-            NamespaceUtil::is_retry_topic("RETRY_GROUP_TOPIC_PREFIXmy_topic"),
-            false
-        );
-        assert_eq!(
-            NamespaceUtil::is_retry_topic("%RETRY%RETRY_GROUP_TOPIC_PREFIXmy_topic"),
-            true
-        );
+        assert!(!NamespaceUtil::is_retry_topic(
+            "RETRY_GROUP_TOPIC_PREFIXmy_topic"
+        ));
+        assert!(NamespaceUtil::is_retry_topic(
+            "%RETRY%RETRY_GROUP_TOPIC_PREFIXmy_topic"
+        ));
     }
 
     #[test]
     fn is_dlq_topic_returns_false_when_empty() {
-        assert_eq!(NamespaceUtil::is_dlq_topic(""), false);
+        assert!(!NamespaceUtil::is_dlq_topic(""));
     }
 
     #[test]
     fn is_dlq_topic_returns_true_when_dlq_topic() {
-        assert_eq!(
-            NamespaceUtil::is_dlq_topic("DLQ_GROUP_TOPIC_PREFIXmy_topic"),
-            false
-        );
-        assert_eq!(
-            NamespaceUtil::is_dlq_topic("%DLQ%DLQ_GROUP_TOPIC_PREFIXmy_topic"),
-            true
-        );
+        assert!(!NamespaceUtil::is_dlq_topic(
+            "DLQ_GROUP_TOPIC_PREFIXmy_topic"
+        ));
+        assert!(NamespaceUtil::is_dlq_topic(
+            "%DLQ%DLQ_GROUP_TOPIC_PREFIXmy_topic"
+        ));
     }
 }

--- a/rocketmq-store/src/ha/ha_connection_state_notification_request.rs
+++ b/rocketmq-store/src/ha/ha_connection_state_notification_request.rs
@@ -127,13 +127,13 @@ mod tests {
         // Check getters
         assert_eq!(request.expect_state(), HAConnectionState::Transfer);
         assert_eq!(request.remote_addr(), "127.0.0.1:9876");
-        assert_eq!(request.notify_when_shutdown(), true);
+        assert!(request.notify_when_shutdown());
 
         // Complete the request
         assert!(request.complete(true).await);
 
         // Verify the result was received
-        assert_eq!(receiver.await.unwrap(), true);
+        assert!(receiver.await.unwrap());
 
         // Completing again should fail
         assert!(!request.complete(false).await);

--- a/rocketmq-store/src/store/running_flags.rs
+++ b/rocketmq-store/src/store/running_flags.rs
@@ -207,37 +207,37 @@ mod tests {
     #[test]
     fn test_get_and_make_readable() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.get_and_make_readable(), true);
-        assert_eq!(running_flags.is_readable(), true);
-        assert_eq!(running_flags.get_and_make_readable(), true);
-        assert_eq!(running_flags.is_readable(), true);
+        assert!(running_flags.get_and_make_readable());
+        assert!(running_flags.is_readable());
+        assert!(running_flags.get_and_make_readable());
+        assert!(running_flags.is_readable());
     }
 
     #[test]
     fn test_is_readable() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.is_readable(), true);
+        assert!(running_flags.is_readable());
         running_flags
             .flag_bits
             .store(NOT_READABLE_BIT, Ordering::Relaxed);
-        assert_eq!(running_flags.is_readable(), false);
+        assert!(!running_flags.is_readable());
     }
 
     #[test]
     fn test_is_fenced() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.is_fenced(), false);
+        assert!(!running_flags.is_fenced());
         running_flags.flag_bits.store(FENCED_BIT, Ordering::Relaxed);
-        assert_eq!(running_flags.is_fenced(), true);
+        assert!(running_flags.is_fenced());
     }
 
     #[test]
     fn test_get_and_make_not_readable() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.get_and_make_not_readable(), true);
-        assert_eq!(running_flags.is_readable(), false);
-        assert_eq!(running_flags.get_and_make_not_readable(), false);
-        assert_eq!(running_flags.is_readable(), false);
+        assert!(running_flags.get_and_make_not_readable());
+        assert!(!running_flags.is_readable());
+        assert!(!running_flags.get_and_make_not_readable());
+        assert!(!running_flags.is_readable());
     }
 
     #[test]
@@ -247,111 +247,111 @@ mod tests {
             .flag_bits
             .store(WRITE_LOGICS_QUEUE_ERROR_BIT, Ordering::Relaxed);
         running_flags.clear_logics_queue_error();
-        assert_eq!(running_flags.is_logics_queue_error(), false);
+        assert!(!running_flags.is_logics_queue_error());
     }
 
     #[test]
     fn test_get_and_make_writeable() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.get_and_make_writeable(), true);
-        assert_eq!(running_flags.is_writeable(), true);
-        assert_eq!(running_flags.is_cq_writeable(), true);
+        assert!(running_flags.get_and_make_writeable());
+        assert!(running_flags.is_writeable());
+        assert!(running_flags.is_cq_writeable());
     }
 
     #[test]
     fn test_is_writeable() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.is_writeable(), true);
+        assert!(running_flags.is_writeable());
         running_flags
             .flag_bits
             .store(NOT_WRITEABLE_BIT, Ordering::Relaxed);
-        assert_eq!(running_flags.is_writeable(), false);
+        assert!(!running_flags.is_writeable());
     }
 
     #[test]
     fn test_is_cq_writeable() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.is_cq_writeable(), true);
+        assert!(running_flags.is_cq_writeable());
         running_flags.flag_bits.store(
             NOT_WRITEABLE_BIT | WRITE_LOGICS_QUEUE_ERROR_BIT,
             Ordering::Relaxed,
         );
-        assert_eq!(running_flags.is_cq_writeable(), false);
+        assert!(!running_flags.is_cq_writeable());
     }
 
     #[test]
     fn test_get_and_make_not_writeable() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.get_and_make_not_writeable(), true);
-        assert_eq!(running_flags.is_writeable(), false);
-        assert_eq!(running_flags.get_and_make_not_writeable(), false);
-        assert_eq!(running_flags.is_writeable(), false);
+        assert!(running_flags.get_and_make_not_writeable());
+        assert!(!running_flags.is_writeable());
+        assert!(!running_flags.get_and_make_not_writeable());
+        assert!(!running_flags.is_writeable());
     }
 
     #[test]
     fn test_make_logics_queue_error() {
         let running_flags = RunningFlags::new();
         running_flags.make_logics_queue_error();
-        assert_eq!(running_flags.is_logics_queue_error(), true);
+        assert!(running_flags.is_logics_queue_error());
     }
 
     #[test]
     fn test_make_fenced() {
         let running_flags = RunningFlags::new();
         running_flags.make_fenced(true);
-        assert_eq!(running_flags.is_fenced(), true);
+        assert!(running_flags.is_fenced());
         running_flags.make_fenced(false);
-        assert_eq!(running_flags.is_fenced(), false);
+        assert!(!running_flags.is_fenced());
     }
 
     #[test]
     fn test_is_logics_queue_error() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.is_logics_queue_error(), false);
+        assert!(!running_flags.is_logics_queue_error());
         running_flags
             .flag_bits
             .store(WRITE_LOGICS_QUEUE_ERROR_BIT, Ordering::Relaxed);
-        assert_eq!(running_flags.is_logics_queue_error(), true);
+        assert!(running_flags.is_logics_queue_error());
     }
 
     #[test]
     fn test_make_index_file_error() {
         let running_flags = RunningFlags::new();
         running_flags.make_index_file_error();
-        assert_eq!(running_flags.is_index_file_error(), true);
+        assert!(running_flags.is_index_file_error());
     }
 
     #[test]
     fn test_is_index_file_error() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.is_index_file_error(), false);
+        assert!(!running_flags.is_index_file_error());
         running_flags
             .flag_bits
             .store(WRITE_INDEX_FILE_ERROR_BIT, Ordering::Relaxed);
-        assert_eq!(running_flags.is_index_file_error(), true);
+        assert!(running_flags.is_index_file_error());
     }
 
     #[test]
     fn test_get_and_make_disk_full() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.get_and_make_disk_full(), true);
+        assert!(running_flags.get_and_make_disk_full());
     }
 
     #[test]
     fn test_get_and_make_disk_ok() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.get_and_make_disk_ok(), true);
+        assert!(running_flags.get_and_make_disk_ok());
     }
 
     #[test]
     fn test_get_and_make_logic_disk_full() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.get_and_make_logic_disk_full(), true);
+        assert!(running_flags.get_and_make_logic_disk_full());
     }
 
     #[test]
     fn test_get_and_make_logic_disk_ok() {
         let running_flags = RunningFlags::new();
-        assert_eq!(running_flags.get_and_make_logic_disk_ok(), true);
+        assert!(running_flags.get_and_make_logic_disk_ok());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

#4087 Not completed yet.
Fix #4092 
### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Clean up existing clippy warnings of types:

- bool_assert_comparison
- assertions_on_constant

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
All these modifications have been made in the tests module and all the tests passed when running `cargo test`