### PR TITLE
[ISSUE #4751]✨Add some helper methods for RpcClientError

### DIFF
--- a/rocketmq-error/src/unified/rpc.rs
+++ b/rocketmq-error/src/unified/rpc.rs
@@ -50,3 +50,44 @@ pub enum RpcClientError {
     #[error("RPC error from remote: code={0}, message={1}")]
     RemoteError(i32, String),
 }
+
+impl RpcClientError {
+    /// Helper to construct a `BrokerNotFound` error.
+    pub fn broker_not_found(broker_name: impl Into<String>) -> Self {
+        RpcClientError::BrokerNotFound {
+            broker_name: broker_name.into(),
+        }
+    }
+    /// Helper to construct a `RequestFailed` error.
+    pub fn request_failed<E>(
+        addr: impl Into<String>,
+        request_code: i32,
+        timeout_ms: u64,
+        source: E,
+    ) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        RpcClientError::RequestFailed {
+            addr: addr.into(),
+            request_code,
+            timeout_ms,
+            source: Box::new(source),
+        }
+    }
+    /// Helper to construct an `UnexpectedResponseCode` error.
+    pub fn unexpected_response_code(code: i32, code_name: impl Into<String>) -> Self {
+        RpcClientError::UnexpectedResponseCode {
+            code,
+            code_name: code_name.into(),
+        }
+    }
+    /// Helper to construct an `UnsupportedRequestCode` error.
+    pub fn unsupported_request_code(code: i32) -> Self {
+        RpcClientError::UnsupportedRequestCode { code }
+    }
+    /// Helper to construct a `RemoteError`.
+    pub fn remote_error(code: i32, message: impl Into<String>) -> Self {
+        RpcClientError::RemoteError(code, message.into())
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4751

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced RPC error handling with new constructors for common error scenarios: broker not found, request failures, invalid response codes, unsupported requests, and remote errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->