### PR TITLE
Added test case for ResourceType in rocketmq-common crate 

### DIFF
--- a/rocketmq-common/src/common/resource/resource_type.rs
+++ b/rocketmq-common/src/common/resource/resource_type.rs
@@ -220,7 +220,6 @@ mod tests {
         for invalid_code in ["6", "99", "255"] {
             let result: Result<ResourceType, _> = serde_json::from_str(invalid_code);
             assert!(result.is_err());
-            
             let err = result.unwrap_err();
             let err_msg = err.to_string();
             assert!(err_msg.contains("invalid ResourceType code"));


### PR DESCRIPTION
Fixes #5081 

Added comprehensive unit tests for the ResourceType enum in rocketmq-common crate to improve code coverage and reliability. Tests cover all public methods including get_by_name(), code(), name(), and custom Serialize/Deserialize trait implementations.

To test the change ,I ran cargo test --package rocketmq-common --lib -- common::resource::resource_type::tests to verify all 9 test cases pass successfully. All tests validated enum variants, serialization/deserialization logic, case-insensitive matching, error handling, and Copy trait behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for ResourceType: case-insensitive name lookup, variant name/code access, JSON serialize/deserialize (including round-trip and bulk checks), handling of invalid JSON codes, and comprehensive per-variant validations. Changes are test-only; no public API signatures were added or modified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->