### PR TITLE
[ISSUE #5491] - fix error handling in send_message_in_transaction

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -945,7 +945,12 @@ impl MQProducer for DefaultMQProducer {
         M: MessageTrait + Send + Sync,
     {
         let mut batch = self.batch(msgs)?;
-        let result = self.default_mqproducer_impl.as_mut().unwrap().send(&mut batch).await?;
+        let result = self
+            .default_mqproducer_impl
+            .as_mut()
+            .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
+            .send(&mut batch)
+            .await?;
         Ok(result.expect("SendResult should not be None"))
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #5491 

### Brief Description

This PR adds proper error handling for `DefaultMQProducer` in the `send_message_in_transaction` method.

Previously, the code used `unwrap()`, which could panic at runtime if the producer was uninitialized. This change replaces the unsafe unwrap with structured error handling and returns a descriptive `RocketMQError`.

### How Did You Test This Change?

- Built the project using `cargo build`  
- Ran unit tests using `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to return explicit errors when producer operations are invoked on an uninitialized state, replacing previous behavior that could cause application panics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->