### PR TITLE
[ISSUE #5281]🚀Add AuthenticationMetadataProvider trait and re-exports for user management support

### DIFF
--- a/rocketmq-auth/src/authentication.rs
+++ b/rocketmq-auth/src/authentication.rs
@@ -25,6 +25,7 @@ pub mod provider;
 pub mod strategy;
 
 // Re-export commonly used types for convenience
+pub use provider::AuthenticationMetadataProvider;
 pub use provider::AuthenticationProvider;
 pub use strategy::AuthenticationStrategy;
 

--- a/rocketmq-auth/src/authentication/provider.rs
+++ b/rocketmq-auth/src/authentication/provider.rs
@@ -19,8 +19,9 @@
 
 // Declare submodules using #[path] attribute
 
+pub mod authentication_metadata_provider;
 pub mod authentication_provider;
-
 // Re-export for convenience
 
+pub use authentication_metadata_provider::AuthenticationMetadataProvider;
 pub use authentication_provider::AuthenticationProvider;

--- a/rocketmq-auth/src/authentication/provider/authentication_metadata_provider.rs
+++ b/rocketmq-auth/src/authentication/provider/authentication_metadata_provider.rs
@@ -1,0 +1,60 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+//! Authentication Metadata Provider Trait (Rust 2021 Standard)
+
+use std::any::Any;
+use std::sync::Arc;
+
+use rocketmq_error::RocketMQResult;
+
+use crate::authentication::model::user::User;
+use crate::config::AuthConfig;
+
+/// Authentication metadata provider for user management.
+///
+/// Maps to Java interface:
+/// ```java
+/// public interface AuthenticationMetadataProvider
+/// ```
+#[allow(async_fn_in_trait)]
+pub trait AuthenticationMetadataProvider: Send + Sync {
+    /// Initialize the provider.
+    async fn initialize(
+        &mut self,
+        config: AuthConfig,
+        metadata_service: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> RocketMQResult<()>;
+
+    /// Shutdown the provider.
+    async fn shutdown(&mut self) -> RocketMQResult<()>;
+
+    /// Create a user.
+    async fn create_user(&self, user: User) -> RocketMQResult<()>;
+
+    /// Delete a user.
+    async fn delete_user(&self, username: &str) -> RocketMQResult<()>;
+
+    /// Update a user.
+    async fn update_user(&self, user: User) -> RocketMQResult<()>;
+
+    /// Get a user by username.
+    async fn get_user(&self, username: &str) -> RocketMQResult<User>;
+
+    /// List users with optional filter.
+    async fn list_user(&self, filter: Option<&str>) -> RocketMQResult<Vec<User>>;
+}

--- a/rocketmq-auth/src/lib.rs
+++ b/rocketmq-auth/src/lib.rs
@@ -24,6 +24,7 @@ pub mod migration;
 
 // Re-export commonly used authentication types
 pub use authentication::context::default_authentication_context::DefaultAuthenticationContext;
+pub use authentication::provider::AuthenticationMetadataProvider;
 pub use authentication::provider::AuthenticationProvider;
 pub use authentication::strategy::AllowAllAuthenticationStrategy;
 pub use authentication::strategy::AuthenticationStrategy;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5281

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new authentication metadata provider interface enabling user account management capabilities, including user creation, deletion, updates, retrieval, and listing operations with lifecycle management support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->