### PR TITLE
[ISSUE #4572]🚀Add support for additional request codes in admin_broker_processor and request_code modules

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -154,6 +154,8 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .get_all_topic_config(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::GetTimerCheckPoint => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::GetTimerMetrics => Some(get_unknown_cmd_response(request_code)),
             RequestCode::UpdateBrokerConfig => {
                 self.broker_config_request_handler
                     .update_broker_config(channel, ctx, request_code, request)
@@ -164,11 +166,55 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .get_broker_config(channel, ctx, request_code, request)
                     .await
             }
-            RequestCode::GetSystemTopicListFromBroker => {
-                self.topic_request_handler
-                    .get_system_topic_list_from_broker(channel, ctx, request_code, request)
+            RequestCode::UpdateColdDataFlowCtrConfig => {
+                Some(get_unknown_cmd_response(request_code))
+            }
+            RequestCode::RemoveColdDataFlowCtrConfig => {
+                Some(get_unknown_cmd_response(request_code))
+            }
+            RequestCode::GetColdDataFlowCtrInfo => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::SetCommitlogReadMode => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::SearchOffsetByTimestamp => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::GetMaxOffset => {
+                self.offset_request_handler
+                    .get_max_offset(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::GetMinOffset => {
+                self.offset_request_handler
+                    .get_min_offset(channel, ctx, request_code, request)
+                    .await
+            }
+            RequestCode::GetEarliestMsgStoreTime => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::GetBrokerRuntimeInfo => {
+                self.broker_config_request_handler
+                    .get_broker_runtime_info(channel, ctx, request_code, request)
+                    .await
+            }
+            RequestCode::LockBatchMq => {
+                self.batch_mq_handler
+                    .lock_natch_mq(channel, ctx, request_code, request)
+                    .await
+            }
+            RequestCode::UnlockBatchMq => {
+                self.batch_mq_handler
+                    .unlock_batch_mq(channel, ctx, request_code, request)
+                    .await
+            }
+            RequestCode::UpdateAndCreateSubscriptionGroup => {
+                self.subscription_group_handler
+                    .update_and_create_subscription_group(channel, ctx, request_code, request)
+                    .await
+            }
+            RequestCode::UpdateAndCreateSubscriptionGroupList => {
+                Some(get_unknown_cmd_response(request_code))
+            }
+            RequestCode::GetAllSubscriptionGroupConfig => {
+                self.offset_request_handler
+                    .get_all_subscription_group_config(channel, ctx, request_code, request)
+                    .await
+            }
+            RequestCode::DeleteSubscriptionGroup => Some(get_unknown_cmd_response(request_code)),
             RequestCode::GetTopicStatsInfo => {
                 self.topic_request_handler
                     .get_topic_stats_info(channel, ctx, request_code, request)
@@ -179,6 +225,8 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .get_consumer_connection_list(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::GetProducerConnectionList => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::GetAllProducerInfo => Some(get_unknown_cmd_response(request_code)),
             RequestCode::GetConsumeStats => {
                 self.consumer_request_handler
                     .get_consume_stats(channel, ctx, request_code, request)
@@ -189,15 +237,15 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .get_all_consumer_offset(channel, ctx, request_code, request)
                     .await
             }
-            RequestCode::GetTopicConfig => {
-                self.topic_request_handler
-                    .get_topic_config(channel, ctx, request_code, request)
+            RequestCode::GetAllDelayOffset => {
+                self.offset_request_handler
+                    .get_all_delay_offset(channel, ctx, request_code, request)
                     .await
             }
-            RequestCode::GetBrokerRuntimeInfo => {
-                self.broker_config_request_handler
-                    .get_broker_runtime_info(channel, ctx, request_code, request)
-                    .await
+            RequestCode::GetAllMessageRequestMode => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::InvokeBrokerToResetOffset => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::InvokeBrokerToGetConsumerStatus => {
+                Some(get_unknown_cmd_response(request_code))
             }
             RequestCode::QueryTopicConsumeByWho => {
                 self.topic_request_handler
@@ -209,44 +257,43 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .query_topics_by_consumer(channel, ctx, request_code, request)
                     .await
             }
-            RequestCode::GetMaxOffset => {
-                self.offset_request_handler
-                    .get_max_offset(channel, ctx, request_code, request)
+            RequestCode::QuerySubscriptionByConsumer => {
+                Some(get_unknown_cmd_response(request_code))
+            }
+            RequestCode::QueryConsumeTimeSpan => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::GetSystemTopicListFromBroker => {
+                self.topic_request_handler
+                    .get_system_topic_list_from_broker(channel, ctx, request_code, request)
                     .await
             }
-            RequestCode::GetMinOffset => {
-                self.offset_request_handler
-                    .get_min_offset(channel, ctx, request_code, request)
+            RequestCode::CleanExpiredConsumequeue => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::DeleteExpiredCommitlog => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::CleanUnusedTopic => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::GetConsumerRunningInfo => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::QueryCorrectionOffset => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::ConsumeMessageDirectly => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::CloneGroupOffset => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::ViewBrokerStatsData => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::GetBrokerConsumeStats => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::QueryConsumeQueue => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::CheckRocksdbCqWriteProgress => {
+                Some(get_unknown_cmd_response(request_code))
+            }
+            RequestCode::UpdateAndGetGroupForbidden => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::GetSubscriptionGroupConfig => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::UpdateAndCreateAclConfig => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::DeleteAclConfig => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::GetBrokerClusterAclInfo => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::UpdateGlobalWhiteAddrsConfig => {
+                Some(get_unknown_cmd_response(request_code))
+            }
+            RequestCode::ResumeCheckHalfMessage => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::GetTopicConfig => {
+                self.topic_request_handler
+                    .get_topic_config(channel, ctx, request_code, request)
                     .await
             }
-
-            RequestCode::LockBatchMq => {
-                self.batch_mq_handler
-                    .lock_natch_mq(channel, ctx, request_code, request)
-                    .await
-            }
-
-            RequestCode::UnlockBatchMq => {
-                self.batch_mq_handler
-                    .unlock_batch_mq(channel, ctx, request_code, request)
-                    .await
-            }
-            RequestCode::UpdateAndCreateSubscriptionGroup => {
-                self.subscription_group_handler
-                    .update_and_create_subscription_group(channel, ctx, request_code, request)
-                    .await
-            }
-
-            RequestCode::GetAllDelayOffset => {
-                self.offset_request_handler
-                    .get_all_delay_offset(channel, ctx, request_code, request)
-                    .await
-            }
-            RequestCode::GetAllSubscriptionGroupConfig => {
-                self.offset_request_handler
-                    .get_all_subscription_group_config(channel, ctx, request_code, request)
-                    .await
-            }
+            RequestCode::UpdateAndCreateStaticTopic => Some(get_unknown_cmd_response(request_code)),
             RequestCode::NotifyMinBrokerIdChange => {
                 self.notify_min_broker_handler
                     .notify_min_broker_id_change(channel, ctx, request_code, request)
@@ -257,6 +304,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .update_broker_ha_info(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::GetBrokerHaStatus => Some(get_unknown_cmd_response(request_code)),
             RequestCode::ResetMasterFlushOffset => {
                 self.reset_master_flusg_offset_handler
                     .reset_master_flush_offset(channel, ctx, request_code, request)
@@ -272,6 +320,16 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .notify_broker_role_changed(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::AuthCreateUser => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::AuthUpdateUser => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::AuthDeleteUser => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::AuthGetUser => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::AuthListUser => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::AuthCreateAcl => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::AuthUpdateAcl => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::AuthDeleteAcl => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::AuthGetAcl => Some(get_unknown_cmd_response(request_code)),
+            RequestCode::AuthListAcl => Some(get_unknown_cmd_response(request_code)),
             _ => Some(get_unknown_cmd_response(request_code)),
         }
     }

--- a/rocketmq-remoting/src/code/request_code.rs
+++ b/rocketmq-remoting/src/code/request_code.rs
@@ -153,6 +153,7 @@ define_request_code! {
         GetConsumerStatusFromClient = 221,
         InvokeBrokerToResetOffset = 222,
         InvokeBrokerToGetConsumerStatus = 223,
+        UpdateAndCreateSubscriptionGroupList = 225,
 
         QueryTopicConsumeByWho = 300,
         GetTopicsByCluster = 224,
@@ -190,6 +191,8 @@ define_request_code! {
         GetTopicConfig = 351,
         GetSubscriptionGroupConfig = 352,
         UpdateAndGetGroupForbidden = 353,
+        CheckRocksdbCqWriteProgress = 354,
+
         LitePullMessage = 361,
 
         QueryAssignment = 400,


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4572

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated broker command handling to consolidate and streamline request processing pathways.
  * Deprecated support for multiple administrative broker commands, which now return unknown-command responses.
  * Preserved core operational command support including offset management, topic statistics, and broker runtime information.

* **New Features**
  * Added new command codes to support additional broker operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->