### PR TITLE
[ISSUE #4699] [Enhancement✨] Replace topic_config_and_queue_mapping encode with ? to avoid panic in TopicRequestHandler#get_topic_config

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -515,9 +515,8 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut response = RemotingCommand::create_response_command();
-        let request_header = request
-            .decode_command_custom_header::<GetTopicConfigRequestHeader>()
-            .unwrap();
+        let request_header =
+            request.decode_command_custom_header::<GetTopicConfigRequestHeader>()?;
         let topic = &request_header.topic;
         let topic_config = self
             .broker_runtime_inner
@@ -547,11 +546,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         let topic_config = (*topic_config.unwrap()).clone();
         let topic_config_and_queue_mapping =
             TopicConfigAndQueueMapping::new(topic_config, topic_queue_mapping_detail);
-        response.set_body_mut_ref(
-            topic_config_and_queue_mapping
-                .encode()
-                .expect("encode TopicConfigAndQueueMapping failed"),
-        );
+        response.set_body_mut_ref(topic_config_and_queue_mapping.encode()?);
         Ok(Some(response))
     }
 
@@ -563,9 +558,8 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut response = RemotingCommand::create_response_command();
-        let request_header = request
-            .decode_command_custom_header::<QueryTopicConsumeByWhoRequestHeader>()
-            .unwrap();
+        let request_header =
+            request.decode_command_custom_header::<QueryTopicConsumeByWhoRequestHeader>()?;
         let topic = request_header.topic.as_ref();
         let mut groups = self
             .broker_runtime_inner


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4699 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in broker admin operations. Invalid headers and encoding failures during topic requests now return proper error responses instead of causing unexpected terminations, enhancing system stability and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->