### PR TITLE
[ISSUE #4605]🚀Implement logic for retrieving queue offsets by timestamp with boundary checks in local file stores

### DIFF
--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1235,7 +1235,12 @@ impl MessageStore for LocalFileMessageStore {
         timestamp: i64,
         boundary_type: BoundaryType,
     ) -> i64 {
-        todo!()
+        self.consume_queue_store.get_offset_in_queue_by_time(
+            topic,
+            queue_id,
+            timestamp,
+            boundary_type,
+        )
     }
 
     fn look_message_by_offset(&self, commit_log_offset: i64) -> Option<MessageExt> {

--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -409,7 +409,12 @@ impl ConsumeQueueStoreTrait for ConsumeQueueStore {
         timestamp: i64,
         boundary_type: BoundaryType,
     ) -> i64 {
-        todo!()
+        let logic = self.find_or_create_consume_queue(topic, queue_id);
+        let result_offset =
+            logic.get_offset_in_queue_by_time_with_boundary(timestamp, boundary_type);
+        result_offset
+            .max(logic.get_min_offset_in_queue())
+            .min(logic.get_max_offset_in_queue())
     }
 
     fn find_or_create_consume_queue(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4605

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented timestamp-based message offset retrieval with boundary awareness. This feature enables querying message queues by timestamp to locate specific messages efficiently. The system automatically handles boundary constraints to ensure retrieved offsets remain within valid queue ranges, providing reliable and consistent message access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->