### PR TITLE
[ISSUE #6213] [Test🧪] Add unit tests for QueueTimeSpan 

### DIFF
--- a/rocketmq-remoting/src/protocol/body/queue_time_span.rs
+++ b/rocketmq-remoting/src/protocol/body/queue_time_span.rs
@@ -187,8 +187,12 @@ mod tests {
             delay_time: 4,
         };
 
-        assert_eq!(body.get_min_time_stamp_str(), "1970-01-01 01:00:00,001".to_string());
-        assert_eq!(body.get_max_time_stamp_str(), "1970-01-01 01:00:00,002".to_string());
-        assert_eq!(body.get_consume_time_stamp_str(), "1970-01-01 01:00:00,003".to_string());
+        let expected_min = time_millis_to_human_string2(body.get_min_time_stamp());
+        let expected_max = time_millis_to_human_string2(body.get_max_time_stamp());
+        let expected_consume = time_millis_to_human_string2(body.get_consume_time_stamp());
+
+        assert_eq!(body.get_min_time_stamp_str(), expected_min);
+        assert_eq!(body.get_max_time_stamp_str(), expected_max);
+        assert_eq!(body.get_consume_time_stamp_str(), expected_consume);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6213 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests covering queue time span behavior: initialization defaults, cloning, getter/setter behavior, and timestamp-to-string conversions.
  * Tests include JSON serialization/deserialization checks and validate instances both with and without associated queue information to ensure consistent observable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->