### PR TITLE
[ISSUE #4643]🚀Add NopLongHistogram implementation for OpenTelemetry metrics

### DIFF
--- a/rocketmq-common/src/common/metrics.rs
+++ b/rocketmq-common/src/common/metrics.rs
@@ -17,3 +17,4 @@
 
 pub mod metrics_exporter_type;
 pub mod nop_long_counter;
+pub mod nop_long_histogram;

--- a/rocketmq-common/src/common/metrics/nop_long_histogram.rs
+++ b/rocketmq-common/src/common/metrics/nop_long_histogram.rs
@@ -1,0 +1,88 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use opentelemetry::Context;
+use opentelemetry::KeyValue;
+
+/// No-op LongHistogram implementation
+///
+/// This is a no-operation histogram that implements the same interface as
+/// OpenTelemetry's LongHistogram but does nothing when methods are called.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NopLongHistogram;
+
+impl NopLongHistogram {
+    /// Creates a new NopLongHistogram instance
+    #[inline]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Record a value (no-op)
+    #[inline]
+    pub fn record(&self, _value: i64) {
+        // no-op
+    }
+
+    /// Record a value with attributes (no-op)
+    #[inline]
+    pub fn record_with_attributes(&self, _value: i64, _attributes: &[KeyValue]) {
+        // no-op
+    }
+
+    /// Record a value with attributes and context (no-op)
+    #[inline]
+    pub fn record_with_context(&self, _value: i64, _attributes: &[KeyValue], _context: &Context) {
+        // no-op
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nop_long_histogram_default() {
+        let histogram = NopLongHistogram;
+        // Should not panic
+        histogram.record(100);
+    }
+
+    #[test]
+    fn test_nop_long_histogram_new() {
+        let histogram = NopLongHistogram::new();
+        // Should not panic
+        histogram.record(100);
+    }
+
+    #[test]
+    fn test_nop_long_histogram_record_with_attributes() {
+        let histogram = NopLongHistogram::new();
+        let attributes = [KeyValue::new("key", "value")];
+        // Should not panic
+        histogram.record_with_attributes(100, &attributes);
+    }
+
+    #[test]
+    fn test_nop_long_histogram_record_with_context() {
+        let histogram = NopLongHistogram::new();
+        let attributes = [KeyValue::new("key", "value")];
+        let context = Context::current();
+        // Should not panic
+        histogram.record_with_context(100, &attributes, &context);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4643

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for no-operation histogram metric recording, enabling flexible implementation options for metrics tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->