### PR TITLE
[ISSUE #4804]🧪Add test case for GetNextBrokerIdResponseHeader struct

### DIFF
--- a/rocketmq-remoting/src/protocol/header/controller/get_next_broker_id_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/controller/get_next_broker_id_response_header.rs
@@ -16,17 +16,96 @@
 //  under the License.
 
 use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
 
-#[derive(
-    Debug,
-    Clone,
-    serde::Serialize,
-    serde::Deserialize,
-    Default,
-    rocketmq_macros::RequestHeaderCodecV2,
-)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
 pub struct GetNextBrokerIdResponseHeader {
     pub cluster_name: Option<CheetahString>,
     pub broker_name: Option<CheetahString>,
     pub next_broker_id: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn get_next_broker_id_response_header_serializes_correctly() {
+        let header = GetNextBrokerIdResponseHeader {
+            cluster_name: Some(CheetahString::from_static_str("test_cluster")),
+            broker_name: Some(CheetahString::from_static_str("test_broker")),
+            next_broker_id: Some(12345),
+        };
+        let map = header.to_map().unwrap();
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("clusterName"))
+                .unwrap(),
+            "test_cluster"
+        );
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("brokerName"))
+                .unwrap(),
+            "test_broker"
+        );
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("nextBrokerId"))
+                .unwrap(),
+            "12345"
+        );
+    }
+
+    #[test]
+    fn get_next_broker_id_response_header_deserializes_correctly() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("clusterName"),
+            CheetahString::from_static_str("test_cluster"),
+        );
+        map.insert(
+            CheetahString::from_static_str("brokerName"),
+            CheetahString::from_static_str("test_broker"),
+        );
+        map.insert(
+            CheetahString::from_static_str("nextBrokerId"),
+            CheetahString::from_static_str("12345"),
+        );
+        let header = <GetNextBrokerIdResponseHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(
+            header.cluster_name,
+            Some(CheetahString::from_static_str("test_cluster"))
+        );
+        assert_eq!(
+            header.broker_name,
+            Some(CheetahString::from_static_str("test_broker"))
+        );
+        assert_eq!(header.next_broker_id, Some(12345));
+    }
+
+    #[test]
+    fn get_next_broker_id_response_header_default() {
+        let header = GetNextBrokerIdResponseHeader::default();
+        assert_eq!(header.cluster_name, None);
+        assert_eq!(header.broker_name, None);
+        assert_eq!(header.next_broker_id, None);
+    }
+
+    #[test]
+    fn get_next_broker_id_response_header_clone() {
+        let header = GetNextBrokerIdResponseHeader {
+            cluster_name: Some(CheetahString::from_static_str("test_cluster")),
+            broker_name: Some(CheetahString::from_static_str("test_broker")),
+            next_broker_id: Some(12345),
+        };
+        let cloned = header.clone();
+        assert_eq!(header.cluster_name, cloned.cluster_name);
+        assert_eq!(header.broker_name, cloned.broker_name);
+        assert_eq!(header.next_broker_id, cloned.next_broker_id);
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4804 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted struct metadata and serialization configuration to standardize serialized field naming (camelCase) and simplify derived behaviors.

* **Tests**
  * Added unit tests covering serialization/deserialization, default values, and cloning to improve reliability and prevent regressions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->