### PR TITLE
[ISSUE #5492] - fix error handling in send_batch_with_timeout

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -961,7 +961,7 @@ impl MQProducer for DefaultMQProducer {
         let result = self
             .default_mqproducer_impl
             .as_mut()
-            .unwrap()
+            .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
             .send_with_timeout(&mut batch, timeout)
             .await?;
         Ok(result.expect("SendResult should not be None"))


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #5492 

### Brief Description

This PR adds proper error handling for `DefaultMQProducer` in the `send_batch_with_timeout` method.

Previously, the code relied on `unwrap()`, which could panic at runtime if the producer was uninitialized. This change replaces the unsafe unwrap with structured error handling and returns a descriptive `RocketMQError`.

### How Did You Test This Change?

- Built the project using `cargo build`  
- Ran unit tests with `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the producer to prevent unrecoverable failures when the internal implementation is not properly initialized. The system now returns a recoverable error instead of crashing, enhancing overall reliability and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->