### PR TITLE
[ISSUE #4588]✨Optimized PullMessageRequestHeader to implement TopicRequestHeaderTrait, which may cause panic

### DIFF
--- a/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pull_message_request_header.rs
@@ -64,11 +64,13 @@ pub struct PullMessageRequestHeader {
 
 impl TopicRequestHeaderTrait for PullMessageRequestHeader {
     fn set_lo(&mut self, lo: Option<bool>) {
-        self.topic_request.as_mut().unwrap().lo = lo;
+        if let Some(header) = self.topic_request.as_mut() {
+            header.lo = lo;
+        }
     }
 
     fn lo(&self) -> Option<bool> {
-        self.topic_request.as_ref().unwrap().lo
+        self.topic_request.as_ref().and_then(|h| h.lo)
     }
 
     fn set_topic(&mut self, topic: CheetahString) {
@@ -82,83 +84,61 @@ impl TopicRequestHeaderTrait for PullMessageRequestHeader {
     fn broker_name(&self) -> Option<&CheetahString> {
         self.topic_request
             .as_ref()
-            .unwrap()
-            .rpc
-            .as_ref()
-            .unwrap()
-            .broker_name
-            .as_ref()
+            .and_then(|h| h.rpc.as_ref())
+            .and_then(|h| h.broker_name.as_ref())
     }
 
     fn set_broker_name(&mut self, broker_name: CheetahString) {
-        self.topic_request
-            .as_mut()
-            .unwrap()
-            .rpc
-            .as_mut()
-            .unwrap()
-            .broker_name = Some(broker_name);
+        if let Some(header) = self.topic_request.as_mut() {
+            if let Some(rpc_header) = header.rpc.as_mut() {
+                rpc_header.broker_name = Some(broker_name);
+            }
+        }
     }
 
     fn namespace(&self) -> Option<&str> {
         self.topic_request
             .as_ref()
-            .unwrap()
-            .rpc
-            .as_ref()
-            .unwrap()
-            .namespace
-            .as_deref()
+            .and_then(|h| h.rpc.as_ref())
+            .and_then(|r| r.namespace.as_deref())
     }
 
     fn set_namespace(&mut self, namespace: CheetahString) {
-        self.topic_request
-            .as_mut()
-            .unwrap()
-            .rpc
-            .as_mut()
-            .unwrap()
-            .namespace = Some(namespace);
+        if let Some(header) = self.topic_request.as_mut() {
+            if let Some(rpc_header) = header.rpc.as_mut() {
+                rpc_header.namespace = Some(namespace);
+            }
+        }
     }
 
     fn namespaced(&self) -> Option<bool> {
         self.topic_request
             .as_ref()
-            .unwrap()
-            .rpc
-            .as_ref()
-            .unwrap()
-            .namespaced
+            .and_then(|h| h.rpc.as_ref())
+            .and_then(|r| r.namespaced)
     }
 
     fn set_namespaced(&mut self, namespaced: bool) {
-        self.topic_request
-            .as_mut()
-            .unwrap()
-            .rpc
-            .as_mut()
-            .unwrap()
-            .namespaced = Some(namespaced);
+        if let Some(header) = self.topic_request.as_mut() {
+            if let Some(rpc_header) = header.rpc.as_mut() {
+                rpc_header.namespaced = Some(namespaced);
+            }
+        }
     }
 
     fn oneway(&self) -> Option<bool> {
         self.topic_request
             .as_ref()
-            .unwrap()
-            .rpc
-            .as_ref()
-            .unwrap()
-            .oneway
+            .and_then(|h| h.rpc.as_ref())
+            .and_then(|r| r.oneway)
     }
 
     fn set_oneway(&mut self, oneway: bool) {
-        self.topic_request
-            .as_mut()
-            .unwrap()
-            .rpc
-            .as_mut()
-            .unwrap()
-            .oneway = Some(oneway);
+        if let Some(header) = self.topic_request.as_mut() {
+            if let Some(rpc_header) = header.rpc.as_mut() {
+                rpc_header.oneway = Some(oneway);
+            }
+        }
     }
 
     fn queue_id(&self) -> i32 {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4588 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of message-pull handling to avoid runtime panics when request data is partially missing — prevents crashes and handles missing fields more gracefully. Public interfaces remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->