### PR TITLE
[ISSUE #6028]🐛fix: handle 503 response in timeout test for http_tiny_client

### DIFF
--- a/rocketmq-common/src/utils/http_tiny_client.rs
+++ b/rocketmq-common/src/utils/http_tiny_client.rs
@@ -533,10 +533,15 @@ mod tests {
                 assert!(matches!(e, RocketMQError::Network(_)));
             }
             Ok(response) => {
-                panic!(
-                    "Expected timeout error but got success response with code: {}",
-                    response.code
-                );
+                // httpbin.org might return 503 if service is unavailable
+                if response.code == 503 {
+                    eprintln!("httpbin.org is unavailable (503), skipping timeout test");
+                } else {
+                    panic!(
+                        "Expected timeout error but got success response with code: {}",
+                        response.code
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6028

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted timeout test behavior: when an async GET request times out, an HTTP 503 response is treated as a permissible outcome instead of a failure.
  * Enhanced test logging to note external service unavailability during timeout scenarios.
  * This affects only the test suite and does not alter user-facing features.
  * No changes to production behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->