### PR TITLE
[Enhancement✨] update MessageTrait get_compressed_body_mut method signature to return an Option<&mut Bytes>

### DIFF
--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -541,11 +541,12 @@ impl MQClientAPIImpl {
         };
 
         // if compressed_body is not None, set request body to compressed_body
-        if msg.get_compressed_body_mut().is_some() {
-            let compressed_body = std::mem::take(msg.get_compressed_body_mut());
-            request.set_body_mut_ref(compressed_body.unwrap());
+        if let Some(compressed_body) = msg.get_compressed_body() {
+            request.set_body_mut_ref(compressed_body.clone());
+        } else if let Some(body) = msg.get_body() {
+            request.set_body_mut_ref(body.clone());
         } else {
-            request.set_body_mut_ref(msg.get_body().cloned().unwrap());
+            return Err(mq_client_err!(-1, "Message body is None"));
         }
         match communication_mode {
             CommunicationMode::Sync => {

--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -408,8 +408,8 @@ pub trait MessageTrait: Any + Display + Debug {
     /// Retrieves a mutable reference to the compressed body of the message.
     ///
     /// # Returns
-    /// A mutable reference to an `Option<Bytes>` containing the compressed body, if it exists.
-    fn get_compressed_body_mut(&mut self) -> &mut Option<Bytes>;
+    /// An `Option<&mut Bytes>` containing the compressed body, if it exists.
+    fn get_compressed_body_mut(&mut self) -> Option<&mut Bytes>;
 
     /// Retrieves an immutable reference to the compressed body of the message.
     ///

--- a/rocketmq-common/src/common/message/message_batch.rs
+++ b/rocketmq-common/src/common/message/message_batch.rs
@@ -241,8 +241,8 @@ impl MessageTrait for MessageBatch {
     }
 
     #[inline]
-    fn get_compressed_body_mut(&mut self) -> &mut Option<Bytes> {
-        &mut self.final_message.compressed_body
+    fn get_compressed_body_mut(&mut self) -> Option<&mut Bytes> {
+        self.final_message.compressed_body.as_mut()
     }
 
     #[inline]
@@ -252,7 +252,7 @@ impl MessageTrait for MessageBatch {
 
     #[inline]
     fn set_compressed_body_mut(&mut self, compressed_body: Bytes) {
-        self.final_message.compressed_body = Some(compressed_body);
+        self.final_message.set_compressed_body_mut(compressed_body);
     }
 
     #[inline]

--- a/rocketmq-common/src/common/message/message_client_ext.rs
+++ b/rocketmq-common/src/common/message/message_client_ext.rs
@@ -135,7 +135,7 @@ impl MessageTrait for MessageClientExt {
     }
 
     #[inline]
-    fn get_compressed_body_mut(&mut self) -> &mut Option<Bytes> {
+    fn get_compressed_body_mut(&mut self) -> Option<&mut Bytes> {
         self.message_ext_inner.get_compressed_body_mut()
     }
 

--- a/rocketmq-common/src/common/message/message_ext.rs
+++ b/rocketmq-common/src/common/message/message_ext.rs
@@ -349,7 +349,7 @@ impl MessageTrait for MessageExt {
         self.message.set_transaction_id(transaction_id);
     }
 
-    fn get_compressed_body_mut(&mut self) -> &mut Option<Bytes> {
+    fn get_compressed_body_mut(&mut self) -> Option<&mut Bytes> {
         self.message.get_compressed_body_mut()
     }
 
@@ -360,7 +360,6 @@ impl MessageTrait for MessageExt {
     fn set_compressed_body_mut(&mut self, compressed_body: Bytes) {
         self.message.set_compressed_body_mut(compressed_body);
     }
-
     #[inline]
     fn take_body(&mut self) -> Option<Bytes> {
         self.message.take_body()

--- a/rocketmq-common/src/common/message/message_ext_broker_inner.rs
+++ b/rocketmq-common/src/common/message/message_ext_broker_inner.rs
@@ -318,7 +318,7 @@ impl MessageTrait for MessageExtBrokerInner {
     }
 
     #[inline]
-    fn get_compressed_body_mut(&mut self) -> &mut Option<Bytes> {
+    fn get_compressed_body_mut(&mut self) -> Option<&mut Bytes> {
         self.message_ext_inner.get_compressed_body_mut()
     }
 

--- a/rocketmq-common/src/common/message/message_single.rs
+++ b/rocketmq-common/src/common/message/message_single.rs
@@ -440,8 +440,8 @@ impl MessageTrait for Message {
     }
 
     #[inline]
-    fn get_compressed_body_mut(&mut self) -> &mut Option<Bytes> {
-        &mut self.compressed_body
+    fn get_compressed_body_mut(&mut self) -> Option<&mut Bytes> {
+        self.compressed_body.as_mut()
     }
 
     #[inline]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

Fixes #5749 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved message body selection logic in send operations to prioritize compressed bodies when available.
  * Simplified internal API surface for accessing compressed message bodies across message implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->