### PR TITLE
fix：Add error handlingor uninitialized TransactionMQProducer in send_…

### DIFF
--- a/rocketmq-client/src/producer/transaction_mq_producer.rs
+++ b/rocketmq-client/src/producer/transaction_mq_producer.rs
@@ -289,7 +289,9 @@ impl MQProducer for TransactionMQProducer {
         self.default_producer
             .default_mqproducer_impl
             .as_mut()
-            .unwrap()
+            .ok_or(rocketmq_error::RocketMQError::not_initialized(
+                "DefaultMQProducerImpl is not initialized",
+            ))?
             .send_message_in_transaction(msg, arg.map(|x| Box::new(x) as Box<dyn Any + Sync + Send>))
             .await
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5415 

### Brief Description

Add error handlingor uninitialized TransactionMQProducer in send_message_in_transaction

### How Did You Test This Change?

cargo build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in transaction message sending: the producer now returns a clear initialization error instead of crashing when its underlying implementation is not set up. This prevents panics and allows callers to handle the uninitialized state gracefully.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->