### PR TITLE
[ISSUE #5017]add unit test for AuthConfig default implementation

### DIFF
--- a/rocketmq-auth/src/config.rs
+++ b/rocketmq-auth/src/config.rs
@@ -137,4 +137,3 @@ mod tests {
         assert_eq!(config.stateful_authorization_cache_expired_second, 60);
     }
 }
-    


### PR DESCRIPTION
Adds a unit test to verify the default values of the `AuthConfig` struct.

This improves test coverage and ensures configuration defaults remain consistent.

Fix #5017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests that validate the default authentication configuration values to ensure stability and prevent regressions. No runtime or production behavior was changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->