### PR TITLE
[ISSUE #6464]🚀Add type aliases for internal tables in MQClientInstance for improved clarity and maintainability

### DIFF
--- a/rocketmq-client/src/factory.rs
+++ b/rocketmq-client/src/factory.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod client_tables;
 pub mod mq_client_instance;

--- a/rocketmq-client/src/factory/client_tables.rs
+++ b/rocketmq-client/src/factory/client_tables.rs
@@ -1,0 +1,75 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Type definitions for MQClientInstance internal tables
+//!
+//! This module defines type aliases for the complex concurrent data structures
+//! used in MQClientInstance to manage producers, consumers, brokers, and topics.
+//!
+//! The semantic string type aliases (ProducerGroupName, ConsumerGroupName, TopicName, etc.)
+//! are defined in the `crate::types` module.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use rocketmq_common::common::message::message_queue::MessageQueue;
+use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+
+use crate::admin::mq_admin_ext_async_inner::MQAdminExtInnerImpl;
+use crate::consumer::mq_consumer_inner::MQConsumerInnerImpl;
+use crate::producer::producer_impl::mq_producer_inner::MQProducerInnerImpl;
+use crate::types::AdminGroupName;
+use crate::types::BrokerAddr;
+use crate::types::BrokerName;
+use crate::types::ConsumerGroupName;
+use crate::types::ProducerGroupName;
+use crate::types::TopicName;
+
+// ===== Table Type Aliases =====
+
+/// Container for registered producers, indexed by producer group name.
+pub type ProducerTable = Arc<DashMap<ProducerGroupName, MQProducerInnerImpl>>;
+
+/// Container for registered consumers, indexed by consumer group name.
+pub type ConsumerTable = Arc<DashMap<ConsumerGroupName, MQConsumerInnerImpl>>;
+
+/// Container for registered admin extensions, indexed by admin group name.
+pub type AdminExtTable = Arc<DashMap<AdminGroupName, MQAdminExtInnerImpl>>;
+
+/// Topic routing information table.
+/// Maps topic name to its routing data (broker addresses, queue configuration, etc.).
+pub type TopicRouteTable = Arc<DashMap<TopicName, TopicRouteData>>;
+
+/// Topic endpoint mapping table for static topics.
+/// Maps topic name to a mapping of message queues to their broker names.
+pub type TopicEndPointsTable = Arc<DashMap<TopicName, HashMap<MessageQueue, BrokerName>>>;
+
+/// Broker address table.
+/// Maps broker name to a mapping of broker ID to broker address.
+/// Broker ID 0 is master, others are slaves.
+pub type BrokerAddrTable = Arc<DashMap<BrokerName, HashMap<u64, BrokerAddr>>>;
+
+/// Broker version table.
+/// Maps broker name to a mapping of broker address to version code.
+pub type BrokerVersionTable = Arc<DashMap<BrokerName, HashMap<BrokerAddr, i32>>>;
+
+/// Broker heartbeat fingerprint cache for HeartbeatV2 protocol.
+/// Maps broker address to the last heartbeat fingerprint value.
+/// Used to optimize heartbeat by sending minimal data when fingerprint unchanged.
+pub type BrokerHeartbeatFingerprintTable = Arc<DashMap<BrokerAddr, i32>>;
+
+/// Set of brokers that support HeartbeatV2 protocol.
+/// Maps broker address to unit value (used as a set).
+pub type BrokerSupportV2HeartbeatSet = Arc<DashMap<BrokerAddr, ()>>;

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -54,6 +54,7 @@ use crate::consumer::consumer_impl::pull_message_service::PullMessageService;
 use crate::consumer::consumer_impl::re_balance::rebalance_service::RebalanceService;
 use crate::consumer::mq_consumer_inner::MQConsumerInner;
 use crate::consumer::mq_consumer_inner::MQConsumerInnerImpl;
+use crate::factory::client_tables::*;
 use crate::implementation::client_remoting_processor::ClientRemotingProcessor;
 use crate::implementation::find_broker_result::FindBrokerResult;
 use crate::implementation::mq_admin_impl::MQAdminImpl;
@@ -73,22 +74,21 @@ pub struct MQClientInstance {
      * The container of the producer in the current client. The key is the name of
      * producerGroup.
      */
-    producer_table: Arc<DashMap<CheetahString, MQProducerInnerImpl>>,
+    producer_table: ProducerTable,
     /**
      * The container of the consumer in the current client. The key is the name of
      * consumer_group.
      */
-    consumer_table: Arc<DashMap<CheetahString, MQConsumerInnerImpl>>,
+    consumer_table: ConsumerTable,
     /**
      * The container of the adminExt in the current client. The key is the name of
      * adminExtGroup.
      */
-    admin_ext_table: Arc<DashMap<CheetahString, MQAdminExtInnerImpl>>,
+    admin_ext_table: AdminExtTable,
     pub(crate) mq_client_api_impl: Option<ArcMut<MQClientAPIImpl>>,
     pub(crate) mq_admin_impl: ArcMut<MQAdminImpl>,
-    pub(crate) topic_route_table: Arc<DashMap<CheetahString /* Topic */, TopicRouteData>>,
-    topic_end_points_table:
-        Arc<DashMap<CheetahString /* Topic */, HashMap<MessageQueue, CheetahString /* brokerName */>>>,
+    pub(crate) topic_route_table: TopicRouteTable,
+    topic_end_points_table: TopicEndPointsTable,
     lock_namesrv: Arc<RocketMQTokioMutex<()>>,
     lock_heartbeat: Arc<RocketMQTokioMutex<()>>,
 
@@ -96,14 +96,14 @@ pub struct MQClientInstance {
     pub(crate) pull_message_service: ArcMut<PullMessageService>,
     rebalance_service: RebalanceService,
     pub(crate) default_producer: ArcMut<DefaultMQProducer>,
-    broker_addr_table: Arc<DashMap<CheetahString, HashMap<u64, CheetahString>>>,
-    broker_version_table: Arc<DashMap<CheetahString /* Broker Name */, HashMap<CheetahString /* address */, i32>>>,
+    broker_addr_table: BrokerAddrTable,
+    broker_version_table: BrokerVersionTable,
     send_heartbeat_times_total: Arc<AtomicI64>,
     scheduled_task_manager: ScheduledTaskManager,
     /// HeartbeatV2: Cache of broker address -> last fingerprint
-    broker_heartbeat_fingerprint_table: Arc<DashMap<CheetahString, i32>>,
+    broker_heartbeat_fingerprint_table: BrokerHeartbeatFingerprintTable,
     /// HeartbeatV2: Set of brokers that support V2 protocol
-    broker_support_v2_heartbeat_set: Arc<DashMap<CheetahString, ()>>,
+    broker_support_v2_heartbeat_set: BrokerSupportV2HeartbeatSet,
 }
 
 impl MQClientInstance {

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -81,6 +81,7 @@ pub mod implementation;
 mod latency;
 pub mod producer;
 mod trace;
+mod types;
 pub mod utils;
 
 pub use crate::consumer::consumer_impl::pull_request_ext::PullResultExt;

--- a/rocketmq-client/src/types.rs
+++ b/rocketmq-client/src/types.rs
@@ -1,0 +1,63 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Semantic type aliases for RocketMQ client
+//!
+//! This module provides type aliases that give semantic meaning to CheetahString
+//! usage throughout the rocketmq-client crate. These types improve code readability
+//! and documentation by explicitly distinguishing different string identifiers.
+//!
+//! These types are only visible within the `rocketmq-client` crate.
+//!
+//! ## Available Types
+//!
+//! - `ProducerGroupName` - Producer group name identifier
+//! - `ConsumerGroupName` - Consumer group name identifier
+//! - `AdminGroupName` - Admin extension group name identifier
+//! - `TopicName` - Topic name identifier
+//! - `BrokerName` - Broker name identifier
+//! - `BrokerAddr` - Broker address (IP:Port format)
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use crate::types::{TopicName, BrokerName, ProducerGroupName};
+//!
+//! fn process_topic(topic: TopicName) {
+//!     // ...
+//! }
+//!
+//! let topic: TopicName = "my_topic".into();
+//! let broker: BrokerName = "broker-a".into();
+//! ```
+
+use cheetah_string::CheetahString;
+
+/// Producer group name identifier.
+pub(crate) type ProducerGroupName = CheetahString;
+
+/// Consumer group name identifier.
+pub(crate) type ConsumerGroupName = CheetahString;
+
+/// Admin extension group name identifier.
+pub(crate) type AdminGroupName = CheetahString;
+
+/// Topic name identifier.
+pub(crate) type TopicName = CheetahString;
+
+/// Broker name identifier.
+pub(crate) type BrokerName = CheetahString;
+
+/// Broker address (IP:Port format).
+pub(crate) type BrokerAddr = CheetahString;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6464

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal data structure definitions by extracting type aliases into a dedicated module for improved code organization and maintainability.
  * Applied semantic type aliases throughout the codebase to enhance code clarity and type safety in message queue client components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->