### PR TITLE
[ISSUE #4803]🧪Add test case for ApplyBrokerIdResponseHeader struct

### DIFF
--- a/rocketmq-remoting/src/protocol/header/controller/apply_broker_id_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/controller/apply_broker_id_response_header.rs
@@ -17,9 +17,80 @@
 
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
 pub struct ApplyBrokerIdResponseHeader {
     pub cluster_name: Option<CheetahString>,
     pub broker_name: Option<CheetahString>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn apply_broker_id_response_header_serializes_correctly() {
+        let header = ApplyBrokerIdResponseHeader {
+            cluster_name: Some(CheetahString::from_static_str("test_cluster")),
+            broker_name: Some(CheetahString::from_static_str("test_broker")),
+        };
+        let map = header.to_map().unwrap();
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("clusterName"))
+                .unwrap(),
+            "test_cluster"
+        );
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("brokerName"))
+                .unwrap(),
+            "test_broker"
+        );
+    }
+
+    #[test]
+    fn apply_broker_id_response_header_deserializes_correctly() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("clusterName"),
+            CheetahString::from_static_str("test_cluster"),
+        );
+        map.insert(
+            CheetahString::from_static_str("brokerName"),
+            CheetahString::from_static_str("test_broker"),
+        );
+        let header = <ApplyBrokerIdResponseHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(
+            header.cluster_name,
+            Some(CheetahString::from_static_str("test_cluster"))
+        );
+        assert_eq!(
+            header.broker_name,
+            Some(CheetahString::from_static_str("test_broker"))
+        );
+    }
+
+    #[test]
+    fn apply_broker_id_response_header_default() {
+        let header = ApplyBrokerIdResponseHeader::default();
+        assert_eq!(header.cluster_name, None);
+        assert_eq!(header.broker_name, None);
+    }
+
+    #[test]
+    fn apply_broker_id_response_header_clone() {
+        let header = ApplyBrokerIdResponseHeader {
+            cluster_name: Some(CheetahString::from_static_str("test_cluster")),
+            broker_name: Some(CheetahString::from_static_str("test_broker")),
+        };
+        let cloned_header = header.clone();
+        assert_eq!(header.cluster_name, cloned_header.cluster_name);
+        assert_eq!(header.broker_name, cloned_header.broker_name);
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4803

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved JSON serialization to use camelCase field names and added default value handling for response objects to improve API compatibility.

* **Tests**
  * Added unit tests covering serialization, deserialization, default values, and cloning to ensure stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->