### PR TITLE
[ISSUE #5538] -  Implement ControllerElectMaster Request Handler

### DIFF
--- a/rocketmq-controller/src/processor/controller_request_processor.rs
+++ b/rocketmq-controller/src/processor/controller_request_processor.rs
@@ -95,6 +95,7 @@ use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::controller::apply_broker_id_request_header::ApplyBrokerIdRequestHeader;
+use rocketmq_remoting::protocol::header::controller::elect_master_request_header::ElectMasterRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingDeserializable;
@@ -316,9 +317,23 @@ impl ControllerRequestProcessor {
         &mut self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
-        _request: &mut RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> RocketMQResult<Option<RemotingCommand>> {
-        unimplemented!("unimplemented handle_elect_master")
+        // Decode request header
+        let request_header = request
+            .decode_command_custom_header::<ElectMasterRequestHeader>()
+            .map_err(|e| {
+                RocketMQError::request_header_error(format!("Failed to decode ElectMasterRequestHeader: {:?}", e))
+            })?;
+
+        // Forward to Controller
+        let response = self
+            .controller_manager
+            .controller()
+            .elect_master(&request_header)
+            .await?;
+
+        Ok(response)
     }
 
     /// Handle GET_REPLICA_INFO request


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

Fixes #5538 

### Brief Description
This PR implements handling for the `ControllerElectMaster` request in `ControllerRequestProcessor` by adding the missing `handle_elect_master` logic. This enables the controller to process master election requests for broker groups, which is a core capability for ensuring high availability and automatic failover in the RocketMQ cluster.

- Decodes `ElectMasterRequestHeader` from the incoming `RemotingCommand`
- Forwards the request to the active controller via `controller_manager.controller().elect_master(...)`
- Awaits the asynchronous controller response
- Returns a `RemotingCommand` containing:
  - Newly elected master broker information
  - Success or failure status
  - Error details when election fails

### How Did You Test This Change?
- Verified that the project builds successfully using `cargo build`  
- Ran unit tests with `cargo test` to ensure no functionality was affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented handling for master election requests in the controller so requests are properly processed instead of returning "unimplemented".
  * Decoding and forwarding of election requests to the controller are now operational, and responses are returned to callers.
  * Reduces previous failures when initiating or processing master election operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->