### PR TITLE
refactor: change return type of MQProducer::send_to_queue to RocketMQ::Result<Option<SendResult>>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- **refactor(client):** Change `MQProducer::send_to_queue` return type to `RocketMQResult<Option<SendResult>>` in `mq_producer.rs`, `default_mq_producer.rs` and `transaction_mq_producer.rs` ([#5169](https://github.com/mxsm/rocketmq-rust/issues/5169))
 - **refactor(client):** Replace `lazy_static!` with `std::sync::LazyLock` in `trace_view.rs` ([#5092](https://github.com/mxsm/rocketmq-rust/issues/5092))
 - **refactor(store):** Replace `lazy_static!` with `std::sync::LazyLock` in `delivery.rs` and remove `lazy_static` dependency from `rocketmq-store` ([#5091](https://github.com/mxsm/rocketmq-rust/issues/5091))
 - **refactor(common):** Replace `lazy_static!` with `std::sync::LazyLock` in `name_server_address_utils.rs` ([#5068](https://github.com/mxsm/rocketmq-rust/issues/5068))

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -156,9 +156,14 @@ pub trait MQProducer {
     ///
     /// # Returns
     ///
-    /// * `rocketmq_error::RocketMQResult<SendResult>` - A result containing the send result or an
-    ///   error.
-    async fn send_to_queue<M>(&mut self, msg: M, mq: MessageQueue) -> rocketmq_error::RocketMQResult<SendResult>
+    /// * `rocketmq_error::RocketMQResult<SendResult>` - A result containing an optional send result
+    ///   or an error. Returns `Some(SendResult)` for synchronous sends, or `None` when the result
+    ///   is delivered asynchronously via a callback.
+    async fn send_to_queue<M>(
+        &mut self,
+        msg: M,
+        mq: MessageQueue,
+    ) -> rocketmq_error::RocketMQResult<Option<SendResult>>
     where
         M: MessageTrait + Send + Sync;
 

--- a/rocketmq-client/src/producer/transaction_mq_producer.rs
+++ b/rocketmq-client/src/producer/transaction_mq_producer.rs
@@ -140,7 +140,7 @@ impl MQProducer for TransactionMQProducer {
         self.default_producer.send_oneway(msg).await
     }
 
-    async fn send_to_queue<M>(&mut self, msg: M, mq: MessageQueue) -> rocketmq_error::RocketMQResult<SendResult>
+    async fn send_to_queue<M>(&mut self, msg: M, mq: MessageQueue) -> rocketmq_error::RocketMQResult<Option<SendResult>>
     where
         M: MessageTrait + Send + Sync,
     {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Resolves #5169 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

Ran `cargo test` locally

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Producer send now returns an optional send result: sends may succeed without yielding a concrete send result. This affects all producer interfaces and is a breaking change for callers that previously relied on a guaranteed result.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->