### PR TITLE
[ISSUE #5187]🧪Add test case for TopicOffset in rocketmq-remoting crate

### DIFF
--- a/rocketmq-remoting/src/protocol/admin/topic_offset.rs
+++ b/rocketmq-remoting/src/protocol/admin/topic_offset.rs
@@ -69,3 +69,64 @@ impl std::fmt::Display for TopicOffset {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_topic_offset_default_and_new() {
+        let offset = TopicOffset::default();
+        assert_eq!(offset.get_min_offset(), 0);
+        assert_eq!(offset.get_max_offset(), 0);
+        assert_eq!(offset.get_last_update_timestamp(), 0);
+
+        let offset = TopicOffset::new();
+        assert_eq!(offset.get_min_offset(), 0);
+        assert_eq!(offset.get_max_offset(), 0);
+        assert_eq!(offset.get_last_update_timestamp(), 0);
+    }
+
+    #[test]
+    fn test_topic_offset_setters_and_getters() {
+        let mut offset = TopicOffset::new();
+        offset.set_min_offset(10);
+        offset.set_max_offset(20);
+        offset.set_last_update_timestamp(1000);
+
+        assert_eq!(offset.get_min_offset(), 10);
+        assert_eq!(offset.get_max_offset(), 20);
+        assert_eq!(offset.get_last_update_timestamp(), 1000);
+    }
+
+    #[test]
+    fn test_topic_offset_serialization_and_deserialization() {
+        let mut offset = TopicOffset::new();
+        offset.set_min_offset(-10);
+        offset.set_max_offset(-20);
+        offset.set_last_update_timestamp(-1000);
+
+        let serialized = serde_json::to_string(&offset).unwrap();
+        let expected = r#"{"minOffset":-10,"maxOffset":-20,"lastUpdateTimestamp":-1000}"#;
+        assert_eq!(serialized, expected);
+
+        let deserialized: TopicOffset = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.get_min_offset(), -10);
+        assert_eq!(deserialized.get_max_offset(), -20);
+        assert_eq!(deserialized.get_last_update_timestamp(), -1000);
+    }
+
+    #[test]
+    fn test_topic_offset_display() {
+        let mut offset = TopicOffset::new();
+        offset.set_min_offset(10);
+        offset.set_max_offset(20);
+        offset.set_last_update_timestamp(1000);
+
+        let display = format!("{}", offset);
+        assert_eq!(
+            display,
+            "TopicOffset{min_offset=10, max_offset=20, last_update_timestamp=1000}"
+        );
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5187 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for TopicOffset functionality, including validation of constructors, property accessors, serialization/deserialization, and output formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->