### PR TITLE
 remove unnecessary `.as_str()` in `DefaultMQProducer::start` #6316

### DIFF
--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -692,7 +692,8 @@ impl DefaultMQProducer {
 
 impl MQProducer for DefaultMQProducer {
     async fn start(&mut self) -> rocketmq_error::RocketMQResult<()> {
-        let producer_group = self.with_namespace(self.producer_config.producer_group.clone().as_str());
+        let producer_group_clone = self.producer_config.producer_group.clone();
+        let producer_group = self.with_namespace(&producer_group_clone);
         self.set_producer_group(producer_group);
         let default_mqproducer_impl = self
             .default_mqproducer_impl


### PR DESCRIPTION
## What changed
Refactor in `rocketmq-client/src/producer/default_mq_producer.rs` (`DefaultMQProducer::start`, around L695–696) to drop a redundant `.as_str()`.

**Before**
```rust
let producer_group = self.with_namespace(self.producer_config.producer_group.clone().as_str());
```

**After**
```rust
let producer_group_clone = self.producer_config.producer_group.clone();
let producer_group = self.with_namespace(&producer_group_clone);
```
### Testing

All existing tests pass:
```
cd rocketmq-client && cargo test
```

### Notes
Pure cleanup. No functional or performance impact.


Fixes #6316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of producer group configuration processing for better code stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->