### PR TITLE
[ISSUE #6385]🚀Implement ProducerConnection Command in rocketmq-admin-core

### DIFF
--- a/rocketmq-remoting/src/protocol/body/producer_connection.rs
+++ b/rocketmq-remoting/src/protocol/body/producer_connection.rs
@@ -24,12 +24,17 @@ use crate::protocol::body::connection::Connection;
 pub struct ProducerConnection {
     connection_set: HashSet<Connection>,
 }
+
 impl ProducerConnection {
     pub fn new() -> Self {
         Self {
             connection_set: HashSet::new(),
         }
     }
+    pub fn connection_set(&self) -> &HashSet<Connection> {
+        &self.connection_set
+    }
+
     pub fn connection_set_mut(&mut self) -> &mut HashSet<Connection> {
         &mut self.connection_set
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -17,6 +17,7 @@ pub mod command_util;
 mod auth_commands;
 mod broker_commands;
 mod cluster_commands;
+mod connection_commands;
 mod consumer_commands;
 mod controller_commands;
 mod namesrv_commands;
@@ -88,6 +89,11 @@ pub enum Commands {
     Cluster(cluster_commands::ClusterCommands),
 
     #[command(subcommand)]
+    #[command(about = "Connection commands")]
+    #[command(name = "connection")]
+    Connection(connection_commands::ConnectionCommands),
+
+    #[command(subcommand)]
     #[command(about = "Consumer commands")]
     #[command(name = "consumer")]
     Consumer(consumer_commands::ConsumerCommands),
@@ -116,6 +122,7 @@ impl CommandExecute for Commands {
             Commands::Auth(value) => value.execute(rpc_hook).await,
             Commands::Broker(value) => value.execute(rpc_hook).await,
             Commands::Cluster(value) => value.execute(rpc_hook).await,
+            Commands::Connection(value) => value.execute(rpc_hook).await,
             Commands::Consumer(value) => value.execute(rpc_hook).await,
             Commands::Controller(value) => value.execute(rpc_hook).await,
             Commands::NameServer(value) => value.execute(rpc_hook).await,
@@ -263,6 +270,11 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "Cluster",
                 command: "clusterList",
                 remark: "List cluster infos.",
+            },
+            Command {
+                category: "Connection",
+                command: "producerConnection",
+                remark: "Query producer's socket connection and client version.",
             },
             Command {
                 category: "Consumer",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection_commands.rs
@@ -1,0 +1,38 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod producer_connection_sub_command;
+
+use std::sync::Arc;
+
+use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::connection_commands::producer_connection_sub_command::ProducerConnectionSubCommand;
+use crate::commands::CommandExecute;
+
+#[derive(Subcommand)]
+pub enum ConnectionCommands {
+    #[command(name = "producerConnection", about = "Query producer's connection")]
+    ProducerConnection(ProducerConnectionSubCommand),
+}
+
+impl CommandExecute for ConnectionCommands {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self {
+            ConnectionCommands::ProducerConnection(cmd) => cmd.execute(rpc_hook).await,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection_commands/producer_connection_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection_commands/producer_connection_sub_command.rs
@@ -1,0 +1,73 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::mq_version::RocketMqVersion;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct ProducerConnectionSubCommand {
+    #[arg(short = 'g', long = "producerGroup", required = true, help = "producer group name")]
+    producer_group: String,
+
+    #[arg(short = 't', long = "topic", required = true, help = "topic name")]
+    topic: String,
+}
+
+impl CommandExecute for ProducerConnectionSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> rocketmq_error::RocketMQResult<()> {
+        let mut default_mq_admin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mq_admin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        default_mq_admin_ext.start().await?;
+
+        let group = self.producer_group.trim();
+        let topic = self.topic.trim();
+
+        let pc = default_mq_admin_ext
+            .examine_producer_connection_info(group.into(), topic.into())
+            .await?;
+
+        let mut connections: Vec<_> = pc.connection_set().iter().collect();
+        connections.sort_by_key(|a| a.get_client_id());
+        for (idx, conn) in connections.iter().enumerate() {
+            let version_desc = RocketMqVersion::from_ordinal(conn.get_version() as u32).name();
+            println!(
+                "{:04}  {:<32} {:<22} {:<8} {}",
+                idx + 1,
+                conn.get_client_id(),
+                conn.get_client_addr(),
+                conn.get_language(),
+                version_desc
+            );
+        }
+
+        default_mq_admin_ext.shutdown().await;
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6385 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI "producer connection" command that lists active producer connections with index, client ID, client address, language, and RocketMQ version in a formatted table.

* **Improvements**
  * Added read-only access to producer connection data to support reliable listing from the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->