### PR TITLE
[ISSUE #4155]⚡️Remove return and semicolon refactor code

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -112,9 +112,8 @@ where
             | RequestCode::SendMessageV2
             | RequestCode::SendBatchMessage
             | RequestCode::ConsumerSendMsgBack => {
-                return self
-                    .process_request_inner(channel, ctx, request_code, request)
-                    .await;
+                self.process_request_inner(channel, ctx, request_code, request)
+                    .await
             }
             _ => {
                 warn!(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4155 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Remove return and semicolon refactor code

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified async control flow in message processing by replacing an explicit return with a direct await, improving readability and consistency.
* **Style**
  * Minor code style cleanup in the message handling path to align with modern Rust patterns.

No functional changes; end-user behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->