### PR TITLE
[ISSUE #5525]♻️Refactor controller to remove RocketMQRuntime dependency and use ControllerConfig instead

### DIFF
--- a/rocketmq-controller/src/controller.rs
+++ b/rocketmq-controller/src/controller.rs
@@ -124,7 +124,6 @@ use rocketmq_remoting::protocol::header::controller::get_next_broker_id_request_
 use rocketmq_remoting::protocol::header::controller::get_replica_info_request_header::GetReplicaInfoRequestHeader;
 use rocketmq_remoting::protocol::header::controller::register_broker_to_controller_request_header::RegisterBrokerToControllerRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
-use rocketmq_runtime::RocketMQRuntime;
 
 use crate::helper::broker_lifecycle_listener::BrokerLifecycleListener;
 
@@ -482,28 +481,6 @@ pub trait Controller: Send + Sync {
     /// controller.register_broker_lifecycle_listener(Arc::new(MyListener));
     /// ```
     fn register_broker_lifecycle_listener(&self, listener: Arc<dyn BrokerLifecycleListener>);
-
-    // ==================== Runtime Access ====================
-
-    /// Get the runtime used by this controller
-    ///
-    /// Returns a reference to the underlying Tokio runtime, allowing upper
-    /// layers to spawn tasks or access network resources.
-    ///
-    /// # Returns
-    ///
-    /// Arc to the RocketMQRuntime instance
-    ///
-    /// # Use Cases
-    ///
-    /// - Spawning background tasks
-    /// - Accessing network layer
-    /// - Resource management
-    ///
-    /// # Lifetime
-    ///
-    /// The returned runtime is valid for the lifetime of the controller.
-    fn get_runtime(&self) -> Arc<RocketMQRuntime>;
 }
 
 // ==================== Mock Controller for Testing ====================
@@ -620,9 +597,9 @@ impl Controller for MockController {
         // No-op
     }
 
-    fn get_runtime(&self) -> Arc<RocketMQRuntime> {
+    /*    fn get_runtime(&self) -> Arc<RocketMQRuntime> {
         unimplemented!("MockController does not provide runtime in tests")
-    }
+    }*/
 }
 
 #[cfg(test)]

--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -36,7 +36,6 @@ use rocketmq_remoting::remoting::RemotingService;
 use rocketmq_remoting::remoting_server::rocketmq_tokio_server::RocketMQServer;
 use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
-use rocketmq_runtime::RocketMQRuntime;
 use rocketmq_rust::ArcMut;
 use tracing::error;
 use tracing::info;
@@ -143,12 +142,12 @@ impl ControllerManager {
         info!("Creating controller manager with config: {:?}", config);
 
         // Initialize RocketMQ runtime for Raft controller
-        let runtime = Arc::new(RocketMQRuntime::new_multi(2, "controller-runtime"));
+        //let runtime = Arc::new(RocketMQRuntime::new_multi(2, "controller-runtime"));
 
         // Initialize Raft controller for leader election
         // This MUST succeed before proceeding
         // Using OpenRaft implementation by default
-        let raft_arc = Arc::new(RaftController::new_open_raft(runtime));
+        let raft_arc = Arc::new(RaftController::new_open_raft(Arc::clone(&config)));
 
         // Initialize metadata store
         // This MUST succeed before proceeding

--- a/rocketmq-controller/src/controller/raft_controller.rs
+++ b/rocketmq-controller/src/controller/raft_controller.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
+use rocketmq_common::common::controller::ControllerConfig;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::sync_state_set_body::SyncStateSet;
 use rocketmq_remoting::protocol::header::controller::alter_sync_state_set_request_header::AlterSyncStateSetRequestHeader;
@@ -47,8 +48,8 @@ pub enum RaftController {
 
 impl RaftController {
     /// Create a new OpenRaft-based controller
-    pub fn new_open_raft(runtime: Arc<RocketMQRuntime>) -> Self {
-        Self::OpenRaft(ArcMut::new(OpenRaftController::new(runtime)))
+    pub fn new_open_raft(config: Arc<ControllerConfig>) -> Self {
+        Self::OpenRaft(ArcMut::new(OpenRaftController::new(config)))
     }
 
     /// Create a new raft-rs based controller
@@ -174,13 +175,6 @@ impl Controller for RaftController {
         match self {
             Self::OpenRaft(controller) => controller.register_broker_lifecycle_listener(listener),
             Self::RaftRs(controller) => controller.register_broker_lifecycle_listener(listener),
-        }
-    }
-
-    fn get_runtime(&self) -> Arc<RocketMQRuntime> {
-        match self {
-            Self::OpenRaft(controller) => controller.get_runtime(),
-            Self::RaftRs(controller) => controller.get_runtime(),
         }
     }
 }

--- a/rocketmq-controller/src/controller/raft_rs_controller.rs
+++ b/rocketmq-controller/src/controller/raft_rs_controller.rs
@@ -134,8 +134,4 @@ impl Controller for RaftRsController {
     fn register_broker_lifecycle_listener(&self, _listener: Arc<dyn BrokerLifecycleListener>) {
         // TODO: Register listener
     }
-
-    fn get_runtime(&self) -> Arc<RocketMQRuntime> {
-        self.runtime.clone()
-    }
 }

--- a/rocketmq-controller/tests/raft_controller_test.rs
+++ b/rocketmq-controller/tests/raft_controller_test.rs
@@ -14,30 +14,19 @@
 
 use std::sync::Arc;
 
+use rocketmq_common::common::controller::ControllerConfig;
 use rocketmq_controller::Controller;
 use rocketmq_controller::RaftController;
 use rocketmq_runtime::RocketMQRuntime;
 
 #[tokio::test]
 async fn test_open_raft_controller_lifecycle() {
-    // Use spawn_blocking to create runtime outside async context
-    let runtime = tokio::task::spawn_blocking(|| Arc::new(RocketMQRuntime::new_multi(4, "test-runtime")))
-        .await
-        .unwrap();
-
-    let controller = RaftController::new_open_raft(runtime.clone());
+    let config = Arc::new(ControllerConfig::test_config());
+    let controller = RaftController::new_open_raft(config);
 
     assert!(controller.startup().await.is_ok());
     assert!(!controller.is_leader()); // Default is false
     assert!(controller.shutdown().await.is_ok());
-
-    // Drop controller first, then runtime in blocking context
-    drop(controller);
-    tokio::task::spawn_blocking(move || {
-        drop(runtime);
-    })
-    .await
-    .unwrap();
 }
 
 #[tokio::test]
@@ -65,9 +54,10 @@ async fn test_raft_controller_wrapper() {
     let runtime = tokio::task::spawn_blocking(|| Arc::new(RocketMQRuntime::new_multi(4, "test-runtime")))
         .await
         .unwrap();
+    let config = Arc::new(ControllerConfig::test_config());
 
     // Test OpenRaft variant
-    let open_raft_controller = RaftController::new_open_raft(runtime.clone());
+    let open_raft_controller = RaftController::new_open_raft(config.clone());
     assert!(open_raft_controller.startup().await.is_ok());
     assert!(!open_raft_controller.is_leader());
     assert!(open_raft_controller.shutdown().await.is_ok());


### PR DESCRIPTION

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5525

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated controller initialization to use configuration-based approach instead of runtime-based initialization, improving the abstraction layer and internal architecture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->