### PR TITLE
[ISSUE #5659]🚀Implement DeleteAcl Command for ACL Entry Removal

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1099,7 +1099,14 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         subject: CheetahString,
         resource: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        if let Some(ref client_instance) = self.client_instance {
+            let mq_client_api = client_instance.get_mq_client_api_impl();
+            mq_client_api
+                .delete_acl(broker_addr, subject, resource, self.timeout_millis.as_millis() as u64)
+                .await
+        } else {
+            Err(rocketmq_error::RocketMQError::ClientNotStarted)
+        }
     }
 
     async fn create_lite_pull_topic(

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -23,6 +23,7 @@ pub mod consumer_send_msg_back_request_header;
 pub mod controller;
 pub mod create_topic_request_header;
 pub mod create_user_request_header;
+pub mod delete_acl_request_header;
 pub mod delete_subscription_group_request_header;
 pub mod delete_topic_request_header;
 pub mod elect_master_response_header;

--- a/rocketmq-remoting/src/protocol/header/delete_acl_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/delete_acl_request_header.rs
@@ -1,0 +1,132 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteAclRequestHeader {
+    pub subject: CheetahString,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource: Option<CheetahString>,
+}
+
+impl DeleteAclRequestHeader {
+    pub fn new(subject: CheetahString, resource: Option<CheetahString>) -> Self {
+        Self { subject, resource }
+    }
+
+    pub fn with_subject(subject: CheetahString) -> Self {
+        Self {
+            subject,
+            resource: None,
+        }
+    }
+
+    pub fn set_subject(&mut self, subject: CheetahString) {
+        self.subject = subject;
+    }
+
+    pub fn set_resource(&mut self, resource: Option<CheetahString>) {
+        self.resource = resource;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn delete_acl_request_header_new() {
+        let subject = CheetahString::from_static_str("user:alice");
+        let resource = Some(CheetahString::from_static_str("Topic:test-topic"));
+        let header = DeleteAclRequestHeader::new(subject.clone(), resource.clone());
+
+        assert_eq!(header.subject, subject);
+        assert_eq!(header.resource, resource);
+    }
+
+    #[test]
+    fn delete_acl_request_header_with_subject() {
+        let subject = CheetahString::from_static_str("user:bob");
+        let header = DeleteAclRequestHeader::with_subject(subject.clone());
+
+        assert_eq!(header.subject, subject);
+        assert!(header.resource.is_none());
+    }
+
+    #[test]
+    fn delete_acl_request_header_default() {
+        let header = DeleteAclRequestHeader::default();
+
+        assert!(header.subject.is_empty());
+        assert!(header.resource.is_none());
+    }
+
+    #[test]
+    fn delete_acl_request_header_set_methods() {
+        let mut header = DeleteAclRequestHeader::default();
+        let subject = CheetahString::from_static_str("user:charlie");
+        let resource = Some(CheetahString::from_static_str("Group:consumer-group"));
+
+        header.set_subject(subject.clone());
+        header.set_resource(resource.clone());
+
+        assert_eq!(header.subject, subject);
+        assert_eq!(header.resource, resource);
+    }
+
+    #[test]
+    fn delete_acl_request_header_serializes_correctly() {
+        let header = DeleteAclRequestHeader::new(
+            CheetahString::from_static_str("user:alice"),
+            Some(CheetahString::from_static_str("Topic:test")),
+        );
+
+        let map = header.to_map().unwrap();
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("subject")),
+            Some(&CheetahString::from_static_str("user:alice"))
+        );
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("resource")),
+            Some(&CheetahString::from_static_str("Topic:test"))
+        );
+    }
+
+    #[test]
+    fn delete_acl_request_header_deserializes_correctly() {
+        let mut map: HashMap<CheetahString, CheetahString> = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("subject"),
+            CheetahString::from_static_str("user:alice"),
+        );
+        map.insert(
+            CheetahString::from_static_str("resource"),
+            CheetahString::from_static_str("Topic:test"),
+        );
+
+        let header = <DeleteAclRequestHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(header.subject, CheetahString::from_static_str("user:alice"));
+        assert_eq!(header.resource, Some(CheetahString::from_static_str("Topic:test")));
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -903,7 +903,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         subject: CheetahString,
         resource: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .delete_acl(broker_addr, subject, resource)
+            .await
     }
 
     async fn create_lite_pull_topic(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -151,6 +151,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Auth",
+                command: "deleteAcl",
+                remark: "Delete acl from cluster.",
+            },
+            Command {
+                category: "Auth",
                 command: "updateAcl",
                 remark: "Update ACL.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
@@ -16,6 +16,7 @@ mod copy_acl_sub_command;
 mod copy_users_sub_command;
 mod create_acl_sub_command;
 mod create_user_sub_command;
+mod delete_acl_sub_command;
 mod list_users_sub_command;
 mod update_acl_sub_command;
 mod update_user_sub_command;
@@ -58,6 +59,13 @@ pub enum AuthCommands {
     CreateUser(create_user_sub_command::CreateUserSubCommand),
 
     #[command(
+        name = "deleteAcl",
+        about = "Delete acl from cluster.",
+        long_about = None,
+    )]
+    DeleteAcl(delete_acl_sub_command::DeleteAclSubCommand),
+
+    #[command(
         name = "listUsers",
         about = "List users.",
         long_about = None,
@@ -86,6 +94,7 @@ impl CommandExecute for AuthCommands {
             AuthCommands::CopyUsers(value) => value.execute(rpc_hook).await,
             AuthCommands::CreateAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::CreateUser(value) => value.execute(rpc_hook).await,
+            AuthCommands::DeleteAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::ListUsers(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateUser(value) => value.execute(rpc_hook).await,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/delete_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/delete_acl_sub_command.rs
@@ -1,0 +1,174 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::ArgGroup;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(ArgGroup::new("target")
+    .required(true)
+    .args(&["cluster_name", "broker_addr"])))]
+pub struct DeleteAclSubCommand {
+    #[arg(
+        short = 'c',
+        long = "clusterName",
+        required = false,
+        help = "delete acl from which cluster"
+    )]
+    cluster_name: Option<String>,
+
+    #[arg(
+        short = 'b',
+        long = "brokerAddr",
+        required = false,
+        help = "delete acl from which broker"
+    )]
+    broker_addr: Option<String>,
+
+    #[arg(
+        short = 's',
+        long = "subject",
+        required = true,
+        help = "the subject of acl to delete"
+    )]
+    subject: String,
+
+    #[arg(
+        short = 'r',
+        long = "resources",
+        required = false,
+        help = "the resources of acl to delete"
+    )]
+    resources: Option<String>,
+}
+
+#[derive(Clone)]
+struct ParsedDeleteAclSubCommand {
+    cluster_name: Option<CheetahString>,
+    broker_addr: Option<CheetahString>,
+    subject: CheetahString,
+    resource: Option<CheetahString>,
+}
+
+impl ParsedDeleteAclSubCommand {
+    fn new(command: &DeleteAclSubCommand) -> Result<Self, RocketMQError> {
+        let cluster_name: Option<CheetahString> = command
+            .cluster_name
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.into());
+
+        let broker_addr: Option<CheetahString> = command
+            .broker_addr
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.into());
+
+        if cluster_name.is_none() && broker_addr.is_none() {
+            return Err(RocketMQError::IllegalArgument(
+                "DeleteAclSubCommand: Specify either --brokerAddr (-b) or --clusterName (-c)".into(),
+            ));
+        }
+
+        let subject: CheetahString = {
+            let subject = command.subject.trim();
+            if subject.is_empty() {
+                return Err(RocketMQError::IllegalArgument(
+                    "DeleteAclSubCommand: subject cannot be empty".into(),
+                ));
+            } else {
+                subject.into()
+            }
+        };
+
+        let resource: Option<CheetahString> = command
+            .resources
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.into());
+
+        Ok(Self {
+            cluster_name,
+            broker_addr,
+            subject,
+            resource,
+        })
+    }
+}
+
+impl CommandExecute for DeleteAclSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let command = ParsedDeleteAclSubCommand::new(self)?;
+
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        MQAdminExt::start(&mut default_mqadmin_ext)
+            .await
+            .map_err(|e| RocketMQError::Internal(format!("DeleteAclSubCommand: Failed to start MQAdminExt: {}", e)))?;
+
+        let operation_result = delete_acl(&command, &default_mqadmin_ext).await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+async fn delete_acl(
+    parsed_command: &ParsedDeleteAclSubCommand,
+    default_mqadmin_ext: &DefaultMQAdminExt,
+) -> Result<(), RocketMQError> {
+    let subject = parsed_command.subject.clone();
+    let resource = parsed_command.resource.clone().unwrap_or_default();
+
+    if let Some(ref broker_addr) = parsed_command.broker_addr {
+        default_mqadmin_ext
+            .delete_acl(broker_addr.clone(), subject.clone(), resource.clone())
+            .await?;
+        println!("delete acl to {} success.", broker_addr);
+    } else if let Some(ref cluster_name) = parsed_command.cluster_name {
+        let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await?;
+        let broker_addrs = CommandUtil::fetch_master_and_slave_addr_by_cluster_name(&cluster_info, cluster_name)?;
+
+        for addr in broker_addrs {
+            default_mqadmin_ext
+                .delete_acl(addr.clone(), subject.clone(), resource.clone())
+                .await?;
+            println!("delete acl to {} success.", addr);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5659 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented ACL deletion end-to-end: users can delete ACL entries from a specific broker or across a cluster via the CLI, with input validation, optional resource targeting, and per-target feedback.
  * Added remote request support so the client now performs real delete operations against brokers.

* **Tests**
  * Added unit tests validating the new ACL request payload construction and (de)serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->