### PR TITLE
[ISSUE #6471]♻️Refactor message listener types for improved clarity and consistency

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -41,7 +41,7 @@ use crate::consumer::default_mq_push_consumer::ConsumerConfig;
 use crate::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
 use crate::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
 use crate::consumer::listener::consume_return_type::ConsumeReturnType;
-use crate::consumer::listener::message_listener_concurrently::ArcBoxMessageListenerConcurrently;
+use crate::consumer::listener::message_listener_concurrently::ArcMessageListenerConcurrently;
 use crate::hook::consume_message_context::ConsumeMessageContext;
 
 pub struct ConsumeMessageConcurrentlyService {
@@ -49,7 +49,7 @@ pub struct ConsumeMessageConcurrentlyService {
     pub(crate) client_config: ArcMut<ClientConfig>,
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
-    pub(crate) message_listener: ArcBoxMessageListenerConcurrently,
+    pub(crate) message_listener: ArcMessageListenerConcurrently,
     pub(crate) consume_runtime: RocketMQRuntime,
 }
 
@@ -58,7 +58,7 @@ impl ConsumeMessageConcurrentlyService {
         client_config: ArcMut<ClientConfig>,
         consumer_config: ArcMut<ConsumerConfig>,
         consumer_group: CheetahString,
-        message_listener: ArcBoxMessageListenerConcurrently,
+        message_listener: ArcMessageListenerConcurrently,
         default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
     ) -> Self {
         let consume_thread = consumer_config.consume_thread_max;
@@ -237,10 +237,8 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
 
         let begin_timestamp = Instant::now();
 
-        let status = self.message_listener.consume_message(
-            &msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<&MessageExt>>(),
-            &context,
-        );
+        let msgs_refs: Vec<&MessageExt> = msgs.iter().map(|msg| msg.as_ref()).collect();
+        let status = self.message_listener.consume_message(&msgs_refs, &context);
         let mut result = ConsumeMessageDirectlyResult::default();
         result.set_order(false);
         result.set_auto_commit(true);
@@ -320,7 +318,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
 
 struct ConsumeRequest {
     msgs: Vec<ArcMut<MessageExt>>,
-    message_listener: ArcBoxMessageListenerConcurrently,
+    message_listener: ArcMessageListenerConcurrently,
     process_queue: Arc<ProcessQueue>,
     message_queue: MessageQueue,
     dispatch_to_consume: bool,
@@ -380,8 +378,8 @@ impl ConsumeRequest {
                 });
                 default_mqpush_consumer_impl.execute_hook_before(&mut consume_message_context);
             }
-            let vec = self.msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<&MessageExt>>();
-            status = self.execute_consume_with_error_handling(&vec, &context, &mut has_exception);
+            let msgs_refs: Vec<&MessageExt> = self.msgs.iter().map(|msg| msg.as_ref()).collect();
+            status = self.execute_consume_with_error_handling(&msgs_refs, &context, &mut has_exception);
         }
 
         let consume_rt = begin_timestamp.elapsed().as_millis() as u64;

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -49,7 +49,7 @@ use crate::consumer::default_mq_push_consumer::ConsumerConfig;
 use crate::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
 use crate::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
 use crate::consumer::listener::consume_return_type::ConsumeReturnType;
-use crate::consumer::listener::message_listener_concurrently::ArcBoxMessageListenerConcurrently;
+use crate::consumer::listener::message_listener_concurrently::ArcMessageListenerConcurrently;
 use crate::hook::consume_message_context::ConsumeMessageContext;
 
 pub struct ConsumeMessagePopConcurrentlyService {
@@ -57,7 +57,7 @@ pub struct ConsumeMessagePopConcurrentlyService {
     pub(crate) client_config: ArcMut<ClientConfig>,
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
-    pub(crate) message_listener: ArcBoxMessageListenerConcurrently,
+    pub(crate) message_listener: ArcMessageListenerConcurrently,
     pub(crate) stopped: Arc<AtomicBool>,
     pub(crate) active_tasks: Arc<AtomicUsize>,
     pub(crate) concurrency_limiter: Arc<Semaphore>,
@@ -69,7 +69,7 @@ impl ConsumeMessagePopConcurrentlyService {
         client_config: ArcMut<ClientConfig>,
         consumer_config: ArcMut<ConsumerConfig>,
         consumer_group: CheetahString,
-        message_listener: ArcBoxMessageListenerConcurrently,
+        message_listener: ArcMessageListenerConcurrently,
         default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
     ) -> Self {
         let consume_thread = consumer_config.consume_thread_max;
@@ -182,10 +182,8 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
 
         let begin_timestamp = Instant::now();
 
-        let status = self.message_listener.consume_message(
-            &msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<&MessageExt>>(),
-            &context,
-        );
+        let msgs_refs: Vec<&MessageExt> = msgs.iter().map(|msg| msg.as_ref()).collect();
+        let status = self.message_listener.consume_message(&msgs_refs, &context);
         let mut result = ConsumeMessageDirectlyResult::default();
         result.set_order(false);
         result.set_auto_commit(true);
@@ -469,7 +467,7 @@ struct ConsumeRequest {
     pop_time: u64,
     invisible_time: u64,
     consumer_group: CheetahString,
-    message_listener: ArcBoxMessageListenerConcurrently,
+    message_listener: ArcMessageListenerConcurrently,
     default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
 }
 
@@ -521,7 +519,7 @@ impl ConsumeRequest {
             pop_time,
             invisible_time,
             consumer_group: CheetahString::new(),
-            message_listener: Arc::new(Box::new(DummyListener)),
+            message_listener: Arc::new(DummyListener),
             default_mqpush_consumer_impl: None,
         }
     }
@@ -621,8 +619,8 @@ impl ConsumeRequest {
             });
             default_mqpush_consumer_impl.execute_hook_before(&mut consume_message_context);
         }
-        let vec = self.msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<&MessageExt>>();
-        match self.message_listener.consume_message(&vec, &context) {
+        let msgs_refs: Vec<&MessageExt> = self.msgs.iter().map(|msg| msg.as_ref()).collect();
+        match self.message_listener.consume_message(&msgs_refs, &context) {
             Ok(value) => {
                 status = Some(value);
             }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -246,13 +246,13 @@ impl DefaultMQPushConsumerImpl {
 
                 if let Some(message_listener) = self.message_listener.as_ref() {
                     if message_listener.message_listener_concurrently.is_some() {
-                        let (listener, _) = message_listener.message_listener_concurrently.clone().unwrap();
+                        let listener = message_listener.message_listener_concurrently.clone().unwrap();
                         self.consume_orderly = false;
                         let consume_message_concurrently_service = ArcMut::new(ConsumeMessageConcurrentlyService::new(
                             self.client_config.clone(),
                             self.consumer_config.clone(),
                             self.consumer_config.consumer_group.clone(),
-                            listener.clone().expect("listener is None"),
+                            listener.clone(),
                             self.default_mqpush_consumer_impl.clone(),
                         ));
                         self.consume_message_service = Some(ArcMut::new(ConsumeMessageServiceGeneral::new(
@@ -264,7 +264,7 @@ impl DefaultMQPushConsumerImpl {
                                 self.client_config.clone(),
                                 self.consumer_config.clone(),
                                 self.consumer_config.consumer_group.clone(),
-                                listener.expect("listener is None"),
+                                listener.clone(),
                                 self.default_mqpush_consumer_impl.clone(),
                             ));
 

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -472,7 +472,7 @@ impl MQPushConsumer for DefaultMQPushConsumer {
         ML: MessageListenerConcurrently + Send + Sync + 'static,
     {
         let message_listener = MessageListener {
-            message_listener_concurrently: Some((Some(Arc::new(Box::new(message_listener))), None)),
+            message_listener_concurrently: Some(Arc::new(message_listener)),
             message_listener_orderly: None,
         };
         self.consumer_config.message_listener = Some(ArcMut::new(message_listener));

--- a/rocketmq-client/src/consumer/listener.rs
+++ b/rocketmq-client/src/consumer/listener.rs
@@ -20,3 +20,14 @@ pub mod consume_return_type;
 pub mod message_listener;
 pub mod message_listener_concurrently;
 pub mod message_listener_orderly;
+
+// Re-export commonly used types for convenience
+pub use consume_concurrently_context::ConsumeConcurrentlyContext;
+pub use consume_concurrently_status::ConsumeConcurrentlyStatus;
+pub use consume_orderly_context::ConsumeOrderlyContext;
+pub use consume_orderly_status::ConsumeOrderlyStatus;
+pub use message_listener_concurrently::ArcMessageListenerConcurrently;
+pub use message_listener_concurrently::MessageListenerConcurrently;
+pub use message_listener_orderly::ArcBoxMessageListenerOrderly;
+pub use message_listener_orderly::MessageListenerOrderly;
+pub use message_listener_orderly::MessageListenerOrderlyFn;

--- a/rocketmq-client/src/consumer/listener/consume_concurrently_context.rs
+++ b/rocketmq-client/src/consumer/listener/consume_concurrently_context.rs
@@ -14,6 +14,7 @@
 
 use rocketmq_common::common::message::message_queue::MessageQueue;
 
+#[derive(Debug)]
 pub struct ConsumeConcurrentlyContext {
     pub(crate) message_queue: MessageQueue,
     pub(crate) delay_level_when_next_consume: i32,

--- a/rocketmq-client/src/consumer/listener/message_listener.rs
+++ b/rocketmq-client/src/consumer/listener/message_listener.rs
@@ -12,26 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::consumer::listener::message_listener_concurrently::ArcBoxMessageListenerConcurrently;
-use crate::consumer::listener::message_listener_concurrently::MessageListenerConcurrentlyFn;
+use crate::consumer::listener::message_listener_concurrently::ArcMessageListenerConcurrently;
 use crate::consumer::listener::message_listener_orderly::ArcBoxMessageListenerOrderly;
 use crate::consumer::listener::message_listener_orderly::MessageListenerOrderlyFn;
 
 pub(crate) struct MessageListener {
-    pub(crate) message_listener_concurrently: Option<(
-        Option<ArcBoxMessageListenerConcurrently>,
-        Option<MessageListenerConcurrentlyFn>,
-    )>,
+    pub(crate) message_listener_concurrently: Option<ArcMessageListenerConcurrently>,
     pub(crate) message_listener_orderly:
         Option<(Option<ArcBoxMessageListenerOrderly>, Option<MessageListenerOrderlyFn>)>,
 }
 
 impl MessageListener {
     pub(crate) fn new(
-        message_listener_concurrently: Option<(
-            Option<ArcBoxMessageListenerConcurrently>,
-            Option<MessageListenerConcurrentlyFn>,
-        )>,
+        message_listener_concurrently: Option<ArcMessageListenerConcurrently>,
         message_listener_orderly: Option<(Option<ArcBoxMessageListenerOrderly>, Option<MessageListenerOrderlyFn>)>,
     ) -> Self {
         Self {

--- a/rocketmq-client/src/consumer/listener/message_listener_concurrently.rs
+++ b/rocketmq-client/src/consumer/listener/message_listener_concurrently.rs
@@ -19,7 +19,78 @@ use rocketmq_common::common::message::message_ext::MessageExt;
 use crate::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
 use crate::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
 
-pub trait MessageListenerConcurrently: Sync + Send {
+/// A trait for processing messages concurrently.
+///
+/// This trait provides a zero-cost abstraction for concurrent message consumption.
+/// Implement this trait for your custom message processing logic, or use closures
+/// directly as they automatically implement this trait.
+///
+/// # Type Parameters
+///
+/// Note: This trait does not use generic type parameters. The message type is
+/// fixed to `MessageExt` and the context to `ConsumeConcurrentlyContext` for
+/// compatibility with RocketMQ protocol.
+///
+/// # Performance
+///
+/// When using closures or custom implementations directly (without type erasure),
+/// this trait provides zero-cost abstraction through:
+/// - Compile-time monomorphization
+/// - Full function inlining
+/// - No dynamic dispatch overhead
+///
+/// # Example
+///
+/// ```rust
+/// use rocketmq_client_rust::consumer::listener::ConsumeConcurrentlyContext;
+/// use rocketmq_client_rust::consumer::listener::ConsumeConcurrentlyStatus;
+/// use rocketmq_client_rust::consumer::listener::MessageListenerConcurrently;
+/// use rocketmq_common::common::message::message_ext::MessageExt;
+///
+/// // Closures automatically implement MessageListenerConcurrently
+/// let listener = |msgs: &[&MessageExt],
+///                 _context: &ConsumeConcurrentlyContext|
+///  -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus> {
+///     for msg in msgs {
+///         println!("Processing message: {:?}", msg.msg_id());
+///     }
+///     Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+/// };
+///
+/// // Struct-based implementation
+/// struct MyListener;
+///
+/// impl MessageListenerConcurrently for MyListener {
+///     fn consume_message(
+///         &self,
+///         msgs: &[&MessageExt],
+///         context: &ConsumeConcurrentlyContext,
+///     ) -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus> {
+///         // Process messages
+///         Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+///     }
+/// }
+/// ```
+pub trait MessageListenerConcurrently: Send + Sync {
+    /// Processes a batch of messages concurrently.
+    ///
+    /// # Arguments
+    ///
+    /// * `msgs` - Slice of message references. Zero-cost borrowing without cloning.
+    /// * `context` - Context for concurrent consumption containing metadata like message queue,
+    ///   delay level, etc.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)` - Messages processed successfully
+    /// * `Ok(ConsumeConcurrentlyStatus::ReconsumeLater)` - Messages should be retried later
+    /// * `Err(error)` - Processing failed with an error
+    ///
+    /// # Notes
+    ///
+    /// - This method may be called concurrently for different message batches
+    /// - Messages from the same queue are never processed concurrently
+    /// - The default batch size is 1, configurable via consumer settings
     fn consume_message(
         &self,
         msgs: &[&MessageExt],
@@ -27,10 +98,57 @@ pub trait MessageListenerConcurrently: Sync + Send {
     ) -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus>;
 }
 
-pub type ArcBoxMessageListenerConcurrently = Arc<Box<dyn MessageListenerConcurrently>>;
-
-pub type MessageListenerConcurrentlyFn = Arc<
-    dyn Fn(&[&MessageExt], &ConsumeConcurrentlyContext) -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus>
+/// Implement MessageListenerConcurrently for all compatible closures and functions.
+///
+/// This blanket implementation allows closures to be used directly as message listeners
+/// without explicit trait implementation, providing a convenient and zero-cost API.
+impl<F> MessageListenerConcurrently for F
+where
+    F: Fn(&[&MessageExt], &ConsumeConcurrentlyContext) -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus>
         + Send
         + Sync,
->;
+{
+    fn consume_message(
+        &self,
+        msgs: &[&MessageExt],
+        context: &ConsumeConcurrentlyContext,
+    ) -> rocketmq_error::RocketMQResult<ConsumeConcurrentlyStatus> {
+        self(msgs, context)
+    }
+}
+
+/// Type-erased message listener for storage and cross-boundary passing.
+///
+/// This type uses dynamic dispatch (`Arc<dyn Trait>`) and is suitable for scenarios where:
+/// - The listener needs to be stored in a struct field
+/// - The listener crosses async boundaries
+/// - The listener type cannot be determined at compile time
+///
+/// # Performance Note
+///
+/// This type incurs runtime overhead due to:
+/// - Dynamic dispatch (~5-10ns per call)
+/// - Arc reference counting
+///
+/// For best performance, prefer using generic parameters with the `MessageListenerConcurrently`
+/// trait in function signatures instead of this type alias.
+///
+/// # Example
+///
+/// ```rust
+/// use rocketmq_client_rust::consumer::listener::ArcMessageListenerConcurrently;
+/// use rocketmq_client_rust::consumer::listener::ConsumeConcurrentlyStatus;
+/// use rocketmq_client_rust::consumer::listener::MessageListenerConcurrently;
+/// use std::sync::Arc;
+///
+/// struct Consumer {
+///     listener: Option<ArcMessageListenerConcurrently>,
+/// }
+///
+/// impl Consumer {
+///     fn register_listener<L: MessageListenerConcurrently + 'static>(&mut self, listener: L) {
+///         self.listener = Some(Arc::new(listener));
+///     }
+/// }
+/// ```
+pub type ArcMessageListenerConcurrently = Arc<dyn MessageListenerConcurrently>;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6471

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined message listener registration by eliminating unnecessary type complexity, making the consumer API more straightforward to use.
  * Exposed core listener types and context classes through the main listener module for improved discoverability and simpler imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->