### PR TITLE
[ISSUE #6284]♻️Refactor subscribe method to accept multiple input types for topic and subscription expression

### DIFF
--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -562,9 +562,13 @@ impl MQPushConsumer for DefaultMQPushConsumer {
             .register_message_listener(self.consumer_config.message_listener.clone());
     }
 
-    async fn subscribe(&mut self, topic: &str, sub_expression: &str) -> rocketmq_error::RocketMQResult<()> {
-        let topic = CheetahString::from_slice(topic);
-        let sub_expression = CheetahString::from_slice(sub_expression);
+    async fn subscribe(
+        &mut self,
+        topic: impl Into<CheetahString>,
+        sub_expression: impl Into<CheetahString>,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let topic = topic.into();
+        let sub_expression = sub_expression.into();
 
         self.default_mqpush_consumer_impl
             .as_mut()

--- a/rocketmq-client/src/consumer/mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/mq_push_consumer.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_ext::MessageExt;
 
 use crate::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
@@ -79,13 +80,33 @@ pub trait MQPushConsumer: MQConsumer {
     ///
     /// # Parameters
     ///
-    /// * `topic` - The topic to subscribe to.
-    /// * `sub_expression` - The subscription expression.
+    /// * `topic` - The topic to subscribe to. Can be `&str`, `String`, or `CheetahString`.
+    /// * `sub_expression` - The subscription expression. Can be `&str`, `String`, or
+    ///   `CheetahString`.
     ///
     /// # Returns
     ///
     /// * `rocketmq_error::RocketMQResult<()>` - An empty result indicating success or an error.
-    async fn subscribe(&mut self, topic: &str, sub_expression: &str) -> rocketmq_error::RocketMQResult<()>;
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// // Using &str
+    /// consumer.subscribe("TopicTest", "*").await?;
+    ///
+    /// // Using String
+    /// let topic = String::from("TopicTest");
+    /// consumer.subscribe(topic, "*").await?;
+    ///
+    /// // Using CheetahString
+    /// let topic = CheetahString::from_slice("TopicTest");
+    /// consumer.subscribe(topic, "*").await?;
+    /// ```
+    async fn subscribe(
+        &mut self,
+        topic: impl Into<CheetahString>,
+        sub_expression: impl Into<CheetahString>,
+    ) -> rocketmq_error::RocketMQResult<()>;
 
     /// Subscribes to a topic with an optional message selector.
     ///


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6284

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the subscribe method to accept multiple input types (string references, owned strings, and native string types) for greater flexibility and convenience when subscribing to topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->