### PR TITLE
[ISSUE #5730]🚀Convert the DBMsgConstants, FIleReadaheadMode, HAProxyConstants class to Rust code

### DIFF
--- a/rocketmq-common/src/common/constant.rs
+++ b/rocketmq-common/src/common/constant.rs
@@ -14,6 +14,9 @@
 
 pub mod common_constants;
 pub mod consume_init_mode;
+pub mod db_msg_constants;
+pub mod file_readahead_mode;
+pub mod ha_proxy_constants;
 
 use std::ops::Deref;
 

--- a/rocketmq-common/src/common/constant/db_msg_constants.rs
+++ b/rocketmq-common/src/common/constant/db_msg_constants.rs
@@ -1,0 +1,15 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const MAX_BODY_SIZE: usize = 64 * 1024 * 1024;

--- a/rocketmq-common/src/common/constant/file_readahead_mode.rs
+++ b/rocketmq-common/src/common/constant/file_readahead_mode.rs
@@ -1,0 +1,15 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const READ_AHEAD_MODE: &str = "READ_AHEAD_MODE";

--- a/rocketmq-common/src/common/constant/ha_proxy_constants.rs
+++ b/rocketmq-common/src/common/constant/ha_proxy_constants.rs
@@ -1,0 +1,27 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const CHANNEL_ID: &str = "channel_id";
+
+pub const PROXY_PROTOCOL_PREFIX: &str = "proxy_protocol_";
+
+pub const PROXY_PROTOCOL_ADDR: &str = "proxy_protocol_addr";
+
+pub const PROXY_PROTOCOL_PORT: &str = "proxy_protocol_port";
+
+pub const PROXY_PROTOCOL_SERVER_ADDR: &str = "proxy_protocol_server_addr";
+
+pub const PROXY_PROTOCOL_SERVER_PORT: &str = "proxy_protocol_server_port";
+
+pub const PROXY_PROTOCOL_TLV_PREFIX: &str = "proxy_protocol_tlv_0x";


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5730 
- Fixes #5731 
- Fixes #5732 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database message operation constants with configurable size limits.
  * Added file read-ahead mode configuration constants for optimized file operations.
  * Added HA proxy protocol and channel configuration constants to support enhanced proxy communication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->