### PR TITLE
[ISSUE #5080]🚀Add resource module with ResourceType enum for modular resource type management

### DIFF
--- a/rocketmq-common/src/common.rs
+++ b/rocketmq-common/src/common.rs
@@ -56,6 +56,7 @@ pub mod stats;
 pub mod sys_flag;
 
 pub mod metrics;
+pub mod resource;
 pub mod system_clock;
 pub mod thread;
 pub mod topic;

--- a/rocketmq-common/src/common/resource.rs
+++ b/rocketmq-common/src/common/resource.rs
@@ -1,0 +1,18 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+pub mod resource_type;

--- a/rocketmq-common/src/common/resource/resource_type.rs
+++ b/rocketmq-common/src/common/resource/resource_type.rs
@@ -1,0 +1,96 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u8)]
+pub enum ResourceType {
+    Unknown = 0,
+    Any = 1,
+    Cluster = 2,
+    Namespace = 3,
+    Topic = 4,
+    Group = 5,
+}
+
+impl ResourceType {
+    pub fn get_by_name(name: &str) -> Option<Self> {
+        if name.eq_ignore_ascii_case("Unknown") {
+            Some(Self::Unknown)
+        } else if name.eq_ignore_ascii_case("Any") {
+            Some(Self::Any)
+        } else if name.eq_ignore_ascii_case("Cluster") {
+            Some(Self::Cluster)
+        } else if name.eq_ignore_ascii_case("Namespace") {
+            Some(Self::Namespace)
+        } else if name.eq_ignore_ascii_case("Topic") {
+            Some(Self::Topic)
+        } else if name.eq_ignore_ascii_case("Group") {
+            Some(Self::Group)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn code(self) -> u8 {
+        self as u8
+    }
+
+    #[inline]
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Unknown => "Unknown",
+            Self::Any => "Any",
+            Self::Cluster => "Cluster",
+            Self::Namespace => "Namespace",
+            Self::Topic => "Topic",
+            Self::Group => "Group",
+        }
+    }
+}
+
+impl Serialize for ResourceType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(self.code())
+    }
+}
+
+impl<'de> Deserialize<'de> for ResourceType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v = u8::deserialize(deserializer)?;
+        match v {
+            0 => Ok(ResourceType::Unknown),
+            1 => Ok(ResourceType::Any),
+            2 => Ok(ResourceType::Cluster),
+            3 => Ok(ResourceType::Namespace),
+            4 => Ok(ResourceType::Topic),
+            5 => Ok(ResourceType::Group),
+            _ => Err(serde::de::Error::custom("invalid ResourceType code")),
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5080

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced resource type classification supporting identification and management of clusters, namespaces, topics, and groups. Includes comprehensive serialization capabilities, case-insensitive name lookups, numeric code mappings, and seamless platform integration for enhanced resource handling and system interoperability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->