### PR TITLE
[ISSUE #6273]🚀Implement BrokerStatus command in rocketmq-admin-core

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -179,6 +179,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Broker",
+                command: "brokerStatus",
+                remark: "Fetch broker runtime status data.",
+            },
+            Command {
+                category: "Broker",
                 command: "cleanExpiredCQ",
                 remark: "Clean expired ConsumeQueue on broker.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod broker_status_sub_command;
 mod clean_expired_cq_sub_command;
 mod clean_unused_topic_sub_command;
 mod delete_expired_commit_log_sub_command;
@@ -30,6 +31,7 @@ use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
+use crate::commands::broker_commands::broker_status_sub_command::BrokerStatusSubCommand;
 use crate::commands::broker_commands::clean_expired_cq_sub_command::CleanExpiredCQSubCommand;
 use crate::commands::broker_commands::clean_unused_topic_sub_command::CleanUnusedTopicSubCommand;
 use crate::commands::broker_commands::delete_expired_commit_log_sub_command::DeleteExpiredCommitLogSubCommand;
@@ -45,6 +47,13 @@ use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
 pub enum BrokerCommands {
+    #[command(
+        name = "brokerStatus",
+        about = "Fetch broker runtime status data.",
+        long_about = None,
+    )]
+    BrokerStatus(BrokerStatusSubCommand),
+
     #[command(
         name = "cleanExpiredCQ",
         about = "Clean expired ConsumeQueue on broker.",
@@ -126,6 +135,7 @@ pub enum BrokerCommands {
 impl CommandExecute for BrokerCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
+            BrokerCommands::BrokerStatus(cmd) => cmd.execute(rpc_hook).await,
             BrokerCommands::CleanExpiredCQ(value) => value.execute(rpc_hook).await,
             BrokerCommands::CleanUnusedTopic(value) => value.execute(rpc_hook).await,
             BrokerCommands::DeleteExpiredCommitLog(value) => value.execute(rpc_hook).await,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/broker_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/broker_status_sub_command.rs
@@ -1,0 +1,125 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(
+    clap::ArgGroup::new("target")
+        .required(true)
+        .args(&["broker_addr", "cluster_name"])
+))]
+pub struct BrokerStatusSubCommand {
+    #[arg(short = 'b', long = "brokerAddr", help = "Broker address")]
+    broker_addr: Option<String>,
+
+    #[arg(short = 'c', long = "clusterName", help = "which cluster")]
+    cluster_name: Option<String>,
+}
+
+impl BrokerStatusSubCommand {
+    async fn print_broker_runtime_stats(
+        default_mqadmin_ext: &DefaultMQAdminExt,
+        broker_addr: &str,
+        print_broker: bool,
+    ) -> RocketMQResult<()> {
+        let kv_table = default_mqadmin_ext
+            .fetch_broker_runtime_stats(CheetahString::from(broker_addr))
+            .await
+            .map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "BrokerStatusSubCommand: Failed to fetch broker runtime stats from {}: {}",
+                    broker_addr, e
+                ))
+            })?;
+
+        let mut sorted_entries: Vec<_> = kv_table.table.iter().collect();
+        sorted_entries.sort_by(|a, b| a.0.cmp(b.0));
+
+        for (key, value) in &sorted_entries {
+            if print_broker {
+                println!("{:<24} {:<32}: {}", broker_addr, key, value);
+            } else {
+                println!("{:<32}: {}", key, value);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl CommandExecute for BrokerStatusSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("BrokerStatusSubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            if let Some(broker_addr) = &self.broker_addr {
+                let broker_addr = broker_addr.trim();
+                Self::print_broker_runtime_stats(&default_mqadmin_ext, broker_addr, false).await?;
+            } else if let Some(cluster_name) = &self.cluster_name {
+                let cluster_name = cluster_name.trim();
+                let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await.map_err(|e| {
+                    RocketMQError::Internal(format!(
+                        "BrokerStatusSubCommand: Failed to examine broker cluster info: {}",
+                        e
+                    ))
+                })?;
+
+                let master_set = CommandUtil::fetch_master_and_slave_addr_by_cluster_name(&cluster_info, cluster_name)?;
+
+                for broker_addr in &master_set {
+                    match Self::print_broker_runtime_stats(&default_mqadmin_ext, broker_addr.as_str(), true).await {
+                        Ok(()) => {}
+                        Err(e) => {
+                            eprintln!(
+                                "BrokerStatusSubCommand: Failed to fetch runtime stats from {}: {}",
+                                broker_addr, e
+                            );
+                        }
+                    }
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6273 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `brokerStatus` command to query and display broker runtime status data. Supports lookups by individual broker address or across an entire cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->