### PR TITLE
Remove unimplemented MQAdmin methods from consumer

### DIFF
--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -27,8 +27,6 @@ use rocketmq_remoting::runtime::RPCHook;
 use rocketmq_rust::ArcMut;
 
 use crate::base::client_config::ClientConfig;
-use crate::base::mq_admin::MQAdmin;
-use crate::base::query_result::QueryResult;
 use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::default_mq_push_consumer_builder::DefaultMQPushConsumerBuilder;
@@ -421,60 +419,6 @@ impl MQConsumer for DefaultMQPushConsumer {
         topic: &str,
     ) -> rocketmq_error::RocketMQResult<Vec<MessageQueue>> {
         todo!()
-    }
-}
-
-impl MQAdmin for DefaultMQPushConsumer {
-    fn create_topic(
-        &self,
-        key: &str,
-        new_topic: &str,
-        queue_num: i32,
-        attributes: HashMap<String, String>,
-    ) -> rocketmq_error::RocketMQResult<()> {
-        panic!("This method is not implemented for DefaultMQPushConsumer");
-    }
-
-    fn create_topic_with_flag(
-        &self,
-        key: &str,
-        new_topic: &str,
-        queue_num: i32,
-        topic_sys_flag: i32,
-        attributes: HashMap<String, String>,
-    ) -> rocketmq_error::RocketMQResult<()> {
-        panic!("This method is not implemented for DefaultMQPushConsumer");
-    }
-
-    fn search_offset(&self, mq: &MessageQueue, timestamp: u64) -> rocketmq_error::RocketMQResult<i64> {
-        panic!("This method is not implemented for DefaultMQPushConsumer");
-    }
-
-    fn max_offset(&self, mq: &MessageQueue) -> rocketmq_error::RocketMQResult<i64> {
-        panic!("This method is not implemented for DefaultMQPushConsumer");
-    }
-
-    fn min_offset(&self, mq: &MessageQueue) -> rocketmq_error::RocketMQResult<i64> {
-        panic!("This method is not implemented for DefaultMQPushConsumer");
-    }
-
-    fn earliest_msg_store_time(&self, mq: &MessageQueue) -> rocketmq_error::RocketMQResult<u64> {
-        panic!("This method is not implemented for DefaultMQPushConsumer");
-    }
-
-    fn query_message(
-        &self,
-        topic: &str,
-        key: &str,
-        max_num: i32,
-        begin: u64,
-        end: u64,
-    ) -> rocketmq_error::RocketMQResult<QueryResult> {
-        panic!("This method is not implemented for DefaultMQPushConsumer");
-    }
-
-    fn view_message(&self, topic: &str, msg_id: &str) -> rocketmq_error::RocketMQResult<MessageExt> {
-        panic!("This method is not implemented for DefaultMQPushConsumer");
     }
 }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6288

### Brief Description
As the title suggests

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed eight non-functional public methods from the consumer API that would trigger errors if invoked. These methods for topic creation, offset searching, message querying, and timestamp operations are no longer available. The consumer's core messaging push functionality remains fully operational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->