### PR TITLE
[ISSUE #4970]🚀Add OpenRaft log store, state machine, and storage modules for RocketMQ controller

### DIFF
--- a/rocketmq-controller/src/lib.rs
+++ b/rocketmq-controller/src/lib.rs
@@ -81,13 +81,13 @@ pub(crate) mod helper;
 pub mod manager;
 pub mod metadata;
 pub mod metrics;
+pub mod openraft;
 pub mod processor;
 pub mod raft;
 pub mod rpc;
 pub mod storage;
 pub mod task;
 pub mod typ;
-
 pub mod protobuf {
     tonic::include_proto!("rocketmq_rust_controller");
 }

--- a/rocketmq-controller/src/openraft.rs
+++ b/rocketmq-controller/src/openraft.rs
@@ -1,0 +1,31 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! OpenRaft implementation modules for RocketMQ Controller
+//!
+//! This module contains the OpenRaft-based implementation for distributed
+//! consensus and metadata management.
+
+mod log_store;
+mod state_machine;
+pub mod storage;
+
+pub use log_store::LogStore;
+pub use state_machine::BrokerMetadata;
+pub use state_machine::StateMachine;
+pub use state_machine::TopicConfig;
+pub use storage::Store;

--- a/rocketmq-controller/src/openraft/log_store.rs
+++ b/rocketmq-controller/src/openraft/log_store.rs
@@ -1,0 +1,204 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! Raft log storage implementation
+//!
+//! This module provides the log storage layer for OpenRaft, handling:
+//! - Log entry persistence
+//! - Vote information storage
+//! - Log compaction and purging
+
+use std::fmt::Debug;
+use std::ops::RangeBounds;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use openraft::storage::RaftLogStorage;
+use openraft::LogState;
+use openraft::OptionalSend;
+use openraft::RaftLogReader;
+use tokio::sync::RwLock;
+
+use crate::typ::LogEntry;
+use crate::typ::LogId;
+use crate::typ::TypeConfig;
+use crate::typ::Vote;
+
+/// In-memory log store for Raft
+///
+/// This implementation stores all log entries in memory using DashMap.
+/// For production use, consider implementing persistent storage.
+#[derive(Debug, Clone)]
+pub struct LogStore {
+    /// Log entries indexed by log index
+    logs: Arc<DashMap<u64, LogEntry>>,
+    /// Last purged log ID
+    last_purged_log_id: Arc<RwLock<Option<LogId>>>,
+    /// Committed log ID
+    committed: Arc<RwLock<Option<LogId>>>,
+    /// Current vote information
+    vote: Arc<RwLock<Option<Vote>>>,
+}
+
+impl Default for LogStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LogStore {
+    /// Create a new log store
+    pub fn new() -> Self {
+        Self {
+            logs: Arc::new(DashMap::new()),
+            last_purged_log_id: Arc::new(RwLock::new(None)),
+            committed: Arc::new(RwLock::new(None)),
+            vote: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Get the last log ID
+    async fn last_log_id(&self) -> Option<LogId> {
+        self.logs.iter().map(|entry| entry.value().log_id).max()
+    }
+
+    /// Get logs in the specified range
+    fn get_log_entries<R: RangeBounds<u64>>(&self, range: R) -> Vec<LogEntry> {
+        use std::ops::Bound;
+
+        let start = match range.start_bound() {
+            Bound::Included(&n) => n,
+            Bound::Excluded(&n) => n + 1,
+            Bound::Unbounded => 0,
+        };
+
+        let mut entries = Vec::new();
+        let mut index = start;
+        loop {
+            match range.end_bound() {
+                Bound::Included(&n) if index > n => break,
+                Bound::Excluded(&n) if index >= n => break,
+                Bound::Unbounded => {}
+                _ => {}
+            }
+
+            if let Some(entry) = self.logs.get(&index) {
+                entries.push(entry.value().clone());
+                index += 1;
+            } else {
+                break;
+            }
+        }
+        entries
+    }
+}
+
+impl RaftLogReader<TypeConfig> for LogStore {
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
+        &mut self,
+        range: RB,
+    ) -> Result<Vec<LogEntry>, std::io::Error> {
+        Ok(self.get_log_entries(range))
+    }
+
+    async fn read_vote(&mut self) -> Result<Option<Vote>, std::io::Error> {
+        Ok(*self.vote.read().await)
+    }
+}
+
+impl RaftLogStorage<TypeConfig> for LogStore {
+    type LogReader = Self;
+
+    async fn get_log_state(&mut self) -> Result<LogState<TypeConfig>, std::io::Error> {
+        let last_purged = *self.last_purged_log_id.read().await;
+        let last_log_id = self.last_log_id().await;
+
+        Ok(LogState {
+            last_purged_log_id: last_purged,
+            last_log_id,
+        })
+    }
+
+    async fn get_log_reader(&mut self) -> Self::LogReader {
+        self.clone()
+    }
+
+    async fn save_vote(&mut self, vote: &Vote) -> Result<(), std::io::Error> {
+        *self.vote.write().await = Some(*vote);
+        Ok(())
+    }
+
+    async fn append<I>(
+        &mut self,
+        entries: I,
+        callback: openraft::storage::IOFlushed<TypeConfig>,
+    ) -> Result<(), std::io::Error>
+    where
+        I: IntoIterator<Item = LogEntry> + OptionalSend,
+        I::IntoIter: OptionalSend,
+    {
+        for entry in entries {
+            let log_id = entry.log_id;
+            self.logs.insert(log_id.index, entry);
+        }
+        callback.io_completed(Ok(())).await;
+        Ok(())
+    }
+
+    async fn truncate(&mut self, log_id: LogId) -> Result<(), std::io::Error> {
+        // Remove all logs with index > log_id.index
+        let keys_to_remove: Vec<u64> = self
+            .logs
+            .iter()
+            .filter_map(|entry| {
+                if entry.key() > &log_id.index {
+                    Some(*entry.key())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for key in keys_to_remove {
+            self.logs.remove(&key);
+        }
+
+        Ok(())
+    }
+
+    async fn purge(&mut self, log_id: LogId) -> Result<(), std::io::Error> {
+        // Remove all logs with index <= log_id.index
+        let keys_to_remove: Vec<u64> = self
+            .logs
+            .iter()
+            .filter_map(|entry| {
+                if entry.key() <= &log_id.index {
+                    Some(*entry.key())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for key in keys_to_remove {
+            self.logs.remove(&key);
+        }
+
+        *self.last_purged_log_id.write().await = Some(log_id);
+        Ok(())
+    }
+}

--- a/rocketmq-controller/src/openraft/state_machine.rs
+++ b/rocketmq-controller/src/openraft/state_machine.rs
@@ -1,0 +1,383 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! Raft state machine implementation
+//!
+//! This module provides the state machine for OpenRaft, handling:
+//! - Applying committed log entries
+//! - Managing broker metadata
+//! - Managing topic configurations
+//! - Snapshot creation and installation
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use openraft::storage::RaftStateMachine;
+use openraft::storage::Snapshot;
+use openraft::EntryPayload;
+use openraft::OptionalSend;
+use openraft::RaftSnapshotBuilder;
+use openraft::StoredMembership;
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+use crate::typ::ControllerRequest;
+use crate::typ::ControllerResponse;
+use crate::typ::LogId;
+use crate::typ::TypeConfig;
+
+/// Broker metadata stored in state machine
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrokerMetadata {
+    pub broker_name: String,
+    pub broker_addr: String,
+    pub broker_id: u64,
+    pub cluster_name: String,
+    pub epoch: i32,
+    pub max_offset: i64,
+    pub election_priority: i64,
+    pub last_heartbeat: i64,
+}
+
+/// Topic configuration stored in state machine
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopicConfig {
+    pub topic_name: String,
+    pub read_queue_nums: i32,
+    pub write_queue_nums: i32,
+    pub perm: i32,
+}
+
+/// Snapshot data structure
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotData {
+    pub brokers: Vec<(String, BrokerMetadata)>,
+    pub topics: Vec<(String, TopicConfig)>,
+    pub configs: Vec<(String, String)>,
+    pub last_applied: Option<LogId>,
+    pub last_membership: Option<StoredMembership<TypeConfig>>,
+}
+
+/// Raft state machine for controller
+///
+/// This stores all the metadata and state for the controller cluster.
+#[derive(Debug, Clone)]
+pub struct StateMachine {
+    /// Broker metadata indexed by broker name
+    brokers: Arc<DashMap<String, BrokerMetadata>>,
+    /// Topic configurations indexed by topic name
+    topics: Arc<DashMap<String, TopicConfig>>,
+    /// Controller configurations
+    configs: Arc<DashMap<String, String>>,
+    /// Last applied log ID
+    last_applied: Arc<RwLock<Option<LogId>>>,
+    /// Last membership configuration
+    last_membership: Arc<RwLock<StoredMembership<TypeConfig>>>,
+}
+
+impl Default for StateMachine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StateMachine {
+    /// Create a new state machine
+    pub fn new() -> Self {
+        Self {
+            brokers: Arc::new(DashMap::new()),
+            topics: Arc::new(DashMap::new()),
+            configs: Arc::new(DashMap::new()),
+            last_applied: Arc::new(RwLock::new(None)),
+            last_membership: Arc::new(RwLock::new(StoredMembership::default())),
+        }
+    }
+
+    /// Apply a request to the state machine
+    fn apply_request(&self, request: &ControllerRequest) -> ControllerResponse {
+        match request {
+            ControllerRequest::RegisterBroker {
+                broker_name,
+                broker_addr,
+                broker_id,
+                cluster_name,
+                epoch,
+                max_offset,
+                election_priority,
+            } => {
+                let metadata = BrokerMetadata {
+                    broker_name: broker_name.clone(),
+                    broker_addr: broker_addr.clone(),
+                    broker_id: *broker_id,
+                    cluster_name: cluster_name.clone(),
+                    epoch: *epoch,
+                    max_offset: *max_offset,
+                    election_priority: *election_priority,
+                    last_heartbeat: chrono::Utc::now().timestamp_millis(),
+                };
+
+                self.brokers.insert(broker_name.clone(), metadata);
+
+                ControllerResponse::RegisterBroker {
+                    success: true,
+                    error: None,
+                    master_addr: Some(broker_addr.clone()),
+                    master_epoch: Some(*epoch),
+                    sync_state_set_epoch: Some(0),
+                }
+            }
+            ControllerRequest::BrokerHeartbeat {
+                broker_name,
+                broker_addr,
+                broker_id,
+                epoch,
+                max_offset,
+                confirm_offset: _,
+                heartbeat_timeout_millis: _,
+            } => {
+                if let Some(mut broker) = self.brokers.get_mut(broker_name) {
+                    broker.broker_addr = broker_addr.clone();
+                    broker.broker_id = *broker_id;
+                    broker.epoch = *epoch;
+                    broker.max_offset = *max_offset;
+                    broker.last_heartbeat = chrono::Utc::now().timestamp_millis();
+
+                    ControllerResponse::BrokerHeartbeat {
+                        success: true,
+                        error: None,
+                        is_master: true,
+                        master_addr: Some(broker_addr.clone()),
+                        master_epoch: Some(*epoch),
+                        sync_state_set_epoch: Some(0),
+                    }
+                } else {
+                    ControllerResponse::BrokerHeartbeat {
+                        success: false,
+                        error: Some(format!("Broker {} not registered", broker_name)),
+                        is_master: false,
+                        master_addr: None,
+                        master_epoch: None,
+                        sync_state_set_epoch: None,
+                    }
+                }
+            }
+            ControllerRequest::UpdateConfig { key, value } => {
+                self.configs.insert(key.clone(), value.clone());
+                ControllerResponse::Success
+            }
+            ControllerRequest::UpdateTopic {
+                topic_name,
+                read_queue_nums,
+                write_queue_nums,
+                perm,
+            } => {
+                let config = TopicConfig {
+                    topic_name: topic_name.clone(),
+                    read_queue_nums: *read_queue_nums,
+                    write_queue_nums: *write_queue_nums,
+                    perm: *perm,
+                };
+
+                self.topics.insert(topic_name.clone(), config);
+                ControllerResponse::Success
+            }
+        }
+    }
+
+    /// Build a snapshot of current state
+    async fn build_snapshot_data(&self) -> SnapshotData {
+        let brokers: Vec<_> = self
+            .brokers
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+
+        let topics: Vec<_> = self
+            .topics
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+
+        let configs: Vec<_> = self
+            .configs
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+
+        let last_applied = *self.last_applied.read().await;
+        let last_membership = self.last_membership.read().await.clone();
+
+        SnapshotData {
+            brokers,
+            topics,
+            configs,
+            last_applied,
+            last_membership: Some(last_membership),
+        }
+    }
+
+    /// Install snapshot data
+    async fn install_snapshot_data(&self, data: SnapshotData) {
+        self.brokers.clear();
+        for (key, value) in data.brokers {
+            self.brokers.insert(key, value);
+        }
+
+        self.topics.clear();
+        for (key, value) in data.topics {
+            self.topics.insert(key, value);
+        }
+
+        self.configs.clear();
+        for (key, value) in data.configs {
+            self.configs.insert(key, value);
+        }
+
+        *self.last_applied.write().await = data.last_applied;
+        *self.last_membership.write().await = data.last_membership.unwrap_or_default();
+    }
+
+    /// Get broker metadata
+    pub fn get_broker(&self, broker_name: &str) -> Option<BrokerMetadata> {
+        self.brokers.get(broker_name).map(|v| v.clone())
+    }
+
+    /// Get all brokers
+    pub fn get_all_brokers(&self) -> Vec<BrokerMetadata> {
+        self.brokers.iter().map(|v| v.value().clone()).collect()
+    }
+
+    /// Get topic config
+    pub fn get_topic(&self, topic_name: &str) -> Option<TopicConfig> {
+        self.topics.get(topic_name).map(|v| v.clone())
+    }
+
+    /// Get all topics
+    pub fn get_all_topics(&self) -> Vec<TopicConfig> {
+        self.topics.iter().map(|v| v.value().clone()).collect()
+    }
+}
+
+impl RaftSnapshotBuilder<TypeConfig> for StateMachine {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, std::io::Error> {
+        let data = self.build_snapshot_data().await;
+        let last_applied = data.last_applied.unwrap_or_default();
+        let last_membership = data.last_membership.clone().unwrap_or_default();
+
+        let snapshot_data = serde_json::to_vec(&data)
+            .map_err(|e| std::io::Error::other(format!("Failed to serialize snapshot: {}", e)))?;
+
+        Ok(Snapshot {
+            meta: openraft::SnapshotMeta {
+                last_log_id: Some(last_applied),
+                last_membership,
+                snapshot_id: format!("snapshot-{}", last_applied.index),
+            },
+            snapshot: snapshot_data,
+        })
+    }
+}
+
+impl RaftStateMachine<TypeConfig> for StateMachine {
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(
+        &mut self,
+    ) -> Result<(Option<LogId>, StoredMembership<TypeConfig>), std::io::Error> {
+        let last_applied = *self.last_applied.read().await;
+        let last_membership = self.last_membership.read().await.clone();
+        Ok((last_applied, last_membership))
+    }
+
+    #[tracing::instrument(level = "trace", skip(self, entries))]
+    async fn apply<Strm>(&mut self, entries: Strm) -> Result<(), std::io::Error>
+    where
+        Strm: futures::Stream<
+                Item = Result<openraft::storage::EntryResponder<TypeConfig>, std::io::Error>,
+            > + Unpin
+            + OptionalSend,
+    {
+        use futures::StreamExt;
+
+        futures::pin_mut!(entries);
+
+        while let Some(entry_result) = entries.next().await {
+            let (entry, responder) = entry_result?;
+            let log_id = entry.log_id;
+            tracing::debug!("Applying entry to state machine: {}", log_id);
+
+            *self.last_applied.write().await = Some(log_id);
+
+            let response = match entry.payload {
+                EntryPayload::Blank => ControllerResponse::Success,
+                EntryPayload::Normal(ref request) => self.apply_request(request),
+                EntryPayload::Membership(ref membership) => {
+                    *self.last_membership.write().await =
+                        StoredMembership::new(Some(log_id), membership.clone());
+                    ControllerResponse::Success
+                }
+            };
+
+            if let Some(tx) = responder {
+                tx.send(response);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        Self {
+            brokers: self.brokers.clone(),
+            topics: self.topics.clone(),
+            configs: self.configs.clone(),
+            last_applied: self.last_applied.clone(),
+            last_membership: self.last_membership.clone(),
+        }
+    }
+
+    async fn begin_receiving_snapshot(&mut self) -> Result<Vec<u8>, std::io::Error> {
+        Ok(Vec::new())
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        meta: &openraft::SnapshotMeta<TypeConfig>,
+        snapshot: Vec<u8>,
+    ) -> Result<(), std::io::Error> {
+        let snapshot_data: SnapshotData = serde_json::from_slice(&snapshot).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Failed to deserialize snapshot: {}", e),
+            )
+        })?;
+
+        self.install_snapshot_data(snapshot_data).await;
+
+        tracing::info!("Installed snapshot at {:?}", meta.last_log_id);
+        Ok(())
+    }
+
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> Result<Option<Snapshot<TypeConfig>>, std::io::Error> {
+        // For simplicity, we don't keep snapshots in memory
+        // In production, you might want to cache the last snapshot
+        Ok(None)
+    }
+}

--- a/rocketmq-controller/src/openraft/storage.rs
+++ b/rocketmq-controller/src/openraft/storage.rs
@@ -1,0 +1,50 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! Storage layer for OpenRaft
+//!
+//! This module provides the storage implementation for OpenRaft,
+//! including log storage and state machine.
+
+use super::log_store::LogStore;
+use super::state_machine::StateMachine;
+
+/// Combined store containing both log store and state machine
+///
+/// In OpenRaft 0.10, the log store and state machine are separate components
+/// that are passed to Raft::new() independently.
+#[derive(Clone)]
+pub struct Store {
+    pub log_store: LogStore,
+    pub state_machine: StateMachine,
+}
+
+impl Store {
+    /// Create a new store
+    pub fn new() -> Self {
+        Self {
+            log_store: LogStore::new(),
+            state_machine: StateMachine::new(),
+        }
+    }
+}
+
+impl Default for Store {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rocketmq-controller/src/typ.rs
+++ b/rocketmq-controller/src/typ.rs
@@ -142,8 +142,8 @@ pub type Raft = openraft::Raft<TypeConfig>;
 /// Type alias for Raft configuration
 pub type RaftConfig = openraft::Config;
 
-/// Type alias for log ID
-pub type LogId = openraft::LogId<NodeId>;
+/// Type alias for log ID (using TypeConfig)
+pub type LogId = openraft::LogId<TypeConfig>;
 
 /// Type alias for log entry
 pub type LogEntry = openraft::Entry<TypeConfig>;
@@ -151,8 +151,8 @@ pub type LogEntry = openraft::Entry<TypeConfig>;
 /// Type alias for committed log entry
 pub type CommittedLogEntry = openraft::entry::Entry<TypeConfig>;
 
-/// Type alias for vote
-pub type Vote = openraft::Vote<NodeId>;
+/// Type alias for vote (using TypeConfig)
+pub type Vote = openraft::Vote<TypeConfig>;
 
 /// Type alias for Raft metrics
 pub type RaftMetrics = openraft::metrics::RaftMetrics<TypeConfig>;


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4970

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated OpenRaft module enabling distributed Raft consensus for controller operations.
  * Implemented log storage and state machine for managing broker metadata, topic configurations, and cluster settings.
  * Added snapshot support for persistent state management and recovery capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->