### PR TITLE
[ISSUE #5884][Enhancement✨] Deprecate BrokerOperatorResult, MessageTrack, and TrackType structs due to relocation to rocketmq_common

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -34,7 +34,9 @@ use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::mix_all;
+#[allow(deprecated)]
 use rocketmq_common::common::tools::broker_operator_result::BrokerOperatorResult;
+#[allow(deprecated)]
 use rocketmq_common::common::tools::message_track::MessageTrack;
 use rocketmq_common::common::FAQUrl;
 use rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats;
@@ -1294,7 +1296,7 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
     ) -> rocketmq_error::RocketMQResult<()> {
         unimplemented!("trigger_lite_dispatch not implemented yet")
     }
-
+    #[allow(deprecated)]
     async fn delete_topic_in_broker_concurrent(
         &self,
         _addrs: HashSet<CheetahString>,
@@ -1312,7 +1314,7 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
     ) -> rocketmq_error::RocketMQResult<Vec<RollbackStats>> {
         unimplemented!("reset_offset_by_timestamp_old not implemented yet")
     }
-
+    #[allow(deprecated)]
     async fn reset_offset_new_concurrent(
         &self,
         _group: CheetahString,
@@ -1337,11 +1339,11 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
     ) -> AdminToolResult<Vec<QueueTimeSpan>> {
         unimplemented!("query_consume_time_span_concurrent not implemented yet")
     }
-
+    #[allow(deprecated)]
     async fn message_track_detail(&self, _msg_id: CheetahString) -> rocketmq_error::RocketMQResult<Vec<MessageTrack>> {
         unimplemented!("message_track_detail not implemented yet")
     }
-
+    #[allow(deprecated)]
     async fn message_track_detail_concurrent(&self, _msg_id: CheetahString) -> AdminToolResult<Vec<MessageTrack>> {
         unimplemented!("message_track_detail_concurrent not implemented yet")
     }

--- a/rocketmq-client/src/admin/mq_admin_ext_async.rs
+++ b/rocketmq-client/src/admin/mq_admin_ext_async.rs
@@ -21,7 +21,9 @@ use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
+#[allow(deprecated)]
 use rocketmq_common::common::tools::broker_operator_result::BrokerOperatorResult;
+#[allow(deprecated)]
 use rocketmq_common::common::tools::message_track::MessageTrack;
 use rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats;
 use rocketmq_remoting::protocol::admin::consume_stats_list::ConsumeStatsList;
@@ -234,7 +236,7 @@ pub trait MQAdminExt: Send {
         addrs: HashSet<CheetahString>,
         topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()>;
-
+    #[allow(deprecated)]
     async fn delete_topic_in_broker_concurrent(
         &self,
         addrs: HashSet<CheetahString>,
@@ -291,7 +293,7 @@ pub trait MQAdminExt: Send {
         topic: CheetahString,
         timestamp: u64,
     ) -> rocketmq_error::RocketMQResult<()>;
-
+    #[allow(deprecated)]
     async fn reset_offset_new_concurrent(
         &self,
         group: CheetahString,
@@ -379,9 +381,9 @@ pub trait MQAdminExt: Send {
         topic: CheetahString,
         msg_id: CheetahString,
     ) -> rocketmq_error::RocketMQResult<ConsumeMessageDirectlyResult>;
-
+    #[allow(deprecated)]
     async fn message_track_detail(&self, msg_id: CheetahString) -> rocketmq_error::RocketMQResult<Vec<MessageTrack>>;
-
+    #[allow(deprecated)]
     async fn message_track_detail_concurrent(&self, msg_id: CheetahString) -> AdminToolResult<Vec<MessageTrack>>;
 
     async fn clone_group_offset(

--- a/rocketmq-common/src/common/tools/broker_operator_result.rs
+++ b/rocketmq-common/src/common/tools/broker_operator_result.rs
@@ -23,7 +23,7 @@ pub struct BrokerOperatorResult {
     success_list: Vec<CheetahString>,
     failure_list: Vec<CheetahString>,
 }
-
+#[allow(deprecated)]
 impl Default for BrokerOperatorResult {
     fn default() -> Self {
         Self::new()
@@ -31,6 +31,7 @@ impl Default for BrokerOperatorResult {
 }
 
 #[allow(dead_code)]
+#[allow(deprecated)]
 impl BrokerOperatorResult {
     pub fn new() -> Self {
         BrokerOperatorResult {
@@ -55,7 +56,7 @@ impl BrokerOperatorResult {
         self.failure_list = failure_list;
     }
 }
-
+#[allow(deprecated)]
 impl std::fmt::Display for BrokerOperatorResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -73,6 +74,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn broker_operator_result_default_values() {
         let result = BrokerOperatorResult::new();
         assert!(result.get_success_list().is_empty());
@@ -80,6 +82,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn broker_operator_result_set_success_list() {
         let mut result = BrokerOperatorResult::new();
         let success_list = vec![CheetahString::from("success1"), CheetahString::from("success2")];
@@ -88,6 +91,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn broker_operator_result_set_failure_list() {
         let mut result = BrokerOperatorResult::new();
         let failure_list = vec![CheetahString::from("failure1"), CheetahString::from("failure2")];
@@ -96,6 +100,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn broker_operator_result_display_format() {
         let mut result = BrokerOperatorResult::new();
         let success_list = vec![CheetahString::from("success1")];

--- a/rocketmq-common/src/common/tools/message_track.rs
+++ b/rocketmq-common/src/common/tools/message_track.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[allow(deprecated)]
+use crate::common::tools::track_type::TrackType;
 use serde::Deserialize;
 use serde::Serialize;
-
-use crate::common::tools::track_type::TrackType;
 
 #[deprecated(
     since = "0.7.0",
@@ -23,6 +23,7 @@ use crate::common::tools::track_type::TrackType;
 )]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(deprecated)]
 pub struct MessageTrack {
     pub consumer_group: String,
     pub track_type: Option<TrackType>,
@@ -30,6 +31,7 @@ pub struct MessageTrack {
 }
 
 #[allow(dead_code)]
+#[allow(deprecated)]
 impl MessageTrack {
     pub fn get_consumer_group(&self) -> String {
         self.consumer_group.clone()
@@ -55,7 +57,7 @@ impl MessageTrack {
         self.exception_desc = exception_desc;
     }
 }
-
+#[allow(deprecated)]
 impl std::fmt::Display for MessageTrack {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let track_type_str = self
@@ -76,6 +78,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     pub fn test_message_track() {
         let mut message_track = MessageTrack {
             consumer_group: "test_consumer_group".to_string(),

--- a/rocketmq-common/src/common/tools/track_type.rs
+++ b/rocketmq-common/src/common/tools/track_type.rs
@@ -35,7 +35,7 @@ pub enum TrackType {
     ConsumeBroadcasting,
     Unknown,
 }
-
+#[allow(deprecated)]
 impl std::fmt::Display for TrackType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -49,7 +49,7 @@ impl std::fmt::Display for TrackType {
         }
     }
 }
-
+#[allow(deprecated)]
 impl Serialize for TrackType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -67,7 +67,7 @@ impl Serialize for TrackType {
         serializer.serialize_str(s)
     }
 }
-
+#[allow(deprecated)]
 impl<'de> Deserialize<'de> for TrackType {
     fn deserialize<D>(deserializer: D) -> Result<TrackType, D::Error>
     where
@@ -118,6 +118,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn serialize_consumed_but_filtered() {
         let track_type = TrackType::ConsumedButFiltered;
         let serialized = serde_json::to_string(&track_type).unwrap();
@@ -125,6 +126,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn deserialize_not_consumed_yet() {
         let json = "\"NOT_CONSUME_YET\"";
         let deserialized: TrackType = serde_json::from_str(json).unwrap();
@@ -132,6 +134,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn serialize_not_online() {
         let track_type = TrackType::NotOnline;
         let serialized = serde_json::to_string(&track_type).unwrap();
@@ -139,6 +142,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn deserialize_consume_broadcasting() {
         let json = "\"CONSUME_BROADCASTING\"";
         let deserialized: TrackType = serde_json::from_str(json).unwrap();
@@ -146,6 +150,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn display_pull_variant() {
         let track_type = TrackType::Pull;
         assert_eq!(track_type.to_string(), "PULL");

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -29,7 +29,9 @@ use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
+#[allow(deprecated)]
 use rocketmq_common::common::tools::broker_operator_result::BrokerOperatorResult;
+#[allow(deprecated)]
 use rocketmq_common::common::tools::message_track::MessageTrack;
 use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_error::RocketMQResult;
@@ -1124,7 +1126,7 @@ impl MQAdminExt for DefaultMQAdminExt {
     ) -> rocketmq_error::RocketMQResult<ProducerTableInfo> {
         unimplemented!("get_all_producer_info not implemented yet")
     }
-
+    #[allow(deprecated)]
     async fn delete_topic_in_broker_concurrent(
         &self,
         _addrs: HashSet<CheetahString>,
@@ -1142,7 +1144,7 @@ impl MQAdminExt for DefaultMQAdminExt {
     ) -> rocketmq_error::RocketMQResult<Vec<RollbackStats>> {
         unimplemented!("reset_offset_by_timestamp_old not implemented yet")
     }
-
+    #[allow(deprecated)]
     async fn reset_offset_new_concurrent(
         &self,
         _group: CheetahString,
@@ -1167,11 +1169,11 @@ impl MQAdminExt for DefaultMQAdminExt {
     ) -> AdminToolResult<Vec<QueueTimeSpan>> {
         unimplemented!("query_consume_time_span_concurrent not implemented yet")
     }
-
+    #[allow(deprecated)]
     async fn message_track_detail(&self, _msg_id: CheetahString) -> rocketmq_error::RocketMQResult<Vec<MessageTrack>> {
         unimplemented!("message_track_detail not implemented yet")
     }
-
+    #[allow(deprecated)]
     async fn message_track_detail_concurrent(&self, _msg_id: CheetahString) -> AdminToolResult<Vec<MessageTrack>> {
         unimplemented!("message_track_detail_concurrent not implemented yet")
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5884 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

Add a deprecation attribute to BrokerOperatorResult, MessageTrack, and TrackType structs due to relocation to rocketmq_common.
### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Marked three message-tracking types as deprecated (since v0.7.0): BrokerOperatorResult, MessageTrack, and TrackType. They remain functional but are moved; plan migration to their new locations.
* **Chores**
  * Suppressed deprecation warnings across admin and client APIs so existing calls continue without compile-time noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->