### PR TITLE
[ISSUE #5816]🚀Add GetLiteGroupInfoResponseBody struct for lite group information handling

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -18,6 +18,7 @@ pub mod create_topic_list_request_body;
 pub mod get_broker_lite_info_response_body;
 pub mod get_consumer_listby_group_response_body;
 pub mod get_lite_client_info_response_body;
+pub mod get_lite_group_info_response_body;
 pub mod get_parent_topic_info_response_body;
 
 pub mod consumer_connection;
@@ -44,6 +45,7 @@ pub mod ha_client_runtime_info;
 pub mod ha_connection_runtime_info;
 pub mod ha_runtime_info;
 pub mod kv_table;
+pub mod lite_lag_info;
 pub mod message_request_mode_serialize_wrapper;
 pub mod pop_process_queue_info;
 pub mod process_queue_info;

--- a/rocketmq-remoting/src/protocol/body/get_lite_group_info_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/get_lite_group_info_response_body.rs
@@ -1,0 +1,145 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::admin::offset_wrapper::OffsetWrapper;
+use crate::protocol::body::lite_lag_info::LiteLagInfo;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetLiteGroupInfoResponseBody {
+    #[serde(default)]
+    group: CheetahString,
+
+    #[serde(default)]
+    parent_topic: CheetahString,
+
+    #[serde(default)]
+    lite_topic: CheetahString,
+
+    #[serde(default)]
+    earliest_unconsumed_timestamp: i64,
+
+    #[serde(default)]
+    total_lag_count: i64,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lite_topic_offset_wrapper: Option<OffsetWrapper>,
+
+    #[serde(default)]
+    lag_count_top_k: Vec<LiteLagInfo>,
+
+    #[serde(default)]
+    lag_timestamp_top_k: Vec<LiteLagInfo>,
+}
+
+impl GetLiteGroupInfoResponseBody {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn group(&self) -> &CheetahString {
+        &self.group
+    }
+
+    pub fn with_group(&mut self, group: CheetahString) -> &mut Self {
+        self.group = group;
+        self
+    }
+
+    #[must_use]
+    pub fn parent_topic(&self) -> &CheetahString {
+        &self.parent_topic
+    }
+
+    pub fn with_parent_topic(&mut self, parent_topic: CheetahString) -> &mut Self {
+        self.parent_topic = parent_topic;
+        self
+    }
+
+    #[must_use]
+    pub fn lite_topic(&self) -> &CheetahString {
+        &self.lite_topic
+    }
+
+    pub fn with_lite_topic(&mut self, lite_topic: CheetahString) -> &mut Self {
+        self.lite_topic = lite_topic;
+        self
+    }
+
+    #[must_use]
+    pub fn earliest_unconsumed_timestamp(&self) -> i64 {
+        self.earliest_unconsumed_timestamp
+    }
+
+    pub fn with_earliest_unconsumed_timestamp(&mut self, earliest_unconsumed_timestamp: i64) -> &mut Self {
+        self.earliest_unconsumed_timestamp = earliest_unconsumed_timestamp;
+        self
+    }
+
+    #[must_use]
+    pub fn total_lag_count(&self) -> i64 {
+        self.total_lag_count
+    }
+
+    pub fn with_total_lag_count(&mut self, total_lag_count: i64) -> &mut Self {
+        self.total_lag_count = total_lag_count;
+        self
+    }
+
+    #[must_use]
+    pub fn lite_topic_offset_wrapper(&self) -> Option<&OffsetWrapper> {
+        self.lite_topic_offset_wrapper.as_ref()
+    }
+
+    pub fn with_lite_topic_offset_wrapper(&mut self, lite_topic_offset_wrapper: OffsetWrapper) -> &mut Self {
+        self.lite_topic_offset_wrapper = Some(lite_topic_offset_wrapper);
+        self
+    }
+
+    #[must_use]
+    pub fn lag_count_top_k(&self) -> &[LiteLagInfo] {
+        &self.lag_count_top_k
+    }
+
+    pub fn with_lag_count_top_k(&mut self, lag_count_top_k: Vec<LiteLagInfo>) -> &mut Self {
+        self.lag_count_top_k = lag_count_top_k;
+        self
+    }
+
+    pub fn add_lag_count_top_k(&mut self, lag_info: LiteLagInfo) -> &mut Self {
+        self.lag_count_top_k.push(lag_info);
+        self
+    }
+
+    #[must_use]
+    pub fn lag_timestamp_top_k(&self) -> &[LiteLagInfo] {
+        &self.lag_timestamp_top_k
+    }
+
+    pub fn with_lag_timestamp_top_k(&mut self, lag_timestamp_top_k: Vec<LiteLagInfo>) -> &mut Self {
+        self.lag_timestamp_top_k = lag_timestamp_top_k;
+        self
+    }
+
+    pub fn add_lag_timestamp_top_k(&mut self, lag_info: LiteLagInfo) -> &mut Self {
+        self.lag_timestamp_top_k.push(lag_info);
+        self
+    }
+}

--- a/rocketmq-remoting/src/protocol/body/lite_lag_info.rs
+++ b/rocketmq-remoting/src/protocol/body/lite_lag_info.rs
@@ -1,0 +1,67 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiteLagInfo {
+    #[serde(default)]
+    lite_topic: CheetahString,
+
+    #[serde(default)]
+    lag_count: i64,
+
+    #[serde(default)]
+    earliest_unconsumed_timestamp: i64,
+}
+
+impl LiteLagInfo {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn lite_topic(&self) -> &CheetahString {
+        &self.lite_topic
+    }
+
+    pub fn with_lite_topic(&mut self, lite_topic: CheetahString) -> &mut Self {
+        self.lite_topic = lite_topic;
+        self
+    }
+
+    #[must_use]
+    pub fn lag_count(&self) -> i64 {
+        self.lag_count
+    }
+
+    pub fn with_lag_count(&mut self, lag_count: i64) -> &mut Self {
+        self.lag_count = lag_count;
+        self
+    }
+
+    #[must_use]
+    pub fn earliest_unconsumed_timestamp(&self) -> i64 {
+        self.earliest_unconsumed_timestamp
+    }
+
+    pub fn with_earliest_unconsumed_timestamp(&mut self, earliest_unconsumed_timestamp: i64) -> &mut Self {
+        self.earliest_unconsumed_timestamp = earliest_unconsumed_timestamp;
+        self
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5816

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new protocol message types for querying lightweight consumer group information and lag metrics. Users can now retrieve consumer group details including lag counts and timestamps through updated remoting protocol support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->