### PR TITLE
[ISSUE #4594]✨Add #[required] and test case for GetEarliestMsgStoretimeResponseHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_earliest_msg_storetime_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_earliest_msg_storetime_response_header.rs
@@ -21,5 +21,46 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV2)]
 pub struct GetEarliestMsgStoretimeResponseHeader {
+    #[required]
     pub timestamp: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn get_earliest_msg_storetime_response_header_display_format() {
+        let header = GetEarliestMsgStoretimeResponseHeader {
+            timestamp: 1234567890,
+        };
+        assert_eq!(
+            format!("{:?}", header),
+            "GetEarliestMsgStoretimeResponseHeader { timestamp: 1234567890 }"
+        );
+    }
+
+    #[test]
+    fn get_earliest_msg_storetime_response_header_serialize() {
+        let header = GetEarliestMsgStoretimeResponseHeader {
+            timestamp: 1234567890,
+        };
+        let serialized = serde_json::to_string(&header).unwrap();
+        assert_eq!(serialized, r#"{"timestamp":1234567890}"#);
+    }
+
+    #[test]
+    fn get_earliest_msg_storetime_response_header_deserialize() {
+        let json = r#"{"timestamp":1234567890}"#;
+        let header: GetEarliestMsgStoretimeResponseHeader = serde_json::from_str(json).unwrap();
+        assert_eq!(header.timestamp, 1234567890);
+    }
+
+    #[test]
+    fn get_earliest_msg_storetime_response_header_default() {
+        let header = GetEarliestMsgStoretimeResponseHeader::default();
+        assert_eq!(header.timestamp, 0);
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4594

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Strengthened validation for timestamp fields in response headers to ensure data integrity by marking the field as required.

* **Tests**
  * Enhanced test coverage for response header serialization and deserialization behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->