### PR TITLE
[ISSUE #4693]🐛Fix buffer length calculations and simplify get method in consume queue

### DIFF
--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -1757,11 +1757,12 @@ impl CommitLog {
                 let buffer = result.get_buffer();
                 let sys_flag = (&buffer[MessageDecoder::SYSFLAG_POSITION..]).get_i32();
                 let born_host_length = if sys_flag & MessageSysFlag::BORNHOST_V6_FLAG == 0 {
-                    4 + 4 + 4 + 4 + 4 + 8 + 8 + 4 + 8 + 8
+                    8
                 } else {
-                    4 + 4 + 4 + 4 + 4 + 8 + 8 + 4 + 8 + 20
+                    20
                 };
-                (&buffer[born_host_length..]).get_i64()
+                let msg_store_time_pos = born_host_length + 4 + 4 + 4 + 4 + 4 + 8 + 8 + 4 + 8;
+                (&buffer[msg_store_time_pos..]).get_i64()
             } else {
                 -1
             }

--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -804,10 +804,7 @@ impl<MS: MessageStore> ConsumeQueueTrait for ConsumeQueue<MS> {
 
     #[inline]
     fn get(&self, index: i64) -> Option<CqUnit> {
-        match self.iterate_from(index) {
-            None => None,
-            Some(value) => None,
-        }
+        self.iterate_from(index).and_then(|mut iter| iter.next())
     }
 
     #[inline]


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4693
relation: #4645

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected message header timestamp extraction logic to properly handle different network address family configurations, ensuring accurate and reliable timestamp reads from stored messages
  * Resolved a critical message queue retrieval issue where messages were not being properly returned to consumers, restoring full message consumption functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->