### PR TITLE
[ISSUE #6245]🚀Add RecallMessageResponseHeader struct

### DIFF
--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -77,6 +77,7 @@ pub mod query_subscription_by_consumer_request_header;
 pub mod query_topic_consume_by_who_request_header;
 pub mod query_topics_by_consumer_request_header;
 pub mod recall_message_request_header;
+pub mod recall_message_response_header;
 pub mod reply_message_request_header;
 pub mod reset_master_flush_offset_header;
 pub mod reset_offset_request_header;

--- a/rocketmq-remoting/src/protocol/header/recall_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/recall_message_response_header.rs
@@ -1,0 +1,50 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Response header for message recall operation.
+///
+/// This header is returned by the broker after processing a recall message request.
+/// It contains the message ID of the recalled message.
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct RecallMessageResponseHeader {
+    /// Message ID of the recalled message (required).
+    #[required]
+    pub msg_id: CheetahString,
+}
+
+impl RecallMessageResponseHeader {
+    pub fn new(msg_id: impl Into<CheetahString>) -> Self {
+        Self { msg_id: msg_id.into() }
+    }
+
+    pub fn msg_id(&self) -> &CheetahString {
+        &self.msg_id
+    }
+
+    pub fn set_msg_id(&mut self, msg_id: impl Into<CheetahString>) {
+        self.msg_id = msg_id.into();
+    }
+}
+
+impl std::fmt::Display for RecallMessageResponseHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RecallMessageResponseHeader {{ msg_id: {} }}", self.msg_id)
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6245

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recall message responses, enabling enhanced message handling capabilities in the protocol layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->