### PR TITLE
[ISSUE #4854]♻️Refactor send_message_in_transaction to accept generic message types implementing MessageTrait

### DIFF
--- a/rocketmq-client/examples/transaction/transaction_producer.rs
+++ b/rocketmq-client/examples/transaction/transaction_producer.rs
@@ -58,7 +58,7 @@ pub async fn main() -> RocketMQResult<()> {
     for _ in 0..10 {
         let message = Message::with_tags(TOPIC, TAG, "Hello RocketMQ".as_bytes());
         let send_result = producer
-            .send_message_in_transaction::<()>(message, None)
+            .send_message_in_transaction::<(), _>(message, None)
             .await?;
         println!("send result: {}", send_result);
     }
@@ -85,7 +85,7 @@ impl Default for TransactionListenerImpl {
 impl TransactionListener for TransactionListenerImpl {
     fn execute_local_transaction(
         &self,
-        msg: &Message,
+        msg: &dyn MessageTrait,
         _arg: Option<&(dyn Any + Send + Sync)>,
     ) -> LocalTransactionState {
         let value = self

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -1020,13 +1020,14 @@ impl MQProducer for DefaultMQProducer {
             .await
     }
 
-    async fn send_message_in_transaction<T>(
+    async fn send_message_in_transaction<T, M>(
         &mut self,
-        msg: Message,
+        msg: M,
         arg: Option<T>,
     ) -> rocketmq_error::RocketMQResult<TransactionSendResult>
     where
         T: std::any::Any + Sync + Send,
+        M: MessageTrait + Send + Sync,
     {
         unimplemented!("DefaultMQProducer not support send_message_in_transaction")
     }

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -456,13 +456,14 @@ pub trait MQProducer {
     ///
     /// * `rocketmq_error::RocketMQResult<TransactionSendResult>` - A result containing the
     ///   transaction send result or an error.
-    async fn send_message_in_transaction<T>(
+    async fn send_message_in_transaction<T, M>(
         &mut self,
-        msg: Message,
+        msg: M,
         arg: Option<T>,
     ) -> rocketmq_error::RocketMQResult<TransactionSendResult>
     where
-        T: std::any::Any + Sync + Send;
+        T: std::any::Any + Sync + Send,
+        M: MessageTrait + Send + Sync;
 
     /// Sends a batch of messages.
     ///

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -1849,11 +1849,14 @@ impl DefaultMQProducerImpl {
         }
     }
 
-    pub async fn send_message_in_transaction(
+    pub async fn send_message_in_transaction<M>(
         &mut self,
-        mut msg: Message,
+        mut msg: M,
         arg: Option<Box<dyn Any + Send + Sync>>,
-    ) -> rocketmq_error::RocketMQResult<TransactionSendResult> {
+    ) -> rocketmq_error::RocketMQResult<TransactionSendResult>
+    where
+        M: MessageTrait + Send + Sync,
+    {
         // ignore DelayTimeLevel parameter
         if msg.get_delay_time_level() != 0 {
             MessageAccessor::clear_property(&mut msg, MessageConst::PROPERTY_DELAY_TIME_LEVEL);
@@ -1930,7 +1933,7 @@ impl DefaultMQProducerImpl {
 
     pub async fn end_transaction(
         &mut self,
-        msg: &Message,
+        msg: &dyn MessageTrait,
         send_result: &SendResult,
         local_transaction_state: LocalTransactionState,
     ) -> rocketmq_error::RocketMQResult<()> {

--- a/rocketmq-client/src/producer/transaction_listener.rs
+++ b/rocketmq-client/src/producer/transaction_listener.rs
@@ -18,14 +18,14 @@
 use std::any::Any;
 
 use rocketmq_common::common::message::message_ext::MessageExt;
-use rocketmq_common::common::message::message_single::Message;
+use rocketmq_common::common::message::MessageTrait;
 
 use crate::producer::local_transaction_state::LocalTransactionState;
 
 pub trait TransactionListener: Send + Sync + 'static {
     fn execute_local_transaction(
         &self,
-        msg: &Message,
+        msg: &dyn MessageTrait,
         arg: Option<&(dyn Any + Send + Sync)>,
     ) -> LocalTransactionState;
 

--- a/rocketmq-client/src/producer/transaction_mq_producer.rs
+++ b/rocketmq-client/src/producer/transaction_mq_producer.rs
@@ -329,13 +329,14 @@ impl MQProducer for TransactionMQProducer {
             .await
     }
 
-    async fn send_message_in_transaction<T>(
+    async fn send_message_in_transaction<T, M>(
         &mut self,
-        mut msg: Message,
+        mut msg: M,
         arg: Option<T>,
     ) -> rocketmq_error::RocketMQResult<TransactionSendResult>
     where
         T: std::any::Any + Sync + Send,
+        M: MessageTrait + Send + Sync,
     {
         msg.set_topic(self.default_producer.with_namespace(msg.get_topic()));
         self.default_producer

--- a/rocketmq-common/src/common/message/message_batch.rs
+++ b/rocketmq-common/src/common/message/message_batch.rs
@@ -90,7 +90,6 @@ impl MessageBatch {
             }
 
             if let Some(first_message) = first {
-                let first_message = first.unwrap();
                 if first_message.get_topic() != message.get_topic() {
                     return Err(RocketMQError::illegal_argument(
                         "The topic of the messages in one batch should be the same",


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4854 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced transaction producer to support custom message types, improving API flexibility for developers.
  * Optimized internal message batch processing logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->