### PR TITLE
[ISSUE #4550]Remove useless commented code from file_to_string

### DIFF
--- a/rocketmq-common/src/utils/file_utils.rs
+++ b/rocketmq-common/src/utils/file_utils.rs
@@ -38,11 +38,6 @@ static ASYNC_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 pub fn file_to_string(file_name: impl AsRef<Path>) -> RocketMQResult<String> {
     let path = file_name.as_ref();
-    /*if !path.exists() {
-        warn!("file not exist: {}", path.display());
-        return Ok(String::new());
-    }
-    std::fs::read_to_string(path).map_err(RocketMQError::IO)*/
     match std::fs::read_to_string(path) {
         Ok(sr) => Ok(sr),
         Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
@@ -52,7 +47,6 @@ pub fn file_to_string(file_name: impl AsRef<Path>) -> RocketMQResult<String> {
         Err(e) => Err(RocketMQError::IO(e)),
     }
 }
-
 pub fn string_to_file(str_content: &str, file_name: impl AsRef<Path>) -> RocketMQResult<()> {
     let _lock = LOCK.lock();
 


### PR DESCRIPTION
[Enhancement] Remove useless commented code from file_to_string

- Removed commented-out dead code in file_utils.rs
- The functionality is now handled by the match statement

Fixes #4550

### Which Issue(s) This PR Fixes(Closes)
Closes #4550

### Brief Description
Removed commented-out dead code from the `file_to_string` method in `file_utils.rs` (lines 41-45). This code block contained an old implementation using `if !path.exists()` that was no longer functional. The same functionality is already properly handled by the `match` statement that follows, making the commented code redundant and cluttering the codebase.

### How Did You Test This Change?
- ✅ Built the project successfully using `cargo build` to ensure no compilation errors
- ✅ Verified all existing unit tests pass
- ✅ Confirmed this is a cleanup-only change with no functional modifications
- ✅ The `match` statement below the removed code already handles the same logic correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized file handling logic for improved efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->