### PR TITLE
[ISSUE #6090]🧪Add test case for TopicQueueMappingContext

### DIFF
--- a/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_context.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_context.rs
@@ -45,9 +45,7 @@ impl TopicQueueMappingContext {
             current_item: None,
         }
     }
-}
 
-impl TopicQueueMappingContext {
     pub fn is_leader(&self) -> bool {
         if let Some(leader_item) = &self.leader_item {
             match leader_item.bname {
@@ -66,5 +64,93 @@ impl TopicQueueMappingContext {
             }
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo;
+
+    #[test]
+    fn topic_queue_mapping_context_default() {
+        let context = TopicQueueMappingContext::default();
+        assert_eq!(context.topic, "");
+        assert!(context.global_id.is_none());
+        assert!(context.mapping_detail.is_none());
+        assert!(context.mapping_item_list.is_empty());
+        assert!(context.leader_item.is_none());
+        assert!(context.current_item.is_none());
+    }
+
+    #[test]
+    fn topic_queue_mapping_context_new() {
+        let topic = "test_topic";
+        let global_id = Some(1);
+        let mapping_detail = ArcMut::new(TopicQueueMappingDetail::default());
+        let mapping_item_list = vec![LogicQueueMappingItem::default()];
+        let leader_item = LogicQueueMappingItem::default();
+
+        let context = TopicQueueMappingContext::new(
+            topic,
+            global_id,
+            Some(mapping_detail.clone()),
+            mapping_item_list.clone(),
+            Some(leader_item.clone()),
+        );
+
+        assert_eq!(context.topic, CheetahString::from(topic));
+        assert_eq!(context.global_id, global_id);
+        assert_eq!(context.mapping_detail.unwrap(), mapping_detail);
+        assert_eq!(context.mapping_item_list.len(), 1);
+        assert_eq!(context.leader_item.unwrap(), leader_item);
+        assert!(context.current_item.is_none());
+    }
+
+    #[test]
+    fn topic_queue_mapping_context_is_leader() {
+        let broker_name = CheetahString::from("broker_a");
+        let leader_item = LogicQueueMappingItem {
+            bname: Some(broker_name.clone()),
+            ..Default::default()
+        };
+        let mapping_detail = TopicQueueMappingDetail {
+            topic_queue_mapping_info: TopicQueueMappingInfo {
+                bname: Some(broker_name.clone()),
+                ..TopicQueueMappingInfo::default()
+            },
+            ..Default::default()
+        };
+        let mut context = TopicQueueMappingContext {
+            leader_item: Some(leader_item.clone()),
+            mapping_detail: Some(ArcMut::new(mapping_detail)),
+            ..Default::default()
+        };
+
+        // Match: should be leader
+        assert!(context.is_leader());
+
+        // No mapping_detail: not leader
+        context.mapping_detail = None;
+        assert!(!context.is_leader());
+
+        // Different bname in mapping_detail: not leader
+        let diff_mapping_detail = TopicQueueMappingDetail {
+            topic_queue_mapping_info: TopicQueueMappingInfo {
+                bname: Some(CheetahString::from("broker_b")),
+                ..TopicQueueMappingInfo::default()
+            },
+            ..Default::default()
+        };
+        context.mapping_detail = Some(ArcMut::new(diff_mapping_detail));
+        assert!(!context.is_leader());
+
+        // No bname in leader_item: not leader
+        context.leader_item.as_mut().unwrap().bname = None;
+        assert!(!context.is_leader());
+
+        // No leader_item: not leader
+        context.leader_item = None;
+        assert!(!context.is_leader());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6090

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive unit test suite added for topic queue mapping context, validating default field initialization, constructor behavior, equality verification, and leader identification logic under various conditions including matching broker names, missing mapping details, and missing leader items.

* **Refactor**
  * Implementation blocks consolidated for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->