### PR TITLE
[ISSUE #5812][Test🧪] Add test case for CreateTopicListRequestBody

### DIFF
--- a/rocketmq-remoting/src/protocol/body/create_topic_list_request_body.rs
+++ b/rocketmq-remoting/src/protocol/body/create_topic_list_request_body.rs
@@ -71,7 +71,7 @@ mod tests {
 
         let topic = &body.topic_config_list[0];
 
-        assert_eq!(topic.topic_name.as_deref(), Some("test_topic".into()));
+        assert_eq!(topic.topic_name.as_deref(), Some("test_topic"));
         assert_eq!(topic.read_queue_nums, 2);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5812 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
**Please note!**
While creating a test section, I noticed that `TopicFilterType` enum has different representations:
1. For JSON serialization/deserialization (serde) it uses `"SINGLE_TAG"` / `"MULTI_TAG"`.
2. The `decode()` method (I guess the legacy text format) expects `"SingleTag"` / `"MultiTag"`.

This PR uses the serde-compatible form in the test

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for internal components to improve reliability and stability, ensuring serialization/deserialization behavior and default construction are validated. This increases confidence in runtime behavior without changing any public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->