### PR TITLE
[ISSUE #4113]🚀Add RemotingGeneral struct and message processing methods

### DIFF
--- a/rocketmq-remoting/src/remoting.rs
+++ b/rocketmq-remoting/src/remoting.rs
@@ -72,6 +72,9 @@ pub trait InvokeCallback {
 
 #[allow(unused_variables)]
 mod inner {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
     use crate::base::response_future::ResponseFuture;
     use crate::net::channel::Channel;
     use crate::protocol::remoting_command::RemotingCommand;
@@ -80,8 +83,6 @@ mod inner {
     use crate::runtime::connection_handler_context::ConnectionHandlerContext;
     use crate::runtime::processor::RequestProcessor;
     use crate::runtime::RPCHook;
-    use std::collections::HashMap;
-    use std::sync::Arc;
 
     struct RemotingGeneral<RP> {
         request_processor: RP,
@@ -90,11 +91,16 @@ mod inner {
         response_table: HashMap<i32, ResponseFuture>,
     }
 
-    impl<RP> RemotingGeneral<RP> where RP: RequestProcessor + Sync + 'static + Clone {
-
-        pub fn process_message_received(&mut self, channel: Channel,
-                                        ctx: ConnectionHandlerContext,
-                                        cmd: &mut RemotingCommand,) {
+    impl<RP> RemotingGeneral<RP>
+    where
+        RP: RequestProcessor + Sync + 'static + Clone,
+    {
+        pub fn process_message_received(
+            &mut self,
+            channel: Channel,
+            ctx: ConnectionHandlerContext,
+            cmd: &mut RemotingCommand,
+        ) {
             match cmd.get_type() {
                 RemotingCommandType::REQUEST => {
                     self.process_request_command(channel, ctx, cmd);
@@ -103,22 +109,25 @@ mod inner {
                     self.process_response_command(channel, ctx, cmd);
                 }
             }
-
         }
 
-        fn process_request_command(&mut self, channel: Channel,
-                                   ctx: ConnectionHandlerContext,
-                                   cmd: &mut RemotingCommand,) {
-
+        fn process_request_command(
+            &mut self,
+            channel: Channel,
+            ctx: ConnectionHandlerContext,
+            cmd: &mut RemotingCommand,
+        ) {
         }
 
-        fn process_response_command(&mut self, channel: Channel,
-                                   ctx: ConnectionHandlerContext,
-                                   cmd: &mut RemotingCommand,) {
-
+        fn process_response_command(
+            &mut self,
+            channel: Channel,
+            ctx: ConnectionHandlerContext,
+            cmd: &mut RemotingCommand,
+        ) {
         }
 
-         fn do_after_rpc_hooks(
+        fn do_after_rpc_hooks(
             &self,
             channel: &Channel,
             request: &RemotingCommand,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4113

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal message routing and response handling in the remoting layer to enhance reliability and performance.

* **Chores**
  * Removed an obsolete callback pathway as part of internal cleanup.

* **Notes**
  * No user-facing behavior changes; functionality remains the same for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->