### PR TITLE
[ISSUE #4296] Fix error handling in KV config persistence to correctly indicate write failures

### DIFF
--- a/rocketmq-namesrv/src/kvconfig/kvconfig_mananger.rs
+++ b/rocketmq-namesrv/src/kvconfig/kvconfig_mananger.rs
@@ -212,7 +212,7 @@ impl KVConfigManager {
 
         FileUtils::string_to_file(content.as_str(), config_path).map_err(|e| {
             error!("Failed to persist KV config to {}: {}", config_path, e);
-            RocketMQError::storage_read_failed(config_path, format!("Write failed: {}", e))
+            RocketMQError::storage_write_failed(config_path, format!("Write failed: {}", e))
         })?;
 
         // Reset counters after successful persistence


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4296

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Replace storage_read_failed with storage_write_failed in KVConfigManager::persist() method to correctly indicate write operation failures.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
This change is verified by running `cargo build`, `cargo clippy`, and `cargo test`, all checks passed successfully.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error reporting to correctly identify write operation failures instead of misclassifying them as read errors, improving diagnostic accuracy when storage operations encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->