### PR TITLE
[ISSUE #5494] - fix error handling in send_batch_to_queue_with_timeout

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -998,7 +998,7 @@ impl MQProducer for DefaultMQProducer {
         let result = self
             .default_mqproducer_impl
             .as_mut()
-            .unwrap()
+            .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
             .sync_send_with_message_queue_timeout(batch, mq, timeout)
             .await?;
         Ok(result.expect("SendResult should not be None"))


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #5494 

### Brief Description

This PR adds proper error handling for `DefaultMQProducer` in the `send_batch_to_queue_with_timeout` method.  

Previously, the code relied on `unwrap()`, which could panic if the producer was uninitialized. This change replaces the unsafe unwrap with structured error handling and returns a meaningful `RocketMQError` instead.

### How Did You Test This Change?

- Built the project using `cargo build`  
- Ran unit tests with `cargo test`  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved error handling in the producer to return explicit errors instead of crashing when the producer hasn't been initialized, providing better stability and clearer error messages for troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->