### PR TITLE
[ISSUE #5761]📝Clean up redundant documentation comments to improve readability

### DIFF
--- a/rocketmq-tools/src/cli/commands/add_write_perm_command.rs
+++ b/rocketmq-tools/src/cli/commands/add_write_perm_command.rs
@@ -25,7 +25,6 @@ use crate::core::RocketMQResult;
 /// Add write permission for broker
 #[derive(Debug, Clone, Parser)]
 pub struct AddWritePermCommand {
-    /// Broker name
     #[arg(short = 'b', long = "broker-name", required = true)]
     pub broker_name: String,
 

--- a/rocketmq-tools/src/cli/commands/get_namesrv_config_command.rs
+++ b/rocketmq-tools/src/cli/commands/get_namesrv_config_command.rs
@@ -28,7 +28,6 @@ use crate::core::RocketMQResult;
 /// Get NameServer configuration
 #[derive(Debug, Args, Clone)]
 pub struct GetNamesrvConfigCommand {
-    /// NameServer address
     #[arg(short = 'n', long = "namesrvAddr", value_parser = validators::validate_namesrv_addr)]
     pub namesrv_addr: String,
 
@@ -38,9 +37,7 @@ pub struct GetNamesrvConfigCommand {
 }
 
 impl GetNamesrvConfigCommand {
-    /// Execute the command
     pub async fn execute(&self) -> RocketMQResult<()> {
-        // Validate inputs
         self.validate()?;
 
         // Create admin client with RAII guard
@@ -72,9 +69,7 @@ impl GetNamesrvConfigCommand {
         Ok(())
     }
 
-    /// Validate command parameters
     fn validate(&self) -> RocketMQResult<()> {
-        // Validate format
         if !["table", "json", "yaml"].contains(&self.format.as_str()) {
             return Err(crate::core::ToolsError::validation_error(
                 "format",
@@ -86,7 +81,6 @@ impl GetNamesrvConfigCommand {
         Ok(())
     }
 
-    /// Print configuration based on format
     fn print_config(&self, config: &std::collections::HashMap<String, String>) -> RocketMQResult<()> {
         match self.format.as_str() {
             "json" => {
@@ -110,7 +104,6 @@ impl GetNamesrvConfigCommand {
         Ok(())
     }
 
-    /// Print configuration as a table
     fn print_table(&self, config: &std::collections::HashMap<String, String>) {
         println!("\nNameServer Configuration");
         println!("Address: {}", self.namesrv_addr);

--- a/rocketmq-tools/src/cli/commands/update_namesrv_config_command.rs
+++ b/rocketmq-tools/src/cli/commands/update_namesrv_config_command.rs
@@ -32,15 +32,12 @@ pub struct UpdateNamesrvConfigCommand {
     #[arg(short = 'v', long = "value")]
     pub value: String,
 
-    /// NameServer address
     #[arg(short = 'n', long = "namesrvAddr", value_parser = validators::validate_namesrv_addr)]
     pub namesrv_addr: String,
 }
 
 impl UpdateNamesrvConfigCommand {
-    /// Execute the command
     pub async fn execute(&self) -> RocketMQResult<()> {
-        // Validate inputs
         self.validate()?;
 
         // Create admin client with RAII guard
@@ -75,14 +72,11 @@ impl UpdateNamesrvConfigCommand {
         Ok(())
     }
 
-    /// Validate command parameters
     fn validate(&self) -> RocketMQResult<()> {
-        // Validate key
         if self.key.trim().is_empty() {
             return Err(crate::core::ToolsError::validation_error("key", "Configuration key cannot be empty").into());
         }
 
-        // Validate value
         if self.value.trim().is_empty() {
             return Err(
                 crate::core::ToolsError::validation_error("value", "Configuration value cannot be empty").into(),
@@ -92,7 +86,6 @@ impl UpdateNamesrvConfigCommand {
         Ok(())
     }
 
-    /// Print success message
     fn print_success(&self) {
         println!("NameServer configuration updated successfully");
         println!("\nConfiguration:");

--- a/rocketmq-tools/src/cli/commands/wipe_write_perm_command.rs
+++ b/rocketmq-tools/src/cli/commands/wipe_write_perm_command.rs
@@ -28,7 +28,6 @@ use crate::ui::prompt;
 /// Wipe write permission for broker
 #[derive(Debug, Clone, Parser)]
 pub struct WipeWritePermCommand {
-    /// Broker name
     #[arg(short = 'b', long = "broker-name", required = true)]
     pub broker_name: String,
 

--- a/rocketmq-tools/src/commands/consumer_commands/delete_subscription_group_sub_command.rs
+++ b/rocketmq-tools/src/commands/consumer_commands/delete_subscription_group_sub_command.rs
@@ -30,11 +30,9 @@ use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteSubscriptionGroupSubCommand {
-    /// Common arguments
     #[command(flatten)]
     common_args: CommonArgs,
 
-    /// Broker address
     #[arg(
         short = 'b',
         long = "brokerAddr",
@@ -44,7 +42,6 @@ pub struct DeleteSubscriptionGroupSubCommand {
     )]
     broker_addr: Option<String>,
 
-    /// Cluster name
     #[arg(
         short = 'c',
         long = "clusterName",

--- a/rocketmq-tools/src/commands/consumer_commands/update_sub_group_sub_command.rs
+++ b/rocketmq-tools/src/commands/consumer_commands/update_sub_group_sub_command.rs
@@ -38,6 +38,7 @@ pub struct UpdateSubGroupSubCommand {
         help = "create subscription group to which broker"
     )]
     broker_addr: Option<String>,
+
     #[arg(
         short = 'c',
         long = "clusterName",
@@ -45,6 +46,7 @@ pub struct UpdateSubGroupSubCommand {
         help = "create subscription group to which cluster"
     )]
     cluster_name: Option<String>,
+
     #[arg(short = 'g', long = "groupName", required = true, help = "consumer group name")]
     group_name: String,
 

--- a/rocketmq-tools/src/commands/topic_commands/delete_topic_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/delete_topic_sub_command.rs
@@ -26,11 +26,9 @@ use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteTopicSubCommand {
-    /// Common arguments
     #[command(flatten)]
     common_args: CommonArgs,
 
-    /// Cluster name
     #[arg(
         short = 'c',
         long = "clusterName",
@@ -40,7 +38,6 @@ pub struct DeleteTopicSubCommand {
     )]
     cluster_name: Option<String>,
 
-    /// Topic name
     #[arg(short = 't', long = "topic", required = true, help = "topic name")]
     topic: String,
 }

--- a/rocketmq-tools/src/commands/topic_commands/remapping_static_topic_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/remapping_static_topic_sub_command.rs
@@ -37,15 +37,12 @@ const DEFAULT_BLOCK_SEQ_SIZE: i64 = 10000;
 
 #[derive(Debug, Clone, Parser)]
 pub struct RemappingStaticTopicSubCommand {
-    /// Common arguments
     #[command(flatten)]
     common_args: CommonArgs,
 
-    /// Topic name
     #[arg(short = 't', long = "topic", required = true, help = "topic name")]
     topic: String,
 
-    /// Broker names to remapping
     #[arg(
         short = 'b',
         long = "brokers",
@@ -54,7 +51,6 @@ pub struct RemappingStaticTopicSubCommand {
     )]
     brokers: Option<String>,
 
-    /// Cluster names
     #[arg(
         short = 'c',
         long = "clusters",
@@ -63,11 +59,9 @@ pub struct RemappingStaticTopicSubCommand {
     )]
     clusters: Option<String>,
 
-    /// Map file
     #[arg(short = 'm', long = "mapFile", required = false, help = "The mapping data file name")]
     mapping_file: Option<String>,
 
-    /// Force replace
     #[arg(
         short = 'f',
         long = "forceReplace",

--- a/rocketmq-tools/src/commands/topic_commands/topic_list_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/topic_list_sub_command.rs
@@ -28,11 +28,9 @@ use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
 pub struct TopicListSubCommand {
-    /// Common arguments
     #[command(flatten)]
     common_args: CommonArgs,
 
-    /// Cluster name
     #[arg(
         short = 'c',
         long = "clusterName",

--- a/rocketmq-tools/src/commands/topic_commands/topic_route_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/topic_route_sub_command.rs
@@ -29,13 +29,12 @@ use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
 pub struct TopicRouteSubCommand {
-    /// Common arguments
     #[command(flatten)]
     common_args: CommonArgs,
-    /// Topic name
+
     #[arg(short = 't', long = "topic", required = true, help = "topic name")]
     topic: String,
-    /// List format
+
     #[arg(short = 'l', long = "list format", required = false, help = "list format")]
     list_format: Option<bool>,
 }

--- a/rocketmq-tools/src/commands/topic_commands/topic_status_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/topic_status_sub_command.rs
@@ -26,13 +26,12 @@ use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
 pub struct TopicStatusSubCommand {
-    /// Common arguments
     #[command(flatten)]
     common_args: CommonArgs,
-    /// Topic name
+
     #[arg(short = 't', long = "topic", required = true, help = "topic name")]
     topic: String,
-    /// Cluster name
+
     #[arg(
         short = 'c',
         long = "clusterName",

--- a/rocketmq-tools/src/commands/topic_commands/update_order_conf_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/update_order_conf_command.rs
@@ -24,13 +24,12 @@ use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateOrderConfCommand {
-    /// Common arguments
     #[command(flatten)]
     common_args: CommonArgs,
-    /// Topic name
+
     #[arg(short = 't', long = "topic", required = true, help = "topic name")]
     topic: String,
-    /// Method
+
     #[arg(
         short = 'm',
         long = "method",
@@ -38,7 +37,7 @@ pub struct UpdateOrderConfCommand {
         help = "option type [eg. put|get|delete"
     )]
     method: String,
-    /// OrderConf
+
     #[arg(
         short = 'v',
         long = "orderConf",

--- a/rocketmq-tools/src/commands/topic_commands/update_static_topic_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/update_static_topic_sub_command.rs
@@ -32,13 +32,12 @@ use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateStaticTopicSubCommand {
-    /// Common arguments
     #[command(flatten)]
     common_args: CommonArgs,
-    /// Topic name
+
     #[arg(short = 't', long = "topic", required = true, help = "topic name")]
     topic: String,
-    /// Broker address
+
     #[arg(
         short = 'b',
         long = "brokerAddr",
@@ -46,10 +45,10 @@ pub struct UpdateStaticTopicSubCommand {
         help = "create topic to which broker"
     )]
     broker_addr: String,
-    /// "totalQueueNum"
+
     #[arg(short = 'q', long = "totalQueueNum", required = true, help = "totalQueueNum")]
     queue_num: String,
-    /// Cluster name
+
     #[arg(
         short = 'c',
         long = "clusterName",
@@ -57,10 +56,10 @@ pub struct UpdateStaticTopicSubCommand {
         help = "create topic to which cluster"
     )]
     cluster_name: Option<String>,
-    /// Map file
+
     #[arg(short = 'm', long = "mapFile", required = false, help = "The mapping data file name")]
     mapping_file: Option<String>,
-    /// Force replace
+
     #[arg(
         short = 'f',
         long = "forceReplace",

--- a/rocketmq-tools/src/commands/topic_commands/update_topic_perm_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/update_topic_perm_sub_command.rs
@@ -34,7 +34,6 @@ pub struct UpdateTopicPermSubCommand {
     #[command(flatten)]
     common_args: CommonArgs,
 
-    /// Broker address
     #[arg(
         short = 'b',
         long = "brokerAddr",
@@ -44,7 +43,6 @@ pub struct UpdateTopicPermSubCommand {
     )]
     broker_addr: Option<String>,
 
-    /// Cluster name
     #[arg(
         short = 'c',
         long = "clusterName",
@@ -53,11 +51,9 @@ pub struct UpdateTopicPermSubCommand {
     )]
     cluster_name: Option<String>,
 
-    /// Topic name
     #[arg(short = 't', long = "topic", required = true, help = "Topic name")]
     topic: String,
 
-    /// Perm
     #[arg(
         short = 'p',
         long = "perm",

--- a/rocketmq-tools/src/commands/topic_commands/update_topic_sub_command.rs
+++ b/rocketmq-tools/src/commands/topic_commands/update_topic_sub_command.rs
@@ -31,11 +31,9 @@ use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateTopicSubCommand {
-    /// Common arguments
     #[command(flatten)]
     common_args: CommonArgs,
 
-    /// Broker address
     #[arg(
         short = 'b',
         long = "brokerAddr",
@@ -45,7 +43,6 @@ pub struct UpdateTopicSubCommand {
     )]
     broker_addr: Option<String>,
 
-    /// Cluster name
     #[arg(
         short = 'c',
         long = "clusterName",
@@ -55,11 +52,9 @@ pub struct UpdateTopicSubCommand {
     )]
     cluster_name: Option<String>,
 
-    /// Topic name
     #[arg(short = 't', long = "topic", required = true, help = "topic name")]
     topic: String,
 
-    /// Number of read queues
     #[arg(
         short = 'r',
         long = "readQueueNums",
@@ -70,7 +65,6 @@ pub struct UpdateTopicSubCommand {
     )]
     read_queue_nums: u32,
 
-    /// Number of write queues
     #[arg(
         short = 'w',
         long = "writeQueueNums",
@@ -81,8 +75,6 @@ pub struct UpdateTopicSubCommand {
     )]
     write_queue_nums: u32,
 
-    /// Topic permission
-    /// 2: Write only, 4: Read only, 6: Read and Write
     #[arg(
         short = 'p',
         long = "perm",
@@ -92,7 +84,6 @@ pub struct UpdateTopicSubCommand {
     )]
     perm: Option<String>,
 
-    /// Whether it's an ordered message topic
     #[arg(
         short = 'o',
         long = "order",
@@ -101,11 +92,9 @@ pub struct UpdateTopicSubCommand {
     )]
     order: Option<bool>,
 
-    /// Whether it's a unit topic
     #[arg(short = 'u', long = "unit", required = false, help = "is unit topic (true|false)")]
     unit: Option<bool>,
 
-    /// Whether there's a unit subscription group
     #[arg(
         short = 's',
         long = "hasUnitSub",

--- a/rocketmq-tools/src/rocketmq_cli.rs
+++ b/rocketmq-tools/src/rocketmq_cli.rs
@@ -26,7 +26,6 @@ use crate::commands::Commands;
 #[command(name = "rocketmq-admin-cli-rust")]
 #[command(about = "Rocketmq Rust admin commands", long_about = None, author="mxsm")]
 pub struct RocketMQCli {
-    /// Generate shell completion script
     #[arg(
         long = "generate-completion",
         value_name = "SHELL",


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5761 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
"Comments should be used to explain why and how of some difficult-to-understand parts, rather than what, which can be completely understood by reading the code."
Cleaned up some comments that I thought were completely unnecessary, as they would only increase the difficulty of reading the code. However, there are still many comments that I feel are also unnecessary, but out of caution, I only cleaned up those that were too "redundant."

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cluster name option to subscription group update command for enhanced configuration flexibility.

* **Chores**
  * Removed inline documentation comments across multiple command files for code cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->