### PR TITLE
[ISSUE #6166][Test🧪] Add unit tests for GetConsumeStatsRequestHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_consume_stats_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_consume_stats_request_header.rs
@@ -99,8 +99,6 @@ mod tests {
 
     #[test]
     fn get_consume_stats_request_header_with_topic_request_header_some() {
-        // Construct a header with a populated TopicRequestHeader to exercise the
-        // #[serde(flatten)] behavior when the option is Some(...)
         let topic_header = TopicRequestHeader::default();
 
         let header = GetConsumeStatsRequestHeader {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6166


### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for getters/setters and serialization/deserialization, including handling of extra/unknown fields and flattened serialization behavior.

* **Chores**
  * Removed obsolete commented-out code to improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->