### PR TITLE
[ISSUE #4554] [Enhancement✨] Change topic field in ViewMessageRequestHeader from CheetahString to Option<CheetahString> for improved flexibility

### DIFF
--- a/rocketmq-remoting/src/protocol/header/view_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/view_message_request_header.rs
@@ -21,6 +21,35 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV2, Default)]
 pub struct ViewMessageRequestHeader {
-    pub topic: CheetahString,
+    pub topic: Option<CheetahString>,
     pub offset: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_view_message_request_header_with_none_topic() {
+        let header = ViewMessageRequestHeader {
+            topic: None,
+            offset: 100,
+        };
+
+        assert!(header.topic.is_none());
+        assert_eq!(header.offset, 100);
+    }
+
+    #[test]
+    fn test_view_message_request_header_with_topic_value() {
+        let topic_name = CheetahString::from("test_topic");
+        let header = ViewMessageRequestHeader {
+            topic: Some(topic_name.clone()),
+            offset: 200,
+        };
+
+        assert!(header.topic.is_some());
+        assert_eq!(header.topic.unwrap(), topic_name);
+        assert_eq!(header.offset, 200);
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4554 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to validate message viewing requests with optional topic fields, covering scenarios where topic is specified and omitted, including offset value verification.

* **Updates**
  * The topic field in message viewing request headers is now optional.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->