### PR TITLE
[ISSUE #5704]✨Update criterion dependency to version 0.8.1 and clean up benchmark imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,34 +787,6 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.5.0",
- "futures",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "tokio",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
@@ -824,7 +796,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.8.1",
+ "criterion-plot",
  "futures",
  "itertools 0.13.0",
  "num-traits",
@@ -838,16 +810,6 @@ dependencies = [
  "tinytemplate",
  "tokio",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1998,15 +1960,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3531,7 +3484,7 @@ dependencies = [
  "cfg-if",
  "cheetah-string",
  "clap",
- "criterion 0.8.1",
+ "criterion",
  "crossbeam-skiplist",
  "dashmap",
  "dirs",
@@ -3579,7 +3532,7 @@ version = "0.8.0"
 dependencies = [
  "bytes",
  "cheetah-string",
- "criterion 0.5.1",
+ "criterion",
  "dashmap",
  "futures",
  "num_cpus",
@@ -3609,7 +3562,7 @@ dependencies = [
  "chrono-tz",
  "config",
  "crc",
- "criterion 0.8.1",
+ "criterion",
  "dashmap",
  "dirs",
  "flate2",
@@ -3655,7 +3608,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
- "criterion 0.8.1",
+ "criterion",
  "dashmap",
  "env_logger",
  "futures",
@@ -3734,7 +3687,7 @@ dependencies = [
 name = "rocketmq-macros"
 version = "0.8.0"
 dependencies = [
- "criterion 0.8.1",
+ "criterion",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3748,7 +3701,7 @@ dependencies = [
  "cheetah-string",
  "clap",
  "config",
- "criterion 0.8.1",
+ "criterion",
  "dashmap",
  "futures",
  "hashbrown 0.16.1",
@@ -3778,7 +3731,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "cheetah-string",
- "criterion 0.8.1",
+ "criterion",
  "dashmap",
  "flate2",
  "flume",
@@ -3838,7 +3791,7 @@ dependencies = [
  "arc-swap",
  "bytes",
  "cheetah-string",
- "criterion 0.8.1",
+ "criterion",
  "dashmap",
  "dirs",
  "futures-util",

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -40,7 +40,7 @@ futures        = { workspace = true }
 cheetah-string = { workspace = true }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["async_tokio"] }
+criterion = { version = "0.8.1", features = ["async_tokio"] }
 
 [[bench]]
 name = "produce_accumulator_benchmark"

--- a/rocketmq-client/benches/concurrent_optimization_benchmark.rs
+++ b/rocketmq-client/benches/concurrent_optimization_benchmark.rs
@@ -31,12 +31,13 @@
 //!
 //! Run with: cargo bench --bench concurrent_optimization_benchmark
 
+use std::hint::black_box;
 use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
 
 use cheetah_string::CheetahString;
-use criterion::black_box;
+
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;

--- a/rocketmq-client/benches/produce_accumulator_benchmark.rs
+++ b/rocketmq-client/benches/produce_accumulator_benchmark.rs
@@ -21,10 +21,10 @@
 //! Run with: cargo bench --bench produce_accumulator_benchmark
 
 use std::collections::HashMap;
+use std::hint::black_box;
 use std::sync::Arc;
 use std::time::Duration;
 
-use criterion::black_box;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5704

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development benchmarking dependencies to the latest version
  * Optimized internal benchmark utilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->