### PR TITLE
[Feature🚀] Add get_keys_ref method to MessageTrait trait for improved tag access 

### DIFF
--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -183,11 +183,19 @@ pub trait MessageTrait: Any + Display + Debug {
     ///
     /// # Returns
     ///
-    /// An `Option<String>` containing the keys if they exist, otherwise `None`.
+    /// An `Option<CheetahString>` containing the keys if they exist, otherwise `None`.
     fn get_keys(&self) -> Option<CheetahString> {
         self.get_property(&CheetahString::from_static_str(MessageConst::PROPERTY_KEYS))
     }
-
+    /// Retrieves the keys associated with the message.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<&CheetahString>` containing a reference to the keys if they exist, otherwise
+    /// `None`.
+    fn get_keys_ref(&self) -> Option<&CheetahString> {
+        self.get_property_ref(&CheetahString::from_static_str(MessageConst::PROPERTY_KEYS))
+    }
     /// Sets multiple keys from a collection for the message.
     ///
     /// # Arguments


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5746

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized message key retrieval API for improved performance and efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->