### PR TITLE
[ISSUE #4537]♻️Refactor file reading logic to return an empty string for non-existent files instead of an error

### DIFF
--- a/rocketmq-common/src/utils/file_utils.rs
+++ b/rocketmq-common/src/utils/file_utils.rs
@@ -31,17 +31,16 @@ use tracing::warn;
 
 static LOCK: Mutex<()> = Mutex::new(());
 
+const FILE_EMPTY: &str = "";
+
 #[cfg(feature = "async_fs")]
 static ASYNC_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 pub fn file_to_string(file_name: impl AsRef<Path>) -> RocketMQResult<String> {
     let path = file_name.as_ref();
     if !path.exists() {
-        warn!("file not exist: {}", path.display());
-        return Err(RocketMQError::IO(io::Error::new(
-            io::ErrorKind::NotFound,
-            format!("File not found: {}", path.display()),
-        )));
+        warn!("file not exist file_to_string: {}", path.display());
+        return Ok(String::new());
     }
     std::fs::read_to_string(path).map_err(RocketMQError::IO)
 }
@@ -213,12 +212,8 @@ mod tests {
     #[test]
     fn test_file_to_string_not_found() {
         let result = file_to_string("/nonexistent/path/file.txt");
-        assert!(result.is_err());
-        if let Err(RocketMQError::IO(io_err)) = result {
-            assert_eq!(io_err.kind(), io::ErrorKind::NotFound);
-        } else {
-            panic!("Expected RocketMQError::IO with NotFound");
-        }
+        assert!(result.is_ok());
+        assert!(result.unwrap_or("".to_string()).is_empty())
     }
 
     #[cfg(feature = "async_fs")]


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4537

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file handling to gracefully return empty content for missing files instead of raising errors, enabling smoother operation when expected files are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->