### PR TITLE
[ISSUE #6094]🧪Add test case for GroupRetryPolicy and SimpleSubscriptionData

### DIFF
--- a/rocketmq-remoting/src/protocol/subscription/simple_subscription_data.rs
+++ b/rocketmq-remoting/src/protocol/subscription/simple_subscription_data.rs
@@ -50,3 +50,26 @@ impl SimpleSubscriptionData {
         self.version
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_subscription_data_default() {
+        let data = SimpleSubscriptionData::default();
+        assert_eq!(data.topic(), "");
+        assert_eq!(data.expression_type(), "");
+        assert_eq!(data.expression(), "");
+        assert_eq!(data.version(), 0);
+    }
+
+    #[test]
+    fn simple_subscription_data_new_and_getters() {
+        let data = SimpleSubscriptionData::new("topic".to_string(), "TAG".to_string(), "*".to_string(), 123);
+        assert_eq!(data.topic(), "topic");
+        assert_eq!(data.expression_type(), "TAG");
+        assert_eq!(data.expression(), "*");
+        assert_eq!(data.version(), 123);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6094 
- Fixes #6095 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for retry policy management and subscription data initialization, including validation of default states and fallback behavior.

* **Refactor**
  * Simplified retry policy configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->