### PR TITLE
[ISSUE #5157] - fix error handling for uninitialized DefaultMQProducer in start

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -588,7 +588,11 @@ impl MQProducer for DefaultMQProducer {
     async fn start(&mut self) -> rocketmq_error::RocketMQResult<()> {
         let producer_group = self.with_namespace(self.producer_config.producer_group.clone().as_str());
         self.set_producer_group(producer_group);
-        self.default_mqproducer_impl.as_mut().unwrap().start().await?;
+        self.default_mqproducer_impl
+            .as_mut()
+            .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
+            .start()
+            .await?;
         if let Some(ref mut produce_accumulator) = self.producer_config.produce_accumulator {
             produce_accumulator.start();
         }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #5157  

### Brief Description
This PR adds proper error handling for `DefaultMQProducer` in start.

Previously, the code used `unwrap()`, which could panic if the producer was uninitialized. This change replaces the unsafe unwrap with structured error handling and returns a descriptive `RocketMQError`.

### How Did You Test This Change?
- Built the project with `cargo build`  
- Ran unit tests using `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced producer initialization error handling to return an explicit error message instead of an unexpected crash when the producer is not properly initialized.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->