### PR TITLE
[ISSUE #4195]🐛Fix incorrect reference in send_message_processor.rs pre_send call remove as_ref

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -292,7 +292,7 @@ where
     where
         F: Fn(&mut SendMessageContext, &mut RemotingCommand),
     {
-        let mut response = self.pre_send(channel, ctx, request.as_ref(), &request_header);
+        let mut response = self.pre_send(channel, ctx, request, &request_header);
         if response.code() != -1 {
             return Ok(Some(response));
         }
@@ -526,7 +526,7 @@ where
     where
         F: Fn(&mut SendMessageContext, &mut RemotingCommand),
     {
-        let mut response = self.pre_send(channel, ctx, request.as_ref(), &request_header);
+        let mut response = self.pre_send(channel, ctx, request, &request_header);
         if response.code() != -1 {
             return Ok(Some(response));
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4195 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Fix incorrect reference in send_message_processor.rs pre_send call remove as_ref

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected internal argument handling to align with function signatures, ensuring type consistency without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->