### PR TITLE
[ISSUE #5142] Refactor DefaultMQProducer#set_trace_dispatcher to alwa…

### DIFF
--- a/rocketmq-client/src/producer/default_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/default_mq_produce_builder.rs
@@ -298,7 +298,9 @@ impl DefaultMQProducerBuilder {
             mq_producer.set_max_message_size(max_message_size);
         }
 
-        mq_producer.set_trace_dispatcher(self.trace_dispatcher);
+        if let Some(trace_dispatcher) = self.trace_dispatcher {
+            mq_producer.set_trace_dispatcher(trace_dispatcher);
+        }
         if let Some(auto_batch) = self.auto_batch {
             mq_producer.set_auto_batch(auto_batch);
         }

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -409,9 +409,9 @@ impl DefaultMQProducer {
 
     pub fn set_trace_dispatcher(
         &mut self,
-        trace_dispatcher: Option<Arc<Box<dyn TraceDispatcher + Send + Sync>>>,
+        trace_dispatcher: Arc<Box<dyn TraceDispatcher + Send + Sync>>,
     ) {
-        self.producer_config.trace_dispatcher = trace_dispatcher;
+        self.producer_config.trace_dispatcher = Some(trace_dispatcher);
     }
 
     pub fn set_auto_batch(&mut self, auto_batch: bool) {

--- a/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
@@ -287,7 +287,9 @@ impl TransactionMQProducerBuilder {
             mq_producer.set_max_message_size(max_message_size);
         }
 
-        mq_producer.set_trace_dispatcher(self.trace_dispatcher);
+        if let Some(trace_dispatcher) = self.trace_dispatcher {
+            mq_producer.set_trace_dispatcher(trace_dispatcher);
+        }
         if let Some(auto_batch) = self.auto_batch {
             mq_producer.set_auto_batch(auto_batch);
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Closes #5142 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

Ran `cargo test` locally
 
<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified trace dispatcher configuration: the method now requires an explicit dispatcher parameter instead of accepting an optional value. Trace dispatchers are only applied when explicitly provided during producer setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->