### PR TITLE
Return borrowed reference from produce_accumulator getter

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -156,8 +156,8 @@ impl ProducerConfig {
         self.auto_batch
     }
 
-    pub fn produce_accumulator(&self) -> &Option<ArcMut<ProduceAccumulator>> {
-        &self.produce_accumulator
+    pub fn produce_accumulator(&self) -> Option<&ArcMut<ProduceAccumulator>> {
+        self.produce_accumulator.as_ref()
     }
 
     pub fn enable_backpressure_for_async_mode(&self) -> bool {
@@ -309,8 +309,8 @@ impl DefaultMQProducer {
         self.producer_config.auto_batch
     }
 
-    pub fn produce_accumulator(&self) -> &Option<ArcMut<ProduceAccumulator>> {
-        &self.producer_config.produce_accumulator
+    pub fn produce_accumulator(&self) -> Option<&ArcMut<ProduceAccumulator>> {
+        self.producer_config.produce_accumulator()
     }
 
     pub fn enable_backpressure_for_async_mode(&self) -> bool {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5130

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
This PR updates `produce_accumulator()` to return a borrowed reference instead of exposing the internal `Option<ArcMut<_>>`.

This mirrors the earlier `trace_dispatcher()` change and avoids unnecessary ownership exposure while preserving existing behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal producer accumulator access patterns for improved efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->