### PR TITLE
[ISSUE #6386]🚀Implement ConsumerConnection Command in rocketmq-admin-core

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -27,6 +27,7 @@ use crate::common::admin_tool_result::AdminToolResult;
 use crate::factory::mq_client_instance::MQClientInstance;
 use crate::implementation::mq_client_manager::MQClientManager;
 use cheetah_string::CheetahString;
+use rand::seq::IndexedRandom;
 use rocketmq_common::common::base::plain_access_config::PlainAccessConfig;
 use rocketmq_common::common::base::service_state::ServiceState;
 use rocketmq_common::common::config::TopicConfig;
@@ -505,7 +506,53 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         consumer_group: CheetahString,
         broker_addr: Option<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<ConsumerConnection> {
-        todo!()
+        let mut result = ConsumerConnection::new();
+        let timeout = self.timeout_millis.as_millis() as u64;
+
+        if let Some(broker_addr) = broker_addr {
+            result = self
+                .client_instance
+                .as_ref()
+                .unwrap()
+                .get_mq_client_api_impl()
+                .get_consumer_connection_list(broker_addr.as_str(), consumer_group.clone(), timeout)
+                .await?;
+        } else {
+            let topic = CheetahString::from_string(mix_all::get_retry_topic(consumer_group.as_str()));
+            let topic_route_data = self
+                .client_instance
+                .as_ref()
+                .unwrap()
+                .get_mq_client_api_impl()
+                .get_topic_route_info_from_name_server(&topic, timeout)
+                .await?;
+
+            if let Some(topic_route_data) = topic_route_data {
+                let brokers = &topic_route_data.broker_datas;
+                if !brokers.is_empty() {
+                    if let Some(broker_data) = brokers.choose(&mut rand::rng()) {
+                        if let Some(addr) = broker_data.select_broker_addr() {
+                            result = self
+                                .client_instance
+                                .as_ref()
+                                .unwrap()
+                                .get_mq_client_api_impl()
+                                .get_consumer_connection_list(addr.as_str(), consumer_group.clone(), timeout)
+                                .await?;
+                        }
+                    }
+                }
+            }
+        }
+
+        if result.get_connection_set().is_empty() {
+            return Err(mq_client_err!(
+                rocketmq_remoting::code::response_code::ResponseCode::ConsumerNotOnline,
+                "Not found the consumer group connection"
+            ));
+        }
+
+        Ok(result)
     }
 
     async fn examine_producer_connection_info(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -123,6 +123,7 @@ use rocketmq_remoting::protocol::header::unlock_batch_mq_request_header::UnlockB
 use rocketmq_remoting::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader;
 use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::update_user_request_header::UpdateUserRequestHeader;
+use rocketmq_remoting::protocol::headers::client::GetConsumerConnectionListRequestHeader;
 use rocketmq_remoting::protocol::heartbeat::heartbeat_data::HeartbeatData;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
@@ -137,6 +138,7 @@ use rocketmq_remoting::rpc::rpc_request_header::RpcRequestHeader;
 use rocketmq_remoting::rpc::topic_request_header::TopicRequestHeader;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_remoting::runtime::RPCHook;
+use rocketmq_remoting::ConsumerConnection;
 use rocketmq_rust::ArcMut;
 use tracing::error;
 use tracing::warn;
@@ -1546,6 +1548,47 @@ impl MQClientAPIImpl {
                             .remark()
                             .map_or("".to_string(), |s| s.to_string()))),
                     };
+                }
+            }
+            _ => {
+                return Err(client_broker_err!(
+                    response.code(),
+                    response.remark().map_or("".to_string(), |s| s.to_string()),
+                    addr.to_string()
+                ));
+            }
+        }
+        Err(client_broker_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string()),
+            addr.to_string()
+        ))
+    }
+
+    pub async fn get_consumer_connection_list(
+        &mut self,
+        addr: &str,
+        consumer_group: CheetahString,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<rocketmq_remoting::protocol::body::consumer_connection::ConsumerConnection>
+    {
+        let request_header = GetConsumerConnectionListRequestHeader {
+            consumer_group,
+            rpc_request_header: None,
+        };
+        let request = RemotingCommand::create_request_command(RequestCode::GetConsumerConnectionList, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(
+                Some(mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr).as_ref()),
+                request,
+                timeout_millis,
+            )
+            .await?;
+        match ResponseCode::from(response.code()) {
+            ResponseCode::Success => {
+                if let Some(body) = response.body() {
+                    return ConsumerConnection::decode(body);
                 }
             }
             _ => {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -428,7 +428,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         consumer_group: CheetahString,
         broker_addr: Option<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<ConsumerConnection> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .examine_consumer_connection_info(consumer_group, broker_addr)
+            .await
     }
 
     async fn examine_producer_connection_info(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -273,6 +273,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Connection",
+                command: "consumerConnection",
+                remark: "Query consumer's socket connection, client version and subscription.",
+            },
+            Command {
+                category: "Connection",
                 command: "producerConnection",
                 remark: "Query producer's socket connection and client version.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection_commands.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod consumer_connection_sub_command;
 mod producer_connection_sub_command;
 
 use std::sync::Arc;
@@ -20,11 +21,18 @@ use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
+use crate::commands::connection_commands::consumer_connection_sub_command::ConsumerConnectionSubCommand;
 use crate::commands::connection_commands::producer_connection_sub_command::ProducerConnectionSubCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
 pub enum ConnectionCommands {
+    #[command(
+        name = "consumerConnection",
+        about = "Query consumer's socket connection, client version and subscription"
+    )]
+    ConsumerConnection(ConsumerConnectionSubCommand),
+
     #[command(name = "producerConnection", about = "Query producer's connection")]
     ProducerConnection(ProducerConnectionSubCommand),
 }
@@ -32,6 +40,7 @@ pub enum ConnectionCommands {
 impl CommandExecute for ConnectionCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
+            ConnectionCommands::ConsumerConnection(cmd) => cmd.execute(rpc_hook).await,
             ConnectionCommands::ProducerConnection(cmd) => cmd.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection_commands/consumer_connection_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection_commands/consumer_connection_sub_command.rs
@@ -1,0 +1,108 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::mq_version::RocketMqVersion;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct ConsumerConnectionSubCommand {
+    #[arg(short = 'g', long = "consumerGroup", required = true, help = "consumer group name")]
+    consumer_group: String,
+
+    #[arg(short = 'b', long = "brokerAddr", required = false, help = "broker address")]
+    broker_addr: Option<String>,
+}
+
+impl CommandExecute for ConsumerConnectionSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> rocketmq_error::RocketMQResult<()> {
+        let mut default_mq_admin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mq_admin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        default_mq_admin_ext.start().await?;
+
+        let group = self.consumer_group.trim();
+        let broker_addr = self
+            .broker_addr
+            .as_ref()
+            .map(|s| CheetahString::from_string(s.trim().to_string()));
+
+        let cc = default_mq_admin_ext
+            .examine_consumer_connection_info(group.into(), broker_addr)
+            .await?;
+
+        println!("{:<36} {:<22} {:<10} #Version", "#ClientId", "#ClientAddr", "#Language");
+
+        let mut connections: Vec<_> = cc.get_connection_set().iter().collect();
+        connections.sort_by_key(|a| a.get_client_id());
+        for conn in &connections {
+            let version_desc = RocketMqVersion::from_ordinal(conn.get_version() as u32).name();
+            println!(
+                "{:<36} {:<22} {:<10} {}",
+                conn.get_client_id(),
+                conn.get_client_addr(),
+                conn.get_language(),
+                version_desc
+            );
+        }
+
+        println!("\nBelow is subscription:");
+        println!("{:<20} #SubExpression", "#Topic");
+        for sd in cc.get_subscription_table().values() {
+            println!("{:<20} {}", sd.topic, sd.sub_string);
+        }
+
+        println!();
+        if let Some(consume_type) = cc.get_consume_type() {
+            let consume_type_str = match consume_type {
+                rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType::ConsumeActively => {
+                    "CONSUME_ACTIVELY"
+                }
+                rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType::ConsumePassively => {
+                    "CONSUME_PASSIVELY"
+                }
+                rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType::ConsumePop => "CONSUME_POP",
+            };
+            println!("ConsumeType: {}", consume_type_str);
+        }
+        if let Some(message_model) = cc.get_message_model() {
+            println!("MessageModel: {}", message_model);
+        }
+        if let Some(consume_from_where) = cc.get_consume_from_where() {
+            let consume_from_where_str = serde_json::to_string(&consume_from_where)
+                .unwrap_or_default()
+                .trim_matches('"')
+                .to_string();
+            println!("ConsumeFromWhere: {}", consume_from_where_str);
+        }
+
+        default_mq_admin_ext.shutdown().await;
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6386 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consumer connection examination functionality to retrieve and display detailed consumer group connection information, including connected clients, addresses, language, and versions.
  * Introduced a new 'consumerConnection' admin command to query consumer socket connections, subscription details, and consumption preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->