### PR TITLE
[ISSUE #5819]🧪Add test case for LiteLagInfo

### DIFF
--- a/rocketmq-common/src/common/lite/lite_lag_info.rs
+++ b/rocketmq-common/src/common/lite/lite_lag_info.rs
@@ -89,3 +89,54 @@ impl fmt::Display for LiteLagInfo {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lite_lag_info_default() {
+        let info = LiteLagInfo::default();
+        assert!(info.lite_topic().is_empty());
+        assert_eq!(info.lag_count(), 0);
+        assert_eq!(info.earliest_unconsumed_timestamp(), 0);
+    }
+
+    #[test]
+    fn lite_lag_info_new() {
+        let info = LiteLagInfo::new("topic".into(), 10, 100);
+        assert_eq!(info.lite_topic(), "topic");
+        assert_eq!(info.lag_count(), 10);
+        assert_eq!(info.earliest_unconsumed_timestamp(), 100);
+    }
+
+    #[test]
+    fn lite_lag_info_getters_and_setters() {
+        let mut info = LiteLagInfo::default();
+        info.set_lite_topic("topic".into());
+        info.set_lag_count(10);
+        info.set_earliest_unconsumed_timestamp(default_earliest_unconsumed_timestamp());
+
+        assert_eq!(info.lite_topic(), "topic");
+        assert_eq!(info.lag_count(), 10);
+        assert_eq!(info.earliest_unconsumed_timestamp(), -1);
+    }
+
+    #[test]
+    fn lite_lag_info_display() {
+        let info = LiteLagInfo::new("topic".into(), 10, 100);
+        let display = format!("{}", info);
+        let expected = "LiteLagInfo { lite_topic: topic, lag_count: 10, earliest_unconsumed_timestamp: 100 }";
+        assert_eq!(display, expected);
+    }
+
+    #[test]
+    fn lite_lag_info_serialization_and_deserialization() {
+        let info = LiteLagInfo::new("topic".into(), 10, 100);
+        let json = serde_json::to_string(&info).unwrap();
+        let expected = r#"{"liteTopic":"topic","lagCount":10,"earliestUnconsumedTimestamp":100}"#;
+        assert_eq!(json, expected);
+        let decoded: LiteLagInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, info);
+    }
+}

--- a/rocketmq-remoting/src/protocol/body/lite_lag_info.rs
+++ b/rocketmq-remoting/src/protocol/body/lite_lag_info.rs
@@ -65,3 +65,45 @@ impl LiteLagInfo {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lite_lag_info_default() {
+        let info = LiteLagInfo::default();
+        assert!(info.lite_topic().is_empty());
+        assert_eq!(info.lag_count(), 0);
+        assert_eq!(info.earliest_unconsumed_timestamp(), 0);
+    }
+
+    #[test]
+    fn lite_lag_info_with_getters_and_setters() {
+        let mut info = LiteLagInfo::new();
+        info.with_lite_topic("topic".into())
+            .with_lag_count(10)
+            .with_earliest_unconsumed_timestamp(100);
+
+        assert_eq!(info.lite_topic(), "topic");
+        assert_eq!(info.lag_count(), 10);
+        assert_eq!(info.earliest_unconsumed_timestamp(), 100);
+    }
+
+    #[test]
+    fn lite_lag_info_serialization_and_deserialization() {
+        let mut info = LiteLagInfo::new();
+        info.with_lite_topic("topic".into())
+            .with_lag_count(10)
+            .with_earliest_unconsumed_timestamp(100);
+
+        let json = serde_json::to_string(&info).unwrap();
+        let expected = r#"{"liteTopic":"topic","lagCount":10,"earliestUnconsumedTimestamp":100}"#;
+        assert_eq!(json, expected);
+
+        let decoded: LiteLagInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.lite_topic(), "topic");
+        assert_eq!(decoded.lag_count(), 10);
+        assert_eq!(decoded.earliest_unconsumed_timestamp(), 100);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5819 
- Fixes #5842 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for LiteLagInfo across modules covering default initialization, builders/setters, getters, display formatting, and JSON serialization/deserialization to ensure correct round-trip behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->