### PR TITLE
[ISSUE #6185]🧪Add unit tests for SubscriptionData

### DIFF
--- a/rocketmq-remoting/src/protocol/heartbeat/subscription_data.rs
+++ b/rocketmq-remoting/src/protocol/heartbeat/subscription_data.rs
@@ -69,3 +69,80 @@ impl Hash for SubscriptionData {
         self.filter_class_source.hash(state);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+
+    #[test]
+    fn subscription_data_default() {
+        let before = get_current_millis() as i64;
+        let data = SubscriptionData::default();
+        let after = get_current_millis() as i64;
+
+        assert!(!data.class_filter_mode);
+        assert!(data.topic.is_empty());
+        assert!(data.sub_string.is_empty());
+        assert!(data.tags_set.is_empty());
+        assert!(data.code_set.is_empty());
+        assert!(data.sub_version >= before && data.sub_version <= after);
+        assert_eq!(data.expression_type, ExpressionType::TAG);
+        assert!(data.filter_class_source.is_empty());
+    }
+
+    #[test]
+    fn subscription_data_sub_all_constant() {
+        assert_eq!(SubscriptionData::SUB_ALL, "*");
+    }
+
+    #[test]
+    fn subscription_data_hash_and_eq() {
+        let data1 = SubscriptionData {
+            topic: CheetahString::from("topic"),
+            sub_version: 12345,
+            ..Default::default()
+        };
+
+        let mut data2 = data1.clone();
+        assert_eq!(data1, data2);
+
+        let mut hasher1 = DefaultHasher::new();
+        data1.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = DefaultHasher::new();
+        data2.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2);
+
+        data2.sub_version = 54321;
+        assert_ne!(data1, data2);
+    }
+
+    #[test]
+    fn subscription_data_serde() {
+        let mut data = SubscriptionData {
+            topic: CheetahString::from("test_topic"),
+            filter_class_source: CheetahString::from("source"),
+            ..Default::default()
+        };
+        data.tags_set.insert(CheetahString::from("tag1"));
+        data.code_set.insert(1);
+
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(json.contains("\"topic\":\"test_topic\""));
+        assert!(json.contains("\"tagsSet\":[\"tag1\"]"));
+        assert!(json.contains("\"codeSet\":[1]"));
+        assert!(!json.contains("filterClassSource"));
+        assert!(!json.contains("source"));
+
+        let deserialized: SubscriptionData = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.topic, data.topic);
+        assert_eq!(deserialized.tags_set, data.tags_set);
+        assert_eq!(deserialized.code_set, data.code_set);
+        assert_eq!(deserialized.sub_version, data.sub_version);
+        assert!(deserialized.filter_class_source.is_empty());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6185 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for subscription data covering initialization defaults, hash and equality operations, and serialization/deserialization of subscription topics and codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->