### PR TITLE
[ISSUE #4960]🚀Add command module with Args struct for CLI argument parsing using clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,6 +2928,7 @@ dependencies = [
  "bytes",
  "cheetah-string",
  "chrono",
+ "clap",
  "criterion",
  "dashmap",
  "env_logger",

--- a/rocketmq-controller/Cargo.toml
+++ b/rocketmq-controller/Cargo.toml
@@ -65,6 +65,8 @@ rocksdb = { version = "0.24", optional = true }
 
 cheetah-string = { workspace = true }
 
+clap = { version = "4.5.53", features = ["derive"] }
+
 [dev-dependencies]
 criterion = { version = "0.8", features = ["async_tokio"] }
 tempfile = "3.10"

--- a/rocketmq-controller/src/command.rs
+++ b/rocketmq-controller/src/command.rs
@@ -1,0 +1,55 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(
+    author = "mxsm",
+    version = "0.8.0",
+    about = "RocketMQ Controller Server (Rust)",
+    long_about = "RocketMQ Controller Server implemented in Rust.\nResponsible for broker \
+                  metadata management and leader election."
+)]
+pub struct Args {
+    /// Controller configuration file path
+    ///
+    /// Example:
+    ///   --config-file ./conf/controller.toml
+    #[arg(short, long, value_name = "FILE")]
+    pub config_file: Option<PathBuf>,
+
+    /// Print important configuration items and exit
+    #[arg(short = 'p', long = "print-config-item")]
+    pub print_config_item: bool,
+
+    /// NameServer address list
+    ///
+    /// Format:
+    ///   ip:port;ip:port
+    ///
+    /// Example:
+    ///   192.168.0.1:9876;192.168.0.2:9876
+    #[arg(short, long, value_name = "ADDR", default_value = "127.0.0.1:9876")]
+    pub namesrv_addr: String,
+
+    /// Print all configuration items and exit
+    #[arg(long)]
+    pub print_all_config_item: bool,
+}

--- a/rocketmq-controller/src/lib.rs
+++ b/rocketmq-controller/src/lib.rs
@@ -70,6 +70,7 @@
 #![allow(dead_code)]
 #![allow(clippy::module_inception)]
 
+mod command;
 pub mod config;
 pub mod controller;
 pub(crate) mod elect;
@@ -86,6 +87,7 @@ pub mod rpc;
 pub mod storage;
 pub mod task;
 
+pub use command::Args;
 pub use config::ControllerConfig;
 pub use elect::policy::DefaultElectPolicy;
 pub use error::ControllerError;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4960

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added command-line argument support for server configuration, allowing users to specify a configuration file, customize the name server address (defaults to 127.0.0.1:9876), and control configuration output options during startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->