### PR TITLE
[ISSUE #4862]♻️Refactor send_batch_to_queue_with_callback_timeout to accept generic message types implementing MessageTrait

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -1154,14 +1154,15 @@ impl MQProducer for DefaultMQProducer {
             .await
     }
 
-    async fn send_batch_to_queue_with_callback_timeout<F>(
+    async fn send_batch_to_queue_with_callback_timeout<M, F>(
         &mut self,
-        msgs: Vec<Message>,
+        msgs: Vec<M>,
         mq: MessageQueue,
         f: F,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
+        M: MessageTrait + Send + Sync,
         F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
     {
         let batch = self.batch(msgs)?;

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -607,14 +607,15 @@ pub trait MQProducer {
     /// # Returns
     ///
     /// * `rocketmq_error::RocketMQResult<()>` - An empty result indicating success or failure.
-    async fn send_batch_to_queue_with_callback_timeout<F>(
+    async fn send_batch_to_queue_with_callback_timeout<M, F>(
         &mut self,
-        msgs: Vec<Message>,
+        msgs: Vec<M>,
         mq: MessageQueue,
         f: F,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
+        M: MessageTrait + Send + Sync,
         F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static;
 
     /// Sends a request message.

--- a/rocketmq-client/src/producer/transaction_mq_producer.rs
+++ b/rocketmq-client/src/producer/transaction_mq_producer.rs
@@ -434,14 +434,15 @@ impl MQProducer for TransactionMQProducer {
             .await
     }
 
-    async fn send_batch_to_queue_with_callback_timeout<F>(
+    async fn send_batch_to_queue_with_callback_timeout<M, F>(
         &mut self,
-        msgs: Vec<Message>,
+        msgs: Vec<M>,
         mq: MessageQueue,
         f: F,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
+        M: MessageTrait + Send + Sync,
         F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
     {
         self.default_producer


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4862 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch message sending methods now support generic message types implementing `MessageTrait`, enabling flexibility beyond the standard message format across all producer implementations (DefaultMQProducer, MQProducer, TransactionMQProducer).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->