### PR TITLE
[ISSUE #4528]✨Change hook_name return type from String to &'static str for improved performance

### DIFF
--- a/rocketmq-broker/src/hook/batch_check_before_put_message.rs
+++ b/rocketmq-broker/src/hook/batch_check_before_put_message.rs
@@ -39,8 +39,8 @@ impl BatchCheckBeforePutMessageHook {
 }
 
 impl PutMessageHook for BatchCheckBeforePutMessageHook {
-    fn hook_name(&self) -> String {
-        "batchCheckBeforePutMessage".to_string()
+    fn hook_name(&self) -> &'static str {
+        "batchCheckBeforePutMessage"
     }
 
     fn execute_before_put_message(&self, msg: &mut dyn MessageTrait) -> Option<PutMessageResult> {

--- a/rocketmq-broker/src/hook/check_before_put_message.rs
+++ b/rocketmq-broker/src/hook/check_before_put_message.rs
@@ -41,8 +41,8 @@ impl<MS: MessageStore> CheckBeforePutMessageHook<MS> {
 }
 
 impl<MS: MessageStore> PutMessageHook for CheckBeforePutMessageHook<MS> {
-    fn hook_name(&self) -> String {
-        "checkBeforePutMessage".to_string()
+    fn hook_name(&self) -> &'static str {
+        "checkBeforePutMessage"
     }
 
     fn execute_before_put_message(&self, msg: &mut dyn MessageTrait) -> Option<PutMessageResult> {

--- a/rocketmq-broker/src/hook/schedule_message_hook.rs
+++ b/rocketmq-broker/src/hook/schedule_message_hook.rs
@@ -38,8 +38,8 @@ impl<MS: MessageStore> ScheduleMessageHook<MS> {
 }
 
 impl<MS: MessageStore> PutMessageHook for ScheduleMessageHook<MS> {
-    fn hook_name(&self) -> String {
-        "ScheduleMessageHook".to_string()
+    fn hook_name(&self) -> &'static str {
+        "ScheduleMessageHook"
     }
 
     fn execute_before_put_message(&self, msg: &mut dyn MessageTrait) -> Option<PutMessageResult> {

--- a/rocketmq-store/src/hook/put_message_hook.rs
+++ b/rocketmq-store/src/hook/put_message_hook.rs
@@ -22,7 +22,7 @@ use crate::base::message_result::PutMessageResult;
 /// Trait for hook executed before putting a message.
 pub trait PutMessageHook {
     /// Returns the name of the hook.
-    fn hook_name(&self) -> String;
+    fn hook_name(&self) -> &'static str;
 
     /// Execute before putting a message.
     /// For example, message verification or special message transformation.


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4528 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
`cargo check` ,`cargo clippy` and `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal hook naming mechanism for improved performance by using static string literals instead of dynamically allocated strings across multiple hook implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->