### PR TITLE
[ISSUE #4900]🧪Add test case for AlterSyncStateSetEvent

### DIFF
--- a/rocketmq-controller/src/event/alter_sync_state_set_event.rs
+++ b/rocketmq-controller/src/event/alter_sync_state_set_event.rs
@@ -61,3 +61,49 @@ impl EventMessage for AlterSyncStateSetEvent {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alter_sync_state_set_event_new_and_getters() {
+        let broker_name = "test_broker";
+        let sync_state_set = vec![1, 2, 3];
+        let event = AlterSyncStateSetEvent::new(broker_name, sync_state_set.clone());
+
+        assert_eq!(event.broker_name(), broker_name);
+        assert_eq!(event.new_sync_state_set().len(), 3);
+        for id in sync_state_set {
+            assert!(event.new_sync_state_set().contains(&id));
+        }
+    }
+
+    #[test]
+    fn alter_sync_state_set_event_get_event_type() {
+        let event = AlterSyncStateSetEvent::new("broker", vec![1]);
+        assert_eq!(event.get_event_type(), EventType::AlterSyncStateSet);
+    }
+
+    #[test]
+    fn alter_sync_state_set_event_as_any() {
+        let event = AlterSyncStateSetEvent::new("broker", vec![1]);
+        let any = event.as_any();
+        assert!(any.is::<AlterSyncStateSetEvent>());
+        let downcast = any.downcast_ref::<AlterSyncStateSetEvent>().unwrap();
+        assert_eq!(downcast.broker_name(), "broker");
+    }
+
+    #[test]
+    fn alter_sync_state_set_event_serialization_and_deserialization() {
+        let event = AlterSyncStateSetEvent::new("broker", vec![1, 2]);
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: AlterSyncStateSetEvent = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.broker_name(), event.broker_name());
+        assert_eq!(
+            deserialized.new_sync_state_set(),
+            event.new_sync_state_set()
+        );
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #4900

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the alter sync state set event, covering construction and property accessors, event type verification, type casting/downcasting behavior, and JSON serialization/deserialization checks to improve reliability and prevent regressions. No public API or production behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->