### PR TITLE
feat: implement ListUsersSubCommand (#5664)

### DIFF
--- a/rocketmq-auth/examples/authentication_manager_usage.rs
+++ b/rocketmq-auth/examples/authentication_manager_usage.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 7. List all users
     println!("\n7. Listing all users...");
-    let all_users: Vec<User> = manager.list_user(None).await?;
+    let all_users: Vec<User> = manager.list_users(None).await?;
     println!("   Total users: {}", all_users.len());
     for user in &all_users {
         let user_type = user
@@ -125,7 +125,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("   ✓ User 'alice' and related ACLs deleted");
 
     // Verify deletion
-    let remaining_users: Vec<User> = manager.list_user(None).await?;
+    let remaining_users: Vec<User> = manager.list_users(None).await?;
     println!("   Remaining users: {}", remaining_users.len());
 
     println!("\n=== Example completed successfully! ===");

--- a/rocketmq-auth/src/authentication/manager/authentication_metadata_manager.rs
+++ b/rocketmq-auth/src/authentication/manager/authentication_metadata_manager.rs
@@ -149,7 +149,7 @@ pub trait AuthenticationMetadataManager: Send + Sync {
     ///
     /// * `Ok(Vec<User>)` - List of matching users
     /// * `Err(RocketMQError)` - Query error
-    async fn list_user(&self, filter: Option<&str>) -> ManagerResult<Vec<User>>;
+    async fn list_users(&self, filter: Option<&str>) -> ManagerResult<Vec<User>>;
 
     /// Check if a user is a super user.
     ///

--- a/rocketmq-auth/src/authentication/manager/authentication_metadata_manager_impl.rs
+++ b/rocketmq-auth/src/authentication/manager/authentication_metadata_manager_impl.rs
@@ -395,7 +395,7 @@ where
         provider.get_user(username).await.map_err(|e| self.handle_exception(e))
     }
 
-    async fn list_user(&self, filter: Option<&str>) -> ManagerResult<Vec<User>> {
+    async fn list_users(&self, filter: Option<&str>) -> ManagerResult<Vec<User>> {
         let guard = self.authentication_metadata_provider.read().await;
         let provider = match &*guard {
             Some(p) => p,

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -17,6 +17,7 @@ use crate::processor::admin_broker_processor::batch_mq_handler::BatchMqHandler;
 use crate::processor::admin_broker_processor::broker_config_request_handler::BrokerConfigRequestHandler;
 use crate::processor::admin_broker_processor::broker_epoch_cache_handler::BrokerEpochCacheHandler;
 use crate::processor::admin_broker_processor::consumer_request_handler::ConsumerRequestHandler;
+use crate::processor::admin_broker_processor::list_users_request_handler::ListUsersRequestHandler;
 use crate::processor::admin_broker_processor::message_related_handler::MessageRelatedHandler;
 use crate::processor::admin_broker_processor::notify_broker_role_change_handler::NotifyBrokerRoleChangeHandler;
 use crate::processor::admin_broker_processor::notify_min_broker_id_handler::NotifyMinBrokerChangeIdHandler;
@@ -41,6 +42,7 @@ mod batch_mq_handler;
 mod broker_config_request_handler;
 mod broker_epoch_cache_handler;
 mod consumer_request_handler;
+mod list_users_request_handler;
 mod message_related_handler;
 mod notify_broker_role_change_handler;
 mod notify_min_broker_id_handler;
@@ -70,6 +72,7 @@ pub struct AdminBrokerProcessor<MS: MessageStore> {
     message_related_handler: MessageRelatedHandler<MS>,
     producer_request_handler: ProducerRequestHandler<MS>,
     update_user_request_handler: UpdateUserRequestHandler<MS>,
+    list_users_request_handler: ListUsersRequestHandler<MS>,
 }
 
 impl<MS> RequestProcessor for AdminBrokerProcessor<MS>
@@ -109,6 +112,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
         let message_related_handler = MessageRelatedHandler::new(broker_runtime_inner.clone());
         let producer_request_handler = ProducerRequestHandler::new(broker_runtime_inner.clone());
         let update_user_request_handler = UpdateUserRequestHandler::new(broker_runtime_inner.clone());
+        let list_users_request_handler = ListUsersRequestHandler::new(broker_runtime_inner.clone());
 
         AdminBrokerProcessor {
             topic_request_handler,
@@ -126,6 +130,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
             message_related_handler,
             producer_request_handler,
             update_user_request_handler,
+            list_users_request_handler,
         }
     }
 }
@@ -327,7 +332,11 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
             RequestCode::AuthUpdateUser => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::AuthDeleteUser => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::AuthGetUser => Ok(get_unknown_cmd_response(request_code)),
-            RequestCode::AuthListUser => Ok(get_unknown_cmd_response(request_code)),
+            RequestCode::AuthListUsers => {
+                self.list_users_request_handler
+                    .list_users_request(channel, ctx, request_code, request)
+                    .await
+            }
             RequestCode::AuthCreateAcl => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::AuthUpdateAcl => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::AuthDeleteAcl => Ok(get_unknown_cmd_response(request_code)),

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
@@ -1,0 +1,35 @@
+use crate::broker_runtime::BrokerRuntimeInner;
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+
+#[derive(Clone)]
+pub struct ListUsersRequestHandler<MS: MessageStore> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+}
+
+impl<MS: MessageStore> ListUsersRequestHandler<MS> {
+    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        Self { broker_runtime_inner }
+    }
+
+    pub async fn list_users_request(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        _request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        // let request_header = request.decode_command_custom_header::<ListUsersRequestHeader>()?;
+        let response = RemotingCommand::default();
+
+        // TODO get authentication metadata manager and do operations
+        Ok(Some(response.set_code(ResponseCode::SystemError).set_remark(
+            "ListUsers not implemented: authentication metadata manager not configured",
+        )))
+    }
+}

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1468,10 +1468,17 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn list_users(
         &self,
-        _broker_addr: CheetahString,
-        _filter: CheetahString,
+        broker_addr: CheetahString,
+        filter: CheetahString,
     ) -> rocketmq_error::RocketMQResult<Vec<UserInfo>> {
-        unimplemented!("list_users not implemented yet")
+        if let Some(ref mq_client_instance) = self.client_instance {
+            let mq_client_api = mq_client_instance.get_mq_client_api_impl();
+            let timeout_millis = self.timeout_millis.as_millis() as u64;
+            let result = mq_client_api.list_users(broker_addr, filter, timeout_millis).await?;
+            Ok(result)
+        } else {
+            Err(rocketmq_error::RocketMQError::ClientNotStarted)
+        }
     }
 
     async fn create_acl_with_info(

--- a/rocketmq-remoting/src/code/request_code.rs
+++ b/rocketmq-remoting/src/code/request_code.rs
@@ -238,7 +238,7 @@ define_request_code! {
         AuthUpdateUser = 3002,
         AuthDeleteUser = 3003,
         AuthGetUser = 3004,
-        AuthListUser = 3005,
+        AuthListUsers = 3005,
         AuthCreateAcl = 3006,
         AuthUpdateAcl = 3007,
         AuthDeleteAcl = 3008,

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -49,6 +49,7 @@ pub mod get_topic_config_request_header;
 pub mod get_topic_stats_info_request_header;
 pub mod get_topic_stats_request_header;
 pub mod heartbeat_request_header;
+pub mod list_users_request_header;
 pub mod lock_batch_mq_request_header;
 pub mod message_operation_header;
 pub mod namesrv;

--- a/rocketmq-remoting/src/protocol/header/list_users_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/list_users_request_header.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct ListUsersRequestHeader {
+    pub filter: CheetahString,
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1298,10 +1298,10 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn list_users(
         &self,
-        _broker_addr: CheetahString,
-        _filter: CheetahString,
+        broker_addr: CheetahString,
+        filter: CheetahString,
     ) -> rocketmq_error::RocketMQResult<Vec<UserInfo>> {
-        unimplemented!("list_users not implemented yet")
+        self.default_mqadmin_ext_impl.list_users(broker_addr, filter).await
     }
 
     async fn create_acl_with_info(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
@@ -16,6 +16,7 @@ mod copy_acl_sub_command;
 mod copy_users_sub_command;
 mod create_acl_sub_command;
 mod create_user_sub_command;
+mod list_users_sub_command;
 mod update_acl_sub_command;
 mod update_user_sub_command;
 
@@ -57,6 +58,13 @@ pub enum AuthCommands {
     CreateUser(create_user_sub_command::CreateUserSubCommand),
 
     #[command(
+        name = "listUsers",
+        about = "List users.",
+        long_about = None,
+    )]
+    ListUsers(list_users_sub_command::ListUsersSubCommand),
+
+    #[command(
         name = "updateAcl",
         about = "Update Access Control List (ACL)",
         long_about = None,
@@ -78,6 +86,7 @@ impl CommandExecute for AuthCommands {
             AuthCommands::CopyUsers(value) => value.execute(rpc_hook).await,
             AuthCommands::CreateAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::CreateUser(value) => value.execute(rpc_hook).await,
+            AuthCommands::ListUsers(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateUser(value) => value.execute(rpc_hook).await,
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/list_users_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/list_users_sub_command.rs
@@ -1,0 +1,263 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::ArgGroup;
+use clap::Parser;
+
+use cheetah_string::CheetahString;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::body::user_info::UserInfo;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(ArgGroup::new("target")
+    .required(true)
+    .args(&["cluster_name", "broker_addr"])))]
+pub struct ListUsersSubCommand {
+    #[arg(short = 'c', long = "clusterName", required = false)]
+    cluster_name: Option<String>,
+
+    #[arg(short = 'b', long = "brokerAddr", required = false)]
+    broker_addr: Option<String>,
+
+    #[arg(short = 'f', long = "filter", required = false)]
+    filter: Option<String>,
+}
+
+enum Target {
+    BrokerAddr(String),
+    ClusterName(String),
+}
+
+impl Target {
+    fn new(cluster_name: &Option<String>, broker_addr: &Option<String>) -> Result<Self, RocketMQError> {
+        let cluster_name: Option<String> = cluster_name
+            .as_ref()
+            .map(|cluster_name| cluster_name.trim())
+            .filter(|cluster_name| !cluster_name.is_empty())
+            .map(|cluster_name| cluster_name.into());
+        let broker_addr: Option<String> = broker_addr
+            .as_ref()
+            .map(|broker_addr| broker_addr.trim())
+            .filter(|broker_addr| !broker_addr.is_empty())
+            .map(|broker_addr| broker_addr.into());
+        if (cluster_name.is_none() && broker_addr.is_none()) || (cluster_name.is_some() && broker_addr.is_some()) {
+            return Err(RocketMQError::IllegalArgument(
+                "ListUsersSubCommand: Specify exactly one of --brokerAddr (-b) or --clusterName (-c)".into(),
+            ));
+        }
+        if let Some(cluster_name) = cluster_name {
+            Ok(Target::ClusterName(cluster_name))
+        } else {
+            Ok(Target::BrokerAddr(broker_addr.unwrap()))
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ParseListUsersSubCommand {
+    filter: Option<CheetahString>,
+}
+
+impl ParseListUsersSubCommand {
+    fn new(command: &ListUsersSubCommand) -> Result<Self, RocketMQError> {
+        let filter: Option<CheetahString> = command
+            .filter
+            .as_ref()
+            .map(|filter| filter.trim())
+            .filter(|filter| !filter.is_empty())
+            .map(|filter| filter.into());
+
+        Ok(Self { filter })
+    }
+}
+
+impl CommandExecute for ListUsersSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let command = ParseListUsersSubCommand::new(self)?;
+        let target = Target::new(&self.cluster_name, &self.broker_addr)?;
+
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        MQAdminExt::start(&mut default_mqadmin_ext)
+            .await
+            .map_err(|e| RocketMQError::Internal(format!("ListUsersSubCommand: Failed to start MQAdminExt: {}", e)))?;
+
+        let operation_result = async {
+            match target {
+                Target::BrokerAddr(broker_addr) => {
+                    let user_info = get_list_users_broker(&command, &default_mqadmin_ext, &broker_addr).await?;
+                    print_users(user_info);
+                    Ok(())
+                }
+                Target::ClusterName(cluster_name) => {
+                    let (user_info, failed_broker_addr) =
+                        get_list_users_cluster(&command, &default_mqadmin_ext, &cluster_name).await?;
+                    print_users(user_info);
+                    if failed_broker_addr.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(RocketMQError::Internal(format!(
+                            "ListUsersSubCommand: Failed to list users for brokers {}",
+                            failed_broker_addr.join(", ")
+                        )))
+                    }
+                }
+            }
+        }
+        .await;
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+async fn get_list_users_broker(
+    parsed_command: &ParseListUsersSubCommand,
+    default_mqadmin_ext: &DefaultMQAdminExt,
+    broker_addr: &str,
+) -> Result<Vec<UserInfo>, RocketMQError> {
+    let broker_list_users_result = {
+        match default_mqadmin_ext
+            .list_users(
+                broker_addr.into(),
+                parsed_command.filter.clone().unwrap_or_else(|| CheetahString::from("")),
+            )
+            .await
+        {
+            Ok(user_info) => {
+                println!("List users command was successful for broker {}.", broker_addr);
+                Ok(user_info)
+            }
+            Err(e) => Err(RocketMQError::Internal(format!(
+                "ListUsersSubCommand: Failed to list users for broker {}: {}",
+                broker_addr, e
+            ))),
+        }
+    };
+    broker_list_users_result
+}
+
+async fn get_list_users_cluster(
+    parsed_command: &ParseListUsersSubCommand,
+    default_mqadmin_ext: &DefaultMQAdminExt,
+    cluster_name: &str,
+) -> Result<(Vec<UserInfo>, Vec<CheetahString>), RocketMQError> {
+    let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await?;
+
+    match CommandUtil::fetch_master_addr_by_cluster_name(&cluster_info, cluster_name) {
+        Ok(addresses) => {
+            let results: Vec<Result<Vec<UserInfo>, CheetahString>> =
+                futures::future::join_all(addresses.into_iter().map(|addr| async {
+                    get_list_users_broker(parsed_command, default_mqadmin_ext, addr.as_str())
+                        .await
+                        .map_err(|_err| addr)
+                }))
+                .await;
+
+            let (users, errors): (Vec<_>, Vec<_>) = results.into_iter().partition(Result::is_ok);
+            let users: Vec<UserInfo> = users.into_iter().flat_map(Result::unwrap).collect();
+            let failed_addr: Vec<CheetahString> = errors.into_iter().map(Result::unwrap_err).collect();
+
+            Ok((users, failed_addr))
+        }
+        Err(e) => Err(RocketMQError::Internal(format!(
+            "ListUsersSubCommand: Failed to list users: {}",
+            e
+        ))),
+    }
+}
+
+fn print_users(users: Vec<UserInfo>) {
+    println!(
+        "{}",
+        format_row(&UserInfo {
+            username: Some("#UserName".into()),
+            password: Some("#Password".into()),
+            user_type: Some("#UserType".into()),
+            user_status: Some("#UserStatus".into()),
+        })
+    );
+    users.iter().for_each(|user| println!("{}", format_row(user)));
+    println!("Total users: {}", users.len());
+}
+
+fn format_row(user: &UserInfo) -> String {
+    format!(
+        "{:<16}  {:<22}  {:<22}",
+        user.username.as_deref().unwrap_or(""),
+        user.user_type.as_deref().unwrap_or(""),
+        user.user_status.as_deref().unwrap_or(""),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+
+    use clap::Parser;
+
+    use crate::commands::auth_commands::list_users_sub_command::ListUsersSubCommand;
+
+    #[test]
+    fn test_list_users_sub_command_with_broker_addr_using_short_commands() {
+        let args = [vec![""], vec!["-b", "127.0.0.1:3434"], vec!["-f", "some_filter"]];
+
+        let args = args.concat();
+
+        let cmd = ListUsersSubCommand::try_parse_from(args).unwrap();
+        assert_eq!(Some("127.0.0.1:3434"), cmd.broker_addr.as_deref());
+        assert_eq!(Some("some_filter"), cmd.filter.as_deref());
+    }
+
+    #[test]
+    fn test_list_users_sub_command_with_cluster_name_using_short_commands() {
+        let args = [vec![""], vec!["-c", "DefaultCluster"], vec!["-f", "some_filter"]];
+
+        let args = args.concat();
+
+        let cmd = ListUsersSubCommand::try_parse_from(args).unwrap();
+        assert_eq!(Some("DefaultCluster"), cmd.cluster_name.as_deref());
+        assert_eq!(Some("some_filter"), cmd.filter.as_deref());
+    }
+
+    #[test]
+    fn test_list_users_sub_command_using_conflicting_commands() {
+        let args = [
+            vec![""],
+            vec!["-b", "127.0.0.1:3434"],
+            vec!["-c", "DefaultCluster"],
+            vec!["-f", "some_filter"],
+        ];
+
+        let args = args.concat();
+
+        let result = ListUsersSubCommand::try_parse_from(args);
+        assert!(result.is_err());
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/update_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/update_acl_sub_command.rs
@@ -178,7 +178,7 @@ impl CommandExecute for UpdateAclSubCommand {
             } else {
                 // This case can not happen.
                 Err(RocketMQError::Internal(
-                    "UpdateAclSubCommand: Failed to start MQAdminExt:".into(),
+                    "UpdateAclSubCommand: broker_address or cluster_name must be set.".into(),
                 ))
             }
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Resolves #5664 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User listing across brokers and clusters is now available.
  * New CLI subcommand to list users with filtering and broker/cluster selection; prints tabular user info.

* **API Changes**
  * Authentication listing API renamed for consistency.

* **Bug Fixes / Behavior**
  * Client and admin tools now perform actual user listing instead of remaining unimplemented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->