### PR TITLE
[ISSUE #4270]♻️Refactor JSON deserialization to use from_json_bytes for consistency and improved clarity

### DIFF
--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -310,7 +310,8 @@ impl BrokerOuterAPI {
                             header.master_addr.clone().unwrap_or(CheetahString::empty());
                     }
                     if let Some(body) = response.body() {
-                        result.kv_table = SerdeJsonUtils::decode::<KVTable>(body.as_ref()).unwrap();
+                        result.kv_table =
+                            SerdeJsonUtils::from_json_bytes::<KVTable>(body.as_ref()).unwrap();
                     }
                     Some(result)
                 }

--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -177,7 +177,7 @@ where
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let heartbeat_data = SerdeJsonUtils::decode::<HeartbeatData>(
+        let heartbeat_data = SerdeJsonUtils::from_json_bytes::<HeartbeatData>(
             request.body().as_ref().map(|v| v.as_ref()).unwrap(),
         )
         .unwrap();

--- a/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
@@ -501,7 +501,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
                     }
 
                     let mut point: PopCheckPoint =
-                        SerdeJsonUtils::decode(message_ext.get_body().unwrap()).unwrap();
+                        SerdeJsonUtils::from_json_bytes(message_ext.get_body().unwrap()).unwrap();
                     if point.topic.is_empty() || point.cid.is_empty() {
                         continue;
                     }
@@ -525,7 +525,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
                     }
                 } else if PopAckConstants::ACK_TAG == message_ext.get_tags().unwrap_or_default() {
                     let ack_msg: AckMsg =
-                        SerdeJsonUtils::decode(message_ext.get_body().unwrap()).unwrap();
+                        SerdeJsonUtils::from_json_bytes(message_ext.get_body().unwrap()).unwrap();
                     // PopMetricsManager::inc_pop_revive_ack_get_count(&ack_msg, self.queue_id);
                     let merge_key = CheetahString::from_string(format!(
                         "{}{}{}{}{}{}",
@@ -574,7 +574,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
                         );
                     }
                     let b_ack_msg: BatchAckMsg =
-                        SerdeJsonUtils::decode(message_ext.get_body().unwrap()).unwrap();
+                        SerdeJsonUtils::from_json_bytes(message_ext.get_body().unwrap()).unwrap();
                     // PopMetricsManager::inc_pop_revive_ack_get_count(&b_ack_msg, self.queue_id);
                     let merge_key = CheetahString::from_string(format!(
                         "{}{}{}{}{}{}",

--- a/rocketmq-common/src/utils/serde_json_utils.rs
+++ b/rocketmq-common/src/utils/serde_json_utils.rs
@@ -18,13 +18,31 @@
 pub struct SerdeJsonUtils;
 
 impl SerdeJsonUtils {
+    /// Deserialize JSON from bytes into a Rust type.
+    /// Alias for `from_json_slice` for backward compatibility.
+    #[inline]
+    pub fn from_json_bytes<T>(bytes: &[u8]) -> rocketmq_error::RocketMQResult<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        Self::from_json_slice(bytes)
+    }
+
+    /// Deserialize JSON from bytes into a Rust type.
+    #[deprecated(
+        since = "0.7.0",
+        note = "Use `from_json_bytes` or `from_json_slice` instead"
+    )]
+    #[inline]
     pub fn decode<T>(bytes: &[u8]) -> rocketmq_error::RocketMQResult<T>
     where
         T: serde::de::DeserializeOwned,
     {
-        Ok(serde_json::from_slice::<T>(bytes)?)
+        Self::from_json_bytes(bytes)
     }
 
+    /// Deserialize JSON from a string into a Rust type.
+    #[inline]
     pub fn from_json_str<T>(json: &str) -> rocketmq_error::RocketMQResult<T>
     where
         T: serde::de::DeserializeOwned,
@@ -32,6 +50,8 @@ impl SerdeJsonUtils {
         Ok(serde_json::from_str(json)?)
     }
 
+    /// Deserialize JSON from a byte slice into a Rust type.
+    #[inline]
     pub fn from_json_slice<T>(json: &[u8]) -> rocketmq_error::RocketMQResult<T>
     where
         T: serde::de::DeserializeOwned,
@@ -39,6 +59,8 @@ impl SerdeJsonUtils {
         Ok(serde_json::from_slice(json)?)
     }
 
+    /// Serialize a Rust type into a JSON string (compact format).
+    #[inline]
     pub fn to_json<T>(value: &T) -> rocketmq_error::RocketMQResult<String>
     where
         T: serde::Serialize,
@@ -46,6 +68,8 @@ impl SerdeJsonUtils {
         Ok(serde_json::to_string(value)?)
     }
 
+    /// Serialize a Rust type into a JSON string (pretty-printed format).
+    #[inline]
     pub fn to_json_pretty<T>(value: &T) -> rocketmq_error::RocketMQResult<String>
     where
         T: serde::Serialize,
@@ -53,6 +77,8 @@ impl SerdeJsonUtils {
         Ok(serde_json::to_string_pretty(value)?)
     }
 
+    /// Serialize a Rust type into a JSON byte vector (compact format).
+    #[inline]
     pub fn to_json_vec<T>(value: &T) -> rocketmq_error::RocketMQResult<Vec<u8>>
     where
         T: serde::Serialize,
@@ -60,6 +86,8 @@ impl SerdeJsonUtils {
         Ok(serde_json::to_vec(value)?)
     }
 
+    /// Serialize a Rust type into a JSON byte vector (pretty-printed format).
+    #[inline]
     pub fn to_json_vec_pretty<T>(value: &T) -> rocketmq_error::RocketMQResult<Vec<u8>>
     where
         T: serde::Serialize,

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -685,7 +685,7 @@ fn extract_register_topic_config_from_request(
         if body_inner.is_empty() {
             return TopicConfigAndMappingSerializeWrapper::default();
         }
-        return SerdeJsonUtils::decode::<TopicConfigAndMappingSerializeWrapper>(
+        return SerdeJsonUtils::from_json_bytes::<TopicConfigAndMappingSerializeWrapper>(
             body_inner.as_ref(),
         )
         .expect("decode TopicConfigAndMappingSerializeWrapper failed");

--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -484,7 +484,7 @@ impl<T: Serialize> RemotingSerializable for T {
 impl<T: serde::de::DeserializeOwned> RemotingDeserializable for T {
     type Output = T;
     fn decode(bytes: &[u8]) -> rocketmq_error::RocketMQResult<Self::Output> {
-        SerdeJsonUtils::decode(bytes)
+        SerdeJsonUtils::from_json_bytes(bytes)
     }
 }
 

--- a/rocketmq-remoting/src/protocol/body/broker_body/register_broker_body.rs
+++ b/rocketmq-remoting/src/protocol/body/broker_body/register_broker_body.rs
@@ -122,7 +122,8 @@ impl RegisterBrokerBody {
         broker_version: RocketMqVersion,
     ) -> RegisterBrokerBody {
         if !compressed {
-            return SerdeJsonUtils::decode::<RegisterBrokerBody>(bytes.iter().as_slice()).unwrap();
+            return SerdeJsonUtils::from_json_bytes::<RegisterBrokerBody>(bytes.iter().as_slice())
+                .unwrap();
         }
         let mut decoder = DeflateDecoder::new(bytes.as_ref());
         let mut vec = Vec::new();

--- a/rocketmq-remoting/src/protocol/heartbeat/heartbeat_data.rs
+++ b/rocketmq-remoting/src/protocol/heartbeat/heartbeat_data.rs
@@ -62,7 +62,8 @@ mod tests {
         };
 
         let serialized = original.encode().expect("encode");
-        let deserialized = SerdeJsonUtils::decode::<HeartbeatData>(serialized.as_slice()).unwrap();
+        let deserialized =
+            SerdeJsonUtils::from_json_bytes::<HeartbeatData>(serialized.as_slice()).unwrap();
 
         assert_eq!(original, deserialized);
     }
@@ -78,7 +79,8 @@ mod tests {
         };
 
         let serialized = original.encode().expect("encode");
-        let deserialized = SerdeJsonUtils::decode::<HeartbeatData>(serialized.as_slice()).unwrap();
+        let deserialized =
+            SerdeJsonUtils::from_json_bytes::<HeartbeatData>(serialized.as_slice()).unwrap();
 
         assert_eq!(original, deserialized);
     }
@@ -94,7 +96,8 @@ mod tests {
         };
 
         let serialized = original.encode().expect("encode");
-        let deserialized = SerdeJsonUtils::decode::<HeartbeatData>(serialized.as_slice()).unwrap();
+        let deserialized =
+            SerdeJsonUtils::from_json_bytes::<HeartbeatData>(serialized.as_slice()).unwrap();
 
         assert_eq!(original, deserialized);
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4270

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored JSON utilities to improve API consistency and clarity across the platform.
  * Deprecated legacy deserialization method, replacing it with clearer, more flexible alternatives.
  * Expanded JSON handling capabilities with new serialization and formatting options for various data types.
  * Standardized internal implementations throughout broker and naming service components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->