### PR TITLE
[ISSUE #4673] ✨Enhance StatsItem with atomic operations and sampling methods for improved concurrency and performance

### DIFF
--- a/rocketmq-common/src/common/stats/stats_item.rs
+++ b/rocketmq-common/src/common/stats/stats_item.rs
@@ -31,8 +31,8 @@ use crate::common::stats::call_snapshot::CallSnapshot;
 use crate::common::stats::stats_snapshot::StatsSnapshot;
 
 pub struct StatsItem {
-    value: AtomicU64,
-    times: AtomicU64,
+    value: Arc<AtomicU64>,
+    times: Arc<AtomicU64>,
     cs_list_minute: Arc<Mutex<LinkedList<CallSnapshot>>>,
     cs_list_hour: Arc<Mutex<LinkedList<CallSnapshot>>>,
     cs_list_day: Arc<Mutex<LinkedList<CallSnapshot>>>,
@@ -43,14 +43,48 @@ pub struct StatsItem {
 impl StatsItem {
     pub fn new(stats_name: &str, stats_key: &str) -> Self {
         StatsItem {
-            value: AtomicU64::new(0),
-            times: AtomicU64::new(0),
+            value: Arc::new(AtomicU64::new(0)),
+            times: Arc::new(AtomicU64::new(0)),
             cs_list_minute: Arc::new(Mutex::new(LinkedList::new())),
             cs_list_hour: Arc::new(Mutex::new(LinkedList::new())),
             cs_list_day: Arc::new(Mutex::new(LinkedList::new())),
             stats_name: stats_name.to_string(),
             stats_key: stats_key.to_string(),
         }
+    }
+
+    /// Atomically increments the value by delta and increments times by 1.
+    ///
+    /// # Arguments
+    /// * `delta` - The amount to add to the value counter
+    ///
+    /// # Thread Safety
+    /// This method is lock-free and safe to call from multiple threads concurrently.
+    /// Uses `Ordering::Relaxed` as no synchronization with other variables is required.
+    #[inline]
+    pub fn increment(&self, delta: u64) {
+        self.value.fetch_add(delta, Ordering::Relaxed);
+        self.times.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Returns the current accumulated value.
+    ///
+    /// # Thread Safety
+    /// This method uses `Ordering::Relaxed` for optimal performance.
+    /// The returned value is a snapshot at the time of the call.
+    #[inline]
+    pub fn get_value(&self) -> u64 {
+        self.value.load(Ordering::Relaxed)
+    }
+
+    /// Returns the current accumulated times (call count).
+    ///
+    /// # Thread Safety
+    /// This method uses `Ordering::Relaxed` for optimal performance.
+    /// The returned value is a snapshot at the time of the call.
+    #[inline]
+    pub fn get_times(&self) -> u64 {
+        self.times.load(Ordering::Relaxed)
     }
 
     pub fn compute_stats_data(cs_list: Arc<Mutex<LinkedList<CallSnapshot>>>) -> StatsSnapshot {
@@ -97,19 +131,33 @@ impl StatsItem {
         let stats_name = self.stats_name.clone();
         let stats_key = self.stats_key.clone();
 
+        // Clone Arc references to value and times for sampling threads
+        let value_for_seconds = Arc::clone(&self.value);
+        let times_for_seconds = Arc::clone(&self.times);
+        let value_for_minutes = Arc::clone(&self.value);
+        let times_for_minutes = Arc::clone(&self.times);
+        let value_for_hour = Arc::clone(&self.value);
+        let times_for_hour = Arc::clone(&self.times);
+
         thread::spawn(move || loop {
             thread::sleep(Duration::from_secs(10));
-            Self::sampling_in_seconds(cs_list_minute.clone());
+            let current_value = value_for_seconds.load(Ordering::Relaxed);
+            let current_times = times_for_seconds.load(Ordering::Relaxed);
+            Self::sampling_in_seconds(cs_list_minute.clone(), current_value, current_times);
         });
 
         thread::spawn(move || loop {
             thread::sleep(Duration::from_secs(600));
-            Self::sampling_in_minutes(cs_list_hour.clone());
+            let current_value = value_for_minutes.load(Ordering::Relaxed);
+            let current_times = times_for_minutes.load(Ordering::Relaxed);
+            Self::sampling_in_minutes(cs_list_hour.clone(), current_value, current_times);
         });
 
         thread::spawn(move || loop {
             thread::sleep(Duration::from_secs(3600));
-            Self::sampling_in_hour(cs_list_day.clone());
+            let current_value = value_for_hour.load(Ordering::Relaxed);
+            let current_times = times_for_hour.load(Ordering::Relaxed);
+            Self::sampling_in_hour(cs_list_day.clone(), current_value, current_times);
         });
 
         let stats_name_clone = stats_name.clone();
@@ -156,7 +204,11 @@ impl StatsItem {
         });
     }
 
-    pub fn sampling_in_seconds(cs_list: Arc<Mutex<LinkedList<CallSnapshot>>>) {
+    pub fn sampling_in_seconds(
+        cs_list: Arc<Mutex<LinkedList<CallSnapshot>>>,
+        current_value: u64,
+        current_times: u64,
+    ) {
         let mut cs_list = cs_list.lock();
         if cs_list.is_empty() {
             cs_list.push_back(CallSnapshot::new(
@@ -174,15 +226,19 @@ impl StatsItem {
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap()
                 .as_millis() as u64,
-            0,
-            0,
+            current_times,
+            current_value,
         ));
         if cs_list.len() > 7 {
             cs_list.pop_front();
         }
     }
 
-    pub fn sampling_in_minutes(cs_list: Arc<Mutex<LinkedList<CallSnapshot>>>) {
+    pub fn sampling_in_minutes(
+        cs_list: Arc<Mutex<LinkedList<CallSnapshot>>>,
+        current_value: u64,
+        current_times: u64,
+    ) {
         let mut cs_list = cs_list.lock();
         if cs_list.is_empty() {
             cs_list.push_back(CallSnapshot::new(
@@ -200,15 +256,19 @@ impl StatsItem {
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap()
                 .as_millis() as u64,
-            0,
-            0,
+            current_times,
+            current_value,
         ));
         if cs_list.len() > 7 {
             cs_list.pop_front();
         }
     }
 
-    pub fn sampling_in_hour(cs_list: Arc<Mutex<LinkedList<CallSnapshot>>>) {
+    pub fn sampling_in_hour(
+        cs_list: Arc<Mutex<LinkedList<CallSnapshot>>>,
+        current_value: u64,
+        current_times: u64,
+    ) {
         let mut cs_list = cs_list.lock();
         if cs_list.is_empty() {
             cs_list.push_back(CallSnapshot::new(
@@ -226,8 +286,8 @@ impl StatsItem {
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap()
                 .as_millis() as u64,
-            0,
-            0,
+            current_times,
+            current_value,
         ));
         if cs_list.len() > 25 {
             cs_list.pop_front();
@@ -382,6 +442,158 @@ mod tests {
         assert_eq!(snapshot.get_sum(), 0);
         assert_eq!(snapshot.get_tps(), 0.0);
         assert_eq!(snapshot.get_times(), 0);
+        assert_eq!(snapshot.get_avgpt(), 0.0);
+    }
+
+    #[test]
+    fn test_increment_updates_value_and_times() {
+        let stats = StatsItem::new("test", "key");
+        stats.increment(100);
+        assert_eq!(stats.get_value(), 100);
+        assert_eq!(stats.get_times(), 1);
+
+        stats.increment(50);
+        assert_eq!(stats.get_value(), 150);
+        assert_eq!(stats.get_times(), 2);
+    }
+
+    #[test]
+    fn test_multi_threaded_increment_atomicity() {
+        use std::thread;
+        let stats = Arc::new(StatsItem::new("test", "key"));
+        let mut handles = vec![];
+
+        // Spawn 10 threads, each incrementing 1000 times
+        for _ in 0..10 {
+            let stats_clone = Arc::clone(&stats);
+            let handle = thread::spawn(move || {
+                for _ in 0..1000 {
+                    stats_clone.increment(1);
+                }
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all threads
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Verify atomicity: 10 threads * 1000 increments = 10000
+        assert_eq!(stats.get_value(), 10_000);
+        assert_eq!(stats.get_times(), 10_000);
+    }
+
+    #[test]
+    fn test_sampling_captures_current_values() {
+        let stats = StatsItem::new("test", "key");
+
+        // Increment some values
+        stats.increment(100);
+        stats.increment(200);
+        stats.increment(300);
+
+        // Perform manual sampling
+        let current_value = stats.get_value();
+        let current_times = stats.get_times();
+
+        StatsItem::sampling_in_seconds(
+            Arc::clone(&stats.cs_list_minute),
+            current_value,
+            current_times,
+        );
+
+        // Verify snapshot contains non-zero values
+        let snapshot = stats.get_stats_data_in_minute();
+        assert!(
+            snapshot.get_sum() > 0,
+            "Snapshot should capture incremented value"
+        );
+        assert!(snapshot.get_times() > 0, "Snapshot should capture times");
+    }
+
+    #[test]
+    fn test_tps_and_avgpt_calculation() {
+        let cs_list = Arc::new(Mutex::new(LinkedList::new()));
+
+        // Add snapshots with known values
+        // t=0ms: 0 calls, value=0
+        // t=1000ms: 10 calls, value=500
+        {
+            let mut list = cs_list.lock();
+            list.push_back(CallSnapshot::new(0, 0, 0));
+            list.push_back(CallSnapshot::new(1000, 10, 500));
+        }
+
+        let snapshot = StatsItem::compute_stats_data(Arc::clone(&cs_list));
+
+        // TPS = (500 - 0) * 1000 / (1000 - 0) = 500
+        assert_eq!(snapshot.get_tps(), 500.0);
+
+        // AVGPT = (500 - 0) / (10 - 0) = 50
+        assert_eq!(snapshot.get_avgpt(), 50.0);
+
+        // Sum = 500 - 0 = 500
+        assert_eq!(snapshot.get_sum(), 500);
+
+        // Times = 10 - 0 = 10
+        assert_eq!(snapshot.get_times(), 10);
+    }
+
+    #[test]
+    fn test_concurrent_read_write() {
+        use std::thread;
+        use std::time::Duration;
+
+        let stats = Arc::new(StatsItem::new("concurrent", "test"));
+        let stats_writer = Arc::clone(&stats);
+        let stats_reader = Arc::clone(&stats);
+
+        // Writer thread: continuously increment
+        let writer = thread::spawn(move || {
+            for _ in 0..1000 {
+                stats_writer.increment(1);
+                thread::sleep(Duration::from_micros(10));
+            }
+        });
+
+        // Reader thread: continuously read values
+        let reader = thread::spawn(move || {
+            let mut last_value = 0;
+            for _ in 0..1000 {
+                let current = stats_reader.get_value();
+                // Value should monotonically increase or stay same
+                assert!(
+                    current >= last_value,
+                    "Value decreased! Was {}, now {}",
+                    last_value,
+                    current
+                );
+                last_value = current;
+                thread::sleep(Duration::from_micros(10));
+            }
+        });
+
+        writer.join().unwrap();
+        reader.join().unwrap();
+
+        assert_eq!(stats.get_value(), 1000);
+    }
+
+    #[test]
+    fn test_zero_times_avgpt_calculation() {
+        let cs_list = Arc::new(Mutex::new(LinkedList::new()));
+
+        // Add snapshots with same times (delta = 0)
+        {
+            let mut list = cs_list.lock();
+            list.push_back(CallSnapshot::new(0, 5, 100));
+            list.push_back(CallSnapshot::new(1000, 5, 200));
+        }
+
+        let snapshot = StatsItem::compute_stats_data(Arc::clone(&cs_list));
+
+        // When times_diff is 0, avgpt should be 0.0 (not division by zero)
         assert_eq!(snapshot.get_avgpt(), 0.0);
     }
 }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4673

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added increment(), get_value(), and get_times() methods for statistics tracking.
  * Updated sampling methods to accept and propagate current value and call count data.

* **Tests**
  * Expanded test coverage for atomic operations, sampling behavior, and concurrent access scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->