### PR TITLE
[ISSUE #5443] - common(producer): replace unwrap with proper error handling

### DIFF
--- a/rocketmq-client/src/producer/transaction_mq_producer.rs
+++ b/rocketmq-client/src/producer/transaction_mq_producer.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::MessageTrait;
+use rocketmq_error::RocketMQError;
 use rocketmq_runtime::RocketMQRuntime;
 
 use crate::producer::default_mq_producer::DefaultMQProducer;
@@ -77,7 +78,13 @@ impl TransactionMQProducer {
 impl MQProducer for TransactionMQProducer {
     async fn start(&mut self) -> rocketmq_error::RocketMQResult<()> {
         let transaction_listener = self.transaction_producer_config.transaction_listener.clone();
-        let default_mqproducer_impl = self.default_producer.default_mqproducer_impl.as_mut().unwrap();
+        let default_mqproducer_impl =
+            self.default_producer
+                .default_mqproducer_impl
+                .as_mut()
+                .ok_or(RocketMQError::not_initialized(
+                    "DefaultMQProducerImpl is not initialized",
+                ))?;
         default_mqproducer_impl.init_transaction_env(self.transaction_producer_config.check_runtime.take());
         if let Some(transaction_listener) = transaction_listener {
             default_mqproducer_impl.set_transaction_listener(transaction_listener);


### PR DESCRIPTION

### Which Issue(s) This PR Fixes(Closes)

Fixes #5443

### Brief Description

This PR adds proper error handling for the `TransactionMQProducer` in the `start` method.  

- Replaces `unwrap()` calls with structured error handling using `RocketMQError`.  
- Returns a descriptive error if `TransactionMQProducer` is not initialized.  
- Ensures safer runtime behavior and prevents potential panics in production.

### How Did You Test This Change?

- Verified compilation with `cargo build`  
- Ran unit tests with `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error reporting in TransactionMQProducer initialization to provide clearer feedback when the producer fails to initialize properly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->