### PR TITLE
[ISSUE #4363]Remove unused table_size_for method

### DIFF
--- a/rocketmq-store/src/base/topic_queue_lock.rs
+++ b/rocketmq-store/src/base/topic_queue_lock.rs
@@ -68,46 +68,9 @@ impl TopicQueueLock {
     }
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn calculates_table_size_for_zero_capacity() {
-        assert_eq!(table_size_for(0), 1);
-    }
-
-    #[test]
-    fn calculates_table_size_for_one_capacity() {
-        assert_eq!(table_size_for(1), 1);
-    }
-
-    #[test]
-    fn calculates_table_size_for_exact_power_of_two() {
-        assert_eq!(table_size_for(64), 64);
-    }
-
-    #[test]
-    fn calculates_table_size_for_just_above_power_of_two() {
-        assert_eq!(table_size_for(65), 64);
-    }
-
-    #[test]
-    fn calculates_table_size_for_maximum_capacity() {
-        assert_eq!(table_size_for(MAXIMUM_CAPACITY), MAXIMUM_CAPACITY);
-    }
-
-    #[test]
-    fn calculates_table_size_for_above_maximum_capacity() {
-        assert_eq!(table_size_for(MAXIMUM_CAPACITY + 1), MAXIMUM_CAPACITY);
-    }
-
-    #[test]
-    fn calculates_table_size_for_large_number() {
-        assert_eq!(table_size_for(1_000_000), 64);
-    }
 
     #[test]
     fn creates_correct_number_of_locks() {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes
Fixes #4363

### Brief Description
This PR removes the unused `table_size_for` method from the `TopicQueueLock` implementation in `rocketmq-store/src/base/topic_queue_lock.rs`. The method was identified as dead code and removing it helps clean up the codebase.

### Changes Made
- Removed the `table_size_for` method (lines 71-85) from `topic_queue_lock.rs`
- The method was a copy from Java HashMap implementation but was never used in the Rust codebase

### Testing
The existing test suite confirms this method is not required for any functionality. All tests continue to pass after removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed an internal helper and its associated tests as part of code cleanup.
  * No changes to public APIs or external behavior; only tests unrelated to lock creation and zero-capacity handling remain.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->