### PR TITLE
[ISSUE #4646]🚀Add NopObservableLongGauge implementation for OpenTelemetry metrics

### DIFF
--- a/rocketmq-common/src/common/metrics.rs
+++ b/rocketmq-common/src/common/metrics.rs
@@ -18,3 +18,4 @@
 pub mod metrics_exporter_type;
 pub mod nop_long_counter;
 pub mod nop_long_histogram;
+pub mod nop_observable_long_gauge;

--- a/rocketmq-common/src/common/metrics/nop_observable_long_gauge.rs
+++ b/rocketmq-common/src/common/metrics/nop_observable_long_gauge.rs
@@ -1,0 +1,63 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+/// No-op ObservableLongGauge implementation (equivalent to Java NopObservableLongGauge)
+///
+/// This is a no-operation observable gauge that does nothing.
+/// Observable gauges are typically registered with callbacks that are invoked
+/// during metric collection. This no-op implementation is used when metrics
+/// are disabled.
+///
+/// # Note
+/// Unlike Counter and Histogram, ObservableGauge in OpenTelemetry is registered
+/// with a callback and doesn't have explicit record methods. This struct serves
+/// as a placeholder when metrics are disabled.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NopObservableLongGauge;
+
+impl NopObservableLongGauge {
+    /// Creates a new NopObservableLongGauge instance
+    #[inline]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nop_observable_long_gauge_default() {
+        let _gauge = NopObservableLongGauge;
+        // Just ensure it can be created without issues
+    }
+
+    #[test]
+    fn test_nop_observable_long_gauge_new() {
+        let _gauge = NopObservableLongGauge::new();
+        // Just ensure it can be created without issues
+    }
+
+    #[test]
+    fn test_nop_observable_long_gauge_is_copy() {
+        let gauge1 = NopObservableLongGauge::new();
+        let gauge2 = gauge1; // Copy
+        let _gauge3 = gauge2; // Still can use gauge2
+                              // Ensures Copy trait works
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4646

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal metrics infrastructure to properly handle no-op scenarios when metrics collection is disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->