### PR TITLE
[ISSUE #4723]🧪Add test case for PollingInfoRequestHeader struct

### DIFF
--- a/rocketmq-remoting/src/protocol/header/polling_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/polling_info_request_header.rs
@@ -17,11 +17,13 @@
 
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV2)]
 #[serde(rename_all = "camelCase")]
 pub struct PollingInfoRequestHeader {
     #[required]
@@ -122,5 +124,253 @@ impl TopicRequestHeaderTrait for PollingInfoRequestHeader {
 
     fn set_queue_id(&mut self, queue_id: i32) {
         self.queue_id = queue_id;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::FromMap;
+    use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+    #[test]
+    fn polling_info_request_header_serializes_correctly() {
+        let header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_consumer_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 1,
+            topic_request_header: None,
+        };
+        let map = header.to_map().unwrap();
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("consumerGroup"))
+                .unwrap(),
+            "test_consumer_group"
+        );
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("topic")).unwrap(),
+            "test_topic"
+        );
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("queueId")).unwrap(),
+            "1"
+        );
+    }
+
+    #[test]
+    fn polling_info_request_header_deserializes_correctly() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("consumerGroup"),
+            CheetahString::from_static_str("test_consumer_group"),
+        );
+        map.insert(
+            CheetahString::from_static_str("topic"),
+            CheetahString::from_static_str("test_topic"),
+        );
+        map.insert(
+            CheetahString::from_static_str("queueId"),
+            CheetahString::from_static_str("1"),
+        );
+
+        let header = <PollingInfoRequestHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(header.consumer_group, "test_consumer_group");
+        assert_eq!(header.topic, "test_topic");
+        assert_eq!(header.queue_id, 1);
+        assert!(header.topic_request_header.is_some());
+    }
+
+    #[test]
+    fn polling_info_request_header_handles_invalid_data() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("consumerGroup"),
+            CheetahString::from_static_str("test_consumer_group"),
+        );
+        map.insert(
+            CheetahString::from_static_str("topic"),
+            CheetahString::from_static_str("test_topic"),
+        );
+        map.insert(
+            CheetahString::from_static_str("queueId"),
+            CheetahString::from_static_str("invalid"),
+        );
+
+        let result = <PollingInfoRequestHeader as FromMap>::from(&map);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn topic_request_header_trait_set_and_get_lo() {
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: Some(TopicRequestHeader::default()),
+        };
+
+        header.set_lo(Some(true));
+        assert_eq!(header.lo(), Some(true));
+
+        header.set_lo(Some(false));
+        assert_eq!(header.lo(), Some(false));
+
+        header.set_lo(None);
+        assert_eq!(header.lo(), None);
+
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: None,
+        };
+
+        header.set_lo(Some(true));
+        assert_eq!(header.lo(), None);
+    }
+
+    #[test]
+    fn topic_request_header_trait_set_and_get_topic() {
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: None,
+        };
+
+        header.set_topic(CheetahString::from_static_str("new_topic"));
+        assert_eq!(header.topic(), "new_topic");
+    }
+
+    #[test]
+    fn topic_request_header_trait_set_and_get_broker_name() {
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: Some(TopicRequestHeader {
+                lo: None,
+                rpc: Some(RpcRequestHeader::default()),
+            }),
+        };
+
+        header.set_broker_name(CheetahString::from_static_str("new_broker"));
+        assert_eq!(
+            header.broker_name(),
+            Some(&CheetahString::from_static_str("new_broker"))
+        );
+
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: None,
+        };
+
+        header.set_broker_name(CheetahString::from_static_str("new_broker"));
+        assert_eq!(header.broker_name(), None);
+    }
+
+    #[test]
+    fn topic_request_header_trait_set_and_get_namespace() {
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: Some(TopicRequestHeader {
+                lo: None,
+                rpc: Some(RpcRequestHeader::default()),
+            }),
+        };
+
+        header.set_namespace(CheetahString::from_static_str("new_namespace"));
+        assert_eq!(header.namespace(), Some("new_namespace"));
+
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: None,
+        };
+
+        header.set_namespace(CheetahString::from_static_str("new_namespace"));
+        assert_eq!(header.namespace(), None);
+    }
+
+    #[test]
+    fn topic_request_header_trait_set_and_get_namespaced() {
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: Some(TopicRequestHeader {
+                lo: None,
+                rpc: Some(RpcRequestHeader::default()),
+            }),
+        };
+
+        header.set_namespaced(true);
+        assert_eq!(header.namespaced(), Some(true));
+
+        header.set_namespaced(false);
+        assert_eq!(header.namespaced(), Some(false));
+
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: None,
+        };
+
+        header.set_namespaced(true);
+        assert_eq!(header.namespaced(), None);
+    }
+
+    #[test]
+    fn topic_request_header_trait_set_and_get_oneway() {
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: Some(TopicRequestHeader {
+                lo: None,
+                rpc: Some(RpcRequestHeader::default()),
+            }),
+        };
+
+        header.set_oneway(true);
+        assert_eq!(header.oneway(), Some(true));
+
+        header.set_oneway(false);
+        assert_eq!(header.oneway(), Some(false));
+
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: None,
+        };
+
+        header.set_oneway(true);
+        assert_eq!(header.oneway(), None);
+    }
+
+    #[test]
+    fn topic_request_header_trait_set_and_get_queue_id() {
+        let mut header = PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("test_group"),
+            topic: CheetahString::from_static_str("test_topic"),
+            queue_id: 0,
+            topic_request_header: None,
+        };
+
+        header.set_queue_id(10);
+        assert_eq!(header.queue_id(), 10);
+
+        header.set_queue_id(-1);
+        assert_eq!(header.queue_id(), -1);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4723

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit tests covering serialization/deserialization and accessor/mutator behaviors to improve reliability.

* **Refactor**
  * Enabled standard serialization support for request-header structures to streamline data interchange.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->