### PR TITLE
[ISSUE #6198]✨Re-export RPC types for convenient access

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
@@ -5182,9 +5182,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -101,6 +101,12 @@ pub use crate::protocol::header::update_consumer_offset_header::UpdateConsumerOf
 // Client management
 pub use crate::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader;
 
+// RPC types (remote procedure call infrastructure)
+pub use crate::rpc::rpc_request::RpcRequest;
+pub use crate::rpc::rpc_request_header::RpcRequestHeader;
+pub use crate::rpc::rpc_response::RpcResponse;
+pub use crate::rpc::topic_request_header::TopicRequestHeader;
+
 // Most Common Bodies (Top-Level Exports)
 
 // Message operations

--- a/rocketmq-remoting/src/prelude.rs
+++ b/rocketmq-remoting/src/prelude.rs
@@ -55,6 +55,12 @@ pub use crate::protocol::header::client_request_header::GetRouteInfoRequestHeade
 pub use crate::protocol::header::heartbeat_request_header::HeartbeatRequestHeader;
 pub use crate::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader;
 
+// RPC types (remote procedure call infrastructure)
+pub use crate::rpc::rpc_request::RpcRequest;
+pub use crate::rpc::rpc_request_header::RpcRequestHeader;
+pub use crate::rpc::rpc_response::RpcResponse;
+pub use crate::rpc::topic_request_header::TopicRequestHeader;
+
 // NameServer operations
 pub use crate::protocol::header::namesrv::broker_request::UnRegisterBrokerRequestHeader;
 pub use crate::protocol::header::namesrv::register_broker_header::RegisterBrokerRequestHeader;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6198

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced RPC API accessibility: Core RPC infrastructure types (RpcRequest, RpcRequestHeader, RpcResponse, TopicRequestHeader) are now publicly re-exported through both the crate root and prelude module. This improvement makes these essential types more discoverable and readily accessible, simplifying import statements and enhancing the developer experience for users working with RPC functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->