### PR TITLE
[ISSUE #5490] - fix error handling in send_oneway_with_selector

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -923,7 +923,7 @@ impl MQProducer for DefaultMQProducer {
         msg.set_topic(self.with_namespace(msg.get_topic()));
         self.default_mqproducer_impl
             .as_mut()
-            .unwrap()
+            .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
             .send_oneway_with_selector(msg, Arc::new(selector), arg)
             .await
     }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #5490 

### Brief Description

This PR adds proper error handling for `DefaultMQProducer` in the `send_oneway_with_selector` method.

Previously, the code used `unwrap()`, which could panic if the producer was uninitialized. This change replaces the unsafe unwrap with structured error handling and returns a descriptive `RocketMQError` instead, preventing runtime panics and improving stability.

### How Did You Test This Change?

- Built the project with `cargo build`  
- Ran unit tests using `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed one-way message sending to properly return error messages when the producer is not initialized, preventing unexpected application crashes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->