### PR TITLE
[ISSUE #6130]🧪Add test case for NotifyBrokerRoleChangedRequestHeader

### DIFF
--- a/rocketmq-broker/src/processor/consumer_manage_processor.rs
+++ b/rocketmq-broker/src/processor/consumer_manage_processor.rs
@@ -15,7 +15,7 @@
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
-use rocketmq_remoting::protocol::body::get_consumer_listby_group_response_body::GetConsumerListByGroupResponseBody;
+use rocketmq_remoting::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
 use rocketmq_remoting::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use rocketmq_remoting::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -70,7 +70,7 @@ use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::body::batch_ack_message_request_body::BatchAckMessageRequestBody;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_remoting::protocol::body::check_client_request_body::CheckClientRequestBody;
-use rocketmq_remoting::protocol::body::get_consumer_listby_group_response_body::GetConsumerListByGroupResponseBody;
+use rocketmq_remoting::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
 use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;

--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -118,7 +118,7 @@ pub use crate::protocol::body::broker_body::cluster_info::ClusterInfo;
 // Consumer operations
 pub use crate::protocol::body::consumer_connection::ConsumerConnection;
 pub use crate::protocol::body::consumer_running_info::ConsumerRunningInfo;
-pub use crate::protocol::body::get_consumer_listby_group_response_body::GetConsumerListByGroupResponseBody;
+pub use crate::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
 
 // Topic operations
 pub use crate::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigSerializeWrapper;

--- a/rocketmq-remoting/src/prelude.rs
+++ b/rocketmq-remoting/src/prelude.rs
@@ -89,7 +89,7 @@ pub use crate::protocol::body::broker_body::cluster_info::ClusterInfo;
 pub use crate::protocol::body::broker_body::register_broker_body::RegisterBrokerBody;
 pub use crate::protocol::body::consumer_connection::ConsumerConnection;
 pub use crate::protocol::body::consumer_running_info::ConsumerRunningInfo;
-pub use crate::protocol::body::get_consumer_listby_group_response_body::GetConsumerListByGroupResponseBody;
+pub use crate::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
 pub use crate::protocol::body::producer_connection::ProducerConnection;
 pub use crate::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
 pub use crate::protocol::body::subscription_group_wrapper::SubscriptionGroupWrapper;

--- a/rocketmq-remoting/src/protocol/bodies.rs
+++ b/rocketmq-remoting/src/protocol/bodies.rs
@@ -60,7 +60,7 @@ pub mod consumer {
     pub use super::super::body::consumer_connection::ConsumerConnection;
     pub use super::super::body::consumer_offset_serialize_wrapper::ConsumerOffsetSerializeWrapper;
     pub use super::super::body::consumer_running_info::ConsumerRunningInfo;
-    pub use super::super::body::get_consumer_listby_group_response_body::GetConsumerListByGroupResponseBody;
+    pub use super::super::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
     pub use super::super::body::get_lite_client_info_response_body::GetLiteClientInfoResponseBody;
     pub use super::super::body::get_lite_group_info_response_body::GetLiteGroupInfoResponseBody;
     pub use super::super::body::lite_lag_info::LiteLagInfo;
@@ -177,7 +177,7 @@ pub use super::body::broker_body::cluster_info::ClusterInfo;
 // Consumer operations
 pub use super::body::consumer_connection::ConsumerConnection;
 pub use super::body::consumer_running_info::ConsumerRunningInfo;
-pub use super::body::get_consumer_listby_group_response_body::GetConsumerListByGroupResponseBody;
+pub use super::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
 
 // Topic operations
 pub use super::body::topic_info_wrapper::topic_config_wrapper::TopicConfigSerializeWrapper;

--- a/rocketmq-remoting/src/protocol/body.rs
+++ b/rocketmq-remoting/src/protocol/body.rs
@@ -16,7 +16,7 @@ pub mod broker_body;
 pub mod consumer_running_info;
 pub mod create_topic_list_request_body;
 pub mod get_broker_lite_info_response_body;
-pub mod get_consumer_listby_group_response_body;
+pub mod get_consumer_list_by_group_response_body;
 pub mod get_lite_client_info_response_body;
 pub mod get_lite_group_info_response_body;
 pub mod get_lite_topic_info_response_body;

--- a/rocketmq-remoting/src/protocol/body/get_consumer_list_by_group_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/get_consumer_list_by_group_response_body.rs
@@ -21,3 +21,26 @@ use serde::Serialize;
 pub struct GetConsumerListByGroupResponseBody {
     pub consumer_id_list: Vec<CheetahString>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_consumer_list_by_group_response_body_serialization() {
+        let body = GetConsumerListByGroupResponseBody {
+            consumer_id_list: vec![CheetahString::from("id1"), CheetahString::from("id2")],
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(json.contains("\"consumerIdList\":[\"id1\",\"id2\"]"));
+    }
+
+    #[test]
+    fn get_consumer_list_by_group_response_body_deserialization() {
+        let json = r#"{"consumerIdList":["id1","id2"]}"#;
+        let body: GetConsumerListByGroupResponseBody = serde_json::from_str(json).unwrap();
+        assert_eq!(body.consumer_id_list.len(), 2);
+        assert_eq!(body.consumer_id_list[0], "id1");
+        assert_eq!(body.consumer_id_list[1], "id2");
+    }
+}

--- a/rocketmq-remoting/src/protocol/header/get_consumer_connection_list_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consumer_connection_list_request_header.rs
@@ -37,3 +37,19 @@ impl GetConsumerConnectionListRequestHeader {
         self.consumer_group = consumer_group;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn getters_and_setters() {
+        let mut header = GetConsumerConnectionListRequestHeader {
+            consumer_group: CheetahString::from("group1"),
+            rpc_request_header: None,
+        };
+        assert_eq!(header.get_consumer_group(), "group1");
+        header.set_consumer_group(CheetahString::from("group2"));
+        assert_eq!(header.get_consumer_group(), "group2");
+    }
+}

--- a/rocketmq-remoting/src/protocol/header/notify_broker_role_change_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/notify_broker_role_change_request_header.rs
@@ -44,3 +44,21 @@ impl Display for NotifyBrokerRoleChangedRequestHeader {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notify_broker_role_changed_request_header_display() {
+        let header = NotifyBrokerRoleChangedRequestHeader {
+            master_address: Some(CheetahString::from("addr")),
+            master_epoch: Some(1),
+            sync_state_set_epoch: Some(2),
+            master_broker_id: Some(3),
+        };
+        let display = format!("{}", header);
+        let expected = r#"(master_address=Some("addr"), master_epoch=Some(1), sync_state_set_epoch=Some(2), master_broker_id=Some(3))"#;
+        assert_eq!(display, expected);
+    }
+}

--- a/rocketmq-remoting/src/protocol/header/notify_consumer_ids_changed_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/notify_consumer_ids_changed_request_header.rs
@@ -28,3 +28,25 @@ pub struct NotifyConsumerIdsChangedRequestHeader {
     #[serde(flatten)]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notify_consumer_ids_changed_request_header_serialization() {
+        let header = NotifyConsumerIdsChangedRequestHeader {
+            consumer_group: CheetahString::from("group1"),
+            rpc_request_header: None,
+        };
+        let json = serde_json::to_string(&header).unwrap();
+        assert!(json.contains("\"consumerGroup\":\"group1\""));
+    }
+
+    #[test]
+    fn notify_consumer_ids_changed_request_header_deserialization() {
+        let json = r#"{"consumerGroup":"group1"}"#;
+        let header: NotifyConsumerIdsChangedRequestHeader = serde_json::from_str(json).unwrap();
+        assert_eq!(header.consumer_group, "group1");
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6130 
- Fixes #6131 
- Fixes #6132 
- Fixes #6133 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->
also rename file name for `get_consumer_list_by_group_response_body` and update related callers

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected module naming inconsistencies across the broker, client, and remoting components to align with standard naming conventions and project requirements.

* **Tests**
  * Added unit test coverage for consumer list response body serialization and deserialization functionality.
  * Added unit test coverage for consumer connection request header operations.
  * Added unit test coverage for broker role change notification headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->