### PR TITLE
[ISSUE #5337]✨Simplify ArcMut cloning in LatencyFaultTolerance initialization in MQFaultStrategy

### DIFF
--- a/rocketmq-client/src/latency/mq_fault_strategy.rs
+++ b/rocketmq-client/src/latency/mq_fault_strategy.rs
@@ -48,13 +48,13 @@ impl MQFaultStrategy {
         tolerance_impl.set_start_detector_enable(client_config.start_detector_enable);
         let latency_fault_tolerance = ArcMut::new(tolerance_impl);
         Self {
-            latency_fault_tolerance: latency_fault_tolerance.clone(),
+            latency_fault_tolerance: ArcMut::clone(&latency_fault_tolerance),
             send_latency_fault_enable: AtomicBool::new(client_config.send_latency_enable),
             start_detector_enable: AtomicBool::new(client_config.start_detector_enable),
             latency_max: &[50, 100, 550, 1800, 3000, 5000, 15000],
             not_available_duration: &[0, 0, 2000, 5000, 6000, 10000, 30000],
             reachable_filter: Box::new(ReachableFilter {
-                latency_fault_tolerance: latency_fault_tolerance.clone(),
+                latency_fault_tolerance: ArcMut::clone(&latency_fault_tolerance),
             }),
             available_filter: Box::new(AvailableFilter {
                 latency_fault_tolerance,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5337 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
