### PR TITLE
[ISSUE #5735]🚀Refactor JavaStringHasher to use UTF-16 encoding in hash_str method

### DIFF
--- a/rocketmq-common/src/common/hasher/string_hasher.rs
+++ b/rocketmq-common/src/common/hasher/string_hasher.rs
@@ -16,13 +16,13 @@ pub struct JavaStringHasher;
 
 impl JavaStringHasher {
     pub fn hash_str(s: &str) -> i32 {
-        let mut state = 0i32;
+        let mut h = 0i32;
         if !s.is_empty() {
-            for c in s.chars() {
-                state = state.wrapping_mul(31).wrapping_add(c as i32);
+            for c in s.encode_utf16() {
+                h = h.wrapping_mul(31).wrapping_add(c as i32);
             }
         }
-        state
+        h
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5735

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal string hashing implementation to use UTF-16 encoding for hash computation instead of Unicode scalar values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->