### PR TITLE
[ISSUE #6247][Test🧪] Add test case for RecallMessageResponseHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/recall_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/recall_message_response_header.rs
@@ -56,10 +56,10 @@ mod tests {
     #[test]
     fn new_with_msg_id() {
         let mut body = RecallMessageResponseHeader::new("some_message");
-        assert_eq!(body.msg_id, "some_message".to_string());
+        assert_eq!(body.msg_id(), &CheetahString::from("some_message"));
 
         body.set_msg_id("some_new_message");
-        assert_eq!(body.msg_id, "some_new_message".to_string());
+        assert_eq!(body.msg_id(), &CheetahString::from("some_new_message"));
 
         let display_output = format!("{}", body);
         assert_eq!(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6247 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering message-recall response behavior: JSON serialization and deserialization, cloning consistency, and display formatting.
  * Verifies getter/setter behavior for the message identifier.
  * Confirms no changes to the public API surface or runtime signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->