### PR TITLE
[ISSUE #5153]Add NotInitialized error variant to unified error enum

### DIFF
--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -370,6 +370,9 @@ pub enum RocketMQError {
     #[deprecated(since = "0.7.0", note = "Use specific error types instead")]
     #[error("{0}")]
     Legacy(String),
+
+    #[error("Not initialized: {0}")]
+    NotInitialized(String),
 }
 
 // ============================================================================
@@ -520,6 +523,12 @@ impl RocketMQError {
     #[inline]
     pub fn nameserver_config_invalid(reason: impl Into<String>) -> Self {
         Self::Tools(ToolsError::nameserver_config_invalid(reason))
+    }
+
+    /// Create a not initialized error
+    #[inline]
+    pub fn not_initialized(reason: impl Into<String>) -> Self {
+        Self::NotInitialized(reason.into())
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5153

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling with a dedicated error type for initialization failures, providing clearer diagnostics for debugging initialization-related issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->