### PR TITLE
[ISSUE #5648]🚀Implement DeleteSubscriptionGroupCommand for removing consumer groups

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -439,7 +439,17 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         group_name: CheetahString,
         remove_offset: Option<bool>,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .delete_subscription_group(
+                &addr,
+                group_name,
+                remove_offset.unwrap_or(false),
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await
     }
 
     async fn create_and_update_kv_config(

--- a/rocketmq-tools/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/src/admin/default_mq_admin_ext.rs
@@ -442,7 +442,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         group_name: CheetahString,
         remove_offset: Option<bool>,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .delete_subscription_group(addr, group_name, remove_offset)
+            .await
     }
 
     async fn create_and_update_kv_config(

--- a/rocketmq-tools/src/commands.rs
+++ b/rocketmq-tools/src/commands.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod command_util;
+mod consumer_commands;
 mod controller_commands;
 mod namesrv_commands;
 mod topic_commands;
@@ -67,6 +68,11 @@ pub struct CommonArgs {
 #[derive(Subcommand)]
 pub enum Commands {
     #[command(subcommand)]
+    #[command(about = "Consumer commands")]
+    #[command(name = "consumer")]
+    Consumer(consumer_commands::ConsumerCommands),
+
+    #[command(subcommand)]
     #[command(about = "Controller commands")]
     #[command(name = "controller")]
     Controller(controller_commands::ControllerCommands),
@@ -87,6 +93,7 @@ pub enum Commands {
 impl CommandExecute for Commands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
+            Commands::Consumer(value) => value.execute(rpc_hook).await,
             Commands::Controller(value) => value.execute(rpc_hook).await,
             Commands::NameServer(value) => value.execute(rpc_hook).await,
             Commands::Topic(value) => value.execute(rpc_hook).await,
@@ -114,6 +121,11 @@ pub(crate) struct ClassificationTablePrint;
 impl CommandExecute for ClassificationTablePrint {
     async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         let commands: Vec<Command> = vec![
+            Command {
+                category: "Consumer",
+                command: "deleteSubGroup",
+                remark: "Delete subscription group from broker.",
+            },
             Command {
                 category: "Controller",
                 command: "cleanBrokerMetadata",

--- a/rocketmq-tools/src/commands/consumer_commands.rs
+++ b/rocketmq-tools/src/commands/consumer_commands.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod delete_subscription_group_sub_command;
+
+use std::sync::Arc;
+
+use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::CommandExecute;
+
+#[derive(Subcommand)]
+pub enum ConsumerCommands {
+    #[command(
+        name = "deleteSubGroup",
+        about = "Delete subscription group",
+        long_about = r#"Delete subscription group from broker."#
+    )]
+    DeleteSubGroup(delete_subscription_group_sub_command::DeleteSubscriptionGroupSubCommand),
+}
+
+impl CommandExecute for ConsumerCommands {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self {
+            ConsumerCommands::DeleteSubGroup(cmd) => cmd.execute(rpc_hook).await,
+        }
+    }
+}

--- a/rocketmq-tools/src/commands/consumer_commands/delete_subscription_group_sub_command.rs
+++ b/rocketmq-tools/src/commands/consumer_commands/delete_subscription_group_sub_command.rs
@@ -1,0 +1,173 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::mix_all::get_dlq_topic;
+use rocketmq_common::common::mix_all::get_retry_topic;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct DeleteSubscriptionGroupSubCommand {
+    /// Common arguments
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    /// Broker address
+    #[arg(
+        short = 'b',
+        long = "brokerAddr",
+        required = false,
+        conflicts_with = "cluster_name",
+        help = "delete subscription group from which broker"
+    )]
+    broker_addr: Option<String>,
+
+    /// Cluster name
+    #[arg(
+        short = 'c',
+        long = "clusterName",
+        required = false,
+        conflicts_with = "broker_addr",
+        help = "delete subscription group from which cluster"
+    )]
+    cluster_name: Option<String>,
+
+    /// Subscription group name
+    #[arg(short = 'g', long = "groupName", required = true, help = "subscription group name")]
+    group_name: String,
+
+    /// Whether to remove consumer offset
+    #[arg(
+        short = 'r',
+        long = "removeOffset",
+        required = false,
+        default_value = "false",
+        help = "remove offset"
+    )]
+    remove_offset: bool,
+}
+
+impl DeleteSubscriptionGroupSubCommand {
+    async fn delete_from_broker(
+        admin_ext: &mut DefaultMQAdminExt,
+        broker_addr: &str,
+        group_name: &str,
+        clean_offset: bool,
+    ) -> RocketMQResult<()> {
+        admin_ext
+            .delete_subscription_group(broker_addr.into(), group_name.into(), Some(clean_offset))
+            .await?;
+        println!(
+            "delete subscription group [{}] from broker [{}] success.",
+            group_name, broker_addr
+        );
+        Ok(())
+    }
+
+    async fn delete_from_cluster(
+        admin_ext: &mut DefaultMQAdminExt,
+        cluster_name: &str,
+        group_name: &str,
+        clean_offset: bool,
+    ) -> RocketMQResult<()> {
+        let cluster_info = admin_ext.examine_broker_cluster_info().await?;
+        let master_set = CommandUtil::fetch_master_addr_by_cluster_name(&cluster_info, cluster_name)?;
+
+        for master_addr in &master_set {
+            admin_ext
+                .delete_subscription_group(master_addr.clone(), group_name.into(), Some(clean_offset))
+                .await?;
+            println!(
+                "delete subscription group [{}] from broker [{}] in cluster [{}] success.",
+                group_name, master_addr, cluster_name
+            );
+        }
+
+        let retry_topic = get_retry_topic(group_name);
+        let dlq_topic = get_dlq_topic(group_name);
+
+        if let Err(e) = admin_ext
+            .delete_topic(retry_topic.clone().into(), cluster_name.into())
+            .await
+        {
+            eprintln!("{}", e);
+        }
+
+        if let Err(e) = admin_ext
+            .delete_topic(dlq_topic.clone().into(), cluster_name.into())
+            .await
+        {
+            eprintln!("{}", e);
+        }
+
+        Ok(())
+    }
+}
+
+impl CommandExecute for DeleteSubscriptionGroupSubCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        if self.broker_addr.is_none() && self.cluster_name.is_none() {
+            return Err(RocketMQError::IllegalArgument(
+                "DeleteSubscriptionGroupSubCommand: Either brokerAddr (-b) or clusterName (-c) must be provided".into(),
+            ));
+        }
+
+        let group_name = self.group_name.trim();
+        if group_name.is_empty() {
+            return Err(RocketMQError::IllegalArgument(
+                "DeleteSubscriptionGroupSubCommand: groupName (-g) cannot be empty".into(),
+            ));
+        }
+
+        let mut admin_ext = DefaultMQAdminExt::new();
+        admin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        if let Some(addr) = &self.common_args.namesrv_addr {
+            admin_ext.set_namesrv_addr(addr.trim());
+        }
+
+        admin_ext.start().await.map_err(|e| {
+            RocketMQError::Internal(format!(
+                "DeleteSubscriptionGroupSubCommand: Failed to start MQAdminExt: {}",
+                e
+            ))
+        })?;
+
+        let result = if let Some(broker_addr) = &self.broker_addr {
+            Self::delete_from_broker(&mut admin_ext, broker_addr.trim(), group_name, self.remove_offset).await
+        } else if let Some(cluster_name) = &self.cluster_name {
+            Self::delete_from_cluster(&mut admin_ext, cluster_name.trim(), group_name, self.remove_offset).await
+        } else {
+            Err(RocketMQError::IllegalArgument(
+                "DeleteSubscriptionGroupSubCommand: Either brokerAddr (-b) or clusterName (-c) must be provided".into(),
+            ))
+        };
+
+        admin_ext.shutdown().await;
+        result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5648 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI consumer command "deleteSubGroup" to delete subscription groups from a broker or entire cluster.
  * Option to remove stored offsets when deleting a subscription group.
  * Cluster mode deletes on all masters and attempts retry/DLQ topic cleanup with logs.

* **Bug Fixes**
  * Implemented functional remote deletion flow (replaced previous placeholders) with proper error reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->