### PR TITLE
[ISSUE #4087]♻️Clean up remaining clippy warnings

### DIFF
--- a/rocketmq-common/src/utils/util_all.rs
+++ b/rocketmq-common/src/utils/util_all.rs
@@ -425,7 +425,7 @@ mod tests {
     fn time_millis_to_human_string_formats_correctly() {
         let timestamp = 1743239631601;
         let expected = Local
-            .timestamp_millis_opt(timestamp as i64)
+            .timestamp_millis_opt(timestamp)
             .unwrap()
             .format("%Y%m%d%H%M%S%3f")
             .to_string();
@@ -489,7 +489,7 @@ mod tests {
         use chrono::Utc;
         let timestamp = 1625140800000;
         let expected = Local
-            .timestamp_millis_opt(timestamp as i64)
+            .timestamp_millis_opt(timestamp)
             .unwrap()
             .format("%Y-%m-%d %H:%M:%S,%3f")
             .to_string();

--- a/rocketmq-remoting/src/protocol/body/epoch_entry_cache.rs
+++ b/rocketmq-remoting/src/protocol/body/epoch_entry_cache.rs
@@ -72,8 +72,7 @@ mod tests {
 
     #[test]
     fn new_creates_instance_of_epoch_entry_cache() {
-        let epoch_entry_cache =
-            EpochEntryCache::new("cluster1", "broker1", 1, vec![EpochEntry::default()], 1);
+        let epoch_entry_cache = EpochEntryCache::new("cluster1", "broker1", 1, vec![EpochEntry], 1);
         assert_eq!(
             epoch_entry_cache.get_cluster_name(),
             &CheetahString::from("cluster1")
@@ -87,7 +86,7 @@ mod tests {
     #[test]
     fn set_broker_name_updates_broker_name() {
         let mut epoch_entry_cache =
-            EpochEntryCache::new("cluster1", "broker1", 1, vec![EpochEntry::default()], 1);
+            EpochEntryCache::new("cluster1", "broker1", 1, vec![EpochEntry], 1);
         epoch_entry_cache.set_broker_name("broker2");
         assert_eq!(
             epoch_entry_cache.get_broker_name(),
@@ -98,7 +97,7 @@ mod tests {
     #[test]
     fn set_cluster_name_updates_cluster_name() {
         let mut epoch_entry_cache =
-            EpochEntryCache::new("cluster1", "broker1", 1, vec![EpochEntry::default()], 1);
+            EpochEntryCache::new("cluster1", "broker1", 1, vec![EpochEntry], 1);
         epoch_entry_cache.set_cluster_name("cluster2");
         assert_eq!(
             epoch_entry_cache.get_cluster_name(),

--- a/rocketmq-remoting/src/protocol/filter/filter_api.rs
+++ b/rocketmq-remoting/src/protocol/filter/filter_api.rs
@@ -126,17 +126,17 @@ mod tests {
     fn build_subscription_data_with_expression_type_sets_expression_type() {
         let topic = "test_topic".into();
         let sub_string = "tag1||tag2".into();
-        let expression_type = Some("SQL92".into());
+        let expression_type: CheetahString = "SQL92".into();
         let subscription_data = FilterAPI::build_subscription_data_with_expression_type(
             &topic,
             &sub_string,
-            expression_type.clone(),
+            Some(expression_type.clone()),
         )
         .unwrap();
 
         assert_eq!(subscription_data.topic.as_str(), topic.as_str());
         assert_eq!(subscription_data.sub_string.as_str(), sub_string.as_str());
-        assert_eq!(subscription_data.expression_type, expression_type.unwrap());
+        assert_eq!(subscription_data.expression_type, expression_type);
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/header/ack_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/ack_message_request_header.rs
@@ -84,7 +84,7 @@ mod tests {
         assert_eq!(header.queue_id, 1);
         assert_eq!(header.extra_info, CheetahString::from("extra_info"));
         assert_eq!(header.offset, 12345);
-        assert!(!header.topic_request_header.is_none());
+        assert!(header.topic_request_header.is_some());
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/header/delete_subscription_group_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/delete_subscription_group_request_header.rs
@@ -60,7 +60,7 @@ mod tests {
             CheetahString::from_static_str("test_group")
         );
         assert!(header.clean_offset);
-        assert!(!header.rpc_request_header.is_none());
+        assert!(header.rpc_request_header.is_some());
     }
 
     #[test]
@@ -72,7 +72,7 @@ mod tests {
             CheetahString::from_static_str("test_group")
         );
         assert!(!header.clean_offset);
-        assert!(!header.rpc_request_header.is_none());
+        assert!(header.rpc_request_header.is_some());
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/header/delete_topic_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/delete_topic_request_header.rs
@@ -89,7 +89,7 @@ mod tests {
 
         let header = <DeleteTopicRequestHeader as FromMap>::from(&map).unwrap();
         assert_eq!(header.topic, CheetahString::from("test_topic"));
-        assert!(!header.topic_request_header.is_none());
+        assert!(header.topic_request_header.is_some());
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/header/get_consumer_running_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consumer_running_info_request_header.rs
@@ -69,7 +69,7 @@ mod tests {
             CheetahString::from_static_str("client_id")
         );
         assert!(header.jstack_enable);
-        assert!(!header.rpc_request_header.is_none());
+        assert!(header.rpc_request_header.is_some());
     }
 
     #[test]
@@ -85,7 +85,7 @@ mod tests {
             CheetahString::from_static_str("client_id")
         );
         assert!(!header.jstack_enable);
-        assert!(!header.rpc_request_header.is_none());
+        assert!(header.rpc_request_header.is_some());
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/header/get_topic_stats_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_topic_stats_info_request_header.rs
@@ -53,7 +53,7 @@ mod tests {
         let data = r#"{"topic":"test_topic"}"#;
         let header: GetTopicStatsInfoRequestHeader = serde_json::from_str(data).unwrap();
         assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
-        assert!(!header.topic_request_header.is_none());
+        assert!(header.topic_request_header.is_some());
     }
 
     #[test]
@@ -61,7 +61,7 @@ mod tests {
         let data = r#"{"topic":"test_topic"}"#;
         let header: GetTopicStatsInfoRequestHeader = serde_json::from_str(data).unwrap();
         assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
-        assert!(!header.topic_request_header.is_none());
+        assert!(header.topic_request_header.is_some());
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/header/query_consume_time_span_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_consume_time_span_request_header.rs
@@ -58,7 +58,7 @@ mod tests {
         let header: QueryConsumeTimeSpanRequestHeader = serde_json::from_str(data).unwrap();
         assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
         assert_eq!(header.group, CheetahString::from_static_str("test_group"));
-        assert!(!header.topic_request_header.is_none());
+        assert!(header.topic_request_header.is_some());
     }
 
     #[test]
@@ -67,7 +67,7 @@ mod tests {
         let header: QueryConsumeTimeSpanRequestHeader = serde_json::from_str(data).unwrap();
         assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
         assert_eq!(header.group, CheetahString::from_static_str("test_group"));
-        assert!(!header.topic_request_header.is_none());
+        assert!(header.topic_request_header.is_some());
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/header/query_subscription_by_consumer_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_subscription_by_consumer_request_header.rs
@@ -58,7 +58,7 @@ mod tests {
         let header: QuerySubscriptionByConsumerRequestHeader = serde_json::from_str(data).unwrap();
         assert_eq!(header.group, CheetahString::from_static_str("test_group"));
         assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
-        assert!(!header.topic_request_header.is_none());
+        assert!(header.topic_request_header.is_some());
     }
 
     #[test]
@@ -67,7 +67,7 @@ mod tests {
         let header: QuerySubscriptionByConsumerRequestHeader = serde_json::from_str(data).unwrap();
         assert_eq!(header.group, CheetahString::from_static_str("test_group"));
         assert_eq!(header.topic, CheetahString::from_static_str("test_topic"));
-        assert!(!header.topic_request_header.is_none());
+        assert!(header.topic_request_header.is_some());
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/header/reply_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/reply_message_request_header.rs
@@ -161,7 +161,7 @@ mod reply_message_request_header_tests {
         assert_eq!(map.get("producerGroup").unwrap(), "test_producer_group");
         assert_eq!(map.get("defaultTopicQueueNums").unwrap(), "10");
         assert_eq!(map.get("bornTimestamp").unwrap(), "1622547800");
-        assert!(map.get("topicRequest").is_none());
+        assert!(!map.contains_key("topicRequest"));
         assert_eq!(map.get("queueId").unwrap(), "1");
         assert_eq!(map.get("sysFlag").unwrap(), "0");
         assert_eq!(map.get("bornHost").unwrap(), "test_born_host");

--- a/rocketmq-remoting/src/protocol/header/unregister_client_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/unregister_client_request_header.rs
@@ -125,6 +125,6 @@ mod tests {
             CheetahString::from_static_str("test_client_id")
         );
         assert_eq!(header.consumer_group.as_deref(), None);
-        assert!(!header.rpc_request_header.is_none());
+        assert!(header.rpc_request_header.is_some());
     }
 }

--- a/rocketmq-remoting/src/protocol/route/route_data_view.rs
+++ b/rocketmq-remoting/src/protocol/route/route_data_view.rs
@@ -271,7 +271,7 @@ mod tests {
 
         broker_data.remove_broker_by_addr(1, &"127.0.0.1".into());
         //assert!(broker_data.broker_addrs.get(&1).is_none());
-        assert!(broker_data.broker_addrs.get(&2).is_some());
+        assert!(broker_data.broker_addrs.contains_key(&2));
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4087 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Clean up remaining clippy warnings
Now all clippy warnings have been cleaned up

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
ran `cargo clippy` and `cargo test` as mentioned in `CONTRIBUTING.md`, all passed and there were no warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated assertions to expect presence of optional headers in multiple request/response header tests.
  - Simplified assertion style (e.g., using is_some and contains_key) and removed unnecessary negations.
  - Migrated tests from nested modules to top-level test functions; cleaned up variable mutability.
  - Adjusted test data construction (e.g., vector initialization and typed values).
  - Removed redundant type casts in time-related tests.

- **Chores**
  - No user-facing changes; behavior and public interfaces remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->