### PR TITLE
[ISSUE #5051]🚀Add user_type enum with serialization support for user type management in authentication

### DIFF
--- a/rocketmq-auth/src/authentication/enums.rs
+++ b/rocketmq-auth/src/authentication/enums.rs
@@ -17,3 +17,4 @@
 
 pub mod subject_type;
 pub mod user_status;
+pub mod user_type;

--- a/rocketmq-auth/src/authentication/enums/user_type.rs
+++ b/rocketmq-auth/src/authentication/enums/user_type.rs
@@ -1,0 +1,77 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UserType {
+    Super = 1,
+    Normal = 2,
+}
+
+impl UserType {
+    #[inline]
+    pub fn get_by_name(name: &str) -> Option<Self> {
+        if name.eq_ignore_ascii_case("Super") {
+            Some(UserType::Super)
+        } else if name.eq_ignore_ascii_case("Normal") {
+            Some(UserType::Normal)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn code(self) -> u8 {
+        self as u8
+    }
+
+    #[inline]
+    pub fn name(self) -> &'static str {
+        match self {
+            UserType::Super => "Super",
+            UserType::Normal => "Normal",
+        }
+    }
+}
+
+impl Serialize for UserType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(*self as u8)
+    }
+}
+
+impl<'de> Deserialize<'de> for UserType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v = u8::deserialize(deserializer)?;
+        match v {
+            1 => Ok(UserType::Super),
+            2 => Ok(UserType::Normal),
+            _ => Err(serde::de::Error::custom("invalid UserType")),
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5051

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented user type classification system for the authentication module, enabling role-based user differentiation and access control. The system now supports multiple user types with full serialization and deserialization capabilities, allowing seamless data persistence across authentication flows and system interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->