### PR TITLE
[ISSUE #5372]🚀Add error variant for missing required message property…

### DIFF
--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -383,6 +383,9 @@ pub enum RocketMQError {
 
     #[error("Not initialized: {0}")]
     NotInitialized(String),
+
+    #[error("Message is missing required property: {property}")]
+    MissingRequiredMessageProperty { property: &'static str },
 }
 
 // ============================================================================


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5372

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

N/A

### How Did You Test This Change?

N/A

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error messages for missing required message properties, enabling better error diagnostics and clearer feedback when messages lack required fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->