### PR TITLE
[ISSUE #4184]✨Add Criterion benchmarks for PermName::perm2string vs perm_to_string comparison

### DIFF
--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -77,3 +77,7 @@ criterion = { version = "0.7", features = ["html_reports"] }
 [[bench]]
 name = "delete_property"
 harness = false
+
+[[bench]]
+name = "perm_name"
+harness = false

--- a/rocketmq-common/benches/perm_name.rs
+++ b/rocketmq-common/benches/perm_name.rs
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::hint::black_box;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use rocketmq_common::common::constant::PermName;
+
+fn bench_perm2string(c: &mut Criterion) {
+    let mut group = c.benchmark_group("perm2string");
+
+    // Test with different permission combinations
+    let test_cases = vec![
+        (0, "no_permissions"),
+        (PermName::PERM_READ, "read_only"),
+        (PermName::PERM_WRITE, "write_only"),
+        (PermName::PERM_INHERIT, "inherit_only"),
+        (PermName::PERM_READ | PermName::PERM_WRITE, "read_write"),
+        (
+            PermName::PERM_READ | PermName::PERM_WRITE | PermName::PERM_INHERIT,
+            "all_permissions",
+        ),
+        (
+            PermName::PERM_READ | PermName::PERM_WRITE | PermName::PERM_PRIORITY,
+            "with_priority",
+        ),
+        (
+            PermName::PERM_READ
+                | PermName::PERM_WRITE
+                | PermName::PERM_INHERIT
+                | PermName::PERM_PRIORITY,
+            "all_flags",
+        ),
+    ];
+
+    for (perm, name) in test_cases {
+        group.bench_with_input(BenchmarkId::new("v1", name), &perm, |b, &p| {
+            b.iter(|| PermName::perm2string(black_box(p)))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_perm_to_string(c: &mut Criterion) {
+    let mut group = c.benchmark_group("perm_to_string");
+
+    let test_cases = vec![
+        (0, "no_permissions"),
+        (PermName::PERM_READ, "read_only"),
+        (PermName::PERM_WRITE, "write_only"),
+        (PermName::PERM_INHERIT, "inherit_only"),
+        (PermName::PERM_READ | PermName::PERM_WRITE, "read_write"),
+        (
+            PermName::PERM_READ | PermName::PERM_WRITE | PermName::PERM_INHERIT,
+            "all_permissions",
+        ),
+        (
+            PermName::PERM_READ | PermName::PERM_WRITE | PermName::PERM_PRIORITY,
+            "with_priority",
+        ),
+        (
+            PermName::PERM_READ
+                | PermName::PERM_WRITE
+                | PermName::PERM_INHERIT
+                | PermName::PERM_PRIORITY,
+            "all_flags",
+        ),
+    ];
+
+    for (perm, name) in test_cases {
+        group.bench_with_input(BenchmarkId::new("v2", name), &perm, |b, &p| {
+            b.iter(|| PermName::perm_to_string(black_box(p)))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_perm2string, bench_perm_to_string,);
+criterion_main!(benches);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4184

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new methods for permission name formatting and validation.

* **Tests**
  * Added performance benchmarks for permission name operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->