### PR TITLE
[ISSUE#4427] RouteInfoManagerWrapper#get_broker_member_group method to use CheetahString for improved type safety

### DIFF
--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -378,7 +378,7 @@ impl DefaultRequestProcessor {
         let broker_member_group = self
             .name_server_runtime_inner
             .route_info_manager_mut()
-            .get_broker_member_group(&request_header.cluster_name, &request_header.broker_name);
+            .get_broker_member_group(request_header.cluster_name, request_header.broker_name);
         let response_body = GetBrokerMemberGroupResponseBody {
             broker_member_group,
         };

--- a/rocketmq-namesrv/src/route/route_info_manager_wrapper.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_wrapper.rs
@@ -353,12 +353,9 @@ impl RouteInfoManagerWrapper {
     /// Get broker member group
     pub fn get_broker_member_group(
         &mut self,
-        cluster_name: &str,
-        broker_name: &str,
+        cluster_name: CheetahString,
+        broker_name: CheetahString,
     ) -> Option<BrokerMemberGroup> {
-        use cheetah_string::CheetahString;
-        let cluster_name = CheetahString::from_string(cluster_name.to_string());
-        let broker_name = CheetahString::from_string(broker_name.to_string());
         match self {
             RouteInfoManagerWrapper::V1(manager) => {
                 manager.get_broker_member_group(cluster_name, broker_name)


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4427 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized string parameter handling in broker member group operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->