### PR TITLE
[ISSUE #5809]🚀Add ConsumeByWho struct for tracking consumption groups and related metadata

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -31,6 +31,7 @@ pub mod check_rocksdb_cqwrite_progress_response_body;
 pub mod cluster_acl_version_info;
 pub mod cm_result;
 pub mod connection;
+pub mod consume_by_who;
 pub mod consume_message_directly_result;
 pub mod consume_queue_data;
 pub mod consume_status;

--- a/rocketmq-remoting/src/protocol/body/consume_by_who.rs
+++ b/rocketmq-remoting/src/protocol/body/consume_by_who.rs
@@ -1,0 +1,83 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use cheetah_string::CheetahString;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumeByWho {
+    #[serde(default)]
+    consumed_group: HashSet<CheetahString>,
+
+    #[serde(default)]
+    not_consumed_group: HashSet<CheetahString>,
+
+    topic: Option<CheetahString>,
+
+    #[serde(default)]
+    queue_id: i32,
+
+    #[serde(default)]
+    offset: i64,
+}
+
+impl ConsumeByWho {
+    pub fn new() -> Self {
+        ConsumeByWho::default()
+    }
+
+    pub fn get_consumed_group(&self) -> &HashSet<CheetahString> {
+        &self.consumed_group
+    }
+
+    pub fn set_consumed_group(&mut self, consumed_group: HashSet<CheetahString>) {
+        self.consumed_group = consumed_group;
+    }
+
+    pub fn get_not_consumed_group(&self) -> &HashSet<CheetahString> {
+        &self.not_consumed_group
+    }
+
+    pub fn set_not_consumed_group(&mut self, not_consumed_group: HashSet<CheetahString>) {
+        self.not_consumed_group = not_consumed_group;
+    }
+
+    pub fn get_topic(&self) -> Option<&CheetahString> {
+        self.topic.as_ref()
+    }
+
+    pub fn set_topic(&mut self, topic: CheetahString) {
+        self.topic = Some(topic);
+    }
+
+    pub fn get_queue_id(&self) -> i32 {
+        self.queue_id
+    }
+
+    pub fn set_queue_id(&mut self, queue_id: i32) {
+        self.queue_id = queue_id;
+    }
+
+    pub fn get_offset(&self) -> i64 {
+        self.offset
+    }
+
+    pub fn set_offset(&mut self, offset: i64) {
+        self.offset = offset;
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5809

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced protocol layer infrastructure to support expanded message consumption tracking and group management capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->