### PR TITLE
[ISSUE #5527] Update default controller listen port to 60109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **refactor(common):** Replace `lazy_static!` with `std::sync::LazyLock` in `broker_config.rs` ([#5056](https://github.com/mxsm/rocketmq-rust/issues/5056))
 - **refactor(remoting):** Replace `lazy_static!` with `std::sync::LazyLock` in `remoting_command.rs` and remove `lazy_static` dependency from `rocketmq-remoting` ([#5060](https://github.com/mxsm/rocketmq-rust/issues/5060))
 - **perf(ArcMut):** Add the `#[inline]` attribute to the `mut_from_ref`, `downgrade`, and `get_inner` methods for `ArcMut`, improving performance ([#2876](https://github.com/mxsm/rocketmq-rust/pull/2876))
+- **chore(controller):** Update default controller listen address to use port 60109 ([#5527](https://github.com/mxsm/rocketmq-rust/issues/5527))

--- a/rocketmq-common/src/common/controller/controller_config.rs
+++ b/rocketmq-common/src/common/controller/controller_config.rs
@@ -241,7 +241,7 @@ impl Default for ControllerConfig {
             metrics_in_delta: false,
             config_black_list: "configBlackList;configStorePath".to_string(),
             node_id: 1,
-            listen_addr: "127.0.0.1:9876".parse().unwrap(),
+            listen_addr: "127.0.0.1:60109".parse().unwrap(),
             raft_peers: Vec::new(),
             election_timeout_ms: 1000,
             heartbeat_interval_ms: 300,
@@ -418,7 +418,7 @@ impl ControllerConfig {
 
     /// Test config helper
     pub fn test_config() -> Self {
-        Self::default().with_node_info(1, "127.0.0.1:9876".parse().unwrap())
+        Self::default().with_node_info(1, "127.0.0.1:60109".parse().unwrap())
     }
 
     /// Check if a configuration key is in the blacklist

--- a/rocketmq-controller/examples/controller_metrics_example.rs
+++ b/rocketmq-controller/examples/controller_metrics_example.rs
@@ -37,7 +37,7 @@ async fn main() {
 
     // 1. Initialize controller configuration
     println!("1. Initializing controller configuration...");
-    let config = Arc::new(ControllerConfig::new_node(1, "127.0.0.1:9876".parse().unwrap()));
+    let config = Arc::new(ControllerConfig::new_node(1, "127.0.0.1:60109".parse().unwrap()));
 
     // 2. Initialize metrics manager (singleton)
     println!("2. Initializing metrics manager...");

--- a/rocketmq-controller/examples/single_node.rs
+++ b/rocketmq-controller/examples/single_node.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Step 1: Create configuration
     println!("1. Creating node configuration...");
     let node_id = 1;
-    let listen_addr = "127.0.0.1:9876".parse()?;
+    let listen_addr = "127.0.0.1:60109".parse()?;
 
     let config = Arc::new(
         ControllerConfig::new_node(node_id, listen_addr)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5527 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
This PR updates the default controller listen address to use port `60109` instead of the previously hardcoded port.

The change has been applied consistently across:

- `ControllerConfig` default configuration
- `ControllerConfig::new_node`
- Controller example files

Please let me know if updating these locations is sufficient, or if there are additional places where this port should be updated.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->

- Built the project using `cargo build`
- Ran all tests using `cargo test --all-features --workspace`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default controller listen port from 9876 to 60109 in configuration and example files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->