### PR TITLE
[ISSUE #4867]🧪Add test case for GetProducerConnectionListRequestHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_producer_connection_list_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_producer_connection_list_request_header.rs
@@ -26,10 +26,10 @@ use crate::rpc::rpc_request_header::RpcRequestHeader;
 pub struct GetProducerConnectionListRequestHeader {
     #[required]
     #[serde(rename = "producerGroup")]
-    producer_group: CheetahString,
+    pub producer_group: CheetahString,
 
     #[serde(flatten)]
-    rpc_request_header: Option<RpcRequestHeader>,
+    pub rpc_request_header: Option<RpcRequestHeader>,
 }
 
 impl GetProducerConnectionListRequestHeader {
@@ -39,5 +39,52 @@ impl GetProducerConnectionListRequestHeader {
 
     pub fn set_producer_group(&mut self, producer_group: CheetahString) {
         self.producer_group = producer_group;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn get_producer_connection_list_request_header_serialize() {
+        let mut header = GetProducerConnectionListRequestHeader::default();
+        header.set_producer_group(CheetahString::from_static_str("test_group"));
+        let json = serde_json::to_string(&header).unwrap();
+        assert_eq!(json, r#"{"producerGroup":"test_group"}"#);
+
+        let mut header = GetProducerConnectionListRequestHeader::default();
+        header.set_producer_group(CheetahString::from_static_str("test_group"));
+        let rpc_header = RpcRequestHeader {
+            broker_name: Some(CheetahString::from_static_str("broker_a")),
+            ..Default::default()
+        };
+        header.rpc_request_header = Some(rpc_header);
+        let json = serde_json::to_string(&header).unwrap();
+        assert!(json.contains("\"producerGroup\":\"test_group\""));
+        assert!(json.contains("\"brokerName\":\"broker_a\""));
+    }
+
+    #[test]
+    fn get_producer_connection_list_request_header_deserialize() {
+        let json = r#"{"producerGroup":"test_group"}"#;
+        let header: GetProducerConnectionListRequestHeader = serde_json::from_str(json).unwrap();
+        assert_eq!(header.producer_group(), "test_group");
+    }
+
+    #[test]
+    fn get_producer_connection_list_request_header_default() {
+        let header = GetProducerConnectionListRequestHeader::default();
+        assert_eq!(header.producer_group(), "");
+    }
+
+    #[test]
+    fn get_producer_connection_list_request_header_clone() {
+        let mut header = GetProducerConnectionListRequestHeader::default();
+        header.set_producer_group(CheetahString::from_static_str("test_group"));
+        let cloned = header.clone();
+        assert_eq!(cloned.producer_group(), header.producer_group());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4867 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced public API accessibility for producer connection list request headers by exposing previously private struct fields for direct access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->