### PR TITLE
[ISSUE #5663]🚀Implement ListAcl command for ACL enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **feat(tools):** Add `ListAclSubCommand` for ACL enumeration and subject filtering ([#5663](https://github.com/mxsm/rocketmq-rust/issues/5663))
 - **feat(tools):** Add `UpdateAclSubCommand` ([#5665](https://github.com/mxsm/rocketmq-rust/issues/5665))
 - **feat(tools):** Add `UpdateSubGroupSubCommand` in update_sub_group_sub_command.rs ([#5653](https://github.com/mxsm/rocketmq-rust/issues/5653))
 - **feat(tools):** Add `GetControllerMetadataSubCommand` ([#5624](https://github.com/mxsm/rocketmq-rust/issues/5624))

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1530,11 +1530,20 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn list_acl(
         &self,
-        _broker_addr: CheetahString,
-        _subject_filter: CheetahString,
-        _resource_filter: CheetahString,
+        broker_addr: CheetahString,
+        subject_filter: CheetahString,
+        resource_filter: CheetahString,
     ) -> rocketmq_error::RocketMQResult<Vec<AclInfo>> {
-        unimplemented!("list_acl not implemented yet")
+        if let Some(ref mq_client_instance) = self.client_instance {
+            let mq_client_api = mq_client_instance.get_mq_client_api_impl();
+            let timeout_millis = self.timeout_millis.as_millis() as u64;
+            let result = mq_client_api
+                .list_acl(broker_addr, subject_filter, resource_filter, timeout_millis)
+                .await?;
+            Ok(result)
+        } else {
+            Err(rocketmq_error::RocketMQError::ClientNotStarted)
+        }
     }
 
     async fn get_broker_lite_info(

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -52,6 +52,7 @@ pub mod get_topic_stats_info_request_header;
 pub mod get_topic_stats_request_header;
 pub mod get_user_request_headers;
 pub mod heartbeat_request_header;
+pub mod list_acl_request_header;
 pub mod list_users_request_header;
 pub mod lock_batch_mq_request_header;
 pub mod message_operation_header;

--- a/rocketmq-remoting/src/protocol/header/list_acl_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/list_acl_request_header.rs
@@ -1,0 +1,25 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct ListAclRequestHeader {
+    pub subject_filter: CheetahString,
+    pub resource_filter: CheetahString,
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1334,11 +1334,13 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn list_acl(
         &self,
-        _broker_addr: CheetahString,
-        _subject_filter: CheetahString,
-        _resource_filter: CheetahString,
+        broker_addr: CheetahString,
+        subject_filter: CheetahString,
+        resource_filter: CheetahString,
     ) -> rocketmq_error::RocketMQResult<Vec<AclInfo>> {
-        unimplemented!("list_acl not implemented yet")
+        self.default_mqadmin_ext_impl
+            .list_acl(broker_addr, subject_filter, resource_filter)
+            .await
     }
 
     async fn get_broker_lite_info(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -162,6 +162,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Auth",
+                command: "listAcl",
+                remark: "List acl from cluster.",
+            },
+            Command {
+                category: "Auth",
                 command: "updateAcl",
                 remark: "Update ACL.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
@@ -19,6 +19,7 @@ mod create_user_sub_command;
 mod delete_acl_sub_command;
 mod delete_user_sub_command;
 mod get_user_sub_command;
+mod list_acl_sub_command;
 mod list_users_sub_command;
 mod update_acl_sub_command;
 mod update_user_sub_command;
@@ -89,6 +90,13 @@ pub enum AuthCommands {
     ListUsers(list_users_sub_command::ListUsersSubCommand),
 
     #[command(
+        name = "listAcl",
+        about = "List acl from cluster",
+        long_about = None,
+    )]
+    ListAcl(list_acl_sub_command::ListAclSubCommand),
+
+    #[command(
         name = "updateAcl",
         about = "Update Access Control List (ACL)",
         long_about = None,
@@ -113,6 +121,7 @@ impl CommandExecute for AuthCommands {
             AuthCommands::DeleteAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::DeleteUser(value) => value.execute(rpc_hook).await,
             AuthCommands::GetUser(value) => value.execute(rpc_hook).await,
+            AuthCommands::ListAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::ListUsers(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateUser(value) => value.execute(rpc_hook).await,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/list_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands/list_acl_sub_command.rs
@@ -1,0 +1,339 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use clap::ArgGroup;
+use clap::Parser;
+
+use cheetah_string::CheetahString;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::body::acl_info::AclInfo;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::target::Target;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(ArgGroup::new("target")
+    .required(true)
+    .args(&["cluster_name", "broker_addr"])))]
+pub struct ListAclSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(short = 'c', long = "clusterName", required = false)]
+    cluster_name: Option<String>,
+
+    #[arg(short = 'b', long = "brokerAddr", required = false)]
+    broker_addr: Option<String>,
+
+    #[arg(short = 's', long = "subject", required = false)]
+    subject: Option<String>,
+}
+
+#[derive(Clone)]
+struct ParsedListAclSubCommand {
+    subject_filter: CheetahString,
+}
+
+impl ParsedListAclSubCommand {
+    fn new(command: &ListAclSubCommand) -> Result<Self, RocketMQError> {
+        let subject_filter = command
+            .subject
+            .as_ref()
+            .map(|subject| subject.trim())
+            .filter(|subject| !subject.is_empty())
+            .unwrap_or("")
+            .into();
+
+        Ok(Self { subject_filter })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+struct AclRow {
+    subject: String,
+    resource: String,
+    actions: String,
+    source_ips: String,
+    decision: String,
+    policy_type: String,
+}
+
+impl CommandExecute for ListAclSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let command = ParsedListAclSubCommand::new(self)?;
+        let target = Target::new(&self.cluster_name, &self.broker_addr).map_err(|_| {
+            RocketMQError::IllegalArgument(
+                "ListAclSubCommand: Specify exactly one of --brokerAddr (-b) or --clusterName (-c)".into(),
+            )
+        })?;
+
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+        if let Some(addr) = &self.common_args.namesrv_addr {
+            default_mqadmin_ext.set_namesrv_addr(addr.trim());
+        }
+
+        MQAdminExt::start(&mut default_mqadmin_ext)
+            .await
+            .map_err(|e| RocketMQError::Internal(format!("ListAclSubCommand: Failed to start MQAdminExt: {}", e)))?;
+
+        let operation_result = async {
+            match target {
+                Target::BrokerAddr(broker_addr) => {
+                    let acl_infos = list_acl_from_broker(&command, &default_mqadmin_ext, &broker_addr).await?;
+                    print_acls(acl_infos);
+                    Ok(())
+                }
+                Target::ClusterName(cluster_name) => {
+                    let (acl_infos, failed_broker_addr) =
+                        list_acl_from_cluster(&command, &default_mqadmin_ext, &cluster_name).await?;
+                    print_acls(acl_infos);
+                    if failed_broker_addr.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(RocketMQError::Internal(format!(
+                            "ListAclSubCommand: Failed to list ACLs for brokers {}",
+                            failed_broker_addr.join(", ")
+                        )))
+                    }
+                }
+            }
+        }
+        .await;
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+async fn list_acl_from_broker(
+    parsed_command: &ParsedListAclSubCommand,
+    default_mqadmin_ext: &DefaultMQAdminExt,
+    broker_addr: &str,
+) -> Result<Vec<AclInfo>, RocketMQError> {
+    match default_mqadmin_ext
+        .list_acl(
+            broker_addr.into(),
+            parsed_command.subject_filter.clone(),
+            CheetahString::default(),
+        )
+        .await
+    {
+        Ok(acl_infos) => {
+            println!("List ACL command was successful for broker {}.", broker_addr);
+            Ok(acl_infos)
+        }
+        Err(e) => Err(RocketMQError::Internal(format!(
+            "ListAclSubCommand: Failed to list ACL for broker {}: {}",
+            broker_addr, e
+        ))),
+    }
+}
+
+async fn list_acl_from_cluster(
+    parsed_command: &ParsedListAclSubCommand,
+    default_mqadmin_ext: &DefaultMQAdminExt,
+    cluster_name: &str,
+) -> Result<(Vec<AclInfo>, Vec<CheetahString>), RocketMQError> {
+    let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await?;
+
+    match CommandUtil::fetch_master_and_slave_addr_by_cluster_name(&cluster_info, cluster_name) {
+        Ok(addresses) => {
+            let results: Vec<Result<Vec<AclInfo>, CheetahString>> =
+                futures::future::join_all(addresses.into_iter().map(|addr| async {
+                    list_acl_from_broker(parsed_command, default_mqadmin_ext, addr.as_str())
+                        .await
+                        .map_err(|_err| addr)
+                }))
+                .await;
+
+            let (acls, errors): (Vec<_>, Vec<_>) = results.into_iter().partition(Result::is_ok);
+            let acls: Vec<AclInfo> = acls.into_iter().flat_map(Result::unwrap).collect();
+            let failed_addr: Vec<CheetahString> = errors.into_iter().map(Result::unwrap_err).collect();
+
+            Ok((acls, failed_addr))
+        }
+        Err(e) => Err(RocketMQError::Internal(format!(
+            "ListAclSubCommand: Failed to list ACL: {}",
+            e
+        ))),
+    }
+}
+
+fn print_acls(acls: Vec<AclInfo>) {
+    let rows = deduplicate_rows(expand_acl_rows(acls));
+    println!(
+        "{:<24}  {:<24}  {:<20}  {:<24}  {:<12}  {:<12}",
+        "Subject", "Resources", "Actions", "SourceIps", "Decision", "PolicyType"
+    );
+    println!("{}", "=".repeat(126));
+    rows.iter().for_each(|row| {
+        println!(
+            "{:<24}  {:<24}  {:<20}  {:<24}  {:<12}  {:<12}",
+            row.subject, row.resource, row.actions, row.source_ips, row.decision, row.policy_type
+        );
+    });
+    println!();
+    println!("Total ACL entries: {}", rows.len());
+}
+
+fn expand_acl_rows(acls: Vec<AclInfo>) -> Vec<AclRow> {
+    let mut rows = Vec::new();
+
+    for acl in acls {
+        let subject = value_or_default(acl.subject.as_ref().map(|v| v.as_str()));
+        let policies = acl.policies.unwrap_or_default();
+        if policies.is_empty() {
+            rows.push(AclRow {
+                subject: subject.clone(),
+                resource: "*".to_string(),
+                actions: "*".to_string(),
+                source_ips: "*".to_string(),
+                decision: "*".to_string(),
+                policy_type: "*".to_string(),
+            });
+            continue;
+        }
+
+        for policy in policies {
+            let policy_type = value_or_default(policy.policy_type.as_ref().map(|v| v.as_str()));
+            let entries = policy.entries.unwrap_or_default();
+            if entries.is_empty() {
+                rows.push(AclRow {
+                    subject: subject.clone(),
+                    resource: "*".to_string(),
+                    actions: "*".to_string(),
+                    source_ips: "*".to_string(),
+                    decision: "*".to_string(),
+                    policy_type: policy_type.clone(),
+                });
+                continue;
+            }
+
+            for entry in entries {
+                let source_ips = entry
+                    .source_ips
+                    .as_ref()
+                    .filter(|ips| !ips.is_empty())
+                    .map(|ips| ips.iter().map(|ip| ip.as_str()).collect::<Vec<_>>().join(","))
+                    .unwrap_or_else(|| "*".to_string());
+
+                rows.push(AclRow {
+                    subject: subject.clone(),
+                    resource: value_or_default(entry.resource.as_ref().map(|v| v.as_str())),
+                    actions: value_or_default(entry.actions.as_ref().map(|v| v.as_str())),
+                    source_ips,
+                    decision: value_or_default(entry.decision.as_ref().map(|v| v.as_str())),
+                    policy_type: policy_type.clone(),
+                });
+            }
+        }
+    }
+
+    rows
+}
+
+fn deduplicate_rows(rows: Vec<AclRow>) -> Vec<AclRow> {
+    let mut unique = HashSet::new();
+    let mut deduplicated = Vec::new();
+    for row in rows {
+        if unique.insert(row.clone()) {
+            deduplicated.push(row);
+        }
+    }
+    deduplicated.sort();
+    deduplicated
+}
+
+fn value_or_default(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "*".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+
+    use clap::Parser;
+
+    use crate::commands::auth_commands::list_acl_sub_command::ListAclSubCommand;
+
+    #[test]
+    fn test_list_acl_sub_command_with_broker_addr_using_short_commands() {
+        let args = [
+            vec![""],
+            vec!["-n", "127.0.0.1:9876"],
+            vec!["-b", "127.0.0.1:10911"],
+            vec!["-s", "user:alice"],
+        ];
+
+        let args = args.concat();
+
+        let cmd = ListAclSubCommand::try_parse_from(args).unwrap();
+        assert_eq!(Some("127.0.0.1:10911"), cmd.broker_addr.as_deref());
+        assert_eq!(Some("user:alice"), cmd.subject.as_deref());
+        assert_eq!(Some("127.0.0.1:9876"), cmd.common_args.namesrv_addr.as_deref());
+    }
+
+    #[test]
+    fn test_list_acl_sub_command_with_cluster_name_using_short_commands() {
+        let args = [
+            vec![""],
+            vec!["-n", "127.0.0.1:9876"],
+            vec!["-c", "DefaultCluster"],
+            vec!["-s", "user:bob"],
+        ];
+
+        let args = args.concat();
+
+        let cmd = ListAclSubCommand::try_parse_from(args).unwrap();
+        assert_eq!(Some("DefaultCluster"), cmd.cluster_name.as_deref());
+        assert_eq!(Some("user:bob"), cmd.subject.as_deref());
+        assert_eq!(Some("127.0.0.1:9876"), cmd.common_args.namesrv_addr.as_deref());
+    }
+
+    #[test]
+    fn test_list_acl_sub_command_using_conflicting_commands() {
+        let args = [
+            vec![""],
+            vec!["-n", "127.0.0.1:9876"],
+            vec!["-b", "127.0.0.1:10911"],
+            vec!["-c", "DefaultCluster"],
+            vec!["-s", "user:alice"],
+        ];
+
+        let args = args.concat();
+
+        let result = ListAclSubCommand::try_parse_from(args);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5663

### Brief Description

- Implement `auth listAcl` command for ACL enumeration from broker/cluster.
- Add optional subject filter (`-s/--subject`), deduplicate ACL rows across cluster results, print tabular output, and show total ACL entries.
- Wire `AuthListAcl` request path end-to-end:
  - add `ListAclRequestHeader`
  - implement `MQClientAPIImpl::list_acl`
  - implement admin ext forwarding for `list_acl`
- Apply namesrv address from `-n/--namesrvAddr` in `listAcl` execution.
- Implementation pattern follows existing auth command: `listUsers`.


<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
- `cargo fmt --all`
- `cargo test -p rocketmq-admin-core commands::auth_commands::list_acl_sub_command`
- `cargo check -p rocketmq-client-rust`
- `cargo test -p rocketmq-admin-core`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new ACL listing command to the admin tool. Users can now enumerate Access Control Lists from a specific broker or across the entire cluster, with optional filtering by subject name. Results are deduplicated, formatted, and displayed with a summary count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->