### PR TITLE
[ISSUE #5824]🚀Add GetLiteTopicInfoResponseBody struct for lite topic information handling

### DIFF
--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -19,6 +19,7 @@ pub mod get_broker_lite_info_response_body;
 pub mod get_consumer_listby_group_response_body;
 pub mod get_lite_client_info_response_body;
 pub mod get_lite_group_info_response_body;
+pub mod get_lite_topic_info_response_body;
 pub mod get_parent_topic_info_response_body;
 
 pub mod consumer_connection;

--- a/rocketmq-remoting/src/protocol/body/get_lite_topic_info_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/get_lite_topic_info_response_body.rs
@@ -1,0 +1,103 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use cheetah_string::CheetahString;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::protocol::admin::topic_offset::TopicOffset;
+use rocketmq_common::common::entity::ClientGroup;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetLiteTopicInfoResponseBody {
+    #[serde(default)]
+    parent_topic: CheetahString,
+
+    #[serde(default)]
+    lite_topic: CheetahString,
+
+    #[serde(default)]
+    subscriber: HashSet<ClientGroup>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    topic_offset: Option<TopicOffset>,
+
+    #[serde(default)]
+    sharding_to_broker: bool,
+}
+
+impl GetLiteTopicInfoResponseBody {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn parent_topic(&self) -> &CheetahString {
+        &self.parent_topic
+    }
+
+    pub fn with_parent_topic(&mut self, parent_topic: CheetahString) -> &mut Self {
+        self.parent_topic = parent_topic;
+        self
+    }
+
+    #[must_use]
+    pub fn lite_topic(&self) -> &CheetahString {
+        &self.lite_topic
+    }
+
+    pub fn with_lite_topic(&mut self, lite_topic: CheetahString) -> &mut Self {
+        self.lite_topic = lite_topic;
+        self
+    }
+
+    #[must_use]
+    pub fn subscriber(&self) -> &HashSet<ClientGroup> {
+        &self.subscriber
+    }
+
+    pub fn with_subscriber(&mut self, subscriber: HashSet<ClientGroup>) -> &mut Self {
+        self.subscriber = subscriber;
+        self
+    }
+
+    pub fn add_subscriber(&mut self, subscriber: ClientGroup) -> &mut Self {
+        self.subscriber.insert(subscriber);
+        self
+    }
+
+    #[must_use]
+    pub fn topic_offset(&self) -> Option<&TopicOffset> {
+        self.topic_offset.as_ref()
+    }
+
+    pub fn with_topic_offset(&mut self, topic_offset: TopicOffset) -> &mut Self {
+        self.topic_offset = Some(topic_offset);
+        self
+    }
+
+    #[must_use]
+    pub fn sharding_to_broker(&self) -> bool {
+        self.sharding_to_broker
+    }
+
+    pub fn with_sharding_to_broker(&mut self, sharding_to_broker: bool) -> &mut Self {
+        self.sharding_to_broker = sharding_to_broker;
+        self
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5824

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new public API data structures with fluent builder-style setter and getter accessor methods for managing topic information responses. These additions expand the protocol layer with enhanced interfaces for handling topic-related data, offering comprehensive serialization and deserialization support for both required and optional field configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->