### PR TITLE
[ISSUE #4835]♻️Refactor client metadata handling to use Arc for shared ownership

### DIFF
--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -118,7 +118,7 @@ pub struct BrokerOuterAPI {
     remoting_client: ArcMut<RocketmqDefaultClient<DefaultRemotingRequestProcessor>>,
     name_server_address: Option<String>,
     rpc_client: RpcClientImpl,
-    client_metadata: ClientMetadata,
+    client_metadata: Arc<ClientMetadata>,
 }
 
 impl BrokerOuterAPI {
@@ -127,11 +127,11 @@ impl BrokerOuterAPI {
             tokio_client_config,
             DefaultRemotingRequestProcessor,
         ));
-        let client_metadata = ClientMetadata::new();
+        let client_metadata = Arc::new(ClientMetadata::new());
         Self {
             remoting_client: client.clone(),
             name_server_address: None,
-            rpc_client: RpcClientImpl::new(client_metadata.clone(), client),
+            rpc_client: RpcClientImpl::new(Arc::clone(&client_metadata), client),
             client_metadata,
         }
     }
@@ -144,14 +144,14 @@ impl BrokerOuterAPI {
             tokio_client_config,
             DefaultRemotingRequestProcessor,
         ));
-        let client_metadata = ClientMetadata::new();
+        let client_metadata = Arc::new(ClientMetadata::new());
         if let Some(rpc_hook) = rpc_hook {
             client.register_rpc_hook(rpc_hook);
         }
         Self {
             remoting_client: client.clone(),
             name_server_address: None,
-            rpc_client: RpcClientImpl::new(client_metadata.clone(), client),
+            rpc_client: RpcClientImpl::new(Arc::clone(&client_metadata), client),
             client_metadata,
         }
     }

--- a/rocketmq-remoting/src/rpc/client_metadata.rs
+++ b/rocketmq-remoting/src/rpc/client_metadata.rs
@@ -29,7 +29,6 @@ use crate::protocol::route::topic_route_data::TopicRouteData;
 use crate::protocol::static_topic::topic_queue_info::TopicQueueMappingInfo;
 use crate::protocol::static_topic::topic_queue_mapping_utils::TopicQueueMappingUtils;
 
-#[derive(Default, Clone)]
 pub struct ClientMetadata {
     topic_route_table: Arc<RwLock<HashMap<CheetahString /* Topic */, TopicRouteData>>>,
     topic_end_points_table: Arc<
@@ -56,6 +55,12 @@ pub struct ClientMetadata {
             >,
         >,
     >,
+}
+
+impl Default for ClientMetadata {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ClientMetadata {

--- a/rocketmq-remoting/src/rpc/rpc_client_impl.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_impl.rs
@@ -51,6 +51,7 @@
 //! ```
 
 use std::any::Any;
+use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_queue::MessageQueue;
@@ -120,7 +121,7 @@ impl ResponseConfig {
 /// ```
 pub struct RpcClientImpl {
     /// Client metadata for broker address resolution
-    client_metadata: ClientMetadata,
+    client_metadata: Arc<ClientMetadata>,
     /// Underlying remoting client for network communication
     remoting_client: ArcMut<RocketmqDefaultClient<DefaultRemotingRequestProcessor>>,
     /// Registered client hooks for request interception
@@ -135,7 +136,7 @@ impl RpcClientImpl {
     /// * `client_metadata` - Metadata for broker address resolution
     /// * `remoting_client` - Network client for sending requests
     pub fn new(
-        client_metadata: ClientMetadata,
+        client_metadata: Arc<ClientMetadata>,
         remoting_client: ArcMut<RocketmqDefaultClient<DefaultRemotingRequestProcessor>>,
     ) -> Self {
         RpcClientImpl {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4835

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal memory management for RPC client metadata handling through shared ownership patterns.
  * Simplified default initialization logic for metadata objects.
  * Updated RPC client construction to align with new memory management strategy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->