### PR TITLE
[ISSUE #4482]Change log level from info to debug for scanNotActiveBroker method

### DIFF
--- a/rocketmq-namesrv/src/route/route_info_manager_v2.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_v2.rs
@@ -1686,7 +1686,7 @@ impl RouteInfoManagerV2 {
     /// - Submissions are batched and processed together
     /// - This reduces lock contention on the global route tables
     pub fn scan_not_active_broker(&self) -> RouteResult<usize> {
-        info!("start scanNotActiveBroker");
+        debug!("start scanNotActiveBroker");
         let current_time = get_current_millis();
 
         // Get expired brokers by checking heartbeat timeout


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4482

### Brief Description

Changed the log level from `info!` to `debug!` for the `scan_not_active_broker` method in `route_info_manager_v2.rs`.

This method is called periodically (every 5 seconds) to scan for inactive brokers. The "start scanNotActiveBroker" log message is primarily useful for debugging purposes rather than production monitoring. Logging at `info` level creates unnecessary log verbosity, especially in production environments where this message would appear every 5 seconds.

This is a minimal, single-line change that reduces log noise while still preserving the ability to see this message when debug logging is enabled.

### How Did You Test This Change?

This is a straightforward log level change from `info!` to `debug!`. The `debug` macro is already imported and used elsewhere in the same file. No functional behavior is changed—only the log verbosity level is reduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity for broker monitoring operations to reduce log output during startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->