### PR TITLE
[ISSUE #4139] 🚀 Implement TopicClusterSubCommand

### DIFF
--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -643,7 +643,10 @@ impl MQAdminExt for DefaultMQAdminExt {
         &self,
         topic: String,
     ) -> rocketmq_error::RocketMQResult<HashSet<CheetahString>> {
-        todo!()
+        return self
+            .default_mqadmin_ext_impl
+            .get_topic_cluster_list(topic)
+            .await;
     }
 
     async fn get_all_topic_config(

--- a/rocketmq-tools/src/commands.rs
+++ b/rocketmq-tools/src/commands.rs
@@ -111,6 +111,11 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Update or create topic.",
             },
             Command {
+                category: "Topic",
+                command: "topicClusterList",
+                remark: "Get cluster info for topic.",
+            },
+            Command {
                 category: "NameServer",
                 command: "getNamesrvConfig",
                 remark: "Get configs of name server.",

--- a/rocketmq-tools/src/commands/topic_commands.rs
+++ b/rocketmq-tools/src/commands/topic_commands.rs
@@ -16,6 +16,7 @@
  */
 mod allocate_mq_sub_command;
 mod delete_topic_sub_command;
+mod topic_cluster_sub_command;
 mod update_topic_sub_command;
 use std::sync::Arc;
 
@@ -42,6 +43,13 @@ more memory space, you can use this command to allocate it."#
         long_about = r#"Update or create topic with specified configuration."#
     )]
     UpdateTopic(update_topic_sub_command::UpdateTopicSubCommand),
+
+    #[command(
+        name = "topicClusterList",
+        about = "Get cluster info for topic",
+        long_about = r#"Get cluster info for a given topic. This command queries which clusters contain the specified topic."#
+    )]
+    TopicClusterList(topic_cluster_sub_command::TopicClusterSubCommand),
 }
 
 impl CommandExecute for TopicCommands {
@@ -49,6 +57,7 @@ impl CommandExecute for TopicCommands {
         match self {
             TopicCommands::AllocateMQ(cmd) => cmd.execute(rpc_hook).await,
             TopicCommands::UpdateTopic(cmd) => cmd.execute(rpc_hook).await,
+            TopicCommands::TopicClusterList(cmd) => cmd.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/src/commands/topic_commands/topic_cluster_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/topic_cluster_sub_command.rs
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct TopicClusterSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(short = 't', long = "topic", required = true, help = "Topic name")]
+    topic: String,
+}
+
+impl TopicClusterSubCommand {
+    fn init_admin_ext(&self) -> DefaultMQAdminExt {
+        let mut admin_ext = DefaultMQAdminExt::new();
+        admin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+        if let Some(addr) = &self.common_args.namesrv_addr {
+            admin_ext.set_namesrv_addr(addr.trim());
+        }
+        admin_ext
+    }
+
+    async fn get_topic_clusters(
+        &self,
+        admin_ext: &mut DefaultMQAdminExt,
+    ) -> RocketMQResult<HashSet<CheetahString>> {
+        admin_ext
+            .get_topic_cluster_list(self.topic.trim().to_string())
+            .await
+            .map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "TopicClusterSubCommand: Failed to get topic cluster list: {}",
+                    e
+                ))
+            })
+    }
+
+    fn print_clusters(&self, clusters: &HashSet<CheetahString>) {
+        for cluster in clusters {
+            println!("{}", cluster);
+        }
+    }
+}
+impl CommandExecute for TopicClusterSubCommand {
+    async fn execute(
+        &self,
+        _rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let mut admin_ext = self.init_admin_ext();
+        MQAdminExt::start(&mut admin_ext).await.map_err(|e| {
+            RocketMQError::Internal(format!(
+                "TopicClusterSubCommand: Failed to start MQAdminExt: {}",
+                e
+            ))
+        })?;
+        let operation_result = async {
+            let clusters = self.get_topic_clusters(&mut admin_ext).await?;
+            self.print_clusters(&clusters);
+            Ok(())
+        }
+        .await;
+        admin_ext.shutdown().await;
+        operation_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn topic_cluster_sub_command_parse() {
+        let args = vec!["topicClusterList", "-t", "test-topic"];
+
+        let cmd = TopicClusterSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.topic, "test-topic");
+    }
+
+    #[test]
+    fn topic_cluster_sub_command_with_namesrv() {
+        let args = vec![
+            "topicClusterList",
+            "-t",
+            "test-topic",
+            "-n",
+            "127.0.0.1:9876",
+        ];
+
+        let cmd = TopicClusterSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.topic, "test-topic");
+        assert_eq!(
+            cmd.common_args.namesrv_addr,
+            Some("127.0.0.1:9876".to_string())
+        );
+    }
+
+    #[test]
+    fn topic_cluster_sub_command_missing_topic() {
+        let args = vec!["topicClusterList"];
+
+        let cmd = TopicClusterSubCommand::try_parse_from(args);
+        assert!(cmd.is_err());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Refs: #4139

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Add topicClusterList admin command to query which clusters contain a specific topic.  This command is equivalent to Java version's `TopicClusterSubCommand` and provides the same functionality to list all clusters that contain the specified topic.

#### Changes include: 
- Implement TopicClusterSubCommand in rocketmq-tools with CLI argument parsing 
- Implement get_topic_cluster_list() method in DefaultMQAdminExtImpl 
- Implement get_broker_cluster_info() API method in MQClientAPIImpl 
- Add command registration in TopicCommands enum 
- Add unit tests for command argument parsing  


### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
I followed the [contribution guide](https://rocketmqrust.com/docs/contribute-guide/) and ran all required checks, including `cargo fmt`, `cargo build`, and `cargo test`, all related tests passed.
Additionally, I started a local NameServer and Broker in my environment, created a test topic, and manually ran the  `topicClusterList` command to verify it works as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `topicClusterList` command to query which clusters contain a specified topic, supporting optional nameserver configuration.
  * Enhanced admin capabilities to retrieve broker cluster information and derive topic cluster distributions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->