### PR TITLE
[ISSUE #6267]🚀Implement CleanUnusedTopic command in rocketmq-admin-core

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -179,6 +179,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Broker",
+                command: "cleanUnusedTopic",
+                remark: "Clean unused topic on broker.",
+            },
+            Command {
+                category: "Broker",
                 command: "switchTimerEngine",
                 remark: "Switch the engine of timer message in broker.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod clean_unused_topic_command;
 mod switch_timer_engine_sub_command;
 
 use std::sync::Arc;
@@ -20,11 +21,19 @@ use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
+use crate::commands::broker_commands::clean_unused_topic_command::CleanUnusedTopicCommand;
 use crate::commands::broker_commands::switch_timer_engine_sub_command::SwitchTimerEngineSubCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
 pub enum BrokerCommands {
+    #[command(
+        name = "cleanUnusedTopic",
+        about = "Clean unused topic on broker.",
+        long_about = None,
+    )]
+    CleanUnusedTopic(CleanUnusedTopicCommand),
+
     #[command(
         name = "switchTimerEngine",
         about = "Switch the engine of timer message in broker.",
@@ -36,6 +45,7 @@ pub enum BrokerCommands {
 impl CommandExecute for BrokerCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
+            BrokerCommands::CleanUnusedTopic(value) => value.execute(rpc_hook).await,
             BrokerCommands::SwitchTimerEngine(value) => value.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/clean_unused_topic_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/clean_unused_topic_command.rs
@@ -1,0 +1,86 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::ArgGroup;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(ArgGroup::new("target")
+    .required(false)
+    .args(&["broker_addr", "cluster_name"]))
+)]
+pub struct CleanUnusedTopicCommand {
+    #[arg(short = 'b', long = "brokerAddr", required = false, help = "Broker address")]
+    broker_addr: Option<String>,
+
+    #[arg(short = 'c', long = "cluster", required = false, help = "Cluster name")]
+    cluster_name: Option<String>,
+}
+
+impl CommandExecute for CleanUnusedTopicCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+            RocketMQError::Internal(format!("CleanUnusedTopicCommand: Failed to start MQAdminExt: {}", e))
+        })?;
+
+        let operation_result = clean_unused_topic(&default_mqadmin_ext, self).await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+async fn clean_unused_topic(
+    default_mqadmin_ext: &DefaultMQAdminExt,
+    command: &CleanUnusedTopicCommand,
+) -> RocketMQResult<()> {
+    let addr = command
+        .broker_addr
+        .as_ref()
+        .map(|s| CheetahString::from(s.trim().to_string()));
+    let cluster = command
+        .cluster_name
+        .as_ref()
+        .map(|s| CheetahString::from(s.trim().to_string()));
+
+    let result = default_mqadmin_ext.clean_unused_topic(cluster, addr).await?;
+
+    if result {
+        println!("success");
+    } else {
+        println!("false");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6267  

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command to clean unused topics on brokers.
  * Supports optional parameters for specifying target broker address and cluster name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->