### PR TITLE
[ISSUE #5085]🚀Add action module with Action enum for modular action type management in authorization

### DIFF
--- a/rocketmq-common/src/common.rs
+++ b/rocketmq-common/src/common.rs
@@ -55,6 +55,7 @@ pub mod statistics;
 pub mod stats;
 pub mod sys_flag;
 
+mod action;
 pub mod metrics;
 pub mod resource;
 pub mod system_clock;

--- a/rocketmq-common/src/common/action.rs
+++ b/rocketmq-common/src/common/action.rs
@@ -1,0 +1,105 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use std::convert::TryFrom;
+use std::fmt;
+
+/// Action represents the operations that can be authorized.
+/// Mirrors the Java `Action` enum:
+/// UNKNOWN(0, "Unknown"), ALL(1, "All"), ANY(2, "Any"), PUB(3, "Pub"),
+/// SUB(4, "Sub"), CREATE(5, "Create"), UPDATE(6, "Update"), DELETE(7, "Delete"),
+/// GET(8, "Get"), LIST(9, "List").
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Action {
+    Unknown = 0,
+    All = 1,
+    Any = 2,
+    Pub = 3,
+    Sub = 4,
+    Create = 5,
+    Update = 6,
+    Delete = 7,
+    Get = 8,
+    List = 9,
+}
+
+impl Action {
+    /// Return the numeric code associated with the action.
+    pub fn code(self) -> u8 {
+        self as u8
+    }
+
+    /// Return the display name of the action.
+    pub fn name(self) -> &'static str {
+        match self {
+            Action::Unknown => "Unknown",
+            Action::All => "All",
+            Action::Any => "Any",
+            Action::Pub => "Pub",
+            Action::Sub => "Sub",
+            Action::Create => "Create",
+            Action::Update => "Update",
+            Action::Delete => "Delete",
+            Action::Get => "Get",
+            Action::List => "List",
+        }
+    }
+
+    /// Case-insensitive lookup by name. Returns `None` if no match.
+    pub fn get_by_name(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "unknown" => Some(Action::Unknown),
+            "all" => Some(Action::All),
+            "any" => Some(Action::Any),
+            "pub" => Some(Action::Pub),
+            "sub" => Some(Action::Sub),
+            "create" => Some(Action::Create),
+            "update" => Some(Action::Update),
+            "delete" => Some(Action::Delete),
+            "get" => Some(Action::Get),
+            "list" => Some(Action::List),
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<u8> for Action {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Action::Unknown),
+            1 => Ok(Action::All),
+            2 => Ok(Action::Any),
+            3 => Ok(Action::Pub),
+            4 => Ok(Action::Sub),
+            5 => Ok(Action::Create),
+            6 => Ok(Action::Update),
+            7 => Ok(Action::Delete),
+            8 => Ok(Action::Get),
+            9 => Ok(Action::List),
+            _ => Err(()),
+        }
+    }
+}
+
+impl fmt::Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5085

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Action type system supporting typed operations with automatic conversion between numeric codes and display names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->