### PR TITLE
fix: remove commented-out dead code from offset_request_handler.rs

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
@@ -113,13 +113,6 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
             response_header,
         )))
     }
-    /*
-    async fn handle_get_min_offset(
-        &mut self,
-        mut request_header: GetMinOffsetRequestHeader,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-
-    }*/
 
     async fn handle_get_min_offset_for_static_topic(
         &mut self,


### PR DESCRIPTION
## Summary
- Remove the unused commented-out `handle_get_min_offset` function stub in `offset_request_handler.rs`
- The actual implementation is `handle_get_min_offset_for_static_topic` which is already in use

Closes #6332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused code from the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->