### PR TITLE
[ISSUE #4634] 🚀Add InvocationStatus enum for metrics tracking

### DIFF
--- a/rocketmq-broker/src/metrics.rs
+++ b/rocketmq-broker/src/metrics.rs
@@ -17,6 +17,7 @@
 
 pub(crate) mod broker_metrics_constant;
 pub(crate) mod consumer_attr;
+pub(crate) mod invocation_status;
 pub(crate) mod pop_metrics_constant;
 pub(crate) mod pop_revive_message_type;
 pub(crate) mod producer_attr;

--- a/rocketmq-broker/src/metrics/invocation_status.rs
+++ b/rocketmq-broker/src/metrics/invocation_status.rs
@@ -1,0 +1,61 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use std::fmt::Display;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Invocation status for metrics tracking
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum InvocationStatus {
+    Success,
+    Failure,
+}
+
+impl InvocationStatus {
+    /// Get the name of the invocation status
+    pub fn get_name(&self) -> &'static str {
+        match self {
+            InvocationStatus::Success => "success",
+            InvocationStatus::Failure => "failure",
+        }
+    }
+}
+
+impl Display for InvocationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invocation_status_name() {
+        assert_eq!(InvocationStatus::Success.get_name(), "success");
+        assert_eq!(InvocationStatus::Failure.get_name(), "failure");
+    }
+
+    #[test]
+    fn test_invocation_status_display() {
+        assert_eq!(format!("{}", InvocationStatus::Success), "success");
+        assert_eq!(format!("{}", InvocationStatus::Failure), "failure");
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4634

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics system enhanced with invocation status tracking to monitor operation success and failure outcomes. Enables improved visibility into application performance and operational health for better diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->