### PR TITLE
[ISSUE #5719]🧪Add test case for GetConsumerStatusBody

### DIFF
--- a/rocketmq-remoting/src/protocol/body/response/get_consumer_status_body.rs
+++ b/rocketmq-remoting/src/protocol/body/response/get_consumer_status_body.rs
@@ -50,3 +50,53 @@ impl GetConsumerStatusBody {
         serde_json::from_slice(body).ok()
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_consumer_status_body_new_and_default() {
+        let body = GetConsumerStatusBody::new();
+        assert!(body.message_queue_table.is_empty());
+        assert!(body.consumer_table.is_empty());
+
+        let body = GetConsumerStatusBody::default();
+        assert!(body.message_queue_table.is_empty());
+        assert!(body.consumer_table.is_empty());
+    }
+
+    #[test]
+    fn get_consumer_status_body_encode_and_decode() {
+        let mut body = GetConsumerStatusBody::new();
+        let mq = MessageQueue::from_parts(CheetahString::from("topic"), CheetahString::from("broker"), 1);
+        body.message_queue_table.insert(mq.clone(), 123);
+
+        let encoded = body.encode();
+        assert!(!encoded.is_empty());
+        let decoded: GetConsumerStatusBody =
+            GetConsumerStatusBody::decode(&encoded).expect("Failed to deserialize GetConsumerStatusBody");
+        assert_eq!(decoded.message_queue_table.get(&mq), Some(&123));
+    }
+
+    #[test]
+    fn get_consumer_status_body_serialization_and_deserialization() {
+        let mut body = GetConsumerStatusBody::new();
+        let mq = MessageQueue::from_parts(CheetahString::from("topic"), CheetahString::from("broker"), 1);
+        body.message_queue_table.insert(mq.clone(), 123);
+
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(json.contains("messageQueueTable"));
+        assert!(json.contains("consumerTable"));
+        let deserialized: GetConsumerStatusBody = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.message_queue_table.get(&mq), Some(&123));
+    }
+
+    #[test]
+    fn get_consumer_status_body_debug() {
+        let body = GetConsumerStatusBody::new();
+        let debug = format!("{:?}", body);
+        assert!(debug.contains("GetConsumerStatusBody"));
+        assert!(debug.contains("message_queue_table"));
+        assert!(debug.contains("consumer_table"));
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5719 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests to improve reliability around consumer-status data handling — covering construction defaults, binary encode/decode round-trips, JSON serialization/deserialization, and debug output formatting.
  * No user-facing API changes; these are internal test improvements to increase confidence in message handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->