### PR TITLE
[ISSUE #5423]🚀Add an EmptyEvaluationContext struct based on Java code

### DIFF
--- a/rocketmq-filter/src/expression.rs
+++ b/rocketmq-filter/src/expression.rs
@@ -14,6 +14,7 @@
 
 pub mod binary_expression;
 pub mod boolean_expression;
+pub mod empty_evaluation_context;
 pub mod evaluation_context;
 
 use std::error::Error;
@@ -27,6 +28,7 @@ pub use boolean_expression::BooleanExpression;
 pub use boolean_expression::NotExpression;
 pub use boolean_expression::OrExpression;
 pub use boolean_expression::PropertyEqualsExpression;
+pub use empty_evaluation_context::EmptyEvaluationContext;
 pub use evaluation_context::EvaluationContext;
 pub use evaluation_context::MessageEvaluationContext;
 

--- a/rocketmq-filter/src/expression/empty_evaluation_context.rs
+++ b/rocketmq-filter/src/expression/empty_evaluation_context.rs
@@ -1,0 +1,15 @@
+use crate::expression::EvaluationContext;
+use cheetah_string::CheetahString;
+use std::collections::HashMap;
+
+pub struct EmptyEvaluationContext;
+
+impl EvaluationContext for EmptyEvaluationContext {
+    fn get(&self, _name: &str) -> Option<&CheetahString> {
+        None
+    }
+
+    fn key_values(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+        None
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5423

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
N/A

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added empty evaluation context implementation, enabling streamlined message filtering operations that don't require context data or variable lookup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->