### PR TITLE
Refactor: remove useless code from get_all_topic_config_response_head…

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_all_topic_config_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_all_topic_config_response_header.rs
@@ -21,18 +21,3 @@ use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
 pub struct GetAllTopicConfigResponseHeader;
-
-// impl CommandCustomHeader for GetAllTopicConfigResponseHeader {
-//     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-//         None
-//     }
-// }
-// impl FromMap for GetAllTopicConfigResponseHeader {
-//     type Error = rocketmq_error::RocketmqError;
-
-//     type Target = Self;
-
-//     fn from(_map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-//         Ok(Self {})
-//     }
-// }


### PR DESCRIPTION
Fixes #4597

Removed redundant, commented-out code from `get_all_topic_config_response_header.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused code to improve codebase cleanliness and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->