### PR TITLE
[ISSUE #4156]✨Add request_code method to RemotingCommand and inline annotation to parse_request_header

### DIFF
--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header.rs
@@ -380,6 +380,7 @@ impl TopicRequestHeaderTrait for SendMessageRequestHeader {
 /// * `Ok(SendMessageRequestHeader)` if the header is successfully parsed and converted (if
 ///   necessary).
 /// * `Err(crate::Error)` if there is an error in decoding the header.
+#[inline]
 pub fn parse_request_header(
     request: &RemotingCommand,
     request_code: RequestCode,

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -41,6 +41,7 @@ use tracing::error;
 use super::RemotingCommandType;
 use super::RemotingSerializable;
 use super::SerializeType;
+use crate::code::request_code::RequestCode;
 use crate::code::response_code::RemotingSysResponseCode;
 use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
@@ -577,6 +578,11 @@ impl RemotingCommand {
     #[inline]
     pub fn code(&self) -> i32 {
         self.code
+    }
+
+    #[inline]
+    pub fn request_code(&self) -> RequestCode {
+        RequestCode::from(self.code)
     }
 
     #[inline]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4156

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds transparent support for newer and batch message send requests, automatically handling both V1 and V2 formats for seamless interoperability.

* **Bug Fixes**
  * Improves reliability of decoding message send requests, reducing errors when communicating with different client/broker versions.

* **Refactor**
  * Streamlines request handling logic by consolidating code paths for message send decoding, improving maintainability without changing external behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->