### PR TITLE
[Refactor♻️] Change default_mqproducer_impl_inner to use WeakArcMut for improved memory management 

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -362,7 +362,7 @@ impl DefaultMQProducer {
         self.default_mqproducer_impl
             .as_mut()
             .unwrap()
-            .set_default_mqproducer_impl_inner(wrapper);
+            .set_default_mqproducer_impl_inner(ArcMut::downgrade(&wrapper));
     }
 
     pub fn set_retry_response_codes(&mut self, retry_response_codes: HashSet<i32>) {


### PR DESCRIPTION
[Refactor♻️] Change default_mqproducer_impl_inner to use WeakArcMut for improved memory management 

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5678

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched internal ownership to non‑owning references for producer internals to improve lifecycle handling and reduce unexpected retention.
  * Standardized access with explicit upgrade checks and clearer failure messages to make runtime issues easier to diagnose.
  * No changes to public APIs or visible external behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->