### PR TITLE
[ISSUE #4811]♻️Refactor MappedFileQueue to use ArcSwap for lock-free access to mapped files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,6 +3086,7 @@ name = "rocketmq-store"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bytes",
  "cheetah-string",
  "criterion",

--- a/rocketmq-store/Cargo.toml
+++ b/rocketmq-store/Cargo.toml
@@ -36,6 +36,7 @@ dirs.workspace = true
 
 parking_lot.workspace = true
 bytes.workspace = true
+arc-swap = "1.7"
 
 #tokio
 tokio.workspace = true

--- a/rocketmq-store/benches/commitlog_load_bench.rs
+++ b/rocketmq-store/benches/commitlog_load_bench.rs
@@ -238,7 +238,7 @@ fn bench_post_load_access(c: &mut Criterion) {
     );
     queue.load();
     let files = queue.get_mapped_files();
-    let files_guard = files.read();
+    let files_guard = files.load();
 
     // Benchmark: Sequential reads from first file
     group.bench_function("sequential_read_4KB_blocks", |b| {

--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -636,7 +636,7 @@ impl<MS: MessageStore> FileQueueLifeCycle for ConsumeQueue<MS> {
 
     fn recover(&mut self) {
         let binding = self.mapped_file_queue.get_mapped_files();
-        let mapped_files = binding.read();
+        let mapped_files = binding.load();
         if mapped_files.is_empty() {
             return;
         }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4811

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal synchronization mechanisms for mapped file queue operations, replacing lock-based patterns with copy-on-write semantics to improve efficiency and reduce contention during file access and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->