### PR TITLE
[ISSUE #4367] Refactor RouteInfoManagerWrapper#get_topics_by_cluster method to use CheetahString type for cluster name

### DIFF
--- a/rocketmq-namesrv/src/route/route_info_manager_wrapper.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_wrapper.rs
@@ -426,12 +426,9 @@ impl RouteInfoManagerWrapper {
     }
 
     /// Get topics by cluster
-    pub fn get_topics_by_cluster(&self, cluster: &str) -> TopicList {
-        use cheetah_string::CheetahString;
+    pub fn get_topics_by_cluster(&self, cluster: &CheetahString) -> TopicList {
         match self {
-            RouteInfoManagerWrapper::V1(manager) => {
-                manager.get_topics_by_cluster(&CheetahString::from_string(cluster.to_string()))
-            }
+            RouteInfoManagerWrapper::V1(manager) => manager.get_topics_by_cluster(cluster),
             RouteInfoManagerWrapper::V2(manager) => {
                 let topics = manager
                     .get_topics_by_cluster(cluster)


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4367 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal efficiency of the topic cluster retrieval mechanism by streamlining parameter handling and eliminating unnecessary intermediate conversions in the request forwarding process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->