### PR TITLE
[ISSUE #6474]♻️Refactor message listener orderly types to improve clarity and consistency

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -47,7 +47,7 @@ use crate::consumer::default_mq_push_consumer::ConsumerConfig;
 use crate::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
 use crate::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
 use crate::consumer::listener::consume_return_type::ConsumeReturnType;
-use crate::consumer::listener::message_listener_orderly::ArcBoxMessageListenerOrderly;
+use crate::consumer::listener::message_listener_orderly::ArcMessageListenerOrderly;
 use crate::consumer::message_queue_lock::MessageQueueLock;
 use crate::consumer::mq_consumer_inner::MQConsumerInnerLocal;
 use crate::hook::consume_message_context::ConsumeMessageContext;
@@ -65,7 +65,7 @@ pub struct ConsumeMessageOrderlyService {
     pub(crate) client_config: ArcMut<ClientConfig>,
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
-    pub(crate) message_listener: ArcBoxMessageListenerOrderly,
+    pub(crate) message_listener: ArcMessageListenerOrderly,
     pub(crate) stopped: Arc<AtomicBool>,
     pub(crate) global_lock: Arc<RocketMQTokioMutex<()>>,
     pub(crate) message_queue_lock: MessageQueueLock,
@@ -78,7 +78,7 @@ impl ConsumeMessageOrderlyService {
         client_config: ArcMut<ClientConfig>,
         consumer_config: ArcMut<ConsumerConfig>,
         consumer_group: CheetahString,
-        message_listener: ArcBoxMessageListenerOrderly,
+        message_listener: ArcMessageListenerOrderly,
         default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
     ) -> Self {
         Self {

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -43,7 +43,7 @@ use crate::consumer::consumer_impl::process_queue::ProcessQueue;
 use crate::consumer::default_mq_push_consumer::ConsumerConfig;
 use crate::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
 use crate::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
-use crate::consumer::listener::message_listener_orderly::ArcBoxMessageListenerOrderly;
+use crate::consumer::listener::message_listener_orderly::ArcMessageListenerOrderly;
 use crate::consumer::message_queue_lock::MessageQueueLock;
 
 pub struct ConsumeMessagePopOrderlyService {
@@ -51,7 +51,7 @@ pub struct ConsumeMessagePopOrderlyService {
     pub(crate) client_config: ArcMut<ClientConfig>,
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) consumer_group: CheetahString,
-    pub(crate) message_listener: ArcBoxMessageListenerOrderly,
+    pub(crate) message_listener: ArcMessageListenerOrderly,
     pub(crate) concurrency_limiter: Arc<Semaphore>,
     pub(self) consume_request_set: Arc<DashSet<ConsumeRequest>>,
     pub(crate) message_queue_lock: MessageQueueLock,
@@ -76,7 +76,7 @@ impl ConsumeMessagePopOrderlyService {
         client_config: ArcMut<ClientConfig>,
         consumer_config: ArcMut<ConsumerConfig>,
         consumer_group: CheetahString,
-        message_listener: ArcBoxMessageListenerOrderly,
+        message_listener: ArcMessageListenerOrderly,
         default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
     ) -> Self {
         let consume_thread = consumer_config.consume_thread_max;

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -273,13 +273,13 @@ impl DefaultMQPushConsumerImpl {
                             None,
                         )));
                     } else if message_listener.message_listener_orderly.is_some() {
-                        let (listener, _) = message_listener.message_listener_orderly.clone().unwrap();
+                        let listener = message_listener.message_listener_orderly.clone().unwrap();
                         self.consume_orderly = true;
                         let consume_message_orderly_service = ArcMut::new(ConsumeMessageOrderlyService::new(
                             self.client_config.clone(),
                             self.consumer_config.clone(),
                             self.consumer_config.consumer_group.clone(),
-                            listener.clone().expect("listener is None"),
+                            listener.clone(),
                             self.default_mqpush_consumer_impl.clone(),
                         ));
                         self.consume_message_service = Some(ArcMut::new(ConsumeMessageServiceGeneral::new(
@@ -291,7 +291,7 @@ impl DefaultMQPushConsumerImpl {
                             self.client_config.clone(),
                             self.consumer_config.clone(),
                             self.consumer_config.consumer_group.clone(),
-                            listener.expect("listener is None"),
+                            listener,
                             self.default_mqpush_consumer_impl.clone(),
                         ));
                         self.consume_message_pop_service = Some(ArcMut::new(ConsumeMessagePopServiceGeneral::new(

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -497,7 +497,7 @@ impl MQPushConsumer for DefaultMQPushConsumer {
     {
         let message_listener = MessageListener {
             message_listener_concurrently: None,
-            message_listener_orderly: Some((Some(Arc::new(Box::new(message_listener))), None)),
+            message_listener_orderly: Some(Arc::new(message_listener)),
         };
         self.consumer_config.message_listener = Some(ArcMut::new(message_listener));
         self.default_mqpush_consumer_impl

--- a/rocketmq-client/src/consumer/listener.rs
+++ b/rocketmq-client/src/consumer/listener.rs
@@ -28,6 +28,5 @@ pub use consume_orderly_context::ConsumeOrderlyContext;
 pub use consume_orderly_status::ConsumeOrderlyStatus;
 pub use message_listener_concurrently::ArcMessageListenerConcurrently;
 pub use message_listener_concurrently::MessageListenerConcurrently;
-pub use message_listener_orderly::ArcBoxMessageListenerOrderly;
+pub use message_listener_orderly::ArcMessageListenerOrderly;
 pub use message_listener_orderly::MessageListenerOrderly;
-pub use message_listener_orderly::MessageListenerOrderlyFn;

--- a/rocketmq-client/src/consumer/listener/message_listener.rs
+++ b/rocketmq-client/src/consumer/listener/message_listener.rs
@@ -13,19 +13,17 @@
 // limitations under the License.
 
 use crate::consumer::listener::message_listener_concurrently::ArcMessageListenerConcurrently;
-use crate::consumer::listener::message_listener_orderly::ArcBoxMessageListenerOrderly;
-use crate::consumer::listener::message_listener_orderly::MessageListenerOrderlyFn;
+use crate::consumer::listener::message_listener_orderly::ArcMessageListenerOrderly;
 
 pub(crate) struct MessageListener {
     pub(crate) message_listener_concurrently: Option<ArcMessageListenerConcurrently>,
-    pub(crate) message_listener_orderly:
-        Option<(Option<ArcBoxMessageListenerOrderly>, Option<MessageListenerOrderlyFn>)>,
+    pub(crate) message_listener_orderly: Option<ArcMessageListenerOrderly>,
 }
 
 impl MessageListener {
     pub(crate) fn new(
         message_listener_concurrently: Option<ArcMessageListenerConcurrently>,
-        message_listener_orderly: Option<(Option<ArcBoxMessageListenerOrderly>, Option<MessageListenerOrderlyFn>)>,
+        message_listener_orderly: Option<ArcMessageListenerOrderly>,
     ) -> Self {
         Self {
             message_listener_concurrently,

--- a/rocketmq-client/src/consumer/listener/message_listener_orderly.rs
+++ b/rocketmq-client/src/consumer/listener/message_listener_orderly.rs
@@ -19,7 +19,89 @@ use rocketmq_common::common::message::message_ext::MessageExt;
 use crate::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
 use crate::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
 
-pub trait MessageListenerOrderly: Sync + Send {
+/// A trait for processing messages in order.
+///
+/// This trait ensures messages from the same queue are consumed sequentially.
+/// Implement this trait for your custom sequential message processing logic, or use
+/// closures directly as they automatically implement this trait.
+///
+/// # Difference from MessageListenerConcurrently
+///
+/// - **Orderly**: Messages from the same queue are processed sequentially
+/// - **Concurrently**: Messages from different queues can be processed in parallel
+///
+/// # Context Mutability
+///
+/// The `context` parameter is mutable (`&mut`) to allow consumers to:
+/// - Control auto-commit behavior via `set_auto_commit()`
+/// - Set queue suspension time via `set_suspend_current_queue_time_millis()`
+///
+/// # Performance
+///
+/// When using closures or custom implementations directly (without type erasure),
+/// this trait provides zero-cost abstraction through:
+/// - Compile-time monomorphization
+/// - Full function inlining
+/// - No dynamic dispatch overhead
+///
+/// # Example
+///
+/// ```rust
+/// use rocketmq_client_rust::consumer::listener::ConsumeOrderlyContext;
+/// use rocketmq_client_rust::consumer::listener::ConsumeOrderlyStatus;
+/// use rocketmq_client_rust::consumer::listener::MessageListenerOrderly;
+/// use rocketmq_common::common::message::message_ext::MessageExt;
+///
+/// // Closures automatically implement MessageListenerOrderly
+/// let listener = |msgs: &[&MessageExt],
+///                 context: &mut ConsumeOrderlyContext|
+///  -> rocketmq_error::RocketMQResult<ConsumeOrderlyStatus> {
+///     for msg in msgs {
+///         println!("Processing message in order: {:?}", msg.msg_id());
+///     }
+///     // Control commit behavior
+///     context.set_auto_commit(true);
+///     Ok(ConsumeOrderlyStatus::Success)
+/// };
+///
+/// // Struct-based implementation
+/// struct MyOrderlyListener;
+///
+/// impl MessageListenerOrderly for MyOrderlyListener {
+///     fn consume_message(
+///         &self,
+///         msgs: &[&MessageExt],
+///         context: &mut ConsumeOrderlyContext,
+///     ) -> rocketmq_error::RocketMQResult<ConsumeOrderlyStatus> {
+///         // Process messages sequentially
+///         context.set_auto_commit(false);
+///         Ok(ConsumeOrderlyStatus::Success)
+///     }
+/// }
+/// ```
+pub trait MessageListenerOrderly: Send + Sync {
+    /// Processes a batch of messages in order.
+    ///
+    /// # Arguments
+    ///
+    /// * `msgs` - Slice of message references. Zero-cost borrowing without cloning.
+    /// * `context` - Mutable context for orderly consumption. Allows control over commit behavior
+    ///   and queue suspension.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(ConsumeOrderlyStatus::Success)` - Messages processed successfully, commit offset
+    /// * `Ok(ConsumeOrderlyStatus::SuspendCurrentQueueAMoment)` - Suspend consumption temporarily,
+    ///   retry later
+    /// * `Ok(ConsumeOrderlyStatus::Rollback)` - Rollback transaction
+    /// * `Ok(ConsumeOrderlyStatus::Commit)` - Commit transaction explicitly
+    /// * `Err(error)` - Processing failed with an error
+    ///
+    /// # Notes
+    ///
+    /// - Messages from the same queue are NEVER processed concurrently
+    /// - Messages from different queues MAY be processed in parallel
+    /// - The context allows you to control auto-commit and suspension behavior
     fn consume_message(
         &self,
         msgs: &[&MessageExt],
@@ -27,10 +109,62 @@ pub trait MessageListenerOrderly: Sync + Send {
     ) -> rocketmq_error::RocketMQResult<ConsumeOrderlyStatus>;
 }
 
-pub type ArcBoxMessageListenerOrderly = Arc<Box<dyn MessageListenerOrderly>>;
-
-pub type MessageListenerOrderlyFn = Arc<
-    dyn Fn(&[&MessageExt], &ConsumeOrderlyContext) -> rocketmq_error::RocketMQResult<ConsumeOrderlyStatus>
+/// Implement MessageListenerOrderly for all compatible closures and functions.
+///
+/// This blanket implementation allows closures to be used directly as message listeners
+/// without explicit trait implementation, providing a convenient and zero-cost API.
+///
+/// # Note on Mutability
+///
+/// The closure signature requires `&mut ConsumeOrderlyContext` to match the trait
+/// definition. This allows the closure to modify context state (auto-commit, suspension).
+impl<F> MessageListenerOrderly for F
+where
+    F: Fn(&[&MessageExt], &mut ConsumeOrderlyContext) -> rocketmq_error::RocketMQResult<ConsumeOrderlyStatus>
         + Send
         + Sync,
->;
+{
+    fn consume_message(
+        &self,
+        msgs: &[&MessageExt],
+        context: &mut ConsumeOrderlyContext,
+    ) -> rocketmq_error::RocketMQResult<ConsumeOrderlyStatus> {
+        self(msgs, context)
+    }
+}
+
+/// Type-erased message listener for storage and cross-boundary passing.
+///
+/// This type uses dynamic dispatch (`Arc<dyn Trait>`) and is suitable for scenarios where:
+/// - The listener needs to be stored in a struct field
+/// - The listener crosses async boundaries
+/// - The listener type cannot be determined at compile time
+///
+/// # Performance Note
+///
+/// This type incurs runtime overhead due to:
+/// - Dynamic dispatch (~5-10ns per call)
+/// - Arc reference counting
+///
+/// For best performance, prefer using generic parameters with the `MessageListenerOrderly`
+/// trait in function signatures instead of this type alias.
+///
+/// # Example
+///
+/// ```rust
+/// use rocketmq_client_rust::consumer::listener::ArcMessageListenerOrderly;
+/// use rocketmq_client_rust::consumer::listener::ConsumeOrderlyStatus;
+/// use rocketmq_client_rust::consumer::listener::MessageListenerOrderly;
+/// use std::sync::Arc;
+///
+/// struct Consumer {
+///     listener: Option<ArcMessageListenerOrderly>,
+/// }
+///
+/// impl Consumer {
+///     fn register_listener<L: MessageListenerOrderly + 'static>(&mut self, listener: L) {
+///         self.listener = Some(Arc::new(listener));
+///     }
+/// }
+/// ```
+pub type ArcMessageListenerOrderly = Arc<dyn MessageListenerOrderly>;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6474

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified message listener registration API for ordered message consumption by removing unnecessary abstraction layers.

* **New Features**
  * Added support for closure-based message listeners in ordered message consumption scenarios.

* **Documentation**
  * Enhanced documentation for orderly message listeners, covering semantics, mutability expectations, and performance characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->