### PR TITLE
Return borrowed reference from trace_dispatcher

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -148,8 +148,8 @@ impl ProducerConfig {
         self.max_message_size
     }
 
-    pub fn trace_dispatcher(&self) -> &Option<Arc<Box<dyn TraceDispatcher + Send + Sync>>> {
-        &self.trace_dispatcher
+    pub fn trace_dispatcher(&self) -> Option<&Arc<Box<dyn TraceDispatcher + Send + Sync>>> {
+        self.trace_dispatcher.as_ref()
     }
 
     pub fn auto_batch(&self) -> bool {
@@ -301,8 +301,8 @@ impl DefaultMQProducer {
         self.producer_config.max_message_size
     }
 
-    pub fn trace_dispatcher(&self) -> &Option<Arc<Box<dyn TraceDispatcher + Send + Sync>>> {
-        &self.producer_config.trace_dispatcher
+    pub fn trace_dispatcher(&self) -> Option<&Arc<Box<dyn TraceDispatcher + Send + Sync>>> {
+        self.producer_config.trace_dispatcher()
     }
 
     pub fn auto_batch(&self) -> bool {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5131

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

This PR updates `trace_dispatcher()` to return a borrowed reference instead of cloning the `Arc`, as proposed in the issue.This avoids unnecessary reference count increments while preserving existing ownership and behavior. No functional changes are introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal API type signatures for better safety and ergonomics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->