### PR TITLE
[ISSUE #6268]🚀Implement SwitchTimerEngine command in rocketmq-admin-core

### DIFF
--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -628,6 +628,11 @@ impl MessageConst {
     pub const PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX: &'static str = "UNIQ_KEY";
     pub const PROPERTY_WAIT_STORE_MSG_OK: &'static str = "WAIT";
 
+    // Timer engine type constants
+    pub const TIMER_ENGINE_ROCKSDB_TIMELINE: &'static str = "R";
+    pub const TIMER_ENGINE_FILE_TIME_WHEEL: &'static str = "F";
+    pub const TIMER_ENGINE_TYPE: &'static str = "timerEngineType";
+
     // Index type constants
     pub const INDEX_KEY_TYPE: &'static str = "K";
     pub const INDEX_UNIQUE_TYPE: &'static str = "U";

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/cli/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/cli/commands.rs
@@ -52,12 +52,16 @@ pub mod update_kv_config_command;
 pub mod update_namesrv_config_command;
 pub mod wipe_write_perm_command;
 
+// Broker commands
+pub mod switch_timer_engine_command;
+
 // Re-export command structs for convenience
 pub use self::add_write_perm_command::AddWritePermCommand;
 pub use self::allocate_mq_command::AllocateMqCommand;
 pub use self::delete_kv_config_command::DeleteKvConfigCommand;
 pub use self::delete_topic_command::DeleteTopicCommand;
 pub use self::get_namesrv_config_command::GetNamesrvConfigCommand;
+pub use self::switch_timer_engine_command::SwitchTimerEngineCommand;
 pub use self::topic_cluster_command::TopicClusterSubCommand;
 pub use self::topic_list_command::TopicListCommand;
 pub use self::topic_route_command::TopicRouteCommand;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/cli/commands/switch_timer_engine_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/cli/commands/switch_timer_engine_command.rs
@@ -1,0 +1,106 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::ArgGroup;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::message::MessageConst;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+use crate::core::admin::AdminBuilder;
+
+const ROCKSDB_TIMELINE: &str = "ROCKSDB_TIMELINE";
+const FILE_TIME_WHEEL: &str = "FILE_TIME_WHEEL";
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(ArgGroup::new("target")
+    .required(true)
+    .args(&["broker_addr", "cluster_name"]))
+)]
+pub struct SwitchTimerEngineCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(short = 'b', long = "brokerAddr", required = false, help = "update which broker")]
+    broker_addr: Option<String>,
+
+    #[arg(short = 'c', long = "clusterName", required = false, help = "update which cluster")]
+    cluster_name: Option<String>,
+
+    #[arg(
+        short = 'e',
+        long = "engineType",
+        required = true,
+        help = "R/F, R for rocksdb timeline engine, F for file time wheel engine"
+    )]
+    engine_type: String,
+}
+
+impl CommandExecute for SwitchTimerEngineCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let engine_type = self.engine_type.trim().to_string();
+        if engine_type.is_empty()
+            || (engine_type != MessageConst::TIMER_ENGINE_ROCKSDB_TIMELINE
+                && engine_type != MessageConst::TIMER_ENGINE_FILE_TIME_WHEEL)
+        {
+            println!("switchTimerEngine engineType must be R or F");
+            return Ok(());
+        }
+
+        let engine_name = if engine_type == MessageConst::TIMER_ENGINE_ROCKSDB_TIMELINE {
+            ROCKSDB_TIMELINE
+        } else {
+            FILE_TIME_WHEEL
+        };
+
+        let mut builder = AdminBuilder::new();
+        if let Some(addr) = &self.common_args.namesrv_addr {
+            builder = builder.namesrv_addr(addr.trim());
+        }
+        let admin = builder.build_with_guard().await?;
+
+        if let Some(ref broker_addr) = self.broker_addr {
+            let broker_addr = broker_addr.trim();
+            admin
+                .switch_timer_engine(broker_addr.into(), engine_type.into())
+                .await?;
+            println!("switchTimerEngine to {} success, {}", engine_name, broker_addr);
+        } else if let Some(ref cluster_name) = self.cluster_name {
+            let cluster_name = cluster_name.trim();
+            let cluster_info = admin.examine_broker_cluster_info().await?;
+            let master_set = CommandUtil::fetch_master_addr_by_cluster_name(&cluster_info, cluster_name)?;
+            for broker_addr in master_set {
+                match admin
+                    .switch_timer_engine(broker_addr.clone(), engine_type.clone().into())
+                    .await
+                {
+                    Ok(()) => {
+                        println!("switchTimerEngine to {} success, {}", engine_name, broker_addr);
+                    }
+                    Err(e) => {
+                        eprintln!("switchTimerEngine to {} failed, {}: {}", engine_name, broker_addr, e);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -15,6 +15,7 @@
 pub mod command_util;
 
 mod auth_commands;
+mod broker_commands;
 mod consumer_commands;
 mod controller_commands;
 mod namesrv_commands;
@@ -76,6 +77,11 @@ pub enum Commands {
     Auth(auth_commands::AuthCommands),
 
     #[command(subcommand)]
+    #[command(about = "Broker commands")]
+    #[command(name = "broker")]
+    Broker(broker_commands::BrokerCommands),
+
+    #[command(subcommand)]
     #[command(about = "Consumer commands")]
     #[command(name = "consumer")]
     Consumer(consumer_commands::ConsumerCommands),
@@ -102,6 +108,7 @@ impl CommandExecute for Commands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             Commands::Auth(value) => value.execute(rpc_hook).await,
+            Commands::Broker(value) => value.execute(rpc_hook).await,
             Commands::Consumer(value) => value.execute(rpc_hook).await,
             Commands::Controller(value) => value.execute(rpc_hook).await,
             Commands::NameServer(value) => value.execute(rpc_hook).await,
@@ -169,6 +176,11 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "Auth",
                 command: "updateAcl",
                 remark: "Update ACL.",
+            },
+            Command {
+                category: "Broker",
+                command: "switchTimerEngine",
+                remark: "Switch the engine of timer message in broker.",
             },
             Command {
                 category: "Consumer",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod switch_timer_engine_sub_command;
+
+use std::sync::Arc;
+
+use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::broker_commands::switch_timer_engine_sub_command::SwitchTimerEngineSubCommand;
+use crate::commands::CommandExecute;
+
+#[derive(Subcommand)]
+pub enum BrokerCommands {
+    #[command(
+        name = "switchTimerEngine",
+        about = "Switch the engine of timer message in broker.",
+        long_about = None,
+    )]
+    SwitchTimerEngine(SwitchTimerEngineSubCommand),
+}
+
+impl CommandExecute for BrokerCommands {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self {
+            BrokerCommands::SwitchTimerEngine(value) => value.execute(rpc_hook).await,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/switch_timer_engine_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/switch_timer_engine_sub_command.rs
@@ -1,0 +1,125 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::ArgGroup;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::message::MessageConst;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+
+const ROCKSDB_TIMELINE: &str = "ROCKSDB_TIMELINE";
+const FILE_TIME_WHEEL: &str = "FILE_TIME_WHEEL";
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(ArgGroup::new("target")
+    .required(true)
+    .args(&["broker_addr", "cluster_name"]))
+)]
+pub struct SwitchTimerEngineSubCommand {
+    #[arg(short = 'b', long = "brokerAddr", required = false, help = "update which broker")]
+    broker_addr: Option<String>,
+
+    #[arg(short = 'c', long = "clusterName", required = false, help = "update which cluster")]
+    cluster_name: Option<String>,
+
+    #[arg(
+        short = 'e',
+        long = "engineType",
+        required = true,
+        help = "R/F, R for rocksdb timeline engine, F for file time wheel engine"
+    )]
+    engine_type: String,
+}
+
+impl CommandExecute for SwitchTimerEngineSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let engine_type = self.engine_type.trim().to_string();
+        if engine_type.is_empty()
+            || (engine_type != MessageConst::TIMER_ENGINE_ROCKSDB_TIMELINE
+                && engine_type != MessageConst::TIMER_ENGINE_FILE_TIME_WHEEL)
+        {
+            println!("switchTimerEngine engineType must be R or F");
+            return Ok(());
+        }
+
+        let engine_name = if engine_type == MessageConst::TIMER_ENGINE_ROCKSDB_TIMELINE {
+            ROCKSDB_TIMELINE
+        } else {
+            FILE_TIME_WHEEL
+        };
+
+        MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+            RocketMQError::Internal(format!(
+                "SwitchTimerEngineSubCommand: Failed to start MQAdminExt: {}",
+                e
+            ))
+        })?;
+
+        let operation_result = switch_timer_engine(&default_mqadmin_ext, &engine_type, engine_name, self).await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+async fn switch_timer_engine(
+    default_mqadmin_ext: &DefaultMQAdminExt,
+    engine_type: &str,
+    engine_name: &str,
+    command: &SwitchTimerEngineSubCommand,
+) -> RocketMQResult<()> {
+    if let Some(ref broker_addr) = command.broker_addr {
+        let broker_addr = broker_addr.trim();
+        default_mqadmin_ext
+            .switch_timer_engine(broker_addr.into(), engine_type.into())
+            .await?;
+        println!("switchTimerEngine to {} success, {}", engine_name, broker_addr);
+    } else if let Some(ref cluster_name) = command.cluster_name {
+        let cluster_name = cluster_name.trim();
+        let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await?;
+        let master_set = CommandUtil::fetch_master_addr_by_cluster_name(&cluster_info, cluster_name)?;
+        for broker_addr in master_set {
+            match default_mqadmin_ext
+                .switch_timer_engine(broker_addr.clone(), engine_type.into())
+                .await
+            {
+                Ok(()) => {
+                    println!("switchTimerEngine to {} success, {}", engine_name, broker_addr);
+                }
+                Err(e) => {
+                    eprintln!("switchTimerEngine to {} failed, {}: {}", engine_name, broker_addr, e);
+                }
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6268 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command to switch the timer engine in brokers between RocksDB timeline and file time wheel engines, supporting both single broker and cluster-wide operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->