### PR TITLE
[ISSUE #5755]✨Add create_correlation_id_simple method for compact UUID generation

### DIFF
--- a/rocketmq-common/src/utils/correlation_id_util.rs
+++ b/rocketmq-common/src/utils/correlation_id_util.rs
@@ -17,7 +17,27 @@ use uuid::Uuid;
 pub struct CorrelationIdUtil;
 
 impl CorrelationIdUtil {
+    /// Creates a new correlation ID using UUID v4 in standard format.
+    ///
+    /// Uses hyphenated format (36 chars) to maintain compatibility with Java's UUID.toString().
+    /// Format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    ///
+    /// # Returns
+    /// A 36-character UUID string (e.g., "550e8400-e29b-41d4-a716-446655440000")
+    #[inline]
     pub fn create_correlation_id() -> String {
         Uuid::new_v4().to_string()
+    }
+
+    /// Creates a new correlation ID using UUID v4 in simple format (without hyphens).
+    ///
+    /// This format is more compact and has ~11% less memory overhead compared to standard format.
+    /// Format: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (32 hex characters)
+    ///
+    /// # Returns
+    /// A 32-character UUID string (e.g., "550e8400e29b41d4a716446655440000")
+    #[inline]
+    pub fn create_correlation_id_simple() -> String {
+        Uuid::new_v4().simple().to_string()
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5755

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced simplified correlation ID generation method that produces UUID v4 identifiers in a compact 32-character hex format without hyphens.

* **Documentation**
  * Enhanced documentation for correlation ID generation functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->