### PR TITLE
[ISSUE #6396]🚀Implement GetLiteGroupInfo Command for Lite Topic Consumer Group Monitoring

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1718,12 +1718,23 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn get_lite_group_info(
         &self,
-        _broker_addr: CheetahString,
-        _group: CheetahString,
-        _lite_topic: CheetahString,
-        _top_k: i32,
+        broker_addr: CheetahString,
+        group: CheetahString,
+        lite_topic: CheetahString,
+        top_k: i32,
     ) -> rocketmq_error::RocketMQResult<GetLiteGroupInfoResponseBody> {
-        unimplemented!("get_lite_group_info not implemented yet")
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_lite_group_info(
+                &broker_addr,
+                group,
+                lite_topic,
+                top_k,
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await
     }
 
     async fn export_rocksdb_config_to_json(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -75,6 +75,7 @@ use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
 use rocketmq_remoting::protocol::body::check_client_request_body::CheckClientRequestBody;
 use rocketmq_remoting::protocol::body::epoch_entry_cache::EpochEntryCache;
 use rocketmq_remoting::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
+use rocketmq_remoting::protocol::body::get_lite_group_info_response_body::GetLiteGroupInfoResponseBody;
 use rocketmq_remoting::protocol::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
@@ -97,6 +98,7 @@ use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
 use rocketmq_remoting::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
 use rocketmq_remoting::protocol::header::extra_info_util::ExtraInfoUtil;
 use rocketmq_remoting::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
+use rocketmq_remoting::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader;
 use rocketmq_remoting::protocol::header::get_max_offset_request_header::GetMaxOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
 use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
@@ -601,6 +603,35 @@ impl MQClientAPIImpl {
         ))
     }
 
+    pub(crate) async fn get_lite_group_info(
+        &self,
+        addr: &CheetahString,
+        group: CheetahString,
+        lite_topic: CheetahString,
+        top_k: i32,
+        timeout_millis: u64,
+    ) -> RocketMQResult<GetLiteGroupInfoResponseBody> {
+        let request_header = GetLiteGroupInfoRequestHeader {
+            group,
+            lite_topic,
+            top_k,
+            rpc: None,
+        };
+        let request = RemotingCommand::create_request_command(RequestCode::GetLiteGroupInfo, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return GetLiteGroupInfoResponseBody::decode(body.as_ref());
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
     pub(crate) async fn get_parent_topic_info(
         &self,
         addr: &CheetahString,

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -41,6 +41,7 @@ pub mod get_consumer_listby_group_response_header;
 pub mod get_consumer_running_info_request_header;
 pub mod get_consumer_status_request_header;
 pub mod get_earliest_msg_storetime_response_header;
+pub mod get_lite_group_info_request_header;
 pub mod get_max_offset_request_header;
 pub mod get_max_offset_response_header;
 pub mod get_meta_data_response_header;

--- a/rocketmq-remoting/src/protocol/header/get_lite_group_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_lite_group_info_request_header.rs
@@ -1,0 +1,36 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct GetLiteGroupInfoRequestHeader {
+    #[required]
+    pub group: CheetahString,
+
+    #[required]
+    pub lite_topic: CheetahString,
+
+    #[required]
+    pub top_k: i32,
+
+    #[serde(flatten)]
+    pub rpc: Option<RpcRequestHeader>,
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1399,12 +1399,14 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn get_lite_group_info(
         &self,
-        _broker_addr: CheetahString,
-        _group: CheetahString,
-        _lite_topic: CheetahString,
-        _top_k: i32,
+        broker_addr: CheetahString,
+        group: CheetahString,
+        lite_topic: CheetahString,
+        top_k: i32,
     ) -> rocketmq_error::RocketMQResult<GetLiteGroupInfoResponseBody> {
-        unimplemented!("get_lite_group_info not implemented yet")
+        self.default_mqadmin_ext_impl
+            .get_lite_group_info(broker_addr, group, lite_topic, top_k)
+            .await
     }
 
     async fn export_rocksdb_config_to_json(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -397,6 +397,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Lite",
+                command: "getLiteGroupInfo",
+                remark: "Get lite group info.",
+            },
+            Command {
+                category: "Lite",
                 command: "getParentTopicInfo",
                 remark: "Get parent topic info.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite.rs
@@ -14,6 +14,7 @@
 
 mod get_broker_lite_info_sub_command;
 mod get_lite_client_info_sub_command;
+mod get_lite_group_info_sub_command;
 mod get_parent_topic_info_sub_command;
 mod trigger_lite_dispatch_sub_command;
 
@@ -25,6 +26,7 @@ use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::lite::get_broker_lite_info_sub_command::GetBrokerLiteInfoSubCommand;
 use crate::commands::lite::get_lite_client_info_sub_command::GetLiteClientInfoSubCommand;
+use crate::commands::lite::get_lite_group_info_sub_command::GetLiteGroupInfoSubCommand;
 use crate::commands::lite::get_parent_topic_info_sub_command::GetParentTopicInfoSubCommand;
 use crate::commands::lite::trigger_lite_dispatch_sub_command::TriggerLiteDispatchSubCommand;
 use crate::commands::CommandExecute;
@@ -46,6 +48,13 @@ pub enum LiteCommands {
     GetLiteClientInfo(GetLiteClientInfoSubCommand),
 
     #[command(
+        name = "getLiteGroupInfo",
+        about = "Get lite group info.",
+        long_about = None,
+    )]
+    GetLiteGroupInfo(GetLiteGroupInfoSubCommand),
+
+    #[command(
         name = "getParentTopicInfo",
         about = "Get parent topic info.",
         long_about = None,
@@ -65,6 +74,7 @@ impl CommandExecute for LiteCommands {
         match self {
             LiteCommands::GetBrokerLiteInfo(cmd) => cmd.execute(rpc_hook).await,
             LiteCommands::GetLiteClientInfo(cmd) => cmd.execute(rpc_hook).await,
+            LiteCommands::GetLiteGroupInfo(cmd) => cmd.execute(rpc_hook).await,
             LiteCommands::GetParentTopicInfo(cmd) => cmd.execute(rpc_hook).await,
             LiteCommands::TriggerLiteDispatch(cmd) => cmd.execute(rpc_hook).await,
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/get_lite_group_info_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/get_lite_group_info_sub_command.rs
@@ -1,0 +1,235 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::utils::util_all::time_millis_to_human_string2;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::admin::offset_wrapper::OffsetWrapper;
+use rocketmq_remoting::protocol::body::lite_lag_info::LiteLagInfo;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct GetLiteGroupInfoSubCommand {
+    #[arg(short = 'p', long = "parentTopic", required = true, help = "Parent topic name")]
+    parent_topic: String,
+
+    #[arg(short = 'g', long = "group", required = true, help = "Consumer group")]
+    group: String,
+
+    #[arg(short = 'l', long = "liteTopic", required = false, help = "Query lite topic detail")]
+    lite_topic: Option<String>,
+
+    #[arg(short = 'k', long = "topK", required = false, help = "TopK value of each broker")]
+    top_k: Option<i32>,
+}
+
+impl CommandExecute for GetLiteGroupInfoSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("GetLiteGroupInfoSubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            let parent_topic = self.parent_topic.trim();
+            let group = self.group.trim();
+            let top_k = self.top_k.unwrap_or(20);
+            let lite_topic = self.lite_topic.as_deref().map(|s| s.trim().to_string());
+            let query_by_lite_topic = lite_topic.as_ref().is_some_and(|s| !s.is_empty());
+
+            let topic_route_data = default_mqadmin_ext
+                .examine_topic_route_info(CheetahString::from(parent_topic))
+                .await
+                .map_err(|e| {
+                    RocketMQError::Internal(format!(
+                        "GetLiteGroupInfoSubCommand: Failed to examine topic route info: {}",
+                        e
+                    ))
+                })?;
+
+            let topic_route_data = topic_route_data.ok_or_else(|| {
+                RocketMQError::Internal(format!(
+                    "GetLiteGroupInfoSubCommand: Topic route not found for: {}",
+                    parent_topic
+                ))
+            })?;
+
+            println!("Lite Group Info: [{}] [{}]", group, parent_topic);
+
+            let mut total_lag_count: i64 = 0;
+            let mut earliest_unconsumed_timestamp: i64 = current_millis() as i64;
+            let mut lag_count_top_k: Vec<LiteLagInfo> = Vec::new();
+            let mut lag_timestamp_top_k: Vec<LiteLagInfo> = Vec::new();
+
+            if query_by_lite_topic {
+                println!(
+                    "{:<50} {:<16} {:<16} {:<16} {:<30}",
+                    "#Broker Name", "#BrokerOffset", "#ConsumeOffset", "#LagCount", "#LastUpdate"
+                );
+            }
+
+            for broker_data in &topic_route_data.broker_datas {
+                let broker_addr = match broker_data.select_broker_addr() {
+                    Some(addr) => addr,
+                    None => continue,
+                };
+
+                let lite_topic_str = lite_topic.as_deref().map(CheetahString::from).unwrap_or_default();
+
+                match default_mqadmin_ext
+                    .get_lite_group_info(broker_addr.clone(), CheetahString::from(group), lite_topic_str, top_k)
+                    .await
+                {
+                    Ok(body) => {
+                        if body.total_lag_count() > 0 {
+                            total_lag_count += body.total_lag_count();
+                        }
+                        if body.earliest_unconsumed_timestamp() > 0 {
+                            earliest_unconsumed_timestamp =
+                                earliest_unconsumed_timestamp.min(body.earliest_unconsumed_timestamp());
+                        }
+
+                        Self::print_offset_wrapper(
+                            query_by_lite_topic,
+                            broker_data.broker_name(),
+                            body.lite_topic_offset_wrapper(),
+                        );
+
+                        lag_count_top_k.extend_from_slice(body.lag_count_top_k());
+                        lag_timestamp_top_k.extend_from_slice(body.lag_timestamp_top_k());
+                    }
+                    Err(_) => {
+                        println!("[{}] error.", broker_data.broker_name());
+                    }
+                }
+            }
+
+            println!("Total Lag Count: {}", total_lag_count);
+            let lag_time = current_millis() as i64 - earliest_unconsumed_timestamp;
+            println!(
+                "Min Unconsumed Timestamp: {} ({} s ago)\n",
+                earliest_unconsumed_timestamp,
+                lag_time / 1000
+            );
+
+            if query_by_lite_topic {
+                return Ok(());
+            }
+
+            // Sort and print topK by lag count
+            lag_count_top_k.sort_by_key(|b| std::cmp::Reverse(b.lag_count()));
+            println!("------TopK by lag count-----");
+            println!(
+                "{:<6} {:<40} {:<12} {:<30}",
+                "NO", "Lite Topic", "Lag Count", "UnconsumedTimestamp"
+            );
+            for (i, info) in lag_count_top_k.iter().enumerate() {
+                let timestamp_str = if info.earliest_unconsumed_timestamp() > 0 {
+                    time_millis_to_human_string2(info.earliest_unconsumed_timestamp())
+                } else {
+                    "-".to_string()
+                };
+                println!(
+                    "{:<6} {:<40} {:<12} {:<30}",
+                    i + 1,
+                    info.lite_topic(),
+                    info.lag_count(),
+                    timestamp_str
+                );
+            }
+
+            // Sort and print topK by lag time
+            lag_timestamp_top_k.sort_by(|a, b| {
+                a.earliest_unconsumed_timestamp()
+                    .cmp(&b.earliest_unconsumed_timestamp())
+            });
+            println!("\n------TopK by lag time------");
+            println!(
+                "{:<6} {:<40} {:<12} {:<30}",
+                "NO", "Lite Topic", "Lag Count", "UnconsumedTimestamp"
+            );
+            for (i, info) in lag_timestamp_top_k.iter().enumerate() {
+                let timestamp_str = if info.earliest_unconsumed_timestamp() > 0 {
+                    time_millis_to_human_string2(info.earliest_unconsumed_timestamp())
+                } else {
+                    "-".to_string()
+                };
+                println!(
+                    "{:<6} {:<40} {:<12} {:<30}",
+                    i + 1,
+                    info.lite_topic(),
+                    info.lag_count(),
+                    timestamp_str
+                );
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+impl GetLiteGroupInfoSubCommand {
+    fn print_offset_wrapper(
+        query_by_lite_topic: bool,
+        broker_name: &CheetahString,
+        offset_wrapper: Option<&OffsetWrapper>,
+    ) {
+        if !query_by_lite_topic {
+            return;
+        }
+
+        match offset_wrapper {
+            None => {
+                println!("{:<50} {:<16} {:<16} {:<16} {:<30}", broker_name, "-", "-", "-", "-");
+            }
+            Some(wrapper) => {
+                let last_update_str = if wrapper.get_last_timestamp() > 0 {
+                    time_millis_to_human_string2(wrapper.get_last_timestamp())
+                } else {
+                    "-".to_string()
+                };
+                println!(
+                    "{:<50} {:<16} {:<16} {:<16} {:<30}",
+                    broker_name,
+                    wrapper.get_broker_offset(),
+                    wrapper.get_consumer_offset(),
+                    wrapper.get_broker_offset() - wrapper.get_consumer_offset(),
+                    last_update_str
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6396 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added getLiteGroupInfo CLI command to query lite group info per broker with optional lite-topic filter and configurable top-K.
  * Command shows per-broker offsets, aggregated total lag, earliest unconsumed timestamp (with age), and Top-K lists by lag count and lag time.
  * Admin and client now perform live remote queries to retrieve and display these metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->