### PR TITLE
[ISSUE #5720][Test🧪] Add test case for LockBatchResponseBody

### DIFF
--- a/rocketmq-remoting/src/protocol/body/response/lock_batch_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/response/lock_batch_response_body.rs
@@ -23,3 +23,64 @@ pub struct LockBatchResponseBody {
     #[serde(rename = "lockOKMQSet")]
     pub lock_ok_mq_set: HashSet<MessageQueue>,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_lock_batch_response_body_default() {
+        let body = LockBatchResponseBody::default();
+        assert!(body.lock_ok_mq_set.is_empty());
+    }
+
+    #[test]
+    fn test_serialization_json_field_name() {
+        let mut set = HashSet::new();
+        let mq = MessageQueue::from_parts("topic_a", "broker_a", 1);
+        set.insert(mq);
+
+        let body = LockBatchResponseBody { lock_ok_mq_set: set };
+
+        let json = serde_json::to_string(&body).unwrap();
+
+        assert!(json.contains("\"lockOKMQSet\""));
+    }
+
+    #[test]
+    fn test_deserialization_success() {
+        let json = r#"{
+            "lockOKMQSet": [
+                {
+                    "topic": "some_test_topic",
+                    "brokerName": "TEST_BROKER",
+                    "queueId": 1
+                }
+            ]
+        }"#;
+
+        let decoded: LockBatchResponseBody = serde_json::from_str(json).expect("Failed to deserialize");
+
+        assert_eq!(decoded.lock_ok_mq_set.len(), 1);
+        let mq = decoded.lock_ok_mq_set.iter().next().unwrap();
+        assert_eq!(mq.get_broker_name(), "TEST_BROKER");
+        assert_eq!(mq.get_queue_id(), 1);
+    }
+
+    #[test]
+    fn test_hash_set_behavior_with_message_queue() {
+        let mut body = LockBatchResponseBody::default();
+
+        let mq1 = MessageQueue::from_parts("topic", "broker", 1);
+        let mq2 = MessageQueue::from_parts("topic", "broker", 1);
+        let mq3 = MessageQueue::from_parts("topic", "broker", 2);
+
+        body.lock_ok_mq_set.insert(mq1);
+        body.lock_ok_mq_set.insert(mq2);
+        body.lock_ok_mq_set.insert(mq3);
+
+        assert_eq!(body.lock_ok_mq_set.len(), 2);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5720 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for batch response handling, including serialization/deserialization and deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->