### PR TITLE
chore: add Apache 2.0 license headers to rocketmq-dashboard-tauri

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/build.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     tauri_build::build()
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/main.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 


### PR DESCRIPTION
## Summary
Add Apache 2.0 license headers to all Rust source files in rocketmq-dashboard-tauri to maintain consistency with the rest of the project.

## Changes
Added standard Apache 2.0 license headers to:
- `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/main.rs`
- `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs`
- `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/build.rs`

The license header format matches the existing headers used throughout the project.

## Test Plan
- [x] Verify license header format matches existing project files
- [x] Ensure all three files are updated

Closes #6033
Closes #6032
Closes #6031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Apache 2.0 license headers to project files for compliance purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->