### PR TITLE
[ISSUE #6393]🚀Implement HAStatus Command for High Availability Runtime Monitoring

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -17,6 +17,7 @@ use crate::processor::admin_broker_processor::batch_mq_handler::BatchMqHandler;
 use crate::processor::admin_broker_processor::broker_config_request_handler::BrokerConfigRequestHandler;
 use crate::processor::admin_broker_processor::broker_epoch_cache_handler::BrokerEpochCacheHandler;
 use crate::processor::admin_broker_processor::consumer_request_handler::ConsumerRequestHandler;
+use crate::processor::admin_broker_processor::get_broker_ha_status_handler::GetBrokerHaStatusHandler;
 use crate::processor::admin_broker_processor::get_user_request_handler::GetUserRequestHandler;
 use crate::processor::admin_broker_processor::list_users_request_handler::ListUsersRequestHandler;
 use crate::processor::admin_broker_processor::message_related_handler::MessageRelatedHandler;
@@ -44,6 +45,7 @@ mod batch_mq_handler;
 mod broker_config_request_handler;
 mod broker_epoch_cache_handler;
 mod consumer_request_handler;
+mod get_broker_ha_status_handler;
 mod get_user_request_handler;
 mod list_users_request_handler;
 mod message_related_handler;
@@ -79,6 +81,7 @@ pub struct AdminBrokerProcessor<MS: MessageStore> {
     list_users_request_handler: ListUsersRequestHandler<MS>,
     get_user_request_handler: GetUserRequestHandler<MS>,
     update_cold_data_flow_ctr_group_config_request_handler: UpdateColdDataFlowCtrGroupConfigRequestHandler<MS>,
+    get_broker_ha_status_handler: GetBrokerHaStatusHandler<MS>,
 }
 
 impl<MS> RequestProcessor for AdminBrokerProcessor<MS>
@@ -122,6 +125,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
         let get_user_request_handler = GetUserRequestHandler::new(broker_runtime_inner.clone());
         let update_cold_data_flow_ctr_group_config_request_handler =
             UpdateColdDataFlowCtrGroupConfigRequestHandler::new(broker_runtime_inner.clone());
+        let get_broker_ha_status_handler = GetBrokerHaStatusHandler::new(broker_runtime_inner.clone());
 
         AdminBrokerProcessor {
             topic_request_handler,
@@ -142,6 +146,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
             list_users_request_handler,
             get_user_request_handler,
             update_cold_data_flow_ctr_group_config_request_handler,
+            get_broker_ha_status_handler,
         }
     }
 }
@@ -327,7 +332,11 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .update_broker_ha_info(channel, ctx, request_code, request)
                     .await
             }
-            RequestCode::GetBrokerHaStatus => Ok(get_unknown_cmd_response(request_code)),
+            RequestCode::GetBrokerHaStatus => {
+                self.get_broker_ha_status_handler
+                    .get_broker_ha_status(channel, ctx, request_code, request)
+                    .await
+            }
             RequestCode::ResetMasterFlushOffset => {
                 self.reset_master_flusg_offset_handler
                     .reset_master_flush_offset(channel, ctx, request_code, request)

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs
@@ -1,0 +1,80 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::ha::ha_service::HAService;
+
+use crate::broker_runtime::BrokerRuntimeInner;
+
+#[derive(Clone)]
+pub struct GetBrokerHaStatusHandler<MS: MessageStore> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+}
+
+impl<MS: MessageStore> GetBrokerHaStatusHandler<MS> {
+    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        Self { broker_runtime_inner }
+    }
+
+    pub async fn get_broker_ha_status(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        _request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let broker_runtime_inner = self.broker_runtime_inner.as_mut();
+        let response = RemotingCommand::create_response_command();
+
+        let message_store = match broker_runtime_inner.message_store() {
+            Some(store) => store,
+            None => {
+                return Ok(Some(
+                    response
+                        .set_code(ResponseCode::SystemError)
+                        .set_remark("message store is not available"),
+                ));
+            }
+        };
+
+        let ha_service = match message_store.get_ha_service() {
+            Some(service) => service,
+            None => {
+                return Ok(Some(
+                    response
+                        .set_code(ResponseCode::SystemError)
+                        .set_remark("HA service is not available"),
+                ));
+            }
+        };
+
+        let master_put_where = message_store.get_max_phy_offset();
+        let ha_runtime_info = ha_service.get_runtime_info(master_put_where);
+
+        match serde_json::to_vec(&ha_runtime_info) {
+            Ok(body) => Ok(Some(response.set_body(body).set_code(ResponseCode::Success))),
+            Err(e) => Ok(Some(
+                response
+                    .set_code(ResponseCode::SystemError)
+                    .set_remark(format!("Failed to serialize HARuntimeInfo: {}", e)),
+            )),
+        }
+    }
+}

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1532,8 +1532,15 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         unimplemented!("query_message not implemented yet")
     }
 
-    async fn get_broker_ha_status(&self, _broker_addr: CheetahString) -> rocketmq_error::RocketMQResult<HARuntimeInfo> {
-        unimplemented!("get_broker_ha_status not implemented yet")
+    async fn get_broker_ha_status(&self, broker_addr: CheetahString) -> rocketmq_error::RocketMQResult<HARuntimeInfo> {
+        if let Some(ref mq_client_instance) = self.client_instance {
+            Ok(mq_client_instance
+                .get_mq_client_api_impl()
+                .get_broker_ha_status(broker_addr, self.timeout_millis.as_millis() as u64)
+                .await?)
+        } else {
+            Err(rocketmq_error::RocketMQError::ClientNotStarted)
+        }
     }
 
     async fn get_in_sync_state_data(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -74,6 +74,7 @@ use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
 use rocketmq_remoting::protocol::body::check_client_request_body::CheckClientRequestBody;
 use rocketmq_remoting::protocol::body::epoch_entry_cache::EpochEntryCache;
 use rocketmq_remoting::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
+use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
 use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
@@ -2607,6 +2608,32 @@ impl MQClientAPIImpl {
                     Err(mq_client_err!(
                         "get_broker_epoch_cache response body is empty".to_string()
                     ))
+                }
+            }
+            _ => Err(mq_client_err!(
+                response.code(),
+                response.remark().map_or("".to_string(), |s| s.to_string())
+            )),
+        }
+    }
+
+    pub async fn get_broker_ha_status(
+        &self,
+        broker_addr: CheetahString,
+        timeout_millis: u64,
+    ) -> RocketMQResult<HARuntimeInfo> {
+        let request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerHaStatus);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(&broker_addr), request, timeout_millis)
+            .await?;
+        match ResponseCode::from(response.code()) {
+            ResponseCode::Success => {
+                if let Some(body) = response.body() {
+                    serde_json::from_slice(body)
+                        .map_err(|e| mq_client_err!(format!("decode HARuntimeInfo failed: {}", e)))
+                } else {
+                    Err(mq_client_err!("get_broker_ha_status response body is empty".to_string()))
                 }
             }
             _ => Err(mq_client_err!(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1261,8 +1261,8 @@ impl MQAdminExt for DefaultMQAdminExt {
         unimplemented!("query_message not implemented yet")
     }
 
-    async fn get_broker_ha_status(&self, _broker_addr: CheetahString) -> rocketmq_error::RocketMQResult<HARuntimeInfo> {
-        unimplemented!("get_broker_ha_status not implemented yet")
+    async fn get_broker_ha_status(&self, broker_addr: CheetahString) -> rocketmq_error::RocketMQResult<HARuntimeInfo> {
+        self.default_mqadmin_ext_impl.get_broker_ha_status(broker_addr).await
     }
 
     async fn get_in_sync_state_data(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -351,6 +351,11 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Fetch sync state set for target brokers.",
             },
             Command {
+                category: "HA",
+                command: "haStatus",
+                remark: "Fetch ha runtime status data.",
+            },
+            Command {
                 category: "NameServer",
                 command: "addWritePerm",
                 remark: "Add write perm of broker in all name server.",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha_commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha_commands.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod get_sync_state_set_sub_command;
+mod ha_status_sub_command;
 
 use std::sync::Arc;
 
@@ -21,6 +22,7 @@ use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::ha_commands::get_sync_state_set_sub_command::GetSyncStateSetSubCommand;
+use crate::commands::ha_commands::ha_status_sub_command::HAStatusSubCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
@@ -31,12 +33,20 @@ pub enum HACommands {
         long_about = None,
     )]
     GetSyncStateSet(GetSyncStateSetSubCommand),
+
+    #[command(
+        name = "haStatus",
+        about = "Fetch ha runtime status data.",
+        long_about = None,
+    )]
+    HaStatus(HAStatusSubCommand),
 }
 
 impl CommandExecute for HACommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             HACommands::GetSyncStateSet(value) => value.execute(rpc_hook).await,
+            HACommands::HaStatus(value) => value.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha_commands/ha_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha_commands/ha_status_sub_command.rs
@@ -1,0 +1,172 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::UtilAll::time_millis_to_human_string2;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct HAStatusSubCommand {
+    #[arg(
+        short = 'b',
+        long = "brokerAddr",
+        value_name = "HOST:PORT",
+        required = false,
+        help = "which broker to fetch"
+    )]
+    broker_addr: Option<String>,
+
+    #[arg(
+        short = 'c',
+        long = "clusterName",
+        value_name = "CLUSTER",
+        required = false,
+        help = "which cluster"
+    )]
+    cluster_name: Option<String>,
+
+    #[arg(
+        short = 'i',
+        long = "interval",
+        value_name = "SECONDS",
+        required = false,
+        help = "the interval(second) of get info"
+    )]
+    interval: Option<u64>,
+}
+
+impl CommandExecute for HAStatusSubCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = DefaultMQAdminExt::new();
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("HAStatusSubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            if let Some(interval) = self.interval {
+                let flush_second = if interval > 0 { interval } else { 3 };
+                loop {
+                    self.inner_exec(&default_mqadmin_ext).await?;
+                    tokio::time::sleep(tokio::time::Duration::from_secs(flush_second)).await;
+                }
+            } else {
+                self.inner_exec(&default_mqadmin_ext).await?;
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+impl HAStatusSubCommand {
+    async fn inner_exec(&self, default_mqadmin_ext: &DefaultMQAdminExt) -> RocketMQResult<()> {
+        if let Some(ref broker_addr) = self.broker_addr {
+            Self::print_status(broker_addr.trim(), default_mqadmin_ext).await?;
+        } else if let Some(ref cluster_name) = self.cluster_name {
+            let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await.map_err(|e| {
+                RocketMQError::Internal(format!("HAStatusSubCommand: Failed to get cluster info: {}", e))
+            })?;
+            let master_addrs = CommandUtil::fetch_master_addr_by_cluster_name(&cluster_info, cluster_name.trim())?;
+            for addr in master_addrs {
+                Self::print_status(&addr, default_mqadmin_ext).await?;
+            }
+        } else {
+            println!("Error: either -b (brokerAddr) or -c (clusterName) must be specified");
+        }
+
+        Ok(())
+    }
+
+    async fn print_status(broker_addr: &str, default_mqadmin_ext: &DefaultMQAdminExt) -> RocketMQResult<()> {
+        let ha_runtime_info: HARuntimeInfo = default_mqadmin_ext
+            .get_broker_ha_status(CheetahString::from(broker_addr))
+            .await
+            .map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "HAStatusSubCommand: Failed to get broker HA status from {}: {}",
+                    broker_addr, e
+                ))
+            })?;
+
+        if ha_runtime_info.master {
+            Self::print_master_status(broker_addr, &ha_runtime_info);
+        } else {
+            Self::print_slave_status(&ha_runtime_info);
+        }
+
+        Ok(())
+    }
+
+    fn print_master_status(broker_addr: &str, info: &HARuntimeInfo) {
+        let slave_num = info.ha_connection_info.len();
+
+        println!("\n#MasterAddr             {}", broker_addr);
+        println!("#MasterCommitLogMaxOffset        {}", info.master_commit_log_max_offset);
+        println!("#SlaveNum                        {}", slave_num);
+        println!("#InSyncSlaveNum                  {}", info.in_sync_slave_nums);
+
+        println!(
+            "\n{:<36} {:<20} {:<17} {:<22} {:<17} #TransferFromWhere",
+            "#SlaveAddr", "#SlaveAckOffset", "#Diff", "#TransferSpeed(KB/s)", "#Status"
+        );
+
+        for conn in &info.ha_connection_info {
+            let status = if conn.in_sync { "OK" } else { "Fall Behind" };
+            let transfer_speed = conn.transferred_byte_in_second as f64 / 1024.0;
+
+            println!(
+                "{:<36} {:<20} {:<17} {:<22.2} {:<17} {}",
+                conn.addr, conn.slave_ack_offset, conn.diff, transfer_speed, status, conn.transfer_from_where,
+            );
+        }
+    }
+
+    fn print_slave_status(info: &HARuntimeInfo) {
+        let client = &info.ha_client_runtime_info;
+        let transfer_speed = client.transferred_byte_in_second as f64 / 1024.0;
+
+        println!("\n#MasterAddr             {}", client.master_addr);
+        println!("#CommitLogMaxOffset     {}", client.max_offset);
+        println!("#TransferSpeed(KB/s)    {:.2}", transfer_speed);
+        println!(
+            "#LastReadTime           {}",
+            time_millis_to_human_string2(client.last_read_timestamp as i64)
+        );
+        println!(
+            "#LastWriteTime          {}",
+            time_millis_to_human_string2(client.last_write_timestamp as i64)
+        );
+        println!("#MasterFlushOffset      {}", client.master_flush_offset);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6393 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broker high-availability (HA) status retrieval capability to query runtime HA information
  * New admin tool command to fetch and display detailed HA status data with support for individual brokers or cluster-wide queries
  * Added optional interval-based periodic status monitoring for continuous HA metrics tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->