### PR TITLE
[ISSUE #6240]🐛fix(test): Handle all 5xx errors in HTTP client tests

### DIFF
--- a/rocketmq-common/src/utils/http_tiny_client.rs
+++ b/rocketmq-common/src/utils/http_tiny_client.rs
@@ -509,8 +509,11 @@ mod tests {
 
         match result {
             Ok(response) => {
-                if response.code == 503 {
-                    eprintln!("httpbin.org is unavailable (503), skipping test");
+                if response.code >= 500 {
+                    eprintln!(
+                        "httpbin.org is unavailable or having issues ({}), skipping test",
+                        response.code
+                    );
                 } else {
                     assert!(response.is_success());
                     // httpbin echoes back headers
@@ -533,9 +536,12 @@ mod tests {
                 assert!(matches!(e, RocketMQError::Network(_)));
             }
             Ok(response) => {
-                // httpbin.org might return 503 if service is unavailable
-                if response.code == 503 {
-                    eprintln!("httpbin.org is unavailable (503), skipping timeout test");
+                // httpbin.org might return 5xx errors if service is unavailable or having issues
+                if response.code >= 500 {
+                    eprintln!(
+                        "httpbin.org is unavailable or having issues ({}), skipping timeout test",
+                        response.code
+                    );
                 } else {
                     panic!(
                         "Expected timeout error but got success response with code: {}",


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6240

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to recognize all server-side HTTP failure status codes (5xx range), providing more comprehensive failure detection and clearer error messages when servers are unavailable or experiencing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->