### PR TITLE
[ISSUE #4105]♻️Clean up existing clippy warnings of new_without_default, field_reassign_with_default, const_is_empty, large_enum_variant

### DIFF
--- a/rocketmq-broker/benches/syncunsafecell_mut.rs
+++ b/rocketmq-broker/benches/syncunsafecell_mut.rs
@@ -27,6 +27,12 @@ pub struct Test {
     pub b: parking_lot::Mutex<HashSet<String>>,
 }
 
+impl Default for Test {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Test {
     pub fn new() -> Self {
         Test {

--- a/rocketmq-broker/src/metrics/broker_metrics_constant.rs
+++ b/rocketmq-broker/src/metrics/broker_metrics_constant.rs
@@ -341,15 +341,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_constants_not_empty() {
-        assert!(!BrokerMetricsConstant::OPEN_TELEMETRY_METER_NAME.is_empty());
-        assert!(!BrokerMetricsConstant::GAUGE_PROCESSOR_WATERMARK.is_empty());
-        assert!(!BrokerMetricsConstant::COUNTER_MESSAGES_IN_TOTAL.is_empty());
-        assert!(!BrokerMetricsConstant::HISTOGRAM_MESSAGE_SIZE.is_empty());
-        assert!(!BrokerMetricsConstant::LABEL_CLUSTER_NAME.is_empty());
-    }
-
-    #[test]
     fn test_organized_modules() {
         // Test organized gauge constants
         assert_eq!(

--- a/rocketmq-broker/src/metrics/pop_metrics_constant.rs
+++ b/rocketmq-broker/src/metrics/pop_metrics_constant.rs
@@ -332,14 +332,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_constants_not_empty() {
-        assert!(!PopMetricsConstant::HISTOGRAM_POP_BUFFER_SCAN_TIME_CONSUME.is_empty());
-        assert!(!PopMetricsConstant::COUNTER_POP_REVIVE_IN_MESSAGE_TOTAL.is_empty());
-        assert!(!PopMetricsConstant::GAUGE_POP_REVIVE_LAG.is_empty());
-        assert!(!PopMetricsConstant::LABEL_REVIVE_MESSAGE_TYPE.is_empty());
-    }
-
-    #[test]
     fn test_organized_modules() {
         // Test organized metric constants
         assert_eq!(

--- a/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
@@ -62,6 +62,12 @@ pub struct MyMessageListener {
     consume_times: Arc<AtomicI64>,
 }
 
+impl Default for MyMessageListener {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MyMessageListener {
     pub fn new() -> Self {
         Self {

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -773,8 +773,10 @@ mod tests {
         let body = vec![/* some valid data */];
         let crc32 = CRC32Utils::crc32(&body);
         let request = RemotingCommand::new_request(0, body);
-        let mut request_header = RegisterBrokerRequestHeader::default();
-        request_header.body_crc32 = crc32;
+        let request_header = RegisterBrokerRequestHeader {
+            body_crc32: crc32,
+            ..Default::default()
+        };
         let result = check_sum_crc32(&request, &request_header);
         assert!(result);
     }
@@ -783,8 +785,10 @@ mod tests {
     fn check_sum_crc32_invalid_crc() {
         let body = vec![/* some valid data */];
         let request = RemotingCommand::new_request(0, body);
-        let mut request_header = RegisterBrokerRequestHeader::default();
-        request_header.body_crc32 = 12345; // some invalid crc32
+        let request_header = RegisterBrokerRequestHeader {
+            body_crc32: 12345, // some invalid crc32
+            ..Default::default()
+        };
         let result = check_sum_crc32(&request, &request_header);
         assert!(!result);
     }
@@ -793,8 +797,10 @@ mod tests {
     fn check_sum_crc32_zero_crc() {
         let body = vec![/* some valid data */];
         let request = RemotingCommand::new_request(0, body);
-        let mut request_header = RegisterBrokerRequestHeader::default();
-        request_header.body_crc32 = 0;
+        let request_header = RegisterBrokerRequestHeader {
+            body_crc32: 0,
+            ..Default::default()
+        };
         let result = check_sum_crc32(&request, &request_header);
         assert!(result);
     }

--- a/rocketmq-store/src/ha/flow_monitor.rs
+++ b/rocketmq-store/src/ha/flow_monitor.rs
@@ -168,9 +168,11 @@ mod tests {
 
     #[test]
     fn can_transfer_max_byte_num_returns_correct_value_when_flow_control_enabled() {
-        let mut config = MessageStoreConfig::default();
-        config.ha_flow_control_enable = true;
-        config.max_ha_transfer_byte_in_second = 200;
+        let config = MessageStoreConfig {
+            ha_flow_control_enable: true,
+            max_ha_transfer_byte_in_second: 200,
+            ..Default::default()
+        };
         let inner = FlowMonitorInner::new(Arc::new(config));
         inner.add_byte_count_transferred(150);
         assert_eq!(inner.can_transfer_max_byte_num(), 50);
@@ -178,8 +180,10 @@ mod tests {
 
     #[test]
     fn can_transfer_max_byte_num_returns_max_value_when_flow_control_disabled() {
-        let mut config = MessageStoreConfig::default();
-        config.ha_flow_control_enable = false;
+        let config = MessageStoreConfig {
+            ha_flow_control_enable: false,
+            ..Default::default()
+        };
         let inner = FlowMonitorInner::new(Arc::new(config));
         assert_eq!(inner.can_transfer_max_byte_num(), i32::MAX);
     }

--- a/rocketmq-store/src/message_store.rs
+++ b/rocketmq-store/src/message_store.rs
@@ -20,7 +20,7 @@ pub mod rocksdb_message_store;
 
 pub enum GenericMessageStore {
     #[cfg(feature = "local_file_store")]
-    LocalFileStore(local_file_message_store::LocalFileMessageStore),
+    LocalFileStore(Box<local_file_message_store::LocalFileMessageStore>),
 
     #[cfg(feature = "rocksdb_store")]
     RocksDBStore(rocksdb_message_store::RocksDBMessageStore),


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

#4087 Not complete yet
fix #4105 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Clean up existing clippy warnings of types:

- new_without_default
- field_reassign_with_default
- const_is_empty
- large_enum_variant

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
