### PR TITLE
[ISSUE #5740]♻️Refactor put_user_property method for improved error handling and deprecate CommonError type

### DIFF
--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
@@ -752,10 +752,12 @@ where
             }
         }
 
-        msg_ext.put_user_property(
-            CheetahString::from_static_str(MessageConst::PROPERTY_TRANSACTION_CHECK_TIMES),
-            check_time.to_string().into(),
-        );
+        msg_ext
+            .put_user_property(
+                CheetahString::from_static_str(MessageConst::PROPERTY_TRANSACTION_CHECK_TIMES),
+                check_time.to_string().into(),
+            )
+            .ok();
         false
     }
 

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -1912,7 +1912,8 @@ impl DefaultMQProducerImpl {
                     msg.put_user_property(
                         CheetahString::from_static_str(MessageConst::PROPERTY_TRANSACTION_ID),
                         CheetahString::from_string(transaction_id.to_owned()),
-                    );
+                    )
+                    .map_err(|e| mq_client_err!(e.to_string()))?;
                 }
                 let transaction_id = msg.get_property(&CheetahString::from_static_str(
                     MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,

--- a/rocketmq-common/src/error.rs
+++ b/rocketmq-common/src/error.rs
@@ -12,12 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use config::ConfigError;
-
-pub type RocketMQResult<T> = Result<T, CommonError>;
-
-#[derive(thiserror::Error, Debug)]
-pub enum CommonError {
-    #[error("Config error: {0}")]
-    ConfigError(#[from] ConfigError),
-}
+// This module has been deprecated. Use rocketmq_error::RocketMQError and
+// rocketmq_error::RocketMQResult instead.

--- a/rocketmq-common/src/utils/parse_config_file.rs
+++ b/rocketmq-common/src/utils/parse_config_file.rs
@@ -18,8 +18,6 @@ use std::path::PathBuf;
 use config::Config;
 use serde::Deserialize;
 
-use crate::error::CommonError;
-
 pub fn parse_config_file<'de, C>(config_file: PathBuf) -> rocketmq_error::RocketMQResult<C>
 where
     C: Debug + Deserialize<'de>,

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -127,6 +127,13 @@ pub enum RocketMQError {
     Controller(#[from] ControllerError),
 
     // ============================================================================
+    // Message Property Errors
+    // ============================================================================
+    /// Invalid message property
+    #[error("Invalid message property: {0}")]
+    InvalidProperty(String),
+
+    // ============================================================================
     // Broker Errors
     // ============================================================================
     /// Broker not found


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5740

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Message property validation now returns descriptive errors instead of crashes for invalid or reserved properties.
  * Transaction operations have improved error handling and propagation.

* **Improvements**
  * Property parsing is more robust with safer default values.
  * Invalid property assignments provide clear error messages to help diagnose issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->