### PR TITLE
[ISSUE #5345]✨Update sync-issue-labels.yml to trigger on pull request creation only

### DIFF
--- a/.github/workflows/sync-issue-labels.yml
+++ b/.github/workflows/sync-issue-labels.yml
@@ -2,14 +2,17 @@ name: Sync Issue Labels to PR
 
 on:
   pull_request_target:
-    types: [ opened, synchronize, edited ] # Trigger when a PR is created, updated, or edited
+    types: [ opened ] # Trigger only when a PR is first created
 
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
+    permissions:
+
+      contents: read
+
+      issues: write
+
 
     steps:
       # Checkout the repository


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5345

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request label synchronization workflow to run only on PR creation, removing automatic syncing during PR updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->