### PR TITLE
[ISSUE #5656]🚀Implement CopyUsers Command for User Replication

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -223,6 +223,40 @@ impl DefaultMQAdminExtImpl {
 
         Ok(())
     }
+
+    pub async fn create_user_with_user_info(
+        &self,
+        broker_addr: CheetahString,
+        user_info: UserInfo,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let username = user_info
+            .username
+            .clone()
+            .ok_or_else(|| rocketmq_error::RocketMQError::IllegalArgument("User username is required".into()))?;
+
+        let password = user_info.password.clone().unwrap_or_default();
+        let user_type = user_info.user_type.clone().unwrap_or_default();
+
+        self.create_user(broker_addr, username, password, user_type).await
+    }
+
+    pub async fn update_user_with_user_info(
+        &self,
+        broker_addr: CheetahString,
+        user_info: UserInfo,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let username = user_info
+            .username
+            .clone()
+            .ok_or_else(|| rocketmq_error::RocketMQError::IllegalArgument("User username is required".into()))?;
+
+        let password = user_info.password.clone().unwrap_or_default();
+        let user_type = user_info.user_type.clone().unwrap_or_default();
+        let user_status = user_info.user_status.clone().unwrap_or_default();
+
+        self.update_user(broker_addr, username, password, user_type, user_status)
+            .await
+    }
 }
 
 #[allow(unused_variables)]

--- a/rocketmq-remoting/src/protocol/body/user_info.rs
+++ b/rocketmq-remoting/src/protocol/body/user_info.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct UserInfo {
     pub username: Option<CheetahString>,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -229,6 +229,26 @@ impl DefaultMQAdminExt {
             .update_acl_with_acl_info(broker_addr, acl_info)
             .await
     }
+
+    pub async fn create_user_with_user_info(
+        &self,
+        broker_addr: CheetahString,
+        user_info: UserInfo,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.default_mqadmin_ext_impl
+            .create_user_with_user_info(broker_addr, user_info)
+            .await
+    }
+
+    pub async fn update_user_with_user_info(
+        &self,
+        broker_addr: CheetahString,
+        user_info: UserInfo,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.default_mqadmin_ext_impl
+            .update_user_with_user_info(broker_addr, user_info)
+            .await
+    }
 }
 
 impl Default for DefaultMQAdminExt {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -136,6 +136,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Auth",
+                command: "copyUser",
+                remark: "Copy user to cluster.",
+            },
+            Command {
+                category: "Auth",
                 command: "updateAcl",
                 remark: "Update ACL.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod copy_acl_sub_command;
+mod copy_users_sub_command;
 mod update_acl_sub_command;
 mod update_user_sub_command;
 
@@ -33,6 +34,13 @@ pub enum AuthCommands {
     CopyAcl(copy_acl_sub_command::CopyAclSubCommand),
 
     #[command(
+        name = "copyUser",
+        about = "Copy user to cluster",
+        long_about = None,
+    )]
+    CopyUsers(copy_users_sub_command::CopyUsersSubCommand),
+
+    #[command(
         name = "updateAcl",
         about = "Update Access Control List (ACL)",
         long_about = None,
@@ -51,6 +59,7 @@ impl CommandExecute for AuthCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             AuthCommands::CopyAcl(value) => value.execute(rpc_hook).await,
+            AuthCommands::CopyUsers(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateUser(value) => value.execute(rpc_hook).await,
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/copy_users_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/copy_users_sub_command.rs
@@ -1,0 +1,209 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::body::user_info::UserInfo;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct CopyUsersSubCommand {
+    #[arg(
+        short = 'f',
+        long = "fromBroker",
+        required = true,
+        help = "the source broker that the users copy from"
+    )]
+    from_broker: String,
+
+    #[arg(
+        short = 't',
+        long = "toBroker",
+        required = true,
+        help = "the target broker that the users copy to"
+    )]
+    to_broker: String,
+
+    #[arg(
+        short = 'u',
+        long = "usernames",
+        required = false,
+        help = "the username list of user to copy"
+    )]
+    usernames: Option<String>,
+}
+
+#[derive(Clone)]
+struct ParsedCopyUsersSubCommand {
+    from_broker: CheetahString,
+    to_broker: CheetahString,
+    usernames: Option<Vec<CheetahString>>,
+}
+
+impl ParsedCopyUsersSubCommand {
+    fn new(command: &CopyUsersSubCommand) -> Result<Self, RocketMQError> {
+        let from_broker: CheetahString = {
+            let from_broker = command.from_broker.trim();
+            if from_broker.is_empty() {
+                return Err(RocketMQError::IllegalArgument(
+                    "CopyUsersSubCommand: fromBroker cannot be empty".into(),
+                ));
+            }
+            from_broker.into()
+        };
+
+        let to_broker: CheetahString = {
+            let to_broker = command.to_broker.trim();
+            if to_broker.is_empty() {
+                return Err(RocketMQError::IllegalArgument(
+                    "CopyUsersSubCommand: toBroker cannot be empty".into(),
+                ));
+            }
+            to_broker.into()
+        };
+
+        let usernames: Option<Vec<CheetahString>> = command
+            .usernames
+            .as_ref()
+            .map(|usernames| {
+                usernames
+                    .split(',')
+                    .map(|username| username.trim())
+                    .filter(|username| !username.is_empty())
+                    .map(|username| username.into())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|v: &Vec<CheetahString>| !v.is_empty());
+
+        Ok(Self {
+            from_broker,
+            to_broker,
+            usernames,
+        })
+    }
+}
+
+impl CommandExecute for CopyUsersSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let command = ParsedCopyUsersSubCommand::new(self)?;
+
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        MQAdminExt::start(&mut default_mqadmin_ext)
+            .await
+            .map_err(|e| RocketMQError::Internal(format!("CopyUsersSubCommand: Failed to start MQAdminExt: {}", e)))?;
+
+        let operation_result = copy_users(&command, &default_mqadmin_ext).await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+async fn copy_users(
+    parsed_command: &ParsedCopyUsersSubCommand,
+    default_mqadmin_ext: &DefaultMQAdminExt,
+) -> Result<(), RocketMQError> {
+    let source_broker = parsed_command.from_broker.as_str();
+    let target_broker = parsed_command.to_broker.as_str();
+
+    let user_infos: Vec<UserInfo> = if let Some(ref usernames) = parsed_command.usernames {
+        let mut user_list = Vec::new();
+        for username in usernames {
+            match default_mqadmin_ext
+                .get_user(source_broker.into(), username.clone())
+                .await
+            {
+                Ok(user_info) => {
+                    user_list.push(user_info);
+                }
+                Err(e) => {
+                    eprintln!("Warning: Failed to get user {} from {}: {}", username, source_broker, e);
+                }
+            }
+        }
+        user_list
+    } else {
+        default_mqadmin_ext
+            .list_users(source_broker.into(), CheetahString::default())
+            .await
+            .map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "CopyUsersSubCommand: Failed to list users from {}: {}",
+                    source_broker, e
+                ))
+            })?
+    };
+
+    if user_infos.is_empty() {
+        println!("No users found to copy from {}.", source_broker);
+        return Ok(());
+    }
+
+    for user_info in user_infos {
+        let username = match user_info.username.as_ref() {
+            Some(u) => u.clone(),
+            None => {
+                eprintln!("Warning: User has no username, skipping.");
+                continue;
+            }
+        };
+
+        let target_user_result = default_mqadmin_ext
+            .get_user(target_broker.into(), username.clone())
+            .await;
+
+        let copy_result = if target_user_result.is_err() {
+            default_mqadmin_ext
+                .create_user_with_user_info(target_broker.into(), user_info.clone())
+                .await
+        } else {
+            default_mqadmin_ext
+                .update_user_with_user_info(target_broker.into(), user_info.clone())
+                .await
+        };
+
+        match copy_result {
+            Ok(_) => {
+                println!(
+                    "copy user of {} from {} to {} success.",
+                    username, source_broker, target_broker
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "copy user of {} from {} to {} failed: {}",
+                    username, source_broker, target_broker, e
+                );
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5656 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added methods to create/update users from consolidated UserInfo payloads.
  * Added new CLI command "auth copyUser" to copy/sync user accounts between brokers, with optional selective usernames and per-user progress reporting.

* **Chores**
  * Extended admin API surface to expose the new user-info operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->