### PR TITLE
[ISSUE #6388]🚀Implement ExportMetadata Command in rocketmq-admin-core

### DIFF
--- a/rocketmq-client/src/admin/mq_admin_ext_async_inner.rs
+++ b/rocketmq-client/src/admin/mq_admin_ext_async_inner.rs
@@ -29,6 +29,7 @@ use rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInf
 use rocketmq_remoting::protocol::body::group_list::GroupList;
 use rocketmq_remoting::protocol::body::kv_table::KVTable;
 use rocketmq_remoting::protocol::body::producer_connection::ProducerConnection;
+use rocketmq_remoting::protocol::body::subscription_group_wrapper::SubscriptionGroupWrapper;
 use rocketmq_remoting::protocol::body::topic::topic_list::TopicList;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
@@ -496,17 +497,21 @@ impl MQAdminExtInnerImpl {
         unimplemented!()
     }
 
-    /*async fn get_all_subscription_group(
+    async fn get_all_subscription_group(
         &self,
         broker_addr: CheetahString,
         timeout_millis: u64,
-    ) -> rocketmq_error::RocketMQResult<SubscriptionGroupWrapper>{ unimplemented!()}*/
+    ) -> rocketmq_error::RocketMQResult<SubscriptionGroupWrapper> {
+        unimplemented!()
+    }
 
-    /*async fn get_user_subscription_group(
+    async fn get_user_subscription_group(
         &self,
         broker_addr: CheetahString,
         timeout_millis: u64,
-    ) -> rocketmq_error::RocketMQResult<SubscriptionGroupWrapper>{ unimplemented!()}*/
+    ) -> rocketmq_error::RocketMQResult<SubscriptionGroupWrapper> {
+        unimplemented!()
+    }
 
     async fn get_all_topic_config(
         &self,

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -2600,6 +2600,7 @@ impl MQClientAPIImpl {
             )),
         }
     }
+
     pub fn init_remoting_version() {
         INIT_REMOTING_VERSION.get_or_init(|| {
             EnvUtils::put_property(
@@ -2607,6 +2608,53 @@ impl MQClientAPIImpl {
                 (CURRENT_VERSION as u32).to_string(),
             );
         });
+    }
+
+    pub(crate) async fn get_all_topic_config(
+        &self,
+        addr: &CheetahString,
+        timeout_millis: u64,
+    ) -> RocketMQResult<rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper> {
+        let request = RemotingCommand::create_request_command(RequestCode::GetAllTopicConfig, EmptyHeader {});
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper::decode(
+                    body.as_ref(),
+                );
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn get_all_subscription_group_config(
+        &self,
+        addr: &CheetahString,
+        timeout_millis: u64,
+    ) -> RocketMQResult<rocketmq_remoting::protocol::body::subscription_group_wrapper::SubscriptionGroupWrapper> {
+        let request =
+            RemotingCommand::create_request_command(RequestCode::GetAllSubscriptionGroupConfig, EmptyHeader {});
+        let mut response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.take_body() {
+                return rocketmq_remoting::protocol::body::subscription_group_wrapper::SubscriptionGroupWrapper::decode(
+                    body.as_ref(),
+                );
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
     }
 
     fn build_queue_offset_sorted_map(

--- a/rocketmq-remoting/src/protocol/body/topic_info_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/topic_info_wrapper.rs
@@ -71,4 +71,8 @@ impl TopicConfigSerializeWrapper {
     pub fn take_topic_config_table(&mut self) -> Option<HashMap<CheetahString, TopicConfig>> {
         self.topic_config_table.take()
     }
+
+    pub fn topic_config_table_mut(&mut self) -> Option<&mut HashMap<CheetahString, TopicConfig>> {
+        self.topic_config_table.as_mut()
+    }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -666,7 +666,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         broker_addr: CheetahString,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<TopicConfigSerializeWrapper> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .get_all_topic_config(broker_addr, timeout_millis)
+            .await
     }
 
     async fn get_user_topic_config(
@@ -675,7 +677,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         special_topic: bool,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<TopicConfigSerializeWrapper> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .get_user_topic_config(broker_addr, special_topic, timeout_millis)
+            .await
     }
 
     async fn update_consume_offset(
@@ -1206,18 +1210,22 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn get_all_subscription_group(
         &self,
-        _broker_addr: CheetahString,
-        _timeout_millis: u64,
+        broker_addr: CheetahString,
+        timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<SubscriptionGroupWrapper> {
-        unimplemented!("get_all_subscription_group not implemented yet")
+        self.default_mqadmin_ext_impl
+            .get_all_subscription_group(broker_addr, timeout_millis)
+            .await
     }
 
     async fn get_user_subscription_group(
         &self,
-        _broker_addr: CheetahString,
-        _timeout_millis: u64,
+        broker_addr: CheetahString,
+        timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<SubscriptionGroupWrapper> {
-        unimplemented!("get_user_subscription_group not implemented yet")
+        self.default_mqadmin_ext_impl
+            .get_user_subscription_group(broker_addr, timeout_millis)
+            .await
     }
 
     async fn query_consume_queue(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -20,6 +20,7 @@ mod cluster_commands;
 mod connection_commands;
 mod consumer_commands;
 mod controller_commands;
+mod export_commands;
 mod namesrv_commands;
 mod target;
 mod topic_commands;
@@ -104,6 +105,11 @@ pub enum Commands {
     Controller(controller_commands::ControllerCommands),
 
     #[command(subcommand)]
+    #[command(about = "Export commands")]
+    #[command(name = "export")]
+    Export(export_commands::ExportCommands),
+
+    #[command(subcommand)]
     #[command(about = "Name server commands")]
     #[command(name = "nameserver")]
     NameServer(namesrv_commands::NameServerCommands),
@@ -125,6 +131,7 @@ impl CommandExecute for Commands {
             Commands::Connection(value) => value.execute(rpc_hook).await,
             Commands::Consumer(value) => value.execute(rpc_hook).await,
             Commands::Controller(value) => value.execute(rpc_hook).await,
+            Commands::Export(value) => value.execute(rpc_hook).await,
             Commands::NameServer(value) => value.execute(rpc_hook).await,
             Commands::Topic(value) => value.execute(rpc_hook).await,
             Commands::Show(value) => value.execute(rpc_hook).await,
@@ -322,6 +329,41 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Get meta data of controller.",
             },
             Command {
+                category: "Export",
+                command: "exportMetadata",
+                remark: "Export metadata.",
+            },
+            Command {
+                category: "NameServer",
+                command: "addWritePerm",
+                remark: "Add write perm of broker in all name server.",
+            },
+            Command {
+                category: "NameServer",
+                command: "deleteKvConfig",
+                remark: "Delete KV config.",
+            },
+            Command {
+                category: "NameServer",
+                command: "getNamesrvConfig",
+                remark: "Get configs of name server.",
+            },
+            Command {
+                category: "NameServer",
+                command: "updateKvConfig",
+                remark: "Create or update KV config.",
+            },
+            Command {
+                category: "NameServer",
+                command: "updateNamesrvConfig",
+                remark: "Update configs of name server.",
+            },
+            Command {
+                category: "NameServer",
+                command: "wipeWritePerm",
+                remark: "Wipe write perm of broker in all name server.",
+            },
+            Command {
                 category: "Topic",
                 command: "allocateMQ",
                 remark: "Allocate MQ.",
@@ -375,36 +417,6 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "Topic",
                 command: "updateTopic",
                 remark: "Update or create topic.",
-            },
-            Command {
-                category: "NameServer",
-                command: "addWritePerm",
-                remark: "Add write perm of broker in all name server.",
-            },
-            Command {
-                category: "NameServer",
-                command: "deleteKvConfig",
-                remark: "Delete KV config.",
-            },
-            Command {
-                category: "NameServer",
-                command: "getNamesrvConfig",
-                remark: "Get configs of name server.",
-            },
-            Command {
-                category: "NameServer",
-                command: "updateKvConfig",
-                remark: "Create or update KV config.",
-            },
-            Command {
-                category: "NameServer",
-                command: "updateNamesrvConfig",
-                remark: "Update configs of name server.",
-            },
-            Command {
-                category: "NameServer",
-                command: "wipeWritePerm",
-                remark: "Wipe write perm of broker in all name server.",
             },
         ];
         let mut table = Table::new(commands);

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/export_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/export_commands.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod export_metadata_sub_command;
+
+use std::sync::Arc;
+
+use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::export_commands::export_metadata_sub_command::ExportMetadataSubCommand;
+use crate::commands::CommandExecute;
+
+#[derive(Subcommand)]
+pub enum ExportCommands {
+    #[command(
+        name = "exportMetadata",
+        about = "Export metadata.",
+        long_about = None,
+    )]
+    ExportMetadata(ExportMetadataSubCommand),
+}
+
+impl CommandExecute for ExportCommands {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self {
+            ExportCommands::ExportMetadata(cmd) => cmd.execute(rpc_hook).await,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/export_commands/export_metadata_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/export_commands/export_metadata_sub_command.rs
@@ -1,0 +1,282 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::config::TopicConfig;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+const DEFAULT_FILE_PATH: &str = "/tmp/rocketmq/export";
+const TIMEOUT_MILLIS: u64 = 10000;
+
+#[derive(Debug, Clone, Parser)]
+pub struct ExportMetadataSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(
+        short = 'c',
+        long = "clusterName",
+        required = false,
+        conflicts_with = "broker_addr",
+        help = "choose a cluster to export"
+    )]
+    cluster_name: Option<String>,
+
+    #[arg(
+        short = 'b',
+        long = "brokerAddr",
+        required = false,
+        conflicts_with = "cluster_name",
+        help = "choose a broker to export"
+    )]
+    broker_addr: Option<String>,
+
+    #[arg(
+        short = 'f',
+        long = "filePath",
+        required = false,
+        default_value = DEFAULT_FILE_PATH,
+        help = "export metadata.json path | default /tmp/rocketmq/export"
+    )]
+    file_path: String,
+
+    #[arg(
+        short = 't',
+        long = "topic",
+        required = false,
+        default_value = "false",
+        help = "only export topic metadata"
+    )]
+    topic: bool,
+
+    #[arg(
+        short = 'g',
+        long = "subscriptionGroup",
+        required = false,
+        default_value = "false",
+        help = "only export subscriptionGroup metadata"
+    )]
+    subscription_group: bool,
+
+    #[arg(
+        short = 's',
+        long = "specialTopic",
+        required = false,
+        default_value = "false",
+        help = "need retryTopic and dlqTopic"
+    )]
+    special_topic: bool,
+}
+
+impl ExportMetadataSubCommand {
+    async fn export_from_broker(
+        admin_ext: &DefaultMQAdminExt,
+        broker_addr: &str,
+        file_path: &str,
+        topic_only: bool,
+        subscription_group_only: bool,
+        special_topic: bool,
+    ) -> RocketMQResult<()> {
+        let addr: CheetahString = broker_addr.into();
+
+        if topic_only {
+            let export_path = format!("{}/topic.json", file_path);
+            let topic_config_wrapper = admin_ext
+                .get_user_topic_config(addr, special_topic, TIMEOUT_MILLIS)
+                .await?;
+            let json_content = serde_json::to_string_pretty(&topic_config_wrapper)
+                .map_err(|e| RocketMQError::Internal(format!("Failed to serialize topic config: {}", e)))?;
+            rocketmq_common::FileUtils::string_to_file(&json_content, &export_path)?;
+            println!("export {} success", export_path);
+        } else if subscription_group_only {
+            let export_path = format!("{}/subscriptionGroup.json", file_path);
+            let subscription_group_wrapper = admin_ext.get_user_subscription_group(addr, TIMEOUT_MILLIS).await?;
+            let json_content = serde_json::to_string_pretty(&subscription_group_wrapper).map_err(|e| {
+                RocketMQError::Internal(format!("Failed to serialize subscription group config: {}", e))
+            })?;
+            rocketmq_common::FileUtils::string_to_file(&json_content, &export_path)?;
+            println!("export {} success", export_path);
+        } else {
+            return Err(RocketMQError::IllegalArgument(
+                "ExportMetadataSubCommand: When using -b, you must specify -t (topic) or -g (subscriptionGroup)".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    async fn export_from_cluster(
+        admin_ext: &DefaultMQAdminExt,
+        cluster_name: &str,
+        file_path: &str,
+        topic_only: bool,
+        subscription_group_only: bool,
+        special_topic: bool,
+    ) -> RocketMQResult<()> {
+        let cluster_info = admin_ext.examine_broker_cluster_info().await?;
+        let master_set = CommandUtil::fetch_master_addr_by_cluster_name(&cluster_info, cluster_name)?;
+
+        let mut topic_config_map: HashMap<CheetahString, TopicConfig> = HashMap::new();
+        let mut sub_group_config_map: HashMap<CheetahString, SubscriptionGroupConfig> = HashMap::new();
+
+        for addr in &master_set {
+            let topic_config_wrapper = admin_ext
+                .get_user_topic_config(addr.clone(), special_topic, TIMEOUT_MILLIS)
+                .await?;
+
+            let subscription_group_wrapper = admin_ext
+                .get_user_subscription_group(addr.clone(), TIMEOUT_MILLIS)
+                .await?;
+
+            if let Some(topic_table) = topic_config_wrapper.topic_config_table() {
+                for (key, value) in topic_table {
+                    if let Some(existing) = topic_config_map.get(key) {
+                        let mut merged = value.clone();
+                        merged.write_queue_nums = existing.write_queue_nums + value.write_queue_nums;
+                        merged.read_queue_nums = existing.read_queue_nums + value.read_queue_nums;
+                        topic_config_map.insert(key.clone(), merged);
+                    } else {
+                        topic_config_map.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+
+            for entry in subscription_group_wrapper.get_subscription_group_table().iter() {
+                let key = entry.key().clone();
+                let value = entry.value();
+                if let Some(existing) = sub_group_config_map.get(&key) {
+                    let mut merged = (**value).clone();
+                    merged.set_retry_queue_nums(existing.retry_queue_nums() + value.retry_queue_nums());
+                    sub_group_config_map.insert(key, merged);
+                } else {
+                    sub_group_config_map.insert(key, (**value).clone());
+                }
+            }
+        }
+
+        let mut result = serde_json::Map::new();
+
+        let export_path;
+        if topic_only {
+            result.insert(
+                "topicConfigTable".to_string(),
+                serde_json::to_value(&topic_config_map)
+                    .map_err(|e| RocketMQError::Internal(format!("Failed to serialize topic config: {}", e)))?,
+            );
+            export_path = format!("{}/topic.json", file_path);
+        } else if subscription_group_only {
+            result.insert(
+                "subscriptionGroupTable".to_string(),
+                serde_json::to_value(&sub_group_config_map).map_err(|e| {
+                    RocketMQError::Internal(format!("Failed to serialize subscription group config: {}", e))
+                })?,
+            );
+            export_path = format!("{}/subscriptionGroup.json", file_path);
+        } else {
+            result.insert(
+                "topicConfigTable".to_string(),
+                serde_json::to_value(&topic_config_map)
+                    .map_err(|e| RocketMQError::Internal(format!("Failed to serialize topic config: {}", e)))?,
+            );
+            result.insert(
+                "subscriptionGroupTable".to_string(),
+                serde_json::to_value(&sub_group_config_map).map_err(|e| {
+                    RocketMQError::Internal(format!("Failed to serialize subscription group config: {}", e))
+                })?,
+            );
+            export_path = format!("{}/metadata.json", file_path);
+        }
+
+        result.insert(
+            "exportTime".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(get_current_millis())),
+        );
+
+        let json_content = serde_json::to_string_pretty(&result)
+            .map_err(|e| RocketMQError::Internal(format!("Failed to serialize export result: {}", e)))?;
+
+        rocketmq_common::FileUtils::string_to_file(&json_content, &export_path)?;
+        println!("export {} success", export_path);
+
+        Ok(())
+    }
+}
+
+impl CommandExecute for ExportMetadataSubCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        if self.broker_addr.is_none() && self.cluster_name.is_none() {
+            return Err(RocketMQError::IllegalArgument(
+                "ExportMetadataSubCommand: Either brokerAddr (-b) or clusterName (-c) must be provided".into(),
+            ));
+        }
+
+        let mut admin_ext = DefaultMQAdminExt::new();
+        admin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        if let Some(addr) = &self.common_args.namesrv_addr {
+            admin_ext.set_namesrv_addr(addr.trim());
+        }
+
+        admin_ext.start().await.map_err(|e| {
+            RocketMQError::Internal(format!("ExportMetadataSubCommand: Failed to start MQAdminExt: {}", e))
+        })?;
+
+        let file_path = self.file_path.trim();
+
+        let result = if let Some(broker_addr) = &self.broker_addr {
+            Self::export_from_broker(
+                &admin_ext,
+                broker_addr.trim(),
+                file_path,
+                self.topic,
+                self.subscription_group,
+                self.special_topic,
+            )
+            .await
+        } else if let Some(cluster_name) = &self.cluster_name {
+            Self::export_from_cluster(
+                &admin_ext,
+                cluster_name.trim(),
+                file_path,
+                self.topic,
+                self.subscription_group,
+                self.special_topic,
+            )
+            .await
+        } else {
+            Err(RocketMQError::IllegalArgument(
+                "ExportMetadataSubCommand: Either brokerAddr (-b) or clusterName (-c) must be provided".into(),
+            ))
+        };
+
+        admin_ext.shutdown().await;
+        result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6388 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Export command to the admin CLI to export metadata (topics and/or subscription groups) to JSON from a broker or entire cluster.

* **Improvements**
  * Enhanced metadata retrieval: user-visible topic and subscription group listings now exclude system items and invalid entries, and support cluster-wide merging for exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->