### PR TITLE
[ISSUE #5808]🧪Add test case for GetParentTopicInfoResponseBody

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,9 +97,9 @@ futures = "0.3"
 
 cheetah-string = { version = "1.0.1", features = ["serde", "bytes", "simd"] }
 
-flate2  = "1.1.8"
-dashmap = "6.1.0"
-strum   = { version = "0.27.2", features = ["derive"] }
+flate2   = "1.1.8"
+dashmap  = "6.1.0"
+strum    = { version = "0.27.2", features = ["derive"] }
 smallvec = "1.13"
 
 opentelemetry     = { version = "0.31", features = ["metrics"] }

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -44,15 +44,15 @@ cheetah-string = { workspace = true }
 criterion = { version = "0.8.1", features = ["async_tokio"] }
 
 [[bench]]
-name = "produce_accumulator_benchmark"
+name    = "produce_accumulator_benchmark"
 harness = false
 
 [[bench]]
-name = "concurrent_optimization_benchmark"
+name    = "concurrent_optimization_benchmark"
 harness = false
 
 [[bench]]
-name = "thread_local_index_bench"
+name    = "thread_local_index_bench"
 harness = false
 
 [[example]]

--- a/rocketmq-remoting/src/protocol/body/get_parent_topic_info_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/get_parent_topic_info_response_body.rs
@@ -81,3 +81,60 @@ impl GetParentTopicInfoResponseBody {
         self.lite_topic_count = lite_topic_count;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_parent_topic_info_response_body_default() {
+        let body = GetParentTopicInfoResponseBody::default();
+        assert!(body.get_topic().is_none());
+        assert_eq!(body.get_ttl(), 0);
+        assert!(body.get_groups().is_empty());
+        assert_eq!(body.get_lmq_num(), 0);
+        assert_eq!(body.get_lite_topic_count(), 0);
+    }
+
+    #[test]
+    fn get_parent_topic_info_response_body_getters_setters() {
+        let mut body = GetParentTopicInfoResponseBody::new();
+        body.set_topic(CheetahString::from("parent"));
+        body.set_ttl(3600);
+        let mut groups = HashSet::new();
+        groups.insert(CheetahString::from("g1"));
+        body.set_groups(groups.clone());
+        body.set_lmq_num(10);
+        body.set_lite_topic_count(5);
+
+        assert_eq!(body.get_topic().unwrap(), "parent");
+        assert_eq!(body.get_ttl(), 3600);
+        assert_eq!(body.get_groups(), &groups);
+        assert_eq!(body.get_lmq_num(), 10);
+        assert_eq!(body.get_lite_topic_count(), 5);
+    }
+
+    #[test]
+    fn get_parent_topic_info_response_body_serialization_and_deserialization() {
+        let mut body = GetParentTopicInfoResponseBody::new();
+        body.set_topic(CheetahString::from("parent"));
+        body.set_ttl(3600);
+        body.set_groups(HashSet::from([CheetahString::from("g1")]));
+        body.set_lmq_num(10);
+        body.set_lite_topic_count(5);
+
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(json.contains("\"topic\":\"parent\""));
+        assert!(json.contains("\"ttl\":3600"));
+        assert!(json.contains("\"groups\":[\"g1\"]"));
+        assert!(json.contains("\"lmqNum\":10"));
+        assert!(json.contains("\"liteTopicCount\":5"));
+
+        let decoded: GetParentTopicInfoResponseBody = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.get_topic().unwrap(), "parent");
+        assert_eq!(decoded.get_ttl(), 3600);
+        assert_eq!(decoded.get_groups(), &HashSet::from([CheetahString::from("g1")]));
+        assert_eq!(decoded.get_lmq_num(), 10);
+        assert_eq!(decoded.get_lite_topic_count(), 5);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5808 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
Also fix Cargo.toml format with `taplo`

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated formatting alignment in configuration files.

* **Tests**
  * Added comprehensive unit tests for serialization/deserialization and getter/setter functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->