### PR TITLE
[ISSUE #5834]🚀Add LiteSubscriptionAction enum for managing subscription actions in lite mode

### DIFF
--- a/rocketmq-common/src/common.rs
+++ b/rocketmq-common/src/common.rs
@@ -57,6 +57,7 @@ pub mod sys_flag;
 
 pub mod action;
 pub mod entity;
+pub mod lite;
 pub mod metrics;
 pub mod resource;
 pub mod system_clock;

--- a/rocketmq-common/src/common/lite.rs
+++ b/rocketmq-common/src/common/lite.rs
@@ -1,0 +1,17 @@
+//  Copyright 2023 The RocketMQ Rust Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+mod lite_subscription_action;
+
+pub use lite_subscription_action::*;

--- a/rocketmq-common/src/common/lite/lite_subscription_action.rs
+++ b/rocketmq-common/src/common/lite/lite_subscription_action.rs
@@ -1,0 +1,90 @@
+//  Copyright 2023 The RocketMQ Rust Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::fmt;
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Default)]
+pub enum LiteSubscriptionAction {
+    #[default]
+    PartialAdd,
+    PartialRemove,
+    CompleteAdd,
+    CompleteRemove,
+}
+
+impl Serialize for LiteSubscriptionAction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = match self {
+            LiteSubscriptionAction::PartialAdd => "PARTIAL_ADD",
+            LiteSubscriptionAction::PartialRemove => "PARTIAL_REMOVE",
+            LiteSubscriptionAction::CompleteAdd => "COMPLETE_ADD",
+            LiteSubscriptionAction::CompleteRemove => "COMPLETE_REMOVE",
+        };
+        serializer.serialize_str(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for LiteSubscriptionAction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct LiteSubscriptionActionVisitor;
+
+        impl serde::de::Visitor<'_> for LiteSubscriptionActionVisitor {
+            type Value = LiteSubscriptionAction;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string representing LiteSubscriptionAction")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                match value {
+                    "PARTIAL_ADD" => Ok(LiteSubscriptionAction::PartialAdd),
+                    "PARTIAL_REMOVE" => Ok(LiteSubscriptionAction::PartialRemove),
+                    "COMPLETE_ADD" => Ok(LiteSubscriptionAction::CompleteAdd),
+                    "COMPLETE_REMOVE" => Ok(LiteSubscriptionAction::CompleteRemove),
+                    _ => Err(serde::de::Error::unknown_variant(
+                        value,
+                        &["PartialAdd", "PartialRemove", "CompleteAdd", "CompleteRemove"],
+                    )),
+                }
+            }
+        }
+
+        deserializer.deserialize_str(LiteSubscriptionActionVisitor)
+    }
+}
+
+impl fmt::Display for LiteSubscriptionAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LiteSubscriptionAction::PartialAdd => write!(f, "PARTIAL_ADD"),
+            LiteSubscriptionAction::PartialRemove => write!(f, "PARTIAL_REMOVE"),
+            LiteSubscriptionAction::CompleteAdd => write!(f, "COMPLETE_ADD"),
+            LiteSubscriptionAction::CompleteRemove => write!(f, "COMPLETE_REMOVE"),
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5834

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added subscription action types supporting partial and complete add/remove operations with full serialization and deserialization capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->