### PR TITLE
[ISSUE #6209][Test🧪] Add unit tests for EmptyHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/empty_header.rs
+++ b/rocketmq-remoting/src/protocol/header/empty_header.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::protocol::command_custom_header::CommandCustomHeader;
-
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EmptyHeader {}
 
 impl CommandCustomHeader for EmptyHeader {
@@ -15,15 +17,21 @@ impl CommandCustomHeader for EmptyHeader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json;
 
     #[test]
-    fn empty_header_init() {
-        let body = EmptyHeader {};
-        assert!(matches!(body, EmptyHeader {}));
-    }
-    #[test]
-    fn empty_header_map() {
-        let body = EmptyHeader {};
-        assert!(body.to_map().is_none());
+    fn test_empty_header_lifecycle() {
+        let header = EmptyHeader::default();
+
+        let cloned = header.clone();
+        assert_eq!(header, cloned);
+
+        let json = serde_json::to_string(&header).unwrap();
+        assert_eq!(json, "{}");
+        let de: EmptyHeader = serde_json::from_str(&json).unwrap();
+        assert_eq!(header, de);
+        assert!(header.to_map().is_none());
+
+        assert!(format!("{:?}", header).contains("EmptyHeader"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6209 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests validating lifecycle, cloning, equality, serialization/deserialization round-trip, and mapping behavior of an empty header representation.

---

Note: Internal test coverage increased; no user-facing behavior or public APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->