### PR TITLE
[ISSUE #4264]Fix String matching for flatten detection is fragile in RequestHeaderCodecV2 macro

### DIFF
--- a/rocketmq-macros/src/request_header_custom.rs
+++ b/rocketmq-macros/src/request_header_custom.rs
@@ -316,14 +316,14 @@ impl FieldMetadata {
                 if id == "serde" {
                     if let Meta::List(meta_list) = &attr.meta {
                         for token in meta_list.tokens.clone().into_iter() {
-                                if let TokenTree::Ident(ident) = token {
-                                        if ident.eq("flatten") {
-                                                is_flatten = true;
-                                                break;
-                                        }
+                            if let TokenTree::Ident(ident) = token {
+                                if ident.eq("flatten") {
+                                    is_flatten = true;
+                                    break;
                                 }
+                            }
                         }
-                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
in \rocketmq-macros\src\request_header_custom.rs replace
meta_list.tokens.to_string().contains("flatten")
with TokenStream Ident match

fix #4264 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal detection of serialization attributes (including "flatten") used by macro processing to make attribute handling more robust and reliable. This refines how annotations are recognized without changing any public APIs, exported signatures, or visible behavior for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->