### PR TITLE
[ISSUE #4465] BrokerRuntimeInner#message_store method to return an Option reference for improved safety

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -1919,8 +1919,8 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
-    pub fn message_store(&self) -> &Option<ArcMut<MS>> {
-        &self.message_store
+    pub fn message_store(&self) -> Option<&ArcMut<MS>> {
+        self.message_store.as_ref()
     }
 
     #[inline]

--- a/rocketmq-broker/src/failover/escape_bridge.rs
+++ b/rocketmq-broker/src/failover/escape_bridge.rs
@@ -470,7 +470,7 @@ where
         broker_name: &CheetahString,
         de_compress_body: bool,
     ) -> BoxFuture<'_, (Option<MessageExt>, String, bool)> {
-        let message_store = self.broker_runtime_inner.message_store().clone().unwrap();
+        let message_store = self.broker_runtime_inner.message_store().unwrap();
         let inner_consumer_group_name = self.inner_consumer_group_name.clone();
         let topic = topic.clone();
         let broker_name = broker_name.clone();

--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -126,7 +126,6 @@ where
             let max_offset = self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_max_offset_in_queue(&topic, queue_id);
             self.notify_message_arriving(&topic, queue_id, max_offset);
@@ -163,7 +162,6 @@ where
                         newest_offset = self
                             .broker_runtime_inner
                             .message_store()
-                            .as_ref()
                             .unwrap()
                             .get_max_offset_in_queue(topic, queue_id);
                     }

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -232,7 +232,7 @@ where
                 ),
             ));
         }
-        let message_store_inner = self.broker_runtime_inner.message_store().as_ref().unwrap();
+        let message_store_inner = self.broker_runtime_inner.message_store().unwrap();
         let min_offset = message_store_inner
             .get_min_offset_in_queue(&request_header.topic, request_header.queue_id);
         let max_offset = message_store_inner
@@ -361,7 +361,7 @@ where
             let akc_offset = -1;
             let pop_time = batch_ack.pop_time;
             let invisible_time = batch_ack.invisible_time;
-            let message_store = self.broker_runtime_inner.message_store().as_ref().unwrap();
+            let message_store = self.broker_runtime_inner.message_store().unwrap();
             let min_offset = message_store.get_min_offset_in_queue(&topic, qid);
             let max_offset = message_store.get_max_offset_in_queue(&topic, qid);
             if min_offset == -1 || max_offset == -1 {

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -68,7 +68,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         let message_store_config = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .get_message_store_config()
             .clone();
@@ -108,7 +107,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         let mut runtime_info = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .get_runtime_info();
         self.broker_runtime_inner
@@ -176,7 +174,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
             "dispatchBehindBytes".to_string(),
             self.broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .dispatch_behind_bytes()
                 .to_string(),
@@ -185,7 +182,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
             "pageCacheLockTimeMills".to_string(),
             self.broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .lock_time_millis()
                 .to_string(),
@@ -194,7 +190,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
             "earliestMessageTimeStamp".to_string(),
             self.broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_earliest_message_time_store()
                 .to_string(),
@@ -215,7 +210,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
                 "timerReadBehind".to_string(),
                 self.broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_timer_message_store()
                     .unwrap()
@@ -226,7 +220,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
                 "timerOffsetBehind".to_string(),
                 self.broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_timer_message_store()
                     .unwrap()
@@ -237,7 +230,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
                 "timerCongestNum".to_string(),
                 self.broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_timer_message_store()
                     .unwrap()
@@ -248,7 +240,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
                 "timerEnqueueTps".to_string(),
                 self.broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_timer_message_store()
                     .unwrap()
@@ -259,7 +250,6 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
                 "timerDequeueTps".to_string(),
                 self.broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_timer_message_store()
                     .unwrap()
@@ -273,7 +263,7 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
             runtime_info.insert("timerEnqueueTps".to_string(), "0.0".to_string());
             runtime_info.insert("timerDequeueTps".to_string(), "0.0".to_string());
         }
-        let default_message_store = self.broker_runtime_inner.message_store().as_ref().unwrap();
+        let default_message_store = self.broker_runtime_inner.message_store().unwrap();
         runtime_info.insert(
             "remainTransientStoreBufferNumbs".to_string(),
             default_message_store

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_epoch_cache_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_epoch_cache_handler.rs
@@ -68,7 +68,7 @@ impl<MS: MessageStore> BrokerEpochCacheHandler<MS> {
 
         let broker_identity = &broker_config.broker_identity;
 
-        let message_store = broker_runtime_inner.message_store().as_ref().unwrap();
+        let message_store = broker_runtime_inner.message_store().unwrap();
 
         let entry_code = EpochEntryCache::new(
             &broker_identity.broker_cluster_name,

--- a/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
@@ -180,7 +180,6 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
                 let mut broker_offset = self
                     .broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_max_offset_in_queue(topic, i as i32);
                 if broker_offset < 0 {
@@ -210,7 +209,6 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
                     let last_timestamp = self
                         .broker_runtime_inner
                         .message_store()
-                        .as_ref()
                         .unwrap()
                         .get_message_store_timestamp(topic, i as i32, time_offset);
                     if last_timestamp > 0 {

--- a/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
@@ -75,7 +75,6 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         let offset = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .get_max_offset_in_queue(topic.as_ref(), queue_id);
         let response_header = GetMaxOffsetResponseHeader { offset };
@@ -111,7 +110,6 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         let offset = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .get_min_offset_in_queue(topic.as_ref(), queue_id);
         let response_header = GetMinOffsetResponseHeader { offset };
@@ -157,7 +155,6 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         {
             self.broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_min_offset_in_queue(mapping_context.topic.as_ref(), max_item.queue_id)
         } else {
@@ -231,7 +228,6 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         {
             self.broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_max_offset_in_queue(mapping_context.topic.as_ref(), max_item.queue_id)
         } else {

--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -472,7 +472,6 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
             let min = std::cmp::max(
                 self.broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_min_offset_in_queue(topic, i as i32),
                 0,
@@ -480,7 +479,6 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
             let max = std::cmp::max(
                 self.broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_max_offset_in_queue(topic, i as i32),
                 0,
@@ -490,7 +488,6 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
                 timestamp = self
                     .broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_message_store_timestamp(topic, i as i32, max - 1);
             }

--- a/rocketmq-broker/src/processor/change_invisible_time_processor.rs
+++ b/rocketmq-broker/src/processor/change_invisible_time_processor.rs
@@ -181,13 +181,11 @@ where
         let mix_offset = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .get_min_offset_in_queue(&request_header.topic, request_header.queue_id);
         let max_offset = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .get_max_offset_in_queue(&request_header.topic, request_header.queue_id);
         if request_header.offset < mix_offset || request_header.offset > max_offset {

--- a/rocketmq-broker/src/processor/consumer_manage_processor.rs
+++ b/rocketmq-broker/src/processor/consumer_manage_processor.rs
@@ -301,7 +301,6 @@ where
             let min_offset = self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_min_offset_in_queue(request_header.topic.as_ref(), request_header.queue_id);
             if let Some(value) = request_header.set_zero_if_not_found {
@@ -314,7 +313,6 @@ where
                 && self
                     .broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .check_in_mem_by_consume_offset(
                         request_header.topic.as_ref(),

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -900,7 +900,6 @@ where
             return self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_max_offset_in_queue(topic, queue_id)
                 - offset
@@ -910,7 +909,6 @@ where
             let result = self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_max_offset_in_queue(topic, queue_id)
                 - offset
@@ -958,7 +956,6 @@ where
             let result = self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_max_offset_in_queue(topic, queue_id)
                 - offset
@@ -971,7 +968,6 @@ where
         let get_message_result_inner = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .get_message(
                 &request_header.consumer_group,
@@ -1009,7 +1005,6 @@ where
                             atomic_offset.store(value.next_begin_offset(), Ordering::Release);
                             self.broker_runtime_inner
                                 .message_store()
-                                .as_ref()
                                 .unwrap()
                                 .get_message(
                                     &request_header.consumer_group,
@@ -1032,7 +1027,6 @@ where
                 let num = self
                     .broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_max_offset_in_queue(topic, queue_id)
                     - atomic_offset.load(Ordering::Acquire)
@@ -1344,7 +1338,6 @@ where
             offset = self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_min_offset_in_queue(topic, queue_id);
         } else if self
@@ -1354,14 +1347,12 @@ where
             && self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_min_offset_in_queue(topic, queue_id)
                 <= 0
             && self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .check_in_mem_by_consume_offset(topic, queue_id, 0, 1)
         {
@@ -1370,7 +1361,6 @@ where
             offset = self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_max_offset_in_queue(topic, queue_id)
                 - 1;

--- a/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
@@ -245,7 +245,6 @@ impl<MS: MessageStore> PopReviveService<MS> {
         let get_message_result = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .get_message(
                 group, topic, queue_id, offset, nums, //    128 * 1024 * 1024,
@@ -285,7 +284,6 @@ impl<MS: MessageStore> PopReviveService<MS> {
             let max_queue_offset = self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_max_offset_in_queue(topic, queue_id);
             if max_queue_offset > offset {
@@ -331,7 +329,6 @@ impl<MS: MessageStore> PopReviveService<MS> {
                 if !this
                     .broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_message_store_config()
                     .timer_wheel_enable
@@ -441,7 +438,6 @@ impl<MS: MessageStore> PopReviveService<MS> {
                 let timer_delay = self
                     .broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_timer_message_store()
                     .unwrap() // may be need to unwrap
@@ -449,7 +445,6 @@ impl<MS: MessageStore> PopReviveService<MS> {
                 let commit_log_delay = self
                     .broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_timer_message_store()
                     .unwrap() // may be need to unwrap
@@ -854,7 +849,6 @@ impl<MS: MessageStore> PopReviveService<MS> {
         );
         self.broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .mut_from_ref()
             .put_message(ck_msg)

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -776,14 +776,12 @@ where
                 get_message_result.set_min_offset(
                     self.broker_runtime_inner
                         .message_store()
-                        .as_ref()
                         .unwrap()
                         .get_min_offset_in_queue(topic, queue_id),
                 );
                 get_message_result.set_max_offset(
                     self.broker_runtime_inner
                         .message_store()
-                        .as_ref()
                         .unwrap()
                         .get_max_offset_in_queue(topic, queue_id),
                 );
@@ -806,7 +804,6 @@ where
                     let result = self
                         .broker_runtime_inner
                         .message_store()
-                        .as_ref()
                         .unwrap()
                         .get_message(
                             group,

--- a/rocketmq-broker/src/processor/query_message_processor.rs
+++ b/rocketmq-broker/src/processor/query_message_processor.rs
@@ -129,7 +129,6 @@ where
         let Some(query_message_result) = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .query_message(
                 request_header.topic.as_ref(),
@@ -182,7 +181,6 @@ where
         let select_mapped_buffer_result = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .select_one_message_by_offset(request_header.offset);
         if let Some(result) = select_mapped_buffer_result {

--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -301,7 +301,6 @@ where
                     .inner
                     .broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .map(|store| store.get_message_store_config().max_message_size)
                     .unwrap_or(4 * 1024 * 1024); // Default 4MB
                 warn!(

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -1306,7 +1306,6 @@ where
         let message_store = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .ok_or_else(|| RocketMQError::Internal("Message store not initialized".to_string()))?;
 
         let msg_ext: Option<MessageExt> =

--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -151,7 +151,6 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
             let max_offset = self
                 .broker_controller
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_max_offset_in_queue(
                     &CheetahString::from_static_str(TopicValidator::RMQ_SYS_SCHEDULE_TOPIC),

--- a/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
+++ b/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
@@ -273,7 +273,6 @@ where
         let state_machine_version = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .map(|store| store.get_state_machine_version())
             .unwrap_or(0);
 

--- a/rocketmq-broker/src/topic/manager/topic_config_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_config_manager.rs
@@ -360,7 +360,6 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
                     self.data_version.mut_from_ref().next_version_with(
                         self.broker_runtime_inner
                             .message_store()
-                            .as_ref()
                             .unwrap()
                             .get_state_machine_version(),
                     );
@@ -422,7 +421,6 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
             self.data_version.mut_from_ref().next_version_with(
                 self.broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_state_machine_version(),
             );
@@ -479,7 +477,7 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
         if let Some(old) = old {
             info!("delete topic config OK, topic: {:?}", old);
             let state_machine_version =
-                if let Some(message_store) = self.broker_runtime_inner.message_store().as_ref() {
+                if let Some(message_store) = self.broker_runtime_inner.message_store() {
                     message_store.get_state_machine_version()
                 } else {
                     0
@@ -532,7 +530,6 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
         self.data_version.mut_from_ref().next_version_with(
             self.broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_state_machine_version(),
         );
@@ -605,7 +602,6 @@ impl<MS: MessageStore> TopicConfigManager<MS> {
             self.data_version.mut_from_ref().next_version_with(
                 self.broker_runtime_inner
                     .message_store()
-                    .as_ref()
                     .unwrap()
                     .get_state_machine_version(),
             );

--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -86,7 +86,6 @@ where
             offset = self
                 .broker_runtime_inner
                 .message_store()
-                .as_ref()
                 .unwrap()
                 .get_min_offset_in_queue(topic, queue_id);
         }
@@ -169,7 +168,6 @@ where
         let get_message_result = self
             .broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .get_message(
                 group, topic, queue_id, offset, nums, //  MAX_PULL_MSG_SIZE,
@@ -393,7 +391,6 @@ where
     pub fn look_message_by_offset(&self, offset: i64) -> Option<MessageExt> {
         self.broker_runtime_inner
             .message_store()
-            .as_ref()
             .unwrap()
             .look_message_by_offset(offset)
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4465 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal message store access patterns throughout the broker by updating how the optional message store reference is retrieved and used. Removed redundant dereference operations across multiple service handlers and processors, improving code clarity without affecting external functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->