### PR TITLE
[ISSUE #6439]♻️Refactor get_user_property method to user_property for consistency in MessageExt

### DIFF
--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -294,7 +294,7 @@ where
         // The setting of MessageConst::PROPERTY_CHECK_IMMUNITY_TIME_IN_SECONDS is configured in the
         // SendMessageActivity of the Proxy. Therefore, messages sent through the SDK will not have
         // this property.
-        if let Some(check_immunity_time_str) = message_ext.get_user_property(&CheetahString::from_static_str(
+        if let Some(check_immunity_time_str) = message_ext.user_property(&CheetahString::from_static_str(
             MessageConst::PROPERTY_CHECK_IMMUNITY_TIME_IN_SECONDS,
         )) {
             if !check_immunity_time_str.is_empty() {
@@ -458,11 +458,11 @@ fn end_message_transaction(msg_ext: &mut MessageExt) -> MessageExtBrokerInner {
     let mut msg_inner = MessageExtBrokerInner::default();
     msg_inner.set_topic(
         msg_ext
-            .get_user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
+            .user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
             .unwrap_or_default(),
     );
     msg_inner.message_ext_inner.queue_id = msg_ext
-        .get_user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_QUEUE_ID))
+        .user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_QUEUE_ID))
         .unwrap_or_default()
         .parse()
         .unwrap_or_default();
@@ -475,7 +475,7 @@ fn end_message_transaction(msg_ext: &mut MessageExt) -> MessageExtBrokerInner {
     msg_inner.message_ext_inner.store_host = msg_ext.store_host;
     msg_inner.message_ext_inner.reconsume_times = msg_ext.reconsume_times;
     msg_inner.set_wait_store_msg_ok(false);
-    if let Some(transaction_id) = msg_ext.get_user_property(&CheetahString::from_static_str(
+    if let Some(transaction_id) = msg_ext.user_property(&CheetahString::from_static_str(
         MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
     )) {
         msg_inner.set_transaction_id(transaction_id);
@@ -511,13 +511,13 @@ mod tests {
         assert_eq!(
             msg_inner.get_topic(),
             &msg_ext
-                .get_user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
+                .user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
                 .unwrap_or_default()
         );
         assert_eq!(
             msg_inner.message_ext_inner.queue_id,
             msg_ext
-                .get_user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_QUEUE_ID))
+                .user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_QUEUE_ID))
                 .unwrap_or_default()
                 .parse::<i32>()
                 .unwrap_or_default()
@@ -532,7 +532,7 @@ mod tests {
         assert_eq!(
             msg_inner.get_transaction_id(),
             msg_ext
-                .get_user_property(&CheetahString::from_static_str(
+                .user_property(&CheetahString::from_static_str(
                     MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX
                 ))
                 .as_ref()

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
@@ -93,7 +93,7 @@ where
                  commitLogOffset={}, real topic={:?}",
                 msg_ext.queue_offset,
                 msg_ext.commit_log_offset,
-                msg_ext.get_user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC,)),
+                msg_ext.user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC,)),
             );
         } else {
             error!(
@@ -105,7 +105,7 @@ where
     }
 
     async fn send_check_message(&self, mut msg_ext: MessageExt) -> rocketmq_error::RocketMQResult<()> {
-        let msg_id = msg_ext.get_user_property(&CheetahString::from_static_str(
+        let msg_id = msg_ext.user_property(&CheetahString::from_static_str(
             MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
         ));
         let header = CheckTransactionStateRequestHeader {
@@ -120,17 +120,16 @@ where
                 ..Default::default()
             }),
         };
-        let topic = msg_ext.get_user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC));
+        let topic = msg_ext.user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC));
         if let Some(topic) = topic {
             msg_ext.set_topic(topic);
         }
-        let queue_id = msg_ext.get_user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_QUEUE_ID));
+        let queue_id = msg_ext.user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_QUEUE_ID));
         if let Some(queue_id) = queue_id {
             msg_ext.set_queue_id(queue_id.as_str().parse::<i32>().unwrap_or_default());
         }
         msg_ext.store_size = 0;
-        let group_id =
-            msg_ext.get_user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_PRODUCER_GROUP));
+        let group_id = msg_ext.user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_PRODUCER_GROUP));
         let channel = self
             .broker_runtime_inner
             .producer_manager()

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
@@ -388,7 +388,7 @@ where
                             escape_fail_cnt + 1,
                             msg_ext.msg_id(),
                             msg_ext
-                                .get_user_property(&CheetahString::from_static_str(
+                                .user_property(&CheetahString::from_static_str(
                                     MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX
                                 ))
                                 .unwrap_or_default()
@@ -430,7 +430,7 @@ where
                 let value_of_current_minus_born = current_time - msg_ext.born_timestamp();
                 let mut check_immunity_time = transaction_timeout as i64;
 
-                if let Some(immunity_time_str) = msg_ext.get_user_property(&CheetahString::from_static_str(
+                if let Some(immunity_time_str) = msg_ext.user_property(&CheetahString::from_static_str(
                     MessageConst::PROPERTY_CHECK_IMMUNITY_TIME_IN_SECONDS,
                 )) {
                     check_immunity_time = self.get_immunity_time(&immunity_time_str, transaction_timeout as i64);
@@ -475,10 +475,10 @@ where
                     info!(
                         "Check transaction. real_topic={}, uniqKey={}, offset={}, commitLogOffset={}",
                         msg_ext
-                            .get_user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
+                            .user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
                             .unwrap_or_default(),
                         msg_ext
-                            .get_user_property(&CheetahString::from_static_str(
+                            .user_property(&CheetahString::from_static_str(
                                 MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX
                             ))
                             .unwrap_or_default(),
@@ -593,7 +593,7 @@ where
                         msg_ext.commit_log_offset(),
                         msg_ext.msg_id(),
                         msg_ext
-                            .get_user_property(&CheetahString::from_static_str(
+                            .user_property(&CheetahString::from_static_str(
                                 MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX
                             ))
                             .unwrap_or_default(),
@@ -655,7 +655,7 @@ where
         msg_ext: &MessageExt,
         check_immunity_time_str: &str,
     ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
-        let prepare_queue_offset_str = msg_ext.get_user_property(&CheetahString::from_static_str(
+        let prepare_queue_offset_str = msg_ext.user_property(&CheetahString::from_static_str(
             MessageConst::PROPERTY_TRANSACTION_PREPARED_QUEUE_OFFSET,
         ));
 
@@ -670,10 +670,10 @@ where
                             "removeMap contain prepareQueueOffset. real_topic={}, uniqKey={}, immunityTime={}, \
                              offset={}",
                             msg_ext
-                                .get_user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
+                                .user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
                                 .unwrap_or_default(),
                             msg_ext
-                                .get_user_property(&CheetahString::from_static_str(
+                                .user_property(&CheetahString::from_static_str(
                                     MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX
                                 ))
                                 .unwrap_or_default(),

--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -254,7 +254,7 @@ where
     /// 6. **Queue Reset**: Sets queue ID to 0 (all half messages go to queue 0)
     /// 7. **Properties Serialization**: Updates the properties string representation
     pub fn parse_half_message_inner(message: &mut MessageExtBrokerInner) {
-        let uniq_id = message.get_user_property(&CheetahString::from_static_str(
+        let uniq_id = message.user_property(&CheetahString::from_static_str(
             MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
         ));
         if let Some(uniq_id) = uniq_id {
@@ -292,7 +292,7 @@ where
 
     pub fn renew_immunity_half_message_inner(msg_ext: &MessageExt) -> MessageExtBrokerInner {
         let mut message_inner = Self::renew_half_message_inner(msg_ext);
-        let queue_offset_from_prepare = msg_ext.get_user_property(&CheetahString::from_static_str(
+        let queue_offset_from_prepare = msg_ext.user_property(&CheetahString::from_static_str(
             MessageConst::PROPERTY_TRANSACTION_PREPARED_QUEUE_OFFSET,
         ));
         if let Some(queue_offset_from_prepare) = queue_offset_from_prepare {

--- a/rocketmq-client/src/base/validators.rs
+++ b/rocketmq-client/src/base/validators.rs
@@ -89,7 +89,7 @@ impl Validators {
             ));
         }
 
-        let lmq_path = msg.get_user_property(&CheetahString::from_static_str(
+        let lmq_path = msg.user_property(&CheetahString::from_static_str(
             MessageConst::PROPERTY_INNER_MULTI_DISPATCH,
         ));
         if let Some(value) = lmq_path {

--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -116,7 +116,7 @@ pub trait MessageTrait: Any + Display + Debug {
     /// # Returns
     ///
     /// An `Option<String>` containing the property value if it exists, otherwise `None`.
-    fn get_user_property(&self, name: &CheetahString) -> Option<CheetahString> {
+    fn user_property(&self, name: &CheetahString) -> Option<CheetahString> {
         self.property(name)
     }
 
@@ -131,7 +131,7 @@ pub trait MessageTrait: Any + Display + Debug {
     ///
     /// An `Option<&CheetahString>` containing a reference to the property value if it exists,
     /// otherwise `None`.
-    fn get_user_property_ref(&self, name: &CheetahString) -> Option<&CheetahString> {
+    fn user_property_ref(&self, name: &CheetahString) -> Option<&CheetahString> {
         self.property_ref(name)
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6439

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed message property accessor methods from `get_user_property()` and `get_user_property_ref()` to `user_property()` and `user_property_ref()` across broker, client, and common modules for API consistency. All functionality preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->