### PR TITLE
[ISSUE #5395]🚀Implement conversion of FilterContext to Rust based on Java version's FilterContext

### DIFF
--- a/rocketmq-common/src/common/filter.rs
+++ b/rocketmq-common/src/common/filter.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 pub mod expression_type;
+pub mod filter_context;

--- a/rocketmq-common/src/common/filter/filter_context.rs
+++ b/rocketmq-common/src/common/filter/filter_context.rs
@@ -1,0 +1,71 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct FilterContext {
+    consumer_group: Option<CheetahString>,
+}
+
+impl FilterContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get_consumer_group(&self) -> Option<&CheetahString> {
+        self.consumer_group.as_ref()
+    }
+
+    pub fn set_consumer_group(&mut self, consumer_group: CheetahString) {
+        self.consumer_group = Some(consumer_group);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_context_default_and_new() {
+        let filter_context = FilterContext::default();
+        assert!(filter_context.get_consumer_group().is_none());
+
+        let filter_context = FilterContext::new();
+        assert!(filter_context.get_consumer_group().is_none());
+    }
+
+    #[test]
+    fn test_filter_context_setters_and_getters() {
+        let mut filter_context = FilterContext::new();
+        let consumer_group = CheetahString::from("test_consumer_group");
+        filter_context.set_consumer_group(consumer_group.clone());
+
+        assert_eq!(filter_context.get_consumer_group(), Some(&consumer_group));
+    }
+
+    #[test]
+    fn test_filter_context_serialization_and_deserialization() {
+        let mut filter_context = FilterContext::new();
+        let consumer_group = CheetahString::from("test_consumer_group");
+        filter_context.set_consumer_group(consumer_group.clone());
+
+        let serialized = serde_json::to_string(&filter_context).unwrap();
+        let deserialized: FilterContext = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.get_consumer_group(), Some(&consumer_group));
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5395 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
Add unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Enhanced the filtering framework to support consumer group context information, enabling more sophisticated filtering operations within the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->