### PR TITLE
chore: remove redundant hasher code in TopicQueueLock

### DIFF
--- a/rocketmq-store/src/base/topic_queue_lock.rs
+++ b/rocketmq-store/src/base/topic_queue_lock.rs
@@ -64,8 +64,6 @@ impl TopicQueueLock {
 
     #[inline(always)]
     fn index_for_key<K: Hash + ?Sized>(&self, key: &K) -> usize {
-        let mut hasher = self.hasher_builder.build_hasher();
-        key.hash(&mut hasher);
         (self.hasher_builder.hash_one(key) as usize) & self.mask
     }
 }


### PR DESCRIPTION
This PR removes two redundant lines in the index_for_key method of TopicQueueLock.
The removed code performed a manual hash build and key hashing that were not used in the computation, since hash_one(key) already performs the complete hashing operation internally.

This change simplifies the function without affecting behavior or functionality.

Fix #4213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal hash computation logic for improved efficiency with no impact on end-user functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->