### PR TITLE
[ISSUE #5880]🚀Add MessageTrack struct and TrackType enum for message tracking functionality

### DIFF
--- a/rocketmq-common/src/common/tools.rs
+++ b/rocketmq-common/src/common/tools.rs
@@ -13,3 +13,5 @@
 //  limitations under the License.
 
 pub mod broker_operator_result;
+pub mod message_track;
+pub mod track_type;

--- a/rocketmq-common/src/common/tools/message_track.rs
+++ b/rocketmq-common/src/common/tools/message_track.rs
@@ -1,0 +1,100 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::common::tools::track_type::TrackType;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageTrack {
+    pub consumer_group: String,
+    pub track_type: Option<TrackType>,
+    pub exception_desc: String,
+}
+
+#[allow(dead_code)]
+impl MessageTrack {
+    pub fn get_consumer_group(&self) -> String {
+        self.consumer_group.clone()
+    }
+
+    pub fn set_consumer_group(&mut self, consumer_group: String) {
+        self.consumer_group = consumer_group;
+    }
+
+    pub fn get_track_type(&self) -> Option<TrackType> {
+        self.track_type
+    }
+
+    pub fn set_track_type(&mut self, track_type: TrackType) {
+        self.track_type = Some(track_type);
+    }
+
+    pub fn get_exception_desc(&self) -> String {
+        self.exception_desc.clone()
+    }
+
+    pub fn set_exception_desc(&mut self, exception_desc: String) {
+        self.exception_desc = exception_desc;
+    }
+}
+
+impl std::fmt::Display for MessageTrack {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let track_type_str = self
+            .track_type
+            .as_ref()
+            .map_or("None".to_string(), |tt| format!("{tt}"));
+        write!(
+            f,
+            "MessageTrack [consumerGroup={}, trackType={}, exceptionDesc={}]",
+            self.consumer_group, track_type_str, self.exception_desc
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    pub fn test_message_track() {
+        let mut message_track = MessageTrack {
+            consumer_group: "test_consumer_group".to_string(),
+            track_type: Some(TrackType::Consumed),
+            exception_desc: "test_exception_desc".to_string(),
+        };
+
+        assert_eq!(message_track.get_consumer_group(), "test_consumer_group");
+        assert_eq!(message_track.get_exception_desc(), "test_exception_desc");
+        assert_eq!(message_track.get_track_type(), Some(TrackType::Consumed));
+
+        let display = format!("{}", message_track);
+        println!("{}", display);
+        assert_eq!(
+            display,
+            "MessageTrack [consumerGroup=test_consumer_group, trackType=CONSUMED, exceptionDesc=test_exception_desc]"
+        );
+
+        message_track.set_consumer_group("test_consumer_group2".to_string());
+        message_track.set_track_type(TrackType::Pull);
+        message_track.set_exception_desc("test_exception_desc2".to_string());
+
+        assert_eq!(message_track.get_consumer_group(), "test_consumer_group2");
+        assert_eq!(message_track.get_exception_desc(), "test_exception_desc2");
+    }
+}

--- a/rocketmq-common/src/common/tools/track_type.rs
+++ b/rocketmq-common/src/common/tools/track_type.rs
@@ -1,0 +1,149 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use serde::de;
+use serde::de::Visitor;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TrackType {
+    Consumed,
+    ConsumedButFiltered,
+    Pull,
+    NotConsumedYet,
+    NotOnline,
+    ConsumeBroadcasting,
+    Unknown,
+}
+
+impl std::fmt::Display for TrackType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TrackType::Consumed => write!(f, "CONSUMED"),
+            TrackType::ConsumedButFiltered => write!(f, "CONSUMED_BUT_FILTERED"),
+            TrackType::Pull => write!(f, "PULL"),
+            TrackType::NotConsumedYet => write!(f, "NOT_CONSUME_YET"),
+            TrackType::NotOnline => write!(f, "NOT_ONLINE"),
+            TrackType::ConsumeBroadcasting => write!(f, "CONSUME_BROADCASTING"),
+            TrackType::Unknown => write!(f, "UNKNOWN"),
+        }
+    }
+}
+
+impl Serialize for TrackType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = match *self {
+            TrackType::Consumed => "CONSUMED",
+            TrackType::ConsumedButFiltered => "CONSUMED_BUT_FILTERED",
+            TrackType::Pull => "PULL",
+            TrackType::NotConsumedYet => "NOT_CONSUME_YET",
+            TrackType::NotOnline => "NOT_ONLINE",
+            TrackType::ConsumeBroadcasting => "CONSUME_BROADCASTING",
+            TrackType::Unknown => "UNKNOWN",
+        };
+        serializer.serialize_str(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for TrackType {
+    fn deserialize<D>(deserializer: D) -> Result<TrackType, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TrackTypeVisitor;
+
+        impl Visitor<'_> for TrackTypeVisitor {
+            type Value = TrackType;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid track type string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<TrackType, E>
+            where
+                E: de::Error,
+            {
+                match value {
+                    "CONSUMED" => Ok(TrackType::Consumed),
+                    "CONSUMED_BUT_FILTERED" => Ok(TrackType::ConsumedButFiltered),
+                    "PULL" => Ok(TrackType::Pull),
+                    "NOT_CONSUME_YET" => Ok(TrackType::NotConsumedYet),
+                    "NOT_ONLINE" => Ok(TrackType::NotOnline),
+                    "CONSUME_BROADCASTING" => Ok(TrackType::ConsumeBroadcasting),
+                    "UNKNOWN" => Ok(TrackType::Unknown),
+                    _ => Err(de::Error::unknown_variant(
+                        value,
+                        &[
+                            "CONSUMED",
+                            "CONSUMED_BUT_FILTERED",
+                            "PULL",
+                            "NOT_CONSUME_YET",
+                            "NOT_ONLINE",
+                            "CONSUME_BROADCASTING",
+                            "UNKNOWN",
+                        ],
+                    )),
+                }
+            }
+        }
+        deserializer.deserialize_str(TrackTypeVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_consumed_but_filtered() {
+        let track_type = TrackType::ConsumedButFiltered;
+        let serialized = serde_json::to_string(&track_type).unwrap();
+        assert_eq!(serialized, "\"CONSUMED_BUT_FILTERED\"");
+    }
+
+    #[test]
+    fn deserialize_not_consumed_yet() {
+        let json = "\"NOT_CONSUME_YET\"";
+        let deserialized: TrackType = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, TrackType::NotConsumedYet);
+    }
+
+    #[test]
+    fn serialize_not_online() {
+        let track_type = TrackType::NotOnline;
+        let serialized = serde_json::to_string(&track_type).unwrap();
+        assert_eq!(serialized, "\"NOT_ONLINE\"");
+    }
+
+    #[test]
+    fn deserialize_consume_broadcasting() {
+        let json = "\"CONSUME_BROADCASTING\"";
+        let deserialized: TrackType = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, TrackType::ConsumeBroadcasting);
+    }
+
+    #[test]
+    fn display_pull_variant() {
+        let track_type = TrackType::Pull;
+        assert_eq!(track_type.to_string(), "PULL");
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #5880

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message tracking functionality with a new MessageTrack structure supporting consumer group information, tracking states, and exception descriptions.
  * Introduced TrackType enumeration for representing different message consumption states including Consumed, Filtered, Pull, NotOnline, and Broadcasting variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->