### PR TITLE
[ISSUE #4851]♻️Refactor send_with_timeout method to accept generic message types implementing MessageTrait

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -695,12 +695,16 @@ impl MQProducer for DefaultMQProducer {
         Ok(result.expect("SendResult should not be None"))
     }
 
-    async fn send_with_timeout(
+    async fn send_with_timeout<M>(
         &mut self,
-        mut msg: Message,
+        mut msg: M,
         timeout: u64,
-    ) -> rocketmq_error::RocketMQResult<SendResult> {
-        msg.topic = self.with_namespace(msg.topic.as_str());
+    ) -> rocketmq_error::RocketMQResult<SendResult>
+    where
+        M: MessageTrait + Send + Sync,
+    {
+        let topic_build = self.with_namespace(msg.get_topic().as_str());
+        msg.set_topic(topic_build);
         let result = self
             .default_mqproducer_impl
             .as_mut()

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -81,11 +81,13 @@ pub trait MQProducer {
     ///
     /// * `rocketmq_error::RocketMQResult<SendResult>` - A result containing the send result or an
     ///   error.
-    async fn send_with_timeout(
+    async fn send_with_timeout<M>(
         &mut self,
-        msg: Message,
+        msg: M,
         timeout: u64,
-    ) -> rocketmq_error::RocketMQResult<SendResult>;
+    ) -> rocketmq_error::RocketMQResult<SendResult>
+    where
+        M: MessageTrait + Send + Sync;
 
     /// Sends a message with a callback.
     ///

--- a/rocketmq-client/src/producer/transaction_mq_producer.rs
+++ b/rocketmq-client/src/producer/transaction_mq_producer.rs
@@ -117,11 +117,14 @@ impl MQProducer for TransactionMQProducer {
         self.default_producer.send(msg).await
     }
 
-    async fn send_with_timeout(
+    async fn send_with_timeout<M>(
         &mut self,
-        msg: Message,
+        msg: M,
         timeout: u64,
-    ) -> rocketmq_error::RocketMQResult<SendResult> {
+    ) -> rocketmq_error::RocketMQResult<SendResult>
+    where
+        M: MessageTrait + Send + Sync,
+    {
         self.default_producer.send_with_timeout(msg, timeout).await
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4851

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Enhancements**
  * Message sending operations across all producer implementations now support custom message types, increasing flexibility and compatibility.
  * Removed restrictions on message type parameters in send operations.

* **Improvements**
  * Unified message handling approach across producer implementations for consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->