### PR TITLE
[ISSUE #5651]🚀Implement StartMonitoringSubCommand for consumer monitoring

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -196,6 +196,11 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Create or update subscription groups in batch.",
             },
             Command {
+                category: "Consumer",
+                command: "startMonitoring",
+                remark: "Start Monitoring.",
+            },
+            Command {
                 category: "Controller",
                 command: "cleanBrokerMetadata",
                 remark: "Clean metadata of broker on controller.",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer_commands.rs
@@ -16,6 +16,7 @@ mod consumer_status_sub_command;
 mod consumer_sub_command;
 mod delete_subscription_group_sub_command;
 mod set_consume_mode_sub_command;
+mod start_monitoring_sub_command;
 mod update_sub_group_list_sub_command;
 mod update_sub_group_sub_command;
 use std::sync::Arc;
@@ -64,6 +65,12 @@ pub enum ConsumerCommands {
         long_about = None,
     )]
     SetConsumeMode(set_consume_mode_sub_command::SetConsumeModeSubCommand),
+    #[command(
+        name = "startMonitoring",
+        about = "Start Monitoring.",
+        long_about = None,
+    )]
+    StartMonitoring(start_monitoring_sub_command::StartMonitoringSubCommand),
 }
 
 impl CommandExecute for ConsumerCommands {
@@ -75,6 +82,7 @@ impl CommandExecute for ConsumerCommands {
             ConsumerCommands::UpdateSubGroupSubCommand(value) => value.execute(rpc_hook).await,
             ConsumerCommands::UpdateSubGroupList(cmd) => cmd.execute(rpc_hook).await,
             ConsumerCommands::SetConsumeMode(cmd) => cmd.execute(rpc_hook).await,
+            ConsumerCommands::StartMonitoring(cmd) => cmd.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer_commands/start_monitoring_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer_commands/start_monitoring_sub_command.rs
@@ -1,0 +1,37 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct StartMonitoringSubCommand {
+    #[arg(
+        short = 'n',
+        long = "namesrvAddr",
+        required = false,
+        help = "Name server address list, eg: '192.168.0.1:9876;192.168.0.2:9876'"
+    )]
+    namesrv_addr: Option<String>,
+}
+
+impl CommandExecute for StartMonitoringSubCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> rocketmq_error::RocketMQResult<()> {
+        todo!("Depends on MonitorService implementation")
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #5651 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Start Monitoring" command for the Consumer category, enabling users to initiate monitoring functionality via the command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->