### PR TITLE
[ISSUE #4773]🧪Add test case for AlterSyncStateSetResponseHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/controller/alter_sync_state_set_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/controller/alter_sync_state_set_response_header.rs
@@ -24,3 +24,57 @@ use serde::Serialize;
 pub struct AlterSyncStateSetResponseHeader {
     pub new_sync_state_set_epoch: i32,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use cheetah_string::CheetahString;
+
+    use super::*;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn alter_sync_state_set_response_header_serializes_correctly() {
+        let header = AlterSyncStateSetResponseHeader {
+            new_sync_state_set_epoch: 10,
+        };
+        let map = header.to_map().unwrap();
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("newSyncStateSetEpoch"))
+                .unwrap(),
+            "10"
+        );
+    }
+
+    #[test]
+    fn alter_sync_state_set_response_header_deserializes_correctly() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("newSyncStateSetEpoch"),
+            CheetahString::from_static_str("10"),
+        );
+
+        let header = <AlterSyncStateSetResponseHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(header.new_sync_state_set_epoch, 10);
+    }
+
+    #[test]
+    fn alter_sync_state_set_response_header_default() {
+        let header = AlterSyncStateSetResponseHeader::default();
+        assert_eq!(header.new_sync_state_set_epoch, 0);
+    }
+
+    #[test]
+    fn alter_sync_state_set_response_header_clone() {
+        let header = AlterSyncStateSetResponseHeader {
+            new_sync_state_set_epoch: 10,
+        };
+        let cloned = header.clone();
+        assert_eq!(
+            header.new_sync_state_set_epoch,
+            cloned.new_sync_state_set_epoch
+        );
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4773 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for protocol header serialization, deserialization, and default values to improve code reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->