### PR TITLE
[ISSUE #4109]♻️Refactor Remoting Request and Response command handle

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -43,7 +43,7 @@ use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::protocol::namesrv::RegisterBrokerResult;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
 use rocketmq_remoting::protocol::DataVersion;
-use rocketmq_remoting::remoting_server::server::RocketMQServer;
+use rocketmq_remoting::remoting_server::rocketmq_tokio_server::RocketMQServer;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_runtime::RocketMQRuntime;
 use rocketmq_rust::schedule::simple_scheduler::ScheduledTaskManager;

--- a/rocketmq-broker/src/client/manager/producer_manager.rs
+++ b/rocketmq-broker/src/client/manager/producer_manager.rs
@@ -157,6 +157,7 @@ impl ProducerManager {
         }
     }
 
+    #[allow(clippy::mutable_key_type)]
     pub fn register_producer(
         &self,
         group: &CheetahString,
@@ -205,14 +206,14 @@ impl ProducerManager {
                 .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
             let mut index = index.unsigned_abs() as usize % size;
             let mut channel = channels[index];
-            let mut ok = channel.upgrade().is_some();
+            let mut ok = channel.connection_ref().connection_is_ok();
             for _ in 0..GET_AVAILABLE_CHANNEL_RETRY_COUNT {
                 if ok {
                     return Some(channel.clone());
                 }
                 index = (index + 1) % size;
                 channel = channels[index];
-                ok = channel.upgrade().is_some();
+                ok = channel.connection_ref().connection_is_ok();
             }
             return None;
         }

--- a/rocketmq-broker/src/client/net/broker_to_client.rs
+++ b/rocketmq-broker/src/client/net/broker_to_client.rs
@@ -25,7 +25,6 @@ use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 #[derive(Default, Clone)]
 pub struct Broker2Client;
 
-#[allow(unused)]
 impl Broker2Client {
     pub async fn call_client(
         &mut self,
@@ -41,7 +40,7 @@ impl Broker2Client {
 
     pub async fn check_producer_transaction_state(
         &self,
-        group: &CheetahString,
+        _group: &CheetahString,
         channel: &mut Channel,
         request_header: CheckTransactionStateRequestHeader,
         message_ext: MessageExt,

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -486,10 +486,9 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
                     match response {
                         Ok(result) => {
                             if let Some(mut response) = result {
-                                if let Some(channel) = pop_request.get_channel().upgrade() {
-                                    response.set_opaque_mut(opaque);
-                                    let _ = channel.send_one_way(response, 1000).await;
-                                }
+                                let channel = pop_request.get_channel();
+                                response.set_opaque_mut(opaque);
+                                let _ = channel.channel_inner().send_one_way(response, 1000).await;
                             }
                         }
                         Err(e) => {
@@ -530,8 +529,8 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
                     .as_ref()
                     .unwrap()
                     .get_channel()
-                    .upgrade()
-                    .is_some_and(|item| item.is_ok())
+                    .connection_ref()
+                    .connection_is_ok()
             {
                 continue;
             } else {

--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -90,7 +90,7 @@ impl<MS: MessageStore> PullMessageResultHandler for DefaultPullMessageResultHand
         mut get_message_result: GetMessageResult,
         request: &mut RemotingCommand,
         request_header: PullMessageRequestHeader,
-        channel: Channel,
+        mut channel: Channel,
         ctx: ConnectionHandlerContext,
         subscription_data: SubscriptionData,
         subscription_group_config: SubscriptionGroupConfig,
@@ -192,18 +192,17 @@ impl<MS: MessageStore> PullMessageResultHandler for DefaultPullMessageResultHand
                     Some(response)
                 } else {
                     //zero copy transfer
-                    if let Some(mut channel) = channel.upgrade() {
-                        if let Some(header_bytes) = response.encode_header_with_body_length(
-                            get_message_result.buffer_total_size() as usize,
-                        ) {
-                            let _ = channel.connection_mut().send_bytes(header_bytes).await;
-                        }
-                        for select_result in get_message_result.message_mapped_list_mut() {
-                            if let Some(message) = select_result.bytes.take() {
-                                let _ = channel.connection_mut().send_bytes(message).await;
-                            }
+                    if let Some(header_bytes) = response.encode_header_with_body_length(
+                        get_message_result.buffer_total_size() as usize,
+                    ) {
+                        let _ = channel.connection_mut().send_bytes(header_bytes).await;
+                    }
+                    for select_result in get_message_result.message_mapped_list_mut() {
+                        if let Some(message) = select_result.bytes.take() {
+                            let _ = channel.connection_mut().send_bytes(message).await;
                         }
                     }
+
                     None
                 }
             }

--- a/rocketmq-cli/src/content_show.rs
+++ b/rocketmq-cli/src/content_show.rs
@@ -42,10 +42,7 @@ pub fn print_content(from: Option<u32>, to: Option<u32>, path: Option<PathBuf>) 
     // read message number
     let mut counter = 0;
     let form = from.unwrap_or_default();
-    let to = match to {
-        None => u32::MAX,
-        Some(value) => value,
-    };
+    let to = to.unwrap_or(u32::MAX);
     let mut current_pos = 0usize;
     let mut table = vec![];
     loop {

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -84,7 +84,7 @@ const NAMESPACE_ORDER_TOPIC_CONFIG: &str = "ORDER_TOPIC_CONFIG";
 pub struct DefaultMQAdminExtImpl {
     service_state: ServiceState,
     client_instance: Option<ArcMut<MQClientInstance>>,
-    rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    rpc_hook: Option<Arc<dyn RPCHook>>,
     timeout_millis: Duration,
     kv_namespace_to_delete_list: Vec<CheetahString>,
     client_config: ArcMut<ClientConfig>,
@@ -94,7 +94,7 @@ pub struct DefaultMQAdminExtImpl {
 
 impl DefaultMQAdminExtImpl {
     pub fn new(
-        rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
         timeout_millis: Duration,
         client_config: ArcMut<ClientConfig>,
         admin_ext_group: CheetahString,

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -115,7 +115,7 @@ pub struct DefaultMQPushConsumerImpl {
     pub(crate) rebalance_impl: ArcMut<RebalancePushImpl>,
     filter_message_hook_list: Vec<Arc<Box<dyn FilterMessageHook + Send + Sync>>>,
     consume_message_hook_list: Vec<Arc<Box<dyn ConsumeMessageHook + Send + Sync>>>,
-    rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    rpc_hook: Option<Arc<dyn RPCHook>>,
     service_state: ArcMut<ServiceState>,
     pub(crate) client_instance: Option<ArcMut<MQClientInstance>>,
     pub(crate) pull_api_wrapper: Option<ArcMut<PullAPIWrapper>>,
@@ -149,7 +149,7 @@ impl DefaultMQPushConsumerImpl {
     pub fn new(
         client_config: ClientConfig,
         consumer_config: ArcMut<ConsumerConfig>,
-        rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> Self {
         let mut this = Self {
             global_lock: Arc::new(Default::default()),

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -90,7 +90,7 @@ pub struct ConsumerConfig {
     pub(crate) await_termination_millis_when_shutdown: u64,
     pub(crate) trace_dispatcher: Option<Arc<Box<dyn TraceDispatcher + Send + Sync>>>,
     pub(crate) client_rebalance: bool,
-    pub(crate) rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    pub(crate) rpc_hook: Option<Arc<dyn RPCHook>>,
 }
 
 impl ConsumerConfig {
@@ -218,7 +218,7 @@ impl ConsumerConfig {
         self.client_rebalance
     }
 
-    pub fn rpc_hook(&self) -> &Option<Arc<Box<dyn RPCHook>>> {
+    pub fn rpc_hook(&self) -> &Option<Arc<dyn RPCHook>> {
         &self.rpc_hook
     }
 
@@ -374,7 +374,7 @@ impl ConsumerConfig {
         self.client_rebalance = client_rebalance;
     }
 
-    pub fn set_rpc_hook(&mut self, rpc_hook: Option<Arc<Box<dyn RPCHook>>>) {
+    pub fn set_rpc_hook(&mut self, rpc_hook: Option<Arc<dyn RPCHook>>) {
         self.rpc_hook = rpc_hook;
     }
 }

--- a/rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs
@@ -66,7 +66,7 @@ pub struct DefaultMQPushConsumerBuilder {
     await_termination_millis_when_shutdown: Option<u64>,
     trace_dispatcher: Option<Arc<Box<dyn TraceDispatcher + Send + Sync>>>,
     client_rebalance: Option<bool>,
-    rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    rpc_hook: Option<Arc<dyn RPCHook>>,
 }
 
 impl Default for DefaultMQPushConsumerBuilder {
@@ -307,7 +307,7 @@ impl DefaultMQPushConsumerBuilder {
         self
     }
 
-    pub fn rpc_hook(mut self, rpc_hook: Option<Arc<Box<dyn RPCHook>>>) -> Self {
+    pub fn rpc_hook(mut self, rpc_hook: Option<Arc<dyn RPCHook>>) -> Self {
         self.rpc_hook = rpc_hook;
         self
     }

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -189,7 +189,7 @@ impl MQClientInstance {
         client_config: ClientConfig,
         instance_index: i32,
         client_id: impl Into<CheetahString>,
-        rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> ArcMut<MQClientInstance> {
         let broker_addr_table = Arc::new(Default::default());
         let mut instance = ArcMut::new(MQClientInstance {

--- a/rocketmq-client/src/implementation/mq_client_manager.rs
+++ b/rocketmq-client/src/implementation/mq_client_manager.rs
@@ -59,7 +59,7 @@ impl MQClientManager {
     pub fn get_or_create_mq_client_instance(
         &self,
         client_config: ClientConfig,
-        rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> ArcMut<MQClientInstance> {
         let client_id = CheetahString::from_string(client_config.build_mq_client_id());
         let mut factory_table = self.factory_table.write();

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -17,6 +17,7 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![allow(clippy::result_large_err)]
+#![recursion_limit = "256"]
 
 extern crate core;
 

--- a/rocketmq-client/src/producer/default_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/default_mq_produce_builder.rs
@@ -49,7 +49,7 @@ pub struct DefaultMQProducerBuilder {
     enable_backpressure_for_async_mode: Option<bool>,
     back_pressure_for_async_send_num: Option<u32>,
     back_pressure_for_async_send_size: Option<u32>,
-    rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    rpc_hook: Option<Arc<dyn RPCHook>>,
     compress_level: Option<i32>,
     compress_type: Option<CompressionType>,
     compressor: Option<Arc<Box<dyn Compressor + Send + Sync>>>,
@@ -231,8 +231,8 @@ impl DefaultMQProducerBuilder {
     }
 
     #[inline]
-    pub fn rpc_hook(mut self, rpc_hook: Box<dyn RPCHook>) -> Self {
-        self.rpc_hook = Some(Arc::new(rpc_hook));
+    pub fn rpc_hook(mut self, rpc_hook: Arc<dyn RPCHook>) -> Self {
+        self.rpc_hook = Some(rpc_hook);
         self
     }
 

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -98,7 +98,7 @@ pub struct ProducerConfig {
     /// on BackpressureForAsyncMode, limit maximum message size of on-going sending async messages
     /// default is 100M
     back_pressure_for_async_send_size: u32,
-    rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    rpc_hook: Option<Arc<dyn RPCHook>>,
     compress_level: i32,
     compress_type: CompressionType,
     compressor: Option<Arc<Box<dyn Compressor + Send + Sync>>>,
@@ -174,7 +174,7 @@ impl ProducerConfig {
         self.back_pressure_for_async_send_size
     }
 
-    pub fn rpc_hook(&self) -> &Option<Arc<Box<dyn RPCHook>>> {
+    pub fn rpc_hook(&self) -> &Option<Arc<dyn RPCHook>> {
         &self.rpc_hook
     }
 
@@ -329,7 +329,7 @@ impl DefaultMQProducer {
         self.producer_config.back_pressure_for_async_send_size
     }
 
-    pub fn rpc_hook(&self) -> &Option<Arc<Box<dyn RPCHook>>> {
+    pub fn rpc_hook(&self) -> &Option<Arc<dyn RPCHook>> {
         &self.producer_config.rpc_hook
     }
 
@@ -447,7 +447,7 @@ impl DefaultMQProducer {
         self.producer_config.back_pressure_for_async_send_size = back_pressure_for_async_send_size;
     }
 
-    pub fn set_rpc_hook(&mut self, rpc_hook: Option<Arc<Box<dyn RPCHook>>>) {
+    pub fn set_rpc_hook(&mut self, rpc_hook: Option<Arc<dyn RPCHook>>) {
         self.producer_config.rpc_hook = rpc_hook;
     }
 

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -98,7 +98,7 @@ pub struct DefaultMQProducerImpl {
     send_message_hook_list: ArcMut<Vec<Box<dyn SendMessageHook>>>,
     end_transaction_hook_list: Arc<Vec<Box<dyn EndTransactionHook>>>,
     check_forbidden_hook_list: Vec<Arc<Box<dyn CheckForbiddenHook>>>,
-    rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    rpc_hook: Option<Arc<dyn RPCHook>>,
     service_state: ServiceState,
     client_instance: Option<ArcMut<MQClientInstance>>,
     mq_fault_strategy: ArcMut<MQFaultStrategy>,
@@ -117,7 +117,7 @@ impl DefaultMQProducerImpl {
     pub fn new(
         client_config: ClientConfig,
         producer_config: ProducerConfig,
-        rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> Self {
         let semaphore_async_send_num =
             Semaphore::new(producer_config.back_pressure_for_async_send_num().max(10) as usize);

--- a/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
@@ -53,7 +53,7 @@ pub struct TransactionMQProducerBuilder {
     enable_backpressure_for_async_mode: Option<bool>,
     back_pressure_for_async_send_num: Option<u32>,
     back_pressure_for_async_send_size: Option<u32>,
-    rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+    rpc_hook: Option<Arc<dyn RPCHook>>,
     compress_level: Option<i32>,
     compress_type: Option<CompressionType>,
     compressor: Option<Arc<Box<dyn Compressor + Send + Sync>>>,
@@ -218,8 +218,8 @@ impl TransactionMQProducerBuilder {
         self
     }
 
-    pub fn rpc_hook(mut self, rpc_hook: Box<dyn RPCHook>) -> Self {
-        self.rpc_hook = Some(Arc::new(rpc_hook));
+    pub fn rpc_hook(mut self, rpc_hook: Arc<dyn RPCHook>) -> Self {
+        self.rpc_hook = Some(rpc_hook);
         self
     }
 

--- a/rocketmq-client/src/trace/async_trace_dispatcher.rs
+++ b/rocketmq-client/src/trace/async_trace_dispatcher.rs
@@ -34,7 +34,7 @@ impl AsyncTraceDispatcher {
         group: &str,
         type_: Type,
         trace_topic_name: &str,
-        rpc_hook: Option<Arc<Box<dyn RPCHook>>>,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> Self {
         AsyncTraceDispatcher
     }

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -24,11 +24,11 @@ use rocketmq_common::common::server::config::ServerConfig;
 use rocketmq_common::utils::network_util::NetworkUtil;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::base::channel_event_listener::ChannelEventListener;
-use rocketmq_remoting::clients::rocketmq_default_impl::RocketmqDefaultClient;
+use rocketmq_remoting::clients::rocketmq_tokio_client::RocketmqDefaultClient;
 use rocketmq_remoting::clients::RemotingClient;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::remoting::RemotingService;
-use rocketmq_remoting::remoting_server::server::RocketMQServer;
+use rocketmq_remoting::remoting_server::rocketmq_tokio_server::RocketMQServer;
 use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_rust::schedule::simple_scheduler::ScheduledTaskManager;
@@ -138,7 +138,7 @@ impl NameServerRuntime {
     }
     fn initiate_rpc_hooks(&mut self) {
         if let Some(server) = self.server_inner.as_mut() {
-            server.register_rpc_hook(Box::new(ZoneRouteRPCHook));
+            server.register_rpc_hook(Arc::new(ZoneRouteRPCHook));
         }
     }
 

--- a/rocketmq-namesrv/src/processor.rs
+++ b/rocketmq-namesrv/src/processor.rs
@@ -122,15 +122,5 @@ impl RequestProcessor for NameServerRequestProcessor {
                 RequestProcessor::process_request(processor, channel, ctx, request).await
             }
         }
-        /*match request_code {
-            RequestCode::GetRouteinfoByTopic => {
-                self.client_request_processor
-                    .process_request(channel, ctx, request_code, request)
-            }
-            _ => {
-                self.default_request_processor
-                    .process_request(channel, ctx, request_code, request)
-            }
-        }*/
     }
 }

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -674,7 +674,7 @@ impl RouteInfoManager {
                 tokio::spawn(async move {
                     let _ = remoting_client
                         .remoting_client()
-                        .invoke_oneway(
+                        .invoke_request_oneway(
                             &broker_addr,
                             RemotingCommand::create_request_command(
                                 RequestCode::NotifyMinBrokerIdChange,

--- a/rocketmq-remoting/src/clients.rs
+++ b/rocketmq-remoting/src/clients.rs
@@ -28,7 +28,7 @@ mod async_client;
 mod blocking_client;
 
 mod client;
-pub mod rocketmq_default_impl;
+pub mod rocketmq_tokio_client;
 
 /// `RemotingClient` trait extends `RemotingService` to provide client-specific remote interaction
 /// functionalities.
@@ -65,7 +65,7 @@ pub trait RemotingClient: RemotingService {
     ///
     /// # Returns
     /// A `Result` containing either the response `RemotingCommand` or an `Error`.
-    async fn invoke_async(
+    async fn invoke_request(
         &self,
         addr: Option<&CheetahString>,
         request: RemotingCommand,
@@ -78,7 +78,7 @@ pub trait RemotingClient: RemotingService {
     /// * `addr` - The address to invoke the command on.
     /// * `request` - The `RemotingCommand` to be sent.
     /// * `timeout_millis` - The timeout for the operation in milliseconds.
-    async fn invoke_oneway(
+    async fn invoke_request_oneway(
         &self,
         addr: &CheetahString,
         request: RemotingCommand,

--- a/rocketmq-remoting/src/clients/async_client.rs
+++ b/rocketmq-remoting/src/clients/async_client.rs
@@ -18,7 +18,7 @@
 /// Connection with broker or nameserver
 pub struct AsyncClient {
     /// The asynchronous `Client`.
-    inner: crate::clients::Client,
+    //inner: crate::clients::Client,
 
     ///Create a separate thread pool to handle clients.
     rt: tokio::runtime::Runtime,

--- a/rocketmq-remoting/src/clients/async_client.rs
+++ b/rocketmq-remoting/src/clients/async_client.rs
@@ -17,9 +17,6 @@
 
 /// Connection with broker or nameserver
 pub struct AsyncClient {
-    /// The asynchronous `Client`.
-    //inner: crate::clients::Client,
-
     ///Create a separate thread pool to handle clients.
     rt: tokio::runtime::Runtime,
 }

--- a/rocketmq-remoting/src/clients/blocking_client.rs
+++ b/rocketmq-remoting/src/clients/blocking_client.rs
@@ -17,7 +17,7 @@
 
 pub struct BlockingClient {
     /// The asynchronous `Client`.
-    inner: crate::clients::Client,
+   // inner: crate::clients::Client,
 
     /// A `current_thread` runtime for executing operations on the asynchronous
     /// client in a blocking manner.

--- a/rocketmq-remoting/src/clients/blocking_client.rs
+++ b/rocketmq-remoting/src/clients/blocking_client.rs
@@ -16,9 +16,6 @@
  */
 
 pub struct BlockingClient {
-    /// The asynchronous `Client`.
-   // inner: crate::clients::Client,
-
     /// A `current_thread` runtime for executing operations on the asynchronous
     /// client in a blocking manner.
     rt: tokio::runtime::Runtime,

--- a/rocketmq-remoting/src/remoting.rs
+++ b/rocketmq-remoting/src/remoting.rs
@@ -55,7 +55,7 @@ pub trait RemotingService: Send {
     ///
     /// # Arguments
     /// * `hook` - An implementation of the `RPCHook` trait that will be registered.
-    fn register_rpc_hook(&mut self, hook: Arc<Box<dyn RPCHook>>);
+    fn register_rpc_hook(&mut self, hook: Arc<dyn RPCHook>);
 
     /// Clears all registered RPC hooks.
     ///
@@ -71,60 +71,158 @@ pub trait InvokeCallback {
 }
 
 #[allow(unused_variables)]
-mod inner {
+pub(crate) mod inner {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use rocketmq_error::RocketMQResult;
+    use rocketmq_error::RocketmqError;
+    use rocketmq_rust::ArcMut;
+    use tracing::error;
+    use tracing::warn;
+
     use crate::base::response_future::ResponseFuture;
+    use crate::code::response_code::ResponseCode;
     use crate::net::channel::Channel;
     use crate::protocol::remoting_command::RemotingCommand;
     use crate::protocol::RemotingCommandType;
-    use crate::remoting_server::server::Shutdown;
     use crate::runtime::connection_handler_context::ConnectionHandlerContext;
     use crate::runtime::processor::RequestProcessor;
     use crate::runtime::RPCHook;
 
-    struct RemotingGeneral<RP> {
-        request_processor: RP,
-        shutdown: Shutdown,
-        rpc_hooks: Arc<Vec<Box<dyn RPCHook>>>,
-        response_table: HashMap<i32, ResponseFuture>,
+    pub(crate) struct RemotingGeneralHandler<RP> {
+        pub(crate) request_processor: RP,
+        pub(crate) rpc_hooks: Vec<Arc<dyn RPCHook>>,
+        pub(crate) response_table: ArcMut<HashMap<i32, ResponseFuture>>,
     }
 
-    impl<RP> RemotingGeneral<RP>
+    impl<RP> RemotingGeneralHandler<RP>
     where
-        RP: RequestProcessor + Sync + 'static + Clone,
+        RP: RequestProcessor + Sync + 'static,
     {
-        pub fn process_message_received(
+        pub async fn process_message_received(
             &mut self,
-            channel: Channel,
-            ctx: ConnectionHandlerContext,
-            cmd: &mut RemotingCommand,
+            ctx: &mut ConnectionHandlerContext,
+            cmd: RemotingCommand,
         ) {
             match cmd.get_type() {
                 RemotingCommandType::REQUEST => {
-                    self.process_request_command(channel, ctx, cmd);
+                    match self.process_request_command(ctx, cmd).await {
+                        Ok(_) => {}
+                        Err(e) => {
+                            error!("process request command failed: {}", e);
+                        }
+                    }
                 }
                 RemotingCommandType::RESPONSE => {
-                    self.process_response_command(channel, ctx, cmd);
+                    self.process_response_command(ctx, cmd);
                 }
             }
         }
 
-        fn process_request_command(
+        async fn process_request_command(
             &mut self,
-            channel: Channel,
-            ctx: ConnectionHandlerContext,
-            cmd: &mut RemotingCommand,
-        ) {
+            ctx: &mut ConnectionHandlerContext,
+            mut cmd: RemotingCommand,
+        ) -> RocketMQResult<()> {
+            let opaque = cmd.opaque();
+            let reject_request = self.request_processor.reject_request(cmd.code());
+            const REJECT_REQUEST_MSG: &str =
+                "[REJECT REQUEST]system busy, start flow control for a while";
+            if reject_request.0 {
+                let response = if let Some(response) = reject_request.1 {
+                    response
+                } else {
+                    RemotingCommand::create_response_command_with_code_remark(
+                        ResponseCode::SystemBusy,
+                        REJECT_REQUEST_MSG,
+                    )
+                };
+                ctx.channel
+                    .connection_mut()
+                    .send_command(response.set_opaque(opaque))
+                    .await?;
+                return Ok(());
+            }
+            let oneway_rpc = cmd.is_oneway_rpc();
+            //before handle request hooks
+            let exception = self
+                .do_before_rpc_hooks(ctx.channel(), Some(&mut cmd))
+                .err();
+            //handle error if return have
+            match handle_error(ctx, oneway_rpc, opaque, exception).await {
+                HandleErrorResult::ReturnMethod => return Ok(()),
+                HandleErrorResult::GoHead => {}
+            }
+
+            let mut response = {
+                let channel = ctx.channel.clone();
+                let ctx = ctx.clone();
+                let result = self
+                    .request_processor
+                    .process_request(channel, ctx, &mut cmd)
+                    .await
+                    .unwrap_or_else(|_err| {
+                        Some(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::SystemError,
+                        ))
+                    });
+                result
+            };
+
+            let exception = self
+                .do_after_rpc_hooks(ctx.channel(), &cmd, response.as_mut())
+                .err();
+
+            match handle_error(ctx, oneway_rpc, opaque, exception).await {
+                HandleErrorResult::ReturnMethod => return Ok(()),
+                HandleErrorResult::GoHead => {}
+            }
+            if response.is_none() || oneway_rpc {
+                return Ok(());
+            }
+            let response = response.unwrap();
+            let result = ctx
+                .channel_mut()
+                .connection_mut()
+                .send_command(response.set_opaque(opaque))
+                .await;
+            match result {
+                Ok(_) => {}
+                Err(err) => match err {
+                    RocketmqError::Io(io_error) => {
+                        error!("connection disconnect: {}", io_error);
+                        return Ok(());
+                    }
+                    _ => {
+                        error!("send response failed: {}", err);
+                    }
+                },
+            };
+            Ok(())
         }
 
         fn process_response_command(
             &mut self,
-            channel: Channel,
-            ctx: ConnectionHandlerContext,
-            cmd: &mut RemotingCommand,
+            ctx: &mut ConnectionHandlerContext,
+            cmd: RemotingCommand,
         ) {
+            if let Some(future) = self.response_table.remove(&cmd.opaque()) {
+                match future.tx.send(Ok(cmd)) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        warn!("send response to future failed, maybe timeout",);
+                    }
+                }
+            } else {
+                warn!(
+                    "receive response, cmd={}, but not matched any request, address={}, \
+                     channelId={}",
+                    cmd,
+                    ctx.channel().remote_address(),
+                    ctx.channel().channel_id(),
+                );
+            }
         }
 
         fn do_after_rpc_hooks(
@@ -133,7 +231,12 @@ mod inner {
             request: &RemotingCommand,
             response: Option<&mut RemotingCommand>,
         ) -> rocketmq_error::RocketMQResult<()> {
-            unimplemented!("do_after_rpc_hooks unimplemented")
+            if let Some(response) = response {
+                for hook in self.rpc_hooks.iter() {
+                    hook.do_after_response(channel.remote_address(), request, response)?;
+                }
+            }
+            Ok(())
         }
 
         pub fn do_before_rpc_hooks(
@@ -141,7 +244,77 @@ mod inner {
             channel: &Channel,
             request: Option<&mut RemotingCommand>,
         ) -> rocketmq_error::RocketMQResult<()> {
-            unimplemented!("do_before_rpc_hooks unimplemented")
+            if let Some(request) = request {
+                for hook in self.rpc_hooks.iter() {
+                    hook.do_before_request(channel.remote_address(), request)?;
+                }
+            }
+            Ok(())
         }
+
+        pub fn register_rpc_hook(&mut self, hook: Arc<dyn RPCHook>) {
+            self.rpc_hooks.push(hook);
+        }
+    }
+    async fn handle_error(
+        ctx: &mut ConnectionHandlerContext,
+        oneway_rpc: bool,
+        opaque: i32,
+        exception: Option<RocketmqError>,
+    ) -> HandleErrorResult {
+        if let Some(exception_inner) = exception {
+            match exception_inner {
+                RocketmqError::AbortProcessError(code, message) => {
+                    if oneway_rpc {
+                        return HandleErrorResult::ReturnMethod;
+                    }
+                    let response =
+                        RemotingCommand::create_response_command_with_code_remark(code, message);
+                    tokio::select! {
+                        result =ctx.connection_mut().send_command(response.set_opaque(opaque)) => match result{
+                            Ok(_) =>{},
+                            Err(err) => {
+                                match err {
+                                    RocketmqError::Io(io_error) => {
+                                        error!("send response failed: {}", io_error);
+                                        return HandleErrorResult::ReturnMethod;
+                                    }
+                                    _ => { error!("send response failed: {}", err);}
+                                }
+                            },
+                        },
+                    }
+                }
+                _ => {
+                    if !oneway_rpc {
+                        let response = RemotingCommand::create_response_command_with_code_remark(
+                            ResponseCode::SystemError,
+                            exception_inner.to_string(),
+                        );
+                        tokio::select! {
+                            result =ctx.connection_mut().send_command(response.set_opaque(opaque)) => match result{
+                                Ok(_) =>{},
+                                Err(err) => {
+                                    match err {
+                                        RocketmqError::Io(io_error) => {
+                                            error!("send response failed: {}", io_error);
+                                            return HandleErrorResult::ReturnMethod;
+                                        }
+                                        _ => { error!("send response failed: {}", err);}
+                                    }
+                                },
+                            },
+                        }
+                    }
+                }
+            }
+            HandleErrorResult::ReturnMethod
+        } else {
+            HandleErrorResult::GoHead
+        }
+    }
+    enum HandleErrorResult {
+        ReturnMethod,
+        GoHead,
     }
 }

--- a/rocketmq-remoting/src/remoting_server.rs
+++ b/rocketmq-remoting/src/remoting_server.rs
@@ -17,7 +17,7 @@
 
 use crate::remoting::RemotingService;
 
-pub mod server;
+pub mod rocketmq_tokio_server;
 
 pub trait RemotingServer: RemotingService {
     /*fn register_processor(

--- a/rocketmq-remoting/src/rpc/rpc_client_impl.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_impl.rs
@@ -21,7 +21,7 @@ use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_error::RocketmqError::RpcError;
 use rocketmq_rust::ArcMut;
 
-use crate::clients::rocketmq_default_impl::RocketmqDefaultClient;
+use crate::clients::rocketmq_tokio_client::RocketmqDefaultClient;
 use crate::clients::RemotingClient;
 use crate::code::request_code::RequestCode;
 use crate::code::response_code::ResponseCode;
@@ -90,7 +90,7 @@ impl RpcClientImpl {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
-            .invoke_async(Some(addr), request_command, timeout_millis)
+            .invoke_request(Some(addr), request_command, timeout_millis)
             .await
         {
             Ok(response) => match ResponseCode::from(response.code()) {
@@ -128,7 +128,7 @@ impl RpcClientImpl {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
-            .invoke_async(Some(addr), request_command, timeout_millis)
+            .invoke_request(Some(addr), request_command, timeout_millis)
             .await
         {
             Ok(response) => match ResponseCode::from(response.code()) {
@@ -162,7 +162,7 @@ impl RpcClientImpl {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
-            .invoke_async(Some(addr), request_command, timeout_millis)
+            .invoke_request(Some(addr), request_command, timeout_millis)
             .await
         {
             Ok(response) => match ResponseCode::from(response.code()) {
@@ -196,7 +196,7 @@ impl RpcClientImpl {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
-            .invoke_async(Some(addr), request_command, timeout_millis)
+            .invoke_request(Some(addr), request_command, timeout_millis)
             .await
         {
             Ok(response) => match ResponseCode::from(response.code()) {
@@ -230,7 +230,7 @@ impl RpcClientImpl {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
-            .invoke_async(Some(addr), request_command, timeout_millis)
+            .invoke_request(Some(addr), request_command, timeout_millis)
             .await
         {
             Ok(response) => match ResponseCode::from(response.code()) {
@@ -264,7 +264,7 @@ impl RpcClientImpl {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
-            .invoke_async(Some(addr), request_command, timeout_millis)
+            .invoke_request(Some(addr), request_command, timeout_millis)
             .await
         {
             Ok(response) => match ResponseCode::from(response.code()) {
@@ -302,7 +302,7 @@ impl RpcClientImpl {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
-            .invoke_async(Some(addr), request_command, timeout_millis)
+            .invoke_request(Some(addr), request_command, timeout_millis)
             .await
         {
             Ok(response) => match ResponseCode::from(response.code()) {
@@ -336,7 +336,7 @@ impl RpcClientImpl {
         let request_command = RpcClientUtils::create_command_for_rpc_request(request);
         match self
             .remoting_client
-            .invoke_async(Some(addr), request_command, timeout_millis)
+            .invoke_request(Some(addr), request_command, timeout_millis)
             .await
         {
             Ok(response) => match ResponseCode::from(response.code()) {

--- a/rocketmq-remoting/src/runtime/connection_handler_context.rs
+++ b/rocketmq-remoting/src/runtime/connection_handler_context.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::net::SocketAddr;
 
 use rocketmq_rust::ArcMut;
 use tracing::error;
@@ -39,37 +40,27 @@ impl ConnectionHandlerContextWrapper {
         }
     }
 
-    pub fn connection(&self) -> Option<&Connection> {
-        /*match self.channel.upgrade() {
-            None => None,
-            Some(channel) => Some(channel.connection_ref()),
-        }*/
-        unimplemented!("connection() is not implemented");
+    pub fn connection_ref(&self) -> &Connection {
+        self.channel.connection_ref()
+    }
+
+    pub fn connection_mut(&mut self) -> &mut Connection {
+        self.channel.connection_mut()
     }
 
     pub async fn write(&mut self, cmd: RemotingCommand) {
-        match self.channel.upgrade() {
-            Some(mut channel) => match channel.connection_mut().send_command(cmd).await {
-                Ok(_) => {}
-                Err(error) => {
-                    error!("send response failed: {}", error);
-                }
-            },
-            None => {
-                error!("channel is closed");
+        match self.channel.connection_mut().send_command(cmd).await {
+            Ok(_) => {}
+            Err(error) => {
+                error!("send response failed: {}", error);
             }
         }
     }
     pub async fn write_ref(&mut self, cmd: &mut RemotingCommand) {
-        match self.channel.upgrade() {
-            Some(mut channel) => match channel.connection_mut().send_command_ref(cmd).await {
-                Ok(_) => {}
-                Err(error) => {
-                    error!("send response failed: {}", error);
-                }
-            },
-            None => {
-                error!("channel is closed");
+        match self.channel.connection_mut().send_command_ref(cmd).await {
+            Ok(_) => {}
+            Err(error) => {
+                error!("send response failed: {}", error);
             }
         }
     }
@@ -80,6 +71,10 @@ impl ConnectionHandlerContextWrapper {
 
     pub fn channel_mut(&mut self) -> &mut Channel {
         &mut self.channel
+    }
+
+    pub fn remote_address(&self) -> SocketAddr {
+        self.channel.remote_address()
     }
 }
 

--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -110,12 +110,12 @@ impl DefaultMQAdminExt {
 
     pub fn with_rpc_hook(rpc_hook: impl RPCHook) -> Self {
         let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
-        let rpc_hook_inner: Box<dyn RPCHook> = Box::new(rpc_hook);
+        let rpc_hook_inner: Arc<dyn RPCHook> = Arc::new(rpc_hook);
         let client_config = ArcMut::new(ClientConfig::new());
         Self {
             client_config: client_config.clone(),
             default_mqadmin_ext_impl: ArcMut::new(DefaultMQAdminExtImpl::new(
-                Some(Arc::new(rpc_hook_inner)),
+                Some(rpc_hook_inner),
                 Duration::from_millis(5000),
                 client_config,
                 admin_ext_group.clone(),
@@ -130,12 +130,12 @@ impl DefaultMQAdminExt {
 
     pub fn with_rpc_hook_and_timeout(rpc_hook: impl RPCHook, timeout_millis: Duration) -> Self {
         let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
-        let rpc_hook_inner: Box<dyn RPCHook> = Box::new(rpc_hook);
+        let rpc_hook_inner: Arc<dyn RPCHook> = Arc::new(rpc_hook);
         let client_config = ArcMut::new(ClientConfig::new());
         Self {
             client_config: client_config.clone(),
             default_mqadmin_ext_impl: ArcMut::new(DefaultMQAdminExtImpl::new(
-                Some(Arc::new(rpc_hook_inner)),
+                Some(rpc_hook_inner),
                 timeout_millis,
                 client_config,
                 admin_ext_group.clone(),


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4109

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added per-request timeouts to RPC calls; introduced stable connection IDs.

- Refactor
  - Migrated networking to Tokio-based client/server and unified RPC invocation APIs.
  - Simplified RPC hook handling to use Arc<dyn RPCHook> (removed extra boxing).
  - Streamlined channel accessors and connection health checks.

- Bug Fixes
  - Improved long-polling and producer transaction reliability by avoiding stale channel upgrades.

- Chores
  - Increased recursion limit for compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->