### PR TITLE
[ISSUE #6179][Test🧪] Add test case for ListUsersRequestHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/list_users_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/list_users_request_header.rs
@@ -48,20 +48,4 @@ mod tests {
 
         assert_eq!(body.filter, deserialized.filter);
     }
-
-    #[test]
-    fn list_users_request_header_to_map() {
-        let header = ListUsersRequestHeader { filter: "test".into() };
-        let map = header.to_map().unwrap();
-        assert_eq!(map.get("filter"), Some(&"test".to_string()));
-    }
-
-    #[test]
-    fn list_users_request_header_from_map() {
-        let mut map = std::collections::HashMap::new();
-        map.insert("filter".to_string(), "test".to_string());
-
-        let header = ListUsersRequestHeader::from_map(&map).unwrap();
-        assert_eq!(header.filter, "test");
-    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6179 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering defaults, cloning, serialization/deserialization round-trip, and map conversions for the user-listing header.
* **Chores**
  * Test-only improvements; no changes to public APIs or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->