### PR TITLE
[ISSUE #4876]🧪Add test case for BrokerIdentityInfo in controller crate

### DIFF
--- a/rocketmq-controller/src/heartbeat/broker_identity_info.rs
+++ b/rocketmq-controller/src/heartbeat/broker_identity_info.rs
@@ -55,3 +55,58 @@ impl fmt::Display for BrokerIdentityInfo {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn broker_identity_info_new() {
+        let info = BrokerIdentityInfo::new("test_cluster", "test_broker", Some(0));
+        assert_eq!(info.cluster_name, "test_cluster");
+        assert_eq!(info.broker_name, "test_broker");
+        assert_eq!(info.broker_id, Some(0));
+
+        let info = BrokerIdentityInfo::new("cluster1", "broker1", None);
+        assert_eq!(info.cluster_name, "cluster1");
+        assert_eq!(info.broker_name, "broker1");
+        assert_eq!(info.broker_id, None);
+    }
+
+    #[test]
+    fn broker_identity_info_is_empty() {
+        let info = BrokerIdentityInfo::new("", "", None);
+        assert!(info.is_empty());
+
+        let info = BrokerIdentityInfo::new("  ", "  ", None);
+        assert!(info.is_empty());
+
+        let info = BrokerIdentityInfo::new("cluster", "broker", Some(1));
+        assert!(!info.is_empty());
+
+        let info = BrokerIdentityInfo::new("cluster", "", None);
+        assert!(!info.is_empty());
+    }
+
+    #[test]
+    fn broker_identity_info_clone_and_equality() {
+        let info1 = BrokerIdentityInfo::new("test_cluster", "test_broker", Some(100));
+        let info2 = info1.clone();
+        assert_eq!(info1, info2);
+    }
+
+    #[test]
+    fn broker_identity_info_display() {
+        let info = BrokerIdentityInfo::new("test_cluster", "test_broker", Some(0));
+        let display_str = format!("{}", info);
+        assert!(display_str.contains("test_cluster"));
+        assert!(display_str.contains("test_broker"));
+        assert!(display_str.contains("Some(0)"));
+
+        let info = BrokerIdentityInfo::new("cluster", "broker", None);
+        let display_str = format!("{}", info);
+        let expected =
+            "BrokerIdentityInfo{clusterName='cluster', brokerName='broker', brokerId=None}";
+        assert_eq!(display_str, expected);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4876 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for broker identity information handling, including constructor behavior, field validation, cloning, equality checks, and string formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->