### PR TITLE
[ISSUE #4575]🚀Implement BoundaryType enum with serialization, deserialization, and parsing methods; add SearchOffsetRequestHeader struct with tests

### DIFF
--- a/rocketmq-common/src/common/boundary_type.rs
+++ b/rocketmq-common/src/common/boundary_type.rs
@@ -14,13 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#[derive(Debug, PartialEq, Eq)]
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub enum BoundaryType {
+    #[default]
     Lower,
     Upper,
 }
 
 impl BoundaryType {
+    /// Returns the name of the boundary type.
+    ///
+    /// # Returns
+    /// * "lower" for `BoundaryType::Lower`
+    /// * "upper" for `BoundaryType::Upper`
     pub fn get_name(&self) -> &'static str {
         match self {
             BoundaryType::Lower => "lower",
@@ -28,11 +43,189 @@ impl BoundaryType {
         }
     }
 
-    pub fn get_type(name: &str) -> Option<BoundaryType> {
-        match name.to_lowercase().as_str() {
-            "lower" => Some(BoundaryType::Lower),
-            "upper" => Some(BoundaryType::Upper),
-            _ => None,
+    /// Parses a boundary type from a string name.
+    ///
+    /// Matches Java behavior: if the name equals "upper" (case-insensitive),
+    /// returns `BoundaryType::Upper`; otherwise returns `BoundaryType::Lower` as default.
+    ///
+    /// # Arguments
+    /// * `name` - The string name to parse (case-insensitive)
+    ///
+    /// # Returns
+    /// * `BoundaryType::Upper` if name equals "upper" (case-insensitive)
+    /// * `BoundaryType::Lower` otherwise (default fallback, matching Java behavior)
+    pub fn get_type(name: &str) -> BoundaryType {
+        if name.eq_ignore_ascii_case("upper") {
+            BoundaryType::Upper
+        } else {
+            BoundaryType::Lower
         }
+    }
+}
+
+impl Serialize for BoundaryType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Matches Java enum serialization: uses uppercase enum name
+        let name = match self {
+            BoundaryType::Lower => "LOWER",
+            BoundaryType::Upper => "UPPER",
+        };
+        serializer.serialize_str(name)
+    }
+}
+
+impl<'de> Deserialize<'de> for BoundaryType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        // Matches Java behavior: returns Lower as default for any invalid value
+        Ok(BoundaryType::get_type(&s))
+    }
+}
+
+impl fmt::Display for BoundaryType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Display as uppercase to match Java enum.name()
+        match self {
+            BoundaryType::Lower => write!(f, "LOWER"),
+            BoundaryType::Upper => write!(f, "UPPER"),
+        }
+    }
+}
+
+impl FromStr for BoundaryType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Always succeeds, returns Lower as default (matches Java behavior)
+        Ok(BoundaryType::get_type(s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boundary_type_get_name_returns_correct_strings() {
+        assert_eq!(BoundaryType::Lower.get_name(), "lower");
+        assert_eq!(BoundaryType::Upper.get_name(), "upper");
+    }
+
+    #[test]
+    fn boundary_type_get_type_parses_correctly() {
+        assert_eq!(BoundaryType::get_type("lower"), BoundaryType::Lower);
+        assert_eq!(BoundaryType::get_type("LOWER"), BoundaryType::Lower);
+        assert_eq!(BoundaryType::get_type("upper"), BoundaryType::Upper);
+        assert_eq!(BoundaryType::get_type("UPPER"), BoundaryType::Upper);
+        assert_eq!(BoundaryType::get_type("Upper"), BoundaryType::Upper);
+    }
+
+    #[test]
+    fn boundary_type_get_type_returns_lower_as_default() {
+        // Matches Java behavior: invalid values default to Lower
+        assert_eq!(BoundaryType::get_type("invalid"), BoundaryType::Lower);
+        assert_eq!(BoundaryType::get_type(""), BoundaryType::Lower);
+        assert_eq!(BoundaryType::get_type("random"), BoundaryType::Lower);
+    }
+
+    #[test]
+    fn boundary_type_default_is_lower() {
+        assert_eq!(BoundaryType::default(), BoundaryType::Lower);
+    }
+
+    #[test]
+    fn boundary_type_serializes_to_string() {
+        let lower = BoundaryType::Lower;
+        let upper = BoundaryType::Upper;
+
+        let lower_json = serde_json::to_string(&lower).unwrap();
+        let upper_json = serde_json::to_string(&upper).unwrap();
+
+        // Matches Java enum serialization: uppercase enum names
+        assert_eq!(lower_json, r#""LOWER""#);
+        assert_eq!(upper_json, r#""UPPER""#);
+    }
+
+    #[test]
+    fn boundary_type_deserializes_from_string() {
+        // Supports both uppercase (Java format) and lowercase
+        let lower: BoundaryType = serde_json::from_str(r#""LOWER""#).unwrap();
+        let upper: BoundaryType = serde_json::from_str(r#""UPPER""#).unwrap();
+        let lower2: BoundaryType = serde_json::from_str(r#""lower""#).unwrap();
+        let upper2: BoundaryType = serde_json::from_str(r#""upper""#).unwrap();
+
+        assert_eq!(lower, BoundaryType::Lower);
+        assert_eq!(upper, BoundaryType::Upper);
+        assert_eq!(lower2, BoundaryType::Lower);
+        assert_eq!(upper2, BoundaryType::Upper);
+    }
+
+    #[test]
+    fn boundary_type_deserializes_case_insensitive() {
+        // Case-insensitive deserialization
+        let upper1: BoundaryType = serde_json::from_str(r#""Upper""#).unwrap();
+        let upper2: BoundaryType = serde_json::from_str(r#""UpPeR""#).unwrap();
+
+        assert_eq!(upper1, BoundaryType::Upper);
+        assert_eq!(upper2, BoundaryType::Upper);
+    }
+
+    #[test]
+    fn boundary_type_deserialization_defaults_to_lower_for_invalid_value() {
+        // Matches Java behavior: invalid values default to Lower
+        let result: BoundaryType = serde_json::from_str(r#""invalid""#).unwrap();
+        assert_eq!(result, BoundaryType::Lower);
+
+        let result2: BoundaryType = serde_json::from_str(r#""random""#).unwrap();
+        assert_eq!(result2, BoundaryType::Lower);
+    }
+
+    #[test]
+    fn boundary_type_roundtrip_serialization() {
+        let original = BoundaryType::Upper;
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: BoundaryType = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn boundary_type_display_returns_uppercase() {
+        assert_eq!(format!("{}", BoundaryType::Lower), "LOWER");
+        assert_eq!(format!("{}", BoundaryType::Upper), "UPPER");
+    }
+
+    #[test]
+    fn boundary_type_from_str_parses_correctly() {
+        assert_eq!(
+            "UPPER".parse::<BoundaryType>().unwrap(),
+            BoundaryType::Upper
+        );
+        assert_eq!(
+            "upper".parse::<BoundaryType>().unwrap(),
+            BoundaryType::Upper
+        );
+        assert_eq!(
+            "LOWER".parse::<BoundaryType>().unwrap(),
+            BoundaryType::Lower
+        );
+        assert_eq!(
+            "lower".parse::<BoundaryType>().unwrap(),
+            BoundaryType::Lower
+        );
+    }
+
+    #[test]
+    fn boundary_type_from_str_defaults_to_lower_for_invalid() {
+        assert_eq!(
+            "invalid".parse::<BoundaryType>().unwrap(),
+            BoundaryType::Lower
+        );
+        assert_eq!("".parse::<BoundaryType>().unwrap(), BoundaryType::Lower);
     }
 }

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -69,6 +69,7 @@ pub mod query_topics_by_consumer_request_header;
 pub mod reply_message_request_header;
 pub mod reset_master_flush_offset_header;
 pub mod reset_offset_request_header;
+pub mod search_offset_request_header;
 pub mod search_offset_response_header;
 pub mod unlock_batch_mq_request_header;
 pub mod unregister_client_request_header;

--- a/rocketmq-remoting/src/protocol/header/search_offset_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/search_offset_request_header.rs
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cheetah_string::CheetahString;
+use rocketmq_common::common::boundary_type::BoundaryType;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Default, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchOffsetRequestHeader {
+    pub topic: CheetahString,
+    pub queue_id: i32,
+    pub timestamp: i64,
+    pub boundary_type: BoundaryType,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_offset_request_header_default() {
+        let header = SearchOffsetRequestHeader::default();
+        assert_eq!(header.topic, CheetahString::default());
+        assert_eq!(header.queue_id, 0);
+        assert_eq!(header.timestamp, 0);
+        assert_eq!(header.boundary_type, BoundaryType::Lower);
+    }
+
+    #[test]
+    fn search_offset_request_header_creation() {
+        let header = SearchOffsetRequestHeader {
+            topic: CheetahString::from("test_topic"),
+            queue_id: 1,
+            timestamp: 1702345678000,
+            boundary_type: BoundaryType::Upper,
+        };
+
+        assert_eq!(header.topic, CheetahString::from("test_topic"));
+        assert_eq!(header.queue_id, 1);
+        assert_eq!(header.timestamp, 1702345678000);
+        assert_eq!(header.boundary_type, BoundaryType::Upper);
+    }
+
+    #[test]
+    fn search_offset_request_header_serializes_to_json() {
+        let header = SearchOffsetRequestHeader {
+            topic: CheetahString::from("my_topic"),
+            queue_id: 2,
+            timestamp: 1702345678999,
+            boundary_type: BoundaryType::Upper,
+        };
+
+        let json = serde_json::to_string(&header).unwrap();
+
+        // Verify camelCase field names and uppercase enum
+        assert!(json.contains(r#""topic":"my_topic""#));
+        assert!(json.contains(r#""queueId":2"#));
+        assert!(json.contains(r#""timestamp":1702345678999"#));
+        assert!(json.contains(r#""boundaryType":"UPPER""#));
+    }
+
+    #[test]
+    fn search_offset_request_header_deserializes_from_json() {
+        let json = r#"{
+            "topic": "test_topic",
+            "queueId": 3,
+            "timestamp": 1702345678123,
+            "boundaryType": "LOWER"
+        }"#;
+
+        let header: SearchOffsetRequestHeader = serde_json::from_str(json).unwrap();
+
+        assert_eq!(header.topic, CheetahString::from("test_topic"));
+        assert_eq!(header.queue_id, 3);
+        assert_eq!(header.timestamp, 1702345678123);
+        assert_eq!(header.boundary_type, BoundaryType::Lower);
+    }
+
+    #[test]
+    fn search_offset_request_header_deserializes_with_uppercase_boundary_type() {
+        let json = r#"{
+            "topic": "topic1",
+            "queueId": 0,
+            "timestamp": 1000000000,
+            "boundaryType": "UPPER"
+        }"#;
+
+        let header: SearchOffsetRequestHeader = serde_json::from_str(json).unwrap();
+
+        assert_eq!(header.boundary_type, BoundaryType::Upper);
+    }
+
+    #[test]
+    fn search_offset_request_header_deserializes_with_lowercase_boundary_type() {
+        let json = r#"{
+            "topic": "topic2",
+            "queueId": 5,
+            "timestamp": 2000000000,
+            "boundaryType": "lower"
+        }"#;
+
+        let header: SearchOffsetRequestHeader = serde_json::from_str(json).unwrap();
+
+        assert_eq!(header.boundary_type, BoundaryType::Lower);
+    }
+
+    #[test]
+    fn search_offset_request_header_boundary_type_defaults_to_lower_for_invalid_value() {
+        let json = r#"{
+            "topic": "topic3",
+            "queueId": 1,
+            "timestamp": 3000000000,
+            "boundaryType": "invalid"
+        }"#;
+
+        let header: SearchOffsetRequestHeader = serde_json::from_str(json).unwrap();
+
+        // Matches Java behavior: defaults to Lower
+        assert_eq!(header.boundary_type, BoundaryType::Lower);
+    }
+
+    #[test]
+    fn search_offset_request_header_roundtrip_serialization() {
+        let original = SearchOffsetRequestHeader {
+            topic: CheetahString::from("roundtrip_topic"),
+            queue_id: 10,
+            timestamp: 1702400000000,
+            boundary_type: BoundaryType::Upper,
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: SearchOffsetRequestHeader = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.topic, original.topic);
+        assert_eq!(deserialized.queue_id, original.queue_id);
+        assert_eq!(deserialized.timestamp, original.timestamp);
+        assert_eq!(deserialized.boundary_type, original.boundary_type);
+    }
+
+    #[test]
+    fn search_offset_request_header_with_negative_queue_id() {
+        let header = SearchOffsetRequestHeader {
+            topic: CheetahString::from("test"),
+            queue_id: -1,
+            timestamp: 1000,
+            boundary_type: BoundaryType::Lower,
+        };
+
+        assert_eq!(header.queue_id, -1);
+    }
+
+    #[test]
+    fn search_offset_request_header_with_empty_topic() {
+        let header = SearchOffsetRequestHeader {
+            topic: CheetahString::new(),
+            queue_id: 0,
+            timestamp: 0,
+            boundary_type: BoundaryType::Lower,
+        };
+
+        assert!(header.topic.is_empty());
+    }
+
+    #[test]
+    fn search_offset_request_header_with_large_timestamp() {
+        let header = SearchOffsetRequestHeader {
+            topic: CheetahString::from("test"),
+            queue_id: 0,
+            timestamp: i64::MAX,
+            boundary_type: BoundaryType::Upper,
+        };
+
+        assert_eq!(header.timestamp, i64::MAX);
+
+        let json = serde_json::to_string(&header).unwrap();
+        let deserialized: SearchOffsetRequestHeader = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.timestamp, i64::MAX);
+    }
+}


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4575

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced search offset request functionality with configurable boundary types (upper/lower).
  * Enhanced serialization and deserialization handling with case-insensitive parsing.

* **Tests**
  * Expanded test coverage for boundary type defaults, serialization round-trips, and edge cases including empty topics and maximum values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->