### PR TITLE
[ISSUE #4228]♻️Refactor connection state management to use a watch channel; replace boolean flags with reactive state updates for improved clarity and performance

### DIFF
--- a/rocketmq-remoting/src/net/channel.rs
+++ b/rocketmq-remoting/src/net/channel.rs
@@ -396,9 +396,9 @@ pub(crate) async fn handle_send(
             Err(error) => match error {
                 RocketmqError::Io(error) => {
                     // I/O error means connection is broken
+                    // Connection state is automatically marked as degraded by send_command()
                     error!("send request failed: {}", error);
                     response_table.remove(&opaque);
-                    connection.ok = false;
                     return;
                 }
                 _ => {
@@ -638,7 +638,7 @@ impl ChannelInner {
     /// - `false`: Connection has failed, channel should be discarded
     #[inline]
     pub fn is_healthy(&self) -> bool {
-        self.connection.ok
+        self.connection.is_healthy()
     }
 
     /// Legacy alias for `is_healthy()` - kept for backward compatibility.
@@ -649,6 +649,6 @@ impl ChannelInner {
     #[inline]
     #[deprecated(since = "0.1.0", note = "Use `is_healthy()` instead")]
     pub fn is_ok(&self) -> bool {
-        self.connection.ok
+        self.connection.is_healthy()
     }
 }

--- a/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
@@ -138,8 +138,8 @@ impl<RP: RequestProcessor + Sync + 'static> ConnectionHandler<RP> {
 
                 // Branch 2: Shutdown signal received
                 _ = self.shutdown.recv() => {
-                    // Mark connection as unhealthy to prevent further sends
-                    channel.connection_mut().ok = false;
+                    // Mark connection as closed to prevent further sends
+                    channel.connection_mut().close();
                     return Ok(());
                 }
             };
@@ -149,8 +149,9 @@ impl<RP: RequestProcessor + Sync + 'static> ConnectionHandler<RP> {
                 Some(Ok(frame)) => frame,
                 Some(Err(e)) => {
                     // Decode error - log and close connection
+                    // Connection state is automatically managed by receive_command()
                     error!("Failed to decode command: {:?}", e);
-                    channel.connection_mut().ok = false;
+                    channel.connection_mut().close();
                     return Err(e);
                 }
                 None => {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4228

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection state subscription mechanism for real-time health monitoring.

* **Refactor**
  * Replaced manual connection state flags with automatic state management driven by I/O operations and explicit state transitions (Healthy, Degraded, Closed).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->