### PR TITLE
[ISSUE #6276]🚀Implement ResetMasterFlushOffset command in rocketmq-admin-core

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -926,7 +926,14 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         broker_addr: CheetahString,
         master_flush_offset: u64,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        if let Some(ref mq_client_instance) = self.client_instance {
+            mq_client_instance
+                .get_mq_client_api_impl()
+                .reset_master_flush_offset(&broker_addr, master_flush_offset as i64)
+                .await
+        } else {
+            Err(rocketmq_error::RocketMQError::ClientNotStarted)
+        }
     }
 
     async fn get_controller_config(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -776,7 +776,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         broker_addr: CheetahString,
         master_flush_offset: u64,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .reset_master_flush_offset(broker_addr, master_flush_offset)
+            .await
     }
 
     async fn get_controller_config(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -189,6 +189,16 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Broker",
+                command: "getBrokerConfig",
+                remark: "Get broker config by cluster or special broker.",
+            },
+            Command {
+                category: "Broker",
+                command: "resetMasterFlushOffset",
+                remark: "Reset master flush offset in slave.",
+            },
+            Command {
+                category: "Broker",
                 command: "sendMsgStatus",
                 remark: "Send msg to broker.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
@@ -15,6 +15,7 @@
 mod clean_expired_cq_sub_command;
 mod clean_unused_topic_command;
 mod get_broker_config_sub_command;
+mod reset_master_flush_offset_sub_command;
 mod send_msg_status_command;
 mod switch_timer_engine_sub_command;
 
@@ -27,6 +28,7 @@ use rocketmq_remoting::runtime::RPCHook;
 use crate::commands::broker_commands::clean_expired_cq_sub_command::CleanExpiredCQSubCommand;
 use crate::commands::broker_commands::clean_unused_topic_command::CleanUnusedTopicCommand;
 use crate::commands::broker_commands::get_broker_config_sub_command::GetBrokerConfigSubCommand;
+use crate::commands::broker_commands::reset_master_flush_offset_sub_command::ResetMasterFlushOffsetSubCommand;
 use crate::commands::broker_commands::send_msg_status_command::SendMsgStatusCommand;
 use crate::commands::broker_commands::switch_timer_engine_sub_command::SwitchTimerEngineSubCommand;
 use crate::commands::CommandExecute;
@@ -55,6 +57,13 @@ pub enum BrokerCommands {
     GetBrokerConfigSubCommand(GetBrokerConfigSubCommand),
 
     #[command(
+        name = "resetMasterFlushOffset",
+        about = "Reset master flush offset in slave.",
+        long_about = None,
+    )]
+    ResetMasterFlushOffset(ResetMasterFlushOffsetSubCommand),
+
+    #[command(
         name = "sendMsgStatus",
         about = "Send msg to broker.",
         long_about = None,
@@ -75,6 +84,7 @@ impl CommandExecute for BrokerCommands {
             BrokerCommands::CleanExpiredCQ(value) => value.execute(rpc_hook).await,
             BrokerCommands::CleanUnusedTopic(value) => value.execute(rpc_hook).await,
             BrokerCommands::GetBrokerConfigSubCommand(cmd) => cmd.execute(rpc_hook).await,
+            BrokerCommands::ResetMasterFlushOffset(value) => value.execute(rpc_hook).await,
             BrokerCommands::SendMsgStatus(value) => value.execute(rpc_hook).await,
             BrokerCommands::SwitchTimerEngine(value) => value.execute(rpc_hook).await,
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/reset_master_flush_offset_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/reset_master_flush_offset_sub_command.rs
@@ -1,0 +1,81 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct ResetMasterFlushOffsetSubCommand {
+    #[arg(short = 'b', long = "brokerAddr", required = false, help = "which broker to reset")]
+    broker_addr: Option<String>,
+
+    #[arg(short = 'o', long = "offset", required = false, help = "the offset to reset at")]
+    offset: Option<i64>,
+}
+
+impl CommandExecute for ResetMasterFlushOffsetSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+            RocketMQError::Internal(format!(
+                "ResetMasterFlushOffsetSubCommand: Failed to start MQAdminExt: {}",
+                e
+            ))
+        })?;
+
+        let broker_addr = self
+            .broker_addr
+            .as_ref()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| RocketMQError::Internal("brokerAddr is required".into()))?;
+        let master_flush_offset = self
+            .offset
+            .ok_or_else(|| RocketMQError::Internal("offset is required".into()))?;
+
+        let result = default_mqadmin_ext
+            .reset_master_flush_offset(broker_addr.into(), master_flush_offset as u64)
+            .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+
+        match result {
+            Ok(()) => {
+                println!("reset master flush offset to {} success", master_flush_offset);
+                Ok(())
+            }
+            Err(e) => Err(RocketMQError::Internal(format!(
+                "ResetMasterFlushOffsetSubCommand command failed: {}",
+                e
+            ))),
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6276 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to reset a broker's master flush offset (accepts broker address and offset) and prints a confirmation on success.
  * Admin tooling can now perform the reset operation against a broker and returns structured error feedback.

* **Bug Fixes**
  * Implemented the previously unimplemented reset operation; validates inputs, handles client/startup errors, and reports invocation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->