### PR TITLE
[ISSUE #5623]🚀Implement Controller Command: Get Controller Config (getControllerConfig)

### DIFF
--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -715,7 +715,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         &self,
         controller_servers: Vec<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<HashMap<CheetahString, HashMap<CheetahString, CheetahString>>> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .get_controller_config(controller_servers)
+            .await
     }
 
     async fn update_controller_config(

--- a/rocketmq-tools/src/commands.rs
+++ b/rocketmq-tools/src/commands.rs
@@ -121,6 +121,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Controller",
+                command: "getControllerConfig",
+                remark: "Get configuration of controller(s).",
+            },
+            Command {
+                category: "Controller",
                 command: "getControllerMetaData",
                 remark: "Get meta data of controller.",
             },

--- a/rocketmq-tools/src/commands/controller_commands.rs
+++ b/rocketmq-tools/src/commands/controller_commands.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod clean_broker_metadata_command;
+mod get_controller_config_sub_command;
 mod get_controller_metadata_sub_command;
 
 use std::sync::Arc;
@@ -33,6 +34,13 @@ pub enum ControllerCommands {
     CleanBrokerMetadata(clean_broker_metadata_command::CleanBrokerMetadataCommand),
 
     #[command(
+        name = "getControllerConfig",
+        about = "Get configuration of controller(s)",
+        long_about = None,
+    )]
+    GetControllerConfigSubCommand(get_controller_config_sub_command::GetControllerConfigSubCommand),
+
+    #[command(
         name = "getControllerMetadata",
         about = "Get meta data of controller",
         long_about = None,
@@ -44,6 +52,7 @@ impl CommandExecute for ControllerCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             ControllerCommands::CleanBrokerMetadata(cmd) => cmd.execute(rpc_hook).await,
+            ControllerCommands::GetControllerConfigSubCommand(value) => value.execute(rpc_hook).await,
             ControllerCommands::GetControllerMetadataSubCommand(value) => value.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/src/commands/controller_commands/get_controller_config_sub_command.rs
+++ b/rocketmq-tools/src/commands/controller_commands/get_controller_config_sub_command.rs
@@ -1,0 +1,92 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct GetControllerConfigSubCommand {
+    #[arg(
+        short = 'a',
+        long = "controllerAddress",
+        value_name = "HOST:PORT[;HOST:PORT...]",
+        required = true,
+        help = "Controller address list, eg: '192.168.0.1:9878;192.168.0.2:9878'"
+    )]
+    controller_address: String,
+}
+
+impl CommandExecute for GetControllerConfigSubCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = DefaultMQAdminExt::new();
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let controller_servers: Vec<CheetahString> = self
+            .controller_address
+            .split(';')
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| CheetahString::from(s.trim()))
+            .collect();
+
+        if controller_servers.is_empty() {
+            return Err(RocketMQError::Internal(
+                "GetControllerConfigSubCommand: No valid controller address provided".to_string(),
+            ));
+        }
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "GetControllerConfigSubCommand: Failed to start MQAdminExt: {}",
+                    e
+                ))
+            })?;
+
+            let controller_configs = default_mqadmin_ext
+                .get_controller_config(controller_servers)
+                .await
+                .map_err(|e| {
+                    RocketMQError::Internal(format!(
+                        "GetControllerConfigSubCommand: Failed to get controller config: {}",
+                        e
+                    ))
+                })?;
+
+            for (controller_addr, config) in controller_configs {
+                println!("============{}============", controller_addr);
+                for (key, value) in config {
+                    println!("{:<50}=  {}", key, value);
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5623 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to fetch and display controller configurations from one or more controller addresses (semicolon-separated).
  * Queries multiple controllers and prints formatted key=value listings for each controller for easy review.
  * Performs operations with proper startup/shutdown of the client and continues fetching other controllers if individual requests fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->