### PR TITLE
[ISSUE #5071]Replace lazy_static! with LazyLock

### DIFF
--- a/rocketmq-client/src/trace/trace_bean.rs
+++ b/rocketmq-client/src/trace/trace_bean.rs
@@ -15,16 +15,15 @@
 //  specific language governing permissions and limitations
 //  under the License.
 
+use std::sync::LazyLock;
+
 use cheetah_string::CheetahString;
-use lazy_static::lazy_static;
 use rocketmq_common::common::message::message_enum::MessageType;
 use rocketmq_common::utils::util_all;
 
 use crate::producer::local_transaction_state::LocalTransactionState;
 
-lazy_static! {
-    static ref LOCAL_ADDRESS: CheetahString = util_all::get_ip_str();
-}
+static LOCAL_ADDRESS: LazyLock<CheetahString> = LazyLock::new(util_all::get_ip_str);
 
 #[derive(Debug, Clone)]
 pub struct TraceBean {


### PR DESCRIPTION
## Summary
- replace  with  in name_server_address_utils
- keep regex initializers in static lazy locks

## Rationale
- continue removing the  dependency in favor of the standard library LazyLock (issue #5068)

## Changes
- swap lazy_static import for std::sync::LazyLock
- convert regex statics to LazyLock initializers

## Test Plan
- not run locally; minimal refactor

Fixes #5071

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal dependency management for improved code maintainability and standard library alignment. No changes to user-facing functionality or API behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->