### PR TITLE
[ISSUE #6457]♻️Refactor MessageQueue method names for consistency and clarity

### DIFF
--- a/rocketmq-broker/src/failover/escape_bridge.rs
+++ b/rocketmq-broker/src/failover/escape_bridge.rs
@@ -195,21 +195,21 @@ where
             let mq = topic_publish_info
                 .select_one_message_queue_by_broker(broker_name_to_send.as_ref())
                 .unwrap();
-            message_to_put.message_ext_inner.queue_id = mq.get_queue_id();
-            broker_name_to_send = Some(mq.get_broker_name().clone());
+            message_to_put.message_ext_inner.queue_id = mq.queue_id();
+            broker_name_to_send = Some(mq.broker_name().clone());
             if self
                 .broker_runtime_inner
                 .broker_config()
                 .broker_identity
                 .broker_name
                 .as_str()
-                == mq.get_broker_name().as_str()
+                == mq.broker_name().as_str()
             {
                 warn!(
                     "putMessageToRemoteBroker failed, remote broker not found. Topic: {}, MsgId: {}, Broker: {}",
                     message_to_put.get_topic(),
                     message_to_put.message_ext_inner.msg_id,
-                    mq.get_broker_name()
+                    mq.broker_name()
                 );
                 return Ok(None);
             }
@@ -287,8 +287,8 @@ where
                 return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable);
             }
             let message_queue = mq_selected.unwrap();
-            message_ext.message_ext_inner.queue_id = message_queue.get_queue_id();
-            let broker_name_to_send = message_queue.get_broker_name();
+            message_ext.message_ext_inner.queue_id = message_queue.queue_id();
+            let broker_name_to_send = message_queue.broker_name();
             let broker_addr_to_send = self
                 .broker_runtime_inner
                 .topic_route_info_manager()
@@ -345,8 +345,8 @@ where
             let code = JavaStringHasher::hash_str(id.as_str());
             let index = code as usize % topic_publish_info.message_queue_list.len();
             let message_queue = topic_publish_info.message_queue_list[index].clone();
-            message_ext.message_ext_inner.queue_id = message_queue.get_queue_id();
-            let broker_name_to_send = message_queue.get_broker_name();
+            message_ext.message_ext_inner.queue_id = message_queue.queue_id();
+            let broker_name_to_send = message_queue.broker_name();
             let broker_addr_to_send = self
                 .broker_runtime_inner
                 .topic_route_info_manager()

--- a/rocketmq-broker/src/processor/query_assignment_processor.rs
+++ b/rocketmq-broker/src/processor/query_assignment_processor.rs
@@ -418,7 +418,7 @@ impl<MS: MessageStore> QueryAssignmentProcessor<MS> {
             //each client pop all message queue
             Ok(mq_all
                 .iter()
-                .map(|mq| MessageQueue::from_parts(mq.get_topic_cs().clone(), mq.get_broker_name().clone(), -1))
+                .map(|mq| MessageQueue::from_parts(mq.topic().clone(), mq.broker_name().clone(), -1))
                 .collect::<HashSet<MessageQueue>>())
         } else if cid_all.len() <= mq_all.len() {
             //consumer working in pop mode could share the MessageQueues assigned to
@@ -568,7 +568,7 @@ mod tests {
 
         let result = allocate(&consumer_group, &current_cid, &mq_all, &cid_all).unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result.iter().next().unwrap().get_queue_id(), 0);
+        assert_eq!(result.iter().next().unwrap().queue_id(), 0);
     }
 
     #[test]
@@ -583,7 +583,7 @@ mod tests {
 
         let result = allocate(&consumer_group, &current_cid, &mq_all, &cid_all).unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result.iter().next().unwrap().get_queue_id(), 1);
+        assert_eq!(result.iter().next().unwrap().queue_id(), 1);
     }
 
     #[test]

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
@@ -809,7 +809,7 @@ where
     /// Pull half message
     async fn pull_half_msg(&self, mq: &MessageQueue, offset: i64, nums: i32) -> Option<PullResult> {
         self.transactional_message_bridge
-            .get_half_message(mq.get_queue_id(), offset, nums)
+            .get_half_message(mq.queue_id(), offset, nums)
             .await
     }
 
@@ -822,8 +822,8 @@ where
             .or_insert_with(|| {
                 MessageQueue::from_parts(
                     CheetahString::from_static_str(TransactionalMessageUtil::build_op_topic()),
-                    message_queue.get_broker_name(),
-                    message_queue.get_queue_id(),
+                    message_queue.broker_name(),
+                    message_queue.queue_id(),
                 )
             })
             .clone()
@@ -955,7 +955,7 @@ where
     /// Pull operation message
     async fn pull_op_msg(&self, mq: &MessageQueue, offset: i64, nums: i32) -> Option<PullResult> {
         self.transactional_message_bridge
-            .get_op_message(mq.get_queue_id(), offset, nums)
+            .get_op_message(mq.queue_id(), offset, nums)
             .await
     }
 }

--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -73,8 +73,8 @@ where
 {
     pub(crate) fn fetch_consume_offset(&self, mq: &MessageQueue) -> i64 {
         let group = CheetahString::from_static_str(TransactionalMessageUtil::build_consumer_group());
-        let topic = mq.get_topic_cs();
-        let queue_id = mq.get_queue_id();
+        let topic = mq.topic();
+        let queue_id = mq.queue_id();
         let mut offset = self
             .broker_runtime_inner
             .consumer_offset_manager()
@@ -106,8 +106,8 @@ where
         self.broker_runtime_inner.consumer_offset_manager().commit_offset(
             self.store_host.to_string().into(),
             &CheetahString::from_static_str(TransactionalMessageUtil::build_consumer_group()),
-            mq.get_topic_cs(),
-            mq.get_queue_id(),
+            mq.topic(),
+            mq.queue_id(),
             offset,
         );
     }
@@ -333,7 +333,7 @@ where
         msg_inner.message_ext_inner.message = message;
         //msg_inner.set_topic(message.get_topic().to_owned());
         //msg_inner.set_body(message.get_body().expect("message body is empty").clone());
-        msg_inner.message_ext_inner.queue_id = message_queue.get_queue_id();
+        msg_inner.message_ext_inner.queue_id = message_queue.queue_id();
         //msg_inner.set_tags(message.get_tags().unwrap_or_default());
         msg_inner.tags_code =
             MessageExtBrokerInner::tags_string_to_tags_code(msg_inner.get_tags().unwrap_or_default().as_str());

--- a/rocketmq-client/src/base/client_config.rs
+++ b/rocketmq-client/src/base/client_config.rs
@@ -177,7 +177,7 @@ impl ClientConfig {
     pub fn queue_with_namespace(&mut self, mut queue: MessageQueue) -> MessageQueue {
         if let Some(namespace) = self.get_namespace() {
             if !namespace.is_empty() {
-                let topic = NamespaceUtil::wrap_namespace(namespace.as_str(), queue.get_topic());
+                let topic = NamespaceUtil::wrap_namespace(namespace.as_str(), queue.topic_str());
                 queue.set_topic(topic);
                 return queue;
             }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -723,7 +723,7 @@ impl DefaultMQPushConsumerImpl {
             .get_subscription_inner()
             .read()
             .await
-            .get(pop_request.get_message_queue().get_topic_cs())
+            .get(pop_request.get_message_queue().topic())
             .cloned();
         if subscription_data.is_none() {
             self.execute_pop_request_later(pop_request, self.pull_time_delay_mills_when_exception);
@@ -912,7 +912,7 @@ impl DefaultMQPushConsumerImpl {
         let message_queue = pull_request.get_message_queue().clone();
         let inner = self.rebalance_impl.get_subscription_inner();
         let guard = inner.read().await;
-        let subscription_data = guard.get(message_queue.get_topic()).cloned();
+        let subscription_data = guard.get(message_queue.topic_str()).cloned();
 
         if subscription_data.is_none() {
             error!(
@@ -923,7 +923,7 @@ impl DefaultMQPushConsumerImpl {
             return;
         }
         let begin_timestamp = Instant::now();
-        let topic = message_queue.get_topic().to_string();
+        let topic = message_queue.topic_str().to_string();
 
         let message_queue_inner = message_queue.clone();
         let next_offset = pull_request.next_offset;
@@ -1130,7 +1130,7 @@ impl DefaultMQPushConsumerImpl {
             && mq.is_some()
             && mq
                 .unwrap()
-                .get_broker_name()
+                .broker_name()
                 .starts_with(mix_all::LOGICAL_QUEUE_MOCK_BROKER_PREFIX)
         {
             let _ = self.send_message_back_as_normal_message(msg).await;

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
@@ -253,7 +253,7 @@ where
             process_queue_table
                 .iter()
                 .filter_map(|(mq, _pq)| {
-                    if !topics.contains(mq.get_topic()) {
+                    if !topics.contains(mq.topic_str()) {
                         Some(mq.clone())
                     } else {
                         None
@@ -273,7 +273,7 @@ where
                 info!(
                     "doRebalance, {}, truncateMessageQueueNotMyTopic remove unnecessary mq, {}",
                     self.consumer_group.as_ref().unwrap(),
-                    mq.get_topic()
+                    mq.topic_str()
                 );
             }
         }
@@ -284,7 +284,7 @@ where
             pop_process_queue_table
                 .iter()
                 .filter_map(|(mq, _pq)| {
-                    if !topics.contains(mq.get_topic()) {
+                    if !topics.contains(mq.topic_str()) {
                         Some(mq.clone())
                     } else {
                         None
@@ -303,7 +303,7 @@ where
                 info!(
                     "doRebalance, {}, truncateMessageQueueNotMyTopic remove unnecessary pop mq, {}",
                     self.consumer_group.as_ref().unwrap(),
-                    mq.get_topic()
+                    mq.topic_str()
                 );
             }
         }
@@ -465,7 +465,7 @@ where
 
             let process_queue_table = self.process_queue_table.read().await;
             for (mq, pq) in process_queue_table.iter() {
-                if mq.get_topic() == topic {
+                if mq.topic_str() == topic {
                     if !mq2push_assignment.contains_key(mq) {
                         pq.set_dropped(true);
                         remove_queue_map.insert(mq.clone(), pq.clone());
@@ -478,7 +478,7 @@ where
                                     "[BUG]doRebalance, {:?}, try remove unnecessary mq, {}, because pull is pause, so \
                                      try to fixed it",
                                     self.consumer_group,
-                                    mq.get_topic()
+                                    mq.topic_str()
                                 );
                             }
                         }
@@ -499,7 +499,7 @@ where
                             info!(
                                 "doRebalance, {:?}, remove unnecessary mq, {}",
                                 self.consumer_group,
-                                mq.get_topic()
+                                mq.topic_str()
                             );
                         }
                     }
@@ -512,7 +512,7 @@ where
             // Drop process queues no longer belong to me
             let pop_process_queue_table = self.pop_process_queue_table.read().await;
             for (mq, pq) in pop_process_queue_table.iter() {
-                if mq.get_topic() == topic {
+                if mq.topic_str() == topic {
                     if !mq2pop_assignment.contains_key(mq) {
                         pq.set_dropped(true);
                         remove_queue_map.insert(mq.clone(), pq.clone());
@@ -525,7 +525,7 @@ where
                                     "[BUG]doRebalance, {:?}, try remove unnecessary mq, {}, because pull is pause, so \
                                      try to fixed it",
                                     self.consumer_group,
-                                    mq.get_topic()
+                                    mq.topic_str()
                                 );
                             }
                         }
@@ -546,7 +546,7 @@ where
                             info!(
                                 "doRebalance, {:?}, remove unnecessary pop mq, {}",
                                 self.consumer_group,
-                                mq.get_topic()
+                                mq.topic_str()
                             );
                         }
                     }
@@ -593,7 +593,7 @@ where
                         warn!(
                             "doRebalance, {:?}, lock mq failed before adding, {}",
                             self.consumer_group,
-                            mq.get_topic()
+                            mq.topic_str()
                         );
                         all_mq_locked = false;
                     }
@@ -610,7 +610,7 @@ where
                         warn!(
                             "doRebalance, {:?}, skip adding mq because lock failed, {}",
                             self.consumer_group,
-                            mq.get_topic()
+                            mq.topic_str()
                         );
                         continue;
                     }
@@ -628,7 +628,7 @@ where
                             info!(
                                 "doRebalance, {:?}, add a new mq, {}",
                                 self.consumer_group,
-                                mq.get_topic()
+                                mq.topic_str()
                             );
                             pull_request_list.push(PullRequest::new(
                                 self.consumer_group.as_ref().unwrap().clone(),
@@ -641,14 +641,14 @@ where
                             info!(
                                 "doRebalance, {:?}, mq already exists, {}",
                                 self.consumer_group,
-                                mq.get_topic()
+                                mq.topic_str()
                             );
                         }
                     } else {
                         warn!(
                             "doRebalance, {:?}, add new mq failed, {}",
                             self.consumer_group,
-                            mq.get_topic()
+                            mq.topic_str()
                         );
                     }
                 }
@@ -704,7 +704,7 @@ where
             let process_queue_table = process_queue_table_cloned.read().await;
             // Drop process queues no longer belong to me
             for (mq, pq) in process_queue_table.iter() {
-                if mq.get_topic() == topic {
+                if mq.topic_str() == topic {
                     if !mq_set.contains(mq) {
                         pq.set_dropped(true);
                         remove_queue_map.insert(mq.clone(), pq.clone());
@@ -717,7 +717,7 @@ where
                                     "[BUG]doRebalance, {:?}, try remove unnecessary mq, {}, because pull is pause, so \
                                      try to fixed it",
                                     self.consumer_group,
-                                    mq.get_topic()
+                                    mq.topic_str()
                                 );
                             }
                         }
@@ -738,7 +738,7 @@ where
                             info!(
                                 "doRebalance, {:?}, remove unnecessary mq, {}",
                                 self.consumer_group,
-                                mq.get_topic()
+                                mq.topic_str()
                             );
                         }
                     }
@@ -777,7 +777,7 @@ where
                     warn!(
                         "doRebalance, {:?}, lock mq failed before adding, {}",
                         self.consumer_group,
-                        mq.get_topic()
+                        mq.topic_str()
                     );
                     all_mq_locked = false;
                 }
@@ -793,7 +793,7 @@ where
                     warn!(
                         "doRebalance, {:?}, skip adding mq because lock failed, {}",
                         self.consumer_group,
-                        mq.get_topic()
+                        mq.topic_str()
                     );
                     continue;
                 }
@@ -807,7 +807,7 @@ where
                         info!(
                             "doRebalance, {:?}, add a new mq, {}",
                             self.consumer_group,
-                            mq.get_topic()
+                            mq.topic_str()
                         );
                         pull_request_list.push(PullRequest::new(
                             self.consumer_group.as_ref().unwrap().clone(),
@@ -820,14 +820,14 @@ where
                         info!(
                             "doRebalance, {:?}, mq already exists, {}",
                             self.consumer_group,
-                            mq.get_topic()
+                            mq.topic_str()
                         );
                     }
                 } else {
                     warn!(
                         "doRebalance, {:?}, add new mq failed, {}",
                         self.consumer_group,
-                        mq.get_topic()
+                        mq.topic_str()
                     );
                 }
             }
@@ -963,13 +963,13 @@ where
         let mut queue_set = HashSet::new();
         let process_queue_table = self.process_queue_table.read().await;
         for (mq, pq) in process_queue_table.iter() {
-            if mq.get_topic() == topic && !pq.is_dropped() {
+            if mq.topic_str() == topic && !pq.is_dropped() {
                 queue_set.insert(mq.clone());
             }
         }
         let pop_process_queue_table = self.pop_process_queue_table.read().await;
         for (mq, pq) in pop_process_queue_table.iter() {
-            if mq.get_topic() == topic && !pq.is_dropped() {
+            if mq.topic_str() == topic && !pq.is_dropped() {
                 queue_set.insert(mq.clone());
             }
         }

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
@@ -276,7 +276,7 @@ impl Rebalance for RebalancePushImpl {
                 if last_offset >= 0 {
                     last_offset
                 } else if -1 == last_offset {
-                    if mq.get_topic().starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
+                    if mq.topic_str().starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
                         0
                     } else {
                         let Some(client_instance) = self.rebalance_impl_inner.client_instance.as_mut() else {
@@ -313,7 +313,7 @@ impl Rebalance for RebalancePushImpl {
                 if last_offset >= 0 {
                     last_offset
                 } else if -1 == last_offset {
-                    if mq.get_topic().starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
+                    if mq.topic_str().starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
                         let Some(client_instance) = self.rebalance_impl_inner.client_instance.as_mut() else {
                             error!("Client instance not initialized for mq: {}", mq);
                             return Err(mq_client_err!(

--- a/rocketmq-client/src/consumer/pop_callback.rs
+++ b/rocketmq-client/src/consumer/pop_callback.rs
@@ -139,7 +139,7 @@ impl PopCallback for DefaultPopCallback {
 
         let message_queue_inner = self.message_queue_inner.take().unwrap();
         let pop_request = self.pop_request.take().unwrap();
-        let topic = message_queue_inner.get_topic();
+        let topic = message_queue_inner.topic_str();
         if !topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
             if let Some(er) = err.downcast_ref::<RocketmqError>() {
                 match er {

--- a/rocketmq-client/src/consumer/pull_callback.rs
+++ b/rocketmq-client/src/consumer/pull_callback.rs
@@ -148,7 +148,7 @@ impl PullCallback for DefaultPullCallback {
     fn on_exception(&mut self, err: Box<dyn std::error::Error + Send>) {
         let message_queue_inner = self.message_queue_inner.take().unwrap();
         let pull_request = self.pull_request.take().unwrap();
-        let topic = message_queue_inner.get_topic();
+        let topic = message_queue_inner.topic_str();
         if !topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
             if let Some(er) = err.downcast_ref::<RocketmqError>() {
                 match er {

--- a/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_averagely_by_circle.rs
+++ b/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_averagely_by_circle.rs
@@ -85,8 +85,8 @@ mod tests {
             .allocate(&consumer_group, &current_cid, &mq_all, &cid_all)
             .unwrap();
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0].get_queue_id(), 0);
-        assert_eq!(result[1].get_queue_id(), 1);
+        assert_eq!(result[0].queue_id(), 0);
+        assert_eq!(result[1].queue_id(), 1);
     }
 
     #[test]
@@ -109,7 +109,7 @@ mod tests {
             .allocate(&consumer_group, &current_cid, &mq_all, &cid_all)
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].get_queue_id(), 1);
+        assert_eq!(result[0].queue_id(), 1);
     }
 
     #[test]
@@ -142,7 +142,7 @@ mod tests {
                     &consumer_id_list,
                 )
                 .unwrap();
-            let queue_ids: Vec<i32> = queues.iter().map(|q| q.get_queue_id()).collect();
+            let queue_ids: Vec<i32> = queues.iter().map(|q| q.queue_id()).collect();
             consumer_allocate_queue.insert(consumer_id.clone(), queue_ids);
         }
         assert_eq!(vec![0, 4, 8], consumer_allocate_queue["CID_PREFIX0"]);

--- a/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_config.rs
+++ b/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_config.rs
@@ -67,7 +67,7 @@ mod tests {
             let queues = strategy
                 .allocate(&consumer_group, consumer_id, &mq_all, &cid_all)
                 .unwrap();
-            let queue_ids: Vec<i32> = queues.into_iter().map(|mq| mq.get_queue_id()).collect();
+            let queue_ids: Vec<i32> = queues.into_iter().map(|mq| mq.queue_id()).collect();
             consumer_allocate_queue.insert(consumer_id.clone(), queue_ids);
         }
 

--- a/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_machine_room.rs
+++ b/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_machine_room.rs
@@ -49,7 +49,7 @@ impl AllocateMessageQueueStrategy for AllocateMessageQueueByMachineRoom {
         let premq_all: Vec<MessageQueue> = mq_all
             .iter()
             .filter(|mq| {
-                let parts: Vec<&str> = mq.get_broker_name().split('@').collect();
+                let parts: Vec<&str> = mq.broker_name().split('@').collect();
                 parts.len() == 2 && self.consumer_idcs.contains(parts[0])
             })
             .cloned()
@@ -109,7 +109,7 @@ mod tests {
             let queues = strategy
                 .allocate(&consumer_group, consumer_id, &mq_all, &cid_all)
                 .unwrap();
-            let queue_ids: Vec<i32> = queues.into_iter().map(|mq| mq.get_queue_id()).collect();
+            let queue_ids: Vec<i32> = queues.into_iter().map(|mq| mq.queue_id()).collect();
             consumer_allocate_queue.insert(consumer_id.clone(), queue_ids);
         }
 
@@ -152,8 +152,8 @@ mod tests {
             .allocate(&consumer_group, &current_cid, &mq_all, &cid_all)
             .unwrap();
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0].get_queue_id(), 0);
-        assert_eq!(result[1].get_queue_id(), 1);
+        assert_eq!(result[0].queue_id(), 0);
+        assert_eq!(result[1].queue_id(), 1);
     }
 
     #[test]
@@ -177,7 +177,7 @@ mod tests {
             .allocate(&consumer_group, &current_cid, &mq_all, &cid_all)
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].get_queue_id(), 1);
+        assert_eq!(result[0].queue_id(), 1);
     }
 
     #[test]

--- a/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_machine_room_nearby.rs
+++ b/rocketmq-client/src/consumer/rebalance_strategy/allocate_message_queue_by_machine_room_nearby.rs
@@ -119,7 +119,7 @@ mod tests {
 
     impl MachineRoomResolver for TestMachineRoomResolver {
         fn broker_deploy_in(&self, message_queue: &MessageQueue) -> Option<CheetahString> {
-            let parts: Vec<&str> = message_queue.get_broker_name().split('-').collect();
+            let parts: Vec<&str> = message_queue.broker_name().split('-').collect();
             Some(CheetahString::from(parts[0]))
         }
 

--- a/rocketmq-client/src/consumer/store/local_file_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/local_file_offset_store.rs
@@ -235,7 +235,7 @@ impl OffsetStoreTrait for LocalFileOffsetStore {
         let offset_table = self.offset_table.lock().await;
         offset_table
             .iter()
-            .filter(|(mq, _)| topic.is_empty() || mq.get_topic() == topic)
+            .filter(|(mq, _)| topic.is_empty() || mq.topic_str() == topic)
             .map(|(mq, offset)| (mq.clone(), offset.get_offset()))
             .collect()
     }

--- a/rocketmq-client/src/consumer/store/remote_broker_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/remote_broker_offset_store.rs
@@ -60,7 +60,7 @@ impl RemoteBrokerOffsetStore {
         if find_broker_result.is_none() {
             self.client_instance
                 .mut_from_ref()
-                .update_topic_route_info_from_name_server_topic(mq.get_topic_cs())
+                .update_topic_route_info_from_name_server_topic(mq.topic())
                 .await;
             let broker_name = self.client_instance.get_broker_name_from_message_queue(mq).await;
             find_broker_result = self
@@ -72,15 +72,15 @@ impl RemoteBrokerOffsetStore {
         if let Some(find_broker_result) = find_broker_result {
             let request_header = QueryConsumerOffsetRequestHeader {
                 consumer_group: self.group_name.clone(),
-                topic: CheetahString::from_string(mq.get_topic().to_string()),
-                queue_id: mq.get_queue_id(),
+                topic: CheetahString::from_string(mq.topic_str().to_string()),
+                queue_id: mq.queue_id(),
                 set_zero_if_not_found: None,
                 topic_request_header: Some(TopicRequestHeader {
                     lo: None,
                     rpc: Some(RpcRequestHeader {
                         namespace: None,
                         namespaced: None,
-                        broker_name: Some(CheetahString::from_string(mq.get_broker_name().to_string())),
+                        broker_name: Some(CheetahString::from_string(mq.broker_name().to_string())),
                         oneway: None,
                     }),
                 }),
@@ -228,7 +228,7 @@ impl OffsetStoreTrait for RemoteBrokerOffsetStore {
         let offset_table = self.offset_table.lock().await;
         offset_table
             .iter()
-            .filter(|(mq, _)| mq.get_topic() == topic)
+            .filter(|(mq, _)| mq.topic_str() == topic)
             .map(|(mq, offset)| (mq.clone(), offset.get_offset()))
             .collect()
     }
@@ -247,7 +247,7 @@ impl OffsetStoreTrait for RemoteBrokerOffsetStore {
 
         if find_broker_result.is_none() {
             self.client_instance
-                .update_topic_route_info_from_name_server_topic(mq.get_topic_cs())
+                .update_topic_route_info_from_name_server_topic(mq.topic())
                 .await;
             let broker_name = self.client_instance.get_broker_name_from_message_queue(mq).await;
             find_broker_result = self
@@ -259,15 +259,15 @@ impl OffsetStoreTrait for RemoteBrokerOffsetStore {
         if let Some(find_broker_result) = find_broker_result {
             let request_header = UpdateConsumerOffsetRequestHeader {
                 consumer_group: self.group_name.clone(),
-                topic: mq.get_topic_cs().clone(),
-                queue_id: mq.get_queue_id(),
+                topic: mq.topic().clone(),
+                queue_id: mq.queue_id(),
                 commit_offset: offset,
                 topic_request_header: Some(TopicRequestHeader {
                     lo: None,
                     rpc: Some(RpcRequestHeader {
                         namespace: None,
                         namespaced: None,
-                        broker_name: Some(CheetahString::from_string(mq.get_broker_name().to_string())),
+                        broker_name: Some(CheetahString::from_string(mq.broker_name().to_string())),
                         oneway: None,
                     }),
                 }),

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -754,12 +754,12 @@ impl MQClientInstance {
     }
 
     pub async fn get_broker_name_from_message_queue(&self, message_queue: &MessageQueue) -> CheetahString {
-        if let Some(broker_name) = self.topic_end_points_table.get(message_queue.get_topic()) {
+        if let Some(broker_name) = self.topic_end_points_table.get(message_queue.topic_str()) {
             if let Some(addr) = broker_name.value().get(message_queue) {
                 return addr.clone();
             }
         }
-        message_queue.get_broker_name().clone()
+        message_queue.broker_name().clone()
     }
 
     pub async fn find_broker_address_in_publish(&self, broker_name: &CheetahString) -> Option<CheetahString> {
@@ -1565,7 +1565,7 @@ pub fn topic_route_data2topic_publish_info(topic: &str, route: &mut TopicRouteDa
             }
         }
         info.message_queue_list
-            .sort_by(|a, b| match a.get_queue_id().cmp(&b.get_queue_id()) {
+            .sort_by(|a, b| match a.queue_id().cmp(&b.queue_id()) {
                 Ordering::Less => std::cmp::Ordering::Less,
                 Ordering::Equal => std::cmp::Ordering::Equal,
                 Ordering::Greater => std::cmp::Ordering::Greater,

--- a/rocketmq-client/src/implementation/mq_admin_impl.rs
+++ b/rocketmq-client/src/implementation/mq_admin_impl.rs
@@ -48,15 +48,12 @@ impl MQAdminImpl {
         let mut message_queues = Vec::new();
         for message_queue in message_queue_array {
             let user_topic = NamespaceUtil::without_namespace_with_namespace(
-                message_queue.get_topic(),
+                message_queue.topic_str(),
                 client_config.get_namespace().unwrap_or_default().as_str(),
             );
 
-            let message_queue = MessageQueue::from_parts(
-                user_topic,
-                message_queue.get_broker_name(),
-                message_queue.get_queue_id(),
-            );
+            let message_queue =
+                MessageQueue::from_parts(user_topic, message_queue.broker_name(), message_queue.queue_id());
             message_queues.push(message_queue);
         }
         message_queues
@@ -89,9 +86,7 @@ impl MQAdminImpl {
         let broker_name = client.get_broker_name_from_message_queue(mq).await;
         let mut broker_addr = client.find_broker_address_in_publish(broker_name.as_ref()).await;
         if broker_addr.is_none() {
-            client
-                .update_topic_route_info_from_name_server_topic(mq.get_topic_cs())
-                .await;
+            client.update_topic_route_info_from_name_server_topic(mq.topic()).await;
             let broker_name = client.get_broker_name_from_message_queue(mq).await;
             broker_addr = client.find_broker_address_in_publish(broker_name.as_ref()).await;
         }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -2217,12 +2217,12 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<i64> {
         let request_header = GetMaxOffsetRequestHeader {
-            topic: CheetahString::from_slice(message_queue.get_topic()),
-            queue_id: message_queue.get_queue_id(),
+            topic: CheetahString::from_slice(message_queue.topic_str()),
+            queue_id: message_queue.queue_id(),
             committed: false,
             topic_request_header: Some(TopicRequestHeader {
                 rpc_request_header: Some(RpcRequestHeader {
-                    broker_name: Some(CheetahString::from_slice(message_queue.get_broker_name())),
+                    broker_name: Some(CheetahString::from_slice(message_queue.broker_name())),
                     ..Default::default()
                 }),
                 lo: None,

--- a/rocketmq-client/src/latency/mq_fault_strategy.rs
+++ b/rocketmq-client/src/latency/mq_fault_strategy.rs
@@ -177,7 +177,7 @@ struct BrokerFilter {
 impl QueueFilter for BrokerFilter {
     fn filter(&self, message_queue: &MessageQueue) -> bool {
         if let Some(last_broker_name) = &self.last_broker_name {
-            message_queue.get_broker_name() != last_broker_name
+            message_queue.broker_name() != last_broker_name
         } else {
             true
         }
@@ -190,8 +190,7 @@ struct ReachableFilter {
 
 impl QueueFilter for ReachableFilter {
     fn filter(&self, message_queue: &MessageQueue) -> bool {
-        self.latency_fault_tolerance
-            .is_reachable(message_queue.get_broker_name())
+        self.latency_fault_tolerance.is_reachable(message_queue.broker_name())
     }
 }
 
@@ -201,7 +200,6 @@ struct AvailableFilter {
 
 impl QueueFilter for AvailableFilter {
     fn filter(&self, message_queue: &MessageQueue) -> bool {
-        self.latency_fault_tolerance
-            .is_available(message_queue.get_broker_name())
+        self.latency_fault_tolerance.is_available(message_queue.broker_name())
     }
 }

--- a/rocketmq-client/src/producer/producer_impl/queue_filter.rs
+++ b/rocketmq-client/src/producer/producer_impl/queue_filter.rs
@@ -59,14 +59,14 @@ mod tests {
 
     #[test]
     fn queue_filter_closure_returns_true() {
-        let filter = |mq: &MessageQueue| mq.get_topic() == "test_topic";
+        let filter = |mq: &MessageQueue| mq.topic_str() == "test_topic";
         let mq = MessageQueue::from_parts("test_topic", "broker", 1);
         assert!(filter.filter(&mq));
     }
 
     #[test]
     fn queue_filter_closure_returns_false() {
-        let filter = |mq: &MessageQueue| mq.get_topic() == "test_topic";
+        let filter = |mq: &MessageQueue| mq.topic_str() == "test_topic";
         let mq = MessageQueue::from_parts("other_topic", "broker", 1);
         assert!(!filter.filter(&mq));
     }
@@ -74,7 +74,7 @@ mod tests {
     #[test]
     fn queue_filter_function_returns_true() {
         fn filter_fn(mq: &MessageQueue) -> bool {
-            mq.get_queue_id() == 1
+            mq.queue_id() == 1
         }
         let mq = MessageQueue::from_parts("test_topic", "broker", 1);
         assert!(filter_fn.filter(&mq));
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn queue_filter_function_returns_false() {
         fn filter_fn(mq: &MessageQueue) -> bool {
-            mq.get_queue_id() == 1
+            mq.queue_id() == 1
         }
         let mq = MessageQueue::from_parts("test_topic", "broker", 2);
         assert!(!filter_fn.filter(&mq));

--- a/rocketmq-client/src/producer/producer_impl/topic_publish_info.rs
+++ b/rocketmq-client/src/producer/producer_impl/topic_publish_info.rs
@@ -55,7 +55,7 @@ impl TopicPublishInfo {
     pub fn select_one_message_queue_by_broker(&self, last_broker_name: Option<&CheetahString>) -> Option<MessageQueue> {
         if let Some(last_broker_name) = last_broker_name {
             for mq in &self.message_queue_list {
-                if mq.get_broker_name() != last_broker_name {
+                if mq.broker_name() != last_broker_name {
                     return Some(mq.clone());
                 }
             }

--- a/rocketmq-client/tests/integration_tests.rs
+++ b/rocketmq-client/tests/integration_tests.rs
@@ -180,7 +180,7 @@ fn select_by_broker_prefers_different_one() {
     let out = tpi.select_one_message_queue_by_broker(Some(&last));
     assert!(out.is_some());
     let out = out.unwrap();
-    assert_ne!(out.get_broker_name(), &last);
+    assert_ne!(out.broker_name(), &last);
 }
 
 #[test]
@@ -193,7 +193,7 @@ fn select_by_broker_falls_back_when_all_same() {
     let out = tpi.select_one_message_queue_by_broker(Some(&last));
     assert!(out.is_some());
     let out = out.unwrap();
-    assert_eq!(out.get_broker_name(), &last);
+    assert_eq!(out.broker_name(), &last);
 }
 
 #[test]
@@ -203,7 +203,7 @@ fn select_with_filters_matches_and_no_match() {
     let mq2 = MessageQueue::from_parts("t", "b2", 2);
     tpi.message_queue_list = vec![mq1.clone(), mq2.clone()];
 
-    let filter_match = |mq: &MessageQueue| mq.get_queue_id() == 2;
+    let filter_match = |mq: &MessageQueue| mq.queue_id() == 2;
     let out = tpi.select_one_message_queue_filters(&[&filter_match]);
     assert!(out.is_some());
     assert_eq!(out.unwrap(), mq2);

--- a/rocketmq-client/tests/rebalance_concurrent_safety_test.rs
+++ b/rocketmq-client/tests/rebalance_concurrent_safety_test.rs
@@ -85,7 +85,7 @@ impl MockRebalanceImpl {
             process_queue_table
                 .iter()
                 .filter_map(|(mq, _pq)| {
-                    if !topics.contains(mq.get_topic()) {
+                    if !topics.contains(mq.topic_str()) {
                         Some(mq.clone())
                     } else {
                         None
@@ -120,7 +120,7 @@ impl MockRebalanceImpl {
             process_queue_table
                 .iter()
                 .filter_map(|(mq, pq)| {
-                    if !topics.contains(mq.get_topic()) {
+                    if !topics.contains(mq.topic_str()) {
                         pq.set_dropped(true);
                         Some(mq.clone())
                     } else {

--- a/rocketmq-common/src/common/message/message_queue.rs
+++ b/rocketmq-common/src/common/message/message_queue.rs
@@ -55,12 +55,12 @@ impl MessageQueue {
     }
 
     #[inline]
-    pub fn get_topic(&self) -> &str {
+    pub fn topic_str(&self) -> &str {
         &self.topic
     }
 
     #[inline]
-    pub fn get_topic_cs(&self) -> &CheetahString {
+    pub fn topic(&self) -> &CheetahString {
         &self.topic
     }
 
@@ -70,7 +70,7 @@ impl MessageQueue {
     }
 
     #[inline]
-    pub fn get_broker_name(&self) -> &CheetahString {
+    pub fn broker_name(&self) -> &CheetahString {
         &self.broker_name
     }
 
@@ -80,7 +80,7 @@ impl MessageQueue {
     }
 
     #[inline]
-    pub fn get_queue_id(&self) -> i32 {
+    pub fn queue_id(&self) -> i32 {
         self.queue_id
     }
 
@@ -147,9 +147,9 @@ mod test {
     #[test]
     fn new_message_queue_has_default_values() {
         let mq = MessageQueue::new();
-        assert_eq!(mq.get_topic(), "");
-        assert_eq!(mq.get_broker_name(), "");
-        assert_eq!(mq.get_queue_id(), 0);
+        assert_eq!(mq.topic_str(), "");
+        assert_eq!(mq.broker_name(), "");
+        assert_eq!(mq.queue_id(), 0);
     }
 
     #[test]
@@ -162,30 +162,30 @@ mod test {
     #[test]
     fn from_parts_creates_message_queue_with_given_values() {
         let mq = MessageQueue::from_parts("topic1", "broker1", 1);
-        assert_eq!(mq.get_topic(), "topic1");
-        assert_eq!(mq.get_broker_name(), "broker1");
-        assert_eq!(mq.get_queue_id(), 1);
+        assert_eq!(mq.topic_str(), "topic1");
+        assert_eq!(mq.broker_name(), "broker1");
+        assert_eq!(mq.queue_id(), 1);
     }
 
     #[test]
     fn set_topic_updates_topic() {
         let mut mq = MessageQueue::new();
         mq.set_topic(CheetahString::from("new_topic"));
-        assert_eq!(mq.get_topic(), "new_topic");
+        assert_eq!(mq.topic_str(), "new_topic");
     }
 
     #[test]
     fn set_broker_name_updates_broker_name() {
         let mut mq = MessageQueue::new();
         mq.set_broker_name(CheetahString::from("new_broker"));
-        assert_eq!(mq.get_broker_name(), "new_broker");
+        assert_eq!(mq.broker_name(), "new_broker");
     }
 
     #[test]
     fn set_queue_id_updates_queue_id() {
         let mut mq = MessageQueue::new();
         mq.set_queue_id(10);
-        assert_eq!(mq.get_queue_id(), 10);
+        assert_eq!(mq.queue_id(), 10);
     }
 
     #[test]

--- a/rocketmq-common/src/common/message/message_queue_for_c.rs
+++ b/rocketmq-common/src/common/message/message_queue_for_c.rs
@@ -52,9 +52,9 @@ impl MessageQueueForC {
     /// Create from MessageQueue with offset
     pub fn from_message_queue(mq: &MessageQueue, offset: i64) -> Self {
         Self {
-            topic: mq.get_topic().into(),
-            broker_name: mq.get_broker_name().into(),
-            queue_id: mq.get_queue_id(),
+            topic: mq.topic_str().into(),
+            broker_name: mq.broker_name().into(),
+            queue_id: mq.queue_id(),
             offset,
         }
     }

--- a/rocketmq-remoting/src/protocol/body/consumer_running_info.rs
+++ b/rocketmq-remoting/src/protocol/body/consumer_running_info.rs
@@ -74,9 +74,9 @@ impl Display for ConsumerRunningInfo {
         for (k, v) in &self.mq_table {
             let item = format!(
                 "{}  {}  {}  {}\n",
-                k.get_topic(),
-                k.get_broker_name(),
-                k.get_queue_id(),
+                k.topic_str(),
+                k.broker_name(),
+                k.queue_id(),
                 v.commit_offset
             );
 
@@ -87,13 +87,7 @@ impl Display for ConsumerRunningInfo {
         sb.push_str("#Topic #Broker Name #QID #ProcessQueueInfo\n");
 
         for (k, v) in &self.mq_table {
-            let item = format!(
-                "{}  {}  {}  {}\n",
-                k.get_topic(),
-                k.get_broker_name(),
-                k.get_queue_id(),
-                v
-            );
+            let item = format!("{}  {}  {}  {}\n", k.topic_str(), k.broker_name(), k.queue_id(), v);
 
             sb.push_str(&item);
         }
@@ -101,13 +95,7 @@ impl Display for ConsumerRunningInfo {
         sb.push_str("\n\n#Consumer Pop Detail#\n");
         sb.push_str("#Topic #Broker Name #QID #ProcessQueueInfo\n");
         for (k, v) in &self.mq_pop_table {
-            let item = format!(
-                "{}  {}  {}  {}\n",
-                k.get_topic(),
-                k.get_broker_name(),
-                k.get_queue_id(),
-                v
-            );
+            let item = format!("{}  {}  {}  {}\n", k.topic_str(), k.broker_name(), k.queue_id(), v);
 
             sb.push_str(&item);
         }

--- a/rocketmq-remoting/src/protocol/body/response/lock_batch_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/response/lock_batch_response_body.rs
@@ -65,8 +65,8 @@ mod test {
 
         assert_eq!(decoded.lock_ok_mq_set.len(), 1);
         let mq = decoded.lock_ok_mq_set.iter().next().unwrap();
-        assert_eq!(mq.get_broker_name(), "TEST_BROKER");
-        assert_eq!(mq.get_queue_id(), 1);
+        assert_eq!(mq.broker_name(), "TEST_BROKER");
+        assert_eq!(mq.queue_id(), 1);
     }
 
     #[test]

--- a/rocketmq-remoting/src/rpc/client_metadata.rs
+++ b/rocketmq-remoting/src/rpc/client_metadata.rs
@@ -81,9 +81,9 @@ impl ClientMetadata {
 
     pub fn get_broker_name_from_message_queue(&self, mq: &MessageQueue) -> Option<CheetahString> {
         let read_guard = self.topic_end_points_table.read();
-        let topic_end_points = read_guard.get(mq.get_topic());
+        let topic_end_points = read_guard.get(mq.topic_str());
         if topic_end_points.is_none() {
-            return Some(mq.get_broker_name().clone());
+            return Some(mq.broker_name().clone());
         }
         let topic_end_points = topic_end_points.unwrap();
         let broker_name = topic_end_points.get(mq);

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/cli/commands/topic_status_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/cli/commands/topic_status_command.rs
@@ -59,8 +59,8 @@ impl CommandExecute for TopicStatusCommand {
             .get_offset_table()
             .iter()
             .map(|(mq, offset_info)| TopicStatsInfo {
-                broker_name: mq.get_broker_name().to_string(),
-                queue_id: mq.get_queue_id(),
+                broker_name: mq.broker_name().to_string(),
+                queue_id: mq.queue_id(),
                 min_offset: offset_info.get_min_offset(),
                 max_offset: offset_info.get_max_offset(),
                 last_update_timestamp: offset_info.get_last_update_timestamp(),

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/broker_consume_stats_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker_commands/broker_consume_stats_sub_command.rs
@@ -132,10 +132,10 @@ impl CommandExecute for BrokerConsumeStatsSubCommand {
                                 let last_time = format_timestamp(offset_wrapper.get_last_timestamp());
                                 println!(
                                     "{:<64}  {:<64}  {:<32}  {:<4}  {:<20}  {:<20}  {:<20}  {}",
-                                    mq.get_topic(),
+                                    mq.topic_str(),
                                     group,
-                                    mq.get_broker_name(),
-                                    mq.get_queue_id(),
+                                    mq.broker_name(),
+                                    mq.queue_id(),
                                     offset_wrapper.get_broker_offset(),
                                     offset_wrapper.get_consumer_offset(),
                                     diff,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic_commands/topic_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic_commands/topic_status_sub_command.rs
@@ -90,8 +90,8 @@ impl CommandExecute for TopicStatusSubCommand {
                     let human_timestamp = time_millis_to_human_string2(offset.get_last_update_timestamp());
                     println!(
                         "{}  {}  {}  {}  {}",
-                        queue.get_broker_name(),
-                        queue.get_queue_id(),
+                        queue.broker_name(),
+                        queue.queue_id(),
                         offset.get_min_offset(),
                         offset.get_max_offset(),
                         human_timestamp


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6457

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated message queue property accessor methods to use consistent naming conventions for retrieving queue identifiers, broker names, and topic information across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->