### PR TITLE
[ISSUE #6155][Test🧪] Add unit tests for UpdateConsumerOffsetResponseHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/update_consumer_offset_header.rs
+++ b/rocketmq-remoting/src/protocol/header/update_consumer_offset_header.rs
@@ -472,14 +472,4 @@ mod tests {
 
         assert!(map.is_empty());
     }
-
-    #[test]
-    fn response_header_deserializes_from_empty_map() {
-        let map = std::collections::HashMap::new();
-
-        let header = UpdateConsumerOffsetResponseHeader::from_map(map).unwrap();
-        let default = UpdateConsumerOffsetResponseHeader::default();
-
-        assert_eq!(format!("{:?}", header), format!("{:?}", default));
-    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6155 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for consumer-offset update responses covering creation/equality, zero-sized behavior, JSON serialization/deserialization (empty JSON, round-trip), handling of unknown JSON fields, and encoding to empty representations.  
  * Tests increase confidence in data handling and edge cases without modifying runtime behavior or any public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->