### PR TITLE
[ISSUE #4877]🧪Add test case for BrokerLiveInfo in controller crate

### DIFF
--- a/rocketmq-controller/src/heartbeat/broker_live_info.rs
+++ b/rocketmq-controller/src/heartbeat/broker_live_info.rs
@@ -112,6 +112,7 @@ impl BrokerLiveInfo {
         &self.channel
     }
 
+    // setters
     pub fn set_last_update_timestamp(&mut self, ts: u64) {
         self.last_update_timestamp = ts;
     }
@@ -158,5 +159,152 @@ impl fmt::Debug for BrokerLiveInfo {
             .field("confirm_offset", &self.confirm_offset)
             .field("election_priority", &self.election_priority)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+
+    use rocketmq_remoting::connection::Connection;
+    use rocketmq_rust::ArcMut;
+
+    use super::*;
+
+    async fn create_test_channel() -> Channel {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let listener = std::net::TcpListener::bind(addr).unwrap();
+        let local_addr = listener.local_addr().unwrap();
+        let std_stream = std::net::TcpStream::connect(local_addr).unwrap();
+        std_stream.set_nonblocking(true).unwrap();
+        drop(listener);
+        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).unwrap();
+        let connection = Connection::new(tcp_stream);
+        let response_table = ArcMut::new(HashMap::new());
+        let inner = ArcMut::new(rocketmq_remoting::net::channel::ChannelInner::new(
+            connection,
+            response_table,
+        ));
+        Channel::new(inner, local_addr, local_addr)
+    }
+
+    #[tokio::test]
+    async fn broker_live_info_new() {
+        let channel = create_test_channel().await;
+        let info = BrokerLiveInfo::new(
+            "test_broker",
+            "127.0.0.1:10911",
+            0,
+            1000,
+            3000,
+            channel,
+            1,
+            100,
+            Some(10),
+            Some(50),
+        );
+
+        assert_eq!(info.broker_name(), "test_broker");
+        assert_eq!(info.broker_addr(), "127.0.0.1:10911");
+        assert_eq!(info.broker_id(), 0);
+        assert_eq!(info.last_update_timestamp(), 1000);
+        assert_eq!(info.heartbeat_timeout_millis(), 3000);
+        assert_eq!(info.epoch(), 1);
+        assert_eq!(info.max_offset(), 100);
+        assert_eq!(info.confirm_offset(), 50);
+        assert_eq!(info.election_priority(), Some(10));
+    }
+
+    #[tokio::test]
+    async fn broker_live_info_setters_and_getters() {
+        let channel = create_test_channel().await;
+        let mut info = BrokerLiveInfo::new(
+            "test_broker",
+            "127.0.0.1:10911",
+            0,
+            1000,
+            3000,
+            channel.clone(),
+            1,
+            100,
+            Some(10),
+            Some(50),
+        );
+
+        assert_eq!(info.broker_name(), "test_broker");
+        assert_eq!(info.broker_id(), 0);
+
+        info.set_last_update_timestamp(2000);
+        assert_eq!(info.last_update_timestamp(), 2000);
+
+        info.set_heartbeat_timeout_millis(4000);
+        assert_eq!(info.heartbeat_timeout_millis(), 4000);
+
+        info.set_epoch(5);
+        assert_eq!(info.epoch(), 5);
+
+        info.set_max_offset(500);
+        assert_eq!(info.max_offset(), 500);
+
+        info.set_confirm_offset(300);
+        assert_eq!(info.confirm_offset(), 300);
+
+        info.set_election_priority(Some(20));
+        assert_eq!(info.election_priority(), Some(20));
+
+        info.set_broker_addr("192.168.1.100:10911");
+        assert_eq!(info.broker_addr(), "192.168.1.100:10911");
+
+        let new_channel = create_test_channel().await;
+        let expected_channel = new_channel.clone();
+        info.set_channel(new_channel);
+        assert_eq!(info.channel(), &expected_channel);
+    }
+
+    #[tokio::test]
+    async fn broker_live_info_clone() {
+        let channel = create_test_channel().await;
+        let info = BrokerLiveInfo::new(
+            "test_broker",
+            "127.0.0.1:10911",
+            0,
+            1000,
+            3000,
+            channel,
+            1,
+            100,
+            Some(10),
+            Some(50),
+        );
+
+        let cloned = info.clone();
+        assert_eq!(cloned.broker_name(), info.broker_name());
+        assert_eq!(cloned.broker_addr(), info.broker_addr());
+        assert_eq!(cloned.broker_id(), info.broker_id());
+        assert_eq!(cloned.epoch(), info.epoch());
+        assert_eq!(cloned.max_offset(), info.max_offset());
+    }
+
+    #[tokio::test]
+    async fn broker_live_info_debug_format() {
+        let channel = create_test_channel().await;
+        let info = BrokerLiveInfo::new(
+            "test_broker",
+            "127.0.0.1:10911",
+            0,
+            1000,
+            3000,
+            channel,
+            1,
+            100,
+            Some(10),
+            Some(50),
+        );
+
+        let debug_str = format!("{:?}", info);
+        assert!(debug_str.contains("BrokerLiveInfo"));
+        assert!(debug_str.contains("test_broker"));
+        assert!(debug_str.contains("127.0.0.1:10911"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4877 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed additional controls for broker heartbeat and status management, improving runtime configurability and monitoring.
* **Tests**
  * Added comprehensive test coverage for broker heartbeat/status behavior, including constructors, state accessors, mutators, cloning, and debug output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->