### PR TITLE
[ISSUE #5837]🚀Add OffsetOption and OffsetOptionType for flexible message queue offset seeking

### DIFF
--- a/rocketmq-common/src/common/lite.rs
+++ b/rocketmq-common/src/common/lite.rs
@@ -12,6 +12,14 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//! Lightweight RocketMQ common types and utilities for client SDK.
+//!
+//! This module provides essential lightweight types used throughout RocketMQ,
+//! optimized for minimal dependencies and fast execution.
+
 mod lite_subscription_action;
+mod offset_option;
 
 pub use lite_subscription_action::*;
+pub use offset_option::OffsetOption;
+pub use offset_option::OffsetOptionType;

--- a/rocketmq-common/src/common/lite/offset_option.rs
+++ b/rocketmq-common/src/common/lite/offset_option.rs
@@ -1,0 +1,133 @@
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub struct OffsetOption {
+    pub type_: OffsetOptionType,
+    pub value: i64,
+}
+
+impl OffsetOption {
+    pub const POLICY_LAST_VALUE: i64 = 0;
+    pub const POLICY_MIN_VALUE: i64 = 1;
+    pub const POLICY_MAX_VALUE: i64 = 2;
+
+    #[must_use]
+    #[inline]
+    pub const fn new(type_: OffsetOptionType, value: i64) -> Self {
+        Self { type_, value }
+    }
+
+    #[must_use]
+    #[inline]
+    pub const fn policy(policy: i64) -> Self {
+        debug_assert!(
+            policy == Self::POLICY_LAST_VALUE || policy == Self::POLICY_MIN_VALUE || policy == Self::POLICY_MAX_VALUE,
+            "Invalid policy value"
+        );
+        Self {
+            type_: OffsetOptionType::Policy,
+            value: policy,
+        }
+    }
+
+    #[must_use]
+    #[inline]
+    pub const fn offset(value: i64) -> Self {
+        Self {
+            type_: OffsetOptionType::Offset,
+            value,
+        }
+    }
+
+    #[must_use]
+    #[inline]
+    pub const fn tail_n(n: i64) -> Self {
+        Self {
+            type_: OffsetOptionType::TailN,
+            value: n,
+        }
+    }
+
+    #[must_use]
+    #[inline]
+    pub const fn timestamp(timestamp: i64) -> Self {
+        Self {
+            type_: OffsetOptionType::Timestamp,
+            value: timestamp,
+        }
+    }
+
+    #[inline]
+    pub const fn type_(&self) -> OffsetOptionType {
+        self.type_
+    }
+
+    #[inline]
+    pub fn set_type(&mut self, type_: OffsetOptionType) {
+        self.type_ = type_;
+    }
+
+    #[inline]
+    pub const fn value(&self) -> i64 {
+        self.value
+    }
+
+    #[inline]
+    pub fn set_value(&mut self, value: i64) {
+        self.value = value;
+    }
+}
+
+impl Default for OffsetOption {
+    fn default() -> Self {
+        Self::policy(Self::POLICY_LAST_VALUE)
+    }
+}
+
+impl fmt::Display for OffsetOption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "OffsetOption {{ type: {:?}, value: {} }}", self.type_, self.value)
+    }
+}
+
+/// Enumeration of offset seeking strategies.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum OffsetOptionType {
+    Policy = 0,
+    Offset = 1,
+    TailN = 2,
+    Timestamp = 3,
+}
+
+impl OffsetOptionType {
+    #[must_use]
+    #[inline]
+    pub const fn from_i32(value: i32) -> Option<Self> {
+        match value {
+            0 => Some(Self::Policy),
+            1 => Some(Self::Offset),
+            2 => Some(Self::TailN),
+            3 => Some(Self::Timestamp),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    #[inline]
+    pub const fn as_i32(self) -> i32 {
+        self as i32
+    }
+}
+
+impl fmt::Display for OffsetOptionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Policy => f.write_str("POLICY"),
+            Self::Offset => f.write_str("OFFSET"),
+            Self::TailN => f.write_str("TAIL_N"),
+            Self::Timestamp => f.write_str("TIMESTAMP"),
+        }
+    }
+}

--- a/rocketmq-common/src/lib.rs
+++ b/rocketmq-common/src/lib.rs
@@ -30,6 +30,8 @@ pub use rocketmq_error::RocketMQError;
 pub use rocketmq_error::RocketMQResult;
 
 pub use crate::common::attribute::topic_attributes as TopicAttributes;
+pub use crate::common::lite::OffsetOption;
+pub use crate::common::lite::OffsetOptionType;
 pub use crate::common::message::message_accessor as MessageAccessor;
 pub use crate::common::message::message_decoder as MessageDecoder;
 pub use crate::common::mq_version::RocketMqVersion as RocketMQVersion;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5837

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `OffsetOption` and `OffsetOptionType` types for specifying offset-seeking behavior in message consumption.
  * Support for multiple offset strategies: policy-based, explicit offsets, tail-relative positions, and timestamp-based lookups.
  * Includes convenience constructors, accessors, mutators, and conversion utilities for easy integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->