### PR TITLE
[ISSUE #4099]♻️Clean up existing clippy warnings of vec_init_then_push, redundant_closure and useless_conversion

### DIFF
--- a/rocketmq-broker/src/broker_path_config_helper.rs
+++ b/rocketmq-broker/src/broker_path_config_helper.rs
@@ -146,7 +146,7 @@ mod test {
     fn test_get_broker_config_path() {
         let path = get_broker_config_path();
         let home_dir = dirs::home_dir().unwrap();
-        let mut path_ = PathBuf::from(home_dir);
+        let mut path_ = home_dir;
         path_.push("store");
         path_.push("config");
         path_.push("broker.properties");

--- a/rocketmq-client/examples/batch/callback_batch_producer.rs
+++ b/rocketmq-client/examples/batch/callback_batch_producer.rs
@@ -44,25 +44,11 @@ pub async fn main() -> RocketMQResult<()> {
         .build();
     producer.start().await?;
 
-    let mut messages = Vec::new();
-    messages.push(Message::with_keys(
-        TOPIC,
-        TAG,
-        "OrderID001",
-        "Hello world 0".as_bytes(),
-    ));
-    messages.push(Message::with_keys(
-        TOPIC,
-        TAG,
-        "OrderID002",
-        "Hello world 1".as_bytes(),
-    ));
-    messages.push(Message::with_keys(
-        TOPIC,
-        TAG,
-        "OrderID003",
-        "Hello world 2".as_bytes(),
-    ));
+    let messages = vec![
+        Message::with_keys(TOPIC, TAG, "OrderID001", "Hello world 0".as_bytes()),
+        Message::with_keys(TOPIC, TAG, "OrderID002", "Hello world 1".as_bytes()),
+        Message::with_keys(TOPIC, TAG, "OrderID003", "Hello world 2".as_bytes()),
+    ];
     let counter = Arc::new(AtomicI32::new(0));
     for _ in 0..100 {
         let vec = messages.clone();

--- a/rocketmq-client/examples/batch/simple_batch_producer.rs
+++ b/rocketmq-client/examples/batch/simple_batch_producer.rs
@@ -39,25 +39,11 @@ pub async fn main() -> RocketMQResult<()> {
         .build();
     producer.start().await?;
 
-    let mut messages = Vec::new();
-    messages.push(Message::with_keys(
-        TOPIC,
-        TAG,
-        "OrderID001",
-        "Hello world 0".as_bytes(),
-    ));
-    messages.push(Message::with_keys(
-        TOPIC,
-        TAG,
-        "OrderID002",
-        "Hello world 1".as_bytes(),
-    ));
-    messages.push(Message::with_keys(
-        TOPIC,
-        TAG,
-        "OrderID003",
-        "Hello world 2".as_bytes(),
-    ));
+    let messages = vec![
+        Message::with_keys(TOPIC, TAG, "OrderID001", "Hello world 0".as_bytes()),
+        Message::with_keys(TOPIC, TAG, "OrderID002", "Hello world 1".as_bytes()),
+        Message::with_keys(TOPIC, TAG, "OrderID003", "Hello world 2".as_bytes()),
+    ];
     let send_result = producer.send_batch(messages).await?;
     println!("send result: {}", send_result);
     Ok(())

--- a/rocketmq-example/examples/consumer/pop_consumer.rs
+++ b/rocketmq-example/examples/consumer/pop_consumer.rs
@@ -74,7 +74,6 @@ async fn switch_pop_consumer() -> RocketMQResult<()> {
             .broker_addrs()
             .values()
             .cloned()
-            .into_iter()
             .collect::<HashSet<CheetahString>>();
         for broker_addr in broker_addrs {
             MQAdminExt::set_message_request_mode(

--- a/rocketmq-store/benches/delivery.rs
+++ b/rocketmq-store/benches/delivery.rs
@@ -36,8 +36,8 @@ pub fn delivery2() -> i32 {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("delivery1", |b| b.iter(|| delivery1()));
-    c.bench_function("delivery2", |b| b.iter(|| delivery2()));
+    c.bench_function("delivery1", |b| b.iter(delivery1));
+    c.bench_function("delivery2", |b| b.iter(delivery2));
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->
#4087 Not complete yet
Fix #4099 
### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Clean up existing clippy warnings of types:

- vec_init_then_push
- redundant_closure
- useless_conversion

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
