### PR TITLE
[ISSUE #6265] Add broker config admin command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **feat(tools):** Add `broker` command group with `GetBrokerConfigSubCommand` for querying broker configuration by broker address or cluster, with optional `--keyPattern` regex filtering
 - **test(remoting):** Add comprehensive test coverage for `GetMaxOffsetRequestHeader` including required fields, optional nested headers, trait implementation methods, and edge cases
 - **feat(tools):** Add `SetConsumeModeSubCommand` for setting consumer group consumption mode (PULL/POP) ([#5650](https://github.com/mxsm/rocketmq-rust/issues/5650))
 - **feat(tools):** Add `ListAclSubCommand` for ACL enumeration and subject filtering ([#5663](https://github.com/mxsm/rocketmq-rust/issues/5663))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3442,6 +3442,7 @@ dependencies = [
  "dialoguer",
  "futures",
  "indicatif",
+ "regex",
  "rocketmq-client-rust",
  "rocketmq-common",
  "rocketmq-error",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/Cargo.toml
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/Cargo.toml
@@ -54,6 +54,7 @@ futures        = "0.3.31"
 colored        = "3.1"
 indicatif      = "0.18"
 dialoguer      = "0.12"
+regex          = "1.12.3"
 
 [[bin]]
 name = "rocketmq-admin-cli-rust"

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The RocketMQ Rust Authors
+// Copyright 2026 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod clean_unused_topic_command;
+mod get_broker_config_sub_command;
 mod switch_timer_engine_sub_command;
 
 use std::sync::Arc;
@@ -40,6 +41,13 @@ pub enum BrokerCommands {
         long_about = None,
     )]
     SwitchTimerEngine(SwitchTimerEngineSubCommand),
+
+    #[command(
+        name = "getBrokerConfig",
+        about = "Get broker config by cluster or special broker.",
+        long_about = None,
+    )]
+    GetBrokerConfigSubCommand(get_broker_config_sub_command::GetBrokerConfigSubCommand),
 }
 
 impl CommandExecute for BrokerCommands {
@@ -47,6 +55,7 @@ impl CommandExecute for BrokerCommands {
         match self {
             BrokerCommands::CleanUnusedTopic(value) => value.execute(rpc_hook).await,
             BrokerCommands::SwitchTimerEngine(value) => value.execute(rpc_hook).await,
+            BrokerCommands::GetBrokerConfigSubCommand(cmd) => cmd.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/get_broker_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/get_broker_config_sub_command.rs
@@ -1,0 +1,328 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use regex::Regex;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(
+    clap::ArgGroup::new("target")
+        .required(true)
+        .args(&["broker_addr", "cluster_name"])
+))]
+pub struct GetBrokerConfigSubCommand {
+    #[arg(short = 'b', long = "brokerAddr", help = "get which broker")]
+    broker_addr: Option<String>,
+
+    #[arg(short = 'c', long = "clusterName", help = "get which cluster")]
+    cluster_name: Option<String>,
+
+    #[arg(
+        long = "keyPattern",
+        value_name = "REGEX",
+        help = "Filter broker configuration keys by regex pattern"
+    )]
+    key_pattern: Option<String>,
+}
+
+impl GetBrokerConfigSubCommand {
+    fn key_pattern_regex(&self) -> RocketMQResult<Option<Regex>> {
+        self.key_pattern
+            .as_deref()
+            .map(str::trim)
+            .filter(|pattern| !pattern.is_empty())
+            .map(|pattern| {
+                Regex::new(pattern).map_err(|e| {
+                    RocketMQError::Internal(format!(
+                        "GetBrokerConfigSubCommand: Invalid key regex pattern '{}': {}",
+                        pattern, e
+                    ))
+                })
+            })
+            .transpose()
+    }
+
+    async fn get_and_print(
+        &self,
+        default_mqadmin_ext: &DefaultMQAdminExt,
+        print_prefix: &str,
+        addr: &str,
+        key_pattern_regex: Option<&Regex>,
+    ) -> RocketMQResult<()> {
+        if addr == CommandUtil::NO_MASTER_PLACEHOLDER {
+            println!("============(No master found — skipping)============\n");
+            return Ok(());
+        }
+
+        print!("{}", print_prefix);
+
+        let properties = default_mqadmin_ext
+            .get_broker_config(CheetahString::from(addr))
+            .await
+            .map_err(|e| {
+                RocketMQError::Internal(format!("GetBrokerConfigSubCommand: Failed to get broker config: {}", e))
+            })?;
+
+        if properties.is_empty() {
+            println!("Broker[{}] has no config property!", addr);
+            return Ok(());
+        }
+
+        let mut sorted_keys: Vec<_> = properties.keys().collect();
+        sorted_keys.sort();
+
+        let mut matched = false;
+        for key in &sorted_keys {
+            let value = &properties[*key];
+            if key_pattern_regex.is_some_and(|regex| !regex.is_match(key.as_str())) {
+                continue;
+            }
+            println!("{:<50}=  {}", key, value);
+            matched = true;
+        }
+
+        if !matched {
+            if let Some(regex) = key_pattern_regex {
+                println!(
+                    "Broker[{}] has no config property matching key pattern /{}/!",
+                    addr,
+                    regex.as_str()
+                );
+            } else {
+                println!("Broker[{}] has no config property!", addr);
+            }
+        }
+
+        println!();
+
+        Ok(())
+    }
+}
+
+impl CommandExecute for GetBrokerConfigSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+        let key_pattern_regex = self.key_pattern_regex()?;
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("GetBrokerConfigSubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+            if let Some(broker_addr) = &self.broker_addr {
+                let broker_addr = broker_addr.trim();
+                self.get_and_print(
+                    &default_mqadmin_ext,
+                    &format!("============{}============\n", broker_addr),
+                    broker_addr,
+                    key_pattern_regex.as_ref(),
+                )
+                .await?;
+            } else if let Some(cluster_name) = &self.cluster_name {
+                let cluster_name = cluster_name.trim();
+                let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await.map_err(|e| {
+                    RocketMQError::Internal(format!(
+                        "GetBrokerConfigSubCommand: Failed to examine broker cluster info: {}",
+                        e
+                    ))
+                })?;
+
+                let master_and_slave_map =
+                    CommandUtil::fetch_master_and_slave_distinguish(&cluster_info, cluster_name)?;
+
+                let mut sorted_masters: Vec<_> = master_and_slave_map.keys().collect();
+                sorted_masters.sort();
+
+                for master_addr in &sorted_masters {
+                    let slave_addrs = &master_and_slave_map[*master_addr];
+                    self.get_and_print(
+                        &default_mqadmin_ext,
+                        &format!("============Master: {}============\n", master_addr),
+                        master_addr.as_str(),
+                        key_pattern_regex.as_ref(),
+                    )
+                    .await?;
+
+                    let mut sorted_slaves: Vec<_> = slave_addrs.iter().collect();
+                    sorted_slaves.sort();
+
+                    for slave_addr in &sorted_slaves {
+                        self.get_and_print(
+                            &default_mqadmin_ext,
+                            &format!(
+                                "============My Master: {}=====Slave: {}============\n",
+                                master_addr, slave_addr
+                            ),
+                            slave_addr.as_str(),
+                            key_pattern_regex.as_ref(),
+                        )
+                        .await?;
+                    }
+                }
+            }
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_master_placeholder_check() {
+        // Ensure NO_MASTER_PLACEHOLDER constant is correctly defined
+        assert_eq!(CommandUtil::NO_MASTER_PLACEHOLDER, "NO_MASTER");
+    }
+
+    #[test]
+    fn test_parse_with_broker_addr() {
+        let args = vec!["get-broker-config", "-b", "192.168.1.1:10911"];
+
+        let cmd = GetBrokerConfigSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.broker_addr, Some("192.168.1.1:10911".to_string()));
+        assert_eq!(cmd.cluster_name, None);
+    }
+
+    #[test]
+    fn test_parse_with_cluster_name() {
+        let args = vec!["get-broker-config", "-c", "DefaultCluster"];
+
+        let cmd = GetBrokerConfigSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.broker_addr, None);
+        assert_eq!(cmd.cluster_name, Some("DefaultCluster".to_string()));
+        assert_eq!(cmd.key_pattern, None);
+    }
+
+    #[test]
+    fn test_parse_with_long_option_broker_addr() {
+        let args = vec!["get-broker-config", "--brokerAddr", "127.0.0.1:10911"];
+
+        let cmd = GetBrokerConfigSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.broker_addr, Some("127.0.0.1:10911".to_string()));
+        assert_eq!(cmd.cluster_name, None);
+    }
+
+    #[test]
+    fn test_parse_with_long_option_cluster_name() {
+        let args = vec!["get-broker-config", "--clusterName", "TestCluster"];
+
+        let cmd = GetBrokerConfigSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.broker_addr, None);
+        assert_eq!(cmd.cluster_name, Some("TestCluster".to_string()));
+        assert_eq!(cmd.key_pattern, None);
+    }
+
+    #[test]
+    fn test_parse_with_key_pattern() {
+        let args = vec!["get-broker-config", "-b", "127.0.0.1:10911", "--keyPattern", "^flush.*"];
+
+        let cmd = GetBrokerConfigSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.broker_addr, Some("127.0.0.1:10911".to_string()));
+        assert_eq!(cmd.cluster_name, None);
+        assert_eq!(cmd.key_pattern, Some("^flush.*".to_string()));
+    }
+
+    #[test]
+    fn test_invalid_key_pattern_regex_returns_error() {
+        let cmd = GetBrokerConfigSubCommand {
+            broker_addr: Some("127.0.0.1:10911".to_string()),
+            cluster_name: None,
+            key_pattern: Some("[".to_string()),
+        };
+
+        let err = cmd.key_pattern_regex();
+        assert!(err.is_err());
+
+        let err_msg = format!("{}", err.unwrap_err());
+        assert!(err_msg.contains("Invalid key regex pattern"));
+    }
+
+    #[test]
+    fn test_parse_missing_required_option() {
+        let args = vec!["get-broker-config"];
+
+        let cmd = GetBrokerConfigSubCommand::try_parse_from(args);
+        assert!(cmd.is_err());
+    }
+
+    #[test]
+    fn test_parse_both_options_provided() {
+        // Both broker_addr and cluster_name provided (should fail due to mutual exclusivity)
+        let args = vec!["get-broker-config", "-b", "192.168.1.1:10911", "-c", "DefaultCluster"];
+
+        let cmd = GetBrokerConfigSubCommand::try_parse_from(args);
+        assert!(cmd.is_err());
+    }
+
+    #[test]
+    fn test_broker_addr_with_spaces() {
+        let args = vec!["get-broker-config", "-b", "  192.168.1.1:10911  "];
+
+        let cmd = GetBrokerConfigSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.broker_addr.as_ref().unwrap().trim(), "192.168.1.1:10911");
+    }
+
+    #[test]
+    fn test_cluster_name_with_spaces() {
+        let args = vec!["get-broker-config", "-c", "  DefaultCluster  "];
+
+        let cmd = GetBrokerConfigSubCommand::try_parse_from(args);
+        assert!(cmd.is_ok());
+
+        let cmd = cmd.unwrap();
+        assert_eq!(cmd.cluster_name.as_ref().unwrap().trim(), "DefaultCluster");
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6265

### Brief Description

Add a broker command group to rocketmq-admin and include a getBrokerConfig subcommand for reading broker configuration. This lets operators query configuration by broker address or by cluster, improving CLI coverage for broker-focused admin tasks.

Add an optional `--keyPattern <REGEX>` argument to the broker `getBrokerConfig` command so operators can narrow output to relevant configuration keys. Keep existing behavior unchanged when no pattern is provided, and return a clear error for invalid regex input.

Other setups
- Add `fetch_master_and_slave_distinguish` in command util
- Create the minimum `broker_command` mod for this issue
- Add the `regex = "1.12.3"` for the key pattern filering

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

The tests for `GetBrokerConfigSubCommand` focus on CLI argument parsing and local validation behavior. They cover:
- Correct parsing for broker target (`-b` / `--brokerAddr`) and cluster target (`-c` / `--clusterName`)
- Optional regex key filter parsing via `--keyPattern`
- Invalid regex handling (`key_pattern_regex()` returns an error)
- Required target enforcement (fails when neither broker nor cluster is provided)
- Mutual exclusivity enforcement (fails when both broker and cluster are provided)
- Input normalization checks for whitespace around broker address and cluster name
- Constant guard for `NO_MASTER_PLACEHOLDER`


<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a broker configuration command group with a subcommand to fetch configs by broker address or cluster (one required).
  * Optional regex-based key filtering with validation and clear error on invalid patterns.
  * Cluster queries show distinct Master and Slave sections; uses a NO_MASTER placeholder when no master exists.
  * Improved argument handling (mutual exclusivity, trimming) and clearer messages when no matches are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->