### PR TITLE
[ISSUE #5495]✨Add error handlingor uninitialized DefaultMQProducer in…

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -1012,7 +1012,7 @@ impl MQProducer for DefaultMQProducer {
         let batch = self.batch(msgs)?;
         self.default_mqproducer_impl
             .as_mut()
-            .unwrap()
+            .ok_or_else(|| rocketmq_error::RocketMQError::not_initialized("DefaultMQProducerImpl is not initialized"))?
             .async_send_with_callback(batch, Some(Arc::new(f)))
             .await?;
         Ok(())
@@ -1198,8 +1198,9 @@ impl MQProducer for DefaultMQProducer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
     use rocketmq_common::common::message::message_single::Message;
-
+    use rocketmq_error::RocketMQResult;
     #[tokio::test]
     async fn request_with_callback_not_initialized() {
         // Arrange
@@ -1287,6 +1288,36 @@ mod tests {
         let result = producer
             .request_with_selector_callback(msg, selector, 1, callback, 1000)
             .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err {
+            RocketMQError::NotInitialized(reason) => {
+                assert!(reason.contains("not initialized"), "unexpected error message: {reason}");
+            }
+            other => panic!("Unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_batch_with_callback_not_initialized() {
+        // Arrange
+        let mut producer = DefaultMQProducer {
+            client_config: Default::default(),
+            producer_config: Default::default(),
+            default_mqproducer_impl: None,
+        };
+        let msg = Message {
+            topic: "test-topic".into(),
+            flag: 0,
+            properties: Default::default(),
+            body: Some(Bytes::from_static(b"Hello world")),
+            compressed_body: None,
+            transaction_id: None,
+        };
+        let callback = |_msg: Option<&SendResult>, _err: Option<&dyn std::error::Error>| {
+            // no-op
+        };
+        let result: RocketMQResult<()> = producer.send_batch_with_callback(vec![msg], callback).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         match err {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5495

### Brief Description

N/A

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent crashes when sending messages with callbacks in certain uninitialized states; now returns proper error messages instead.

* **Tests**
  * Added test coverage for error handling in callback scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->