### PR TITLE
[ISSUE #4147]⚡️Update log message for channel close event in ConsumerGroupInfo

### DIFF
--- a/rocketmq-broker/src/client/consumer_group_info.rs
+++ b/rocketmq-broker/src/client/consumer_group_info.rs
@@ -130,7 +130,7 @@ impl ConsumerGroupInfo {
     pub fn handle_channel_close_event(&self, channel: &Channel) -> Option<ClientChannelInfo> {
         if let Some((_, info)) = self.channel_info_table.remove(channel) {
             warn!(
-                "NETTY EVENT: remove not active channel [{}] from ConsumerGroupInfo \
+                "Channel close event: remove not active channel [{}] from ConsumerGroupInfo \
                  groupChannelTable, consumer group: {}",
                 info.channel().remote_address(),
                 self.group_name


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4147 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Update log message for channel close event in ConsumerGroupInfo

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Improved warning log wording for channel close events to enhance clarity and consistency across broker logs. The message now clearly indicates removal of inactive channels from consumer groups, aiding monitoring and troubleshooting.
  - Aligns terminology with other runtime logs to reduce confusion during incident analysis.
  - No functional or behavioral changes; this update only affects log readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->