### PR TITLE
[ISSUE #5156] Added error handling in send_by_accumulator for unintialized defaultMQProducer

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -504,6 +504,13 @@ impl DefaultMQProducer {
         })
     }
 
+    #[inline]
+    fn get_accumulator_mut(&mut self) -> rocketmq_error::RocketMQResult<&mut ArcMut<ProduceAccumulator>> {
+        self.producer_config
+            .produce_accumulator
+            .as_mut()
+            .ok_or_else(|| mq_client_err!("ProduceAccumulator is not initialized, auto-batch is enabled"))
+    }
     pub async fn send_direct<M>(
         &mut self,
         mut msg: M,
@@ -550,18 +557,10 @@ impl DefaultMQProducer {
             MessageClientIDSetter::set_uniq_id(&mut msg);
             if send_callback.is_none() {
                 let mq_producer = self.clone();
-                self.producer_config
-                    .produce_accumulator
-                    .as_mut()
-                    .unwrap()
-                    .send(msg, mq, mq_producer)
-                    .await
+                self.get_accumulator_mut()?.send(msg, mq, mq_producer).await
             } else {
                 let mq_producer = self.clone();
-                self.producer_config
-                    .produce_accumulator
-                    .as_mut()
-                    .unwrap()
+                self.get_accumulator_mut()?
                     .send_callback(msg, mq, send_callback, mq_producer)
                     .await?;
                 Ok(None)


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5156

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Adds explicit error handling in `send_by_accumulator` to prevent panics when the `ProduceAccumulator` is not initialized. Replaces internal `unwrap()` usage with a guarded access that returns a clear error, while preserving existing batching behavior for correctly configured producers.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Send operations now detect uninitialized internal state and return errors instead of crashing.
  * Initialization failures during send are propagated as recoverable errors, improving stability and preventing panics during message delivery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->