### PR TITLE
[ISSUE #6392]🚀Implement GetSyncStateSet Command for HA Synchronization Management

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1538,10 +1538,17 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn get_in_sync_state_data(
         &self,
-        _controller_address: CheetahString,
-        _brokers: Vec<CheetahString>,
+        controller_address: CheetahString,
+        brokers: Vec<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<BrokerReplicasInfo> {
-        unimplemented!("get_in_sync_state_data not implemented yet")
+        if let Some(ref mq_client_instance) = self.client_instance {
+            Ok(mq_client_instance
+                .get_mq_client_api_impl()
+                .get_in_sync_state_data(controller_address, brokers, self.timeout_millis.as_millis() as u64)
+                .await?)
+        } else {
+            Err(rocketmq_error::RocketMQError::ClientNotStarted)
+        }
     }
 
     async fn get_broker_epoch_cache(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -70,6 +70,7 @@ use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::body::batch_ack_message_request_body::BatchAckMessageRequestBody;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
+use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
 use rocketmq_remoting::protocol::body::check_client_request_body::CheckClientRequestBody;
 use rocketmq_remoting::protocol::body::epoch_entry_cache::EpochEntryCache;
 use rocketmq_remoting::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
@@ -2541,6 +2542,43 @@ impl MQClientAPIImpl {
                 Ok(header) => Ok(header),
                 Err(_) => Err(mq_client_err!("Could not decode GetMetaDataResponseHeader".to_string())),
             },
+            _ => Err(mq_client_err!(
+                response.code(),
+                response.remark().map_or("".to_string(), |s| s.to_string())
+            )),
+        }
+    }
+
+    pub async fn get_in_sync_state_data(
+        &self,
+        controller_address: CheetahString,
+        brokers: Vec<CheetahString>,
+        timeout_millis: u64,
+    ) -> RocketMQResult<BrokerReplicasInfo> {
+        let controller_meta_data = self.get_controller_metadata(controller_address, timeout_millis).await?;
+        let leader_address = controller_meta_data
+            .controller_leader_address
+            .ok_or_else(|| mq_client_err!("Controller leader address is not available".to_string()))?;
+
+        let request = RemotingCommand::create_remoting_command(RequestCode::ControllerGetSyncStateData);
+        let body = serde_json::to_vec(&brokers)
+            .map_err(|e| mq_client_err!(format!("Failed to serialize broker names: {}", e)))?;
+        let request = request.set_body(body);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(&leader_address), request, timeout_millis)
+            .await?;
+        match ResponseCode::from(response.code()) {
+            ResponseCode::Success => {
+                if let Some(body) = response.body() {
+                    serde_json::from_slice(body)
+                        .map_err(|e| mq_client_err!(format!("Failed to decode BrokerReplicasInfo: {}", e)))
+                } else {
+                    Err(mq_client_err!(
+                        "get_in_sync_state_data response body is empty".to_string()
+                    ))
+                }
+            }
             _ => Err(mq_client_err!(
                 response.code(),
                 response.remark().map_or("".to_string(), |s| s.to_string())

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1267,10 +1267,12 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn get_in_sync_state_data(
         &self,
-        _controller_address: CheetahString,
-        _brokers: Vec<CheetahString>,
+        controller_address: CheetahString,
+        brokers: Vec<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<BrokerReplicasInfo> {
-        unimplemented!("get_in_sync_state_data not implemented yet")
+        self.default_mqadmin_ext_impl
+            .get_in_sync_state_data(controller_address, brokers)
+            .await
     }
 
     async fn get_broker_epoch_cache(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -21,6 +21,7 @@ mod connection_commands;
 mod consumer_commands;
 mod controller_commands;
 mod export_commands;
+mod ha_commands;
 mod namesrv_commands;
 mod target;
 mod topic_commands;
@@ -110,6 +111,11 @@ pub enum Commands {
     Export(export_commands::ExportCommands),
 
     #[command(subcommand)]
+    #[command(about = "HA commands")]
+    #[command(name = "ha")]
+    HA(ha_commands::HACommands),
+
+    #[command(subcommand)]
     #[command(about = "Name server commands")]
     #[command(name = "nameserver")]
     NameServer(namesrv_commands::NameServerCommands),
@@ -132,6 +138,7 @@ impl CommandExecute for Commands {
             Commands::Consumer(value) => value.execute(rpc_hook).await,
             Commands::Controller(value) => value.execute(rpc_hook).await,
             Commands::Export(value) => value.execute(rpc_hook).await,
+            Commands::HA(value) => value.execute(rpc_hook).await,
             Commands::NameServer(value) => value.execute(rpc_hook).await,
             Commands::Topic(value) => value.execute(rpc_hook).await,
             Commands::Show(value) => value.execute(rpc_hook).await,
@@ -337,6 +344,11 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "Export",
                 command: "exportMetadata",
                 remark: "Export metadata.",
+            },
+            Command {
+                category: "HA",
+                command: "getSyncStateSet",
+                remark: "Fetch sync state set for target brokers.",
             },
             Command {
                 category: "NameServer",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha_commands.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod get_sync_state_set_sub_command;
+
+use std::sync::Arc;
+
+use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::ha_commands::get_sync_state_set_sub_command::GetSyncStateSetSubCommand;
+use crate::commands::CommandExecute;
+
+#[derive(Subcommand)]
+pub enum HACommands {
+    #[command(
+        name = "getSyncStateSet",
+        about = "Fetch syncStateSet for target brokers.",
+        long_about = None,
+    )]
+    GetSyncStateSet(GetSyncStateSetSubCommand),
+}
+
+impl CommandExecute for HACommands {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self {
+            HACommands::GetSyncStateSet(value) => value.execute(rpc_hook).await,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha_commands/get_sync_state_set_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha_commands/get_sync_state_set_sub_command.rs
@@ -1,0 +1,174 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct GetSyncStateSetSubCommand {
+    #[arg(
+        short = 'a',
+        long = "controllerAddress",
+        value_name = "HOST:PORT",
+        required = true,
+        help = "the address of controller"
+    )]
+    controller_address: String,
+
+    #[arg(
+        short = 'c',
+        long = "clusterName",
+        value_name = "CLUSTER",
+        required = false,
+        help = "which cluster"
+    )]
+    cluster_name: Option<String>,
+
+    #[arg(
+        short = 'b',
+        long = "brokerName",
+        value_name = "BROKER",
+        required = false,
+        help = "which broker to fetch"
+    )]
+    broker_name: Option<String>,
+
+    #[arg(
+        short = 'i',
+        long = "interval",
+        value_name = "SECONDS",
+        required = false,
+        help = "the interval(second) of get info"
+    )]
+    interval: Option<u64>,
+}
+
+impl CommandExecute for GetSyncStateSetSubCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = DefaultMQAdminExt::new();
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("GetSyncStateSetSubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            if let Some(interval) = self.interval {
+                let flush_second = if interval > 0 { interval } else { 3 };
+                loop {
+                    self.inner_exec(&default_mqadmin_ext).await?;
+                    tokio::time::sleep(tokio::time::Duration::from_secs(flush_second)).await;
+                }
+            } else {
+                self.inner_exec(&default_mqadmin_ext).await?;
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+impl GetSyncStateSetSubCommand {
+    async fn inner_exec(&self, default_mqadmin_ext: &DefaultMQAdminExt) -> RocketMQResult<()> {
+        let controller_address: CheetahString = self
+            .controller_address
+            .trim()
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .into();
+
+        if let Some(ref broker_name) = self.broker_name {
+            let brokers = vec![CheetahString::from(broker_name.trim())];
+            Self::print_data(&controller_address, brokers, default_mqadmin_ext).await?;
+        } else if let Some(ref cluster_name) = self.cluster_name {
+            let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await.map_err(|e| {
+                RocketMQError::Internal(format!("GetSyncStateSetSubCommand: Failed to get cluster info: {}", e))
+            })?;
+            let broker_names = CommandUtil::fetch_broker_name_by_cluster_name(&cluster_info, cluster_name.trim())?;
+            let brokers: Vec<CheetahString> = broker_names.into_iter().map(CheetahString::from_string).collect();
+            Self::print_data(&controller_address, brokers, default_mqadmin_ext).await?;
+        } else {
+            println!("Error: either -b (brokerName) or -c (clusterName) must be specified");
+        }
+
+        Ok(())
+    }
+
+    async fn print_data(
+        controller_address: &CheetahString,
+        brokers: Vec<CheetahString>,
+        default_mqadmin_ext: &DefaultMQAdminExt,
+    ) -> RocketMQResult<()> {
+        if brokers.is_empty() {
+            return Ok(());
+        }
+
+        let broker_replicas_info: BrokerReplicasInfo = default_mqadmin_ext
+            .get_in_sync_state_data(controller_address.clone(), brokers)
+            .await
+            .map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "GetSyncStateSetSubCommand: Failed to get in sync state data: {}",
+                    e
+                ))
+            })?;
+
+        let replicas_info_table = broker_replicas_info.get_replicas_info_table();
+        for (broker_name, replicas_info) in replicas_info_table {
+            let in_sync_replicas = replicas_info.get_in_sync_replicas();
+            let not_in_sync_replicas = replicas_info.get_not_in_sync_replicas();
+
+            println!(
+                "\n#brokerName\t{}\n#MasterBrokerId\t{}\n#MasterAddr\t{}\n#MasterEpoch\t{}\n#SyncStateSetEpoch\t{}\n#\
+                 SyncStateSetNums\t{}",
+                broker_name,
+                replicas_info.get_master_broker_id(),
+                replicas_info.get_master_address(),
+                replicas_info.get_master_epoch(),
+                replicas_info.get_sync_state_set_epoch(),
+                in_sync_replicas.len(),
+            );
+
+            for member in in_sync_replicas {
+                println!("\nInSyncReplica:\t{}", member);
+            }
+
+            for member in not_in_sync_replicas {
+                println!("\nNotInSyncReplica:\t{}", member);
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6392 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to query broker replication synchronization state with support for both single-shot and continuous monitoring
  * Introduced new "getSyncStateSet" HA command to retrieve and display in-sync replica information for brokers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->