### PR TITLE
[ISSUE #4519]✨Remove useless JsonSerializable trait

### DIFF
--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -495,8 +495,6 @@ pub trait RemotingDeserializable {
     }
 }
 
-pub trait JsonSerializable: Serialize + RemotingSerializable {}
-
 impl<T: Serialize> RemotingSerializable for T {
     fn encode(&self) -> rocketmq_error::RocketMQResult<Vec<u8>> {
         SerdeJsonUtils::serialize_json_vec(self)


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4519 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
`cargo check`, `cargo clippy` and `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a public trait declaration from the remoting protocol layer, simplifying the internal API surface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->