### PR TITLE
[ISSUE #6398]🚀Implement GetParentTopicInfo Command for Parent Topic Monitoring

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1686,10 +1686,15 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn get_parent_topic_info(
         &self,
-        _broker_addr: CheetahString,
-        _topic: CheetahString,
+        broker_addr: CheetahString,
+        topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<GetParentTopicInfoResponseBody> {
-        unimplemented!("get_parent_topic_info not implemented yet")
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_parent_topic_info(&broker_addr, topic, self.timeout_millis.as_millis() as u64)
+            .await
     }
 
     async fn get_lite_topic_info(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -75,6 +75,7 @@ use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
 use rocketmq_remoting::protocol::body::check_client_request_body::CheckClientRequestBody;
 use rocketmq_remoting::protocol::body::epoch_entry_cache::EpochEntryCache;
 use rocketmq_remoting::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
+use rocketmq_remoting::protocol::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
@@ -99,6 +100,7 @@ use rocketmq_remoting::protocol::header::get_consumer_listby_group_request_heade
 use rocketmq_remoting::protocol::header::get_max_offset_request_header::GetMaxOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
 use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
+use rocketmq_remoting::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader;
 use rocketmq_remoting::protocol::header::get_user_request_headers::GetUserRequestHeader;
 use rocketmq_remoting::protocol::header::heartbeat_request_header::HeartbeatRequestHeader;
 use rocketmq_remoting::protocol::header::list_acl_request_header::ListAclRequestHeader;
@@ -591,6 +593,29 @@ impl MQClientAPIImpl {
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
                 return GetBrokerLiteInfoResponseBody::decode(body.as_ref());
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn get_parent_topic_info(
+        &self,
+        addr: &CheetahString,
+        topic: CheetahString,
+        timeout_millis: u64,
+    ) -> RocketMQResult<GetParentTopicInfoResponseBody> {
+        let request_header = GetParentTopicInfoRequestHeader { topic, rpc: None };
+        let request = RemotingCommand::create_request_command(RequestCode::GetParentTopicInfo, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return GetParentTopicInfoResponseBody::decode(body.as_ref());
             }
         }
         Err(mq_client_err!(

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -46,6 +46,7 @@ pub mod get_max_offset_response_header;
 pub mod get_meta_data_response_header;
 pub mod get_min_offset_request_header;
 pub mod get_min_offset_response_header;
+pub mod get_parent_topic_info_request_header;
 pub mod get_producer_connection_list_request_header;
 pub mod get_topic_config_request_header;
 pub mod get_topic_stats_info_request_header;

--- a/rocketmq-remoting/src/protocol/header/get_parent_topic_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_parent_topic_info_request_header.rs
@@ -1,0 +1,30 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct GetParentTopicInfoRequestHeader {
+    #[required]
+    pub topic: CheetahString,
+
+    #[serde(flatten)]
+    pub rpc: Option<RpcRequestHeader>,
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1370,10 +1370,12 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn get_parent_topic_info(
         &self,
-        _broker_addr: CheetahString,
-        _topic: CheetahString,
+        broker_addr: CheetahString,
+        topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<GetParentTopicInfoResponseBody> {
-        unimplemented!("get_parent_topic_info not implemented yet")
+        self.default_mqadmin_ext_impl
+            .get_parent_topic_info(broker_addr, topic)
+            .await
     }
 
     async fn get_lite_topic_info(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -397,6 +397,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Lite",
+                command: "getParentTopicInfo",
+                remark: "Get parent topic info.",
+            },
+            Command {
+                category: "Lite",
                 command: "triggerLiteDispatch",
                 remark: "Trigger Lite Dispatch.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite.rs
@@ -14,6 +14,7 @@
 
 mod get_broker_lite_info_sub_command;
 mod get_lite_client_info_sub_command;
+mod get_parent_topic_info_sub_command;
 mod trigger_lite_dispatch_sub_command;
 
 use std::sync::Arc;
@@ -24,6 +25,7 @@ use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::lite::get_broker_lite_info_sub_command::GetBrokerLiteInfoSubCommand;
 use crate::commands::lite::get_lite_client_info_sub_command::GetLiteClientInfoSubCommand;
+use crate::commands::lite::get_parent_topic_info_sub_command::GetParentTopicInfoSubCommand;
 use crate::commands::lite::trigger_lite_dispatch_sub_command::TriggerLiteDispatchSubCommand;
 use crate::commands::CommandExecute;
 
@@ -44,6 +46,13 @@ pub enum LiteCommands {
     GetLiteClientInfo(GetLiteClientInfoSubCommand),
 
     #[command(
+        name = "getParentTopicInfo",
+        about = "Get parent topic info.",
+        long_about = None,
+    )]
+    GetParentTopicInfo(GetParentTopicInfoSubCommand),
+
+    #[command(
         name = "triggerLiteDispatch",
         about = "Trigger Lite Dispatch.",
         long_about = None,
@@ -56,6 +65,7 @@ impl CommandExecute for LiteCommands {
         match self {
             LiteCommands::GetBrokerLiteInfo(cmd) => cmd.execute(rpc_hook).await,
             LiteCommands::GetLiteClientInfo(cmd) => cmd.execute(rpc_hook).await,
+            LiteCommands::GetParentTopicInfo(cmd) => cmd.execute(rpc_hook).await,
             LiteCommands::TriggerLiteDispatch(cmd) => cmd.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/get_parent_topic_info_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/get_parent_topic_info_sub_command.rs
@@ -1,0 +1,129 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct GetParentTopicInfoSubCommand {
+    #[arg(short = 'p', long = "parentTopic", required = true, help = "Parent topic name")]
+    parent_topic: String,
+}
+
+impl CommandExecute for GetParentTopicInfoSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "GetParentTopicInfoSubCommand: Failed to start MQAdminExt: {}",
+                    e
+                ))
+            })?;
+
+            let parent_topic = self.parent_topic.trim();
+
+            let topic_route_data = default_mqadmin_ext
+                .examine_topic_route_info(CheetahString::from(parent_topic))
+                .await
+                .map_err(|e| {
+                    RocketMQError::Internal(format!(
+                        "GetParentTopicInfoSubCommand: Failed to examine topic route info: {}",
+                        e
+                    ))
+                })?;
+
+            let topic_route_data = topic_route_data.ok_or_else(|| {
+                RocketMQError::Internal(format!(
+                    "GetParentTopicInfoSubCommand: Topic route not found for: {}",
+                    parent_topic
+                ))
+            })?;
+
+            println!("Parent Topic Info: [{}]", parent_topic);
+            Self::print_header();
+
+            for broker_data in &topic_route_data.broker_datas {
+                let broker_addr = match broker_data.select_broker_addr() {
+                    Some(addr) => addr,
+                    None => continue,
+                };
+
+                match default_mqadmin_ext
+                    .get_parent_topic_info(broker_addr.clone(), CheetahString::from(parent_topic))
+                    .await
+                {
+                    Ok(body) => {
+                        Self::print_row(broker_data.broker_name(), &body);
+                    }
+                    Err(_) => {
+                        println!("[{}] error.", broker_data.broker_name());
+                    }
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+impl GetParentTopicInfoSubCommand {
+    fn print_header() {
+        println!(
+            "{:<50} {:<8} {:<14} {:<14} {:<100}",
+            "#Broker Name", "#TTL", "#Lite Count", "#LMQ NUM", "#GROUPS"
+        );
+    }
+
+    fn print_row(broker_name: &CheetahString, body: &GetParentTopicInfoResponseBody) {
+        let display_name = Self::front_string_at_least(broker_name.as_str(), 40);
+        let groups_display = format!("{:?}", body.get_groups());
+        println!(
+            "{:<50} {:<8} {:<14} {:<14} {:<100}",
+            display_name,
+            body.get_ttl(),
+            body.get_lite_topic_count(),
+            body.get_lmq_num(),
+            groups_display
+        );
+    }
+
+    fn front_string_at_least(s: &str, size: usize) -> String {
+        s.chars().take(size).collect()
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6398 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve parent-topic information from brokers via the admin API.
  * New admin CLI command "getParentTopicInfo" to query and display parent-topic details per broker, with formatted table output and per-broker error reporting.

* **Public API**
  * Added remoting header support and client-side query to enable parent-topic lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->