### PR TITLE
[ISSUE #4641]🚀Add NopLongCounter implementation for OpenTelemetry metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,6 +2894,7 @@ dependencies = [
  "mockall",
  "num_cpus",
  "once_cell",
+ "opentelemetry",
  "parking_lot",
  "regex",
  "reqwest",

--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -72,6 +72,8 @@ form_urlencoded = "1.2.2"
 uuid = { workspace = true }
 cheetah-string = { workspace = true }
 
+opentelemetry = { workspace = true }
+
 [dev-dependencies]
 mockall = "0.14.0"
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/rocketmq-common/src/common/metrics.rs
+++ b/rocketmq-common/src/common/metrics.rs
@@ -15,4 +15,5 @@
 //  specific language governing permissions and limitations
 //  under the License.
 
-mod metrics_exporter_type;
+pub mod metrics_exporter_type;
+pub mod nop_long_counter;

--- a/rocketmq-common/src/common/metrics/nop_long_counter.rs
+++ b/rocketmq-common/src/common/metrics/nop_long_counter.rs
@@ -1,0 +1,88 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use opentelemetry::Context;
+use opentelemetry::KeyValue;
+
+/// No-op LongCounter implementation (equivalent to Java NopLongCounter)
+///
+/// This is a no-operation counter that implements the same interface as
+/// OpenTelemetry's LongCounter but does nothing when methods are called.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NopLongCounter;
+
+impl NopLongCounter {
+    /// Creates a new NopLongCounter instance
+    #[inline]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Add a value (no-op)
+    #[inline]
+    pub fn add(&self, _value: i64) {
+        // no-op
+    }
+
+    /// Add a value with attributes (no-op)
+    #[inline]
+    pub fn add_with_attributes(&self, _value: i64, _attributes: &[KeyValue]) {
+        // no-op
+    }
+
+    /// Add a value with attributes and context (no-op)
+    #[inline]
+    pub fn add_with_context(&self, _value: i64, _attributes: &[KeyValue], _context: &Context) {
+        // no-op
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nop_long_counter_default() {
+        let counter = NopLongCounter;
+        // Should not panic
+        counter.add(100);
+    }
+
+    #[test]
+    fn test_nop_long_counter_new() {
+        let counter = NopLongCounter::new();
+        // Should not panic
+        counter.add(100);
+    }
+
+    #[test]
+    fn test_nop_long_counter_add_with_attributes() {
+        let counter = NopLongCounter::new();
+        let attributes = [KeyValue::new("key", "value")];
+        // Should not panic
+        counter.add_with_attributes(100, &attributes);
+    }
+
+    #[test]
+    fn test_nop_long_counter_add_with_context() {
+        let counter = NopLongCounter::new();
+        let attributes = [KeyValue::new("key", "value")];
+        let context = Context::current();
+        // Should not panic
+        counter.add_with_context(100, &attributes, &context);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4641

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Dependencies**
  * Added OpenTelemetry integration for enhanced observability and monitoring capabilities.

* **New Features**
  * Extended metrics collection infrastructure with a no-operation counter implementation to support flexible metrics reporting strategies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->