### PR TITLE
[ISSUE #4420]🚀Implement batch broker unregistration for improved performance and cleanup

### DIFF
--- a/rocketmq-namesrv/src/route/route_info_manager_wrapper.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_wrapper.rs
@@ -481,15 +481,7 @@ impl RouteInfoManagerWrapper {
                 manager.un_register_broker(requests);
             }
             RouteInfoManagerWrapper::V2(manager) => {
-                // V2 doesn't have batch unregister yet
-                for req in requests {
-                    let _ = manager.unregister_broker(
-                        req.cluster_name,
-                        req.broker_addr,
-                        req.broker_name,
-                        req.broker_id,
-                    );
-                }
+                manager.un_register_broker(requests);
             }
         }
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4420

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced batch broker unregistration to efficiently process multiple requests as a collective operation
  * Automatic cleanup of topic metadata associated with removed or reduced brokers
  * Enhanced notification system for broker state change events in cluster management scenarios
  * Improved address handling during broker registration startup and promotion workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->