### PR TITLE
[ISSUE #4696]🚀Implement RequestCode GetConsumerRunningInfo(307)

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -272,7 +272,11 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
             RequestCode::CleanExpiredConsumequeue => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::DeleteExpiredCommitlog => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::CleanUnusedTopic => Ok(get_unknown_cmd_response(request_code)),
-            RequestCode::GetConsumerRunningInfo => Ok(get_unknown_cmd_response(request_code)),
+            RequestCode::GetConsumerRunningInfo => {
+                self.consumer_request_handler
+                    .get_consumer_running_info(channel, ctx, request_code, request)
+                    .await
+            }
             RequestCode::QueryCorrectionOffset => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::ConsumeMessageDirectly => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::CloneGroupOffset => Ok(get_unknown_cmd_response(request_code)),


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4696 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
`cargo check --all-targets` `cargo clippy --all-features` `cargo test` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broker admin can now retrieve consumer running information for improved monitoring.
  * Enforced minimum client version checks when querying consumers to ensure compatibility.
  * Added request timeout handling and clearer error responses for consumer status queries.
  * Improved broker-to-client invocation for admin operations, with better error mapping and reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->