### PR TITLE
[ISSUE #4136]🚀Implement UpdateTopicSubCommand

### DIFF
--- a/rocketmq-tools/src/commands.rs
+++ b/rocketmq-tools/src/commands.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+pub mod command_util;
 mod namesrv_commands;
 mod topic_commands;
 
@@ -103,6 +104,11 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "Topic",
                 command: "allocateMQ",
                 remark: "Allocate MQ.",
+            },
+            Command {
+                category: "Topic",
+                command: "updateTopic",
+                remark: "Update or create topic.",
             },
             Command {
                 category: "NameServer",

--- a/rocketmq-tools/src/commands/command_util.rs
+++ b/rocketmq-tools/src/commands/command_util.rs
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::RocketmqError;
+use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
+
+pub struct CommandUtil;
+
+impl CommandUtil {
+    const MASTER_ID: u64 = 0;
+
+    pub fn fetch_master_addr_by_cluster_name(
+        cluster_info: &ClusterInfo,
+        cluster_name: &str,
+    ) -> RocketMQResult<Vec<CheetahString>> {
+        let cluster_addr_table = cluster_info.cluster_addr_table.as_ref().ok_or_else(|| {
+            RocketmqError::SubCommand(
+                "CommandUtil".into(),
+                "No cluster address table available from nameserver.".into(),
+            )
+        })?;
+        let broker_names = cluster_addr_table.get(cluster_name).ok_or_else(|| {
+            RocketmqError::SubCommand(
+                "CommandUtil".into(),
+                format!(
+                    "Make sure the specified clusterName exists or the nameserver which connected \
+                     to is correct. Cluster: {}",
+                    cluster_name
+                ),
+            )
+        })?;
+        let broker_addr_table = cluster_info.broker_addr_table.as_ref().ok_or_else(|| {
+            RocketmqError::SubCommand(
+                "CommandUtil".into(),
+                "No broker address table available from nameserver.".into(),
+            )
+        })?;
+
+        let mut master_addrs = Vec::new();
+        for broker_name in broker_names {
+            if let Some(broker_data) = broker_addr_table.get(broker_name) {
+                if let Some(master_addr) = broker_data.broker_addrs().get(&Self::MASTER_ID) {
+                    master_addrs.push(master_addr.clone());
+                }
+            }
+        }
+        Ok(master_addrs)
+    }
+
+    #[allow(unused)]
+    pub fn fetch_master_addr_by_broker_name(
+        cluster_info: &ClusterInfo,
+        broker_name: &str,
+    ) -> RocketMQResult<CheetahString> {
+        if let Some(broker_addr_table) = &cluster_info.broker_addr_table {
+            if let Some(broker_data) = broker_addr_table.get(broker_name) {
+                if let Some(master_addr) = broker_data.broker_addrs().get(&Self::MASTER_ID) {
+                    return Ok(master_addr.clone());
+                }
+            }
+        }
+        Err(RocketmqError::SubCommand(
+            "CommandUtil".into(),
+            format!("No broker address for broker name: {}", broker_name),
+        ))
+    }
+
+    #[allow(unused)]
+    pub fn fetch_broker_name_by_cluster_name(
+        cluster_info: &ClusterInfo,
+        cluster_name: &str,
+    ) -> RocketMQResult<Vec<String>> {
+        if let Some(cluster_addr_table) = &cluster_info.cluster_addr_table {
+            if let Some(broker_names) = cluster_addr_table.get(cluster_name) {
+                return Ok(broker_names.iter().map(|n| n.to_string()).collect());
+            }
+        }
+        Err(RocketmqError::SubCommand(
+            "CommandUtil".into(),
+            format!(
+                "Make sure the specified clusterName exists or the nameserver which connected to \
+                 is correct. Cluster: {}",
+                cluster_name
+            ),
+        ))
+    }
+
+    #[allow(unused)]
+    pub fn fetch_broker_name_by_addr(
+        cluster_info: &ClusterInfo,
+        broker_addr: &str,
+    ) -> RocketMQResult<String> {
+        if let Some(broker_addr_table) = &cluster_info.broker_addr_table {
+            for (broker_name, broker_data) in broker_addr_table.iter() {
+                for addr in broker_data.broker_addrs().values() {
+                    if addr.as_str() == broker_addr {
+                        return Ok(broker_name.to_string());
+                    }
+                }
+            }
+        }
+        Err(RocketmqError::SubCommand(
+            "CommandUtil".into(),
+            format!(
+                "Make sure the specified broker address exists. Address: {}",
+                broker_addr
+            ),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
+
+    use super::*;
+
+    fn create_test_cluster_info() -> ClusterInfo {
+        let mut broker_addr_table = HashMap::new();
+        let mut broker_addrs = HashMap::new();
+        broker_addrs.insert(0u64, CheetahString::from_static_str("192.168.1.1:10911"));
+        broker_addrs.insert(1u64, CheetahString::from_static_str("192.168.1.2:10911"));
+
+        let broker_data = BrokerData::new(
+            CheetahString::from_static_str("DefaultCluster"),
+            CheetahString::from_static_str("broker-a"),
+            broker_addrs,
+            None,
+        );
+        broker_addr_table.insert(CheetahString::from_static_str("broker-a"), broker_data);
+
+        let mut cluster_addr_table = HashMap::new();
+        let mut broker_names = HashSet::new();
+        broker_names.insert(CheetahString::from_static_str("broker-a"));
+        cluster_addr_table.insert(
+            CheetahString::from_static_str("DefaultCluster"),
+            broker_names,
+        );
+
+        ClusterInfo::new(Some(broker_addr_table), Some(cluster_addr_table))
+    }
+
+    #[test]
+    fn fetch_master_addr_by_cluster_name() {
+        let cluster_info = create_test_cluster_info();
+        let result =
+            CommandUtil::fetch_master_addr_by_cluster_name(&cluster_info, "DefaultCluster");
+
+        assert!(result.is_ok());
+        let addrs = result.unwrap();
+        assert_eq!(addrs.len(), 1);
+        assert_eq!(addrs[0].as_str(), "192.168.1.1:10911");
+    }
+
+    #[test]
+    fn fetch_master_addr_by_cluster_name_not_found() {
+        let cluster_info = create_test_cluster_info();
+        let result =
+            CommandUtil::fetch_master_addr_by_cluster_name(&cluster_info, "NonExistentCluster");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fetch_master_addr_by_broker_name() {
+        let cluster_info = create_test_cluster_info();
+        let result = CommandUtil::fetch_master_addr_by_broker_name(&cluster_info, "broker-a");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "192.168.1.1:10911");
+    }
+
+    #[test]
+    fn fetch_master_addr_by_broker_name_not_found() {
+        let cluster_info = create_test_cluster_info();
+        let result = CommandUtil::fetch_master_addr_by_broker_name(&cluster_info, "broker-z");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fetch_broker_name_by_cluster_name() {
+        let cluster_info = create_test_cluster_info();
+        let result =
+            CommandUtil::fetch_broker_name_by_cluster_name(&cluster_info, "DefaultCluster");
+
+        assert!(result.is_ok());
+        let names = result.unwrap();
+        assert_eq!(names.len(), 1);
+        assert_eq!(names[0], "broker-a");
+    }
+
+    #[test]
+    fn fetch_broker_name_by_cluster_name_not_found() {
+        let cluster_info = create_test_cluster_info();
+        let result =
+            CommandUtil::fetch_broker_name_by_cluster_name(&cluster_info, "NonExistentCluster");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fetch_broker_name_by_addr() {
+        let cluster_info = create_test_cluster_info();
+        let result = CommandUtil::fetch_broker_name_by_addr(&cluster_info, "192.168.1.1:10911");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "broker-a");
+    }
+
+    #[test]
+    fn fetch_broker_name_by_addr_not_found() {
+        let cluster_info = create_test_cluster_info();
+        let result = CommandUtil::fetch_broker_name_by_addr(&cluster_info, "192.168.1.99:10911");
+
+        assert!(result.is_err());
+    }
+}

--- a/rocketmq-tools/src/commands/topic_commands.rs
+++ b/rocketmq-tools/src/commands/topic_commands.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 mod allocate_mq_sub_command;
+mod update_topic_sub_command;
 
 use std::sync::Arc;
 
@@ -34,12 +35,20 @@ space of the topic when the topic is created. The default value is 1. If you wan
 more memory space, you can use this command to allocate it."#
     )]
     AllocateMQ(allocate_mq_sub_command::AllocateMQSubCommand),
+
+    #[command(
+        name = "updateTopic",
+        about = "Update or create topic",
+        long_about = r#"Update or create topic with specified configuration."#
+    )]
+    UpdateTopic(update_topic_sub_command::UpdateTopicSubCommand),
 }
 
 impl CommandExecute for TopicCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             TopicCommands::AllocateMQ(cmd) => cmd.execute(rpc_hook).await,
+            TopicCommands::UpdateTopic(cmd) => cmd.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/src/commands/topic_commands/update_topic_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/update_topic_sub_command.rs
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::config::TopicConfig;
+use rocketmq_common::common::topic::TopicValidator;
+use rocketmq_common::common::TopicSysFlag;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::RocketmqError;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct UpdateTopicSubCommand {
+    /// Common arguments
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    /// Broker address
+    #[arg(
+        short = 'b',
+        long = "brokerAddr",
+        required = false,
+        conflicts_with = "cluster_name",
+        help = "create topic to which broker"
+    )]
+    broker_addr: Option<String>,
+
+    /// Cluster name
+    #[arg(
+        short = 'c',
+        long = "clusterName",
+        required = false,
+        conflicts_with = "broker_addr",
+        help = "create topic to which cluster"
+    )]
+    cluster_name: Option<String>,
+
+    /// Topic name
+    #[arg(short = 't', long = "topic", required = true, help = "topic name")]
+    topic: String,
+
+    /// Number of read queues
+    #[arg(
+        short = 'r',
+        long = "readQueueNums",
+        required = false,
+        default_value = "8",
+        value_parser = clap::value_parser!(u32).range(1..=65535),
+        help = "set read queue nums"
+    )]
+    read_queue_nums: u32,
+
+    /// Number of write queues
+    #[arg(
+        short = 'w',
+        long = "writeQueueNums",
+        required = false,
+        default_value = "8",
+        value_parser = clap::value_parser!(u32).range(1..=65535),
+        help = "set write queue nums"
+    )]
+    write_queue_nums: u32,
+
+    /// Topic permission
+    /// 2: Write only, 4: Read only, 6: Read and Write
+    #[arg(
+        short = 'p',
+        long = "perm",
+        required = false,
+        value_parser = clap::builder::PossibleValuesParser::new(["2", "4", "6"]),
+        help = "set topic's permission(2|4|6), intro[2:W 4:R; 6:RW]"
+    )]
+    perm: Option<String>,
+
+    /// Whether it's an ordered message topic
+    #[arg(
+        short = 'o',
+        long = "order",
+        required = false,
+        help = "set topic's order(true|false)"
+    )]
+    order: Option<bool>,
+
+    /// Whether it's a unit topic
+    #[arg(
+        short = 'u',
+        long = "unit",
+        required = false,
+        help = "is unit topic (true|false)"
+    )]
+    unit: Option<bool>,
+
+    /// Whether there's a unit subscription group
+    #[arg(
+        short = 's',
+        long = "hasUnitSub",
+        required = false,
+        help = "has unit sub (true|false)"
+    )]
+    has_unit_sub: Option<bool>,
+}
+
+impl CommandExecute for UpdateTopicSubCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        if self.broker_addr.is_none() && self.cluster_name.is_none() {
+            return Err(RocketmqError::SubCommand(
+                "UpdateTopicSubCommand".into(),
+                "Either brokerAddr (-b) or clusterName (-c) must be provided".into(),
+            ));
+        }
+
+        let validation_result = TopicValidator::validate_topic(&self.topic);
+        if !validation_result.valid() {
+            return Err(RocketmqError::SubCommand(
+                "UpdateTopicSubCommand".into(),
+                format!(
+                    "Invalid topic name: {}",
+                    validation_result.remark().as_str()
+                ),
+            ));
+        }
+
+        let mut default_mqadmin_ext = DefaultMQAdminExt::new();
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let operation_result = async {
+            if let Some(addr) = &self.common_args.namesrv_addr {
+                default_mqadmin_ext.set_namesrv_addr(addr.trim());
+            }
+
+            MQAdminExt::start(&mut default_mqadmin_ext)
+                .await
+                .map_err(|e| {
+                    RocketmqError::SubCommand(
+                        "UpdateTopicSubCommand".into(),
+                        format!("Failed to start MQAdminExt: {}", e),
+                    )
+                })?;
+
+            let mut topic_config = TopicConfig {
+                topic_name: Some(self.topic.clone().into()),
+                read_queue_nums: self.read_queue_nums,
+                write_queue_nums: self.write_queue_nums,
+                ..Default::default()
+            };
+
+            if let Some(perm) = &self.perm {
+                topic_config.perm = perm
+                    .parse::<u32>()
+                    .expect("clap validated perm to be 2, 4, or 6");
+            } else {
+                topic_config.perm = 6;
+            }
+
+            let is_order = self.order.unwrap_or(false);
+            topic_config.order = is_order;
+
+            let is_unit = self.unit.unwrap_or(false);
+            let is_center_sync = self.has_unit_sub.unwrap_or(false);
+            let topic_sys_flag = TopicSysFlag::build_sys_flag(is_unit, is_center_sync);
+            topic_config.topic_sys_flag = topic_sys_flag;
+
+            if let Some(broker_addr) = &self.broker_addr {
+                println!(
+                    "Creating/updating topic '{}' on broker: {}",
+                    self.topic, broker_addr
+                );
+
+                default_mqadmin_ext
+                    .create_and_update_topic_config(
+                        broker_addr.clone().into(),
+                        topic_config.clone(),
+                    )
+                    .await
+                    .map_err(|e| {
+                        RocketmqError::SubCommand(
+                            "UpdateTopicSubCommand".into(),
+                            format!("Failed to create/update topic: {}", e),
+                        )
+                    })?;
+
+                if is_order {
+                    // Note: Order message configuration is not yet fully implemented in
+                    // rocketmq-rust. The create_or_update_order_conf method is
+                    // still unimplemented. For now, we only create the topic
+                    // with order=true flag. Full order configuration will be
+                    // added when the underlying API is implemented.
+
+                    println!(
+                        "Warning: Order message topic created, but order configuration (queue \
+                         allocation) is not yet implemented."
+                    );
+                    println!(
+                        "The topic will be marked as ordered (order=true), but you may need to \
+                         manually configure queue allocation."
+                    );
+
+                    // TODO: Uncomment when create_or_update_order_conf is implemented:
+                    /*
+                    let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await?;
+                    let broker_name = CommandUtil::fetch_broker_name_by_addr(&cluster_info, broker_addr)?;
+                    let order_conf = format!("{}:{}", broker_name, topic_config.write_queue_nums);
+                    default_mqadmin_ext.create_or_update_order_conf(
+                        self.topic.clone().into(),
+                        order_conf.clone().into(),
+                        false,
+                    ).await?;
+                    */
+                }
+
+                println!("create topic to {} success.", broker_addr);
+                println!("{:?}", topic_config);
+            } else if let Some(cluster_name) = &self.cluster_name {
+                println!(
+                    "Creating/updating topic '{}' on cluster: {}",
+                    self.topic, cluster_name
+                );
+
+                let cluster_info = default_mqadmin_ext
+                    .examine_broker_cluster_info()
+                    .await
+                    .map_err(|e| {
+                        RocketmqError::SubCommand(
+                            "UpdateTopicSubCommand".into(),
+                            format!("Failed to get cluster info: {}", e),
+                        )
+                    })?;
+
+                let master_addrs =
+                    CommandUtil::fetch_master_addr_by_cluster_name(&cluster_info, cluster_name)?;
+
+                if master_addrs.is_empty() {
+                    return Err(RocketmqError::SubCommand(
+                        "UpdateTopicSubCommand".into(),
+                        format!("No master brokers found in cluster: {}", cluster_name),
+                    ));
+                }
+
+                for addr in &master_addrs {
+                    default_mqadmin_ext
+                        .create_and_update_topic_config(addr.clone(), topic_config.clone())
+                        .await
+                        .map_err(|e| {
+                            RocketmqError::SubCommand(
+                                "UpdateTopicSubCommand".into(),
+                                format!("Failed to create/update topic on {}: {}", addr, e),
+                            )
+                        })?;
+                    println!("create topic to {} success.", addr);
+                }
+
+                if is_order {
+                    // Note: Order message configuration is not yet fully implemented in
+                    // rocketmq-rust. The create_or_update_order_conf method is
+                    // still unimplemented. For now, we only create the topic
+                    // with order=true flag on all brokers. Full order
+                    // configuration will be added when the underlying API is implemented.
+
+                    println!(
+                        "Warning: Order message topic created on cluster, but order configuration \
+                         (queue allocation) is not yet implemented."
+                    );
+                    println!(
+                        "The topic will be marked as ordered (order=true) on all brokers, but you \
+                         may need to manually configure queue allocation."
+                    );
+
+                    // TODO: Uncomment when create_or_update_order_conf is implemented:
+                    /*
+                    let broker_names = CommandUtil::fetch_broker_name_by_cluster_name(&cluster_info, cluster_name)?;
+                    let order_conf = broker_names
+                        .iter()
+                        .map(|name| format!("{}:{}", name, topic_config.write_queue_nums))
+                        .collect::<Vec<_>>()
+                        .join(";");
+                    default_mqadmin_ext.create_or_update_order_conf(
+                        self.topic.clone().into(),
+                        order_conf.clone().into(),
+                        true,
+                    ).await?;
+                    */
+                }
+
+                println!("{:?}", topic_config);
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_topic_sub_command_parse_broker_mode() {
+        let args = vec![
+            "update-topic",
+            "-t",
+            "test-topic",
+            "-b",
+            "127.0.0.1:10911",
+            "-r",
+            "8",
+            "-w",
+            "8",
+            "-p",
+            "6",
+        ];
+
+        let cmd = UpdateTopicSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.topic, "test-topic");
+        assert_eq!(cmd.broker_addr, Some("127.0.0.1:10911".to_string()));
+        assert_eq!(cmd.read_queue_nums, 8);
+        assert_eq!(cmd.write_queue_nums, 8);
+        assert_eq!(cmd.perm, Some("6".to_string()));
+    }
+
+    #[test]
+    fn cluster_mode() {
+        let args = vec!["update-topic", "-t", "test-topic", "-c", "DefaultCluster"];
+
+        let cmd = UpdateTopicSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.cluster_name, Some("DefaultCluster".to_string()));
+        assert!(cmd.broker_addr.is_none());
+    }
+
+    #[test]
+    fn conflicting_args() {
+        let args = vec![
+            "update-topic",
+            "-t",
+            "test-topic",
+            "-b",
+            "127.0.0.1:10911",
+            "-c",
+            "DefaultCluster",
+        ];
+
+        let cmd = UpdateTopicSubCommand::try_parse_from(args);
+        assert!(cmd.is_err());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4136 (partial)

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
The core functions of UpdateTopicSubCommand are implemented:

**Fully Available**:
- Broker mode topic creation/update
- Cluster mode topic batch creation
- All CLI parameter parsing and validation
- CommandUtil tool class
- 3 unit tests + 8 CommandUtil tests

**Known Limitations**:
- Sequential message topics can be created (order=true), but queue configuration functionality is limited by the underlying `create_or_update_order_conf` API which has not yet been implemented
- A warning message will be displayed when `-o true` is used

**Not implemented**:
- Attributes configuration (`-a` parameter)
 
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
Compiled and passed
All related tests passed
Can create common topics
Can create sequential topics (but no queue configuration)

### Follow-up work

After implementing the `create_or_update_order_conf` method in `rocketmq-client`,
In order to fully support the queue allocation configuration of sequential messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UpdateTopic command to create or update topic configs in single-broker or cluster-wide modes; supports queue counts, permissions, unit/ordering flags, and prints status/results.

* **Tests**
  * Added argument-parsing and end-to-end tests for broker/cluster modes and error conditions.

* **Chores**
  * Added shared command utilities to resolve broker names and master addresses for CLI operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->