### PR TITLE
[ISSUE #5743]🚀Add get_property_ref method to message structs for improved property access

### DIFF
--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -108,6 +108,21 @@ pub trait MessageTrait: Any + Display + Debug {
         self.get_property(name)
     }
 
+    /// Retrieves a reference to a user-defined property from the message.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - A reference to a `CheetahString` representing the name of the user property to
+    ///   retrieve.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<&CheetahString>` containing a reference to the property value if it exists,
+    /// otherwise `None`.
+    fn get_user_property_ref(&self, name: &CheetahString) -> Option<&CheetahString> {
+        self.get_property_ref(name)
+    }
+
     /// Retrieves a property from the message.
     ///
     /// # Arguments
@@ -118,6 +133,19 @@ pub trait MessageTrait: Any + Display + Debug {
     ///
     /// An `Option<String>` containing the property value if it exists, otherwise `None`.
     fn get_property(&self, name: &CheetahString) -> Option<CheetahString>;
+
+    /// Retrieves a reference to a property value from the message.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - A reference to a `CheetahString` representing the name of the property to
+    ///   retrieve.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<&CheetahString>` containing a reference to the property value if it exists,
+    /// otherwise `None`.
+    fn get_property_ref(&self, name: &CheetahString) -> Option<&CheetahString>;
 
     /// Retrieves the topic of the message.
     ///

--- a/rocketmq-common/src/common/message/message_batch.rs
+++ b/rocketmq-common/src/common/message/message_batch.rs
@@ -186,6 +186,10 @@ impl MessageTrait for MessageBatch {
         self.final_message.properties.get(name).cloned()
     }
 
+    fn get_property_ref(&self, name: &CheetahString) -> Option<&CheetahString> {
+        self.final_message.properties.get(name)
+    }
+
     #[inline]
     fn get_topic(&self) -> &CheetahString {
         &self.final_message.topic

--- a/rocketmq-common/src/common/message/message_client_ext.rs
+++ b/rocketmq-common/src/common/message/message_client_ext.rs
@@ -80,6 +80,10 @@ impl MessageTrait for MessageClientExt {
         self.message_ext_inner.get_property(name)
     }
 
+    fn get_property_ref(&self, name: &CheetahString) -> Option<&CheetahString> {
+        self.message_ext_inner.get_property_ref(name)
+    }
+
     #[inline]
     fn get_topic(&self) -> &CheetahString {
         self.message_ext_inner.get_topic()

--- a/rocketmq-common/src/common/message/message_ext.rs
+++ b/rocketmq-common/src/common/message/message_ext.rs
@@ -304,6 +304,10 @@ impl MessageTrait for MessageExt {
         self.message.get_property(name)
     }
 
+    fn get_property_ref(&self, name: &CheetahString) -> Option<&CheetahString> {
+        self.message.get_property_ref(name)
+    }
+
     fn get_topic(&self) -> &CheetahString {
         self.message.get_topic()
     }

--- a/rocketmq-common/src/common/message/message_ext_broker_inner.rs
+++ b/rocketmq-common/src/common/message/message_ext_broker_inner.rs
@@ -263,6 +263,10 @@ impl MessageTrait for MessageExtBrokerInner {
         self.message_ext_inner.get_property(name)
     }
 
+    fn get_property_ref(&self, name: &CheetahString) -> Option<&CheetahString> {
+        self.message_ext_inner.get_property_ref(name)
+    }
+
     #[inline]
     fn get_topic(&self) -> &CheetahString {
         self.message_ext_inner.get_topic()

--- a/rocketmq-common/src/common/message/message_single.rs
+++ b/rocketmq-common/src/common/message/message_single.rs
@@ -385,6 +385,10 @@ impl MessageTrait for Message {
         self.properties.get(name).cloned()
     }
 
+    fn get_property_ref(&self, name: &CheetahString) -> Option<&CheetahString> {
+        self.properties.get(name)
+    }
+
     #[inline]
     fn get_topic(&self) -> &CheetahString {
         &self.topic


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5743

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reference-based property accessor methods to the message API. These new methods extend property access across all message types, providing an additional way to retrieve message properties.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->