### PR TITLE
[ISSUE #5548] - remove unused code from produce_accumulator.rs

### DIFF
--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -225,68 +225,6 @@ impl MessageAccumulation {
     ) -> rocketmq_error::RocketMQResult<bool> {
         unimplemented!()
     }
-
-    /*    fn ready_to_send(&self, hold_size: i32, hold_ms: u128) -> bool {
-        self.messages_size.load(Ordering::SeqCst) > hold_size
-            || SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("Time went backwards")
-                .as_millis()
-                >= self.create_time + hold_ms
-    }
-
-
-
-    pub fn add_with_callback(
-        &mut self,
-        msg: Message,
-        send_callback: SendCallback,
-    ) -> rocketmq_error::RocketMQResult<bool, ()> {
-        if self.closed.load(Ordering::SeqCst) {
-            return Err(());
-        }
-        self.count += 1;
-        self.messages.push_back(msg);
-        self.send_callbacks.push_back(send_callback);
-        self.messages_size
-            .fetch_add(msg.get_body().len() as i32, Ordering::SeqCst);
-
-        Ok(true)
-    }
-
-    fn batch(&self) -> MessageBatch {
-        // Implementation for creating a message batch from the accumulated messages
-        MessageBatch {}
-    }
-
-    fn split_send_results(&mut self, send_result: SendResult) {
-        // Implementation for splitting send results
-    }
-
-    pub fn send(&mut self) -> rocketmq_error::RocketMQResult<(), ()> {
-        if self.closed.swap(true, Ordering::SeqCst) {
-            return Ok(());
-        }
-        let message_batch = self.batch();
-        let send_result = self
-            .default_mq_producer
-            .send_direct(message_batch, None, None)?;
-        self.split_send_results(send_result);
-        Ok(())
-    }
-
-    pub fn send_with_callback(&mut self, send_callback: SendCallback) -> rocketmq_error::RocketMQResult<(), ()> {
-        if self.closed.swap(true, Ordering::SeqCst) {
-            return Ok(());
-        }
-        let message_batch = self.batch();
-        let size = self.messages_size.load(Ordering::SeqCst);
-
-        self.default_mq_producer
-            .send_direct(message_batch, None, Some(send_callback))?;
-
-        Ok(())
-    }*/
 }
 
 #[derive(Default)]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

Fixes #5548 

### Brief Description

This PR removes unused and commented-out code from `produce_accumulator.rs`.

The removed code included:
- `ready_to_send` function
- `add_with_callback` method
- `batch` and `split_send_results` helpers
- `send` and `send_with_callback` methods

These functions and methods were not used anywhere in the project, and cleaning them up improves code readability and maintainability.

### How Did You Test This Change?

- Verified that the project builds successfully using `cargo build`  
- Ran unit tests with `cargo test` to ensure no functionality was affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the message producer accumulator, simplifying the message batching and sending workflow to a foundational state pending further development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->