### PR TITLE
[ISSUE #6238]🚀Add RecallMessageHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,6 +3497,7 @@ name = "rocketmq-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "base64",
  "byteorder",
  "bytes",
  "cheetah-string",

--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -51,6 +51,7 @@ lz4_flex  = { version = "0.12", default-features = false }
 zstd      = "0.13"
 byteorder = "1.5.0"
 md5       = { package = "md-5", version = "0.10" }
+base64    = "0.22.1"
 
 local-ip-address = "0.6.10"
 chrono           = "0.4.43"

--- a/rocketmq-common/examples/recall_message_handle_example.rs
+++ b/rocketmq-common/examples/recall_message_handle_example.rs
@@ -1,0 +1,123 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Example demonstrating the usage of RecallMessageHandle
+//!
+//! RecallMessageHandle is used to encode and decode handles for recalling
+//! delay messages in RocketMQ.
+
+use rocketmq_common::RecallMessageHandle;
+use rocketmq_common::RecallMessageHandleV1;
+
+fn main() {
+    println!("=== RocketMQ RecallMessageHandle Example ===\n");
+
+    // Example 1: Building a recall handle
+    println!("Example 1: Building a recall handle");
+    let topic = "test_topic";
+    let broker_name = "broker-0";
+    let timestamp_str = "1707111111111";
+    let message_id = "unique_msg_id_123";
+
+    let encoded_handle = RecallMessageHandleV1::build_handle(topic, broker_name, timestamp_str, message_id);
+    println!("Encoded handle: {}", encoded_handle);
+    println!();
+
+    // Example 2: Decoding a recall handle
+    println!("Example 2: Decoding a recall handle");
+    match RecallMessageHandle::decode_handle(&encoded_handle) {
+        Ok(handle) => {
+            println!("Successfully decoded handle:");
+            println!("  Version: {}", handle.version());
+            println!("  Topic: {}", handle.topic());
+            println!("  Broker Name: {}", handle.broker_name());
+            println!("  Timestamp: {}", handle.timestamp_str());
+            println!("  Message ID: {}", handle.message_id());
+            println!("  Display: {}", handle);
+        }
+        Err(e) => {
+            eprintln!("Failed to decode handle: {}", e);
+        }
+    }
+    println!();
+
+    // Example 3: Error handling with invalid handles
+    println!("Example 3: Error handling with invalid handles");
+
+    let wrong_version =
+        base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE, "v2 topic broker time msgid");
+    let too_few_parts = base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE, "v1 topic broker");
+
+    let invalid_handles = vec![
+        ("", "Empty handle"),
+        ("invalid_base64!", "Invalid Base64"),
+        (wrong_version.as_str(), "Wrong version"),
+        (too_few_parts.as_str(), "Too few parts"),
+    ];
+
+    for (handle_str, description) in invalid_handles {
+        match RecallMessageHandle::decode_handle(handle_str) {
+            Ok(_) => println!("  {} - Unexpectedly succeeded", description),
+            Err(e) => println!("  {} - Expected error: {}", description, e),
+        }
+    }
+    println!();
+
+    // Example 4: Round-trip encoding and decoding
+    println!("Example 4: Round-trip encoding and decoding");
+    let original_topic = "production_topic";
+    let original_broker = "broker-prod-1";
+    let original_timestamp = "1707222222222";
+    let original_msg_id = "prod_msg_456";
+
+    let encoded =
+        RecallMessageHandleV1::build_handle(original_topic, original_broker, original_timestamp, original_msg_id);
+
+    match RecallMessageHandle::decode_handle(&encoded) {
+        Ok(decoded) => {
+            let matches = decoded.topic() == original_topic
+                && decoded.broker_name() == original_broker
+                && decoded.timestamp_str() == original_timestamp
+                && decoded.message_id() == original_msg_id;
+
+            if matches {
+                println!("  ✓ Round-trip successful - all fields match!");
+            } else {
+                println!("  ✗ Round-trip failed - fields don't match");
+            }
+        }
+        Err(e) => {
+            eprintln!("  ✗ Round-trip failed with error: {}", e);
+        }
+    }
+    println!();
+
+    // Example 5: Creating HandleV1 directly
+    println!("Example 5: Creating HandleV1 directly");
+    let handle_v1 = RecallMessageHandleV1::new(
+        "direct_topic".to_string(),
+        "direct_broker".to_string(),
+        "1707333333333".to_string(),
+        "direct_msg_789".to_string(),
+    );
+
+    println!("  Topic: {}", handle_v1.topic());
+    println!("  Broker: {}", handle_v1.broker_name());
+    println!("  Timestamp: {}", handle_v1.timestamp_str());
+    println!("  Message ID: {}", handle_v1.message_id());
+    println!("  Version: {}", handle_v1.version());
+    println!();
+
+    println!("=== Example Complete ===");
+}

--- a/rocketmq-common/src/common.rs
+++ b/rocketmq-common/src/common.rs
@@ -48,6 +48,7 @@ pub mod mix_all;
 pub mod mq_version;
 pub mod namesrv;
 pub mod pop_ack_constants;
+pub mod producer;
 
 pub mod running;
 pub mod server;

--- a/rocketmq-common/src/common/producer.rs
+++ b/rocketmq-common/src/common/producer.rs
@@ -1,0 +1,18 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod recall_message_handle;
+
+pub use recall_message_handle::HandleV1;
+pub use recall_message_handle::RecallMessageHandle;

--- a/rocketmq-common/src/common/producer/recall_message_handle.rs
+++ b/rocketmq-common/src/common/producer/recall_message_handle.rs
@@ -1,0 +1,337 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use base64::engine::general_purpose::URL_SAFE;
+use base64::Engine;
+
+const SEPARATOR: &str = " ";
+const VERSION_1: &str = "v1";
+
+/// Handle to recall a message, currently only supports delay messages.
+///
+/// The v1 pattern encodes the following fields in Base64:
+/// version topic brokerName timestamp messageId
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecallMessageHandle {
+    V1(HandleV1),
+}
+
+impl RecallMessageHandle {
+    /// Decode a recall handle string into a RecallMessageHandle.
+    ///
+    /// # Arguments
+    ///
+    /// * `handle` - Base64 encoded handle string
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(RecallMessageHandle)` - Successfully decoded handle
+    /// * `Err(String)` - Error message if decoding fails
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rocketmq_common::common::producer::recall_message_handle::RecallMessageHandle;
+    ///
+    /// let handle_str = "djEgdG9waWMgYnJva2VyLTAgMTcwNzExMTExMTExMSBtc2dJZA==";
+    /// let handle = RecallMessageHandle::decode_handle(handle_str);
+    /// assert!(handle.is_ok());
+    /// ```
+    pub fn decode_handle(handle: &str) -> Result<Self, String> {
+        if handle.is_empty() {
+            return Err("recall handle is invalid".to_string());
+        }
+
+        let raw_bytes = URL_SAFE
+            .decode(handle.as_bytes())
+            .map_err(|_| "recall handle is invalid".to_string())?;
+
+        let raw_string = String::from_utf8(raw_bytes).map_err(|_| "recall handle is invalid".to_string())?;
+
+        let items: Vec<&str> = raw_string.split(SEPARATOR).collect();
+
+        if items.is_empty() || items[0] != VERSION_1 || items.len() < 5 {
+            return Err("recall handle is invalid".to_string());
+        }
+
+        Ok(RecallMessageHandle::V1(HandleV1::new(
+            items[1].to_string(),
+            items[2].to_string(),
+            items[3].to_string(),
+            items[4].to_string(),
+        )))
+    }
+
+    /// Get the topic from the handle.
+    pub fn topic(&self) -> &str {
+        match self {
+            RecallMessageHandle::V1(v1) => &v1.topic,
+        }
+    }
+
+    /// Get the broker name from the handle.
+    pub fn broker_name(&self) -> &str {
+        match self {
+            RecallMessageHandle::V1(v1) => &v1.broker_name,
+        }
+    }
+
+    /// Get the timestamp string from the handle.
+    pub fn timestamp_str(&self) -> &str {
+        match self {
+            RecallMessageHandle::V1(v1) => &v1.timestamp_str,
+        }
+    }
+
+    /// Get the message ID from the handle.
+    pub fn message_id(&self) -> &str {
+        match self {
+            RecallMessageHandle::V1(v1) => &v1.message_id,
+        }
+    }
+
+    /// Get the version string from the handle.
+    pub fn version(&self) -> &str {
+        match self {
+            RecallMessageHandle::V1(_) => VERSION_1,
+        }
+    }
+}
+
+impl fmt::Display for RecallMessageHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RecallMessageHandle::V1(v1) => write!(
+                f,
+                "HandleV1 {{ version: {}, topic: {}, broker_name: {}, timestamp_str: {}, message_id: {} }}",
+                VERSION_1, v1.topic, v1.broker_name, v1.timestamp_str, v1.message_id
+            ),
+        }
+    }
+}
+
+/// Version 1 of the recall message handle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HandleV1 {
+    topic: String,
+    broker_name: String,
+    timestamp_str: String,
+    message_id: String,
+}
+
+impl HandleV1 {
+    /// Create a new HandleV1 instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic name
+    /// * `broker_name` - The broker name
+    /// * `timestamp_str` - The timestamp as a string
+    /// * `message_id` - The message ID (unique key)
+    pub fn new(topic: String, broker_name: String, timestamp_str: String, message_id: String) -> Self {
+        Self {
+            topic,
+            broker_name,
+            timestamp_str,
+            message_id,
+        }
+    }
+
+    /// Build a Base64 encoded handle string from components.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic name
+    /// * `broker_name` - The broker name
+    /// * `timestamp_str` - The timestamp as a string
+    /// * `message_id` - The message ID
+    ///
+    /// # Returns
+    ///
+    /// Base64 encoded handle string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rocketmq_common::common::producer::recall_message_handle::HandleV1;
+    ///
+    /// let handle = HandleV1::build_handle("test_topic", "broker-0", "1707111111111", "msgId123");
+    /// assert!(!handle.is_empty());
+    /// ```
+    pub fn build_handle(topic: &str, broker_name: &str, timestamp_str: &str, message_id: &str) -> String {
+        let raw_string = format!(
+            "{}{}{}{}{}{}{}{}{}",
+            VERSION_1, SEPARATOR, topic, SEPARATOR, broker_name, SEPARATOR, timestamp_str, SEPARATOR, message_id
+        );
+        URL_SAFE.encode(raw_string.as_bytes())
+    }
+
+    /// Get the topic.
+    pub fn topic(&self) -> &str {
+        &self.topic
+    }
+
+    /// Get the broker name.
+    pub fn broker_name(&self) -> &str {
+        &self.broker_name
+    }
+
+    /// Get the timestamp string.
+    pub fn timestamp_str(&self) -> &str {
+        &self.timestamp_str
+    }
+
+    /// Get the message ID.
+    pub fn message_id(&self) -> &str {
+        &self.message_id
+    }
+
+    /// Get the version.
+    pub fn version(&self) -> &str {
+        VERSION_1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_handle_invalid_empty() {
+        let result = RecallMessageHandle::decode_handle("");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "recall handle is invalid");
+    }
+
+    #[test]
+    fn test_handle_invalid_not_base64() {
+        let result = RecallMessageHandle::decode_handle("invalid base64!");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "recall handle is invalid");
+    }
+
+    #[test]
+    fn test_handle_invalid_version() {
+        let invalid_handle = URL_SAFE.encode("v2 a b c d");
+        let result = RecallMessageHandle::decode_handle(&invalid_handle);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "recall handle is invalid");
+    }
+
+    #[test]
+    fn test_handle_invalid_too_few_parts() {
+        let invalid_handle = URL_SAFE.encode("v1 a b c");
+        let result = RecallMessageHandle::decode_handle(&invalid_handle);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "recall handle is invalid");
+    }
+
+    #[test]
+    fn test_encode_and_decode_v1() {
+        let topic = "test_topic";
+        let broker_name = "broker-0";
+        let timestamp_str = "1707111111111";
+        let message_id = "msgId123";
+
+        let handle = HandleV1::build_handle(topic, broker_name, timestamp_str, message_id);
+        assert!(!handle.is_empty());
+
+        let decoded = RecallMessageHandle::decode_handle(&handle).unwrap();
+
+        assert_eq!(decoded.version(), VERSION_1);
+        assert_eq!(decoded.topic(), topic);
+        assert_eq!(decoded.broker_name(), broker_name);
+        assert_eq!(decoded.timestamp_str(), timestamp_str);
+        assert_eq!(decoded.message_id(), message_id);
+
+        let RecallMessageHandle::V1(v1) = decoded;
+        assert_eq!(v1.topic(), topic);
+        assert_eq!(v1.broker_name(), broker_name);
+        assert_eq!(v1.timestamp_str(), timestamp_str);
+        assert_eq!(v1.message_id(), message_id);
+        assert_eq!(v1.version(), VERSION_1);
+    }
+
+    #[test]
+    fn test_handle_v1_new() {
+        let topic = "test_topic";
+        let broker_name = "broker-0";
+        let timestamp_str = "1707111111111";
+        let message_id = "msgId123";
+
+        let handle = HandleV1::new(
+            topic.to_string(),
+            broker_name.to_string(),
+            timestamp_str.to_string(),
+            message_id.to_string(),
+        );
+
+        assert_eq!(handle.topic(), topic);
+        assert_eq!(handle.broker_name(), broker_name);
+        assert_eq!(handle.timestamp_str(), timestamp_str);
+        assert_eq!(handle.message_id(), message_id);
+        assert_eq!(handle.version(), VERSION_1);
+    }
+
+    #[test]
+    fn test_round_trip() {
+        let topic = "my_topic";
+        let broker = "broker-1";
+        let timestamp = "1707222222222";
+        let msg_id = "uniqueMsgId";
+
+        let encoded = HandleV1::build_handle(topic, broker, timestamp, msg_id);
+        let decoded = RecallMessageHandle::decode_handle(&encoded).unwrap();
+
+        assert_eq!(decoded.topic(), topic);
+        assert_eq!(decoded.broker_name(), broker);
+        assert_eq!(decoded.timestamp_str(), timestamp);
+        assert_eq!(decoded.message_id(), msg_id);
+    }
+
+    #[test]
+    fn test_display_format() {
+        let handle = HandleV1::new(
+            "topic".to_string(),
+            "broker".to_string(),
+            "123456".to_string(),
+            "msgId".to_string(),
+        );
+        let recall_handle = RecallMessageHandle::V1(handle);
+        let display = format!("{}", recall_handle);
+        assert!(display.contains("HandleV1"));
+        assert!(display.contains("topic"));
+        assert!(display.contains("broker"));
+        assert!(display.contains("123456"));
+        assert!(display.contains("msgId"));
+    }
+
+    #[test]
+    fn test_clone_and_equality() {
+        let handle1 = HandleV1::new(
+            "topic".to_string(),
+            "broker".to_string(),
+            "123456".to_string(),
+            "msgId".to_string(),
+        );
+        let handle2 = handle1.clone();
+        assert_eq!(handle1, handle2);
+
+        let recall1 = RecallMessageHandle::V1(handle1);
+        let recall2 = recall1.clone();
+        assert_eq!(recall1, recall2);
+    }
+}

--- a/rocketmq-common/src/lib.rs
+++ b/rocketmq-common/src/lib.rs
@@ -43,6 +43,8 @@ pub use crate::common::lite::SEPARATOR;
 pub use crate::common::message::message_accessor as MessageAccessor;
 pub use crate::common::message::message_decoder as MessageDecoder;
 pub use crate::common::mq_version::RocketMqVersion as RocketMQVersion;
+pub use crate::common::producer::recall_message_handle::HandleV1 as RecallMessageHandleV1;
+pub use crate::common::producer::recall_message_handle::RecallMessageHandle;
 pub use crate::thread_pool::FuturesExecutorService;
 pub use crate::thread_pool::FuturesExecutorServiceBuilder;
 pub use crate::thread_pool::ScheduledExecutorService;

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
@@ -5315,6 +5315,7 @@ name = "rocketmq-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "base64",
  "byteorder",
  "bytes",
  "cheetah-string",

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -2021,6 +2021,7 @@ name = "rocketmq-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "base64",
  "byteorder",
  "bytes",
  "cheetah-string",


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6238

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message recall handle functionality, enabling encoding and decoding of recall handles containing message metadata (topic, broker, timestamp, message ID).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->