### PR TITLE
[ISSUE #5660]🚀Implement DeleteUser Command for User Account Removal

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1066,7 +1066,14 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         broker_addr: CheetahString,
         username: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        if let Some(ref mq_client_instance) = self.client_instance {
+            let mq_client_api = mq_client_instance.get_mq_client_api_impl();
+            let timeout_millis = self.timeout_millis.as_millis() as u64;
+            mq_client_api.delete_user(broker_addr, username, timeout_millis).await?;
+            Ok(())
+        } else {
+            Err(rocketmq_error::RocketMQError::ClientNotStarted)
+        }
     }
 
     async fn create_acl(

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -26,6 +26,7 @@ pub mod create_user_request_header;
 pub mod delete_acl_request_header;
 pub mod delete_subscription_group_request_header;
 pub mod delete_topic_request_header;
+pub mod delete_user_request_header;
 pub mod elect_master_response_header;
 pub mod empty_header;
 pub mod end_transaction_request_header;

--- a/rocketmq-remoting/src/protocol/header/delete_user_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/delete_user_request_header.rs
@@ -1,0 +1,95 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteUserRequestHeader {
+    pub username: CheetahString,
+}
+
+impl DeleteUserRequestHeader {
+    pub fn new(username: CheetahString) -> Self {
+        Self { username }
+    }
+
+    pub fn set_username(&mut self, username: CheetahString) {
+        self.username = username;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn delete_user_request_header_new() {
+        let username = CheetahString::from_static_str("test_user");
+        let header = DeleteUserRequestHeader::new(username.clone());
+
+        assert_eq!(header.username, username);
+    }
+
+    #[test]
+    fn delete_user_request_header_default() {
+        let header = DeleteUserRequestHeader::default();
+
+        assert!(header.username.is_empty());
+    }
+
+    #[test]
+    fn delete_user_request_header_set_username() {
+        let mut header = DeleteUserRequestHeader::default();
+        let username = CheetahString::from_static_str("admin");
+
+        header.set_username(username.clone());
+
+        assert_eq!(header.username, username);
+    }
+
+    #[test]
+    fn delete_user_request_header_serializes_correctly() {
+        let header = DeleteUserRequestHeader {
+            username: CheetahString::from_static_str("test_admin"),
+        };
+
+        let map = header.to_map().unwrap();
+
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("username")).unwrap(),
+            "test_admin"
+        );
+    }
+
+    #[test]
+    fn delete_user_request_header_deserializes_correctly() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("username"),
+            CheetahString::from_static_str("deserialized_user"),
+        );
+
+        let header = <DeleteUserRequestHeader as FromMap>::from(&map).unwrap();
+
+        assert_eq!(header.username.as_str(), "deserialized_user");
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -868,7 +868,7 @@ impl MQAdminExt for DefaultMQAdminExt {
         broker_addr: CheetahString,
         username: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl.delete_user(broker_addr, username).await
     }
 
     async fn create_acl(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -156,6 +156,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Auth",
+                command: "deleteUser",
+                remark: "Delete user from cluster.",
+            },
+            Command {
+                category: "Auth",
                 command: "updateAcl",
                 remark: "Update ACL.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
@@ -17,6 +17,7 @@ mod copy_users_sub_command;
 mod create_acl_sub_command;
 mod create_user_sub_command;
 mod delete_acl_sub_command;
+mod delete_user_sub_command;
 mod list_users_sub_command;
 mod update_acl_sub_command;
 mod update_user_sub_command;
@@ -66,6 +67,13 @@ pub enum AuthCommands {
     DeleteAcl(delete_acl_sub_command::DeleteAclSubCommand),
 
     #[command(
+        name = "deleteUser",
+        about = "Delete user from cluster.",
+        long_about = None,
+    )]
+    DeleteUser(delete_user_sub_command::DeleteUserSubCommand),
+
+    #[command(
         name = "listUsers",
         about = "List users.",
         long_about = None,
@@ -95,6 +103,7 @@ impl CommandExecute for AuthCommands {
             AuthCommands::CreateAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::CreateUser(value) => value.execute(rpc_hook).await,
             AuthCommands::DeleteAcl(value) => value.execute(rpc_hook).await,
+            AuthCommands::DeleteUser(value) => value.execute(rpc_hook).await,
             AuthCommands::ListUsers(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateUser(value) => value.execute(rpc_hook).await,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/delete_user_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/delete_user_sub_command.rs
@@ -1,0 +1,139 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+use cheetah_string::CheetahString;
+use clap::ArgGroup;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(ArgGroup::new("target")
+    .required(true)
+    .args(&["cluster_name", "broker_addr"]))
+)]
+pub struct DeleteUserSubCommand {
+    #[arg(
+        short = 'c',
+        long = "clusterName",
+        required = false,
+        help = "delete user from which cluster"
+    )]
+    cluster_name: Option<String>,
+
+    #[arg(
+        short = 'b',
+        long = "brokerAddr",
+        required = false,
+        help = "delete user from which broker"
+    )]
+    broker_addr: Option<String>,
+
+    #[arg(
+        short = 'u',
+        long = "username",
+        required = true,
+        help = "the username of user to delete"
+    )]
+    username: String,
+}
+
+#[derive(Clone)]
+struct ParsedDeleteUserSubCommand {
+    cluster_name: Option<CheetahString>,
+    broker_addr: Option<CheetahString>,
+    username: CheetahString,
+}
+
+impl ParsedDeleteUserSubCommand {
+    fn new(command: &DeleteUserSubCommand) -> Result<Self, RocketMQError> {
+        let username = command.username.trim();
+        if username.is_empty() {
+            return Err(RocketMQError::IllegalArgument(
+                "DeleteUserSubCommand: username cannot be empty".into(),
+            ));
+        }
+
+        Ok(Self {
+            cluster_name: command
+                .cluster_name
+                .as_deref()
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .map(CheetahString::from),
+            broker_addr: command
+                .broker_addr
+                .as_deref()
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .map(CheetahString::from),
+            username: username.into(),
+        })
+    }
+}
+
+impl CommandExecute for DeleteUserSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let parsed_command = ParsedDeleteUserSubCommand::new(self)?;
+
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        MQAdminExt::start(&mut default_mqadmin_ext)
+            .await
+            .map_err(|e| RocketMQError::Internal(format!("DeleteUserSubCommand: Failed to start MQAdminExt: {}", e)))?;
+
+        let operation_result = delete_user(&parsed_command, &default_mqadmin_ext).await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+async fn delete_user(
+    parsed_command: &ParsedDeleteUserSubCommand,
+    default_mqadmin_ext: &DefaultMQAdminExt,
+) -> RocketMQResult<()> {
+    if let Some(ref broker) = parsed_command.broker_addr {
+        default_mqadmin_ext
+            .delete_user(broker.clone(), parsed_command.username.clone())
+            .await?;
+        println!("delete user to {} success.", broker);
+    } else if let Some(ref cluster_name) = parsed_command.cluster_name {
+        let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await?;
+
+        let addresses = CommandUtil::fetch_master_and_slave_addr_by_cluster_name(&cluster_info, cluster_name.as_str())?;
+        for address in addresses {
+            default_mqadmin_ext
+                .delete_user(address.clone(), parsed_command.username.clone())
+                .await?;
+            println!("delete user to {} success.", address);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5660 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI support to delete users: auth deleteUser — works against a specific broker or an entire cluster and shows per-broker success messages.

* **Bug Fixes**
  * Deleting a user now performs the actual remote delete and returns a clear error if no client is running.

* **Documentation**
  * deleteUser added to the CLI command listing for discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->