### PR TITLE
[ISSUE #6000]📝Remove 'rocketmq-dashboard' from CI paths to ignore for push and pull request events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ "main" ]
     paths-ignore:
-      - 'rocketmq-dashboard/**'
       - 'rocketmq-doc/**'
       - 'rocketmq-website/**'
       - 'docker/**'
@@ -16,7 +15,6 @@ on:
   pull_request:
     branches: [ "main" ]
     paths-ignore:
-      - 'rocketmq-dashboard/**'
       - 'rocketmq-doc/**'
       - 'rocketmq-website/**'
       - 'docker/**'

--- a/rocketmq-dashboard/Cargo.lock
+++ b/rocketmq-dashboard/Cargo.lock
@@ -3544,9 +3544,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92488bc8a0f99ee9f23577bdd06526d49657df8bd70504c61f812337cdad01ab"
+checksum = "79ef8c257c92ade496781a32a581d43e3d512cf8ce714ecf04ea80f93ed0ff4a"
 dependencies = [
  "libc",
  "neli",


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6000

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to expand the scope of paths that trigger automated testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->