### PR TITLE
[ISSUE #5700][Enhancement✨] Remove about Java useless comments

### DIFF
--- a/rocketmq-namesrv/src/route/route_info_manager_v2.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_v2.rs
@@ -145,17 +145,6 @@ impl RouteInfoManagerV2 {
     }
 
     /// Start the route manager
-    ///
-    /// This matches Java's start() method which only starts the unRegisterService.
-    /// Channel disconnection events are handled by BrokerHousekeepingService through
-    /// ChannelEventListener interface (on_channel_close, on_channel_exception, on_channel_idle).
-    ///
-    /// Java code:
-    /// ```java
-    /// public void start() {
-    ///     this.unRegisterService.start();
-    /// }
-    /// ```
     pub fn start(&self) {
         info!("Starting RouteInfoManager v2 with DashMap tables");
         self.un_register_service.mut_from_ref().start();


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5700 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal documentation comment from the name server's route information manager, with no functional changes to behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->