### PR TITLE
[ISSUE #4307] Replace get currenttime with get_current_millis() in RouteInfoManagerV2#Replace get current time with rocketmq_common::utils::time_utils::get_current_millis() in RouteInfoManagerV2#update_broker_info_update_timestamp

### DIFF
--- a/rocketmq-namesrv/src/route/route_info_manager_v2.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_v2.rs
@@ -956,10 +956,7 @@ impl RouteInfoManagerV2 {
         _cluster_name: CheetahString,
         broker_addr: CheetahString,
     ) {
-        let current_time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
+        let current_time = get_current_millis();
         self.broker_live_table
             .update_last_update_timestamp(&broker_addr, current_time);
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4307 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal timestamp calculation in broker information updates by consolidating time retrieval logic, improving code consistency and maintainability.

---

**Note:** This release contains internal code improvements with no user-visible changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->