### PR TITLE
[ISSUE #5643]🐛Remove performance assertions from ThreadLocalIndex tests to reduce flakiness

### DIFF
--- a/rocketmq-client/tests/thread_local_index_test.rs
+++ b/rocketmq-client/tests/thread_local_index_test.rs
@@ -155,11 +155,9 @@ fn test_performance_comparison() {
         original_hot.as_nanos() as f64 / optimized_hot.as_nanos() as f64
     );
 
-    // Assert performance improvement
-    assert!(
-        optimized_first <= original_first,
-        "Optimized version should be faster on first call"
-    );
+    // Note: Performance assertions are removed to avoid flaky tests due to system noise.
+    // The actual performance comparison is shown in the output above.
+    // For reliable performance testing, use benchmarks in the benches/ directory.
 }
 
 #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5643

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed flaky performance assertion from test suite due to system noise. Added guidance recommending dedicated benchmark tools for reliable performance testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->