### PR TITLE
[ISSUE #4972]🚀Add OpenRaft network and node management modules

### DIFF
--- a/rocketmq-controller/src/openraft.rs
+++ b/rocketmq-controller/src/openraft.rs
@@ -21,10 +21,15 @@
 //! consensus and metadata management.
 
 mod log_store;
+mod network;
+mod node;
 mod state_machine;
 pub mod storage;
 
 pub use log_store::LogStore;
+pub use network::NetworkConnection;
+pub use network::NetworkFactory;
+pub use node::RaftNodeManager;
 pub use state_machine::BrokerMetadata;
 pub use state_machine::StateMachine;
 pub use state_machine::TopicConfig;

--- a/rocketmq-controller/src/openraft/network.rs
+++ b/rocketmq-controller/src/openraft/network.rs
@@ -1,0 +1,210 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! OpenRaft network implementation
+//!
+//! Provides RPC-based communication between Raft nodes.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use openraft::error::InstallSnapshotError;
+use openraft::error::NetworkError;
+use openraft::error::RPCError;
+use openraft::error::RaftError;
+use openraft::network::RPCOption;
+use openraft::network::RaftNetwork;
+use openraft::network::RaftNetworkFactory;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::AppendEntriesResponse;
+use openraft::raft::InstallSnapshotRequest;
+use openraft::raft::InstallSnapshotResponse;
+use openraft::raft::VoteRequest;
+use openraft::raft::VoteResponse;
+use tokio::sync::RwLock;
+use tracing::debug;
+
+use crate::typ::Node;
+use crate::typ::NodeId;
+use crate::typ::TypeConfig;
+
+/// Network connection to a single Raft node
+#[derive(Clone)]
+pub struct NetworkConnection {
+    /// Target node
+    target: NodeId,
+
+    /// Target address
+    target_addr: String,
+
+    /// gRPC client (placeholder for actual implementation)
+    /// In production, this would be a tonic gRPC client
+    client: Arc<RwLock<Option<()>>>,
+}
+
+impl NetworkConnection {
+    /// Create a new network connection
+    pub fn new(target: NodeId, target_addr: String) -> Self {
+        Self {
+            target,
+            target_addr,
+            client: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Send a request and get response
+    async fn send_rpc<Req, Resp, Err, F>(
+        &self,
+        _req: Req,
+        _handler: F,
+    ) -> Result<Resp, RPCError<TypeConfig, Err>>
+    where
+        F: FnOnce() -> Resp,
+        Err: std::error::Error + 'static,
+    {
+        // TODO: Implement actual gRPC call
+        // For now, return a network error indicating not implemented
+        Err(RPCError::Network(NetworkError::new(&std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            format!(
+                "RPC not implemented for node {} at {}",
+                self.target, self.target_addr
+            ),
+        ))))
+    }
+}
+
+impl RaftNetwork<TypeConfig> for NetworkConnection {
+    async fn append_entries(
+        &mut self,
+        req: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<TypeConfig, RaftError<TypeConfig>>>
+    {
+        debug!(
+            "Sending append_entries to node {}: prev_log_id={:?}, entries={}",
+            self.target,
+            req.prev_log_id,
+            req.entries.len()
+        );
+
+        self.send_rpc(req, || {
+            // Placeholder response
+            AppendEntriesResponse::Success
+        })
+        .await
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        req: InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<
+        InstallSnapshotResponse<TypeConfig>,
+        RPCError<TypeConfig, RaftError<TypeConfig, InstallSnapshotError>>,
+    > {
+        debug!(
+            "Sending install_snapshot to node {}: meta={:?}",
+            self.target, req.meta
+        );
+
+        self.send_rpc(req, || {
+            // Placeholder response
+            InstallSnapshotResponse {
+                vote: Default::default(),
+            }
+        })
+        .await
+    }
+
+    async fn vote(
+        &mut self,
+        req: VoteRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<TypeConfig>, RPCError<TypeConfig, RaftError<TypeConfig>>> {
+        debug!(
+            "Sending vote request to node {}: vote={:?}, last_log_id={:?}",
+            self.target, req.vote, req.last_log_id
+        );
+
+        self.send_rpc(req, || {
+            // Placeholder response
+            VoteResponse {
+                vote: Default::default(),
+                vote_granted: false,
+                last_log_id: None,
+            }
+        })
+        .await
+    }
+}
+
+/// Network factory for creating connections to Raft nodes
+#[derive(Clone)]
+pub struct NetworkFactory {
+    /// Node addresses
+    peer_addrs: Arc<RwLock<HashMap<NodeId, String>>>,
+}
+
+impl NetworkFactory {
+    /// Create a new network factory
+    pub fn new() -> Self {
+        Self {
+            peer_addrs: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Add a peer address
+    pub async fn add_peer(&self, node_id: NodeId, addr: String) {
+        self.peer_addrs.write().await.insert(node_id, addr);
+    }
+
+    /// Remove a peer
+    pub async fn remove_peer(&self, node_id: NodeId) {
+        self.peer_addrs.write().await.remove(&node_id);
+    }
+
+    /// Get all peer addresses
+    pub async fn get_peers(&self) -> HashMap<NodeId, String> {
+        self.peer_addrs.read().await.clone()
+    }
+}
+
+impl Default for NetworkFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RaftNetworkFactory<TypeConfig> for NetworkFactory {
+    type Network = NetworkConnection;
+
+    async fn new_client(&mut self, target: NodeId, _node: &Node) -> Self::Network {
+        let peer_addrs = self.peer_addrs.read().await;
+        let target_addr = peer_addrs
+            .get(&target)
+            .cloned()
+            .unwrap_or_else(|| format!("unknown-{}", target));
+
+        debug!(
+            "Creating network connection to node {} at {}",
+            target, target_addr
+        );
+
+        NetworkConnection::new(target, target_addr)
+    }
+}

--- a/rocketmq-controller/src/openraft/node.rs
+++ b/rocketmq-controller/src/openraft/node.rs
@@ -1,0 +1,195 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! OpenRaft node management
+//!
+//! Provides high-level interface for managing Raft nodes.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use openraft::Config;
+use tracing::info;
+
+use crate::config::ControllerConfig;
+use crate::error::ControllerError;
+use crate::error::Result;
+use crate::openraft::NetworkFactory;
+use crate::openraft::Store;
+use crate::typ::Node;
+use crate::typ::NodeId;
+use crate::typ::Raft;
+
+/// OpenRaft node manager
+///
+/// Manages the lifecycle of an OpenRaft node including:
+/// - Raft instance initialization
+/// - Cluster membership management
+/// - State queries and modifications
+pub struct RaftNodeManager {
+    /// Node ID
+    node_id: NodeId,
+
+    /// Raft instance
+    raft: Raft,
+
+    /// Storage
+    store: Arc<Store>,
+}
+
+impl RaftNodeManager {
+    /// Create a new Raft node manager
+    pub async fn new(config: Arc<ControllerConfig>) -> Result<Self> {
+        let node_id = config.node_id;
+
+        // Create storage
+        let store = Arc::new(Store::new());
+
+        // Create network factory
+        let network = NetworkFactory::new();
+
+        // Add peer addresses
+        for peer in &config.raft_peers {
+            network.add_peer(peer.id, peer.addr.to_string()).await;
+        }
+
+        // Configure OpenRaft
+        let raft_config = Config {
+            heartbeat_interval: config.heartbeat_interval_ms,
+            election_timeout_min: config.election_timeout_ms,
+            election_timeout_max: config.election_timeout_ms * 2,
+            max_in_snapshot_log_to_keep: 1000,
+            snapshot_policy: openraft::SnapshotPolicy::LogsSinceLast(5000),
+            ..Default::default()
+        };
+
+        let raft_config = Arc::new(
+            raft_config
+                .validate()
+                .map_err(|e| ControllerError::Internal(format!("Invalid Raft config: {}", e)))?,
+        );
+
+        // Create Raft instance
+        let raft = openraft::Raft::new(
+            node_id,
+            raft_config,
+            network,
+            store.log_store.clone(),
+            store.state_machine.clone(),
+        )
+        .await
+        .map_err(|e| ControllerError::Internal(format!("Failed to create Raft: {}", e)))?;
+
+        info!("Created OpenRaft node with ID: {}", node_id);
+
+        Ok(Self {
+            node_id,
+            raft,
+            store,
+        })
+    }
+
+    /// Initialize the cluster (called on the first node only)
+    pub async fn initialize_cluster(&self, nodes: BTreeMap<NodeId, Node>) -> Result<()> {
+        info!("Initializing Raft cluster with {} nodes", nodes.len());
+
+        self.raft.initialize(nodes).await.map_err(|e| {
+            ControllerError::Internal(format!("Failed to initialize cluster: {}", e))
+        })?;
+
+        info!("Raft cluster initialized successfully");
+        Ok(())
+    }
+
+    /// Add a learner node to the cluster
+    pub async fn add_learner(&self, node_id: NodeId, node: Node, blocking: bool) -> Result<()> {
+        info!("Adding learner node {} to cluster", node_id);
+
+        self.raft
+            .add_learner(node_id, node, blocking)
+            .await
+            .map_err(|e| ControllerError::Internal(format!("Failed to add learner: {}", e)))?;
+
+        info!("Learner node {} added successfully", node_id);
+        Ok(())
+    }
+
+    /// Change cluster membership
+    pub async fn change_membership(&self, members: BTreeSet<NodeId>, retain: bool) -> Result<()> {
+        info!(
+            "Changing cluster membership: members={:?}, retain={}",
+            members, retain
+        );
+
+        self.raft
+            .change_membership(members, retain)
+            .await
+            .map_err(|e| {
+                ControllerError::Internal(format!("Failed to change membership: {}", e))
+            })?;
+
+        info!("Cluster membership changed successfully");
+        Ok(())
+    }
+
+    /// Check if this node is the leader
+    pub async fn is_leader(&self) -> Result<bool> {
+        let metrics = self.raft.metrics().borrow().clone();
+        Ok(metrics.current_leader == Some(self.node_id))
+    }
+
+    /// Get current leader ID
+    pub async fn get_leader(&self) -> Result<Option<NodeId>> {
+        let metrics = self.raft.metrics().borrow().clone();
+        Ok(metrics.current_leader)
+    }
+
+    /// Submit a client write request
+    pub async fn client_write(
+        &self,
+        request: crate::typ::ControllerRequest,
+    ) -> Result<crate::typ::ClientWriteResponse> {
+        self.raft
+            .client_write(request)
+            .await
+            .map_err(|e| ControllerError::Internal(format!("Client write failed: {}", e)))
+    }
+
+    /// Get the Raft instance
+    pub fn raft(&self) -> &Raft {
+        &self.raft
+    }
+
+    /// Get the storage
+    pub fn store(&self) -> Arc<Store> {
+        self.store.clone()
+    }
+
+    /// Shutdown the Raft node
+    pub async fn shutdown(&self) -> Result<()> {
+        info!("Shutting down Raft node {}", self.node_id);
+
+        self.raft
+            .shutdown()
+            .await
+            .map_err(|e| ControllerError::Internal(format!("Shutdown failed: {}", e)))?;
+
+        info!("Raft node {} shut down successfully", self.node_id);
+        Ok(())
+    }
+}

--- a/rocketmq-controller/src/typ.rs
+++ b/rocketmq-controller/src/typ.rs
@@ -133,7 +133,7 @@ openraft::declare_raft_types!(
         D = ControllerRequest,
         R = ControllerResponse,
         Node = Node,
-        SnapshotData = Vec<u8>,
+        SnapshotData = std::io::Cursor<Vec<u8>>,
 );
 
 /// Type alias for the Raft instance


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4972

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive Raft cluster management capabilities, including cluster initialization, dynamic membership changes, and learner node addition.
  * Added leadership status querying to determine current leaders and leadership eligibility.
  * Added client write operations for submitting requests to the distributed Raft cluster.
  * Added graceful shutdown functionality for the Raft node.
  * Enhanced network connectivity layer with peer address management and network connection handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->