### PR TITLE
[ISSUE #4747]🚀Add RpcClientError type for improved error handling in RPC communications

### DIFF
--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -58,6 +58,7 @@ pub mod unified;
 pub use unified::NetworkError;
 pub use unified::ProtocolError;
 pub use unified::RocketMQError;
+pub use unified::RpcClientError;
 pub use unified::SerializationError;
 // Re-export result types (but don't conflict with legacy ones below)
 pub use unified::ServiceError as UnifiedServiceError;

--- a/rocketmq-error/src/unified/mod.rs
+++ b/rocketmq-error/src/unified/mod.rs
@@ -23,6 +23,7 @@
 
 mod network;
 mod protocol;
+mod rpc;
 mod serialization;
 mod tools;
 
@@ -30,6 +31,7 @@ use std::io;
 
 pub use network::NetworkError;
 pub use protocol::ProtocolError;
+pub use rpc::RpcClientError;
 pub use serialization::SerializationError;
 use thiserror::Error;
 pub use tools::ToolsError;
@@ -90,6 +92,13 @@ pub enum RocketMQError {
     /// RocketMQ protocol errors (invalid commands, version mismatch, etc.)
     #[error(transparent)]
     Protocol(#[from] ProtocolError),
+
+    // ============================================================================
+    // RPC Client Errors
+    // ============================================================================
+    /// RPC client specific errors (broker lookup, request failures, etc.)
+    #[error(transparent)]
+    Rpc(#[from] RpcClientError),
 
     // ============================================================================
     // Broker Errors

--- a/rocketmq-error/src/unified/rpc.rs
+++ b/rocketmq-error/src/unified/rpc.rs
@@ -1,0 +1,52 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! RPC client errors with full context preservation
+
+use thiserror::Error;
+
+/// RPC client specific errors with full context preservation
+#[derive(Error, Debug)]
+pub enum RpcClientError {
+    /// Broker address not found in client metadata
+    #[error("Broker '{broker_name}' address not found in client metadata")]
+    BrokerNotFound { broker_name: String },
+
+    /// RPC request failed
+    #[error(
+        "RPC request failed: addr={addr}, request_code={request_code}, timeout={timeout_ms}ms"
+    )]
+    RequestFailed {
+        addr: String,
+        request_code: i32,
+        timeout_ms: u64,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// Unexpected response code received
+    #[error("Unexpected response code: {code} ({code_name})")]
+    UnexpectedResponseCode { code: i32, code_name: String },
+
+    /// Request code not supported by the handler
+    #[error("Request code not supported: {code}")]
+    UnsupportedRequestCode { code: i32 },
+
+    /// RPC error from remote server
+    #[error("RPC error from remote: code={0}, message={1}")]
+    RemoteError(i32, String),
+}


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4747

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive RPC client error handling with specific error variants for broker failures, request timeouts, unexpected response codes, unsupported requests, and remote errors.
  * Integrated RPC client error types into the unified error system for consistent error handling across the crate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->