### PR TITLE
[ISSUE #5436]🚀Add filter module with core Filter trait and factory for message filtering

### DIFF
--- a/rocketmq-filter/src/filter.rs
+++ b/rocketmq-filter/src/filter.rs
@@ -1,0 +1,86 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Message Filter Module
+//!
+//! This module provides a pluggable filter architecture for RocketMQ message filtering.
+//! It includes the core `Filter` trait (SPI), a factory for filter management, and
+//! default implementations like SQL-92 filtering.
+//!
+//! # Architecture
+//!
+//! The filter system consists of three main components:
+//!
+//! 1. **Filter Trait (SPI)**: Defines the interface for all filter implementations
+//! 2. **Filter Factory**: Manages filter registration and retrieval
+//! 3. **Filter Implementations**: Concrete implementations like `SqlFilter`
+//!
+//! # Usage
+//!
+//! ## Getting a Filter
+//!
+//! ```rust,ignore
+//! use rocketmq_filter::filter::FilterFactory;
+//!
+//! // Get the default SQL-92 filter
+//! let sql_filter = FilterFactory::get_sql_filter();
+//!
+//! // Or get by type
+//! let filter = FilterFactory::instance().get("SQL92").unwrap();
+//! ```
+//!
+//! ## Compiling Expressions
+//!
+//! ```rust,ignore
+//! use rocketmq_filter::filter::{Filter, FilterFactory};
+//!
+//! let filter = FilterFactory::get_sql_filter();
+//! let expr = filter.compile("age > 18 AND region = 'US'")?;
+//! ```
+//!
+//! ## Registering Custom Filters
+//!
+//! ```rust,ignore
+//! use rocketmq_filter::filter::{Filter, FilterFactory};
+//! use std::sync::Arc;
+//!
+//! // Implement the Filter trait
+//! struct CustomFilter;
+//! impl Filter for CustomFilter {
+//!     fn compile(&self, expr: &str) -> Result<Box<dyn Expression>, FilterError> {
+//!         // Custom implementation
+//!     }
+//!     
+//!     fn of_type(&self) -> &str {
+//!         "CUSTOM"
+//!     }
+//! }
+//!
+//! // Register it
+//! let factory = FilterFactory::instance();
+//! factory.register(Arc::new(CustomFilter));
+//! ```
+//!
+//! # Thread Safety
+//!
+//! All components in this module are designed for concurrent use:
+//! - Filters implement `Send + Sync`
+//! - The factory uses `DashMap` for lock-free concurrent access
+//! - Filters are typically wrapped in `Arc` for shared ownership
+
+mod filter_spi;
+
+pub use filter_spi::Filter;
+pub use filter_spi::FilterError;
+pub use filter_spi::FilterSpi;

--- a/rocketmq-filter/src/filter/filter_spi.rs
+++ b/rocketmq-filter/src/filter/filter_spi.rs
@@ -1,0 +1,165 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Filter Service Provider Interface (SPI)
+//!
+//! This module defines the core trait for message filtering in RocketMQ.
+//! Filters are responsible for evaluating expressions against messages to
+//! determine whether they should be delivered to consumers.
+//!
+//! # Design
+//!
+//! The `Filter` trait provides a pluggable architecture for different filter
+//! implementations (SQL92, Tag-based, etc.). Each filter type:
+//! - Compiles expression strings into executable expression objects
+//! - Identifies its type through a unique type identifier
+//! - Supports thread-safe concurrent filtering operations
+//!
+//! # Thread Safety
+//!
+//! All filter implementations must be `Send + Sync` to support concurrent
+//! message filtering across multiple threads in the broker.
+
+use std::fmt;
+
+use crate::expression::Expression;
+
+/// Error type for filter compilation and evaluation failures.
+///
+/// This error wraps various failure scenarios during filter operations:
+/// - Expression parsing errors
+/// - Type conversion failures
+/// - Invalid expression syntax
+#[derive(Debug, Clone)]
+pub struct FilterError {
+    /// Human-readable error message
+    message: String,
+}
+
+impl FilterError {
+    /// Creates a new filter error with the given message.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - Error description
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// Gets the error message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for FilterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FilterError: {}", self.message)
+    }
+}
+
+impl std::error::Error for FilterError {}
+
+/// Core trait for message filter implementations.
+///
+/// This trait defines the service provider interface (SPI) for pluggable
+/// filter implementations. Each filter type (SQL92, Tag, etc.) must implement
+/// this trait to participate in the message filtering pipeline.
+///
+/// # Type Parameters
+///
+/// Implementations must be `Send + Sync` to support multi-threaded filtering.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use rocketmq_filter::filter::{Filter, FilterError};
+/// use rocketmq_filter::expression::Expression;
+///
+/// struct CustomFilter;
+///
+/// impl Filter for CustomFilter {
+///     fn compile(&self, expr: &str) -> Result<Box<dyn Expression>, FilterError> {
+///         // Parse and compile the expression
+///         Ok(Box::new(MyExpression::parse(expr)?))
+///     }
+///
+///     fn of_type(&self) -> &str {
+///         "CUSTOM"
+///     }
+/// }
+/// ```
+///
+/// # Thread Safety
+///
+/// Filter instances are typically wrapped in `Arc` and shared across threads.
+/// Implementations should be stateless or use interior mutability with
+/// appropriate synchronization.
+pub trait Filter: Send + Sync + fmt::Debug {
+    /// Compiles an expression string into an executable expression object.
+    ///
+    /// This method parses the input string according to the filter's syntax
+    /// rules and produces an `Expression` that can be evaluated against messages.
+    ///
+    /// # Arguments
+    ///
+    /// * `expr` - The expression string to compile (e.g., "age > 18 AND region = 'US'")
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Box<dyn Expression>)` - Successfully compiled expression
+    /// * `Err(FilterError)` - Compilation failed due to syntax or semantic errors
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let filter = SqlFilter::new();
+    /// let expr = filter.compile("price > 100 AND category = 'electronics'")?;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `FilterError` if:
+    /// - Expression syntax is invalid
+    /// - Referenced properties don't exist
+    /// - Type constraints are violated
+    fn compile(&self, expr: &str) -> Result<Box<dyn Expression>, FilterError>;
+
+    /// Returns the unique type identifier for this filter.
+    ///
+    /// The type identifier distinguishes different filter implementations
+    /// and is used for filter registration and lookup in the factory.
+    ///
+    /// # Returns
+    ///
+    /// A string slice identifying the filter type. Common values:
+    /// - `"SQL92"` - SQL-92 expression filter
+    /// - `"TAG"` - Tag-based filter
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let filter = SqlFilter::new();
+    /// assert_eq!(filter.of_type(), "SQL92");
+    /// ```
+    fn of_type(&self) -> &str;
+}
+
+/// Type alias for compatibility with Java naming conventions.
+///
+/// In the Java implementation, this is called `FilterSpi`.
+/// This alias allows using either name in Rust code.
+pub type FilterSpi = dyn Filter;

--- a/rocketmq-filter/src/lib.rs
+++ b/rocketmq-filter/src/lib.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 pub mod expression;
+pub mod filter;
 pub mod utils;


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5436

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a pluggable message filtering architecture enabling custom filter implementations
  * Added a service provider interface for extensible filter types with expression compilation support
  * Filters are thread-safe and support flexible filtering implementations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->