### PR TITLE
[ISSUE #4276]⚡️Add `storage_write_failed` constructor for improved error handling in `RocketMQError`

### DIFF
--- a/rocketmq-error/src/unified/mod.rs
+++ b/rocketmq-error/src/unified/mod.rs
@@ -306,6 +306,15 @@ impl RocketMQError {
         }
     }
 
+    /// Create a storage write failed error
+    #[inline]
+    pub fn storage_write_failed(path: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::StorageWriteFailed {
+            path: path.into(),
+            reason: reason.into(),
+        }
+    }
+
     /// Create an illegal argument error
     #[inline]
     pub fn illegal_argument(message: impl Into<String>) -> Self {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4276 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling for storage write operations, enabling better diagnostics and reporting when write failures occur. This complements existing read failure handling, providing consistent error management across storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->