### PR TITLE
Set default use_route_info_manager_v2 to true in NamesrvConfig

### DIFF
--- a/rocketmq-common/src/common/namesrv/namesrv_config.rs
+++ b/rocketmq-common/src/common/namesrv/namesrv_config.rs
@@ -232,7 +232,7 @@ impl Default for NamesrvConfig {
             wait_seconds_for_service: 45,
             delete_topic_with_broker_registration: false,
             config_black_list: "configBlackList;configStorePath;kvConfigPath".to_string(),
-            use_route_info_manager_v2: false, // Default to V2 (production-ready)
+            use_route_info_manager_v2: true, // Default to V2 (production-ready)
         }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5117
 
### Brief Description
This pull request makes a small but important configuration change to the default settings in the `NamesrvConfig` struct. The default value for the `use_route_info_manager_v2` field is now set to `true`, enabling the V2 route info manager by default.

- Changed the default value of `use_route_info_manager_v2` in the `NamesrvConfig` implementation from `false` to `true`, making the V2 route info manager enabled by default.
<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default naming server configuration to enable route info manager v2 by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->