### PR TITLE
[ISSUE #4863]♻️Refactor compressor handling to use static references for improved performance and memory efficiency

### DIFF
--- a/rocketmq-client/src/producer/default_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/default_mq_produce_builder.rs
@@ -53,7 +53,7 @@ pub struct DefaultMQProducerBuilder {
     rpc_hook: Option<Arc<dyn RPCHook>>,
     compress_level: Option<i32>,
     compress_type: Option<CompressionType>,
-    compressor: Option<Arc<Box<dyn Compressor + Send + Sync>>>,
+    compressor: Option<&'static (dyn Compressor + Send + Sync)>,
 }
 
 impl DefaultMQProducerBuilder {
@@ -250,7 +250,7 @@ impl DefaultMQProducerBuilder {
     }
 
     #[inline]
-    pub fn compressor(mut self, compressor: Arc<Box<dyn Compressor + Send + Sync>>) -> Self {
+    pub fn compressor(mut self, compressor: &'static (dyn Compressor + Send + Sync)) -> Self {
         self.compressor = Some(compressor);
         self
     }

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -100,7 +100,7 @@ pub struct ProducerConfig {
     rpc_hook: Option<Arc<dyn RPCHook>>,
     compress_level: i32,
     compress_type: CompressionType,
-    compressor: Option<Arc<Box<dyn Compressor + Send + Sync>>>,
+    compressor: Option<&'static (dyn Compressor + Send + Sync)>,
 }
 
 impl ProducerConfig {
@@ -185,8 +185,8 @@ impl ProducerConfig {
         self.compress_type
     }
 
-    pub fn compressor(&self) -> &Option<Arc<Box<dyn Compressor + Send + Sync>>> {
-        &self.compressor
+    pub fn compressor(&self) -> Option<&'static (dyn Compressor + Send + Sync)> {
+        self.compressor
     }
 }
 
@@ -233,9 +233,7 @@ impl Default for ProducerConfig {
                 .parse()
                 .unwrap(),
             compress_type: compression_type,
-            compressor: Some(Arc::new(CompressorFactory::get_compressor(
-                compression_type,
-            ))),
+            compressor: Some(CompressorFactory::get_compressor(compression_type)),
         }
     }
 }
@@ -340,8 +338,8 @@ impl DefaultMQProducer {
         self.producer_config.compress_type
     }
 
-    pub fn compressor(&self) -> &Option<Arc<Box<dyn Compressor + Send + Sync>>> {
-        &self.producer_config.compressor
+    pub fn compressor(&self) -> Option<&'static (dyn Compressor + Send + Sync)> {
+        self.producer_config.compressor
     }
 
     pub fn set_client_config(&mut self, client_config: ClientConfig) {
@@ -458,7 +456,7 @@ impl DefaultMQProducer {
         self.producer_config.compress_type = compress_type;
     }
 
-    pub fn set_compressor(&mut self, compressor: Option<Arc<Box<dyn Compressor + Send + Sync>>>) {
+    pub fn set_compressor(&mut self, compressor: Option<&'static (dyn Compressor + Send + Sync)>) {
         self.producer_config.compressor = compressor;
     }
 

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -1231,7 +1231,6 @@ impl DefaultMQProducerImpl {
                     let data = self
                         .producer_config
                         .compressor()
-                        .as_ref()
                         .unwrap()
                         .compress(body, self.producer_config.compress_level());
                     if let Ok(data) = data {

--- a/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
@@ -57,7 +57,7 @@ pub struct TransactionMQProducerBuilder {
     rpc_hook: Option<Arc<dyn RPCHook>>,
     compress_level: Option<i32>,
     compress_type: Option<CompressionType>,
-    compressor: Option<Arc<Box<dyn Compressor + Send + Sync>>>,
+    compressor: Option<&'static (dyn Compressor + Send + Sync)>,
     transaction_listener: Option<Arc<Box<dyn TransactionListener>>>,
     check_runtime: Option<Arc<RocketMQRuntime>>,
 }
@@ -234,7 +234,7 @@ impl TransactionMQProducerBuilder {
         self
     }
 
-    pub fn compressor(mut self, compressor: Arc<Box<dyn Compressor + Send + Sync>>) -> Self {
+    pub fn compressor(mut self, compressor: &'static (dyn Compressor + Send + Sync)) -> Self {
         self.compressor = Some(compressor);
         self
     }

--- a/rocketmq-common/src/common/compression/compressor_factory.rs
+++ b/rocketmq-common/src/common/compression/compressor_factory.rs
@@ -21,14 +21,20 @@ use crate::common::compression::lz4_compressor::Lz4Compressor;
 use crate::common::compression::zlib_compressor::ZlibCompressor;
 use crate::common::compression::zstd_compressor::ZstdCompressor;
 
+static LZ4_COMPRESSOR: Lz4Compressor = Lz4Compressor;
+static ZLIB_COMPRESSOR: ZlibCompressor = ZlibCompressor;
+static ZSTD_COMPRESSOR: ZstdCompressor = ZstdCompressor;
+
 pub struct CompressorFactory;
 
 impl CompressorFactory {
-    pub fn get_compressor(compressor_type: CompressionType) -> Box<dyn Compressor + Send + Sync> {
+    pub fn get_compressor(
+        compressor_type: CompressionType,
+    ) -> &'static (dyn Compressor + Send + Sync) {
         match compressor_type {
-            CompressionType::LZ4 => Box::new(Lz4Compressor),
-            CompressionType::Zlib => Box::new(ZlibCompressor),
-            CompressionType::Zstd => Box::new(ZstdCompressor),
+            CompressionType::LZ4 => &LZ4_COMPRESSOR,
+            CompressionType::Zlib => &ZLIB_COMPRESSOR,
+            CompressionType::Zstd => &ZSTD_COMPRESSOR,
         }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4863

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored compression algorithm management in message producers using static singleton instances for LZ4, Zlib, and Zstd compressors. This optimization reduces memory overhead from repeated allocations and improves overall resource efficiency. Producer builder and configuration interfaces have been updated to support this more efficient implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->