### PR TITLE
[ISSUE #4801]🚀Add ElectMasterResponseBody struct

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -36,6 +36,7 @@ pub mod consume_message_directly_result;
 pub mod consume_queue_data;
 pub mod consume_status;
 pub mod consumer_offset_serialize_wrapper;
+pub mod elect_master_response_body;
 pub mod epoch_entry_cache;
 pub mod group_list;
 pub mod ha_client_runtime_info;

--- a/rocketmq-remoting/src/protocol/body/elect_master_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/elect_master_response_body.rs
@@ -1,0 +1,30 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use std::collections::HashSet;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ElectMasterResponseBody {
+    pub broker_member_group: Option<BrokerMemberGroup>,
+    pub sync_state_set: HashSet<i64>,
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4801

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added master election response capability to the remoting protocol layer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->