### PR TITLE
[ISSUE #4958] Update naming from "remoting_server" to "name server" in namesrv_bootstrap_server.rs

### DIFF
--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -93,7 +93,7 @@ fn parse_config_file() -> Result<(NamesrvConfig, u32, String)> {
     };
 
     info!(
-        "Rocketmq name remoting_server(Rust) running on: {}:{}",
+        "Rocketmq name server(Rust) running on: {}:{}",
         args.ip, args.port
     );
     Ok((namesrv_config, args.port, args.ip))
@@ -103,10 +103,10 @@ fn parse_config_file() -> Result<(NamesrvConfig, u32, String)> {
 #[command(
     author = "mxsm",
     version = "0.1.0",
-    about = "RocketMQ Name remoting_server(Rust)"
+    about = "RocketMQ Name server(Rust)"
 )]
 struct Args {
-    /// rocketmq name remoting_server port
+    /// rocketmq name server port
     #[arg(
         short,
         long,
@@ -117,7 +117,7 @@ struct Args {
     )]
     port: u32,
 
-    /// rocketmq name remoting_server ip
+    /// rocketmq name server ip
     #[arg(
         short,
         long,


### PR DESCRIPTION
[ISSUE #4958] Update naming from "remoting_server" to "name server" in namesrv_bootstrap_server.rs

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4958 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology in user-facing strings and help text to ensure consistent naming across logs and CLI information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->