### PR TITLE
[ISSUE #6282]♻️Refactor subscribe method to be asynchronous across consumer implementations

### DIFF
--- a/rocketmq-client/examples/broadcast/push_consumer.rs
+++ b/rocketmq-client/examples/broadcast/push_consumer.rs
@@ -44,7 +44,7 @@ pub async fn main() -> RocketMQResult<()> {
         .name_server_addr(DEFAULT_NAMESRVADDR.to_string())
         .message_model(MessageModel::Broadcasting)
         .build();
-    consumer.subscribe(TOPIC, SUB_EXPRESSION)?;
+    consumer.subscribe(TOPIC, SUB_EXPRESSION).await?;
     consumer.set_consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset);
     consumer.register_message_listener_concurrently(MyMessageListener);
     consumer.start().await?;

--- a/rocketmq-client/examples/consumer/pop_consumer.rs
+++ b/rocketmq-client/examples/consumer/pop_consumer.rs
@@ -42,7 +42,7 @@ pub async fn main() -> RocketMQResult<()> {
         // disable client side load balance, also is pop consumer
         .client_rebalance(false)
         .build();
-    consumer.subscribe(TOPIC, "*")?;
+    consumer.subscribe(TOPIC, "*").await?;
     consumer.register_message_listener_concurrently(MyMessageListener);
     consumer.start().await?;
     let _ = tokio::signal::ctrl_c().await;

--- a/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
@@ -48,7 +48,7 @@ pub async fn main() -> RocketMQResult<()> {
         .name_server_addr(DEFAULT_NAMESRVADDR.to_string())
         .message_model(MessageModel::Clustering)
         .build();
-    consumer.subscribe(TOPIC, TAG)?;
+    consumer.subscribe(TOPIC, TAG).await?;
     consumer.set_consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset);
     consumer.register_message_listener_orderly(MyMessageListener::new());
     consumer.start().await?;

--- a/rocketmq-client/examples/quickstart/consumer.rs
+++ b/rocketmq-client/examples/quickstart/consumer.rs
@@ -40,7 +40,7 @@ pub async fn main() -> RocketMQResult<()> {
         .consumer_group(CONSUMER_GROUP.to_string())
         .name_server_addr(DEFAULT_NAMESRVADDR.to_string())
         .build();
-    consumer.subscribe(TOPIC, "*")?;
+    consumer.subscribe(TOPIC, "*").await?;
     consumer.register_message_listener_concurrently(MyMessageListener);
     consumer.start().await?;
     let _ = tokio::signal::ctrl_c().await;

--- a/rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs
@@ -26,14 +26,12 @@ use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrate
 use crate::consumer::default_mq_push_consumer::ConsumerConfig;
 use crate::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
 use crate::consumer::message_queue_listener::MessageQueueListener;
-use crate::consumer::mq_push_consumer::MQPushConsumer;
 use crate::trace::trace_dispatcher::TraceDispatcher;
 
 #[derive(Default)]
 pub struct DefaultMQPushConsumerBuilder {
     client_config: ClientConfig,
     consumer_group: Option<CheetahString>,
-    topic_sub_expression: (Option<CheetahString>, Option<CheetahString>),
     message_model: Option<MessageModel>,
     consume_from_where: Option<ConsumeFromWhere>,
     consume_timestamp: Option<CheetahString>,
@@ -119,13 +117,6 @@ impl DefaultMQPushConsumerBuilder {
         allocate_message_queue_strategy: Arc<dyn AllocateMessageQueueStrategy>,
     ) -> Self {
         self.allocate_message_queue_strategy = Some(allocate_message_queue_strategy);
-        self
-    }
-
-    #[inline]
-    pub fn subscribe(mut self, topic: impl Into<CheetahString>, sub_expression: impl Into<CheetahString>) -> Self {
-        self.topic_sub_expression.0 = Some(topic.into());
-        self.topic_sub_expression.1 = Some(sub_expression.into());
         self
     }
 
@@ -381,10 +372,6 @@ impl DefaultMQPushConsumerBuilder {
         }
         consumer_config.rpc_hook = self.rpc_hook.clone();
 
-        let mut consumer = DefaultMQPushConsumer::new(self.client_config, consumer_config);
-        if let (Some(topic), Some(sub_expression)) = (self.topic_sub_expression.0, self.topic_sub_expression.1) {
-            consumer.subscribe(&topic, &sub_expression).expect("subscribe failed");
-        }
-        consumer
+        DefaultMQPushConsumer::new(self.client_config, consumer_config)
     }
 }

--- a/rocketmq-client/src/consumer/mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/mq_push_consumer.rs
@@ -85,7 +85,7 @@ pub trait MQPushConsumer: MQConsumer {
     /// # Returns
     ///
     /// * `rocketmq_error::RocketMQResult<()>` - An empty result indicating success or an error.
-    fn subscribe(&mut self, topic: &str, sub_expression: &str) -> rocketmq_error::RocketMQResult<()>;
+    async fn subscribe(&mut self, topic: &str, sub_expression: &str) -> rocketmq_error::RocketMQResult<()>;
 
     /// Subscribes to a topic with an optional message selector.
     ///


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6282

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the `subscribe` method to be asynchronous, requiring callers to `await` subscription completion before proceeding. All example code has been updated to reflect this change. The consumer builder no longer performs automatic subscription during initialization—subscriptions must now be explicitly awaited after consumer creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->