### PR TITLE
[ISSUE #5172]Add error handlingor uninitialized DefaultMQProducer in send_oneway_to_queue

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -796,9 +796,10 @@ impl MQProducer for DefaultMQProducer {
         let mq = self.client_config.queue_with_namespace(mq);
         self.default_mqproducer_impl
             .as_mut()
-            .unwrap()
+            .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
             .send_oneway_with_message_queue(msg, mq)
-            .await
+            .await?;
+        Ok(())
     }
 
     async fn send_with_selector<M, S, T>(


### PR DESCRIPTION
## Description

This PR fixes issue #5172 by adding proper error handling to the [send_oneway_to_queue](cci:1://file:///home/delen019/projects/rocketmq-rust/rocketmq-client/src/producer/default_mq_producer.rs:790:4-802:5) method in [DefaultMQProducer](cci:2://file:///home/delen019/projects/rocketmq-rust/rocketmq-client/src/producer/default_mq_producer.rs:237:0-241:1).

## Changes

- Replaced `.unwrap()` with `.ok_or(RocketMQError::not_initialized(...))` to return a meaningful error instead of panicking when the producer is not initialized
- Added explicit error propagation with `?` operator  
- Added explicit `Ok(())` return for clarity

## Why This Fix is Needed

**Before:** If a developer forgot to call `producer.start()` before sending messages, the application would panic with an unhelpful error message:

Testing
✅ Code compiles successfully with cargo check -p rocketmq-client-rust
✅ Follows the same error-handling pattern used in other methods like 
send_oneway()
✅ Maintains API compatibility (still returns RocketMQResult<()>)

Related Issue
Closes #5172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes in producer when not properly initialized by implementing proper error handling that returns informative error messages instead of panicking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->