### PR TITLE
[ISSUE #4974]🚀Add OpenRaft gRPC network client/server, protobuf definitions, and integration tests; refactor network module for gRPC support

### DIFF
--- a/rocketmq-controller/build.rs
+++ b/rocketmq-controller/build.rs
@@ -20,7 +20,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
-        .compile_protos(&["proto/raft.proto", "proto/controller.proto"], &["proto/"])?;
+        .compile_protos(
+            &[
+                "proto/raft.proto",
+                "proto/controller.proto",
+                "proto/openraft.proto",
+            ],
+            &["proto/"],
+        )?;
 
     Ok(())
 }

--- a/rocketmq-controller/examples/single_node.rs
+++ b/rocketmq-controller/examples/single_node.rs
@@ -1,0 +1,167 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! Example: Single-node Raft cluster
+//!
+//! This example demonstrates how to create and run a single-node OpenRaft cluster.
+//! It shows:
+//! - Node initialization
+//! - Cluster setup
+//! - Leader election
+//! - Client write operations
+//! - State queries
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use rocketmq_controller::config::ControllerConfig;
+use rocketmq_controller::openraft::RaftNodeManager;
+use rocketmq_controller::typ::ControllerRequest;
+use rocketmq_controller::typ::Node;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize logging
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    println!("=== OpenRaft Single Node Example ===\n");
+
+    // Step 1: Create configuration
+    println!("1. Creating node configuration...");
+    let node_id = 1;
+    let listen_addr = "127.0.0.1:9876".parse()?;
+
+    let config = Arc::new(
+        ControllerConfig::new(node_id, listen_addr)
+            .with_election_timeout_ms(1000)
+            .with_heartbeat_interval_ms(300),
+    );
+    println!("   Node ID: {}", node_id);
+    println!("   Listen Address: {}", listen_addr);
+    println!();
+
+    // Step 2: Create Raft node
+    println!("2. Creating Raft node...");
+    let node = RaftNodeManager::new(config).await?;
+    println!("   ✓ Node created successfully");
+    println!();
+
+    // Step 3: Initialize single-node cluster
+    println!("3. Initializing single-node cluster...");
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        node_id,
+        Node {
+            node_id,
+            rpc_addr: listen_addr.to_string(),
+        },
+    );
+
+    node.initialize_cluster(nodes).await?;
+    println!("   ✓ Cluster initialized");
+    println!();
+
+    // Step 4: Wait for leader election
+    println!("4. Waiting for leader election...");
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let is_leader = node.is_leader().await?;
+    println!("   Is Leader: {}", is_leader);
+
+    if is_leader {
+        println!("   ✓ This node is now the leader");
+    } else {
+        println!("   ✗ Leader election did not complete");
+    }
+    println!();
+
+    // Step 5: Perform some client writes
+    println!("5. Performing client write operations...");
+
+    // Register a broker
+    let register_request = ControllerRequest::RegisterBroker {
+        cluster_name: "DefaultCluster".to_string(),
+        broker_addr: "127.0.0.1:10911".to_string(),
+        broker_name: "broker-a".to_string(),
+        broker_id: 0,
+        epoch: 0,
+        max_offset: 0,
+        election_priority: 0,
+    };
+
+    println!("   Writing: Register broker 'broker-a'");
+    match node.client_write(register_request).await {
+        Ok(response) => {
+            println!("   ✓ Write succeeded: {:?}", response.data);
+        }
+        Err(e) => {
+            println!("   ✗ Write failed: {}", e);
+        }
+    }
+    println!();
+
+    // Create a topic
+    let create_topic = ControllerRequest::UpdateTopic {
+        topic_name: "test-topic".to_string(),
+        read_queue_nums: 4,
+        write_queue_nums: 4,
+        perm: 6,
+    };
+
+    println!("   Writing: Create topic 'test-topic'");
+    match node.client_write(create_topic).await {
+        Ok(response) => {
+            println!("   ✓ Write succeeded: {:?}", response.data);
+        }
+        Err(e) => {
+            println!("   ✗ Write failed: {}", e);
+        }
+    }
+    println!();
+
+    // Step 6: Query state
+    println!("6. Querying cluster state...");
+    let store = node.store();
+
+    let all_brokers = store.state_machine.get_all_brokers();
+    println!("   Registered Brokers: {}", all_brokers.len());
+    for broker in all_brokers {
+        println!("     - {}: {}", broker.broker_name, broker.broker_addr);
+    }
+
+    let all_topics = store.state_machine.get_all_topics();
+    println!("   Registered Topics: {}", all_topics.len());
+    for topic in all_topics {
+        println!(
+            "     - {}: {} queues",
+            topic.topic_name, topic.read_queue_nums
+        );
+    }
+    println!();
+
+    // Step 7: Shutdown
+    println!("7. Shutting down...");
+    node.shutdown().await?;
+    println!("   ✓ Node shut down gracefully");
+    println!();
+
+    println!("=== Example Complete ===");
+
+    Ok(())
+}

--- a/rocketmq-controller/examples/three_node_cluster.rs
+++ b/rocketmq-controller/examples/three_node_cluster.rs
@@ -1,0 +1,189 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! Example: Three-node Raft cluster
+//!
+//! This example demonstrates how to create and run a three-node OpenRaft cluster.
+//! Run this example with different node IDs to start different nodes:
+//!
+//! ```bash
+//! # Terminal 1
+//! cargo run --example three_node_cluster -- --node-id 1
+//!
+//! # Terminal 2
+//! cargo run --example three_node_cluster -- --node-id 2
+//!
+//! # Terminal 3
+//! cargo run --example three_node_cluster -- --node-id 3
+//! ```
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_controller::config::ControllerConfig;
+use rocketmq_controller::config::RaftPeer;
+use rocketmq_controller::openraft::RaftNodeManager;
+use rocketmq_controller::typ::ControllerRequest;
+use rocketmq_controller::typ::Node;
+
+#[derive(Parser, Debug)]
+#[clap(name = "three-node-cluster")]
+struct Args {
+    /// Node ID (1, 2, or 3)
+    #[clap(long, default_value = "1")]
+    node_id: u64,
+
+    /// Initialize cluster (only for node 1)
+    #[clap(long)]
+    init: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    // Initialize logging
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    println!("=== OpenRaft Three-Node Cluster ===");
+    println!("Node ID: {}", args.node_id);
+    println!();
+
+    // Define cluster topology
+    let peers = vec![
+        RaftPeer {
+            id: 1,
+            addr: "127.0.0.1:9876".parse()?,
+        },
+        RaftPeer {
+            id: 2,
+            addr: "127.0.0.1:9877".parse()?,
+        },
+        RaftPeer {
+            id: 3,
+            addr: "127.0.0.1:9878".parse()?,
+        },
+    ];
+
+    let current_peer = peers
+        .iter()
+        .find(|p| p.id == args.node_id)
+        .ok_or("Invalid node ID")?;
+
+    // Create configuration
+    let config = Arc::new(
+        ControllerConfig::new(args.node_id, current_peer.addr)
+            .with_election_timeout_ms(1000)
+            .with_heartbeat_interval_ms(300)
+            .with_raft_peers(peers.clone()),
+    );
+
+    // Create Raft node
+    println!("Creating Raft node...");
+    let node = RaftNodeManager::new(config).await?;
+    println!("✓ Node created");
+    println!();
+
+    // If this is node 1 and --init flag is set, initialize the cluster
+    if args.node_id == 1 && args.init {
+        println!("Initializing cluster...");
+
+        let mut nodes = BTreeMap::new();
+        for peer in &peers {
+            nodes.insert(
+                peer.id,
+                Node {
+                    node_id: peer.id,
+                    rpc_addr: peer.addr.to_string(),
+                },
+            );
+        }
+
+        node.initialize_cluster(nodes).await?;
+        println!("✓ Cluster initialized");
+        println!();
+    } else if args.node_id != 1 {
+        // Non-leader nodes: add as learner and wait to join
+        println!("Waiting to join cluster...");
+        println!("(Node 1 should be started with --init flag first)");
+        println!();
+    }
+
+    // Wait a bit for leader election
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    // Check leadership
+    let is_leader = node.is_leader().await?;
+    let leader_id = node.get_leader().await?;
+
+    println!("Cluster Status:");
+    println!("  Is Leader: {}", is_leader);
+    println!("  Current Leader: {:?}", leader_id);
+    println!();
+
+    // If this is the leader, perform some writes
+    if is_leader {
+        println!("This node is the leader. Performing test writes...");
+
+        // Register a broker
+        let register_request = ControllerRequest::RegisterBroker {
+            cluster_name: "DefaultCluster".to_string(),
+            broker_addr: "127.0.0.1:10911".to_string(),
+            broker_name: format!("broker-from-node-{}", args.node_id),
+            broker_id: 0,
+            epoch: 0,
+            max_offset: 0,
+            election_priority: 0,
+        };
+
+        match node.client_write(register_request).await {
+            Ok(response) => {
+                println!("✓ Broker registered: {:?}", response.data);
+            }
+            Err(e) => {
+                println!("✗ Write failed: {}", e);
+            }
+        }
+        println!();
+    }
+
+    // Query state
+    let store = node.store();
+    let all_brokers = store.state_machine.get_all_brokers();
+    println!("Cluster Data:");
+    println!("  Brokers: {}", all_brokers.len());
+    for broker in all_brokers {
+        println!("    - {}: {}", broker.broker_name, broker.broker_addr);
+    }
+    println!();
+
+    // Keep the node running
+    println!("Node is running. Press Ctrl+C to stop.");
+    println!();
+
+    // Wait for shutdown signal
+    tokio::signal::ctrl_c().await?;
+
+    println!("\nShutting down...");
+    node.shutdown().await?;
+    println!("✓ Node shut down gracefully");
+
+    Ok(())
+}

--- a/rocketmq-controller/proto/openraft.proto
+++ b/rocketmq-controller/proto/openraft.proto
@@ -1,0 +1,89 @@
+syntax = "proto3";
+
+package rocketmq_rust_controller.openraft;
+
+// OpenRaft RPC service
+service OpenRaftService {
+  // Append entries RPC
+  rpc AppendEntries(OpenRaftAppendRequest) returns (OpenRaftAppendResponse);
+  
+  // Vote RPC for leader election
+  rpc Vote(OpenRaftVoteRequest) returns (OpenRaftVoteResponse);
+  
+  // Install snapshot RPC
+  rpc InstallSnapshot(stream OpenRaftSnapshotRequest) returns (OpenRaftSnapshotResponse);
+}
+
+// LogId represents a unique log entry identifier
+message OpenRaftLogId {
+  uint64 leader_id = 1;
+  uint64 index = 2;
+}
+
+// Vote information
+message OpenRaftVote {
+  uint64 term = 1;
+  uint64 node_id = 2;
+  bool committed = 3;
+}
+
+// Node information
+message OpenRaftNode {
+  string addr = 1;
+  map<string, string> data = 2;
+}
+
+// Log entry for replication
+message OpenRaftLogEntry {
+  OpenRaftLogId log_id = 1;
+  bytes payload = 2;
+}
+
+// Append entries request
+message OpenRaftAppendRequest {
+  OpenRaftVote vote = 1;
+  optional OpenRaftLogId prev_log_id = 2;
+  repeated OpenRaftLogEntry entries = 3;
+  optional OpenRaftLogId leader_commit = 4;
+}
+
+// Append entries response
+message OpenRaftAppendResponse {
+  OpenRaftVote vote = 1;
+  bool success = 2;
+  optional OpenRaftLogId conflict = 3;
+}
+
+// Vote request
+message OpenRaftVoteRequest {
+  OpenRaftVote vote = 1;
+  optional OpenRaftLogId last_log_id = 2;
+}
+
+// Vote response
+message OpenRaftVoteResponse {
+  OpenRaftVote vote = 1;
+  bool vote_granted = 2;
+  optional OpenRaftLogId last_log_id = 3;
+}
+
+// Snapshot metadata
+message OpenRaftSnapshotMeta {
+  optional OpenRaftLogId last_log_id = 1;
+  string snapshot_id = 2;
+  bytes last_membership = 3;
+}
+
+// Snapshot request (streamed)
+message OpenRaftSnapshotRequest {
+  OpenRaftVote vote = 1;
+  OpenRaftSnapshotMeta meta = 2;
+  uint64 offset = 3;
+  bytes data = 4;
+  bool done = 5;
+}
+
+// Snapshot response
+message OpenRaftSnapshotResponse {
+  OpenRaftVote vote = 1;
+}

--- a/rocketmq-controller/src/lib.rs
+++ b/rocketmq-controller/src/lib.rs
@@ -90,6 +90,11 @@ pub mod task;
 pub mod typ;
 pub mod protobuf {
     tonic::include_proto!("rocketmq_rust_controller");
+
+    // OpenRaft protobuf definitions
+    pub mod openraft {
+        tonic::include_proto!("rocketmq_rust_controller.openraft");
+    }
 }
 
 pub use command::Args;

--- a/rocketmq-controller/src/openraft.rs
+++ b/rocketmq-controller/src/openraft.rs
@@ -20,14 +20,16 @@
 //! This module contains the OpenRaft-based implementation for distributed
 //! consensus and metadata management.
 
+mod grpc_server;
 mod log_store;
 mod network;
 mod node;
 mod state_machine;
 pub mod storage;
 
+pub use grpc_server::GrpcRaftService;
 pub use log_store::LogStore;
-pub use network::NetworkConnection;
+pub use network::GrpcNetworkClient;
 pub use network::NetworkFactory;
 pub use node::RaftNodeManager;
 pub use state_machine::BrokerMetadata;

--- a/rocketmq-controller/src/openraft/grpc_server.rs
+++ b/rocketmq-controller/src/openraft/grpc_server.rs
@@ -1,0 +1,174 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! gRPC server implementation for OpenRaft network communication
+
+use std::sync::Arc;
+
+use tonic::Request;
+use tonic::Response;
+use tonic::Status;
+use tracing::debug;
+use tracing::error;
+
+use crate::protobuf::openraft::open_raft_service_server::OpenRaftService;
+use crate::protobuf::openraft::OpenRaftAppendRequest;
+use crate::protobuf::openraft::OpenRaftAppendResponse;
+use crate::protobuf::openraft::OpenRaftSnapshotRequest;
+use crate::protobuf::openraft::OpenRaftSnapshotResponse;
+use crate::protobuf::openraft::OpenRaftVoteRequest;
+use crate::protobuf::openraft::OpenRaftVoteResponse;
+use crate::typ::Raft;
+
+/// gRPC service implementation for OpenRaft
+pub struct GrpcRaftService {
+    /// Raft instance
+    raft: Arc<Raft>,
+}
+
+impl GrpcRaftService {
+    /// Create a new gRPC Raft service
+    pub fn new(raft: Arc<Raft>) -> Self {
+        Self { raft }
+    }
+}
+
+#[tonic::async_trait]
+impl OpenRaftService for GrpcRaftService {
+    async fn append_entries(
+        &self,
+        request: Request<OpenRaftAppendRequest>,
+    ) -> Result<Response<OpenRaftAppendResponse>, Status> {
+        let req = request.into_inner();
+        debug!("Received append_entries: {} entries", req.entries.len());
+
+        // Convert protobuf to OpenRaft types
+        let vote = req
+            .vote
+            .ok_or_else(|| Status::invalid_argument("Missing vote"))?;
+
+        let raft_vote = openraft::Vote::new(vote.term, vote.node_id);
+
+        let prev_log_id = req.prev_log_id.map(|id| crate::typ::LogId {
+            leader_id: crate::typ::Vote::new(id.leader_id, id.leader_id).leader_id,
+            index: id.index,
+        });
+
+        let entries: Vec<_> = req
+            .entries
+            .into_iter()
+            .filter_map(|e| {
+                let log_id = e.log_id?;
+                let payload: crate::typ::ControllerRequest =
+                    serde_json::from_slice(&e.payload).ok()?;
+                Some(openraft::Entry {
+                    log_id: crate::typ::LogId {
+                        leader_id: crate::typ::Vote::new(log_id.leader_id, log_id.leader_id)
+                            .leader_id,
+                        index: log_id.index,
+                    },
+                    payload: openraft::EntryPayload::Normal(payload),
+                })
+            })
+            .collect();
+
+        let leader_commit = req.leader_commit.map(|id| crate::typ::LogId {
+            leader_id: crate::typ::Vote::new(id.leader_id, id.leader_id).leader_id,
+            index: id.index,
+        });
+
+        let append_req = openraft::raft::AppendEntriesRequest {
+            vote: raft_vote,
+            prev_log_id,
+            entries,
+            leader_commit,
+        };
+
+        // Call Raft
+        match self.raft.append_entries(append_req).await {
+            Ok(resp) => {
+                let success = matches!(resp, openraft::raft::AppendEntriesResponse::Success);
+                Ok(Response::new(OpenRaftAppendResponse {
+                    vote: Some(crate::protobuf::openraft::OpenRaftVote {
+                        term: raft_vote.leader_id.term,
+                        node_id: raft_vote.leader_id.node_id,
+                        committed: raft_vote.committed,
+                    }),
+                    success,
+                    conflict: None,
+                }))
+            }
+            Err(e) => {
+                error!("AppendEntries failed: {}", e);
+                Err(Status::internal(format!("Raft error: {}", e)))
+            }
+        }
+    }
+
+    async fn vote(
+        &self,
+        request: Request<OpenRaftVoteRequest>,
+    ) -> Result<Response<OpenRaftVoteResponse>, Status> {
+        let req = request.into_inner();
+        debug!("Received vote request");
+
+        let vote = req
+            .vote
+            .ok_or_else(|| Status::invalid_argument("Missing vote"))?;
+
+        let raft_vote = openraft::Vote::new(vote.term, vote.node_id);
+
+        let last_log_id = req.last_log_id.map(|id| crate::typ::LogId {
+            leader_id: crate::typ::Vote::new(id.leader_id, id.leader_id).leader_id,
+            index: id.index,
+        });
+
+        let vote_req = openraft::raft::VoteRequest {
+            vote: raft_vote,
+            last_log_id,
+        };
+
+        match self.raft.vote(vote_req).await {
+            Ok(resp) => Ok(Response::new(OpenRaftVoteResponse {
+                vote: Some(crate::protobuf::openraft::OpenRaftVote {
+                    term: resp.vote.leader_id.term,
+                    node_id: resp.vote.leader_id.node_id,
+                    committed: resp.vote.committed,
+                }),
+                vote_granted: resp.vote_granted,
+                last_log_id: resp
+                    .last_log_id
+                    .map(|id| crate::protobuf::openraft::OpenRaftLogId {
+                        leader_id: id.leader_id.node_id,
+                        index: id.index,
+                    }),
+            })),
+            Err(e) => {
+                error!("Vote failed: {}", e);
+                Err(Status::internal(format!("Raft error: {}", e)))
+            }
+        }
+    }
+
+    async fn install_snapshot(
+        &self,
+        _request: Request<tonic::Streaming<OpenRaftSnapshotRequest>>,
+    ) -> Result<Response<OpenRaftSnapshotResponse>, Status> {
+        // TODO: Implement snapshot streaming
+        Err(Status::unimplemented("InstallSnapshot not yet implemented"))
+    }
+}

--- a/rocketmq-controller/src/openraft/network.rs
+++ b/rocketmq-controller/src/openraft/network.rs
@@ -19,139 +19,19 @@
 //!
 //! Provides RPC-based communication between Raft nodes.
 
+mod grpc_client;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use openraft::error::InstallSnapshotError;
-use openraft::error::NetworkError;
-use openraft::error::RPCError;
-use openraft::error::RaftError;
-use openraft::network::RPCOption;
-use openraft::network::RaftNetwork;
+pub use grpc_client::GrpcNetworkClient;
 use openraft::network::RaftNetworkFactory;
-use openraft::raft::AppendEntriesRequest;
-use openraft::raft::AppendEntriesResponse;
-use openraft::raft::InstallSnapshotRequest;
-use openraft::raft::InstallSnapshotResponse;
-use openraft::raft::VoteRequest;
-use openraft::raft::VoteResponse;
 use tokio::sync::RwLock;
 use tracing::debug;
 
 use crate::typ::Node;
 use crate::typ::NodeId;
 use crate::typ::TypeConfig;
-
-/// Network connection to a single Raft node
-#[derive(Clone)]
-pub struct NetworkConnection {
-    /// Target node
-    target: NodeId,
-
-    /// Target address
-    target_addr: String,
-
-    /// gRPC client (placeholder for actual implementation)
-    /// In production, this would be a tonic gRPC client
-    client: Arc<RwLock<Option<()>>>,
-}
-
-impl NetworkConnection {
-    /// Create a new network connection
-    pub fn new(target: NodeId, target_addr: String) -> Self {
-        Self {
-            target,
-            target_addr,
-            client: Arc::new(RwLock::new(None)),
-        }
-    }
-
-    /// Send a request and get response
-    async fn send_rpc<Req, Resp, Err, F>(
-        &self,
-        _req: Req,
-        _handler: F,
-    ) -> Result<Resp, RPCError<TypeConfig, Err>>
-    where
-        F: FnOnce() -> Resp,
-        Err: std::error::Error + 'static,
-    {
-        // TODO: Implement actual gRPC call
-        // For now, return a network error indicating not implemented
-        Err(RPCError::Network(NetworkError::new(&std::io::Error::new(
-            std::io::ErrorKind::NotConnected,
-            format!(
-                "RPC not implemented for node {} at {}",
-                self.target, self.target_addr
-            ),
-        ))))
-    }
-}
-
-impl RaftNetwork<TypeConfig> for NetworkConnection {
-    async fn append_entries(
-        &mut self,
-        req: AppendEntriesRequest<TypeConfig>,
-        _option: RPCOption,
-    ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<TypeConfig, RaftError<TypeConfig>>>
-    {
-        debug!(
-            "Sending append_entries to node {}: prev_log_id={:?}, entries={}",
-            self.target,
-            req.prev_log_id,
-            req.entries.len()
-        );
-
-        self.send_rpc(req, || {
-            // Placeholder response
-            AppendEntriesResponse::Success
-        })
-        .await
-    }
-
-    async fn install_snapshot(
-        &mut self,
-        req: InstallSnapshotRequest<TypeConfig>,
-        _option: RPCOption,
-    ) -> Result<
-        InstallSnapshotResponse<TypeConfig>,
-        RPCError<TypeConfig, RaftError<TypeConfig, InstallSnapshotError>>,
-    > {
-        debug!(
-            "Sending install_snapshot to node {}: meta={:?}",
-            self.target, req.meta
-        );
-
-        self.send_rpc(req, || {
-            // Placeholder response
-            InstallSnapshotResponse {
-                vote: Default::default(),
-            }
-        })
-        .await
-    }
-
-    async fn vote(
-        &mut self,
-        req: VoteRequest<TypeConfig>,
-        _option: RPCOption,
-    ) -> Result<VoteResponse<TypeConfig>, RPCError<TypeConfig, RaftError<TypeConfig>>> {
-        debug!(
-            "Sending vote request to node {}: vote={:?}, last_log_id={:?}",
-            self.target, req.vote, req.last_log_id
-        );
-
-        self.send_rpc(req, || {
-            // Placeholder response
-            VoteResponse {
-                vote: Default::default(),
-                vote_granted: false,
-                last_log_id: None,
-            }
-        })
-        .await
-    }
-}
 
 /// Network factory for creating connections to Raft nodes
 #[derive(Clone)]
@@ -191,7 +71,7 @@ impl Default for NetworkFactory {
 }
 
 impl RaftNetworkFactory<TypeConfig> for NetworkFactory {
-    type Network = NetworkConnection;
+    type Network = GrpcNetworkClient;
 
     async fn new_client(&mut self, target: NodeId, _node: &Node) -> Self::Network {
         let peer_addrs = self.peer_addrs.read().await;
@@ -201,10 +81,10 @@ impl RaftNetworkFactory<TypeConfig> for NetworkFactory {
             .unwrap_or_else(|| format!("unknown-{}", target));
 
         debug!(
-            "Creating network connection to node {} at {}",
+            "Creating gRPC network connection to node {} at {}",
             target, target_addr
         );
 
-        NetworkConnection::new(target, target_addr)
+        GrpcNetworkClient::new(target, target_addr)
     }
 }

--- a/rocketmq-controller/src/openraft/network/grpc_client.rs
+++ b/rocketmq-controller/src/openraft/network/grpc_client.rs
@@ -1,0 +1,241 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! gRPC client implementation for OpenRaft network communication
+
+use std::time::Duration;
+
+use openraft::error::InstallSnapshotError;
+use openraft::error::NetworkError;
+use openraft::error::RPCError;
+use openraft::error::RaftError;
+use openraft::network::RPCOption;
+use openraft::network::RaftNetwork;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::AppendEntriesResponse;
+use openraft::raft::InstallSnapshotRequest;
+use openraft::raft::InstallSnapshotResponse;
+use openraft::raft::VoteRequest;
+use openraft::raft::VoteResponse;
+use tonic::transport::Channel;
+use tonic::Request;
+use tracing::debug;
+use tracing::error;
+
+use crate::protobuf::openraft::open_raft_service_client::OpenRaftServiceClient;
+use crate::protobuf::openraft::OpenRaftAppendRequest;
+use crate::protobuf::openraft::OpenRaftVoteRequest as ProtoVoteRequest;
+use crate::typ::NodeId;
+use crate::typ::TypeConfig;
+
+/// gRPC-based network client for OpenRaft
+#[derive(Clone)]
+pub struct GrpcNetworkClient {
+    /// Target node ID
+    target: NodeId,
+
+    /// Target address
+    target_addr: String,
+
+    /// gRPC client
+    client: Option<OpenRaftServiceClient<Channel>>,
+
+    /// Connection timeout
+    timeout: Duration,
+}
+
+impl GrpcNetworkClient {
+    /// Create a new gRPC network client
+    pub fn new(target: NodeId, target_addr: String) -> Self {
+        Self {
+            target,
+            target_addr,
+            client: None,
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    /// Connect to the target node
+    async fn connect(&mut self) -> Result<(), NetworkError> {
+        if self.client.is_some() {
+            return Ok(());
+        }
+
+        debug!("Connecting to node {} at {}", self.target, self.target_addr);
+
+        let endpoint = format!("http://{}", self.target_addr);
+        let channel = Channel::from_shared(endpoint)
+            .map_err(|e| {
+                NetworkError::new(&std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
+            })?
+            .timeout(self.timeout)
+            .connect()
+            .await
+            .map_err(|e| {
+                error!("Failed to connect to {}: {}", self.target_addr, e);
+                NetworkError::new(&std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    e,
+                ))
+            })?;
+
+        self.client = Some(OpenRaftServiceClient::new(channel));
+        debug!("Connected to node {} at {}", self.target, self.target_addr);
+        Ok(())
+    }
+
+    /// Get or create the client
+    async fn get_client(&mut self) -> Result<&mut OpenRaftServiceClient<Channel>, NetworkError> {
+        self.connect().await?;
+        self.client.as_mut().ok_or_else(|| {
+            NetworkError::new(&std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "Client not connected",
+            ))
+        })
+    }
+}
+
+impl RaftNetwork<TypeConfig> for GrpcNetworkClient {
+    async fn append_entries(
+        &mut self,
+        req: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<TypeConfig, RaftError<TypeConfig>>>
+    {
+        debug!(
+            "Sending append_entries to node {}: prev_log_id={:?}, entries={}",
+            self.target,
+            req.prev_log_id,
+            req.entries.len()
+        );
+
+        // Convert to protobuf request
+        let proto_req = OpenRaftAppendRequest {
+            vote: Some(crate::protobuf::openraft::OpenRaftVote {
+                term: req.vote.leader_id.term,
+                node_id: req.vote.leader_id.node_id,
+                committed: req.vote.committed,
+            }),
+            prev_log_id: req
+                .prev_log_id
+                .map(|id| crate::protobuf::openraft::OpenRaftLogId {
+                    leader_id: id.leader_id.node_id,
+                    index: id.index,
+                }),
+            entries: req
+                .entries
+                .iter()
+                .map(|e| crate::protobuf::openraft::OpenRaftLogEntry {
+                    log_id: Some(crate::protobuf::openraft::OpenRaftLogId {
+                        leader_id: e.log_id.leader_id.node_id,
+                        index: e.log_id.index,
+                    }),
+                    payload: serde_json::to_vec(&e.payload).unwrap_or_default(),
+                })
+                .collect(),
+            leader_commit: req
+                .leader_commit
+                .map(|id| crate::protobuf::openraft::OpenRaftLogId {
+                    leader_id: id.leader_id.node_id,
+                    index: id.index,
+                }),
+        };
+
+        let client = self.get_client().await.map_err(RPCError::Network)?;
+        let response = client
+            .append_entries(Request::new(proto_req))
+            .await
+            .map_err(|e| {
+                error!("AppendEntries RPC failed: {}", e);
+                RPCError::Network(NetworkError::new(&std::io::Error::other(e.to_string())))
+            })?;
+
+        let proto_resp = response.into_inner();
+
+        // Convert protobuf response back to OpenRaft types
+        if proto_resp.success {
+            Ok(AppendEntriesResponse::Success)
+        } else {
+            Ok(AppendEntriesResponse::Conflict)
+        }
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        _req: InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<
+        InstallSnapshotResponse<TypeConfig>,
+        RPCError<TypeConfig, RaftError<TypeConfig, InstallSnapshotError>>,
+    > {
+        debug!("Sending install_snapshot to node {}", self.target);
+
+        // TODO: Implement snapshot streaming
+        Err(RPCError::Network(NetworkError::new(
+            &std::io::Error::other("InstallSnapshot not yet implemented"),
+        )))
+    }
+
+    async fn vote(
+        &mut self,
+        req: VoteRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<TypeConfig>, RPCError<TypeConfig, RaftError<TypeConfig>>> {
+        debug!(
+            "Sending vote request to node {}: vote={:?}, last_log_id={:?}",
+            self.target, req.vote, req.last_log_id
+        );
+
+        let proto_req = ProtoVoteRequest {
+            vote: Some(crate::protobuf::openraft::OpenRaftVote {
+                term: req.vote.leader_id.term,
+                node_id: req.vote.leader_id.node_id,
+                committed: req.vote.committed,
+            }),
+            last_log_id: req
+                .last_log_id
+                .map(|id| crate::protobuf::openraft::OpenRaftLogId {
+                    leader_id: id.leader_id.node_id,
+                    index: id.index,
+                }),
+        };
+
+        let client = self.get_client().await.map_err(RPCError::Network)?;
+        let response = client.vote(Request::new(proto_req)).await.map_err(|e| {
+            error!("Vote RPC failed: {}", e);
+            RPCError::Network(NetworkError::new(&std::io::Error::other(e.to_string())))
+        })?;
+
+        let proto_resp = response.into_inner();
+
+        // Parse vote from response
+        let vote = proto_resp
+            .vote
+            .map(|v| openraft::Vote::new(v.term, crate::typ::NodeId::from(v.node_id)))
+            .unwrap_or_default();
+
+        Ok(VoteResponse {
+            vote,
+            vote_granted: proto_resp.vote_granted,
+            last_log_id: proto_resp.last_log_id.map(|id| crate::typ::LogId {
+                leader_id: crate::typ::Vote::new(id.leader_id, id.leader_id).leader_id,
+                index: id.index,
+            }),
+        })
+    }
+}

--- a/rocketmq-controller/tests/openraft_integration_test.rs
+++ b/rocketmq-controller/tests/openraft_integration_test.rs
@@ -1,0 +1,205 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! Integration tests for OpenRaft implementation
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use rocketmq_controller::config::ControllerConfig;
+use rocketmq_controller::openraft::RaftNodeManager;
+use rocketmq_controller::typ::ControllerRequest;
+use rocketmq_controller::typ::Node;
+
+#[tokio::test]
+async fn test_node_creation() {
+    // Create a test configuration
+    let config = Arc::new(
+        ControllerConfig::new(1, "127.0.0.1:9876".parse().unwrap())
+            .with_election_timeout_ms(1000)
+            .with_heartbeat_interval_ms(300),
+    );
+
+    // Create a Raft node
+    let node = RaftNodeManager::new(config).await;
+    assert!(node.is_ok(), "Failed to create Raft node: {:?}", node.err());
+
+    let _node = node.unwrap();
+    // Note: Raft instance doesn't expose id() method directly
+    // Node ID is verified through configuration
+}
+
+#[tokio::test]
+async fn test_cluster_initialization() {
+    // Create configuration for node 1
+    let config = Arc::new(
+        ControllerConfig::new(1, "127.0.0.1:19876".parse().unwrap())
+            .with_election_timeout_ms(1000)
+            .with_heartbeat_interval_ms(300),
+    );
+
+    // Create the node
+    let node = RaftNodeManager::new(config).await.unwrap();
+
+    // Initialize a single-node cluster
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        1,
+        Node {
+            node_id: 1,
+            rpc_addr: "127.0.0.1:19876".to_string(),
+        },
+    );
+
+    let result = node.initialize_cluster(nodes).await;
+    assert!(
+        result.is_ok(),
+        "Failed to initialize cluster: {:?}",
+        result.err()
+    );
+
+    // Wait a bit for election
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // Check if this node becomes leader
+    let is_leader = node.is_leader().await.unwrap();
+    assert!(
+        is_leader,
+        "Node should be the leader in a single-node cluster"
+    );
+}
+
+#[tokio::test]
+async fn test_log_store() {
+    use openraft::storage::RaftLogReader;
+    use openraft::storage::RaftLogStorage;
+    use rocketmq_controller::openraft::LogStore;
+
+    let mut store = LogStore::new();
+
+    // Test new store is empty
+    let log_state = store.get_log_state().await.unwrap();
+    assert!(log_state.last_log_id.is_none());
+    assert!(log_state.last_purged_log_id.is_none());
+
+    // Test vote operations
+    let vote = openraft::Vote::new(1, 1);
+    store.save_vote(&vote).await.unwrap();
+
+    let saved_vote = store.read_vote().await.unwrap();
+    assert_eq!(saved_vote, Some(vote));
+}
+
+#[tokio::test]
+async fn test_state_machine() {
+    use rocketmq_controller::openraft::BrokerMetadata;
+    use rocketmq_controller::openraft::StateMachine;
+    use rocketmq_controller::openraft::TopicConfig;
+
+    let sm = StateMachine::new();
+
+    // Test broker operations
+    let _broker = BrokerMetadata {
+        broker_name: "test-broker".to_string(),
+        cluster_name: "test-cluster".to_string(),
+        broker_addr: "127.0.0.1:10911".to_string(),
+        broker_id: 0,
+        epoch: 0,
+        max_offset: 0,
+        election_priority: 0,
+        last_heartbeat: 0,
+    };
+
+    // Note: StateMachine doesn't have direct register methods as it's managed by Raft
+    // We can only verify getter methods
+    let retrieved = sm.get_broker("test-broker");
+    assert!(
+        retrieved.is_none(),
+        "Should not have broker before registration"
+    );
+
+    // Test topic operations
+    let _topic = TopicConfig {
+        topic_name: "test-topic".to_string(),
+        read_queue_nums: 4,
+        write_queue_nums: 4,
+        perm: 6,
+    };
+
+    // Similarly, topics are managed through Raft requests
+    let retrieved = sm.get_topic("test-topic");
+    assert!(retrieved.is_none(), "Should not have topic before creation");
+}
+
+#[tokio::test]
+async fn test_storage_operations() {
+    use openraft::storage::RaftLogStorage;
+    use rocketmq_controller::openraft::Store;
+
+    let store = Store::new();
+
+    // Test log store access
+    let mut log_store = store.log_store.clone();
+    let log_state = log_store.get_log_state().await.unwrap();
+    assert!(log_state.last_log_id.is_none());
+
+    // Test state machine access
+    let all_brokers = store.state_machine.get_all_brokers();
+    assert_eq!(all_brokers.len(), 0);
+}
+
+#[tokio::test]
+async fn test_client_write() {
+    // Create configuration
+    let config = Arc::new(
+        ControllerConfig::new(1, "127.0.0.1:29876".parse().unwrap())
+            .with_election_timeout_ms(1000)
+            .with_heartbeat_interval_ms(300),
+    );
+
+    // Create and initialize node
+    let node = RaftNodeManager::new(config).await.unwrap();
+
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        1,
+        Node {
+            node_id: 1,
+            rpc_addr: "127.0.0.1:29876".to_string(),
+        },
+    );
+
+    node.initialize_cluster(nodes).await.unwrap();
+
+    // Wait for leader election
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // Try to write a request
+    let request = ControllerRequest::RegisterBroker {
+        cluster_name: "test-cluster".to_string(),
+        broker_addr: "127.0.0.1:10911".to_string(),
+        broker_name: "test-broker".to_string(),
+        broker_id: 0,
+        epoch: 0,
+        max_offset: 0,
+        election_priority: 0,
+    };
+
+    let result = node.client_write(request).await;
+    // In a single-node cluster, this should succeed
+    assert!(result.is_ok(), "Client write failed: {:?}", result.err());
+}


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4974

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced OpenRaft consensus protocol support enabling distributed cluster coordination via gRPC
  * Added gRPC server implementation for handling replication and voting requests between cluster nodes

* **Documentation**
  * Added examples demonstrating single-node and three-node cluster deployment and operation
  * Added integration tests validating cluster initialization, leadership election, and client operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->