### PR TITLE
[ISSUE #4623]🐛Fix the RocketMQ-Dashboard control panel does not support querying message details by message ID

### DIFF
--- a/rocketmq-remoting/src/protocol/header/query_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_message_request_header.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV2)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryMessageRequestHeader {
     #[required]

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -278,6 +278,9 @@ mod defaults {
     pub fn ha_listen_port() -> usize {
         10912
     }
+    pub fn default_query_max_num() -> usize {
+        32
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -571,7 +574,7 @@ pub struct MessageStoreConfig {
     #[serde(default = "defaults::os_page_cache_busy_timeout_mills")]
     pub os_page_cache_busy_timeout_mills: u64,
 
-    #[serde(default)]
+    #[serde(default = "defaults::default_query_max_num")]
     pub default_query_max_num: usize,
 
     #[serde(default)]
@@ -921,7 +924,7 @@ impl Default for MessageStoreConfig {
             duplication_enable: false,
             disk_fall_recorded: false,
             os_page_cache_busy_timeout_mills: 1000,
-            default_query_max_num: 0,
+            default_query_max_num: 32,
             transient_store_pool_enable: false,
             transient_store_pool_size: 0,
             fast_fail_if_no_buffer_in_store_pool: false,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4623

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default message query limit configuration value to 32

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->