### PR TITLE
[ISSUE #5048]🚀Add user_status enum with serialization support for user status management in authentication

### DIFF
--- a/rocketmq-auth/src/authentication/enums.rs
+++ b/rocketmq-auth/src/authentication/enums.rs
@@ -16,3 +16,4 @@
 //  under the License.
 
 pub mod subject_type;
+pub mod user_status;

--- a/rocketmq-auth/src/authentication/enums/user_status.rs
+++ b/rocketmq-auth/src/authentication/enums/user_status.rs
@@ -1,0 +1,77 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UserStatus {
+    Enable = 1,
+    Disable = 2,
+}
+
+impl UserStatus {
+    #[inline]
+    pub fn get_by_name(name: &str) -> Option<Self> {
+        if name.eq_ignore_ascii_case("enable") {
+            Some(UserStatus::Enable)
+        } else if name.eq_ignore_ascii_case("disable") {
+            Some(UserStatus::Disable)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn code(self) -> u8 {
+        self as u8
+    }
+
+    #[inline]
+    pub fn name(self) -> &'static str {
+        match self {
+            UserStatus::Enable => "enable",
+            UserStatus::Disable => "disable",
+        }
+    }
+}
+
+impl Serialize for UserStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(*self as u8)
+    }
+}
+
+impl<'de> Deserialize<'de> for UserStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v = u8::deserialize(deserializer)?;
+        match v {
+            1 => Ok(UserStatus::Enable),
+            2 => Ok(UserStatus::Disable),
+            _ => Err(serde::de::Error::custom("invalid UserStatus")),
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5048

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced user status management to track whether users are enabled or disabled in the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->