### PR TITLE
[ISSUE #6116]🚀Add re-exported protocol bodies and headers for simplified access

### DIFF
--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -30,12 +30,14 @@ use serde::Serializer;
 use crate::rocketmq_serializable::RocketMQSerializable;
 
 pub mod admin;
+pub mod bodies;
 pub mod body;
 pub mod broker_sync_info;
 pub mod command_custom_header;
 pub mod filter;
 pub mod forbidden_type;
 pub mod header;
+pub mod headers;
 pub mod heartbeat;
 pub mod namespace_util;
 pub mod namesrv;
@@ -47,6 +49,11 @@ pub mod route;
 pub mod static_topic;
 pub mod subscription;
 pub mod topic;
+
+// Re-export commonly used protocol types at protocol module level
+pub use self::command_custom_header::CommandCustomHeader;
+pub use self::command_custom_header::FromMap;
+pub use self::remoting_command::RemotingCommand;
 
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq)]

--- a/rocketmq-remoting/src/protocol/bodies.rs
+++ b/rocketmq-remoting/src/protocol/bodies.rs
@@ -1,0 +1,228 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Re-exported request/response bodies organized by category
+//!
+//! This module provides simplified access to commonly used bodies through re-exports.
+//! Original module paths remain functional for backward compatibility.
+//!
+//! # Usage Examples
+//!
+//! ## Import by category
+//! ```rust
+//! use rocketmq_remoting::protocol::bodies::broker::ClusterInfo;
+//! use rocketmq_remoting::protocol::bodies::consumer::ConsumerConnection;
+//! ```
+//!
+//! ## Import most common types directly
+//! ```rust
+//! use rocketmq_remoting::protocol::bodies::BatchAckMessageRequestBody;
+//! use rocketmq_remoting::protocol::bodies::ClusterInfo;
+//! ```
+
+// ============================================================================
+// Message Bodies
+// ============================================================================
+
+pub mod message {
+    pub use super::super::body::batch_ack::BatchAck;
+    pub use super::super::body::batch_ack_message_request_body::BatchAckMessageRequestBody;
+    pub use super::super::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
+}
+
+// ============================================================================
+// Broker Bodies
+// ============================================================================
+
+pub mod broker {
+    pub use super::super::body::broker_body::broker_member_group::BrokerMemberGroup;
+    pub use super::super::body::broker_body::broker_member_group::GetBrokerMemberGroupResponseBody;
+    pub use super::super::body::broker_body::cluster_info::ClusterInfo;
+    pub use super::super::body::broker_body::register_broker_body::RegisterBrokerBody;
+    pub use super::super::body::broker_item::BrokerStatsItem;
+    pub use super::super::body::broker_replicas_info::BrokerReplicasInfo;
+    pub use super::super::body::broker_replicas_info::ReplicaIdentity;
+    pub use super::super::body::broker_replicas_info::ReplicasInfo;
+    pub use super::super::body::get_broker_lite_info_response_body::GetBrokerLiteInfoResponseBody;
+}
+
+// ============================================================================
+// Consumer Bodies
+// ============================================================================
+
+pub mod consumer {
+    pub use super::super::body::connection::Connection;
+    pub use super::super::body::consume_by_who::ConsumeByWho;
+    pub use super::super::body::consume_queue_data::ConsumeQueueData;
+    pub use super::super::body::consume_status::ConsumeStatus;
+    pub use super::super::body::consumer_connection::ConsumerConnection;
+    pub use super::super::body::consumer_offset_serialize_wrapper::ConsumerOffsetSerializeWrapper;
+    pub use super::super::body::consumer_running_info::ConsumerRunningInfo;
+    pub use super::super::body::get_consumer_listby_group_response_body::GetConsumerListByGroupResponseBody;
+    pub use super::super::body::get_lite_client_info_response_body::GetLiteClientInfoResponseBody;
+    pub use super::super::body::get_lite_group_info_response_body::GetLiteGroupInfoResponseBody;
+    pub use super::super::body::lite_lag_info::LiteLagInfo;
+    pub use super::super::body::pop_process_queue_info::PopProcessQueueInfo;
+    pub use super::super::body::process_queue_info::ProcessQueueInfo;
+}
+
+// ============================================================================
+// Producer Bodies
+// ============================================================================
+
+pub mod producer {
+    pub use super::super::body::producer_connection::ProducerConnection;
+    pub use super::super::body::producer_info::ProducerInfo;
+    pub use super::super::body::producer_table_info::ProducerTableInfo;
+}
+
+// ============================================================================
+// Topic Bodies
+// ============================================================================
+
+pub mod topic {
+    pub use super::super::body::create_topic_list_request_body::CreateTopicListRequestBody;
+    pub use super::super::body::get_lite_topic_info_response_body::GetLiteTopicInfoResponseBody;
+    pub use super::super::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
+    pub use super::super::body::topic::topic_list::TopicList;
+    pub use super::super::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
+    pub use super::super::body::topic_info_wrapper::topic_config_wrapper::TopicConfigSerializeWrapper;
+    pub use super::super::body::topic_info_wrapper::topic_queue_wrapper::TopicQueueMappingSerializeWrapper;
+}
+
+// ============================================================================
+// Subscription Bodies
+// ============================================================================
+
+pub mod subscription {
+    pub use super::super::body::message_request_mode_serialize_wrapper::MessageRequestModeSerializeWrapper;
+    pub use super::super::body::set_message_request_mode_request_body::SetMessageRequestModeRequestBody;
+    pub use super::super::body::subscription_group_wrapper::SubscriptionGroupWrapper;
+}
+
+// ============================================================================
+// Response Bodies
+// ============================================================================
+
+pub mod response {
+    pub use super::super::body::response::get_consumer_status_body::GetConsumerStatusBody;
+    pub use super::super::body::response::lock_batch_response_body::LockBatchResponseBody;
+    pub use super::super::body::response::reset_offset_body::ResetOffsetBody;
+    pub use super::super::body::response::reset_offset_body::ResetOffsetBodyForC;
+}
+
+// ============================================================================
+// Request Bodies
+// ============================================================================
+
+pub mod request {
+    pub use super::super::body::check_client_request_body::CheckClientRequestBody;
+    pub use super::super::body::query_assignment_request_body::QueryAssignmentRequestBody;
+    pub use super::super::body::request::lock_batch_request_body::LockBatchRequestBody;
+    pub use super::super::body::unlock_batch_request_body::UnlockBatchRequestBody;
+}
+
+// ============================================================================
+// Query Bodies
+// ============================================================================
+
+pub mod query {
+    pub use super::super::body::query_assignment_response_body::QueryAssignmentResponseBody;
+    pub use super::super::body::query_consume_queue_response_body::QueryConsumeQueueResponseBody;
+}
+
+// ============================================================================
+// High Availability (HA) Bodies
+// ============================================================================
+
+pub mod ha {
+    pub use super::super::body::ha_client_runtime_info::HAClientRuntimeInfo;
+    pub use super::super::body::ha_connection_runtime_info::HAConnectionRuntimeInfo;
+    pub use super::super::body::ha_runtime_info::HARuntimeInfo;
+}
+
+// ============================================================================
+// ACL and Security Bodies
+// ============================================================================
+
+pub mod acl {
+    pub use super::super::body::acl_info::AclInfo;
+    pub use super::super::body::acl_info::PolicyEntryInfo;
+    pub use super::super::body::acl_info::PolicyInfo;
+    pub use super::super::body::cluster_acl_version_info::ClusterAclVersionInfo;
+}
+
+// ============================================================================
+// User Management Bodies
+// ============================================================================
+
+pub mod user {
+    pub use super::super::body::user_info::UserInfo;
+}
+
+// ============================================================================
+// Controller and Sync Bodies
+// ============================================================================
+
+pub mod controller {
+    pub use super::super::body::elect_master_response_body::ElectMasterResponseBody;
+    pub use super::super::body::sync_state_set_body::SyncStateSet;
+}
+
+// ============================================================================
+// Utility Bodies
+// ============================================================================
+
+pub mod util {
+    pub use super::super::body::cm_result::CMResult;
+    pub use super::super::body::epoch_entry_cache::EpochEntry;
+    pub use super::super::body::epoch_entry_cache::EpochEntryCache;
+    pub use super::super::body::group_list::GroupList;
+    pub use super::super::body::kv_table::KVTable;
+    pub use super::super::body::queue_time_span::QueueTimeSpan;
+    pub use super::super::body::timer_metrics_serialize_wrapper::Metric;
+    pub use super::super::body::timer_metrics_serialize_wrapper::TimerMetricsSerializeWrapper;
+}
+
+// ============================================================================
+// Top-Level Exports (Most Frequently Used Bodies)
+// ============================================================================
+// These are available as: rocketmq_remoting::protocol::bodies::<TypeName>
+
+// Message operations (most frequently used)
+pub use super::body::batch_ack_message_request_body::BatchAckMessageRequestBody;
+
+// Broker operations
+pub use super::body::broker_body::cluster_info::ClusterInfo;
+
+// Consumer operations
+pub use super::body::consumer_connection::ConsumerConnection;
+pub use super::body::consumer_running_info::ConsumerRunningInfo;
+pub use super::body::get_consumer_listby_group_response_body::GetConsumerListByGroupResponseBody;
+
+// Topic operations
+pub use super::body::topic_info_wrapper::topic_config_wrapper::TopicConfigSerializeWrapper;
+
+// Subscription operations
+pub use super::body::subscription_group_wrapper::SubscriptionGroupWrapper;
+
+// Lock operations
+pub use super::body::request::lock_batch_request_body::LockBatchRequestBody;
+pub use super::body::response::lock_batch_response_body::LockBatchResponseBody;
+
+// Query operations
+pub use super::body::query_assignment_response_body::QueryAssignmentResponseBody;
+
+// Utility
+pub use super::body::kv_table::KVTable;

--- a/rocketmq-remoting/src/protocol/headers.rs
+++ b/rocketmq-remoting/src/protocol/headers.rs
@@ -1,0 +1,301 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Re-exported request/response headers organized by category
+//!
+//! This module provides simplified access to commonly used headers through re-exports.
+//! Original module paths remain functional for backward compatibility.
+//!
+//! # Usage Examples
+//!
+//! ## Import by category
+//! ```rust
+//! use rocketmq_remoting::protocol::headers::message::SendMessageRequestHeader;
+//! use rocketmq_remoting::protocol::headers::namesrv::RegisterBrokerRequestHeader;
+//! use rocketmq_remoting::protocol::headers::namesrv::UnRegisterBrokerRequestHeader;
+//! ```
+//!
+//! ## Import most common types directly
+//! ```rust
+//! use rocketmq_remoting::protocol::headers::PullMessageRequestHeader;
+//! use rocketmq_remoting::protocol::headers::SendMessageRequestHeader;
+//! ```
+
+// ============================================================================
+// Message Operation Headers (Most Common)
+// ============================================================================
+
+/// Send and receive message headers
+pub mod message {
+    pub use super::super::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
+    pub use super::super::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
+    pub use super::super::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+}
+
+/// Pull and query message headers
+pub mod polling {
+    pub use super::super::header::peek_message_request_header::PeekMessageRequestHeader;
+    pub use super::super::header::polling_info_request_header::PollingInfoRequestHeader;
+    pub use super::super::header::polling_info_response_header::PollingInfoResponseHeader;
+    pub use super::super::header::pop_message_request_header::PopMessageRequestHeader;
+    pub use super::super::header::pop_message_response_header::PopMessageResponseHeader;
+    pub use super::super::header::pull_message_request_header::PullMessageRequestHeader;
+    pub use super::super::header::pull_message_response_header::PullMessageResponseHeader;
+}
+
+/// Acknowledgment headers
+pub mod ack {
+    pub use super::super::header::ack_message_request_header::AckMessageRequestHeader;
+    pub use super::super::header::change_invisible_time_request_header::ChangeInvisibleTimeRequestHeader;
+    pub use super::super::header::change_invisible_time_response_header::ChangeInvisibleTimeResponseHeader;
+}
+
+/// Query message headers
+pub mod query {
+    pub use super::super::header::query_consume_time_span_request_header::QueryConsumeTimeSpanRequestHeader;
+    pub use super::super::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
+    pub use super::super::header::query_consumer_offset_response_header::QueryConsumerOffsetResponseHeader;
+    pub use super::super::header::query_message_request_header::QueryMessageRequestHeader;
+    pub use super::super::header::query_message_response_header::QueryMessageResponseHeader;
+    pub use super::super::header::query_subscription_by_consumer_request_header::QuerySubscriptionByConsumerRequestHeader;
+    pub use super::super::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
+    pub use super::super::header::query_topics_by_consumer_request_header::QueryTopicsByConsumerRequestHeader;
+}
+
+/// View and search message headers
+pub mod view {
+    pub use super::super::header::search_offset_request_header::SearchOffsetRequestHeader;
+    pub use super::super::header::search_offset_response_header::SearchOffsetResponseHeader;
+    pub use super::super::header::view_message_request_header::ViewMessageRequestHeader;
+    pub use super::super::header::view_message_response_header::ViewMessageResponseHeader;
+}
+
+// ============================================================================
+// Client Management Headers
+// ============================================================================
+
+pub mod client {
+    pub use super::super::header::client_request_header::GetRouteInfoRequestHeader;
+    pub use super::super::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
+    pub use super::super::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
+    pub use super::super::header::get_consumer_listby_group_response_header::GetConsumerListByGroupResponseHeader;
+    pub use super::super::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader;
+    pub use super::super::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader;
+    pub use super::super::header::heartbeat_request_header::HeartbeatRequestHeader;
+    pub use super::super::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
+    pub use super::super::header::unregister_client_request_header::UnregisterClientRequestHeader;
+}
+
+// ============================================================================
+// NameServer Operation Headers
+// ============================================================================
+
+pub mod namesrv {
+    pub use super::super::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
+    pub use super::super::header::namesrv::broker_request::GetBrokerMemberGroupRequestHeader;
+    pub use super::super::header::namesrv::broker_request::UnRegisterBrokerRequestHeader;
+    pub use super::super::header::namesrv::brokerid_change_request_header::NotifyMinBrokerIdChangeRequestHeader;
+    pub use super::super::header::namesrv::kv_config_header::DeleteKVConfigRequestHeader;
+    pub use super::super::header::namesrv::kv_config_header::GetKVConfigRequestHeader;
+    pub use super::super::header::namesrv::kv_config_header::GetKVConfigResponseHeader;
+    pub use super::super::header::namesrv::kv_config_header::GetKVListByNamespaceRequestHeader;
+    pub use super::super::header::namesrv::kv_config_header::PutKVConfigRequestHeader;
+    pub use super::super::header::namesrv::perm_broker_header::AddWritePermOfBrokerRequestHeader;
+    pub use super::super::header::namesrv::perm_broker_header::AddWritePermOfBrokerResponseHeader;
+    pub use super::super::header::namesrv::perm_broker_header::WipeWritePermOfBrokerRequestHeader;
+    pub use super::super::header::namesrv::perm_broker_header::WipeWritePermOfBrokerResponseHeader;
+    pub use super::super::header::namesrv::query_data_version_header::QueryDataVersionRequestHeader;
+    pub use super::super::header::namesrv::query_data_version_header::QueryDataVersionResponseHeader;
+    pub use super::super::header::namesrv::register_broker_header::RegisterBrokerRequestHeader;
+    pub use super::super::header::namesrv::register_broker_header::RegisterBrokerResponseHeader;
+    pub use super::super::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
+    pub use super::super::header::namesrv::topic_operation_header::GetTopicsByClusterRequestHeader;
+    pub use super::super::header::namesrv::topic_operation_header::RegisterTopicRequestHeader;
+    pub use super::super::header::namesrv::topic_operation_header::TopicRequestHeader;
+}
+
+// ============================================================================
+// Broker Operation Headers
+// ============================================================================
+
+pub mod broker {
+    pub use super::super::header::broker::broker_heartbeat_request_header::BrokerHeartbeatRequestHeader;
+}
+
+// ============================================================================
+// Controller Operation Headers
+// ============================================================================
+
+pub mod controller {
+    pub use super::super::header::controller::alter_sync_state_set_request_header::AlterSyncStateSetRequestHeader;
+    pub use super::super::header::controller::alter_sync_state_set_response_header::AlterSyncStateSetResponseHeader;
+    pub use super::super::header::controller::apply_broker_id_request_header::ApplyBrokerIdRequestHeader;
+    pub use super::super::header::controller::apply_broker_id_response_header::ApplyBrokerIdResponseHeader;
+    pub use super::super::header::controller::elect_master_request_header::ElectMasterRequestHeader;
+    pub use super::super::header::controller::get_next_broker_id_request_header::GetNextBrokerIdRequestHeader;
+    pub use super::super::header::controller::get_next_broker_id_response_header::GetNextBrokerIdResponseHeader;
+    pub use super::super::header::controller::get_replica_info_request_header::GetReplicaInfoRequestHeader;
+    pub use super::super::header::controller::get_replica_info_response_header::GetReplicaInfoResponseHeader;
+    pub use super::super::header::controller::register_broker_to_controller_request_header::RegisterBrokerToControllerRequestHeader;
+    pub use super::super::header::controller::register_broker_to_controller_response_header::RegisterBrokerToControllerResponseHeader;
+}
+
+// ============================================================================
+// Administrative Headers
+// ============================================================================
+
+pub mod admin {
+    pub use super::super::header::create_topic_request_header::CreateTopicRequestHeader;
+    pub use super::super::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
+    pub use super::super::header::delete_topic_request_header::DeleteTopicRequestHeader;
+    pub use super::super::header::get_all_topic_config_response_header::GetAllTopicConfigResponseHeader;
+    pub use super::super::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader;
+    pub use super::super::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
+    pub use super::super::header::get_topic_config_request_header::GetTopicConfigRequestHeader;
+    pub use super::super::header::get_topic_stats_info_request_header::GetTopicStatsInfoRequestHeader;
+    pub use super::super::header::get_topic_stats_request_header::GetTopicStatsRequestHeader;
+}
+
+// ============================================================================
+// Transaction Headers
+// ============================================================================
+
+pub mod transaction {
+    pub use super::super::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
+    pub use super::super::header::end_transaction_request_header::EndTransactionRequestHeader;
+}
+
+// ============================================================================
+// Consumer Offset Headers
+// ============================================================================
+
+pub mod offset {
+    pub use super::super::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
+    pub use super::super::header::query_consumer_offset_response_header::QueryConsumerOffsetResponseHeader;
+    pub use super::super::header::reset_offset_request_header::ResetOffsetRequestHeader;
+    pub use super::super::header::search_offset_request_header::SearchOffsetRequestHeader;
+    pub use super::super::header::search_offset_response_header::SearchOffsetResponseHeader;
+    pub use super::super::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
+    pub use super::super::header::update_consumer_offset_header::UpdateConsumerOffsetResponseHeader;
+}
+
+// ============================================================================
+// Message Queue Lock Headers
+// ============================================================================
+
+pub mod lock {
+    pub use super::super::header::lock_batch_mq_request_header::LockBatchMqRequestHeader;
+    pub use super::super::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader;
+}
+
+// ============================================================================
+// Offset Query Headers
+// ============================================================================
+
+pub mod min_offset {
+    pub use super::super::header::get_min_offset_request_header::GetMinOffsetRequestHeader;
+    pub use super::super::header::get_min_offset_response_header::GetMinOffsetResponseHeader;
+}
+
+pub mod max_offset {
+    pub use super::super::header::get_max_offset_request_header::GetMaxOffsetRequestHeader;
+    pub use super::super::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
+}
+
+// ============================================================================
+// ACL and Security Headers
+// ============================================================================
+
+pub mod acl {
+    pub use super::super::header::create_user_request_header::CreateUserRequestHeader;
+    pub use super::super::header::delete_acl_request_header::DeleteAclRequestHeader;
+    pub use super::super::header::delete_user_request_header::DeleteUserRequestHeader;
+    pub use super::super::header::get_user_request_headers::GetUserRequestHeader;
+    pub use super::super::header::list_acl_request_header::ListAclRequestHeader;
+    pub use super::super::header::list_users_request_header::ListUsersRequestHeader;
+    pub use super::super::header::update_user_request_header::UpdateUserRequestHeader;
+}
+
+// ============================================================================
+// Special Message Headers
+// ============================================================================
+
+pub mod special {
+    pub use super::super::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
+    pub use super::super::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
+    pub use super::super::header::reply_message_request_header::ReplyMessageRequestHeader;
+}
+
+// ============================================================================
+// Notification and HA Headers
+// ============================================================================
+
+pub mod notification {
+    pub use super::super::header::notification_request_header::NotificationRequestHeader;
+    pub use super::super::header::notification_response_header::NotificationResponseHeader;
+    pub use super::super::header::notify_broker_role_change_request_header::NotifyBrokerRoleChangedRequestHeader;
+}
+
+pub mod ha {
+    pub use super::super::header::exchange_ha_info_request_header::ExchangeHAInfoRequestHeader;
+    pub use super::super::header::exchange_ha_info_response_header::ExchangeHaInfoResponseHeader;
+    pub use super::super::header::reset_master_flush_offset_header::ResetMasterFlushOffsetHeader;
+}
+
+// ============================================================================
+// Utility Headers
+// ============================================================================
+
+pub mod util {
+    pub use super::super::header::elect_master_response_header::ElectMasterResponseHeader;
+    pub use super::super::header::empty_header::EmptyHeader;
+    pub use super::super::header::get_earliest_msg_storetime_response_header::GetEarliestMsgStoretimeResponseHeader;
+    pub use super::super::header::get_meta_data_response_header::GetMetaDataResponseHeader;
+}
+
+// ============================================================================
+// Top-Level Exports (Most Frequently Used Headers)
+// ============================================================================
+// These are available as: rocketmq_remoting::protocol::headers::<TypeName>
+
+// Message operations (most frequently used)
+pub use super::header::ack_message_request_header::AckMessageRequestHeader;
+pub use super::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
+pub use super::header::pop_message_request_header::PopMessageRequestHeader;
+pub use super::header::pull_message_request_header::PullMessageRequestHeader;
+
+// Client operations
+pub use super::header::client_request_header::GetRouteInfoRequestHeader;
+pub use super::header::heartbeat_request_header::HeartbeatRequestHeader;
+
+// NameServer operations
+pub use super::header::namesrv::broker_request::UnRegisterBrokerRequestHeader;
+pub use super::header::namesrv::register_broker_header::RegisterBrokerRequestHeader;
+
+// Common response headers
+pub use super::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
+pub use super::header::get_min_offset_response_header::GetMinOffsetResponseHeader;
+pub use super::header::pull_message_response_header::PullMessageResponseHeader;
+
+// Administrative operations
+pub use super::header::create_topic_request_header::CreateTopicRequestHeader;
+pub use super::header::delete_topic_request_header::DeleteTopicRequestHeader;
+pub use super::header::get_topic_config_request_header::GetTopicConfigRequestHeader;
+
+// Offset operations
+pub use super::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
+pub use super::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
+
+// Utility
+pub use super::header::empty_header::EmptyHeader;

--- a/rocketmq-remoting/tests/test_reexports.rs
+++ b/rocketmq-remoting/tests/test_reexports.rs
@@ -1,0 +1,114 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the new re-export functionality
+
+#[test]
+fn test_protocol_headers_reexports() {
+    // Test importing from protocol::headers module
+    use rocketmq_remoting::protocol::headers::client::GetRouteInfoRequestHeader;
+    use rocketmq_remoting::protocol::headers::message::SendMessageRequestHeader;
+    use rocketmq_remoting::protocol::headers::namesrv::RegisterBrokerRequestHeader;
+    use rocketmq_remoting::protocol::headers::namesrv::UnRegisterBrokerRequestHeader;
+    use rocketmq_remoting::protocol::headers::polling::PullMessageRequestHeader;
+
+    // Verify types are accessible (just checking type resolution)
+    let _send_header: Option<SendMessageRequestHeader> = None;
+    let _pull_header: Option<PullMessageRequestHeader> = None;
+    let _route_header: Option<GetRouteInfoRequestHeader> = None;
+    let _reg_header: Option<RegisterBrokerRequestHeader> = None;
+    let _unreg_header: Option<UnRegisterBrokerRequestHeader> = None;
+}
+
+#[test]
+fn test_protocol_bodies_reexports() {
+    // Test importing from protocol::bodies module
+    use rocketmq_remoting::protocol::bodies::broker::ClusterInfo;
+    use rocketmq_remoting::protocol::bodies::consumer::ConsumerConnection;
+    use rocketmq_remoting::protocol::bodies::message::BatchAckMessageRequestBody;
+
+    // Verify types are accessible (just checking type resolution)
+    let _ack_body: Option<BatchAckMessageRequestBody> = None;
+    let _cluster_info: Option<ClusterInfo> = None;
+    let _consumer_conn: Option<ConsumerConnection> = None;
+}
+
+#[test]
+fn test_protocol_top_level_reexports() {
+    // Test importing top-level protocol types
+    use rocketmq_remoting::protocol::RemotingCommand;
+
+    // Verify RemotingCommand is accessible
+    let _command: Option<RemotingCommand> = None;
+}
+
+#[test]
+fn test_headers_top_level_reexports() {
+    // Test importing most common headers directly from protocol::headers
+    use rocketmq_remoting::protocol::headers::AckMessageRequestHeader;
+    use rocketmq_remoting::protocol::headers::CreateTopicRequestHeader;
+    use rocketmq_remoting::protocol::headers::GetRouteInfoRequestHeader;
+    use rocketmq_remoting::protocol::headers::HeartbeatRequestHeader;
+    use rocketmq_remoting::protocol::headers::PullMessageRequestHeader;
+    use rocketmq_remoting::protocol::headers::SendMessageRequestHeader;
+
+    // Verify types are accessible (just checking type resolution)
+    let _ack_header: Option<AckMessageRequestHeader> = None;
+    let _create_header: Option<CreateTopicRequestHeader> = None;
+    let _route_header: Option<GetRouteInfoRequestHeader> = None;
+    let _heartbeat_header: Option<HeartbeatRequestHeader> = None;
+    let _pull_header: Option<PullMessageRequestHeader> = None;
+    let _send_header: Option<SendMessageRequestHeader> = None;
+}
+
+#[test]
+fn test_bodies_top_level_reexports() {
+    // Test importing most common bodies directly from protocol::bodies
+    use rocketmq_remoting::protocol::bodies::BatchAckMessageRequestBody;
+    use rocketmq_remoting::protocol::bodies::ClusterInfo;
+    use rocketmq_remoting::protocol::bodies::ConsumerConnection;
+
+    // Verify types are accessible (just checking type resolution)
+    let _ack_body: Option<BatchAckMessageRequestBody> = None;
+    let _cluster_info: Option<ClusterInfo> = None;
+    let _consumer_conn: Option<ConsumerConnection> = None;
+}
+
+#[test]
+fn test_backward_compatibility() {
+    // Verify that old import paths still work
+    use rocketmq_remoting::protocol::body::batch_ack_message_request_body::BatchAckMessageRequestBody;
+    use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
+    use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+
+    // Old paths should still work (just checking type resolution)
+    let _pull_header: Option<PullMessageRequestHeader> = None;
+    let _send_header: Option<SendMessageRequestHeader> = None;
+    let _ack_body: Option<BatchAckMessageRequestBody> = None;
+}
+
+#[test]
+fn test_categorized_imports_by_functionality() {
+    // Test importing related headers together using category modules
+    use rocketmq_remoting::protocol::headers::ack::AckMessageRequestHeader;
+    use rocketmq_remoting::protocol::headers::client::HeartbeatRequestHeader;
+    use rocketmq_remoting::protocol::headers::message::SendMessageRequestHeader;
+    use rocketmq_remoting::protocol::headers::polling::PullMessageRequestHeader;
+
+    // Verify types are accessible (just checking type resolution)
+    let _ack: Option<AckMessageRequestHeader> = None;
+    let _heartbeat: Option<HeartbeatRequestHeader> = None;
+    let _send: Option<SendMessageRequestHeader> = None;
+    let _pull: Option<PullMessageRequestHeader> = None;
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6116

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized protocol module with new categorized sub-modules providing simplified access to commonly used types through strategic top-level re-exports. Improves developer experience by reducing import complexity and promoting cleaner code organization.

* **Tests**
  * Added comprehensive test coverage validating re-export functionality, import accessibility across multiple module structures, and backward compatibility with existing import paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->