### PR TITLE
[ISSUE #4896]🚀Add alter_sync_state_set_event module with AlterSyncStateSetEvent struct for sync state set change events

### DIFF
--- a/rocketmq-controller/src/event.rs
+++ b/rocketmq-controller/src/event.rs
@@ -15,5 +15,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 
+pub(crate) mod alter_sync_state_set_event;
 pub(crate) mod event_message;
 pub(crate) mod event_type;

--- a/rocketmq-controller/src/event/alter_sync_state_set_event.rs
+++ b/rocketmq-controller/src/event/alter_sync_state_set_event.rs
@@ -1,0 +1,55 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use std::collections::HashSet;
+
+use crate::event::event_message::EventMessage;
+use crate::event::event_type::EventType;
+
+#[derive(Debug, Clone)]
+pub struct AlterSyncStateSetEvent {
+    broker_name: String,
+    new_sync_state_set: HashSet<u64>, // BrokerId
+}
+
+impl AlterSyncStateSetEvent {
+    pub fn new(
+        broker_name: impl Into<String>,
+        new_sync_state_set: impl IntoIterator<Item = u64>,
+    ) -> Self {
+        Self {
+            broker_name: broker_name.into(),
+            new_sync_state_set: new_sync_state_set.into_iter().collect(),
+        }
+    }
+
+    #[inline]
+    pub fn broker_name(&self) -> &str {
+        &self.broker_name
+    }
+
+    #[inline]
+    pub fn new_sync_state_set(&self) -> &HashSet<u64> {
+        &self.new_sync_state_set
+    }
+}
+
+impl EventMessage for AlterSyncStateSetEvent {
+    fn get_event_type(&self) -> EventType {
+        EventType::AlterSyncStateSetEvent
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4896

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event support for broker synchronization state modifications, enabling dynamic updates to replica synchronization configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->