### PR TITLE
[ISSUE #5493] - client(producer): replace unwrap with proper error handling

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -979,7 +979,7 @@ impl MQProducer for DefaultMQProducer {
         let result = self
             .default_mqproducer_impl
             .as_mut()
-            .unwrap()
+            .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
             .sync_send_with_message_queue(batch, mq)
             .await?;
         Ok(result.expect("SendResult should not be None"))


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

Fixes #5493 

### Brief Description

This PR adds proper error handling for cases where `DefaultMQProducer` is not initialized when calling `send_batch_to_queue`.

Previously, the code relied on `unwrap()`, which could cause a panic at runtime if the producer was uninitialized. This change replaces the unsafe unwrap with structured error handling and returns a meaningful `RocketMQError` instead.

### How Did You Test This Change?

- Verified compilation with `cargo build`  
- Ran unit tests with `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced producer error handling to prevent application crashes and provide explicit error messages when operations are attempted on an uninitialized producer instance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->