### PR TITLE
[ISSUE #4727]🚀Add PeekMessageRequestHeader for message peeking requests

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -55,6 +55,7 @@ pub mod notification_request_header;
 pub mod notification_response_header;
 pub mod notify_broker_role_change_request_header;
 pub mod notify_consumer_ids_changed_request_header;
+pub mod peek_message_request_header;
 pub mod polling_info_request_header;
 pub mod polling_info_response_header;
 pub mod pop_message_request_header;

--- a/rocketmq-remoting/src/protocol/header/peek_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/peek_message_request_header.rs
@@ -1,0 +1,144 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
+use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct PeekMessageRequestHeader {
+    #[required]
+    pub consumer_group: CheetahString,
+
+    #[required]
+    pub topic: CheetahString,
+
+    /// If negative, peek from all queues
+    #[required]
+    pub queue_id: i32,
+
+    #[required]
+    pub max_msg_nums: i32,
+
+    #[serde(flatten)]
+    pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+impl Default for PeekMessageRequestHeader {
+    fn default() -> Self {
+        PeekMessageRequestHeader {
+            consumer_group: CheetahString::new(),
+            topic: CheetahString::new(),
+            queue_id: 0,
+            max_msg_nums: 32,
+            topic_request_header: None,
+        }
+    }
+}
+
+impl TopicRequestHeaderTrait for PeekMessageRequestHeader {
+    fn set_lo(&mut self, lo: Option<bool>) {
+        if let Some(header) = self.topic_request_header.as_mut() {
+            header.lo = lo;
+        }
+    }
+
+    fn lo(&self) -> Option<bool> {
+        self.topic_request_header.as_ref().and_then(|h| h.lo)
+    }
+
+    fn set_topic(&mut self, topic: CheetahString) {
+        self.topic = topic;
+    }
+
+    fn topic(&self) -> &CheetahString {
+        &self.topic
+    }
+
+    fn broker_name(&self) -> Option<&CheetahString> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|h| h.rpc.as_ref())
+            .and_then(|h| h.broker_name.as_ref())
+    }
+
+    fn set_broker_name(&mut self, broker_name: CheetahString) {
+        if let Some(header) = self.topic_request_header.as_mut() {
+            if let Some(rpc_header) = header.rpc.as_mut() {
+                rpc_header.broker_name = Some(broker_name);
+            }
+        }
+    }
+
+    fn namespace(&self) -> Option<&str> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|h| h.rpc.as_ref())
+            .and_then(|r| r.namespace.as_deref())
+    }
+
+    fn set_namespace(&mut self, namespace: CheetahString) {
+        if let Some(header) = self.topic_request_header.as_mut() {
+            if let Some(rpc_header) = header.rpc.as_mut() {
+                rpc_header.namespace = Some(namespace);
+            }
+        }
+    }
+
+    fn namespaced(&self) -> Option<bool> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|h| h.rpc.as_ref())
+            .and_then(|r| r.namespaced)
+    }
+
+    fn set_namespaced(&mut self, namespaced: bool) {
+        if let Some(header) = self.topic_request_header.as_mut() {
+            if let Some(rpc_header) = header.rpc.as_mut() {
+                rpc_header.namespaced = Some(namespaced);
+            }
+        }
+    }
+
+    fn oneway(&self) -> Option<bool> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|h| h.rpc.as_ref())
+            .and_then(|r| r.oneway)
+    }
+
+    fn set_oneway(&mut self, oneway: bool) {
+        if let Some(header) = self.topic_request_header.as_mut() {
+            if let Some(rpc_header) = header.rpc.as_mut() {
+                rpc_header.oneway = Some(oneway);
+            }
+        }
+    }
+
+    fn queue_id(&self) -> i32 {
+        self.queue_id
+    }
+
+    fn set_queue_id(&mut self, queue_id: i32) {
+        self.queue_id = queue_id;
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4727

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message peeking functionality, allowing users to preview messages from specific consumer groups, topics, and queues without consuming them.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->