### PR TITLE
[ISSUE #6378]✨Refactor MessageTrait: rename get_topic to topic for idiomatic Rust API

### DIFF
--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -761,7 +761,7 @@ impl BrokerOuterAPI {
     ) -> rocketmq_error::RocketMQResult<SendResult> {
         let uniq_msg_id = MessageClientIDSetter::get_uniq_id(&msg);
         let queue_id = msg.queue_id;
-        let topic = msg.get_topic().clone();
+        let topic = msg.topic().clone();
         let request = build_send_message_request(msg, group);
         let response = self
             .remoting_client
@@ -1521,7 +1521,7 @@ fn build_send_message_request(msg: MessageExt, group: CheetahString) -> Remoting
 fn build_send_message_request_header_v2(msg: MessageExt, group: CheetahString) -> SendMessageRequestHeaderV2 {
     let header = SendMessageRequestHeader {
         producer_group: group,
-        topic: msg.get_topic().clone(),
+        topic: msg.topic().clone(),
         default_topic: CheetahString::from_static_str(TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC),
         default_topic_queue_nums: 8,
         queue_id: msg.queue_id,

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -1083,7 +1083,7 @@ where
                                 pop_time as i64,
                                 request_header.invisible_time as i64,
                                 revive_qid,
-                                message_ext.get_topic(),
+                                message_ext.topic(),
                                 broker_name,
                                 message_ext.queue_id(),
                                 message_ext.queue_offset(),

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -1195,7 +1195,7 @@ where
         };
         let retry_topic = msg_ext.property(&CheetahString::from_static_str(MessageConst::PROPERTY_RETRY_TOPIC));
         if retry_topic.is_none() {
-            let topic = msg_ext.get_topic().clone();
+            let topic = msg_ext.topic().clone();
             MessageAccessor::put_property(
                 &mut msg_ext,
                 CheetahString::from_static_str(MessageConst::PROPERTY_RETRY_TOPIC),
@@ -1278,7 +1278,7 @@ where
             .and_then(|value| value.get(BrokerStatsManager::COMMERCIAL_OWNER).cloned());
         let (response, succeeded) = match put_message_result.put_message_status() {
             PutMessageStatus::PutOk => {
-                let mut _back_topic = msg_ext.get_topic().clone();
+                let mut _back_topic = msg_ext.topic().clone();
                 let correct_topic =
                     msg_ext.property(&CheetahString::from_static_str(MessageConst::PROPERTY_RETRY_TOPIC));
                 if let Some(topic) = correct_topic {

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
@@ -98,7 +98,7 @@ where
         } else {
             error!(
                 "Put checked-too-many-time half message to TRANS_CHECK_MAXTIME_TOPIC failed, real topic={}, msgId={}",
-                msg_ext.get_topic(),
+                msg_ext.topic(),
                 msg_ext.msg_id(),
             );
         }

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
@@ -597,7 +597,7 @@ where
                                 MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX
                             ))
                             .unwrap_or_default(),
-                        msg_ext.get_topic()
+                        msg_ext.topic()
                     );
                     return true;
                 }
@@ -606,7 +606,7 @@ where
 
         error!(
             "PutBackToHalfQueueReturnResult write failed, topic: {}, queueId: {}, msgId: {}",
-            msg_ext.get_topic(),
+            msg_ext.topic(),
             msg_ext.queue_id(),
             msg_ext.msg_id()
         );
@@ -911,7 +911,7 @@ where
 
             debug!(
                 "Topic: {} tags: {:?}, OpOffset: {}, HalfOffset: {}",
-                op_message_ext.get_topic(),
+                op_message_ext.topic(),
                 op_message_ext.get_tags(),
                 op_message_ext.queue_offset(),
                 queue_offset_body

--- a/rocketmq-broker/src/util/hook_utils.rs
+++ b/rocketmq-broker/src/util/hook_utils.rs
@@ -83,12 +83,12 @@ impl HookUtils {
             PRINT_TIMES.store(0, Ordering::SeqCst);
         }
 
-        let topic_data = msg.get_topic().as_bytes();
-        let retry_topic = msg.get_topic().starts_with(RETRY_GROUP_TOPIC_PREFIX);
+        let topic_data = msg.topic().as_bytes();
+        let retry_topic = msg.topic().starts_with(RETRY_GROUP_TOPIC_PREFIX);
         if !retry_topic && topic_data.len() > i8::MAX as usize {
             warn!(
                 "putMessage message topic[{}] length too long {}, but it is not supported by broker",
-                msg.get_topic(),
+                msg.topic(),
                 topic_data.len()
             );
             return Some(PutMessageResult::new_default(PutMessageStatus::MessageIllegal));
@@ -96,17 +96,14 @@ impl HookUtils {
         if topic_data.len() > MAX_TOPIC_LENGTH {
             warn!(
                 "putMessage message topic[{}] length too long {}, but it is not supported by broker",
-                msg.get_topic(),
+                msg.topic(),
                 topic_data.len()
             );
             return Some(PutMessageResult::new_default(PutMessageStatus::MessageIllegal));
         }
 
         if msg.get_body().is_none() {
-            warn!(
-                "putMessage message topic[{}], but message body is null",
-                msg.get_topic()
-            );
+            warn!("putMessage message topic[{}], but message body is null", msg.topic());
             return Some(PutMessageResult::new_default(PutMessageStatus::MessageIllegal));
         }
         if message_store.is_os_page_cache_busy() {

--- a/rocketmq-client/src/base/validators.rs
+++ b/rocketmq-client/src/base/validators.rs
@@ -61,8 +61,8 @@ impl Validators {
             ));
         }
         let msg = msg.unwrap();
-        Self::check_topic(msg.get_topic())?;
-        Self::is_not_allowed_send_topic(msg.get_topic())?;
+        Self::check_topic(msg.topic())?;
+        Self::is_not_allowed_send_topic(msg.topic())?;
 
         if msg.get_body().is_none() {
             return Err(mq_client_err!(

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -185,7 +185,7 @@ impl ConsumeMessageConcurrentlyService {
 
     pub async fn send_message_back(&mut self, msg: &mut MessageExt, context: &ConsumeConcurrentlyContext) -> bool {
         let delay_level = context.delay_level_when_next_consume;
-        msg.set_topic(self.client_config.with_namespace(msg.get_topic().as_str()));
+        msg.set_topic(self.client_config.with_namespace(msg.topic().as_str()));
 
         self.default_mqpush_consumer_impl
             .as_mut()

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -228,7 +228,7 @@ impl ConsumeMessageOrderlyService {
         MessageAccessor::put_property(
             &mut new_msg,
             CheetahString::from_static_str(MessageConst::PROPERTY_RETRY_TOPIC),
-            msg.get_topic().to_owned(),
+            msg.topic().to_owned(),
         );
         MessageAccessor::set_reconsume_time(
             &mut new_msg,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -444,7 +444,7 @@ impl ConsumeMessagePopConcurrentlyService {
             .as_mut()
             .unwrap()
             .change_pop_invisible_time_async(
-                message.get_topic(),
+                message.topic(),
                 consumer_group,
                 &extra_info.unwrap_or_default(),
                 (delay_second * 1000) as u64,

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -239,7 +239,7 @@ impl ConsumeMessagePopOrderlyService {
                 let result = impl_
                     .mut_from_ref()
                     .change_pop_invisible_time_async(
-                        msg.get_topic(),
+                        msg.topic(),
                         &self.consumer_group,
                         &extra_info,
                         invisible_time,

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -1058,8 +1058,8 @@ impl DefaultMQPushConsumerImpl {
     pub fn try_reset_pop_retry_topic(msgs: &mut [ArcMut<MessageExt>], consumer_group: &str) {
         let pop_retry_prefix = format!("{}{}_{}", mix_all::RETRY_GROUP_TOPIC_PREFIX, consumer_group, "_");
         for msg in msgs.iter_mut() {
-            if msg.get_topic().starts_with(&pop_retry_prefix) {
-                let normal_topic = KeyBuilder::parse_normal_topic(msg.get_topic(), consumer_group);
+            if msg.topic().starts_with(&pop_retry_prefix) {
+                let normal_topic = KeyBuilder::parse_normal_topic(msg.topic(), consumer_group);
 
                 if !normal_topic.is_empty() {
                     msg.set_topic(CheetahString::from_string(normal_topic));
@@ -1074,13 +1074,13 @@ impl DefaultMQPushConsumerImpl {
         for msg in msgs.iter_mut() {
             if let Some(retry_topic) = msg.property(&CheetahString::from_static_str(MessageConst::PROPERTY_RETRY_TOPIC))
             {
-                if group_topic == msg.get_topic().as_str() {
+                if group_topic == msg.topic().as_str() {
                     msg.set_topic(retry_topic);
                 }
             }
 
             if !namespace.is_empty() {
-                let topic = msg.get_topic().to_string();
+                let topic = msg.topic().to_string();
                 msg.set_topic(CheetahString::from_string(
                     NamespaceUtil::without_namespace_with_namespace(topic.as_str(), namespace.as_str()),
                 ));
@@ -1171,7 +1171,7 @@ impl DefaultMQPushConsumerImpl {
         }
         msg.set_topic(CheetahString::from_string(
             NamespaceUtil::without_namespace_with_namespace(
-                msg.get_topic().as_str(),
+                msg.topic().as_str(),
                 self.client_config.get_namespace().unwrap_or_default().as_str(),
             ),
         ));
@@ -1193,7 +1193,7 @@ impl DefaultMQPushConsumerImpl {
         MessageAccessor::put_property(
             &mut new_msg,
             CheetahString::from_static_str(MessageConst::PROPERTY_RETRY_TOPIC),
-            msg.get_topic().to_owned(),
+            msg.topic().to_owned(),
         );
         MessageAccessor::set_reconsume_time(
             &mut new_msg,
@@ -1246,7 +1246,7 @@ impl DefaultMQPushConsumerImpl {
         let queue_offset = queue_offset.unwrap();
         let broker_name =
             CheetahString::from(ExtraInfoUtil::get_broker_name(extra_info_strs.as_slice()).unwrap_or_default());
-        let topic = message.get_topic();
+        let topic = message.topic();
 
         let client_instance = self.client_instance.as_mut().unwrap();
         let des_broker_name = if !broker_name.is_empty()

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -213,7 +213,7 @@ impl ClientRemotingProcessor {
         if let Some(mut message_ext) = message_ext {
             if let Some(ref namespace) = self.client_instance.client_config.get_namespace() {
                 let topic = NamespaceUtil::without_namespace_with_namespace(
-                    message_ext.get_topic(),
+                    message_ext.topic(),
                     self.client_instance
                         .client_config
                         .get_namespace()

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -1108,7 +1108,7 @@ impl MQClientAPIImpl {
                                         warn!(
                                             "async send msg by retry {} times. topic={}, brokerAddr={}, brokerName={}",
                                             current_times + 1,
-                                            msg.get_topic(),
+                                            msg.topic(),
                                             current_addr,
                                             current_broker_name
                                         );
@@ -1200,7 +1200,7 @@ impl MQClientAPIImpl {
         let response_header = response
             .decode_command_custom_header_fast::<SendMessageResponseHeader>()
             .unwrap();
-        let mut topic = msg.get_topic().to_string();
+        let mut topic = msg.topic().to_string();
         let namespace = self.client_config.get_namespace();
         if let Some(ns) = namespace.as_ref() {
             if !ns.is_empty() {
@@ -1686,7 +1686,7 @@ impl MQClientAPIImpl {
             group: CheetahString::from_slice(consumer_group),
             delay_level,
             origin_msg_id: Some(CheetahString::from_slice(msg.msg_id.as_str())),
-            origin_topic: Some(CheetahString::from_slice(msg.get_topic())),
+            origin_topic: Some(CheetahString::from_slice(msg.topic())),
             unit_mode: false,
             max_reconsume_times: Some(max_consume_retry_times),
             rpc_request_header: Some(RpcRequestHeader {
@@ -2132,14 +2132,14 @@ impl MQClientAPIImpl {
         let mut map = HashMap::with_capacity(5);
         for message in pop_result.msg_found_list.as_mut().map_or(&mut vec![], |v| v) {
             if start_offset_info.is_empty() {
-                let key = CheetahString::from_string(format!("{}{}", message.get_topic(), message.queue_id() as i64));
+                let key = CheetahString::from_string(format!("{}{}", message.topic(), message.queue_id() as i64));
                 if !map.contains_key(&key) {
                     let extra_info = ExtraInfoUtil::build_extra_info(
                         message.queue_offset(),
                         response_header.pop_time as i64,
                         response_header.invisible_time as i64,
                         response_header.revive_qid as i32,
-                        message.get_topic(),
+                        message.topic(),
                         broker_name,
                         message.queue_id(),
                     );
@@ -2206,7 +2206,7 @@ impl MQClientAPIImpl {
                             response_header.pop_time as i64,
                             response_header.invisible_time as i64,
                             response_header.revive_qid as i32,
-                            message.get_topic(),
+                            message.topic(),
                             broker_name,
                             msg_queue_offset as i32,
                         );
@@ -2216,12 +2216,10 @@ impl MQClientAPIImpl {
                         );
                         (queue_offset_key, queue_id_key)
                     } else {
-                        let queue_id_key = ExtraInfoUtil::get_start_offset_info_map_key(
-                            message.get_topic(),
-                            message.queue_id() as i64,
-                        );
+                        let queue_id_key =
+                            ExtraInfoUtil::get_start_offset_info_map_key(message.topic(), message.queue_id() as i64);
                         let queue_offset_key = ExtraInfoUtil::get_queue_offset_map_key(
-                            message.get_topic(),
+                            message.topic(),
                             message.queue_id() as i64,
                             message.queue_offset(),
                         );
@@ -2250,7 +2248,7 @@ impl MQClientAPIImpl {
                             response_header.pop_time as i64,
                             response_header.invisible_time as i64,
                             response_header.revive_qid as i32,
-                            message.get_topic(),
+                            message.topic(),
                             broker_name,
                             msg_queue_offset as i32,
                         );
@@ -2547,7 +2545,7 @@ fn build_queue_offset_sorted_map(
         // Value of POP_CK is used to determine whether it is a pop retry,
         // cause topic could be rewritten by broker.
         key = ExtraInfoUtil::get_start_offset_info_map_key_with_pop_ck(
-            message_ext.get_topic(),
+            message_ext.topic(),
             message_ext
                 .property(&CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK))
                 .clone()

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -562,11 +562,11 @@ impl DefaultMQProducer {
                 for message in &mut msg_batch.messages {
                     Validators::check_message::<Message>(Some(message), &self.producer_config)?;
                     MessageClientIDSetter::set_uniq_id(message);
-                    message.set_topic(self.with_namespace(message.get_topic()));
+                    message.set_topic(self.with_namespace(message.topic()));
                 }
                 MessageClientIDSetter::set_uniq_id(&mut msg_batch.final_message);
                 msg_batch.set_body(msg_batch.encode());
-                msg_batch.set_topic(self.with_namespace(msg_batch.get_topic()));
+                msg_batch.set_topic(self.with_namespace(msg_batch.topic()));
                 Ok(msg_batch)
             }
             Err(err) => {
@@ -672,7 +672,7 @@ impl DefaultMQProducer {
             return false;
         }
         // retry message do not support batch processing
-        if msg.get_topic().starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
+        if msg.topic().starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
             return false;
         }
         // message which have been assigned to producer group do not support batch processing
@@ -755,7 +755,7 @@ impl MQProducer for DefaultMQProducer {
     where
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         if self.get_auto_batch() && msg.as_any().downcast_ref::<MessageBatch>().is_none() {
             self.send_by_accumulator(msg, None, None).await
         } else {
@@ -771,7 +771,7 @@ impl MQProducer for DefaultMQProducer {
     where
         M: MessageTrait + Send + Sync,
     {
-        let topic_build = self.with_namespace(msg.get_topic().as_str());
+        let topic_build = self.with_namespace(msg.topic().as_str());
         msg.set_topic(topic_build);
         self.default_mqproducer_impl
             .as_mut()
@@ -785,7 +785,7 @@ impl MQProducer for DefaultMQProducer {
         M: MessageTrait + Send + Sync,
         F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         let send_callback_inner = Arc::new(send_callback);
         let result = if self.get_auto_batch() && msg.as_any().downcast_ref::<MessageBatch>().is_none() {
             self.send_by_accumulator(msg, None, Some(send_callback_inner.clone()))
@@ -809,7 +809,7 @@ impl MQProducer for DefaultMQProducer {
         F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic().as_str()));
+        msg.set_topic(self.with_namespace(msg.topic().as_str()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
@@ -822,7 +822,7 @@ impl MQProducer for DefaultMQProducer {
     where
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
@@ -839,7 +839,7 @@ impl MQProducer for DefaultMQProducer {
     where
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         let mq = self.client_config.queue_with_namespace(mq);
         if self.get_auto_batch() && msg.as_any().downcast_ref::<MessageBatch>().is_none() {
             self.send_by_accumulator(msg, Some(mq), None).await
@@ -857,7 +857,7 @@ impl MQProducer for DefaultMQProducer {
     where
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         let mq = self.client_config.queue_with_namespace(mq);
         self.default_mqproducer_impl
             .as_mut()
@@ -876,7 +876,7 @@ impl MQProducer for DefaultMQProducer {
         M: MessageTrait + Send + Sync,
         F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         let mq = self.client_config.queue_with_namespace(mq);
 
         if self.get_auto_batch() && msg.as_any().downcast_ref::<MessageBatch>().is_none() {
@@ -900,7 +900,7 @@ impl MQProducer for DefaultMQProducer {
         M: MessageTrait + Send + Sync,
         F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
@@ -912,7 +912,7 @@ impl MQProducer for DefaultMQProducer {
     where
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         let mq = self.client_config.queue_with_namespace(mq);
         self.default_mqproducer_impl
             .as_mut()
@@ -933,7 +933,7 @@ impl MQProducer for DefaultMQProducer {
         S: Fn(&[MessageQueue], &dyn MessageTrait, &dyn std::any::Any) -> Option<MessageQueue> + Send + Sync + 'static,
         T: std::any::Any + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         let mq = self
             .default_mqproducer_impl
             .as_mut()
@@ -965,7 +965,7 @@ impl MQProducer for DefaultMQProducer {
         S: Fn(&[MessageQueue], &dyn MessageTrait, &dyn std::any::Any) -> Option<MessageQueue> + Send + Sync + 'static,
         T: std::any::Any + Sync + Send,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
@@ -985,7 +985,7 @@ impl MQProducer for DefaultMQProducer {
         S: Fn(&[MessageQueue], &dyn MessageTrait, &dyn std::any::Any) -> Option<MessageQueue> + Send + Sync + 'static,
         T: std::any::Any + Sync + Send,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         let mq = self
             .default_mqproducer_impl
             .as_mut()
@@ -1019,7 +1019,7 @@ impl MQProducer for DefaultMQProducer {
         S: Fn(&[MessageQueue], &dyn MessageTrait, &dyn std::any::Any) -> Option<MessageQueue> + Send + Sync + 'static,
         T: std::any::Any + Sync + Send,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
@@ -1038,7 +1038,7 @@ impl MQProducer for DefaultMQProducer {
         S: Fn(&[MessageQueue], &dyn MessageTrait, &dyn std::any::Any) -> Option<MessageQueue> + Send + Sync + 'static,
         T: std::any::Any + Sync + Send,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
@@ -1205,7 +1205,7 @@ impl MQProducer for DefaultMQProducer {
     where
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
@@ -1223,7 +1223,7 @@ impl MQProducer for DefaultMQProducer {
         F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or_else(|| rocketmq_error::RocketMQError::not_initialized("DefaultMQProducerImpl is not initialized"))?
@@ -1243,7 +1243,7 @@ impl MQProducer for DefaultMQProducer {
         T: std::any::Any + Sync + Send,
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or_else(|| rocketmq_error::RocketMQError::not_initialized("DefaultMQProducerImpl is not initialized"))?
@@ -1265,7 +1265,7 @@ impl MQProducer for DefaultMQProducer {
         T: std::any::Any + Sync + Send,
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or_else(|| rocketmq_error::RocketMQError::not_initialized("DefaultMQProducerImpl is not initialized"))?
@@ -1282,7 +1282,7 @@ impl MQProducer for DefaultMQProducer {
     where
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?
@@ -1301,7 +1301,7 @@ impl MQProducer for DefaultMQProducer {
         F: Fn(Option<&dyn MessageTrait>, Option<&dyn std::error::Error>) + Send + Sync + 'static,
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.with_namespace(msg.get_topic()));
+        msg.set_topic(self.with_namespace(msg.topic()));
         self.default_mqproducer_impl
             .as_mut()
             .ok_or(RocketMQError::not_initialized("DefaultMQProducerImpl not initialized"))?

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -280,7 +280,7 @@ impl ProduceAccumulator {
                 concrete_messages.push(msg.clone());
             } else {
                 let mut msg = Message::default();
-                msg.set_topic(boxed_msg.get_topic().clone());
+                msg.set_topic(boxed_msg.topic().clone());
                 if let Some(body) = boxed_msg.get_body() {
                     msg.set_body(Some(body.clone()));
                 }
@@ -343,7 +343,7 @@ impl ProduceAccumulator {
                 concrete_messages.push(msg.clone());
             } else {
                 let mut msg = Message::default();
-                msg.set_topic(boxed_msg.get_topic().clone());
+                msg.set_topic(boxed_msg.topic().clone());
                 if let Some(body) = boxed_msg.get_body() {
                     msg.set_body(Some(body.clone()));
                 }
@@ -387,7 +387,7 @@ pub struct AggregateKey {
 impl AggregateKey {
     pub fn new_from_message<M: MessageTrait>(message: &M) -> Self {
         Self {
-            topic: message.get_topic().clone(),
+            topic: message.topic().clone(),
             mq: None,
             wait_store_msg_ok: message.is_wait_store_msg_ok(),
             tag: message.get_tags(),
@@ -396,7 +396,7 @@ impl AggregateKey {
 
     pub fn new_from_message_queue<M: MessageTrait>(message: &M, mq: Option<MessageQueue>) -> Self {
         Self {
-            topic: message.get_topic().clone(),
+            topic: message.topic().clone(),
             mq,
             wait_store_msg_ok: message.is_wait_store_msg_ok(),
             tag: message.get_tags(),
@@ -706,7 +706,7 @@ impl GuardForAsyncSendService {
                 concrete_messages.push(msg.clone());
             } else {
                 let mut msg = Message::default();
-                msg.set_topic(boxed_msg.get_topic().clone());
+                msg.set_topic(boxed_msg.topic().clone());
                 if let Some(body) = boxed_msg.get_body() {
                     msg.set_body(Some(body.clone()));
                 }

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -434,7 +434,7 @@ impl DefaultMQProducerImpl {
                 continue;
             }
 
-            let topic = msg.get_topic().clone();
+            let topic = msg.topic().clone();
             let topic_publish_info = self.try_to_find_topic_publish_info(&topic).await;
 
             if let Some(info) = topic_publish_info {
@@ -519,7 +519,7 @@ impl DefaultMQProducerImpl {
         self.make_sure_state_ok()?;
         Validators::check_message(Some(&msg), self.producer_config.as_ref())?;
 
-        if msg.get_topic() != mq.get_topic() {
+        if msg.topic() != mq.get_topic() {
             return Err(mq_client_err!(format!(
                 "message topic [{}] is not equal with message queue topic [{}]",
                 msg.get_topic(),
@@ -646,7 +646,7 @@ impl DefaultMQProducerImpl {
         let begin_start_time = Instant::now();
         self.make_sure_state_ok()?;
         Validators::check_message(Some(&msg), self.producer_config.as_ref())?;
-        let topic_publish_info = self.try_to_find_topic_publish_info(msg.get_topic()).await;
+        let topic_publish_info = self.try_to_find_topic_publish_info(msg.topic()).await;
         if let Some(topic_publish_info) = topic_publish_info {
             if topic_publish_info.ok() {
                 let message_queue_list = self
@@ -657,7 +657,7 @@ impl DefaultMQProducerImpl {
                     .parse_publish_message_queues(&topic_publish_info.message_queue_list, &mut self.client_config);
                 let mut user_message = MessageAccessor::clone_message(&msg);
                 let user_topic = NamespaceUtil::without_namespace_with_namespace(
-                    user_message.get_topic(),
+                    user_message.topic(),
                     self.client_config.get_namespace().unwrap_or_default().as_str(),
                 );
                 user_message.set_topic(CheetahString::from_string(user_topic));
@@ -723,12 +723,12 @@ impl DefaultMQProducerImpl {
                 send_callback_inner.as_ref().unwrap()(None, Some(&err));
                 return;
             }
-            if msg.get_topic() != mq.get_topic() {
+            if msg.topic() != mq.get_topic() {
                 send_callback_inner.as_ref().unwrap()(
                     None,
                     Some(&rocketmq_error::RocketmqError::MQClientErr(ClientErr::new(format!(
                         "message topic [{}] is not equal with message queue topic [{}]",
-                        msg.get_topic(),
+                        msg.topic(),
                         mq.get_topic()
                     )))),
                 );
@@ -930,7 +930,7 @@ impl DefaultMQProducerImpl {
     {
         self.make_sure_state_ok()?;
 
-        let topic = msg.get_topic().clone();
+        let topic = msg.topic().clone();
         let topic_publish_info = self.try_to_find_topic_publish_info(&topic).await;
 
         if let Some(topic_publish_info) = topic_publish_info {
@@ -1213,7 +1213,7 @@ impl DefaultMQProducerImpl {
         //build send message request header
         let mut request_header = SendMessageRequestHeader {
             producer_group: CheetahString::from_string(self.producer_config.producer_group().to_string()),
-            topic: CheetahString::from_string(msg.get_topic().to_string()),
+            topic: CheetahString::from_string(msg.topic().to_string()),
             default_topic: CheetahString::from_string(self.producer_config.create_topic_key().to_string()),
             default_topic_queue_nums: self.producer_config.default_topic_queue_nums() as i32,
             queue_id: mq.get_queue_id(),
@@ -1252,7 +1252,7 @@ impl DefaultMQProducerImpl {
         if topic_with_namespace && communication_mode == CommunicationMode::Async {
             msg.set_topic(CheetahString::from_string(
                 NamespaceUtil::without_namespace_with_namespace(
-                    msg.get_topic(),
+                    msg.topic(),
                     self.client_config.get_namespace().unwrap_or_default().as_str(),
                 ),
             ));
@@ -1550,7 +1550,7 @@ impl DefaultMQProducerImpl {
         let begin_start_time = Instant::now();
         self.make_sure_state_ok()?;
         Validators::check_message(Some(msg), self.producer_config.as_ref())?;
-        let topic_publish_info = self.try_to_find_topic_publish_info(msg.get_topic()).await;
+        let topic_publish_info = self.try_to_find_topic_publish_info(msg.topic()).await;
         if let Some(topic_publish_info) = topic_publish_info {
             if topic_publish_info.ok() {
                 let message_queue_list = self
@@ -1561,7 +1561,7 @@ impl DefaultMQProducerImpl {
                     .parse_publish_message_queues(&topic_publish_info.message_queue_list, &mut self.client_config);
                 let mut user_message = MessageAccessor::clone_message(msg);
                 let user_topic = NamespaceUtil::without_namespace_with_namespace(
-                    user_message.get_topic(),
+                    user_message.topic(),
                     self.client_config.get_namespace().unwrap_or_default().as_str(),
                 );
                 user_message.set_topic(CheetahString::from_string(user_topic));
@@ -1648,7 +1648,7 @@ impl DefaultMQProducerImpl {
                 )));
             }
         };
-        let topic = msg.get_topic().clone();
+        let topic = msg.topic().clone();
         let _ = self
             .send_select_impl(
                 msg,
@@ -1751,7 +1751,7 @@ impl DefaultMQProducerImpl {
                 )));
             }
         };
-        let topic = msg.get_topic().clone();
+        let topic = msg.topic().clone();
         let _ = self
             .send_kernel_impl(
                 &mut msg,
@@ -1903,7 +1903,7 @@ impl DefaultMQProducerImpl {
                 )));
             }
         };
-        let topic = msg.get_topic().clone();
+        let topic = msg.topic().clone();
         let cost = begin_timestamp.elapsed().as_millis() as u64;
         self.send_default_impl(
             &mut msg,
@@ -1974,10 +1974,10 @@ impl DefaultMQProducerImpl {
             .as_mut()
             .unwrap()
             .topic_route_table
-            .contains_key(msg.get_topic().as_str());
+            .contains_key(msg.topic().as_str());
         if !has_route_data {
             let begin_timestamp = Instant::now();
-            self.try_to_find_topic_publish_info(msg.get_topic()).await;
+            self.try_to_find_topic_publish_info(msg.topic()).await;
             self.client_instance
                 .as_mut()
                 .unwrap()
@@ -1985,7 +1985,7 @@ impl DefaultMQProducerImpl {
                 .await;
             let cost = begin_timestamp.elapsed().as_millis() as u64;
             if cost > 500 {
-                warn!("prepare send request for <{}> cost {} ms", msg.get_topic(), cost);
+                warn!("prepare send request for <{}> cost {} ms", msg.topic(), cost);
             }
         }
     }
@@ -2090,7 +2090,7 @@ impl DefaultMQProducerImpl {
             .find_broker_address_in_publish(dest_broker_name.as_ref())
             .await;
         let request_header = EndTransactionRequestHeader {
-            topic: CheetahString::from_string(msg.get_topic().to_string()),
+            topic: CheetahString::from_string(msg.topic().to_string()),
             producer_group: CheetahString::from_string(self.producer_config.producer_group().to_string()),
             tran_state_table_offset: send_result.queue_offset,
             commit_log_offset: id.offset as u64,
@@ -2732,7 +2732,7 @@ where
     // Build request header (simplified for oneway)
     let request_header = SendMessageRequestHeader {
         producer_group: CheetahString::from_string(producer_config.producer_group().to_string()),
-        topic: CheetahString::from_string(msg.get_topic().to_string()),
+        topic: CheetahString::from_string(msg.topic().to_string()),
         default_topic: CheetahString::from_string(producer_config.create_topic_key().to_string()),
         default_topic_queue_nums: producer_config.default_topic_queue_nums() as i32,
         queue_id: mq.get_queue_id(),

--- a/rocketmq-client/src/producer/transaction_mq_producer.rs
+++ b/rocketmq-client/src/producer/transaction_mq_producer.rs
@@ -282,7 +282,7 @@ impl MQProducer for TransactionMQProducer {
         T: std::any::Any + Sync + Send,
         M: MessageTrait + Send + Sync,
     {
-        msg.set_topic(self.default_producer.with_namespace(msg.get_topic()));
+        msg.set_topic(self.default_producer.with_namespace(msg.topic()));
         self.default_producer
             .default_mqproducer_impl
             .as_mut()

--- a/rocketmq-client/tests/integration_tests.rs
+++ b/rocketmq-client/tests/integration_tests.rs
@@ -27,7 +27,6 @@ use cheetah_string::CheetahString;
 use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
 use rocketmq_client_rust::producer::producer_impl::topic_publish_info::TopicPublishInfo;
 use rocketmq_common::common::message::message_queue::MessageQueue;
-use rocketmq_common::common::message::MessageTrait;
 
 #[test]
 fn test_producer_creation() {
@@ -109,7 +108,7 @@ fn test_message_creation() {
         .topic("test_topic")
         .body_slice(b"test_body")
         .build_unchecked();
-    assert_eq!(msg.get_topic(), "test_topic");
+    assert_eq!(msg.topic(), "test_topic");
 }
 
 #[tokio::test]

--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -164,7 +164,7 @@ pub trait MessageTrait: Any + Display + Debug {
     /// # Returns
     ///
     /// A reference to the topic as a `&str`.
-    fn get_topic(&self) -> &CheetahString;
+    fn topic(&self) -> &CheetahString;
 
     /// Sets the topic for the message.
     ///

--- a/rocketmq-common/src/common/message/broker_message.rs
+++ b/rocketmq-common/src/common/message/broker_message.rs
@@ -274,7 +274,7 @@ impl MessageTrait for BrokerMessage {
         self.envelope.properties().get(name)
     }
 
-    fn get_topic(&self) -> &CheetahString {
+    fn topic(&self) -> &CheetahString {
         self.envelope.topic()
     }
 

--- a/rocketmq-common/src/common/message/message_accessor.rs
+++ b/rocketmq-common/src/common/message/message_accessor.rs
@@ -265,7 +265,7 @@ impl MessageAccessor {
         M: MessageTrait,
     {
         let mut new_message = Message::default();
-        new_message.set_topic(message.get_topic().clone());
+        new_message.set_topic(message.topic().clone());
         if let Some(body) = message.get_body() {
             new_message.set_body(Some(body.clone()));
         }

--- a/rocketmq-common/src/common/message/message_batch.rs
+++ b/rocketmq-common/src/common/message/message_batch.rs
@@ -81,7 +81,7 @@ impl MessageBatch {
                 message_list.push(m.clone());
             } else {
                 let mut m = Message::default();
-                m.set_topic(msg.get_topic().clone());
+                m.set_topic(msg.topic().clone());
                 if let Some(body) = msg.get_body() {
                     m.set_body(Some(body.clone()));
                 }
@@ -101,14 +101,14 @@ impl MessageBatch {
                     "TimeDelayLevel is not supported for batching",
                 ));
             }
-            if message.get_topic().starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
+            if message.topic().starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
                 return Err(RocketMQError::illegal_argument(
                     "Retry group topic is not supported for batching",
                 ));
             }
 
             if let Some(first_message) = first {
-                if first_message.get_topic() != message.get_topic() {
+                if first_message.topic() != message.topic() {
                     return Err(RocketMQError::illegal_argument(
                         "The topic of the messages in one batch should be the same",
                     ));
@@ -190,7 +190,7 @@ impl MessageTrait for MessageBatch {
     }
 
     #[inline]
-    fn get_topic(&self) -> &CheetahString {
+    fn topic(&self) -> &CheetahString {
         self.final_message.topic()
     }
 
@@ -411,7 +411,7 @@ mod tests {
         let messages = vec![msg1.clone(), msg1];
         let batch = MessageBatch::generate_from_vec(messages).unwrap();
 
-        assert_eq!(batch.final_message.get_topic().as_str(), "topic1");
+        assert_eq!(batch.final_message.topic().as_str(), "topic1");
         assert!(batch.final_message.is_wait_store_msg_ok());
     }
 

--- a/rocketmq-common/src/common/message/message_client_ext.rs
+++ b/rocketmq-common/src/common/message/message_client_ext.rs
@@ -85,8 +85,8 @@ impl MessageTrait for MessageClientExt {
     }
 
     #[inline]
-    fn get_topic(&self) -> &CheetahString {
-        self.message_ext_inner.get_topic()
+    fn topic(&self) -> &CheetahString {
+        self.message_ext_inner.topic()
     }
 
     #[inline]

--- a/rocketmq-common/src/common/message/message_decoder.rs
+++ b/rocketmq-common/src/common/message/message_decoder.rs
@@ -437,7 +437,7 @@ pub fn decode_messages_from(mut message_ext: MessageExt, vec_: &mut Vec<MessageE
             message,
             ..MessageExt::default()
         };
-        message_ext_inner.set_topic(message_ext.get_topic().to_owned());
+        message_ext_inner.set_topic(message_ext.topic().to_owned());
         message_ext_inner.queue_offset = message_ext.queue_offset;
         message_ext_inner.queue_id = message_ext.queue_id;
         message_ext_inner.set_flag(message_ext.get_flag());
@@ -517,7 +517,7 @@ pub fn decode_message_id(msg_id: &str) -> MessageId {
 
 pub fn encode(message_ext: &MessageExt, need_compress: bool) -> rocketmq_error::RocketMQResult<Bytes> {
     let body = message_ext.get_body().unwrap();
-    let topic = message_ext.get_topic().as_bytes();
+    let topic = message_ext.topic().as_bytes();
     let topic_len = topic.len();
     let properties = message_properties_to_string(message_ext.get_properties());
     let properties_bytes = properties.as_bytes();
@@ -642,7 +642,7 @@ pub fn encode(message_ext: &MessageExt, need_compress: bool) -> rocketmq_error::
 
 pub fn encode_uniquely(message_ext: &MessageExt, need_compress: bool) -> rocketmq_error::RocketMQResult<Bytes> {
     let body = message_ext.get_body().unwrap();
-    let topics = message_ext.get_topic().as_bytes();
+    let topics = message_ext.topic().as_bytes();
     let topic_len = topics.len();
     let properties = message_properties_to_string(message_ext.get_properties());
     let properties_bytes = properties.as_bytes();

--- a/rocketmq-common/src/common/message/message_envelope.rs
+++ b/rocketmq-common/src/common/message/message_envelope.rs
@@ -353,7 +353,7 @@ impl crate::common::message::MessageTrait for MessageEnvelope {
         self.message.property_ref(name)
     }
 
-    fn get_topic(&self) -> &CheetahString {
+    fn topic(&self) -> &CheetahString {
         self.topic()
     }
 

--- a/rocketmq-common/src/common/message/message_ext.rs
+++ b/rocketmq-common/src/common/message/message_ext.rs
@@ -308,8 +308,8 @@ impl MessageTrait for MessageExt {
         self.message.property_ref(name)
     }
 
-    fn get_topic(&self) -> &CheetahString {
-        self.message.get_topic()
+    fn topic(&self) -> &CheetahString {
+        self.message.topic()
     }
 
     fn set_topic(&mut self, topic: CheetahString) {

--- a/rocketmq-common/src/common/message/message_ext_broker_inner.rs
+++ b/rocketmq-common/src/common/message/message_ext_broker_inner.rs
@@ -72,7 +72,7 @@ impl MessageExtBrokerInner {
 
     #[inline]
     pub fn get_topic(&self) -> &CheetahString {
-        self.message_ext_inner.get_topic()
+        self.message_ext_inner.topic()
     }
 
     #[inline]
@@ -268,8 +268,8 @@ impl MessageTrait for MessageExtBrokerInner {
     }
 
     #[inline]
-    fn get_topic(&self) -> &CheetahString {
-        self.message_ext_inner.get_topic()
+    fn topic(&self) -> &CheetahString {
+        self.message_ext_inner.topic()
     }
 
     #[inline]

--- a/rocketmq-common/src/common/message/message_single.rs
+++ b/rocketmq-common/src/common/message/message_single.rs
@@ -585,7 +585,7 @@ impl MessageTrait for Message {
     }
 
     #[inline]
-    fn get_topic(&self) -> &CheetahString {
+    fn topic(&self) -> &CheetahString {
         &self.topic
     }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-gpui/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "zeroize",
 ]
 
@@ -501,28 +501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "base62"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,18 +575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
 dependencies = [
  "core2",
-]
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
 ]
 
 [[package]]
@@ -841,12 +807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,27 +837,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.0",
-]
-
-[[package]]
-name = "cheetah-string"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeadb90f88586f7f634f68afcf83750dea1bc147ee042a4ff1013c3af61ab4e"
-dependencies = [
- "bytes",
- "serde",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,19 +845,8 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
-dependencies = [
- "chrono",
- "phf 0.12.1",
 ]
 
 [[package]]
@@ -941,15 +869,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1030,16 +949,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "command-fds"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,7 +1001,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "toml 0.9.11+spec-1.1.0",
- "winnow 0.7.14",
+ "winnow",
  "yaml-rust2",
 ]
 
@@ -1320,47 +1229,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "cron"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
-dependencies = [
- "chrono",
- "once_cell",
- "winnow 0.6.26",
 ]
 
 [[package]]
@@ -1440,56 +1314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
- "serde",
-]
-
-[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,37 +1332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -1921,9 +1714,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "fax"
@@ -1989,7 +1779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "libz-sys",
  "miniz_oxide",
 ]
 
@@ -2029,18 +1818,6 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
-]
-
-[[package]]
-name = "flume"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
-dependencies = [
- "fastrand 2.3.0",
- "futures-core",
- "futures-sink",
  "spin",
 ]
 
@@ -2156,12 +1933,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,12 +1940,6 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -2226,7 +1991,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -2360,21 +2124,8 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core 0.10.0",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -2503,7 +2254,7 @@ dependencies = [
  "embed-resource",
  "etagere",
  "filedescriptor",
- "flume 0.11.1",
+ "flume",
  "foreign-types",
  "futures",
  "gpui-macros",
@@ -2916,17 +2667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "html5ever"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,23 +2764,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
  "libc",
- "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -3153,12 +2888,6 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3333,16 +3062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,28 +3112,6 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -3577,17 +3274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,17 +3290,6 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "local-ip-address"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ef8c257c92ade496781a32a581d43e3d512cf8ce714ecf04ea80f93ed0ff4a"
-dependencies = [
- "libc",
- "neli",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "lock_api"
@@ -3716,12 +3391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4_flex"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3752,7 +3421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
 dependencies = [
  "log",
- "phf 0.11.3",
+ "phf",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -3948,35 +3617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "neli"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
-dependencies = [
- "bitflags 2.10.0",
- "byteorder",
- "derive_builder",
- "getset",
- "libc",
- "log",
- "neli-proc-macros",
- "parking_lot",
-]
-
-[[package]]
-name = "neli-proc-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d8d08c6e98f20a62417478ebf7be8e1425ec9acecc6f63e22da633f6b71609"
-dependencies = [
- "either",
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -4402,20 +4042,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4572,16 +4198,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
-dependencies = [
- "phf_shared 0.12.1",
+ "phf_shared",
 ]
 
 [[package]]
@@ -4591,7 +4208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.3",
+ "phf_shared",
 ]
 
 [[package]]
@@ -4600,7 +4217,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.3",
+ "phf_shared",
  "rand 0.8.5",
 ]
 
@@ -4609,15 +4226,6 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -4943,7 +4551,6 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4989,12 +4596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5013,17 +4614,6 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
-dependencies = [
- "chacha20",
- "getrandom 0.4.1",
- "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -5063,12 +4653,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rangemap"
@@ -5273,46 +4857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "reqwest"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "resvg"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5350,86 +4894,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocketmq-client-rust"
-version = "0.8.0"
-dependencies = [
- "bytes",
- "cheetah-string",
- "dashmap",
- "futures",
- "num_cpus",
- "parking_lot",
- "rand 0.10.0",
- "rocketmq-common",
- "rocketmq-error",
- "rocketmq-remoting",
- "rocketmq-runtime",
- "rocketmq-rust",
- "serde",
- "serde_json",
- "smallvec",
- "tokio",
- "tracing",
- "trait-variant",
-]
-
-[[package]]
-name = "rocketmq-common"
-version = "0.8.0"
-dependencies = [
- "anyhow",
- "base64",
- "byteorder",
- "bytes",
- "cheetah-string",
- "chrono",
- "chrono-tz",
- "config",
- "crc",
- "dashmap",
- "dirs 6.0.0",
- "flate2",
- "form_urlencoded",
- "futures",
- "hostname",
- "iana-time-zone",
- "local-ip-address",
- "lz4_flex",
- "md-5",
- "num_cpus",
- "opentelemetry",
- "parking_lot",
- "regex",
- "reqwest",
- "rocketmq-error",
- "rocketmq-rust",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "trait-variant",
- "uuid",
- "zstd",
-]
-
-[[package]]
 name = "rocketmq-dashboard-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "rocketmq-client-rust",
- "rocketmq-common",
- "rocketmq-remoting",
  "serde",
- "serde_json",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -5460,80 +4930,6 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "trait-variant",
-]
-
-[[package]]
-name = "rocketmq-error"
-version = "0.8.0"
-dependencies = [
- "anyhow",
- "config",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "rocketmq-macros"
-version = "0.8.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "rocketmq-remoting"
-version = "0.8.0"
-dependencies = [
- "anyhow",
- "bitvec",
- "bytemuck",
- "bytes",
- "cheetah-string",
- "dashmap",
- "flate2",
- "flume 0.12.0",
- "futures",
- "futures-util",
- "num_cpus",
- "parking_lot",
- "rand 0.10.0",
- "rocketmq-common",
- "rocketmq-error",
- "rocketmq-macros",
- "rocketmq-runtime",
- "rocketmq-rust",
- "serde",
- "serde_json",
- "serde_json_any_key",
- "tokio",
- "tokio-util",
- "tracing",
- "trait-variant",
- "uuid",
-]
-
-[[package]]
-name = "rocketmq-runtime"
-version = "0.8.0"
-dependencies = [
- "tokio",
-]
-
-[[package]]
-name = "rocketmq-rust"
-version = "0.8.0"
-dependencies = [
- "anyhow",
- "chrono",
- "cron",
- "parking_lot",
- "rocketmq-error",
- "serde",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -5717,7 +5113,6 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5758,39 +5153,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.0",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6129,7 +5496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -6345,7 +5712,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.11.3",
+ "phf_shared",
  "precomputed-hash",
  "serde",
 ]
@@ -6357,16 +5724,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.3",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -6599,17 +5960,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
 name = "system-configuration-sys"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6648,12 +5998,6 @@ dependencies = [
  "libc",
  "objc",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -6951,7 +6295,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.14",
+ "winnow",
 ]
 
 [[package]]
@@ -6983,7 +6327,7 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.14",
+ "winnow",
 ]
 
 [[package]]
@@ -6995,7 +6339,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow 0.7.14",
+ "winnow",
 ]
 
 [[package]]
@@ -7004,7 +6348,7 @@ version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
- "winnow 0.7.14",
+ "winnow",
 ]
 
 [[package]]
@@ -7030,24 +6374,6 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags 2.10.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -7404,7 +6730,6 @@ checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
- "rand 0.9.2",
  "serde_core",
  "sha1_smol",
  "wasm-bindgen",
@@ -7462,12 +6787,6 @@ dependencies = [
  "sval_ref",
  "sval_serde",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -7768,15 +7087,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8008,17 +7318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8074,15 +7373,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -8124,21 +7414,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8200,12 +7475,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -8224,12 +7493,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8245,12 +7508,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8284,12 +7541,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8305,12 +7556,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8332,12 +7577,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8356,12 +7595,6 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -8377,15 +7610,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -8520,15 +7744,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "x11"
@@ -8736,7 +7951,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.14",
+ "winnow",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -8764,7 +7979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "winnow 0.7.14",
+ "winnow",
  "zvariant",
 ]
 
@@ -8842,7 +8057,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tokio-rustls",
  "tokio-socks",
@@ -9012,34 +8227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "zune-core"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9088,7 +8275,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "url",
- "winnow 0.7.14",
+ "winnow",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -9116,5 +8303,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.114",
- "winnow 0.7.14",
+ "winnow",
 ]

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -2046,6 +2046,7 @@ name = "rocketmq-admin-core"
 version = "0.8.0"
 dependencies = [
  "cheetah-string",
+ "chrono",
  "clap",
  "clap_complete",
  "colored",
@@ -2187,7 +2188,6 @@ dependencies = [
  "rocketmq-common",
  "rocketmq-error",
  "rocketmq-macros",
- "rocketmq-runtime",
  "rocketmq-rust",
  "serde",
  "serde_json",


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6378

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal API method naming across broker and client modules for improved code consistency and maintainability. No user-facing changes or functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->