### PR TITLE
[ISSUE #4831]🚀Add rocketmq-auth module with initial implementation and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocketmq-auth"
+version = "0.8.0"
+
+[[package]]
 name = "rocketmq-broker"
 version = "0.8.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "rocketmq",
+    "rocketmq-auth",
     "rocketmq-broker",
     "rocketmq-cli",
     "rocketmq-client",
@@ -50,6 +51,7 @@ rocketmq-remoting = { version = "0.8.0", path = "./rocketmq-remoting" }
 rocketmq-client-rust = { version = "0.8.0", path = "./rocketmq-client" }
 rocketmq-tools = { version = "0.8.0", path = "./rocketmq-tools" }
 rocketmq-error = { version = "0.8.0", path = "./rocketmq-error" }
+rocketmq-auth = { version = "0.8.0", path = "./rocketmq-auth" }
 
 tokio = { version = "1.48", features = ["full"] }
 tokio-util = { version = "0.7.17", features = ["full"] }
@@ -85,8 +87,8 @@ cfg-if = "1.0.4"
 
 sysinfo = "0.37.2"
 uuid = { version = "1.19.0", features = [
-    "v4",                # Lets you generate random UUIDs
-    "fast-rng",          # Use a faster (but still sufficiently random) RNG
+    "v4", # Lets you generate random UUIDs
+    "fast-rng", # Use a faster (but still sufficiently random) RNG
     "macro-diagnostics",
 ] }
 

--- a/rocketmq-auth/Cargo.toml
+++ b/rocketmq-auth/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rocketmq-auth"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+readme = "README.md"
+description.workspace = true
+rust-version.workspace = true
+
+[dependencies]

--- a/rocketmq-auth/README.md
+++ b/rocketmq-auth/README.md
@@ -1,0 +1,6 @@
+# The Rust Implementation of Apache RocketMQ auth
+
+## Overview
+
+This module is mainly the implementation of the [Apache RocketMQ](https://github.com/apache/rocketmq) auth, containing all the functionalities of the Java
+version rocketmq-auth.

--- a/rocketmq-auth/src/lib.rs
+++ b/rocketmq-auth/src/lib.rs
@@ -1,0 +1,31 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4831

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new authentication module to the RocketMQ Rust client library, providing foundational implementation and configuration.

* **Documentation**
  * Added README documentation for the authentication module describing its role in the Apache RocketMQ Rust implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->