### PR TITLE
[ISSUE #6455]🐛Fix get_retry_times incorrect

### DIFF
--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -1043,9 +1043,9 @@ impl DefaultMQProducerImpl {
     #[inline]
     fn get_retry_times(&self, mode: CommunicationMode) -> u32 {
         if mode == CommunicationMode::Sync {
-            self.producer_config.retry_times_when_send_failed() + 1
-        } else {
             1
+        } else {
+            self.producer_config.retry_times_when_send_failed() + 1
         }
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6455

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent retry behavior in the message producer. Previously, only synchronous send operations applied the configured retry count, while asynchronous and other sending modes defaulted to single retry attempts. All message sending modes now uniformly apply the same configured retry count, ensuring consistent error handling and recovery behavior across all producer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->