### PR TITLE
[ISSUE #4262]♻️Refactor error type in request header implementations to use RocketMQError for consistency and improved error handling

### DIFF
--- a/rocketmq-macros/src/request_header_custom.rs
+++ b/rocketmq-macros/src/request_header_custom.rs
@@ -263,7 +263,7 @@ pub(super) fn request_header_codec_inner(
 
         impl crate::protocol::command_custom_header::FromMap for #struct_name {
 
-            type Error = rocketmq_error::RocketmqError;
+            type Error = rocketmq_error::RocketMQError;
 
             type Target = Self;
 
@@ -613,7 +613,7 @@ pub(super) fn request_header_codec_inner_v2(
         }
 
         impl crate::protocol::command_custom_header::FromMap for #struct_name {
-            type Error = rocketmq_error::RocketmqError;
+            type Error = rocketmq_error::RocketMQError;
             type Target = Self;
 
             fn from(map: &std::collections::HashMap<cheetah_string::CheetahString, cheetah_string::CheetahString>) -> Result<Self::Target, Self::Error> {

--- a/rocketmq-remoting/src/protocol/header/check_transaction_state_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/check_transaction_state_request_header.rs
@@ -85,7 +85,7 @@ impl CommandCustomHeader for CheckTransactionStateRequestHeader {
 }
 
 impl FromMap for CheckTransactionStateRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
+    type Error = rocketmq_error::RocketMQError;
 
     type Target = Self;
 

--- a/rocketmq-remoting/src/protocol/header/consumer_send_msg_back_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/consumer_send_msg_back_request_header.rs
@@ -250,7 +250,7 @@ impl CommandCustomHeader for ConsumerSendMsgBackRequestHeader {
 }
 
 impl FromMap for ConsumerSendMsgBackRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
+    type Error = rocketmq_error::RocketMQError;
 
     type Target = Self;
 
@@ -261,26 +261,38 @@ impl FromMap for ConsumerSendMsgBackRequestHeader {
             offset: map
                 .get(&CheetahString::from_static_str(Self::OFFSET))
                 .cloned()
-                .ok_or(Self::Error::RemotingCommandError(
-                    "Missing offset".to_string(),
-                ))?
+                .ok_or_else(|| {
+                    rocketmq_error::RocketMQError::Protocol(
+                        rocketmq_error::ProtocolError::header_missing("offset"),
+                    )
+                })?
                 .parse()
-                .map_err(|_| Self::Error::RemotingCommandError("Invalid offset".to_string()))?,
+                .map_err(|_| {
+                    rocketmq_error::RocketMQError::Protocol(
+                        rocketmq_error::ProtocolError::invalid_message("Invalid offset"),
+                    )
+                })?,
             group: map
                 .get(&CheetahString::from_static_str(Self::GROUP))
                 .cloned()
-                .ok_or(Self::Error::RemotingCommandError(
-                    "Missing group".to_string(),
-                ))?,
+                .ok_or_else(|| {
+                    rocketmq_error::RocketMQError::Protocol(
+                        rocketmq_error::ProtocolError::header_missing("group"),
+                    )
+                })?,
             delay_level: map
                 .get(&CheetahString::from_static_str(Self::DELAY_LEVEL))
                 .cloned()
-                .ok_or(Self::Error::RemotingCommandError(
-                    "Missing delay level".to_string(),
-                ))?
+                .ok_or_else(|| {
+                    rocketmq_error::RocketMQError::Protocol(
+                        rocketmq_error::ProtocolError::header_missing("delay_level"),
+                    )
+                })?
                 .parse()
                 .map_err(|_| {
-                    Self::Error::RemotingCommandError("Invalid delay level".to_string())
+                    rocketmq_error::RocketMQError::Protocol(
+                        rocketmq_error::ProtocolError::invalid_message("Invalid delay level"),
+                    )
                 })?,
             origin_msg_id: map
                 .get(&CheetahString::from_static_str(Self::ORIGIN_MSG_ID))

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -19,8 +19,6 @@ use std::str::FromStr;
 
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
-use rocketmq_error::RocketmqError;
-use rocketmq_error::RocketmqError::DeserializeHeaderError;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -198,23 +196,58 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
         self.d = self
             .get_and_check_not_none(fields, &KEY_D)?
             .parse()
-            .map_err(|_| DeserializeHeaderError("Parse field d error".to_string()))?; //defaultTopicQueueNums
+            .map_err(|_| {
+                rocketmq_error::RocketMQError::Serialization(
+                    rocketmq_error::SerializationError::DecodeFailed {
+                        format: "header",
+                        message: "Parse field d error".to_string(),
+                    },
+                )
+            })?; //defaultTopicQueueNums
         self.e = self
             .get_and_check_not_none(fields, &KEY_E)?
             .parse()
-            .map_err(|_| DeserializeHeaderError("Parse field e error".to_string()))?; //queueId
+            .map_err(|_| {
+                rocketmq_error::RocketMQError::Serialization(
+                    rocketmq_error::SerializationError::DecodeFailed {
+                        format: "header",
+                        message: "Parse field e error".to_string(),
+                    },
+                )
+            })?; //queueId
         self.f = self
             .get_and_check_not_none(fields, &KEY_F)?
             .parse()
-            .map_err(|_| DeserializeHeaderError("Parse field f error".to_string()))?; //sysFlag
+            .map_err(|_| {
+                rocketmq_error::RocketMQError::Serialization(
+                    rocketmq_error::SerializationError::DecodeFailed {
+                        format: "header",
+                        message: "Parse field f error".to_string(),
+                    },
+                )
+            })?; //sysFlag
         self.g = self
             .get_and_check_not_none(fields, &KEY_G)?
             .parse()
-            .map_err(|_| DeserializeHeaderError("Parse field g error".to_string()))?; //bornTimestamp
+            .map_err(|_| {
+                rocketmq_error::RocketMQError::Serialization(
+                    rocketmq_error::SerializationError::DecodeFailed {
+                        format: "header",
+                        message: "Parse field g error".to_string(),
+                    },
+                )
+            })?; //bornTimestamp
         self.h = self
             .get_and_check_not_none(fields, &KEY_H)?
             .parse()
-            .map_err(|_| DeserializeHeaderError("Parse field h error".to_string()))?; //flag
+            .map_err(|_| {
+                rocketmq_error::RocketMQError::Serialization(
+                    rocketmq_error::SerializationError::DecodeFailed {
+                        format: "header",
+                        message: "Parse field h error".to_string(),
+                    },
+                )
+            })?; //flag
 
         if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_I)) {
             self.i = Some(v.clone());
@@ -225,24 +258,36 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
         }
 
         if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_K)) {
-            self.k = Some(
-                v.parse()
-                    .map_err(|_| DeserializeHeaderError("Parse field k error".to_string()))?,
-            );
+            self.k = Some(v.parse().map_err(|_| {
+                rocketmq_error::RocketMQError::Serialization(
+                    rocketmq_error::SerializationError::DecodeFailed {
+                        format: "header",
+                        message: "Parse field k error".to_string(),
+                    },
+                )
+            })?);
         }
 
         if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_L)) {
-            self.l = Some(
-                v.parse()
-                    .map_err(|_| DeserializeHeaderError("Parse field l error".to_string()))?,
-            );
+            self.l = Some(v.parse().map_err(|_| {
+                rocketmq_error::RocketMQError::Serialization(
+                    rocketmq_error::SerializationError::DecodeFailed {
+                        format: "header",
+                        message: "Parse field l error".to_string(),
+                    },
+                )
+            })?);
         }
 
         if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_M)) {
-            self.m = Some(
-                v.parse()
-                    .map_err(|_| DeserializeHeaderError("Parse field m error".to_string()))?,
-            );
+            self.m = Some(v.parse().map_err(|_| {
+                rocketmq_error::RocketMQError::Serialization(
+                    rocketmq_error::SerializationError::DecodeFailed {
+                        format: "header",
+                        message: "Parse field m error".to_string(),
+                    },
+                )
+            })?);
         }
 
         if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_N)) {
@@ -257,7 +302,7 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
 }
 
 impl FromMap for SendMessageRequestHeaderV2 {
-    type Error = rocketmq_error::RocketmqError;
+    type Error = rocketmq_error::RocketMQError;
 
     type Target = Self;
 
@@ -267,9 +312,14 @@ impl FromMap for SendMessageRequestHeaderV2 {
             map: &'a HashMap<CheetahString, CheetahString>,
             key: &CheetahString,
             field: &'static str,
-        ) -> Result<&'a CheetahString, rocketmq_error::RocketmqError> {
+        ) -> Result<&'a CheetahString, rocketmq_error::RocketMQError> {
             map.get(key).ok_or_else(|| {
-                RocketmqError::DeserializeHeaderError(format!("Missing field: {}", field))
+                rocketmq_error::RocketMQError::Serialization(
+                    rocketmq_error::SerializationError::DecodeFailed {
+                        format: "header",
+                        message: format!("Missing field: {}", field),
+                    },
+                )
             })
         }
 
@@ -278,12 +328,17 @@ impl FromMap for SendMessageRequestHeaderV2 {
             map: &HashMap<CheetahString, CheetahString>,
             key: &CheetahString,
             field: &'static str,
-        ) -> Result<T, RocketmqError> {
+        ) -> Result<T, rocketmq_error::RocketMQError> {
             get_required(map, key, field)?
                 .as_str()
                 .parse::<T>()
                 .map_err(|_| {
-                    RocketmqError::DeserializeHeaderError(format!("Parse {} field error", field))
+                    rocketmq_error::RocketMQError::Serialization(
+                        rocketmq_error::SerializationError::DecodeFailed {
+                            format: "header",
+                            message: format!("Parse {} field error", field),
+                        },
+                    )
                 })
         }
 

--- a/rocketmq-remoting/src/protocol/header/namesrv/broker_request.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/broker_request.rs
@@ -108,7 +108,7 @@ impl GetBrokerMemberGroupRequestHeader {
 }
 
 impl FromMap for GetBrokerMemberGroupRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
+    type Error = rocketmq_error::RocketMQError;
     type Target = Self;
 
     fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {

--- a/rocketmq-remoting/src/protocol/header/query_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_message_request_header.rs
@@ -94,7 +94,7 @@ mod query_message_request_header_tests {
         map.insert("key".into(), "test_key".into());
         map.insert("maxNum".into(), "invalid".into());
 
-        let header: Result<QueryMessageRequestHeader, rocketmq_error::RocketmqError> =
+        let header: Result<QueryMessageRequestHeader, rocketmq_error::RocketMQError> =
             <QueryMessageRequestHeader as FromMap>::from(&map);
 
         assert!(header.is_err());

--- a/rocketmq-remoting/src/protocol/header/reply_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/reply_message_request_header.rs
@@ -131,7 +131,7 @@ mod reply_message_request_header_tests {
         map.insert("topic".into(), "test_topic".into());
         map.insert("defaultTopic".into(), "test_default_topic".into());
         map.insert("defaultTopicQueueNums".into(), "invalid".into());
-        let header: Result<ReplyMessageRequestHeader, rocketmq_error::RocketmqError> =
+        let header: Result<ReplyMessageRequestHeader, rocketmq_error::RocketMQError> =
             <ReplyMessageRequestHeader as FromMap>::from(&map);
         assert!(header.is_err());
     }

--- a/rocketmq-remoting/src/protocol/header/update_consumer_offset_header.rs
+++ b/rocketmq-remoting/src/protocol/header/update_consumer_offset_header.rs
@@ -81,7 +81,7 @@ impl CommandCustomHeader for UpdateConsumerOffsetRequestHeader {
 }
 
 impl FromMap for UpdateConsumerOffsetRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
+    type Error = rocketmq_error::RocketMQError;
 
     type Target = Self;
 

--- a/rocketmq-remoting/src/rpc/topic_request_header.rs
+++ b/rocketmq-remoting/src/rpc/topic_request_header.rs
@@ -50,7 +50,7 @@ impl TopicRequestHeader {
 }
 
 impl FromMap for TopicRequestHeader {
-    type Error = rocketmq_error::RocketmqError;
+    type Error = rocketmq_error::RocketMQError;
 
     type Target = Self;
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4262

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error type naming across protocol headers and remote command processing for consistency in error handling APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->