### PR TITLE
[ISSUE #4833]🚀Add rocketmq-proxy module with initial implementation and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocketmq-proxy"
+version = "0.8.0"
+
+[[package]]
 name = "rocketmq-remoting"
 version = "0.8.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
     "rocketmq-example",
     "rocketmq-filter",
     "rocketmq-macros",
-    "rocketmq-namesrv",
+    "rocketmq-namesrv", "rocketmq-proxy",
     "rocketmq-remoting",
     "rocketmq-runtime",
     "rocketmq-store",

--- a/rocketmq-proxy/Cargo.toml
+++ b/rocketmq-proxy/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rocketmq-proxy"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+readme = "README.md"
+description.workspace = true
+rust-version.workspace = true
+
+[dependencies]

--- a/rocketmq-proxy/README.md
+++ b/rocketmq-proxy/README.md
@@ -1,0 +1,7 @@
+# The Rust Implementation of Apache RocketMQ Proxy(GRPC)
+
+## Overview
+
+This module is mainly the implementation of the [Apache RocketMQ](https://github.com/apache/rocketmq) proxy(GRPC), containing all the functionalities of the
+Java
+version rocketmq-proxy.

--- a/rocketmq-proxy/src/lib.rs
+++ b/rocketmq-proxy/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4833

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added rocketmq-proxy crate to workspace with initial configuration and structure

* **Documentation**
  * Added documentation for new RocketMQ Proxy module, a GRPC-based proxy implementation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->