### PR TITLE
[ISSUE #5022]🚀Add AclConfig struct with support for global white addresses and plain access configs

### DIFF
--- a/rocketmq-auth/src/migration/alc.rs
+++ b/rocketmq-auth/src/migration/alc.rs
@@ -15,4 +15,5 @@
 //  specific language governing permissions and limitations
 //  under the License.
 
+pub mod acl_config;
 pub mod plain_access_config;

--- a/rocketmq-auth/src/migration/alc/acl_config.rs
+++ b/rocketmq-auth/src/migration/alc/acl_config.rs
@@ -1,0 +1,62 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use std::fmt;
+
+use cheetah_string::CheetahString;
+
+use crate::migration::alc::plain_access_config::PlainAccessConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AclConfig {
+    pub global_white_addrs: Option<Vec<CheetahString>>,
+    pub plain_access_configs: Option<Vec<PlainAccessConfig>>,
+}
+
+impl AclConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // globalWhiteAddrs
+    pub fn global_white_addrs(&self) -> Option<&[CheetahString]> {
+        self.global_white_addrs.as_deref()
+    }
+
+    pub fn set_global_white_addrs(&mut self, addrs: Vec<CheetahString>) {
+        self.global_white_addrs = Some(addrs);
+    }
+
+    // plainAccessConfigs
+    pub fn plain_access_configs(&self) -> Option<&[PlainAccessConfig]> {
+        self.plain_access_configs.as_deref()
+    }
+
+    pub fn set_plain_access_configs(&mut self, configs: Vec<PlainAccessConfig>) {
+        self.plain_access_configs = Some(configs);
+    }
+}
+
+impl fmt::Display for AclConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "AclConfig{{ global_white_addrs={:?}, plain_access_configs={:?} }}",
+            self.global_white_addrs, self.plain_access_configs
+        )
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5022

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication system with new ACL configuration capabilities, including support for managing global white-listed addresses and access configurations. This enables administrators to implement more granular access control policies and improve security posture within the messaging platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->