### PR TITLE
Refactor: replace lazy_static with OnceLock for SYSTEM_GROUP_SET (fix…

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -20,10 +20,10 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::env;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
-use std::sync::OnceLock;
 use rocketmq_common::common::base::plain_access_config::PlainAccessConfig;
 use rocketmq_common::common::base::service_state::ServiceState;
 use rocketmq_common::common::config::TopicConfig;


### PR DESCRIPTION
Fix #4868 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal system group management: initialization is now deferred until first use and the built‑in set of system groups has been expanded. This reduces startup overhead and improves runtime resource efficiency while preserving existing public behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->