### PR TITLE
[ISSUE #6277]🚀Implement DeleteExpiredCommitLog command in rocketmq-admin-core

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -189,6 +189,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Broker",
+                command: "deleteExpiredCommitLog",
+                remark: "Delete expired CommitLog files.",
+            },
+            Command {
+                category: "Broker",
                 command: "getBrokerConfig",
                 remark: "Get broker config by cluster or special broker.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
@@ -14,6 +14,7 @@
 
 mod clean_expired_cq_sub_command;
 mod clean_unused_topic_command;
+mod delete_expired_commit_log_command;
 mod get_broker_config_sub_command;
 mod reset_master_flush_offset_sub_command;
 mod send_msg_status_command;
@@ -28,6 +29,7 @@ use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::broker_commands::clean_expired_cq_sub_command::CleanExpiredCQSubCommand;
 use crate::commands::broker_commands::clean_unused_topic_command::CleanUnusedTopicCommand;
+use crate::commands::broker_commands::delete_expired_commit_log_command::DeleteExpiredCommitLogCommand;
 use crate::commands::broker_commands::get_broker_config_sub_command::GetBrokerConfigSubCommand;
 use crate::commands::broker_commands::reset_master_flush_offset_sub_command::ResetMasterFlushOffsetSubCommand;
 use crate::commands::broker_commands::send_msg_status_command::SendMsgStatusCommand;
@@ -50,6 +52,13 @@ pub enum BrokerCommands {
         long_about = None,
     )]
     CleanUnusedTopic(CleanUnusedTopicCommand),
+
+    #[command(
+        name = "deleteExpiredCommitLog",
+        about = "Delete expired CommitLog files.",
+        long_about = None,
+    )]
+    DeleteExpiredCommitLog(DeleteExpiredCommitLogCommand),
 
     #[command(
         name = "getBrokerConfig",
@@ -92,6 +101,7 @@ impl CommandExecute for BrokerCommands {
         match self {
             BrokerCommands::CleanExpiredCQ(value) => value.execute(rpc_hook).await,
             BrokerCommands::CleanUnusedTopic(value) => value.execute(rpc_hook).await,
+            BrokerCommands::DeleteExpiredCommitLog(value) => value.execute(rpc_hook).await,
             BrokerCommands::GetBrokerConfigSubCommand(cmd) => cmd.execute(rpc_hook).await,
             BrokerCommands::ResetMasterFlushOffset(value) => value.execute(rpc_hook).await,
             BrokerCommands::SendMsgStatus(value) => value.execute(rpc_hook).await,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/delete_expired_commit_log_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/delete_expired_commit_log_command.rs
@@ -1,0 +1,89 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::ArgGroup;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(ArgGroup::new("target")
+    .required(false)
+    .args(&["broker_addr", "cluster_name"]))
+)]
+pub struct DeleteExpiredCommitLogCommand {
+    #[arg(short = 'b', long = "brokerAddr", required = false, help = "Broker address")]
+    broker_addr: Option<String>,
+
+    #[arg(short = 'c', long = "cluster", required = false, help = "Cluster name")]
+    cluster_name: Option<String>,
+}
+
+impl CommandExecute for DeleteExpiredCommitLogCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+            RocketMQError::Internal(format!(
+                "DeleteExpiredCommitLogCommand: Failed to start MQAdminExt: {}",
+                e
+            ))
+        })?;
+
+        let operation_result = delete_expired_commit_log(&default_mqadmin_ext, self).await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+async fn delete_expired_commit_log(
+    default_mqadmin_ext: &DefaultMQAdminExt,
+    command: &DeleteExpiredCommitLogCommand,
+) -> RocketMQResult<()> {
+    let addr = command
+        .broker_addr
+        .as_ref()
+        .map(|s| CheetahString::from(s.trim().to_string()));
+    let cluster = command
+        .cluster_name
+        .as_ref()
+        .map(|s| CheetahString::from(s.trim().to_string()));
+
+    let result = default_mqadmin_ext.delete_expired_commit_log(cluster, addr).await?;
+
+    if result {
+        println!("success");
+    } else {
+        println!("false");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6277 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new broker CLI command, deleteExpiredCommitLog, to remove expired CommitLog files.
  * Command accepts optional broker address or cluster name to target the operation.
  * Integrates with existing broker command set and prints a simple success/false result to indicate outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->