### PR TITLE
[ISSUE #5655]🚀Implement CopyAcls Command for ACL Replication

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -136,6 +136,94 @@ impl DefaultMQAdminExtImpl {
     pub fn set_inner(&mut self, inner: ArcMut<DefaultMQAdminExtImpl>) {
         self.inner = Some(inner);
     }
+
+    pub async fn create_acl_with_acl_info(
+        &self,
+        broker_addr: CheetahString,
+        acl_info: AclInfo,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let subject = acl_info
+            .subject
+            .clone()
+            .ok_or_else(|| rocketmq_error::RocketMQError::IllegalArgument("ACL subject is required".into()))?;
+
+        if let Some(ref policies) = acl_info.policies {
+            for policy in policies {
+                if let Some(ref entries) = policy.entries {
+                    for entry in entries {
+                        let resources: Vec<CheetahString> =
+                            entry.resource.as_ref().map(|r| vec![r.clone()]).unwrap_or_default();
+
+                        let actions: Vec<CheetahString> = entry
+                            .actions
+                            .as_ref()
+                            .map(|a| a.split(',').map(|s| CheetahString::from(s.trim())).collect())
+                            .unwrap_or_default();
+
+                        let source_ips: Vec<CheetahString> = entry.source_ips.clone().unwrap_or_default();
+
+                        let decision: CheetahString = entry.decision.clone().unwrap_or_default();
+
+                        self.create_acl(
+                            broker_addr.clone(),
+                            subject.clone(),
+                            resources,
+                            actions,
+                            source_ips,
+                            decision,
+                        )
+                        .await?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn update_acl_with_acl_info(
+        &self,
+        broker_addr: CheetahString,
+        acl_info: AclInfo,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let subject = acl_info
+            .subject
+            .clone()
+            .ok_or_else(|| rocketmq_error::RocketMQError::IllegalArgument("ACL subject is required".into()))?;
+
+        if let Some(ref policies) = acl_info.policies {
+            for policy in policies {
+                if let Some(ref entries) = policy.entries {
+                    for entry in entries {
+                        let resources: Vec<CheetahString> =
+                            entry.resource.as_ref().map(|r| vec![r.clone()]).unwrap_or_default();
+
+                        let actions: Vec<CheetahString> = entry
+                            .actions
+                            .as_ref()
+                            .map(|a| a.split(',').map(|s| CheetahString::from(s.trim())).collect())
+                            .unwrap_or_default();
+
+                        let source_ips: Vec<CheetahString> = entry.source_ips.clone().unwrap_or_default();
+
+                        let decision: CheetahString = entry.decision.clone().unwrap_or_default();
+
+                        self.update_acl(
+                            broker_addr.clone(),
+                            subject.clone(),
+                            resources,
+                            actions,
+                            source_ips,
+                            decision,
+                        )
+                        .await?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[allow(unused_variables)]

--- a/rocketmq-remoting/src/protocol/body/acl_info.rs
+++ b/rocketmq-remoting/src/protocol/body/acl_info.rs
@@ -16,7 +16,7 @@ use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PolicyEntryInfo {
     pub resource: Option<CheetahString>,
@@ -25,14 +25,14 @@ pub struct PolicyEntryInfo {
     pub decision: Option<CheetahString>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PolicyInfo {
     pub policy_type: Option<CheetahString>,
     pub entries: Option<Vec<PolicyEntryInfo>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AclInfo {
     pub subject: Option<CheetahString>,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -209,6 +209,26 @@ impl DefaultMQAdminExt {
     pub fn client_config_mut(&mut self) -> &mut ArcMut<ClientConfig> {
         &mut self.client_config
     }
+
+    pub async fn create_acl_with_acl_info(
+        &self,
+        broker_addr: CheetahString,
+        acl_info: AclInfo,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.default_mqadmin_ext_impl
+            .create_acl_with_acl_info(broker_addr, acl_info)
+            .await
+    }
+
+    pub async fn update_acl_with_acl_info(
+        &self,
+        broker_addr: CheetahString,
+        acl_info: AclInfo,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.default_mqadmin_ext_impl
+            .update_acl_with_acl_info(broker_addr, acl_info)
+            .await
+    }
 }
 
 impl Default for DefaultMQAdminExt {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -131,6 +131,11 @@ impl CommandExecute for ClassificationTablePrint {
         let commands: Vec<Command> = vec![
             Command {
                 category: "Auth",
+                command: "copyAcl",
+                remark: "Copy acl to cluster.",
+            },
+            Command {
+                category: "Auth",
                 command: "updateAcl",
                 remark: "Update ACL.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 The RocketMQ Rust Authors
+// Copyright 2023 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod copy_acl_sub_command;
 mod update_acl_sub_command;
 
 use std::sync::Arc;
@@ -20,22 +21,29 @@ use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
-use crate::commands::auth_commands::update_acl_sub_command::UpdateAclSubCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
 pub enum AuthCommands {
     #[command(
+        name = "copyAcl",
+        about = "Copy acl to cluster",
+        long_about = None,
+    )]
+    CopyAclSubCommand(copy_acl_sub_command::CopyAclSubCommand),
+
+    #[command(
         name = "updateAcl",
         about = "Update Access Control List (ACL)",
         long_about = None,
     )]
-    UpdateAclSubCommand(UpdateAclSubCommand),
+    UpdateAclSubCommand(update_acl_sub_command::UpdateAclSubCommand),
 }
 
 impl CommandExecute for AuthCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
+            AuthCommands::CopyAclSubCommand(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateAclSubCommand(value) => value.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/copy_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/copy_acl_sub_command.rs
@@ -1,0 +1,208 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::body::acl_info::AclInfo;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct CopyAclSubCommand {
+    #[arg(
+        short = 'f',
+        long = "fromBroker",
+        required = true,
+        help = "the source broker that the acls copy from"
+    )]
+    from_broker: String,
+
+    #[arg(
+        short = 't',
+        long = "toBroker",
+        required = true,
+        help = "the target broker that the acls copy to"
+    )]
+    to_broker: String,
+
+    #[arg(
+        short = 's',
+        long = "subjects",
+        required = false,
+        help = "the subject list of acl to copy"
+    )]
+    subjects: Option<String>,
+}
+
+#[derive(Clone)]
+struct ParsedCopyAclSubCommand {
+    from_broker: CheetahString,
+    to_broker: CheetahString,
+    subjects: Option<Vec<CheetahString>>,
+}
+
+impl ParsedCopyAclSubCommand {
+    fn new(command: &CopyAclSubCommand) -> Result<Self, RocketMQError> {
+        let from_broker: CheetahString = {
+            let from_broker = command.from_broker.trim();
+            if from_broker.is_empty() {
+                return Err(RocketMQError::IllegalArgument(
+                    "CopyAclSubCommand: fromBroker cannot be empty".into(),
+                ));
+            }
+            from_broker.into()
+        };
+
+        let to_broker: CheetahString = {
+            let to_broker = command.to_broker.trim();
+            if to_broker.is_empty() {
+                return Err(RocketMQError::IllegalArgument(
+                    "CopyAclSubCommand: toBroker cannot be empty".into(),
+                ));
+            }
+            to_broker.into()
+        };
+
+        let subjects: Option<Vec<CheetahString>> = command
+            .subjects
+            .as_ref()
+            .map(|subjects| {
+                subjects
+                    .split(',')
+                    .map(|subject| subject.trim())
+                    .filter(|subject| !subject.is_empty())
+                    .map(|subject| subject.into())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|v: &Vec<CheetahString>| !v.is_empty());
+
+        Ok(Self {
+            from_broker,
+            to_broker,
+            subjects,
+        })
+    }
+}
+
+impl CommandExecute for CopyAclSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let command = ParsedCopyAclSubCommand::new(self)?;
+
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        MQAdminExt::start(&mut default_mqadmin_ext)
+            .await
+            .map_err(|e| RocketMQError::Internal(format!("CopyAclSubCommand: Failed to start MQAdminExt: {}", e)))?;
+
+        let operation_result = copy_acls(&command, &default_mqadmin_ext).await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+async fn copy_acls(
+    parsed_command: &ParsedCopyAclSubCommand,
+    default_mqadmin_ext: &DefaultMQAdminExt,
+) -> Result<(), RocketMQError> {
+    let source_broker = parsed_command.from_broker.as_str();
+    let target_broker = parsed_command.to_broker.as_str();
+
+    let acl_infos: Vec<AclInfo> = if let Some(ref subjects) = parsed_command.subjects {
+        let mut acl_list = Vec::new();
+        for subject in subjects {
+            match default_mqadmin_ext.get_acl(source_broker.into(), subject.clone()).await {
+                Ok(acl_info) => {
+                    acl_list.push(acl_info);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Warning: Failed to get ACL for subject {} from {}: {}",
+                        subject, source_broker, e
+                    );
+                }
+            }
+        }
+        acl_list
+    } else {
+        default_mqadmin_ext
+            .list_acl(source_broker.into(), CheetahString::default(), CheetahString::default())
+            .await
+            .map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "CopyAclSubCommand: Failed to list ACLs from {}: {}",
+                    source_broker, e
+                ))
+            })?
+    };
+
+    if acl_infos.is_empty() {
+        println!("No ACLs found to copy from {}.", source_broker);
+        return Ok(());
+    }
+
+    for acl_info in acl_infos {
+        let subject = match acl_info.subject.as_ref() {
+            Some(s) => s.clone(),
+            None => {
+                eprintln!("Warning: ACL has no subject, skipping.");
+                continue;
+            }
+        };
+
+        let target_acl_result = default_mqadmin_ext.get_acl(target_broker.into(), subject.clone()).await;
+
+        let copy_result = if target_acl_result.is_err() {
+            default_mqadmin_ext
+                .create_acl_with_acl_info(target_broker.into(), acl_info.clone())
+                .await
+        } else {
+            default_mqadmin_ext
+                .update_acl_with_acl_info(target_broker.into(), acl_info.clone())
+                .await
+        };
+
+        match copy_result {
+            Ok(_) => {
+                println!(
+                    "copy acl of {} from {} to {} success.",
+                    subject, source_broker, target_broker
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "copy acl of {} from {} to {} failed: {}",
+                    subject, source_broker, target_broker, e
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/update_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/update_acl_sub_command.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 The RocketMQ Rust Authors
+// Copyright 2023 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5655 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command to copy ACL entries between brokers, with optional subject filtering.
  * Added operations to create and update ACLs from detailed ACL info structures.

* **Improvements**
  * ACL data types can now be duplicated more easily, improving handling and manipulation.
  * Enhanced ACL handling flow and error propagation for more reliable admin operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->