### PR TITLE
[ISSUE #4096]♻️Clean up existing clippy warnings of clone_on_copy and needless_borrow

### DIFF
--- a/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_config.rs
+++ b/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_config.rs
@@ -67,7 +67,7 @@ mod tests {
         let mut consumer_allocate_queue = HashMap::new();
         for consumer_id in &cid_all {
             let queues = strategy
-                .allocate(&consumer_group, &consumer_id, &mq_all, &cid_all)
+                .allocate(&consumer_group, consumer_id, &mq_all, &cid_all)
                 .unwrap();
             let queue_ids: Vec<i32> = queues.into_iter().map(|mq| mq.get_queue_id()).collect();
             consumer_allocate_queue.insert(consumer_id.clone(), queue_ids);

--- a/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_machine_room.rs
+++ b/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_machine_room.rs
@@ -113,7 +113,7 @@ mod tests {
         let mut consumer_allocate_queue = HashMap::new();
         for consumer_id in &cid_all {
             let queues = strategy
-                .allocate(&consumer_group, &consumer_id, &mq_all, &cid_all)
+                .allocate(&consumer_group, consumer_id, &mq_all, &cid_all)
                 .unwrap();
             let queue_ids: Vec<i32> = queues.into_iter().map(|mq| mq.get_queue_id()).collect();
             consumer_allocate_queue.insert(consumer_id.clone(), queue_ids);

--- a/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_machine_room_nearby.rs
+++ b/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_machine_room_nearby.rs
@@ -157,7 +157,7 @@ mod tests {
     fn create_message_queue_list(machine_room: &str, size: usize) -> Vec<MessageQueue> {
         (0..size)
             .map(|i| {
-                MessageQueue::from_parts(TOPIC, &format!("{}-brokerName", machine_room), i as i32)
+                MessageQueue::from_parts(TOPIC, format!("{}-brokerName", machine_room), i as i32)
             })
             .collect()
     }

--- a/rocketmq-remoting/src/protocol/body/consume_message_directly_result.rs
+++ b/rocketmq-remoting/src/protocol/body/consume_message_directly_result.rs
@@ -144,13 +144,8 @@ mod tests {
     fn consume_message_directly_result_new_initializes_correctly() {
         let consume_result = CMResult::default();
         let remark = CheetahString::from_static_str("test remark");
-        let result = ConsumeMessageDirectlyResult::new(
-            true,
-            false,
-            consume_result.clone(),
-            remark.clone(),
-            12345,
-        );
+        let result =
+            ConsumeMessageDirectlyResult::new(true, false, consume_result, remark.clone(), 12345);
         assert!(result.order());
         assert!(!result.auto_commit());
         assert_eq!(result.consume_result().unwrap(), &consume_result);
@@ -164,7 +159,7 @@ mod tests {
         result.set_order(true);
         result.set_auto_commit(false);
         let consume_result = CMResult::default();
-        result.set_consume_result(consume_result.clone());
+        result.set_consume_result(consume_result);
         let remark = CheetahString::from_static_str("updated remark");
         result.set_remark(remark.clone());
         result.set_spent_time_mills(67890);
@@ -180,13 +175,8 @@ mod tests {
     fn consume_message_directly_result_display_formats_correctly() {
         let consume_result = CMResult::default();
         let remark = CheetahString::from_static_str("test remark");
-        let result = ConsumeMessageDirectlyResult::new(
-            true,
-            false,
-            consume_result.clone(),
-            remark.clone(),
-            12345,
-        );
+        let result =
+            ConsumeMessageDirectlyResult::new(true, false, consume_result, remark.clone(), 12345);
         let display = format!("{}", result);
         let expected = format!(
             "ConsumeMessageDirectlyResult [order=true, auto_commit=false, consume_result={:?}, \

--- a/rocketmq-remoting/src/protocol/body/consume_status.rs
+++ b/rocketmq-remoting/src/protocol/body/consume_status.rs
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn consume_status_deserialization() {
         let serialized = r#"{"pullRT":1.1,"pullTPS":1.2,"consumeRT":1.3,"consumeOKTPS":1.4,"consumeFailedTPS":1.5,"consumeFailedMsgs":6}"#;
-        let deserialized: ConsumeStatus = serde_json::from_str(&serialized).unwrap();
+        let deserialized: ConsumeStatus = serde_json::from_str(serialized).unwrap();
         assert_eq!(deserialized.pull_rt, 1.1);
         assert_eq!(deserialized.pull_tps, 1.2);
         assert_eq!(deserialized.consume_rt, 1.3);

--- a/rocketmq-store/src/base/get_message_result.rs
+++ b/rocketmq-store/src/base/get_message_result.rs
@@ -342,7 +342,7 @@ mod tests {
 
         //result.set_message_buffer_list(buffer_list);
         result.set_message_queue_offset(queue_offset);
-        result.set_status(status.clone());
+        result.set_status(status);
         result.set_next_begin_offset(next_begin_offset);
         result.set_min_offset(min_offset);
         result.set_max_offset(max_offset);

--- a/rocketmq-store/src/base/store_enum.rs
+++ b/rocketmq-store/src/base/store_enum.rs
@@ -101,10 +101,10 @@ mod tests {
         let rocks_db = StoreType::RocksDB;
 
         assert_eq!(
-            serde_json::to_value(&local_file).unwrap(),
+            serde_json::to_value(local_file).unwrap(),
             json!("LocalFile")
         );
-        assert_eq!(serde_json::to_value(&rocks_db).unwrap(), json!("RocksDB"));
+        assert_eq!(serde_json::to_value(rocks_db).unwrap(), json!("RocksDB"));
     }
 
     #[test]

--- a/rocketmq-store/src/config/flush_disk_type.rs
+++ b/rocketmq-store/src/config/flush_disk_type.rs
@@ -124,8 +124,8 @@ mod tests {
     #[test]
     fn test_copy_clone_traits() {
         let sync_flush = FlushDiskType::SyncFlush;
-        let copied = sync_flush;
-        let cloned = sync_flush.clone();
+        let copied = sync_flush; // copy
+        let cloned: FlushDiskType = sync_flush; // clone
 
         assert_eq!(sync_flush, copied);
         assert_eq!(sync_flush, cloned);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->
#4087 Not complete yet
Fix #4096 
### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Clean up existing clippy warnings of types:

- clone_on_copy
- needless_borrow

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
All these modifications have been made in the tests module and all the tests passed when running `cargo test`