### PR TITLE
[ISSUE #6124]🧪Add test case for PermBrokerHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/perm_broker_header.rs
@@ -69,15 +69,40 @@ pub struct AddWritePermOfBrokerResponseHeader {
 }
 
 impl AddWritePermOfBrokerResponseHeader {
-    //const ADD_TOPIC_COUNT: &'static str = "addTopicCount";
-
     pub fn new(add_topic_count: i32) -> Self {
         Self { add_topic_count }
     }
-}
 
-impl AddWritePermOfBrokerResponseHeader {
     pub fn get_add_topic_count(&self) -> i32 {
         self.add_topic_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wipe_write_perm_of_broker_request_header_new() {
+        let header = WipeWritePermOfBrokerRequestHeader::new("broker1");
+        assert_eq!(header.broker_name, CheetahString::from("broker1"));
+    }
+
+    #[test]
+    fn wipe_write_perm_of_broker_response_header_new_and_getters() {
+        let header = WipeWritePermOfBrokerResponseHeader::new(10);
+        assert_eq!(header.get_wipe_topic_count(), 10);
+    }
+
+    #[test]
+    fn add_write_perm_of_broker_request_header_new() {
+        let header = AddWritePermOfBrokerRequestHeader::new("broker1");
+        assert_eq!(header.broker_name, CheetahString::from("broker1"));
+    }
+
+    #[test]
+    fn add_write_perm_of_broker_response_header_new_and_getters() {
+        let header = AddWritePermOfBrokerResponseHeader::new(20);
+        assert_eq!(header.get_add_topic_count(), 20);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6124
- Fixes #6125 
- Fixes #6127 
- Fixes #6128 
- Fixes #6129 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for broker permission headers, validating proper storage of broker names and topic count retrieval.

* **Refactor**
  * Improved internal code organization for broker permission header implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->