### PR TITLE
[ISSUE #5621]🚀Implement Controller Command: Clean Broker Metadata (cleanBrokerMetadata)

### DIFF
--- a/rocketmq-tools/src/commands.rs
+++ b/rocketmq-tools/src/commands.rs
@@ -67,6 +67,11 @@ pub struct CommonArgs {
 #[derive(Subcommand)]
 pub enum Commands {
     #[command(subcommand)]
+    #[command(about = "Controller commands")]
+    #[command(name = "controller")]
+    Controller(controller_commands::ControllerCommands),
+
+    #[command(subcommand)]
     #[command(about = "Name server commands")]
     #[command(name = "nameserver")]
     NameServer(namesrv_commands::NameServerCommands),
@@ -75,11 +80,6 @@ pub enum Commands {
     #[command(about = "Topic commands")]
     Topic(topic_commands::TopicCommands),
 
-    #[command(subcommand)]
-    #[command(about = "Controller commands")]
-    #[command(name = "controller")]
-    Controller(controller_commands::ControllerCommands),
-
     #[command(about = "Category commands show")]
     Show(ClassificationTablePrint),
 }
@@ -87,9 +87,9 @@ pub enum Commands {
 impl CommandExecute for Commands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
+            Commands::Controller(value) => value.execute(rpc_hook).await,
             Commands::NameServer(value) => value.execute(rpc_hook).await,
             Commands::Topic(value) => value.execute(rpc_hook).await,
-            Commands::Controller(value) => value.execute(rpc_hook).await,
             Commands::Show(value) => value.execute(rpc_hook).await,
         }
     }
@@ -114,6 +114,16 @@ pub(crate) struct ClassificationTablePrint;
 impl CommandExecute for ClassificationTablePrint {
     async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         let commands: Vec<Command> = vec![
+            Command {
+                category: "Controller",
+                command: "cleanBrokerMetadata",
+                remark: "Clean metadata of broker on controller.",
+            },
+            Command {
+                category: "Controller",
+                command: "getControllerMetaData",
+                remark: "Get meta data of controller.",
+            },
             Command {
                 category: "Topic",
                 command: "allocateMQ",
@@ -198,11 +208,6 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "NameServer",
                 command: "wipeWritePerm",
                 remark: "Wipe write perm of broker in all name server.",
-            },
-            Command {
-                category: "Controller",
-                command: "getControllerMetaData",
-                remark: "Get meta data of controller.",
             },
         ];
         let mut table = Table::new(commands);

--- a/rocketmq-tools/src/commands/controller_commands.rs
+++ b/rocketmq-tools/src/commands/controller_commands.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod clean_broker_metadata_command;
 mod get_controller_metadata_sub_command;
 
 use std::sync::Arc;
@@ -20,22 +21,29 @@ use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
-use crate::commands::controller_commands::get_controller_metadata_sub_command::GetControllerMetadataSubCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
 pub enum ControllerCommands {
     #[command(
+        name = "cleanBrokerMetadata",
+        about = "Clean metadata of broker on controller.",
+        long_about = None,
+    )]
+    CleanBrokerMetadata(clean_broker_metadata_command::CleanBrokerMetadataCommand),
+
+    #[command(
         name = "getControllerMetadata",
         about = "Get meta data of controller",
         long_about = None,
     )]
-    GetControllerMetadataSubCommand(GetControllerMetadataSubCommand),
+    GetControllerMetadataSubCommand(get_controller_metadata_sub_command::GetControllerMetadataSubCommand),
 }
 
 impl CommandExecute for ControllerCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
+            ControllerCommands::CleanBrokerMetadata(cmd) => cmd.execute(rpc_hook).await,
             ControllerCommands::GetControllerMetadataSubCommand(value) => value.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/src/commands/controller_commands/clean_broker_metadata_command.rs
+++ b/rocketmq-tools/src/commands/controller_commands/clean_broker_metadata_command.rs
@@ -1,0 +1,243 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct CleanBrokerMetadataCommand {
+    #[arg(
+        short = 'a',
+        long = "controllerAddress",
+        required = true,
+        help = "The address of controller"
+    )]
+    controller_address: String,
+
+    #[arg(
+        short = 'b',
+        long = "brokerControllerIdsToClean",
+        required = false,
+        help = "The brokerController id list which requires to clean metadata. eg: 1;2;3, means that clean broker-1, \
+                broker-2 and broker-3"
+    )]
+    broker_controller_ids_to_clean: Option<String>,
+
+    #[arg(
+        long = "brokerName",
+        visible_alias = "bn",
+        required = true,
+        help = "The broker name of the replicas that require to be manipulated"
+    )]
+    broker_name: String,
+
+    #[arg(
+        short = 'c',
+        long = "clusterName",
+        required = false,
+        help = "The clusterName of broker"
+    )]
+    cluster_name: Option<String>,
+
+    #[arg(
+        short = 'l',
+        long = "cleanLivingBroker",
+        required = false,
+        help = "Whether clean up living brokers, default value is false"
+    )]
+    clean_living_broker: bool,
+}
+
+impl CleanBrokerMetadataCommand {
+    fn validate_broker_controller_ids(ids: &str) -> RocketMQResult<()> {
+        for id_str in ids.split(';') {
+            let trimmed = id_str.trim();
+            if !trimmed.is_empty() {
+                trimmed.parse::<i64>().map_err(|_| {
+                    RocketMQError::IllegalArgument(format!(
+                        "please set the option <brokerControllerIdsToClean> according to the format, invalid id: {}",
+                        id_str
+                    ))
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl CommandExecute for CleanBrokerMetadataCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let controller_address = self.controller_address.trim();
+        let broker_name = self.broker_name.trim();
+
+        if let Some(ref ids) = self.broker_controller_ids_to_clean {
+            Self::validate_broker_controller_ids(ids)?;
+        }
+
+        if !self.clean_living_broker && self.cluster_name.is_none() {
+            return Err(RocketMQError::IllegalArgument(
+                "cleanLivingBroker option is false, clusterName option can not be empty.".to_string(),
+            ));
+        }
+
+        let cluster_name = self.cluster_name.clone().unwrap_or_default();
+
+        let mut default_mqadmin_ext = DefaultMQAdminExt::new();
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("CleanBrokerMetadataCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            default_mqadmin_ext
+                .clean_controller_broker_data(
+                    controller_address.into(),
+                    cluster_name.into(),
+                    broker_name.into(),
+                    self.broker_controller_ids_to_clean.clone().map(Into::into),
+                    self.clean_living_broker,
+                )
+                .await
+                .map_err(|e| {
+                    RocketMQError::Internal(format!(
+                        "CleanBrokerMetadataCommand: Failed to clean broker metadata: {}",
+                        e
+                    ))
+                })?;
+
+            println!("clear broker {} metadata from controller success!", broker_name);
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_basic_command() {
+        let args = vec![
+            "clean-broker-metadata",
+            "-a",
+            "127.0.0.1:9878",
+            "--brokerName",
+            "broker-a",
+            "-c",
+            "DefaultCluster",
+        ];
+
+        let cmd = CleanBrokerMetadataCommand::try_parse_from(args).unwrap();
+        assert_eq!(cmd.controller_address, "127.0.0.1:9878");
+        assert_eq!(cmd.broker_name, "broker-a");
+        assert_eq!(cmd.cluster_name, Some("DefaultCluster".to_string()));
+        assert!(!cmd.clean_living_broker);
+        assert!(cmd.broker_controller_ids_to_clean.is_none());
+    }
+
+    #[test]
+    fn parse_with_broker_name_alias() {
+        let args = vec![
+            "clean-broker-metadata",
+            "-a",
+            "127.0.0.1:9878",
+            "--bn",
+            "broker-a",
+            "-c",
+            "DefaultCluster",
+        ];
+        assert_eq!(
+            CleanBrokerMetadataCommand::try_parse_from(args).unwrap().broker_name,
+            "broker-a"
+        );
+    }
+
+    #[test]
+    fn parse_with_broker_controller_ids() {
+        let args = vec![
+            "clean-broker-metadata",
+            "-a",
+            "127.0.0.1:9878",
+            "--brokerName",
+            "broker-a",
+            "-c",
+            "DefaultCluster",
+            "-b",
+            "1;2;3",
+        ];
+
+        let cmd = CleanBrokerMetadataCommand::try_parse_from(args).unwrap();
+        assert_eq!(cmd.broker_controller_ids_to_clean, Some("1;2;3".to_string()));
+    }
+
+    #[test]
+    fn parse_with_clean_living_broker() {
+        let args = vec![
+            "clean-broker-metadata",
+            "-a",
+            "127.0.0.1:9878",
+            "--brokerName",
+            "broker-a",
+            "-l",
+        ];
+
+        let cmd = CleanBrokerMetadataCommand::try_parse_from(args).unwrap();
+        assert!(cmd.clean_living_broker);
+        assert!(cmd.cluster_name.is_none());
+    }
+
+    #[test]
+    fn missing_required_controller_address() {
+        let args = vec!["clean-broker-metadata", "--brokerName", "broker-a"];
+        assert!(CleanBrokerMetadataCommand::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn missing_required_broker_name() {
+        let args = vec!["clean-broker-metadata", "-a", "127.0.0.1:9878"];
+        assert!(CleanBrokerMetadataCommand::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn validate_broker_controller_ids_valid() {
+        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("1").is_ok());
+        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("1;2;3").is_ok());
+        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("0;1;2").is_ok());
+        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("100").is_ok());
+    }
+
+    #[test]
+    fn validate_broker_controller_ids_invalid() {
+        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("abc").is_err());
+        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("1;abc;3").is_err());
+        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("1.5").is_err());
+        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("1;2;").is_ok());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5621

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
Add some tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Controller CLI command to clean broker metadata, exposed in help and command listings.
  * New options: controller address, broker name, cluster name, broker controller IDs, and a flag to include live brokers.
* **Tests**
  * Added unit tests covering argument parsing, validation, flags, and error cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->