### PR TITLE
[ISSUE #5542] Implement ControllerGetSyncStateData Request Handler

### DIFF
--- a/rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs
+++ b/rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs
@@ -32,6 +32,7 @@ use crate::controller::broker_heartbeat_manager::DEFAULT_BROKER_CHANNEL_EXPIRED_
 use crate::heartbeat::broker_identity_info::BrokerIdentityInfo;
 use crate::heartbeat::broker_live_info::BrokerLiveInfo;
 use crate::helper::broker_lifecycle_listener::BrokerLifecycleListener;
+use crate::helper::broker_valid_predicate::BrokerValidPredicate;
 
 /// Default implementation of BrokerHeartbeatManager
 ///
@@ -357,6 +358,12 @@ impl BrokerHeartbeatManager for DefaultBrokerHeartbeatManager {
         }
 
         result
+    }
+}
+
+impl BrokerValidPredicate for DefaultBrokerHeartbeatManager {
+    fn check(&self, cluster_name: &str, broker_name: &str, broker_id: Option<i64>) -> bool {
+        self.is_broker_active(cluster_name, broker_name, broker_id.unwrap_or_default())
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5542 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Implement get_sync_state_data for OpenRaftController to support mqadmin getSyncStateSet 
queries. RaftRsController not implemented as it misses core components and with no production usage.

### How Did You Test This Change?
All required checks, including `cargo fmt`, `cargo build`, and `cargo test` passed.
<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker synchronization state data handling with proper validation of broker status and health checks.
  * Fixed request processing to correctly handle broker state queries and return accurate synchronized state information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->