### PR TITLE
[ISSUE #6162]🧪Add unit tests for UnlockBatchRequestBody

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_consumer_status_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consumer_status_request_header.rs
@@ -25,8 +25,10 @@ use crate::rpc::rpc_request_header::RpcRequestHeader;
 pub struct GetConsumerStatusRequestHeader {
     #[required]
     pub topic: CheetahString,
+
     #[required]
     pub group: CheetahString,
+
     pub client_addr: Option<CheetahString>,
 
     #[serde(flatten)]
@@ -41,5 +43,80 @@ impl GetConsumerStatusRequestHeader {
             client_addr: None,
             rpc_request_header: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn get_consumer_status_request_header_default() {
+        let header = GetConsumerStatusRequestHeader::default();
+        assert_eq!(header.topic, "");
+        assert_eq!(header.group, "");
+        assert!(header.client_addr.is_none());
+        assert!(header.rpc_request_header.is_none());
+    }
+
+    #[test]
+    fn get_consumer_status_request_header_new() {
+        let header = GetConsumerStatusRequestHeader::new(CheetahString::from("topic1"), CheetahString::from("group1"));
+        assert_eq!(header.topic, "topic1");
+        assert_eq!(header.group, "group1");
+        assert!(header.client_addr.is_none());
+        assert!(header.rpc_request_header.is_none());
+    }
+
+    #[test]
+    fn get_consumer_status_request_header_serialization() {
+        let header = GetConsumerStatusRequestHeader {
+            topic: CheetahString::from("topic1"),
+            group: CheetahString::from("group1"),
+            client_addr: Some(CheetahString::from("127.0.0.1")),
+            rpc_request_header: Some(RpcRequestHeader {
+                broker_name: Some(CheetahString::from("broker")),
+                ..Default::default()
+            }),
+        };
+        let json = serde_json::to_string(&header).unwrap();
+        assert!(json.contains("\"topic\":\"topic1\""));
+        assert!(json.contains("\"group\":\"group1\""));
+        assert!(json.contains("\"clientAddr\":\"127.0.0.1\""));
+        assert!(json.contains("\"brokerName\":\"broker\""));
+    }
+
+    #[test]
+    fn get_consumer_status_request_header_deserialization() {
+        let json = r#"{"topic":"topic1","group":"group1","clientAddr":"127.0.0.1","brokerName":"broker"}"#;
+        let header: GetConsumerStatusRequestHeader = serde_json::from_str(json).unwrap();
+        assert_eq!(header.topic, "topic1");
+        assert_eq!(header.group, "group1");
+        assert_eq!(header.client_addr, Some(CheetahString::from("127.0.0.1")));
+        assert_eq!(
+            header.rpc_request_header.unwrap().broker_name,
+            Some(CheetahString::from("broker"))
+        );
+    }
+
+    #[test]
+    fn get_consumer_status_request_header_from_map() {
+        let mut map = HashMap::new();
+        map.insert(CheetahString::from("topic"), CheetahString::from("topic1"));
+        map.insert(CheetahString::from("group"), CheetahString::from("group1"));
+        map.insert(CheetahString::from("clientAddr"), CheetahString::from("127.0.0.1"));
+        map.insert(CheetahString::from("brokerName"), CheetahString::from("broker1"));
+
+        let header = <GetConsumerStatusRequestHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(header.topic, "topic1");
+        assert_eq!(header.group, "group1");
+        assert_eq!(header.client_addr, Some(CheetahString::from("127.0.0.1")));
+        assert_eq!(
+            header.rpc_request_header.unwrap().broker_name,
+            Some(CheetahString::from("broker1"))
+        );
     }
 }

--- a/rocketmq-remoting/src/protocol/header/query_topics_by_consumer_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_topics_by_consumer_request_header.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2, Default)]
 pub struct QueryTopicsByConsumerRequestHeader {
     #[required]
     #[serde(rename = "group")]
@@ -30,11 +30,81 @@ pub struct QueryTopicsByConsumerRequestHeader {
 }
 
 impl QueryTopicsByConsumerRequestHeader {
+    pub fn new(group: impl Into<CheetahString>) -> Self {
+        Self {
+            group: group.into(),
+            rpc_request_header: None,
+        }
+    }
+
     pub fn get_group(&self) -> &CheetahString {
         &self.group
     }
 
     pub fn set_group(&mut self, group: CheetahString) {
         self.group = group;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn query_topics_by_consumer_request_header_default() {
+        let header = QueryTopicsByConsumerRequestHeader::default();
+        assert_eq!(header.get_group(), "");
+        assert!(header.rpc_request_header.is_none());
+    }
+
+    #[test]
+    fn query_topics_by_consumer_request_header_new() {
+        let mut header = QueryTopicsByConsumerRequestHeader::new("group1");
+        assert_eq!(header.get_group(), "group1");
+        assert!(header.rpc_request_header.is_none());
+        header.set_group(CheetahString::from("group2"));
+        assert_eq!(header.get_group(), "group2");
+    }
+
+    #[test]
+    fn query_topics_by_consumer_request_header_serialization() {
+        let header = QueryTopicsByConsumerRequestHeader {
+            group: CheetahString::from("group1"),
+            rpc_request_header: Some(RpcRequestHeader {
+                broker_name: Some(CheetahString::from("broker")),
+                ..Default::default()
+            }),
+        };
+        let json = serde_json::to_string(&header).unwrap();
+        assert!(json.contains("\"group\":\"group1\""));
+        assert!(json.contains("\"brokerName\":\"broker\""));
+    }
+
+    #[test]
+    fn query_topics_by_consumer_request_header_deserialization() {
+        let json = r#"{"group":"group1","brokerName":"broker"}"#;
+        let header: QueryTopicsByConsumerRequestHeader = serde_json::from_str(json).unwrap();
+        assert_eq!(header.group, "group1");
+        assert_eq!(
+            header.rpc_request_header.unwrap().broker_name,
+            Some(CheetahString::from("broker"))
+        );
+    }
+
+    #[test]
+    fn query_topics_by_consumer_request_header_from_map() {
+        let mut map = HashMap::new();
+        map.insert(CheetahString::from("group"), CheetahString::from("group1"));
+        map.insert(CheetahString::from("brokerName"), CheetahString::from("broker1"));
+
+        let header = <QueryTopicsByConsumerRequestHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(header.group, "group1");
+        assert_eq!(
+            header.rpc_request_header.unwrap().broker_name,
+            Some(CheetahString::from("broker1"))
+        );
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6162 
- Fixes #6163 
- Fixes #6168 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consumer topic query requests now support default construction and a new constructor method for simplified initialization.
  * Consumer status request structure now includes a required group identifier field.

* **Tests**
  * Added comprehensive unit test coverage for request body validation, serialization, deserialization, and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->