### PR TITLE
[ISSUE #5075]🚀Add policy_type module with PolicyType enum for modular policy type management in authorization

### DIFF
--- a/rocketmq-auth/src/authorization/enums.rs
+++ b/rocketmq-auth/src/authorization/enums.rs
@@ -16,3 +16,4 @@
 //  under the License.
 
 mod decision;
+mod policy_type;

--- a/rocketmq-auth/src/authorization/enums/policy_type.rs
+++ b/rocketmq-auth/src/authorization/enums/policy_type.rs
@@ -1,0 +1,74 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u8)]
+pub enum PolicyType {
+    Custom = 1,
+    Default = 2,
+}
+
+impl PolicyType {
+    pub fn get_by_name(name: &str) -> Option<Self> {
+        if name.eq_ignore_ascii_case("Custom") {
+            Some(Self::Custom)
+        } else if name.eq_ignore_ascii_case("Default") {
+            Some(Self::Default)
+        } else {
+            None
+        }
+    }
+
+    pub fn code(self) -> u8 {
+        self as u8
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Custom => "Custom",
+            Self::Default => "Default",
+        }
+    }
+}
+
+impl Serialize for PolicyType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(self.code())
+    }
+}
+
+impl<'de> Deserialize<'de> for PolicyType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v = u8::deserialize(deserializer)?;
+        match v {
+            1 => Ok(PolicyType::Custom),
+            2 => Ok(PolicyType::Default),
+            _ => Err(serde::de::Error::custom("invalid PolicyType code")),
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5075

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for policy types with Custom and Default variants, enabling improved authorization configuration options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->