### PR TITLE
[ISSUE #5042]🚀Add DefaultAuthenticationContext struct with username, content, and signature fields for extensible authentication context management

### DIFF
--- a/rocketmq-auth/src/authentication/context.rs
+++ b/rocketmq-auth/src/authentication/context.rs
@@ -15,5 +15,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 
-mod authentication_context;
+pub mod authentication_context;
 pub mod base_authentication_context;
+pub mod default_authentication_context;

--- a/rocketmq-auth/src/authentication/context/default_authentication_context.rs
+++ b/rocketmq-auth/src/authentication/context/default_authentication_context.rs
@@ -1,0 +1,75 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use std::any::Any;
+
+use cheetah_string::CheetahString;
+
+use crate::authentication::context::authentication_context::AuthenticationContext;
+use crate::authentication::context::base_authentication_context::BaseAuthenticationContext;
+use crate::authentication::AsAny;
+
+#[derive(Debug, Default)]
+pub struct DefaultAuthenticationContext {
+    pub base: BaseAuthenticationContext,
+
+    username: Option<CheetahString>,
+    content: Option<Vec<u8>>,
+    signature: Option<CheetahString>,
+}
+
+impl DefaultAuthenticationContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn username(&self) -> Option<&CheetahString> {
+        self.username.as_ref()
+    }
+
+    pub fn set_username(&mut self, username: CheetahString) {
+        self.username = Some(username);
+    }
+
+    pub fn content(&self) -> Option<&[u8]> {
+        self.content.as_deref()
+    }
+
+    pub fn set_content(&mut self, content: Vec<u8>) {
+        self.content = Some(content);
+    }
+
+    pub fn signature(&self) -> Option<&CheetahString> {
+        self.signature.as_ref()
+    }
+
+    pub fn set_signature(&mut self, signature: CheetahString) {
+        self.signature = Some(signature);
+    }
+}
+
+impl AsAny for DefaultAuthenticationContext {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl AuthenticationContext for DefaultAuthenticationContext {}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5042

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced authentication context infrastructure with reorganized module structure and introduced new default authentication context implementation supporting comprehensive credential management capabilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->