### PR TITLE
[ISSUE #4891]🚀Add event module with EventType enum for standardized event identification and handling

### DIFF
--- a/rocketmq-controller/src/event.rs
+++ b/rocketmq-controller/src/event.rs
@@ -1,0 +1,18 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+pub(crate) mod event_type;

--- a/rocketmq-controller/src/event/event_type.rs
+++ b/rocketmq-controller/src/event/event_type.rs
@@ -1,0 +1,66 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use std::fmt;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[repr(i16)]
+#[allow(clippy::enum_variant_names)]
+pub enum EventType {
+    AlterSyncStateSetEvent = 1,
+    ApplyBrokerIdEvent = 2,
+    ElectMasterEvent = 3,
+    ReadEvent = 4,
+    CleanBrokerDataEvent = 5,
+    UpdateBrokerAddressEvent = 6,
+}
+
+impl EventType {
+    pub fn from_id(id: i16) -> Option<Self> {
+        match id {
+            1 => Some(Self::AlterSyncStateSetEvent),
+            2 => Some(Self::ApplyBrokerIdEvent),
+            3 => Some(Self::ElectMasterEvent),
+            4 => Some(Self::ReadEvent),
+            5 => Some(Self::CleanBrokerDataEvent),
+            6 => Some(Self::UpdateBrokerAddressEvent),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn id(self) -> i16 {
+        self as i16
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::AlterSyncStateSetEvent => "AlterSyncStateSetEvent",
+            Self::ApplyBrokerIdEvent => "ApplyBrokerIdEvent",
+            Self::ElectMasterEvent => "ElectMasterEvent",
+            Self::ReadEvent => "ReadEvent",
+            Self::CleanBrokerDataEvent => "CleanBrokerDataEvent",
+            Self::UpdateBrokerAddressEvent => "UpdateBrokerAddressEvent",
+        }
+    }
+}
+
+impl fmt::Display for EventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}

--- a/rocketmq-controller/src/lib.rs
+++ b/rocketmq-controller/src/lib.rs
@@ -73,6 +73,7 @@
 pub mod config;
 pub(crate) mod elect;
 pub mod error;
+pub(crate) mod event;
 pub(crate) mod heartbeat;
 pub(crate) mod helper;
 pub mod manager;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4891

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal event handling architecture by establishing dedicated module structures for event type management and definitions
  * Introduced comprehensive event type system with conversion mechanisms between identifiers and types, plus standardized display formatting
  * Enhanced underlying infrastructure to provide a robust foundation for future event identification and processing features

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->