### PR TITLE
[ISSUE #4387] Refactor lazy_static PUT_MESSAGE_ENTIRE_TIME_BUCKETS using std::sync::LazyLock in store_stats_service.rs

### DIFF
--- a/rocketmq-store/src/base/store_stats_service.rs
+++ b/rocketmq-store/src/base/store_stats_service.rs
@@ -21,6 +21,7 @@ use std::fmt;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::time::Instant;
 
 use parking_lot::Mutex;
@@ -48,19 +49,17 @@ const PUT_MESSAGE_ENTIRE_TIME_MAX_DESC: [&str; 13] = [
     "[10s~]",
 ];
 
-lazy_static::lazy_static! {
-    static ref PUT_MESSAGE_ENTIRE_TIME_BUCKETS: BTreeMap<i32, i32> = {
-        let mut m = BTreeMap::new();
-        m.insert(1, 20);
-        m.insert(2, 15);
-        m.insert(5, 10);
-        m.insert(10, 10);
-        m.insert(50, 6);
-        m.insert(100, 5);
-        m.insert(1000, 9);
-        m
-    };
-}
+static PUT_MESSAGE_ENTIRE_TIME_BUCKETS: LazyLock<BTreeMap<i32, i32>> = LazyLock::new(|| {
+    let mut m = BTreeMap::new();
+    m.insert(1, 20);
+    m.insert(2, 15);
+    m.insert(5, 10);
+    m.insert(10, 10);
+    m.insert(50, 6);
+    m.insert(100, 5);
+    m.insert(1000, 9);
+    m
+});
 
 type AtomicUsizeArray = Arc<Vec<AtomicUsize>>;
 


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4387 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal synchronization mechanisms for improved performance and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->