### PR TITLE
[ISSUE #4209]♻️Refactor timestamp retrieval functions to always inline for performance optimization

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -1001,9 +1001,7 @@ where
         if self
             .inner
             .broker_runtime_inner
-            .message_store()
-            .as_ref()
-            .unwrap()
+            .message_store_unchecked()
             .now()
             < (start_timestamp as u64)
         {

--- a/rocketmq-common/src/utils/time_utils.rs
+++ b/rocketmq-common/src/utils/time_utils.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#[inline]
+#[inline(always)]
 pub fn get_current_millis() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -23,7 +23,7 @@ pub fn get_current_millis() -> u64 {
         .as_millis() as u64
 }
 
-#[inline]
+#[inline(always)]
 pub fn get_current_nano() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -346,6 +346,7 @@ pub trait MessageStoreInner: Sync + 'static {
     fn slave_fall_behind_much(&self) -> i64;
 
     /// Return the current timestamp of the store.
+    #[inline(always)]
     fn now(&self) -> u64 {
         get_current_millis()
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4209

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized compiler handling of system time utilities to improve execution efficiency and reduce computational overhead during frequent timestamp operations and monitoring.
  * Enhanced message store access mechanisms to streamline message processing workflows, reduce operational latency, and improve overall efficiency in storage operations and throughput.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->