### PR TITLE
[ISSUE #5115]🚀Add base authorization context abstraction; extend default authorization context with channel ID support and builder methods

### DIFF
--- a/rocketmq-auth/src/authorization/context.rs
+++ b/rocketmq-auth/src/authorization/context.rs
@@ -17,5 +17,6 @@
 
 pub mod authentication_context;
 pub mod base_authentication_context;
+pub mod base_authorization_context;
 pub mod default_authentication_context;
 pub mod default_authorization_context;

--- a/rocketmq-auth/src/authorization/context/base_authorization_context.rs
+++ b/rocketmq-auth/src/authorization/context/base_authorization_context.rs
@@ -1,0 +1,189 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+use std::collections::HashMap;
+
+/// Base authorization context containing common fields for all authorization contexts.
+///
+/// This struct provides the foundational properties that are shared across
+/// all types of authorization contexts in the RocketMQ system.
+#[derive(Debug, Clone, Default)]
+pub struct BaseAuthorizationContext {
+    /// Unique identifier for the communication channel
+    channel_id: Option<String>,
+
+    /// RPC code identifying the type of request
+    rpc_code: Option<String>,
+
+    /// Extension information as key-value pairs for additional context
+    ext_info: Option<HashMap<String, String>>,
+}
+
+impl BaseAuthorizationContext {
+    /// Creates a new empty `BaseAuthorizationContext`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Gets the channel ID.
+    pub fn channel_id(&self) -> Option<&str> {
+        self.channel_id.as_deref()
+    }
+
+    /// Sets the channel ID.
+    pub fn set_channel_id(&mut self, channel_id: String) {
+        self.channel_id = Some(channel_id);
+    }
+
+    /// Gets the RPC code.
+    pub fn rpc_code(&self) -> Option<&str> {
+        self.rpc_code.as_deref()
+    }
+
+    /// Sets the RPC code.
+    pub fn set_rpc_code(&mut self, rpc_code: String) {
+        self.rpc_code = Some(rpc_code);
+    }
+
+    /// Gets an extension info value by key.
+    pub fn get_ext_info(&self, key: &str) -> Option<&str> {
+        self.ext_info.as_ref()?.get(key).map(|s| s.as_str())
+    }
+
+    /// Sets an extension info key-value pair.
+    pub fn set_ext_info(&mut self, key: String, value: String) {
+        if key.is_empty() {
+            return;
+        }
+        self.ext_info
+            .get_or_insert_with(HashMap::new)
+            .insert(key, value);
+    }
+
+    /// Checks if an extension info key exists.
+    pub fn has_ext_info(&self, key: &str) -> bool {
+        self.ext_info
+            .as_ref()
+            .is_some_and(|map| map.contains_key(key))
+    }
+
+    /// Gets a reference to all extension info.
+    pub fn ext_info(&self) -> Option<&HashMap<String, String>> {
+        self.ext_info.as_ref()
+    }
+
+    /// Sets the entire extension info map.
+    pub fn set_ext_info_map(&mut self, ext_info: HashMap<String, String>) {
+        self.ext_info = Some(ext_info);
+    }
+
+    /// Takes ownership of the extension info map, leaving `None` in its place.
+    pub fn take_ext_info(&mut self) -> Option<HashMap<String, String>> {
+        self.ext_info.take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_context() {
+        let context = BaseAuthorizationContext::new();
+        assert!(context.channel_id().is_none());
+        assert!(context.rpc_code().is_none());
+        assert!(context.ext_info().is_none());
+    }
+
+    #[test]
+    fn test_channel_id() {
+        let mut context = BaseAuthorizationContext::new();
+        context.set_channel_id("channel-123".to_string());
+        assert_eq!(context.channel_id(), Some("channel-123"));
+    }
+
+    #[test]
+    fn test_rpc_code() {
+        let mut context = BaseAuthorizationContext::new();
+        context.set_rpc_code("10".to_string());
+        assert_eq!(context.rpc_code(), Some("10"));
+    }
+
+    #[test]
+    fn test_ext_info_operations() {
+        let mut context = BaseAuthorizationContext::new();
+
+        // Initially empty
+        assert!(!context.has_ext_info("key1"));
+        assert!(context.get_ext_info("key1").is_none());
+
+        // Add values
+        context.set_ext_info("key1".to_string(), "value1".to_string());
+        context.set_ext_info("key2".to_string(), "value2".to_string());
+
+        // Check existence
+        assert!(context.has_ext_info("key1"));
+        assert!(context.has_ext_info("key2"));
+        assert!(!context.has_ext_info("key3"));
+
+        // Check values
+        assert_eq!(context.get_ext_info("key1"), Some("value1"));
+        assert_eq!(context.get_ext_info("key2"), Some("value2"));
+        assert_eq!(context.get_ext_info("key3"), None);
+
+        // Check map
+        let map = context.ext_info().unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get("key1").unwrap(), "value1");
+    }
+
+    #[test]
+    fn test_set_ext_info_map() {
+        let mut context = BaseAuthorizationContext::new();
+        let mut map = HashMap::new();
+        map.insert("key1".to_string(), "value1".to_string());
+        map.insert("key2".to_string(), "value2".to_string());
+
+        context.set_ext_info_map(map);
+
+        assert_eq!(context.get_ext_info("key1"), Some("value1"));
+        assert_eq!(context.get_ext_info("key2"), Some("value2"));
+        assert_eq!(context.ext_info().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_take_ext_info() {
+        let mut context = BaseAuthorizationContext::new();
+        context.set_ext_info("key1".to_string(), "value1".to_string());
+
+        let taken = context.take_ext_info();
+        assert!(taken.is_some());
+        assert_eq!(taken.unwrap().get("key1").unwrap(), "value1");
+
+        // After taking, ext_info should be None
+        assert!(context.ext_info().is_none());
+    }
+
+    #[test]
+    fn test_empty_key_ignored() {
+        let mut context = BaseAuthorizationContext::new();
+        context.set_ext_info("".to_string(), "value".to_string());
+
+        // Empty key should be ignored
+        assert!(context.ext_info().is_none());
+    }
+}

--- a/rocketmq-auth/src/authorization/context/default_authorization_context.rs
+++ b/rocketmq-auth/src/authorization/context/default_authorization_context.rs
@@ -75,6 +75,7 @@ impl Clone for SubjectWrapper {
 /// - Resource: what is being accessed (topic, group, cluster)
 /// - Actions: what operations are being performed (PUB, SUB, CREATE, etc.)
 /// - Source IP: where the request originates from
+/// - Channel ID: unique identifier for the communication channel
 /// - RPC code: the RocketMQ request code
 /// - Extended info: additional context-specific metadata
 #[derive(Debug, Clone, Default)]
@@ -90,6 +91,9 @@ pub struct DefaultAuthorizationContext {
 
     /// Source IP address of the request
     source_ip: Option<String>,
+
+    /// Unique identifier for the communication channel (inherited from base context)
+    channel_id: Option<String>,
 
     /// RocketMQ RPC request code (for protocol-specific authorization)
     rpc_code: Option<String>,
@@ -119,6 +123,7 @@ impl DefaultAuthorizationContext {
             resource: Some(resource),
             actions: vec![action],
             source_ip: Some(source_ip.into()),
+            channel_id: None,
             rpc_code: None,
             ext_info: HashMap::new(),
         }
@@ -144,6 +149,7 @@ impl DefaultAuthorizationContext {
             resource: Some(resource),
             actions,
             source_ip: Some(source_ip.into()),
+            channel_id: None,
             rpc_code: None,
             ext_info: HashMap::new(),
         }
@@ -186,6 +192,10 @@ impl DefaultAuthorizationContext {
         self.source_ip.as_deref()
     }
 
+    pub fn channel_id(&self) -> Option<&str> {
+        self.channel_id.as_deref()
+    }
+
     pub fn rpc_code(&self) -> Option<&str> {
         self.rpc_code.as_deref()
     }
@@ -211,6 +221,10 @@ impl DefaultAuthorizationContext {
         self.source_ip = Some(source_ip.into());
     }
 
+    pub fn set_channel_id(&mut self, channel_id: impl Into<String>) {
+        self.channel_id = Some(channel_id.into());
+    }
+
     pub fn set_rpc_code(&mut self, rpc_code: impl Into<String>) {
         self.rpc_code = Some(rpc_code.into());
     }
@@ -231,6 +245,7 @@ pub struct DefaultAuthorizationContextBuilder {
     resource: Option<Resource>,
     actions: Vec<Action>,
     source_ip: Option<String>,
+    channel_id: Option<String>,
     rpc_code: Option<String>,
     ext_info: HashMap<String, String>,
 }
@@ -261,6 +276,11 @@ impl DefaultAuthorizationContextBuilder {
         self
     }
 
+    pub fn channel_id(mut self, channel_id: impl Into<String>) -> Self {
+        self.channel_id = Some(channel_id.into());
+        self
+    }
+
     pub fn rpc_code(mut self, rpc_code: impl Into<String>) -> Self {
         self.rpc_code = Some(rpc_code.into());
         self
@@ -277,6 +297,7 @@ impl DefaultAuthorizationContextBuilder {
             resource: self.resource,
             actions: self.actions,
             source_ip: self.source_ip,
+            channel_id: self.channel_id,
             rpc_code: self.rpc_code,
             ext_info: self.ext_info,
         }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5115

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new authorization context module for managing channel identification, RPC codes, and extensible metadata through accessor and mutator methods.
  * Enhanced the default authorization context with channel identification support and improved builder pattern integration for streamlined configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->