### PR TITLE
[ISSUE #6343]✨Organize and standardize the SubCommands and Commands in rocketmq-admin-core

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth_commands.rs
@@ -27,6 +27,18 @@ mod update_user_sub_command;
 
 use std::sync::Arc;
 
+use crate::commands::auth_commands::copy_acl_sub_command::CopyAclSubCommand;
+use crate::commands::auth_commands::copy_users_sub_command::CopyUsersSubCommand;
+use crate::commands::auth_commands::create_acl_sub_command::CreateAclSubCommand;
+use crate::commands::auth_commands::create_user_sub_command::CreateUserSubCommand;
+use crate::commands::auth_commands::delete_acl_sub_command::DeleteAclSubCommand;
+use crate::commands::auth_commands::delete_user_sub_command::DeleteUserSubCommand;
+use crate::commands::auth_commands::get_acl_sub_command::GetAclSubCommand;
+use crate::commands::auth_commands::get_user_sub_command::GetUserSubCommand;
+use crate::commands::auth_commands::list_acl_sub_command::ListAclSubCommand;
+use crate::commands::auth_commands::list_users_sub_command::ListUsersSubCommand;
+use crate::commands::auth_commands::update_acl_sub_command::UpdateAclSubCommand;
+use crate::commands::auth_commands::update_user_sub_command::UpdateUserSubCommand;
 use crate::commands::CommandExecute;
 use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
@@ -39,84 +51,84 @@ pub enum AuthCommands {
         about = "Copy acl to cluster",
         long_about = None,
     )]
-    CopyAcl(copy_acl_sub_command::CopyAclSubCommand),
+    CopyAcl(CopyAclSubCommand),
 
     #[command(
         name = "copyUser",
         about = "Copy user to cluster",
         long_about = None,
     )]
-    CopyUsers(copy_users_sub_command::CopyUsersSubCommand),
+    CopyUsers(CopyUsersSubCommand),
 
     #[command(
         name = "createAcl",
         about = "Create acl to cluster",
         long_about = None,
     )]
-    CreateAcl(create_acl_sub_command::CreateAclSubCommand),
+    CreateAcl(CreateAclSubCommand),
 
     #[command(
         name = "createUser",
         about = "Create user to cluster.",
         long_about = None,
     )]
-    CreateUser(create_user_sub_command::CreateUserSubCommand),
+    CreateUser(CreateUserSubCommand),
 
     #[command(
         name = "deleteAcl",
         about = "Delete acl from cluster.",
         long_about = None,
     )]
-    DeleteAcl(delete_acl_sub_command::DeleteAclSubCommand),
+    DeleteAcl(DeleteAclSubCommand),
 
     #[command(
         name = "deleteUser",
         about = "Delete user from cluster.",
         long_about = None,
     )]
-    DeleteUser(delete_user_sub_command::DeleteUserSubCommand),
-
-    #[command(
-        name = "getUser",
-        about = "Get user from cluster.",
-        long_about = None,
-    )]
-    GetUser(get_user_sub_command::GetUserSubCommand),
+    DeleteUser(DeleteUserSubCommand),
 
     #[command(
         name = "getAcl",
         about = "Get acl from cluster.",
         long_about = None,
     )]
-    GetAcl(get_acl_sub_command::GetAclSubCommand),
+    GetAcl(GetAclSubCommand),
 
     #[command(
-        name = "listUsers",
-        about = "List users from cluster.",
+        name = "getUser",
+        about = "Get user from cluster.",
         long_about = None,
     )]
-    ListUsers(list_users_sub_command::ListUsersSubCommand),
+    GetUser(GetUserSubCommand),
 
     #[command(
         name = "listAcl",
         about = "List acl from cluster",
         long_about = None,
     )]
-    ListAcl(list_acl_sub_command::ListAclSubCommand),
+    ListAcl(ListAclSubCommand),
+
+    #[command(
+        name = "listUsers",
+        about = "List users from cluster.",
+        long_about = None,
+    )]
+    ListUsers(ListUsersSubCommand),
 
     #[command(
         name = "updateAcl",
         about = "Update Access Control List (ACL)",
         long_about = None,
     )]
-    UpdateAcl(update_acl_sub_command::UpdateAclSubCommand),
+    UpdateAcl(UpdateAclSubCommand),
 
     #[command(
         name = "updateUser",
         about = "Update user to cluster.",
         long_about = None,
     )]
-    UpdateUser(update_user_sub_command::UpdateUserSubCommand),
+    UpdateUser(UpdateUserSubCommand),
 }
 
 impl CommandExecute for AuthCommands {
@@ -128,8 +140,8 @@ impl CommandExecute for AuthCommands {
             AuthCommands::CreateUser(value) => value.execute(rpc_hook).await,
             AuthCommands::DeleteAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::DeleteUser(value) => value.execute(rpc_hook).await,
-            AuthCommands::GetUser(value) => value.execute(rpc_hook).await,
             AuthCommands::GetAcl(value) => value.execute(rpc_hook).await,
+            AuthCommands::GetUser(value) => value.execute(rpc_hook).await,
             AuthCommands::ListAcl(value) => value.execute(rpc_hook).await,
             AuthCommands::ListUsers(value) => value.execute(rpc_hook).await,
             AuthCommands::UpdateAcl(value) => value.execute(rpc_hook).await,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 mod clean_expired_cq_sub_command;
-mod clean_unused_topic_command;
-mod delete_expired_commit_log_command;
+mod clean_unused_topic_sub_command;
+mod delete_expired_commit_log_sub_command;
 mod get_broker_config_sub_command;
 mod reset_master_flush_offset_sub_command;
-mod send_msg_status_command;
+mod send_msg_status_sub_command;
 mod switch_timer_engine_sub_command;
 mod update_cold_data_flow_ctr_group_config_sub_command;
 
@@ -28,11 +28,11 @@ use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::broker_commands::clean_expired_cq_sub_command::CleanExpiredCQSubCommand;
-use crate::commands::broker_commands::clean_unused_topic_command::CleanUnusedTopicCommand;
-use crate::commands::broker_commands::delete_expired_commit_log_command::DeleteExpiredCommitLogCommand;
+use crate::commands::broker_commands::clean_unused_topic_sub_command::CleanUnusedTopicSubCommand;
+use crate::commands::broker_commands::delete_expired_commit_log_sub_command::DeleteExpiredCommitLogSubCommand;
 use crate::commands::broker_commands::get_broker_config_sub_command::GetBrokerConfigSubCommand;
 use crate::commands::broker_commands::reset_master_flush_offset_sub_command::ResetMasterFlushOffsetSubCommand;
-use crate::commands::broker_commands::send_msg_status_command::SendMsgStatusCommand;
+use crate::commands::broker_commands::send_msg_status_sub_command::SendMsgStatusSubCommand;
 use crate::commands::broker_commands::switch_timer_engine_sub_command::SwitchTimerEngineSubCommand;
 use crate::commands::broker_commands::update_cold_data_flow_ctr_group_config_sub_command::UpdateColdDataFlowCtrGroupConfigSubCommand;
 use crate::commands::CommandExecute;
@@ -51,21 +51,21 @@ pub enum BrokerCommands {
         about = "Clean unused topic on broker.",
         long_about = None,
     )]
-    CleanUnusedTopic(CleanUnusedTopicCommand),
+    CleanUnusedTopic(CleanUnusedTopicSubCommand),
 
     #[command(
         name = "deleteExpiredCommitLog",
         about = "Delete expired CommitLog files.",
         long_about = None,
     )]
-    DeleteExpiredCommitLog(DeleteExpiredCommitLogCommand),
+    DeleteExpiredCommitLog(DeleteExpiredCommitLogSubCommand),
 
     #[command(
         name = "getBrokerConfig",
         about = "Get broker config by cluster or special broker.",
         long_about = None,
     )]
-    GetBrokerConfigSubCommand(GetBrokerConfigSubCommand),
+    GetBrokerConfig(GetBrokerConfigSubCommand),
 
     #[command(
         name = "resetMasterFlushOffset",
@@ -79,7 +79,7 @@ pub enum BrokerCommands {
         about = "Send msg to broker.",
         long_about = None,
     )]
-    SendMsgStatus(SendMsgStatusCommand),
+    SendMsgStatus(SendMsgStatusSubCommand),
 
     #[command(
         name = "switchTimerEngine",
@@ -102,7 +102,7 @@ impl CommandExecute for BrokerCommands {
             BrokerCommands::CleanExpiredCQ(value) => value.execute(rpc_hook).await,
             BrokerCommands::CleanUnusedTopic(value) => value.execute(rpc_hook).await,
             BrokerCommands::DeleteExpiredCommitLog(value) => value.execute(rpc_hook).await,
-            BrokerCommands::GetBrokerConfigSubCommand(cmd) => cmd.execute(rpc_hook).await,
+            BrokerCommands::GetBrokerConfig(cmd) => cmd.execute(rpc_hook).await,
             BrokerCommands::ResetMasterFlushOffset(value) => value.execute(rpc_hook).await,
             BrokerCommands::SendMsgStatus(value) => value.execute(rpc_hook).await,
             BrokerCommands::SwitchTimerEngine(value) => value.execute(rpc_hook).await,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/send_msg_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/send_msg_status_sub_command.rs
@@ -43,7 +43,7 @@ fn build_message(topic: &str, message_size: usize) -> Message {
 }
 
 #[derive(Debug, Clone, Parser)]
-pub struct SendMsgStatusCommand {
+pub struct SendMsgStatusSubCommand {
     #[arg(
         short = 'b',
         long = "brokerName",
@@ -71,7 +71,7 @@ pub struct SendMsgStatusCommand {
     count: u32,
 }
 
-impl CommandExecute for SendMsgStatusCommand {
+impl CommandExecute for SendMsgStatusSubCommand {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         let instance_name = format!("PID_SMSC_{}", get_current_millis());
         let mut client_config = ClientConfig::default();
@@ -96,7 +96,7 @@ impl CommandExecute for SendMsgStatusCommand {
         if let Err(e) = warmup_result {
             producer.shutdown().await;
             return Err(RocketMQError::Internal(format!(
-                "SendMsgStatusCommand command failed: {}",
+                "SendMsgStatusSubCommand command failed: {}",
                 e
             )));
         }
@@ -115,7 +115,7 @@ impl CommandExecute for SendMsgStatusCommand {
                 Err(e) => {
                     producer.shutdown().await;
                     return Err(RocketMQError::Internal(format!(
-                        "SendMsgStatusCommand command failed: {}",
+                        "SendMsgStatusSubCommand command failed: {}",
                         e
                     )));
                 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer_commands.rs
@@ -25,6 +25,13 @@ use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
+use crate::commands::consumer_commands::consumer_status_sub_command::ConsumerStatusSubCommand;
+use crate::commands::consumer_commands::consumer_sub_command::ConsumerSubCommand;
+use crate::commands::consumer_commands::delete_subscription_group_sub_command::DeleteSubscriptionGroupSubCommand;
+use crate::commands::consumer_commands::set_consume_mode_sub_command::SetConsumeModeSubCommand;
+use crate::commands::consumer_commands::start_monitoring_sub_command::StartMonitoringSubCommand;
+use crate::commands::consumer_commands::update_sub_group_list_sub_command::UpdateSubGroupListSubCommand;
+use crate::commands::consumer_commands::update_sub_group_sub_command::UpdateSubGroupSubCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
@@ -34,55 +41,61 @@ pub enum ConsumerCommands {
         about = "Query and display consumer's internal data structures, including subscription information, queue allocation, consumption mode, and runtime information.",
         long_about = None,
     )]
-    ConsumerStatusSubCommand(consumer_status_sub_command::ConsumerStatusSubCommand),
+    ConsumerStatus(ConsumerStatusSubCommand),
+
     #[command(
         name = "consumer",
         about = "Query consumer's connection, status, etc.",
         long_about = None,
     )]
-    ConsumerSubCommand(consumer_sub_command::ConsumerSubCommand),
+    Consumer(ConsumerSubCommand),
+
     #[command(
         name = "deleteSubGroup",
         about = "Delete subscription group",
         long_about = r#"Delete subscription group from broker."#
     )]
-    DeleteSubGroup(delete_subscription_group_sub_command::DeleteSubscriptionGroupSubCommand),
-    #[command(
-        name = "updateSubGroup",
-        about = "Update or create subscription group.",
-        long_about = None,
-    )]
-    UpdateSubGroupSubCommand(update_sub_group_sub_command::UpdateSubGroupSubCommand),
-    #[command(
-        name = "updateSubGroupList",
-        about = "Create or update subscription groups in batch.",
-        long_about = None,
-    )]
-    UpdateSubGroupList(update_sub_group_list_sub_command::UpdateSubGroupListSubCommand),
+    DeleteSubscriptionGroup(DeleteSubscriptionGroupSubCommand),
+
     #[command(
         name = "setConsumeMode",
         about = "Set consume message mode. pull/pop etc.",
         long_about = None,
     )]
-    SetConsumeMode(set_consume_mode_sub_command::SetConsumeModeSubCommand),
+    SetConsumeMode(SetConsumeModeSubCommand),
+
     #[command(
         name = "startMonitoring",
         about = "Start Monitoring.",
         long_about = None,
     )]
-    StartMonitoring(start_monitoring_sub_command::StartMonitoringSubCommand),
+    StartMonitoring(StartMonitoringSubCommand),
+
+    #[command(
+        name = "updateSubGroupList",
+        about = "Create or update subscription groups in batch.",
+        long_about = None,
+    )]
+    UpdateSubGroupList(UpdateSubGroupListSubCommand),
+
+    #[command(
+        name = "updateSubGroup",
+        about = "Update or create subscription group.",
+        long_about = None,
+    )]
+    UpdateSubGroup(UpdateSubGroupSubCommand),
 }
 
 impl CommandExecute for ConsumerCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
-            ConsumerCommands::ConsumerStatusSubCommand(cmd) => cmd.execute(rpc_hook).await,
-            ConsumerCommands::ConsumerSubCommand(cmd) => cmd.execute(rpc_hook).await,
-            ConsumerCommands::DeleteSubGroup(cmd) => cmd.execute(rpc_hook).await,
-            ConsumerCommands::UpdateSubGroupSubCommand(value) => value.execute(rpc_hook).await,
-            ConsumerCommands::UpdateSubGroupList(cmd) => cmd.execute(rpc_hook).await,
+            ConsumerCommands::ConsumerStatus(cmd) => cmd.execute(rpc_hook).await,
+            ConsumerCommands::Consumer(cmd) => cmd.execute(rpc_hook).await,
+            ConsumerCommands::DeleteSubscriptionGroup(cmd) => cmd.execute(rpc_hook).await,
             ConsumerCommands::SetConsumeMode(cmd) => cmd.execute(rpc_hook).await,
             ConsumerCommands::StartMonitoring(cmd) => cmd.execute(rpc_hook).await,
+            ConsumerCommands::UpdateSubGroupList(cmd) => cmd.execute(rpc_hook).await,
+            ConsumerCommands::UpdateSubGroup(value) => value.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller_commands.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod clean_broker_metadata_command;
+mod clean_broker_metadata_sub_command;
 mod get_controller_config_sub_command;
 mod get_controller_metadata_sub_command;
 mod update_controller_config_sub_command;
@@ -23,6 +23,8 @@ use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
+use crate::commands::controller_commands::clean_broker_metadata_sub_command::CleanBrokerMetadataSubCommand;
+use crate::commands::controller_commands::get_controller_config_sub_command::GetControllerConfigSubCommand;
 use crate::commands::controller_commands::get_controller_metadata_sub_command::GetControllerMetadataSubCommand;
 use crate::commands::controller_commands::update_controller_config_sub_command::UpdateControllerConfigSubCommand;
 use crate::commands::CommandExecute;
@@ -34,37 +36,37 @@ pub enum ControllerCommands {
         about = "Clean metadata of broker on controller.",
         long_about = None,
     )]
-    CleanBrokerMetadata(clean_broker_metadata_command::CleanBrokerMetadataCommand),
+    CleanBrokerMetadata(CleanBrokerMetadataSubCommand),
 
     #[command(
         name = "getControllerConfig",
         about = "Get configuration of controller(s)",
         long_about = None,
     )]
-    GetControllerConfigSubCommand(get_controller_config_sub_command::GetControllerConfigSubCommand),
+    GetControllerConfig(GetControllerConfigSubCommand),
 
     #[command(
         name = "getControllerMetadata",
         about = "Get meta data of controller",
         long_about = None,
     )]
-    GetControllerMetadataSubCommand(GetControllerMetadataSubCommand),
+    GetControllerMetadata(GetControllerMetadataSubCommand),
 
     #[command(
         name = "updateControllerConfig",
         about = "update controller config",
         long_about = None,
     )]
-    UpdateControllerConfigSubCommand(UpdateControllerConfigSubCommand),
+    UpdateControllerConfig(UpdateControllerConfigSubCommand),
 }
 
 impl CommandExecute for ControllerCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             ControllerCommands::CleanBrokerMetadata(cmd) => cmd.execute(rpc_hook).await,
-            ControllerCommands::GetControllerConfigSubCommand(value) => value.execute(rpc_hook).await,
-            ControllerCommands::GetControllerMetadataSubCommand(value) => value.execute(rpc_hook).await,
-            ControllerCommands::UpdateControllerConfigSubCommand(value) => value.execute(rpc_hook).await,
+            ControllerCommands::GetControllerConfig(value) => value.execute(rpc_hook).await,
+            ControllerCommands::GetControllerMetadata(value) => value.execute(rpc_hook).await,
+            ControllerCommands::UpdateControllerConfig(value) => value.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller_commands/clean_broker_metadata_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller_commands/clean_broker_metadata_sub_command.rs
@@ -25,7 +25,7 @@ use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::commands::CommandExecute;
 
 #[derive(Debug, Clone, Parser)]
-pub struct CleanBrokerMetadataCommand {
+pub struct CleanBrokerMetadataSubCommand {
     #[arg(
         short = 'a',
         long = "controllerAddress",
@@ -68,7 +68,7 @@ pub struct CleanBrokerMetadataCommand {
     clean_living_broker: bool,
 }
 
-impl CleanBrokerMetadataCommand {
+impl CleanBrokerMetadataSubCommand {
     fn validate_broker_controller_ids(ids: &str) -> RocketMQResult<()> {
         for id_str in ids.split(';') {
             let trimmed = id_str.trim();
@@ -85,7 +85,7 @@ impl CleanBrokerMetadataCommand {
     }
 }
 
-impl CommandExecute for CleanBrokerMetadataCommand {
+impl CommandExecute for CleanBrokerMetadataSubCommand {
     async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         let controller_address = self.controller_address.trim();
         let broker_name = self.broker_name.trim();
@@ -109,7 +109,10 @@ impl CommandExecute for CleanBrokerMetadataCommand {
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
-                RocketMQError::Internal(format!("CleanBrokerMetadataCommand: Failed to start MQAdminExt: {}", e))
+                RocketMQError::Internal(format!(
+                    "CleanBrokerMetadataSubCommand: Failed to start MQAdminExt: {}",
+                    e
+                ))
             })?;
 
             default_mqadmin_ext
@@ -123,7 +126,7 @@ impl CommandExecute for CleanBrokerMetadataCommand {
                 .await
                 .map_err(|e| {
                     RocketMQError::Internal(format!(
-                        "CleanBrokerMetadataCommand: Failed to clean broker metadata: {}",
+                        "CleanBrokerMetadataSubCommand: Failed to clean broker metadata: {}",
                         e
                     ))
                 })?;
@@ -135,109 +138,5 @@ impl CommandExecute for CleanBrokerMetadataCommand {
 
         MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
         operation_result
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_basic_command() {
-        let args = vec![
-            "clean-broker-metadata",
-            "-a",
-            "127.0.0.1:9878",
-            "--brokerName",
-            "broker-a",
-            "-c",
-            "DefaultCluster",
-        ];
-
-        let cmd = CleanBrokerMetadataCommand::try_parse_from(args).unwrap();
-        assert_eq!(cmd.controller_address, "127.0.0.1:9878");
-        assert_eq!(cmd.broker_name, "broker-a");
-        assert_eq!(cmd.cluster_name, Some("DefaultCluster".to_string()));
-        assert!(!cmd.clean_living_broker);
-        assert!(cmd.broker_controller_ids_to_clean.is_none());
-    }
-
-    #[test]
-    fn parse_with_broker_name_alias() {
-        let args = vec![
-            "clean-broker-metadata",
-            "-a",
-            "127.0.0.1:9878",
-            "--bn",
-            "broker-a",
-            "-c",
-            "DefaultCluster",
-        ];
-        assert_eq!(
-            CleanBrokerMetadataCommand::try_parse_from(args).unwrap().broker_name,
-            "broker-a"
-        );
-    }
-
-    #[test]
-    fn parse_with_broker_controller_ids() {
-        let args = vec![
-            "clean-broker-metadata",
-            "-a",
-            "127.0.0.1:9878",
-            "--brokerName",
-            "broker-a",
-            "-c",
-            "DefaultCluster",
-            "-b",
-            "1;2;3",
-        ];
-
-        let cmd = CleanBrokerMetadataCommand::try_parse_from(args).unwrap();
-        assert_eq!(cmd.broker_controller_ids_to_clean, Some("1;2;3".to_string()));
-    }
-
-    #[test]
-    fn parse_with_clean_living_broker() {
-        let args = vec![
-            "clean-broker-metadata",
-            "-a",
-            "127.0.0.1:9878",
-            "--brokerName",
-            "broker-a",
-            "-l",
-        ];
-
-        let cmd = CleanBrokerMetadataCommand::try_parse_from(args).unwrap();
-        assert!(cmd.clean_living_broker);
-        assert!(cmd.cluster_name.is_none());
-    }
-
-    #[test]
-    fn missing_required_controller_address() {
-        let args = vec!["clean-broker-metadata", "--brokerName", "broker-a"];
-        assert!(CleanBrokerMetadataCommand::try_parse_from(args).is_err());
-    }
-
-    #[test]
-    fn missing_required_broker_name() {
-        let args = vec!["clean-broker-metadata", "-a", "127.0.0.1:9878"];
-        assert!(CleanBrokerMetadataCommand::try_parse_from(args).is_err());
-    }
-
-    #[test]
-    fn validate_broker_controller_ids_valid() {
-        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("1").is_ok());
-        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("1;2;3").is_ok());
-        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("0;1;2").is_ok());
-        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("100").is_ok());
-    }
-
-    #[test]
-    fn validate_broker_controller_ids_invalid() {
-        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("abc").is_err());
-        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("1;abc;3").is_err());
-        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("1.5").is_err());
-        assert!(CleanBrokerMetadataCommand::validate_broker_controller_ids("1;2;").is_ok());
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv_commands.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 mod add_write_perm_sub_command;
-mod delete_kv_config_command;
-mod get_namesrv_config_command;
-mod update_kv_config_command;
-mod update_namesrv_config;
+mod delete_kv_config_sub_command;
+mod get_namesrv_config_sub_command;
+mod update_kv_config_sub_command;
+mod update_namesrv_config_sub_command;
 mod wipe_write_perm_sub_command;
 
 use std::sync::Arc;
@@ -26,10 +26,10 @@ use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::namesrv_commands::add_write_perm_sub_command::AddWritePermSubCommand;
-use crate::commands::namesrv_commands::delete_kv_config_command::DeleteKvConfigCommand;
-use crate::commands::namesrv_commands::get_namesrv_config_command::GetNamesrvConfigCommand;
-use crate::commands::namesrv_commands::update_kv_config_command::UpdateKvConfigCommand;
-use crate::commands::namesrv_commands::update_namesrv_config::UpdateNamesrvConfig;
+use crate::commands::namesrv_commands::delete_kv_config_sub_command::DeleteKvConfigSubCommand;
+use crate::commands::namesrv_commands::get_namesrv_config_sub_command::GetNamesrvConfigSubCommand;
+use crate::commands::namesrv_commands::update_kv_config_sub_command::UpdateKvConfigSubCommand;
+use crate::commands::namesrv_commands::update_namesrv_config_sub_command::UpdateNamesrvConfigSubCommand;
 use crate::commands::namesrv_commands::wipe_write_perm_sub_command::WipeWritePermSubCommand;
 use crate::commands::CommandExecute;
 
@@ -40,53 +40,53 @@ pub enum NameServerCommands {
         about = "Add write perm of broker in all name server you defined in the -n param.",
         long_about = None,
     )]
-    AddWritePermSubCommand(AddWritePermSubCommand),
+    AddWritePerm(AddWritePermSubCommand),
 
     #[command(
         name = "deleteKvConfig",
         about = "Delete KV config.",
         long_about = None,
     )]
-    DeleteKvConfig(DeleteKvConfigCommand),
+    DeleteKvConfig(DeleteKvConfigSubCommand),
 
     #[command(
         name = "getNamesrvConfig",
         about = "Get configs of name server.",
         long_about = None,
     )]
-    GetNamesrvConfig(GetNamesrvConfigCommand),
+    GetNamesrvConfig(GetNamesrvConfigSubCommand),
 
     #[command(
         name = "updateKvConfig",
         about = "Create or update KV config.",
         long_about = None,
     )]
-    UpdateKvConfigCommand(UpdateKvConfigCommand),
+    UpdateKvConfig(UpdateKvConfigSubCommand),
 
     #[command(
         name = "updateNamesrvConfig",
         about = "Update configs of name server.",
         long_about = None,
     )]
-    UpdateNamesrvConfig(UpdateNamesrvConfig),
+    UpdateNamesrvConfig(UpdateNamesrvConfigSubCommand),
 
     #[command(
         name = "wipeWritePerm",
         about = "Wipe write perm of broker in all name server you defined in the -n param.",
         long_about = None,
     )]
-    WipeWritePermSubCommand(WipeWritePermSubCommand),
+    WipeWritePerm(WipeWritePermSubCommand),
 }
 
 impl CommandExecute for NameServerCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
-            NameServerCommands::AddWritePermSubCommand(value) => value.execute(rpc_hook).await,
+            NameServerCommands::AddWritePerm(value) => value.execute(rpc_hook).await,
             NameServerCommands::DeleteKvConfig(value) => value.execute(rpc_hook).await,
             NameServerCommands::GetNamesrvConfig(value) => value.execute(rpc_hook).await,
-            NameServerCommands::UpdateKvConfigCommand(value) => value.execute(rpc_hook).await,
+            NameServerCommands::UpdateKvConfig(value) => value.execute(rpc_hook).await,
             NameServerCommands::UpdateNamesrvConfig(value) => value.execute(rpc_hook).await,
-            NameServerCommands::WipeWritePermSubCommand(value) => value.execute(rpc_hook).await,
+            NameServerCommands::WipeWritePerm(value) => value.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv_commands/delete_kv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv_commands/delete_kv_config_sub_command.rs
@@ -23,24 +23,17 @@ use rocketmq_remoting::runtime::RPCHook;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::commands::CommandExecute;
-use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
-pub struct UpdateKvConfigCommand {
-    #[command(flatten)]
-    common_args: CommonArgs,
-
-    #[arg(short = 's', long = "namespace", required = true, help = "set the namespace")]
+pub struct DeleteKvConfigSubCommand {
+    #[arg(short = 's', long = "namespace", required = true)]
     namespace: String,
 
-    #[arg(short = 'k', long = "key", required = true, help = "set the key name")]
+    #[arg(short = 'k', long = "key", required = true)]
     key: String,
-
-    #[arg(short = 'v', long = "value", required = true, help = "set the key value")]
-    value: String,
 }
 
-impl CommandExecute for UpdateKvConfigCommand {
+impl CommandExecute for DeleteKvConfigSubCommand {
     async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
@@ -48,26 +41,21 @@ impl CommandExecute for UpdateKvConfigCommand {
             .set_instance_name(get_current_millis().to_string().into());
 
         let operation_result = async {
-            if let Some(addr) = &self.common_args.namesrv_addr {
-                default_mqadmin_ext.set_namesrv_addr(addr.trim());
-            }
-
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
-                RocketMQError::Internal(format!("UpdateKvConfigCommand: Failed to start MQAdminExt: {}", e))
+                RocketMQError::Internal(format!("DeleteKvConfigSubCommand: Failed to start MQAdminExt: {}", e))
             })?;
 
-            default_mqadmin_ext
-                .create_and_update_kv_config(
-                    self.namespace.parse().unwrap(),
-                    self.key.parse().unwrap(),
-                    self.value.parse().unwrap(),
-                )
-                .await
-                .map_err(|e| {
-                    RocketMQError::Internal(format!("UpdateKvConfigCommand: Failed to update kv config: {}", e))
-                })?;
+            MQAdminExt::delete_kv_config(
+                &default_mqadmin_ext,
+                self.namespace.parse().unwrap(),
+                self.key.parse().unwrap(),
+            )
+            .await
+            .map_err(|e| {
+                RocketMQError::Internal(format!("DeleteKvConfigSubCommand: Failed to delete kv config: {}", e))
+            })?;
 
-            println!("update kv config in namespace success.");
+            println!("delete kv config from namespace success.");
             Ok(())
         }
         .await;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv_commands/get_namesrv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv_commands/get_namesrv_config_sub_command.rs
@@ -33,12 +33,12 @@ use crate::commands::CommandExecute;
 use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
-pub struct GetNamesrvConfigCommand {
+pub struct GetNamesrvConfigSubCommand {
     #[command(flatten)]
     common: CommonArgs,
 }
 
-impl GetNamesrvConfigCommand {
+impl GetNamesrvConfigSubCommand {
     fn parse_server_list(&self) -> Option<Vec<CheetahString>> {
         self.common.namesrv_addr.as_ref().and_then(|servers| {
             if servers.trim().is_empty() {
@@ -61,7 +61,7 @@ impl GetNamesrvConfigCommand {
     }
 }
 
-impl CommandExecute for GetNamesrvConfigCommand {
+impl CommandExecute for GetNamesrvConfigSubCommand {
     async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         if self.common.namesrv_addr.is_none() {
             eprintln!("Please set the namesrvAddr parameter");

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv_commands/update_namesrv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv_commands/update_namesrv_config_sub_command.rs
@@ -28,7 +28,7 @@ use crate::commands::CommandExecute;
 use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
-pub struct UpdateNamesrvConfig {
+pub struct UpdateNamesrvConfigSubCommand {
     #[command(flatten)]
     common_args: CommonArgs,
 
@@ -39,7 +39,7 @@ pub struct UpdateNamesrvConfig {
     value: String,
 }
 
-impl CommandExecute for UpdateNamesrvConfig {
+impl CommandExecute for UpdateNamesrvConfigSubCommand {
     async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
@@ -70,13 +70,18 @@ impl CommandExecute for UpdateNamesrvConfig {
             }
 
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
-                RocketMQError::Internal(format!("UpdateNamesrvConfig: Failed to start MQAdminExt: {}", e))
+                RocketMQError::Internal(format!(
+                    "UpdateNamesrvConfigSubCommand: Failed to start MQAdminExt: {}",
+                    e
+                ))
             })?;
 
             default_mqadmin_ext
                 .update_name_server_config(properties, server_list.clone())
                 .await
-                .map_err(|e| RocketMQError::Internal(format!("UpdateNamesrvConfig: Failed to update config: {}", e)))?;
+                .map_err(|e| {
+                    RocketMQError::Internal(format!("UpdateNamesrvConfigSubCommand: Failed to update config: {}", e))
+                })?;
 
             println!(
                 "update name server config success!{}\n{} : {}\n",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic_commands.rs
@@ -19,7 +19,7 @@ mod topic_cluster_sub_command;
 mod topic_list_sub_command;
 mod topic_route_sub_command;
 mod topic_status_sub_command;
-mod update_order_conf_command;
+mod update_order_conf_sub_command;
 mod update_static_topic_sub_command;
 mod update_topic_list_sub_command;
 mod update_topic_perm_sub_command;
@@ -30,6 +30,18 @@ use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
+use crate::commands::topic_commands::allocate_mq_sub_command::AllocateMQSubCommand;
+use crate::commands::topic_commands::delete_topic_sub_command::DeleteTopicSubCommand;
+use crate::commands::topic_commands::remapping_static_topic_sub_command::RemappingStaticTopicSubCommand;
+use crate::commands::topic_commands::topic_cluster_sub_command::TopicClusterSubCommand;
+use crate::commands::topic_commands::topic_list_sub_command::TopicListSubCommand;
+use crate::commands::topic_commands::topic_route_sub_command::TopicRouteSubCommand;
+use crate::commands::topic_commands::topic_status_sub_command::TopicStatusSubCommand;
+use crate::commands::topic_commands::update_order_conf_sub_command::UpdateOrderConfSubCommand;
+use crate::commands::topic_commands::update_static_topic_sub_command::UpdateStaticTopicSubCommand;
+use crate::commands::topic_commands::update_topic_list_sub_command::UpdateTopicListSubCommand;
+use crate::commands::topic_commands::update_topic_perm_sub_command::UpdateTopicPermSubCommand;
+use crate::commands::topic_commands::update_topic_sub_command::UpdateTopicSubCommand;
 use crate::commands::CommandExecute;
 const NAMESPACE_ORDER_TOPIC_CONFIG: &str = "ORDER_TOPIC_CONFIG";
 #[derive(Subcommand)]
@@ -41,83 +53,84 @@ pub enum TopicCommands {
 space of the topic when the topic is created. The default value is 1. If you want to allocate
 more memory space, you can use this command to allocate it."#
     )]
-    AllocateMQ(allocate_mq_sub_command::AllocateMQSubCommand),
+    AllocateMQ(AllocateMQSubCommand),
 
     #[command(
         name = "deleteTopic",
         about = "Delete topic",
         long_about = r#"Delete topic from broker and NameServer."#
     )]
-    DeleteTopic(delete_topic_sub_command::DeleteTopicSubCommand),
+    DeleteTopic(DeleteTopicSubCommand),
 
     #[command(
         name = "remappingStaticTopic",
         about = "Remapping static topic",
         long_about = r#"Remapping static topic to different brokers or clusters."#
     )]
-    RemappingStaticTopic(remapping_static_topic_sub_command::RemappingStaticTopicSubCommand),
+    RemappingStaticTopic(RemappingStaticTopicSubCommand),
 
     #[command(
         name = "topicClusterList",
         about = "Get cluster info for topic",
         long_about = r#"Get cluster info for a given topic. This command queries which clusters contain the specified topic."#
     )]
-    TopicClusterList(topic_cluster_sub_command::TopicClusterSubCommand),
+    TopicCluster(TopicClusterSubCommand),
 
     #[command(
         name = "topicList",
         about = "Get topic list",
         long_about = r#"Fetch all topic list from name server."#
     )]
-    TopicList(topic_list_sub_command::TopicListSubCommand),
+    TopicList(TopicListSubCommand),
 
     #[command(
         name = "topicRoute",
         about = "Examine topic route info",
         long_about = r#"Examine topic route info."#
     )]
-    TopicRoute(topic_route_sub_command::TopicRouteSubCommand),
+    TopicRoute(TopicRouteSubCommand),
 
     #[command(
         name = "topicStatus",
         about = "Examine topic status info",
         long_about = r#"Examine topic status info."#
     )]
-    TopicStatus(topic_status_sub_command::TopicStatusSubCommand),
+    TopicStatus(TopicStatusSubCommand),
 
     #[command(
         name = "updateOrderConf",
         about = "Create or update order conf",
         long_about = r#"Create, update, or delete order topic configuration."#
     )]
-    UpdateOrderConf(update_order_conf_command::UpdateOrderConfCommand),
+    UpdateOrderConf(UpdateOrderConfSubCommand),
 
     #[command(
         name = "updateStaticTopic",
         about = "Update static topic",
         long_about = r#"Update or create static topic with queue mapping."#
     )]
-    UpdateStaticTopic(update_static_topic_sub_command::UpdateStaticTopicSubCommand),
+    UpdateStaticTopic(UpdateStaticTopicSubCommand),
+
+    #[command(
+        name = "updateTopicList",
+        about = "Update topic list",
+        long_about = "Update topic list with specified configuration."
+    )]
+    UpdateTopicList(UpdateTopicListSubCommand),
 
     #[command(
         name = "updateTopicPerm",
         about = "Update topic perm.",
         long_about = r#"Update topic perm."#
     )]
-    UpdateTopicPerm(update_topic_perm_sub_command::UpdateTopicPermSubCommand),
+    UpdateTopicPerm(UpdateTopicPermSubCommand),
 
     #[command(
         name = "updateTopic",
         about = "Update or create topic",
         long_about = r#"Update or create topic with specified configuration."#
     )]
-    UpdateTopic(update_topic_sub_command::UpdateTopicSubCommand),
-    #[command(
-        name = "updateTopicList",
-        about = "Update topic list",
-        long_about = "Update topic list with specified configuration."
-    )]
-    UpdateTopicList(update_topic_list_sub_command::UpdateTopicListSubCommand),
+    UpdateTopic(UpdateTopicSubCommand),
 }
 
 impl CommandExecute for TopicCommands {
@@ -126,15 +139,15 @@ impl CommandExecute for TopicCommands {
             TopicCommands::AllocateMQ(cmd) => cmd.execute(rpc_hook).await,
             TopicCommands::DeleteTopic(cmd) => cmd.execute(rpc_hook).await,
             TopicCommands::RemappingStaticTopic(cmd) => cmd.execute(rpc_hook).await,
-            TopicCommands::TopicClusterList(cmd) => cmd.execute(rpc_hook).await,
+            TopicCommands::TopicCluster(cmd) => cmd.execute(rpc_hook).await,
             TopicCommands::TopicList(cmd) => cmd.execute(rpc_hook).await,
             TopicCommands::TopicRoute(cmd) => cmd.execute(rpc_hook).await,
             TopicCommands::TopicStatus(cmd) => cmd.execute(rpc_hook).await,
             TopicCommands::UpdateOrderConf(cmd) => cmd.execute(rpc_hook).await,
             TopicCommands::UpdateStaticTopic(cmd) => cmd.execute(rpc_hook).await,
+            TopicCommands::UpdateTopicList(cmd) => cmd.execute(rpc_hook).await,
             TopicCommands::UpdateTopicPerm(cmd) => cmd.execute(rpc_hook).await,
             TopicCommands::UpdateTopic(cmd) => cmd.execute(rpc_hook).await,
-            TopicCommands::UpdateTopicList(cmd) => cmd.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic_commands/update_order_conf_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic_commands/update_order_conf_sub_command.rs
@@ -23,7 +23,7 @@ use crate::commands::CommandExecute;
 use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
-pub struct UpdateOrderConfCommand {
+pub struct UpdateOrderConfSubCommand {
     #[command(flatten)]
     common_args: CommonArgs,
 
@@ -46,7 +46,7 @@ pub struct UpdateOrderConfCommand {
     )]
     order_conf: Option<String>,
 }
-impl CommandExecute for UpdateOrderConfCommand {
+impl CommandExecute for UpdateOrderConfSubCommand {
     async fn execute(
         &self,
         _rpc_hook: Option<std::sync::Arc<dyn rocketmq_remoting::runtime::RPCHook>>,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6343 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured command architecture across auth, broker, consumer, controller, namesrv, and topic commands for improved consistency.
  * Standardized command variant naming conventions and simplified public API signatures.
  * Reorganized subcommand module structure and imports throughout the admin tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->