### PR TITLE
[ISSUE #4517]✨Add decode_str and decode_string methods to RemotingDeserializable trait for improved string handling

### DIFF
--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -467,6 +467,32 @@ pub trait RemotingDeserializable {
     /// A `Result` containing either the deserialized object of type `Output` or an `Error` if
     /// deserialization fails.
     fn decode(bytes: &[u8]) -> rocketmq_error::RocketMQResult<Self::Output>;
+
+    /// Decodes a string slice (`&str`) into the output type defined by the implementor of the
+    /// `RemotingDeserializable` trait.
+    ///
+    /// # Arguments
+    /// * `s` - A string slice containing the serialized data to be decoded.
+    ///
+    /// # Returns
+    /// A `RocketMQResult` containing the decoded object of type `Self::Output` if successful, or an
+    /// error if decoding fails.
+    fn decode_str(s: &str) -> rocketmq_error::RocketMQResult<Self::Output> {
+        Self::decode(s.as_bytes())
+    }
+
+    /// Decodes an owned `String` into the output type defined by the implementor of the
+    /// `RemotingDeserializable` trait.
+    ///
+    /// # Arguments
+    /// * `s` - An owned `String` containing the serialized data to be decoded.
+    ///
+    /// # Returns
+    /// A `RocketMQResult` containing the decoded object of type `Self::Output` if successful, or an
+    /// error if decoding fails.
+    fn decode_string(s: String) -> rocketmq_error::RocketMQResult<Self::Output> {
+        Self::decode_str(&s)
+    }
 }
 
 pub trait JsonSerializable: Serialize + RemotingSerializable {}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4517

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the deserialization API with convenient new methods designed to simplify handling of string-formatted data inputs. These additions provide developers with flexible and ergonomic options for converting various string-based data sources while maintaining full backward compatibility with existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->