### PR TITLE
feat: Implement ControllerGetMetadataInfo Request Handler (#5539)

### DIFF
--- a/rocketmq-controller/src/controller.rs
+++ b/rocketmq-controller/src/controller.rs
@@ -435,7 +435,7 @@ pub trait Controller: Send + Sync {
     /// # Note
     ///
     /// This is a read-only operation that does not go through Raft consensus.
-    fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>>;
+    async fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>>;
 
     /// Get sync state data for specified brokers
     ///
@@ -585,7 +585,7 @@ impl Controller for MockController {
         Ok(Some(RemotingCommand::create_response_command()))
     }
 
-    fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>> {
+    async fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>> {
         Ok(Some(RemotingCommand::create_response_command()))
     }
 

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -26,6 +26,8 @@ use cheetah_string::CheetahString;
 use rocketmq_common::common::controller::ControllerConfig;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::protocol::body::controller::controller_metadata_info::ControllerMetadataInfo;
+use rocketmq_remoting::protocol::body::controller::node_info::NodeInfo;
 use rocketmq_remoting::protocol::body::sync_state_set_body::SyncStateSet;
 use rocketmq_remoting::protocol::header::controller::alter_sync_state_set_request_header::AlterSyncStateSetRequestHeader;
 use rocketmq_remoting::protocol::header::controller::apply_broker_id_request_header::ApplyBrokerIdRequestHeader;
@@ -340,9 +342,43 @@ impl Controller for OpenRaftController {
         Ok(Some(RemotingCommand::create_response_command()))
     }
 
-    fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>> {
-        // TODO: Implement metadata query
-        Ok(Some(RemotingCommand::create_response_command()))
+    async fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>> {
+        let controller_metadata_info: ControllerMetadataInfo = {
+            let raft_peers: Vec<NodeInfo> = self
+                .config
+                .raft_peers
+                .iter()
+                .map(|raft_peer| NodeInfo {
+                    node_id: raft_peer.id,
+                    addr: raft_peer.addr.to_string(),
+                })
+                .collect::<Vec<NodeInfo>>();
+
+            let raft_node_manager = self.node.as_ref();
+            let controller_leader_id: Option<u64> = if let Some(raft_node_manager) = raft_node_manager {
+                raft_node_manager.get_leader().await.ok().flatten()
+            } else {
+                None
+            };
+
+            let controller_leader_address: Option<String> = controller_leader_id
+                .and_then(|leader_node_id| raft_peers.iter().find(|raft_peer| raft_peer.node_id == leader_node_id))
+                .map(|node_info| node_info.addr.clone());
+
+            let is_leader = controller_leader_id
+                .map(|id| self.config.node_id == id)
+                .unwrap_or(false);
+
+            ControllerMetadataInfo {
+                controller_leader_id,
+                controller_leader_address,
+                is_leader,
+                raft_peers,
+            }
+        };
+        Ok(Some(
+            RemotingCommand::create_response_command().set_body(serde_json::to_string(&controller_metadata_info)?),
+        ))
     }
 
     async fn get_sync_state_data(&self, _broker_names: &[CheetahString]) -> RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-controller/src/controller/raft_controller.rs
+++ b/rocketmq-controller/src/controller/raft_controller.rs
@@ -157,10 +157,10 @@ impl Controller for RaftController {
         }
     }
 
-    fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>> {
+    async fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>> {
         match self {
-            Self::OpenRaft(controller) => controller.get_controller_metadata(),
-            Self::RaftRs(controller) => controller.get_controller_metadata(),
+            Self::OpenRaft(controller) => controller.get_controller_metadata().await,
+            Self::RaftRs(controller) => controller.get_controller_metadata().await,
         }
     }
 

--- a/rocketmq-controller/src/controller/raft_rs_controller.rs
+++ b/rocketmq-controller/src/controller/raft_rs_controller.rs
@@ -176,7 +176,7 @@ impl Controller for RaftRsController {
         Ok(Some(RemotingCommand::create_response_command()))
     }
 
-    fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>> {
+    async fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>> {
         // TODO: Implement metadata query
         Ok(Some(RemotingCommand::create_response_command()))
     }

--- a/rocketmq-controller/src/processor/controller_request_processor.rs
+++ b/rocketmq-controller/src/processor/controller_request_processor.rs
@@ -362,8 +362,7 @@ impl ControllerRequestProcessor {
         _ctx: ConnectionHandlerContext,
         _request: &mut RemotingCommand,
     ) -> RocketMQResult<Option<RemotingCommand>> {
-        // This is a read-only operation, no timeout needed
-        unimplemented!("unimplemented handle_get_metadata_info")
+        self.controller_manager.controller().get_controller_metadata().await
     }
 
     /// Handle BROKER_HEARTBEAT request

--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -33,6 +33,7 @@ pub mod consume_message_directly_result;
 pub mod consume_queue_data;
 pub mod consume_status;
 pub mod consumer_offset_serialize_wrapper;
+pub mod controller;
 pub mod elect_master_response_body;
 pub mod epoch_entry_cache;
 pub mod group_list;

--- a/rocketmq-remoting/src/protocol/body/controller.rs
+++ b/rocketmq-remoting/src/protocol/body/controller.rs
@@ -1,0 +1,16 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod controller_metadata_info;
+pub mod node_info;

--- a/rocketmq-remoting/src/protocol/body/controller/controller_metadata_info.rs
+++ b/rocketmq-remoting/src/protocol/body/controller/controller_metadata_info.rs
@@ -1,0 +1,69 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::body::controller::node_info::NodeInfo;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ControllerMetadataInfo {
+    pub controller_leader_id: Option<u64>,
+    pub controller_leader_address: Option<String>,
+    pub is_leader: bool,
+    pub raft_peers: Vec<NodeInfo>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::protocol::body::controller::controller_metadata_info::ControllerMetadataInfo;
+
+    #[test]
+    fn test_create_controller_metadata_info_with_default_values() {
+        let controller_metadata_info = ControllerMetadataInfo::default();
+
+        assert!(controller_metadata_info.controller_leader_id.is_none());
+        assert!(controller_metadata_info.controller_leader_address.is_none());
+        assert!(!controller_metadata_info.is_leader);
+        assert!(controller_metadata_info.raft_peers.is_empty());
+    }
+
+    #[test]
+    fn controller_metadata_roundtrip() {
+        let json = r#"
+    {
+        "controllerLeaderId": 12,
+        "controllerLeaderAddress": "XY",
+        "isLeader": true,
+        "raftPeers": [
+            {   
+                "nodeId": 0,
+                "addr": "127.0.0.1"
+            },
+            {
+                "nodeId": 1,
+                "addr": "127.0.0.2"
+            }
+        ]
+    }
+    "#;
+
+        let parsed: ControllerMetadataInfo = serde_json::from_str(json).unwrap();
+        let serialized = serde_json::to_string(&parsed).unwrap();
+
+        let reparsed: ControllerMetadataInfo = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+}

--- a/rocketmq-remoting/src/protocol/body/controller/node_info.rs
+++ b/rocketmq-remoting/src/protocol/body/controller/node_info.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct NodeInfo {
+    #[serde(rename = "nodeId")]
+    pub node_id: u64,
+    pub addr: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::protocol::body::controller::node_info::NodeInfo;
+
+    #[test]
+    fn test_create_node_info_with_default_values() {
+        let node_info = NodeInfo::default();
+
+        assert_eq!(0, node_info.node_id);
+        assert_eq!("", node_info.addr);
+    }
+
+    #[test]
+    fn test_node_info_roundtrip() {
+        let json = r#"
+    {
+        "nodeId": 12,
+        "addr": "127.0.0.1"
+    }
+    "#;
+
+        let parsed: NodeInfo = serde_json::from_str(json).unwrap();
+        let serialized = serde_json::to_string(&parsed).unwrap();
+
+        let reparsed: NodeInfo = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5539

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

Added tests

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controller metadata endpoint now returns structured controller info (leader, leader address, is-leader flag, peer list).

* **Chores**
  * Controller interfaces updated to async to support asynchronous metadata retrieval.

* **New Public Types**
  * Added portable ControllerMetadataInfo and NodeInfo payload types with JSON (camelCase) serialization.

* **Tests**
  * Added unit tests for new types (defaults and JSON round-trip).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->