### PR TITLE
[ISSUE #5198]🚀Add controller error module with unified error types and constructors

### DIFF
--- a/rocketmq-error/examples/controller_error_integration.rs
+++ b/rocketmq-error/examples/controller_error_integration.rs
@@ -1,0 +1,184 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! # ControllerError Integration Example
+//!
+//! This example demonstrates how to use ControllerError integrated with RocketMQError.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use rocketmq_error::RocketMQError;
+//! use rocketmq_error::RocketMQResult;
+//!
+//! // Function returning controller error
+//! fn check_leader() -> RocketMQResult<()> {
+//!     // Automatically converts ControllerError to RocketMQError
+//!     Err(RocketMQError::controller_not_leader(Some(1)))
+//! }
+//!
+//! // Function using convenient constructors
+//! fn handle_request() -> RocketMQResult<String> {
+//!     // Check if controller is leader
+//!     if !is_leader() {
+//!         return Err(RocketMQError::controller_not_leader(None));
+//!     }
+//!
+//!     // Validate request
+//!     if request_invalid() {
+//!         return Err(RocketMQError::controller_invalid_request(
+//!             "missing broker_name",
+//!         ));
+//!     }
+//!
+//!     // Check timeout
+//!     if operation_timeout() {
+//!         return Err(RocketMQError::controller_timeout(5000));
+//!     }
+//!
+//!     Ok("Success".to_string())
+//! }
+//!
+//! // Error propagation works seamlessly
+//! fn process() -> RocketMQResult<()> {
+//!     check_leader()?; // Propagates controller error
+//!     handle_request()?; // Propagates any error
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Available Constructor Methods
+//!
+//! ```rust
+//! use rocketmq_error::RocketMQError;
+//!
+//! // Not leader error
+//! let err = RocketMQError::controller_not_leader(Some(3));
+//!
+//! // Raft consensus error
+//! let err = RocketMQError::controller_raft_error("proposal timeout");
+//!
+//! // Metadata not found
+//! let err = RocketMQError::controller_metadata_not_found("broker-a");
+//!
+//! // Invalid request
+//! let err = RocketMQError::controller_invalid_request("missing field: broker_name");
+//!
+//! // Timeout error
+//! let err = RocketMQError::controller_timeout(5000);
+//!
+//! // Shutdown error
+//! let err = RocketMQError::controller_shutdown();
+//! ```
+//!
+//! ## Pattern Matching
+//!
+//! ```rust
+//! use rocketmq_error::ControllerError;
+//! use rocketmq_error::RocketMQError;
+//!
+//! fn handle_error(err: RocketMQError) {
+//!     match err {
+//!         RocketMQError::Controller(ControllerError::NotLeader { leader_id }) => {
+//!             if let Some(id) = leader_id {
+//!                 println!("Redirect to leader: {}", id);
+//!             } else {
+//!                 println!("No leader elected yet");
+//!             }
+//!         }
+//!         RocketMQError::Controller(ControllerError::Timeout { timeout_ms }) => {
+//!             println!("Operation timed out after {}ms", timeout_ms);
+//!         }
+//!         RocketMQError::Controller(ControllerError::Shutdown) => {
+//!             println!("Controller is shutting down");
+//!         }
+//!         _ => {
+//!             println!("Other error: {}", err);
+//!         }
+//!     }
+//! }
+//! ```
+
+use rocketmq_error::ControllerError;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+
+fn main() {
+    println!("=== ControllerError Integration Example ===\n");
+
+    // Example 1: Using constructor methods
+    println!("1. Creating controller errors using constructor methods:");
+    let err1 = RocketMQError::controller_not_leader(Some(1));
+    println!("   Not leader: {}", err1);
+
+    let err2 = RocketMQError::controller_timeout(5000);
+    println!("   Timeout: {}", err2);
+
+    let err3 = RocketMQError::controller_invalid_request("missing broker_name");
+    println!("   Invalid request: {}", err3);
+
+    // Example 2: Automatic conversion
+    println!("\n2. Automatic conversion from ControllerError:");
+    let controller_err = ControllerError::Raft("consensus failed".to_string());
+    let rocketmq_err: RocketMQError = controller_err.into();
+    println!("   Converted error: {}", rocketmq_err);
+
+    // Example 3: Error propagation
+    println!("\n3. Error propagation in functions:");
+    match simulated_operation() {
+        Ok(_) => println!("   Operation succeeded"),
+        Err(e) => println!("   Operation failed: {}", e),
+    }
+
+    // Example 4: Pattern matching
+    println!("\n4. Pattern matching on errors:");
+    let errors = vec![
+        RocketMQError::controller_not_leader(Some(2)),
+        RocketMQError::controller_timeout(3000),
+        RocketMQError::controller_shutdown(),
+    ];
+
+    for err in errors {
+        print_error_details(err);
+    }
+
+    println!("\n=== Example completed successfully ===");
+}
+
+// Simulated operation that returns controller error
+fn simulated_operation() -> RocketMQResult<()> {
+    // Simulate a not leader scenario
+    Err(RocketMQError::controller_not_leader(None))
+}
+
+// Helper function to print error details
+fn print_error_details(err: RocketMQError) {
+    match err {
+        RocketMQError::Controller(ControllerError::NotLeader { leader_id }) => {
+            println!("   - Not leader error, leader_id: {:?}", leader_id);
+        }
+        RocketMQError::Controller(ControllerError::Timeout { timeout_ms }) => {
+            println!("   - Timeout error after {}ms", timeout_ms);
+        }
+        RocketMQError::Controller(ControllerError::Shutdown) => {
+            println!("   - Controller shutdown error");
+        }
+        _ => {
+            println!("   - Other error: {}", err);
+        }
+    }
+}

--- a/rocketmq-error/src/controller_error.rs
+++ b/rocketmq-error/src/controller_error.rs
@@ -1,0 +1,132 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! Controller module error types
+//!
+//! This module provides error types specific to the RocketMQ controller subsystem,
+//! which manages broker lifecycles, master elections, and cluster coordination.
+
+use std::io;
+
+use thiserror::Error;
+
+/// Controller module error types
+///
+/// Errors that can occur during controller operations including:
+/// - Raft consensus failures
+/// - Leadership transitions
+/// - Broker registration and metadata management
+/// - Network and serialization issues
+#[derive(Debug, Error)]
+pub enum ControllerError {
+    /// IO errors
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Raft consensus errors
+    #[error("Raft error: {0}")]
+    Raft(String),
+
+    /// Not the leader error
+    #[error("Not leader, current leader is: {}", leader_id.map(|id| id.to_string()).unwrap_or_else(|| "unknown".to_string()))]
+    NotLeader { leader_id: Option<u64> },
+
+    /// Metadata not found
+    #[error("Metadata not found: {key}")]
+    MetadataNotFound { key: String },
+
+    /// Invalid request
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
+
+    /// Broker registration error
+    #[error("Broker registration failed: {0}")]
+    BrokerRegistrationFailed(String),
+
+    /// Not initialized error
+    #[error("Not initialized: {0}")]
+    NotInitialized(String),
+
+    /// Initialization failed error
+    #[error("Initialization failed")]
+    InitializationFailed,
+
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+
+    /// Serialization error
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
+
+    /// Storage error
+    #[error("Storage error: {0}")]
+    StorageError(String),
+
+    /// Network error
+    #[error("Network error: {0}")]
+    NetworkError(String),
+
+    /// Timeout error
+    #[error("Operation timeout after {timeout_ms}ms")]
+    Timeout { timeout_ms: u64 },
+
+    /// Internal error
+    #[error("Internal error: {0}")]
+    Internal(String),
+
+    /// Shutdown error
+    #[error("Controller is shutting down")]
+    Shutdown,
+}
+
+/// Result type alias for Controller operations
+pub type ControllerResult<T> = std::result::Result<T, ControllerError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        let err = ControllerError::NotLeader { leader_id: Some(1) };
+        assert!(err.to_string().contains("Not leader"));
+    }
+
+    #[test]
+    fn test_error_conversion() {
+        let io_err = io::Error::other("test");
+        let controller_err: ControllerError = io_err.into();
+        assert!(matches!(controller_err, ControllerError::Io(_)));
+    }
+
+    #[test]
+    fn test_timeout_error() {
+        let err = ControllerError::Timeout { timeout_ms: 5000 };
+        let err_str = err.to_string();
+        assert!(err_str.contains("5000"));
+        assert!(err_str.contains("timeout"));
+    }
+
+    #[test]
+    fn test_metadata_not_found() {
+        let err = ControllerError::MetadataNotFound {
+            key: "broker-a".to_string(),
+        };
+        assert!(err.to_string().contains("broker-a"));
+    }
+}

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -57,8 +57,14 @@ pub mod unified;
 // Auth error module
 pub mod auth_error;
 
+// Controller error module
+pub mod controller_error;
+
 // Re-export new error types as primary API
 // Re-export auth error types from unified module
+// Re-export controller error types
+pub use controller_error::ControllerError;
+pub use controller_error::ControllerResult;
 pub use unified::AuthError;
 pub use unified::NetworkError;
 pub use unified::ProtocolError;

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -43,6 +43,8 @@ pub use crate::auth_error::AuthError;
 pub use crate::client_error::*;
 #[allow(deprecated)]
 pub use crate::common_error::*;
+// Re-export controller error from the controller_error module
+pub use crate::controller_error::ControllerError;
 
 /// Main error type for all RocketMQ operations
 ///
@@ -116,6 +118,13 @@ pub enum RocketMQError {
     /// Authentication/authorization errors (credential validation, access control, etc.)
     #[error(transparent)]
     Authentication(#[from] AuthError),
+
+    // ============================================================================
+    // Controller Errors
+    // ============================================================================
+    /// Controller operation errors (Raft consensus, leader election, broker management, etc.)
+    #[error(transparent)]
+    Controller(#[from] ControllerError),
 
     // ============================================================================
     // Broker Errors
@@ -574,6 +583,46 @@ impl RocketMQError {
     #[inline]
     pub fn invalid_signature(reason: impl Into<String>) -> Self {
         Self::Authentication(AuthError::InvalidSignature(reason.into()))
+    }
+
+    // ============================================================================
+    // Controller Error Constructors
+    // ============================================================================
+
+    /// Create a controller not leader error
+    #[inline]
+    pub fn controller_not_leader(leader_id: Option<u64>) -> Self {
+        Self::Controller(ControllerError::NotLeader { leader_id })
+    }
+
+    /// Create a controller Raft error
+    #[inline]
+    pub fn controller_raft_error(reason: impl Into<String>) -> Self {
+        Self::Controller(ControllerError::Raft(reason.into()))
+    }
+
+    /// Create a controller metadata not found error
+    #[inline]
+    pub fn controller_metadata_not_found(key: impl Into<String>) -> Self {
+        Self::Controller(ControllerError::MetadataNotFound { key: key.into() })
+    }
+
+    /// Create a controller invalid request error
+    #[inline]
+    pub fn controller_invalid_request(reason: impl Into<String>) -> Self {
+        Self::Controller(ControllerError::InvalidRequest(reason.into()))
+    }
+
+    /// Create a controller timeout error
+    #[inline]
+    pub fn controller_timeout(timeout_ms: u64) -> Self {
+        Self::Controller(ControllerError::Timeout { timeout_ms })
+    }
+
+    /// Create a controller shutdown error
+    #[inline]
+    pub fn controller_shutdown() -> Self {
+        Self::Controller(ControllerError::Shutdown)
     }
 }
 

--- a/rocketmq-error/tests/controller_integration_test.rs
+++ b/rocketmq-error/tests/controller_integration_test.rs
@@ -1,0 +1,133 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! Integration tests for ControllerError with RocketMQError
+
+use rocketmq_error::ControllerError;
+use rocketmq_error::RocketMQError;
+
+#[test]
+fn test_controller_error_into_rocketmq_error() {
+    let controller_err = ControllerError::NotLeader { leader_id: Some(1) };
+    let rocketmq_err: RocketMQError = controller_err.into();
+
+    assert!(matches!(rocketmq_err, RocketMQError::Controller(_)));
+    assert!(rocketmq_err.to_string().contains("Not leader"));
+}
+
+#[test]
+fn test_controller_error_from_conversion() {
+    let controller_err = ControllerError::Timeout { timeout_ms: 5000 };
+    let rocketmq_err = RocketMQError::from(controller_err);
+
+    assert!(matches!(rocketmq_err, RocketMQError::Controller(_)));
+    assert!(rocketmq_err.to_string().contains("5000"));
+}
+
+#[test]
+fn test_controller_error_constructors() {
+    // Test not leader constructor
+    let err = RocketMQError::controller_not_leader(Some(3));
+    assert!(matches!(
+        err,
+        RocketMQError::Controller(ControllerError::NotLeader { leader_id: Some(3) })
+    ));
+
+    // Test Raft error constructor
+    let err = RocketMQError::controller_raft_error("consensus failed");
+    assert!(matches!(
+        err,
+        RocketMQError::Controller(ControllerError::Raft(_))
+    ));
+    assert!(err.to_string().contains("consensus failed"));
+
+    // Test metadata not found constructor
+    let err = RocketMQError::controller_metadata_not_found("broker-a");
+    assert!(matches!(
+        err,
+        RocketMQError::Controller(ControllerError::MetadataNotFound { .. })
+    ));
+    assert!(err.to_string().contains("broker-a"));
+
+    // Test invalid request constructor
+    let err = RocketMQError::controller_invalid_request("missing field");
+    assert!(matches!(
+        err,
+        RocketMQError::Controller(ControllerError::InvalidRequest(_))
+    ));
+
+    // Test timeout constructor
+    let err = RocketMQError::controller_timeout(3000);
+    assert!(matches!(
+        err,
+        RocketMQError::Controller(ControllerError::Timeout { timeout_ms: 3000 })
+    ));
+
+    // Test shutdown constructor
+    let err = RocketMQError::controller_shutdown();
+    assert!(matches!(
+        err,
+        RocketMQError::Controller(ControllerError::Shutdown)
+    ));
+}
+
+#[test]
+fn test_controller_error_result_propagation() {
+    fn returns_controller_error() -> Result<(), ControllerError> {
+        Err(ControllerError::NotLeader { leader_id: None })
+    }
+
+    fn returns_rocketmq_error() -> Result<(), RocketMQError> {
+        returns_controller_error()?;
+        Ok(())
+    }
+
+    let result = returns_rocketmq_error();
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err, RocketMQError::Controller(_)));
+}
+
+#[test]
+fn test_all_controller_error_variants_convert() {
+    use std::io;
+
+    let test_cases = vec![
+        ControllerError::Io(io::Error::other("test")),
+        ControllerError::Raft("raft error".to_string()),
+        ControllerError::NotLeader { leader_id: Some(1) },
+        ControllerError::MetadataNotFound {
+            key: "test".to_string(),
+        },
+        ControllerError::InvalidRequest("invalid".to_string()),
+        ControllerError::BrokerRegistrationFailed("failed".to_string()),
+        ControllerError::NotInitialized("not init".to_string()),
+        ControllerError::InitializationFailed,
+        ControllerError::ConfigError("config error".to_string()),
+        ControllerError::SerializationError("ser error".to_string()),
+        ControllerError::StorageError("storage error".to_string()),
+        ControllerError::NetworkError("network error".to_string()),
+        ControllerError::Timeout { timeout_ms: 1000 },
+        ControllerError::Internal("internal".to_string()),
+        ControllerError::Shutdown,
+    ];
+
+    for controller_err in test_cases {
+        let rocketmq_err: RocketMQError = controller_err.into();
+        assert!(matches!(rocketmq_err, RocketMQError::Controller(_)));
+    }
+}


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5198

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive error types for the controller subsystem covering Raft, leadership, metadata, validation, network, and timeout scenarios
  * Added convenience constructors for creating and handling controller errors

* **Documentation**
  * Added examples and tests demonstrating controller error handling, propagation, and conversion patterns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->