### PR TITLE
[ISSUE #4216]⚡️Update return type in parse_config_file function to use rocketmq_error::RocketMQResult

### DIFF
--- a/rocketmq-common/src/utils/parse_config_file.rs
+++ b/rocketmq-common/src/utils/parse_config_file.rs
@@ -19,14 +19,11 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 
 use config::Config;
-use rocketmq_error::RocketMQResult;
 use serde::Deserialize;
-use tracing::error;
-use tracing::warn;
 
 use crate::error::CommonError;
 
-pub fn parse_config_file<'de, C>(config_file: PathBuf) -> crate::error::RocketMQResult<C>
+pub fn parse_config_file<'de, C>(config_file: PathBuf) -> rocketmq_error::RocketMQResult<C>
 where
     C: Debug + Deserialize<'de>,
 {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4216

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error type consistency in configuration file parsing operations, improving module coherence and error handling uniformity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->