### PR TITLE
[ISSUE #6461][Enhancement✨] Change the get_tags method of MessageTrait to tags

### DIFF
--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -487,7 +487,7 @@ fn end_message_transaction(msg_ext: &mut MessageExt) -> MessageExtBrokerInner {
         } else {
             TopicFilterType::SingleTag
         };
-    let tags_code_value = if let Some(tags) = msg_ext.get_tags() {
+    let tags_code_value = if let Some(tags) = msg_ext.tags() {
         MessageExtBrokerInner::tags_string2tags_code(&topic_filter_type, tags.as_str())
     } else {
         0

--- a/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
@@ -121,7 +121,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
             msg_inner.set_body(bytes);
         }
         msg_inner.message_ext_inner.queue_id = 0;
-        if let Some(tags) = message_ext.get_tags() {
+        if let Some(tags) = message_ext.tags() {
             msg_inner.set_tags(tags);
         } else {
             MessageAccessor::set_properties(&mut msg_inner, HashMap::new());
@@ -470,7 +470,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
             }
             let size = message_exts.as_ref().unwrap().len();
             for message_ext in message_exts.unwrap() {
-                if PopAckConstants::CK_TAG == message_ext.get_tags().unwrap_or_default() {
+                if PopAckConstants::CK_TAG == message_ext.tags().unwrap_or_default() {
                     // let raw = String::from_utf8(message_ext.get_body().to_vec()).unwrap();
                     if self.broker_runtime_inner.broker_config().enable_pop_log {
                         info!(
@@ -523,7 +523,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
                     if first_rt == 0 {
                         first_rt = point.get_revive_time() as u64;
                     }
-                } else if PopAckConstants::ACK_TAG == message_ext.get_tags().unwrap_or_default() {
+                } else if PopAckConstants::ACK_TAG == message_ext.tags().unwrap_or_default() {
                     // Safely decode ACK message body
                     let body = match message_ext.get_body() {
                         Some(body) => body,
@@ -572,7 +572,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
                             first_rt = mock_point_map.get(&merge_key).unwrap().get_revive_time() as u64;
                         }
                     }
-                } else if PopAckConstants::BATCH_ACK_TAG == message_ext.get_tags().unwrap_or_default() {
+                } else if PopAckConstants::BATCH_ACK_TAG == message_ext.tags().unwrap_or_default() {
                     //let raw = String::from_utf8(message_ext.get_body().to_vec()).unwrap();
                     if self.broker_runtime_inner.broker_config().enable_pop_log {
                         info!(

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -502,7 +502,7 @@ where
         }
         message_ext.tags_code = MessageExtBrokerInner::tags_string2tags_code(
             &topic_config.topic_filter_type,
-            message_ext.get_tags().unwrap_or_default().as_str(),
+            message_ext.tags().unwrap_or_default().as_str(),
         );
 
         message_ext.message_ext_inner.born_timestamp = request_header.born_timestamp;
@@ -1250,7 +1250,7 @@ where
         MessageAccessor::set_properties(&mut msg_inner, msg_ext.get_properties().clone());
         msg_inner.properties_string = message_properties_to_string(msg_ext.get_properties());
         msg_inner.tags_code =
-            MessageExtBrokerInner::tags_string_to_tags_code(msg_ext.get_tags().unwrap_or_default().as_str());
+            MessageExtBrokerInner::tags_string_to_tags_code(msg_ext.tags().unwrap_or_default().as_str());
         msg_inner.message_ext_inner.queue_id = queue_id_int;
         msg_inner.message_ext_inner.sys_flag = msg_ext.sys_flag;
         msg_inner.message_ext_inner.born_timestamp = msg_ext.born_timestamp;

--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -586,7 +586,7 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
         let topic_filter_type = message_single::parse_topic_filter_type(inner.sys_flag());
         let tags_code = MessageExtBrokerInner::tags_string2tags_code(
             &topic_filter_type,
-            inner.get_tags().as_ref().unwrap_or(&CheetahString::empty()),
+            inner.tags().as_ref().unwrap_or(&CheetahString::empty()),
         );
         inner.tags_code = tags_code;
         inner.properties_string = MessageDecoder::message_properties_to_string(inner.get_properties());

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
@@ -174,7 +174,7 @@ fn to_message_ext_broker_inner(topic_config: &TopicConfig, msg_ext: &MessageExt)
     inner.set_flag(msg_ext.get_flag());
     MessageAccessor::set_properties(&mut inner, msg_ext.get_properties().clone());
     inner.properties_string = MessageDecoder::message_properties_to_string(msg_ext.get_properties());
-    inner.tags_code = MessageExtBrokerInner::tags_string_to_tags_code(msg_ext.get_tags().unwrap_or_default().as_str());
+    inner.tags_code = MessageExtBrokerInner::tags_string_to_tags_code(msg_ext.tags().unwrap_or_default().as_str());
     inner.message_ext_inner.queue_id = 0;
     inner.message_ext_inner.sys_flag = msg_ext.sys_flag();
     inner.message_ext_inner.born_timestamp = msg_ext.born_timestamp;
@@ -209,7 +209,7 @@ mod tests {
         );
         assert_eq!(
             result.tags_code,
-            MessageExtBrokerInner::tags_string_to_tags_code(msg_ext.get_tags().unwrap_or_default().as_str())
+            MessageExtBrokerInner::tags_string_to_tags_code(msg_ext.tags().unwrap_or_default().as_str())
         );
         assert_eq!(result.message_ext_inner.queue_id, result.message_ext_inner.queue_id);
         assert_eq!(result.message_ext_inner.sys_flag, msg_ext.sys_flag());

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
@@ -912,12 +912,12 @@ where
             debug!(
                 "Topic: {} tags: {:?}, OpOffset: {}, HalfOffset: {}",
                 op_message_ext.topic(),
-                op_message_ext.get_tags(),
+                op_message_ext.tags(),
                 op_message_ext.queue_offset(),
                 queue_offset_body
             );
 
-            if op_message_ext.get_tags() == Some(CheetahString::from_static_str(TransactionalMessageUtil::REMOVE_TAG)) {
+            if op_message_ext.tags() == Some(CheetahString::from_static_str(TransactionalMessageUtil::REMOVE_TAG)) {
                 let offset_array: Vec<&str> = queue_offset_body
                     .split(TransactionalMessageUtil::OFFSET_SEPARATOR)
                     .collect();

--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -318,7 +318,7 @@ where
         let mut inner = MessageExtBrokerInner {
             message_ext_inner: msg_ext.clone(),
             properties_string: message_decoder::message_properties_to_string(msg_ext.get_properties()),
-            tags_code: MessageExtBrokerInner::tags_string_to_tags_code(msg_ext.get_tags().unwrap_or_default().as_str()),
+            tags_code: MessageExtBrokerInner::tags_string_to_tags_code(msg_ext.tags().unwrap_or_default().as_str()),
             encoded_buff: None,
             encode_completed: false,
             version: Default::default(),
@@ -331,14 +331,10 @@ where
     fn make_op_message_inner(&self, message: Message, message_queue: &MessageQueue) -> MessageExtBrokerInner {
         let mut msg_inner = MessageExtBrokerInner::default();
         msg_inner.message_ext_inner.message = message;
-        //msg_inner.set_topic(message.get_topic().to_owned());
-        //msg_inner.set_body(message.get_body().expect("message body is empty").clone());
         msg_inner.message_ext_inner.queue_id = message_queue.queue_id();
-        //msg_inner.set_tags(message.get_tags().unwrap_or_default());
         msg_inner.tags_code =
-            MessageExtBrokerInner::tags_string_to_tags_code(msg_inner.get_tags().unwrap_or_default().as_str());
+            MessageExtBrokerInner::tags_string_to_tags_code(msg_inner.tags().unwrap_or_default().as_str());
         msg_inner.message_ext_inner.sys_flag = 0;
-        //MessageAccessor::set_properties(&mut msg_inner, message.get_properties().clone());
         msg_inner.properties_string = MessageDecoder::message_properties_to_string(msg_inner.get_properties());
 
         msg_inner.message_ext_inner.born_timestamp = get_current_millis() as i64;

--- a/rocketmq-broker/src/transaction/queue/transactional_message_util.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_util.rs
@@ -63,7 +63,7 @@ impl TransactionalMessageUtil {
         }
         msg_inner.set_flag(msg_ext.get_flag());
         msg_inner.tags_code =
-            MessageExtBrokerInner::tags_string_to_tags_code(msg_inner.get_tags().unwrap_or_default().as_str());
+            MessageExtBrokerInner::tags_string_to_tags_code(msg_inner.tags().unwrap_or_default().as_str());
         msg_inner.message_ext_inner.set_born_timestamp(msg_ext.born_timestamp);
         msg_inner.message_ext_inner.set_born_host(msg_ext.born_host);
 

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -996,7 +996,7 @@ impl DefaultMQPushConsumerImpl {
                 if !subscription_data.tags_set.is_empty() && !subscription_data.class_filter_mode {
                     let mut msg_vec_again = Vec::with_capacity(msg_vec.len());
                     for msg in msg_vec {
-                        if let Some(ref tag) = msg.get_tags() {
+                        if let Some(ref tag) = msg.tags() {
                             if subscription_data.tags_set.contains(tag.as_str()) {
                                 msg_vec_again.push(msg);
                             }

--- a/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
@@ -132,7 +132,7 @@ impl PullAPIWrapper {
                 if !subscription_data.tags_set.is_empty() && !subscription_data.class_filter_mode {
                     let mut msg_vec_again = Vec::with_capacity(msg_vec.len());
                     for msg in msg_vec {
-                        if let Some(ref tag) = msg.get_tags() {
+                        if let Some(ref tag) = msg.tags() {
                             if subscription_data.tags_set.contains(tag.as_str()) {
                                 msg_vec_again.push(msg);
                             }

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -390,7 +390,7 @@ impl AggregateKey {
             topic: message.topic().clone(),
             mq: None,
             wait_store_msg_ok: message.is_wait_store_msg_ok(),
-            tag: message.get_tags(),
+            tag: message.tags(),
         }
     }
 
@@ -399,7 +399,7 @@ impl AggregateKey {
             topic: message.topic().clone(),
             mq,
             wait_store_msg_ok: message.is_wait_store_msg_ok(),
-            tag: message.get_tags(),
+            tag: message.tags(),
         }
     }
 

--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -178,7 +178,7 @@ pub trait MessageTrait: Any + Display + Debug {
     /// # Returns
     ///
     /// An `Option<String>` containing the tags if they exist, otherwise `None`.
-    fn get_tags(&self) -> Option<CheetahString> {
+    fn tags(&self) -> Option<CheetahString> {
         self.property(&CheetahString::from_static_str(MessageConst::PROPERTY_TAGS))
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6461 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized message tag access methods across broker processors, schedule services, transaction handlers, and client components for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->