### PR TITLE
[ISSUE #5722][Enhancement✨] Remove useless code from perm_broker_header.rs

### DIFF
--- a/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
@@ -81,29 +81,3 @@ impl AddWritePermOfBrokerResponseHeader {
         self.add_topic_count
     }
 }
-
-// impl CommandCustomHeader for AddWritePermOfBrokerResponseHeader {
-//     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-//         Some(HashMap::from([(
-//             CheetahString::from_static_str(Self::ADD_TOPIC_COUNT),
-//             CheetahString::from_string(self.add_topic_count.to_string()),
-//         )]))
-//     }
-// }
-
-// impl FromMap for AddWritePermOfBrokerResponseHeader {
-//     type Error = rocketmq_error::RocketmqError;
-
-//     type Target = Self;
-
-//     fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self::Target, Self::Error> {
-//         Ok(AddWritePermOfBrokerResponseHeader {
-//             add_topic_count: map
-//                 .get(&CheetahString::from_static_str(
-//                     AddWritePermOfBrokerResponseHeader::ADD_TOPIC_COUNT,
-//                 ))
-//                 .and_then(|s| s.parse::<i32>().ok())
-//                 .unwrap_or(0),
-//         })
-//     }
-// }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5722 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused commented-out code from protocol headers.

**Note:** This is a maintenance update with no changes to user-facing functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->