### PR TITLE
[ISSUE #4087]♻️Clean up existing clippy warnings of useless_vec, redundant_field_names, let_unit_value, manual_range_contains

### DIFF
--- a/rocketmq-remoting/src/protocol/body/cluster_acl_version_info.rs
+++ b/rocketmq-remoting/src/protocol/body/cluster_acl_version_info.rs
@@ -65,7 +65,7 @@ mod tests {
         let mut all_acl_config_data_version = HashMap::new();
         all_acl_config_data_version.insert(CheetahString::from("key1"), DataVersion::default());
 
-        let _info1 = ClusterAclVersionInfo {
+        let info1 = ClusterAclVersionInfo {
             broker_name: CheetahString::from("broker1"),
             broker_addr: CheetahString::from("addr1"),
             acl_config_data_version: Some(DataVersion::default()),
@@ -73,18 +73,23 @@ mod tests {
             cluster_name: CheetahString::from("cluster1"),
         };
 
-        let _info2 = ClusterAclVersionInfo {
+        let info2 = ClusterAclVersionInfo {
             broker_name: CheetahString::from("broker1"),
             broker_addr: CheetahString::from("addr1"),
             acl_config_data_version: Some(DataVersion::default()),
-            all_acl_config_data_version: all_acl_config_data_version,
+            all_acl_config_data_version,
             cluster_name: CheetahString::from("cluster1"),
         };
+
+        assert_eq!(
+            serde_json::to_string(&info1).unwrap(),
+            serde_json::to_string(&info2).unwrap()
+        );
     }
 
     #[test]
     fn cluster_acl_version_info_inequality() {
-        let _info1 = ClusterAclVersionInfo {
+        let info1 = ClusterAclVersionInfo {
             broker_name: CheetahString::from("broker1"),
             broker_addr: CheetahString::from("addr1"),
             acl_config_data_version: Some(DataVersion::default()),
@@ -92,13 +97,18 @@ mod tests {
             cluster_name: CheetahString::from("cluster1"),
         };
 
-        let _info2 = ClusterAclVersionInfo {
+        let info2 = ClusterAclVersionInfo {
             broker_name: CheetahString::from("broker2"),
             broker_addr: CheetahString::from("addr2"),
             acl_config_data_version: None,
             all_acl_config_data_version: HashMap::new(),
             cluster_name: CheetahString::from("cluster2"),
         };
+
+        assert_ne!(
+            serde_json::to_string(&info1).unwrap(),
+            serde_json::to_string(&info2).unwrap()
+        );
     }
 
     #[test]
@@ -110,7 +120,7 @@ mod tests {
             broker_name: CheetahString::from("broker1"),
             broker_addr: CheetahString::from("addr1"),
             acl_config_data_version: Some(DataVersion::default()),
-            all_acl_config_data_version: all_acl_config_data_version,
+            all_acl_config_data_version,
             cluster_name: CheetahString::from("cluster1"),
         };
         let serialized = serde_json::to_string(&info).unwrap();

--- a/rocketmq-remoting/src/protocol/header/extra_info_util.rs
+++ b/rocketmq-remoting/src/protocol/header/extra_info_util.rs
@@ -506,13 +506,13 @@ mod tests {
 
     #[test]
     fn get_ck_queue_offset_with_valid_string() {
-        let result = ExtraInfoUtil::get_ck_queue_offset(&vec!["123".to_string()]).unwrap();
+        let result = ExtraInfoUtil::get_ck_queue_offset(&["123".to_string()]).unwrap();
         assert_eq!(result, 123);
     }
 
     #[test]
     fn get_ck_queue_offset_with_invalid_string() {
-        let result = ExtraInfoUtil::get_ck_queue_offset(&vec!["abc".to_string()]).unwrap_err();
+        let result = ExtraInfoUtil::get_ck_queue_offset(&["abc".to_string()]).unwrap_err();
         assert_eq!(
             result.to_string(),
             IllegalArgument("parse ck_queue_offset error".to_string()).to_string()
@@ -521,14 +521,13 @@ mod tests {
 
     #[test]
     fn get_pop_time_with_valid_string() {
-        let result =
-            ExtraInfoUtil::get_pop_time(&vec!["123".to_string(), "456".to_string()]).unwrap();
+        let result = ExtraInfoUtil::get_pop_time(&["123".to_string(), "456".to_string()]).unwrap();
         assert_eq!(result, 456);
     }
 
     #[test]
     fn get_pop_time_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_pop_time(&vec!["123".to_string()]).unwrap_err();
+        let result = ExtraInfoUtil::get_pop_time(&["123".to_string()]).unwrap_err();
         assert_eq!(
             result.to_string(),
             IllegalArgument("getPopTime fail, extraInfoStrs length 1".to_string()).to_string()
@@ -537,7 +536,7 @@ mod tests {
 
     #[test]
     fn get_invisible_time_with_valid_string() {
-        let result = ExtraInfoUtil::get_invisible_time(&vec![
+        let result = ExtraInfoUtil::get_invisible_time(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -548,8 +547,8 @@ mod tests {
 
     #[test]
     fn get_invisible_time_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_invisible_time(&vec!["123".to_string(), "456".to_string()])
-            .unwrap_err();
+        let result =
+            ExtraInfoUtil::get_invisible_time(&["123".to_string(), "456".to_string()]).unwrap_err();
         assert_eq!(
             result.to_string(),
             IllegalArgument("getInvisibleTime fail, extraInfoStrs length 2".to_string())
@@ -559,7 +558,7 @@ mod tests {
 
     #[test]
     fn get_revive_qid_with_valid_string() {
-        let result = ExtraInfoUtil::get_revive_qid(&vec![
+        let result = ExtraInfoUtil::get_revive_qid(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -571,7 +570,7 @@ mod tests {
 
     #[test]
     fn get_revive_qid_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_revive_qid(&vec![
+        let result = ExtraInfoUtil::get_revive_qid(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -586,7 +585,7 @@ mod tests {
     #[test]
     fn get_real_topic_with_retry_v1() {
         let result = ExtraInfoUtil::get_real_topic(
-            &vec![
+            &[
                 "123".to_string(),
                 "456".to_string(),
                 "789".to_string(),
@@ -603,7 +602,7 @@ mod tests {
     #[test]
     fn get_real_topic_with_retry_v2() {
         let result = ExtraInfoUtil::get_real_topic(
-            &vec![
+            &[
                 "123".to_string(),
                 "456".to_string(),
                 "789".to_string(),
@@ -620,7 +619,7 @@ mod tests {
     #[test]
     fn get_real_topic_with_normal_topic() {
         let result = ExtraInfoUtil::get_real_topic(
-            &vec![
+            &[
                 "123".to_string(),
                 "456".to_string(),
                 "789".to_string(),
@@ -637,7 +636,7 @@ mod tests {
     #[test]
     fn get_real_topic_with_insufficient_length() {
         let result = ExtraInfoUtil::get_real_topic(
-            &vec![
+            &[
                 "123".to_string(),
                 "456".to_string(),
                 "789".to_string(),
@@ -664,7 +663,7 @@ mod tests {
 
     #[test]
     fn get_retry_slice_with_valid_string() {
-        let result = ExtraInfoUtil::get_retry(&vec![
+        let result = ExtraInfoUtil::get_retry(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -677,7 +676,7 @@ mod tests {
 
     #[test]
     fn get_retry_slice_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_retry(&vec![
+        let result = ExtraInfoUtil::get_retry(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -692,7 +691,7 @@ mod tests {
 
     #[test]
     fn get_broker_name_with_valid_string() {
-        let result = ExtraInfoUtil::get_broker_name(&vec![
+        let result = ExtraInfoUtil::get_broker_name(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -706,7 +705,7 @@ mod tests {
 
     #[test]
     fn get_broker_name_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_broker_name(&vec![
+        let result = ExtraInfoUtil::get_broker_name(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -722,7 +721,7 @@ mod tests {
 
     #[test]
     fn get_queue_id_with_valid_string() {
-        let result = ExtraInfoUtil::get_queue_id(&vec![
+        let result = ExtraInfoUtil::get_queue_id(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -737,7 +736,7 @@ mod tests {
 
     #[test]
     fn get_queue_id_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_queue_id(&vec![
+        let result = ExtraInfoUtil::get_queue_id(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -754,7 +753,7 @@ mod tests {
 
     #[test]
     fn get_queue_offset_with_valid_string() {
-        let result = ExtraInfoUtil::get_queue_offset(&vec![
+        let result = ExtraInfoUtil::get_queue_offset(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -770,7 +769,7 @@ mod tests {
 
     #[test]
     fn get_queue_offset_with_insufficient_length() {
-        let result = ExtraInfoUtil::get_queue_offset(&vec![
+        let result = ExtraInfoUtil::get_queue_offset(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -830,7 +829,7 @@ mod tests {
     #[test]
     fn build_msg_offset_info_creates_correct_string() {
         let mut string_builder = String::new();
-        ExtraInfoUtil::build_msg_offset_info(&mut string_builder, "topic", 7, &vec![100, 200, 300]);
+        ExtraInfoUtil::build_msg_offset_info(&mut string_builder, "topic", 7, &[100, 200, 300]);
         assert_eq!(string_builder, "0 7 100;200;300");
     }
 
@@ -897,7 +896,7 @@ mod tests {
 
     #[test]
     fn is_order_with_order_queue() {
-        let result = ExtraInfoUtil::is_order(&vec![
+        let result = ExtraInfoUtil::is_order(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),
@@ -913,7 +912,7 @@ mod tests {
 
     #[test]
     fn is_order_with_non_order_queue() {
-        let result = ExtraInfoUtil::is_order(&vec![
+        let result = ExtraInfoUtil::is_order(&[
             "123".to_string(),
             "456".to_string(),
             "789".to_string(),

--- a/rocketmq/src/schedule.rs
+++ b/rocketmq/src/schedule.rs
@@ -747,8 +747,8 @@ mod tests {
             },
         );
 
-        let _ = tokio::time::sleep(Duration::from_secs(1));
-        let _ = manager.cancel_task(task_id);
+        time::sleep(Duration::from_millis(400)).await;
+        manager.cancel_task(task_id);
         assert_eq!(manager.task_count(), 0);
     }
 
@@ -806,7 +806,7 @@ mod tests {
 
         let executed = counter.load(Ordering::Relaxed);
         assert!(
-            executed >= 3 && executed <= 6,
+            (3..=6).contains(&executed),
             "FixedDelay count unexpected: {}",
             executed
         );
@@ -835,7 +835,7 @@ mod tests {
 
         let executed = counter.load(Ordering::Relaxed);
         assert!(
-            executed >= 2 && executed <= 5,
+            (2..=5).contains(&executed),
             "FixedRateNoOverlap count unexpected: {}",
             executed
         );


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->
#4087 Not complete yet


### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Clean up existing clippy warnings of types:

- useless_vec
- redundant_field_names
- let_unit_value
- manual_range_contains

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Tests
  - Updated tests to use slice literals where appropriate and to await timing controls for more stable async behavior.
  - Adjusted assertion styles to use explicit range containment checks.
  - Added serialization parity checks and tightened construction semantics in tests for more robust equality verification.
- Style
  - Simplified test initialization via shorthand and minor naming cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->