### PR TITLE
[ISSUE #6394]🚀Implement GetBrokerLiteInfo Command for Lite Topic Broker Monitoring

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1674,9 +1674,14 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn get_broker_lite_info(
         &self,
-        _broker_addr: CheetahString,
+        broker_addr: CheetahString,
     ) -> rocketmq_error::RocketMQResult<GetBrokerLiteInfoResponseBody> {
-        unimplemented!("get_broker_lite_info not implemented yet")
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_broker_lite_info(&broker_addr, self.timeout_millis.as_millis() as u64)
+            .await
     }
 
     async fn get_parent_topic_info(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -67,6 +67,7 @@ use rocketmq_remoting::clients::rocketmq_tokio_client::RocketmqDefaultClient;
 use rocketmq_remoting::clients::RemotingClient;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::protocol::bodies::broker::GetBrokerLiteInfoResponseBody;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::body::batch_ack_message_request_body::BatchAckMessageRequestBody;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
@@ -569,6 +570,27 @@ impl MQClientAPIImpl {
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
                 return rocketmq_remoting::protocol::body::kv_table::KVTable::decode(body.as_ref());
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn get_broker_lite_info(
+        &self,
+        addr: &CheetahString,
+        timeout_millis: u64,
+    ) -> RocketMQResult<GetBrokerLiteInfoResponseBody> {
+        let request = RemotingCommand::create_request_command(RequestCode::GetBrokerLiteInfo, EmptyHeader {});
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return GetBrokerLiteInfoResponseBody::decode(body.as_ref());
             }
         }
         Err(mq_client_err!(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1363,9 +1363,9 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn get_broker_lite_info(
         &self,
-        _broker_addr: CheetahString,
+        broker_addr: CheetahString,
     ) -> rocketmq_error::RocketMQResult<GetBrokerLiteInfoResponseBody> {
-        unimplemented!("get_broker_lite_info not implemented yet")
+        self.default_mqadmin_ext_impl.get_broker_lite_info(broker_addr).await
     }
 
     async fn get_parent_topic_info(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -22,6 +22,7 @@ mod consumer;
 mod controller;
 mod export;
 mod ha;
+mod lite;
 mod namesrv;
 mod target;
 mod topic;
@@ -116,6 +117,11 @@ pub enum Commands {
     HA(ha::HACommands),
 
     #[command(subcommand)]
+    #[command(about = "Lite commands")]
+    #[command(name = "lite")]
+    Lite(lite::LiteCommands),
+
+    #[command(subcommand)]
     #[command(about = "Name server commands")]
     #[command(name = "nameserver")]
     NameServer(namesrv::NameServerCommands),
@@ -139,6 +145,7 @@ impl CommandExecute for Commands {
             Commands::Controller(value) => value.execute(rpc_hook).await,
             Commands::Export(value) => value.execute(rpc_hook).await,
             Commands::HA(value) => value.execute(rpc_hook).await,
+            Commands::Lite(value) => value.execute(rpc_hook).await,
             Commands::NameServer(value) => value.execute(rpc_hook).await,
             Commands::Topic(value) => value.execute(rpc_hook).await,
             Commands::Show(value) => value.execute(rpc_hook).await,
@@ -354,6 +361,11 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "HA",
                 command: "haStatus",
                 remark: "Fetch ha runtime status data.",
+            },
+            Command {
+                category: "Lite",
+                command: "getBrokerLiteInfo",
+                remark: "Get broker lite info.",
             },
             Command {
                 category: "NameServer",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod get_broker_lite_info_sub_command;
+
+use std::sync::Arc;
+
+use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::lite::get_broker_lite_info_sub_command::GetBrokerLiteInfoSubCommand;
+use crate::commands::CommandExecute;
+
+#[derive(Subcommand)]
+pub enum LiteCommands {
+    #[command(
+        name = "getBrokerLiteInfo",
+        about = "Get broker lite info.",
+        long_about = None,
+    )]
+    GetBrokerLiteInfo(GetBrokerLiteInfoSubCommand),
+}
+
+impl CommandExecute for LiteCommands {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self {
+            LiteCommands::GetBrokerLiteInfo(cmd) => cmd.execute(rpc_hook).await,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/get_broker_lite_info_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/get_broker_lite_info_sub_command.rs
@@ -1,0 +1,156 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::ArgGroup;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::body::get_broker_lite_info_response_body::GetBrokerLiteInfoResponseBody;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::command_util::CommandUtil;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+#[command(group(
+    ArgGroup::new("target")
+        .required(true)
+        .args(&["broker_addr", "cluster_name"])
+))]
+pub struct GetBrokerLiteInfoSubCommand {
+    #[arg(short = 'b', long = "brokerAddr", help = "Broker address")]
+    broker_addr: Option<String>,
+
+    #[arg(short = 'c', long = "clusterName", help = "Cluster name")]
+    cluster_name: Option<String>,
+
+    #[arg(short = 'd', long = "showDetail", help = "Show topic and group detail info")]
+    show_detail: bool,
+}
+
+impl CommandExecute for GetBrokerLiteInfoSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(get_current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "GetBrokerLiteInfoSubCommand: Failed to start MQAdminExt: {}",
+                    e
+                ))
+            })?;
+
+            let show_detail = self.show_detail;
+            Self::print_header();
+
+            if let Some(broker_addr) = &self.broker_addr {
+                let broker_addr = broker_addr.trim();
+                let response_body = default_mqadmin_ext
+                    .get_broker_lite_info(CheetahString::from(broker_addr))
+                    .await?;
+                Self::print_row(&response_body, broker_addr, show_detail);
+            } else if let Some(cluster_name) = &self.cluster_name {
+                let cluster_name = cluster_name.trim();
+                let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await.map_err(|e| {
+                    RocketMQError::Internal(format!(
+                        "GetBrokerLiteInfoSubCommand: Failed to examine broker cluster info: {}",
+                        e
+                    ))
+                })?;
+
+                let master_set = CommandUtil::fetch_master_addr_by_cluster_name(&cluster_info, cluster_name)?;
+
+                for broker_addr in &master_set {
+                    match default_mqadmin_ext
+                        .get_broker_lite_info(CheetahString::from(broker_addr.as_str()))
+                        .await
+                    {
+                        Ok(response_body) => {
+                            Self::print_row(&response_body, broker_addr, show_detail);
+                        }
+                        Err(_) => {
+                            println!("[{}] error.", broker_addr);
+                        }
+                    }
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+impl GetBrokerLiteInfoSubCommand {
+    fn print_header() {
+        println!(
+            "{:<30} {:<17} {:<10} {:<14} {:<20} {:<17} {:<15} {:<18} {:<15}",
+            "#Broker",
+            "#Store Type",
+            "#Max LMQ",
+            "#Current LMQ",
+            "#SubscriptionCount",
+            "#OrderInfoCount",
+            "#CQTableSize",
+            "#OffsetTableSize",
+            "#eventMapSize"
+        );
+    }
+
+    fn print_row(response_body: &GetBrokerLiteInfoResponseBody, broker_addr: &str, show_detail: bool) {
+        let store_type = response_body.get_store_type().map(|s| s.as_str()).unwrap_or("");
+
+        println!(
+            "{:<30} {:<17} {:<10} {:<14} {:<20} {:<17} {:<15} {:<18} {:<15}",
+            broker_addr,
+            store_type,
+            response_body.get_max_lmq_num(),
+            response_body.get_current_lmq_num(),
+            response_body.get_lite_subscription_count(),
+            response_body.get_order_info_count(),
+            response_body.get_cq_table_size(),
+            response_body.get_offset_table_size(),
+            response_body.get_event_map_size()
+        );
+
+        // If show_detail enabled, print Topic Meta and Group Meta on new lines
+        if show_detail {
+            println!(
+                "Topic Meta: {}",
+                serde_json::to_string(response_body.get_topic_meta()).unwrap_or_default()
+            );
+            println!(
+                "Group Meta: {}\n",
+                serde_json::to_string(response_body.get_group_meta()).unwrap_or_default()
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6394 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `getBrokerLiteInfo` command to query broker lightweight information
  * Support for targeting specific broker addresses or entire clusters
  * Optional detailed view displays per-topic and per-group metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->