### PR TITLE
[ISSUE #6539]✨TimeUtils usage to replace get_current_millis with current_millis for consistency

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -31,7 +31,7 @@ use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mix_all::MASTER_ID;
 use rocketmq_common::common::server::config::ServerConfig;
 use rocketmq_common::common::statistics::state_getter::StateGetter;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::compute_next_morning_time_millis;
 use rocketmq_remoting::base::channel_event_listener::ChannelEventListener;
 use rocketmq_remoting::code::request_code::RequestCode;
@@ -226,7 +226,7 @@ impl BrokerRuntime {
             broker_attached_plugins: vec![],
             transactional_message_service: None,
             slave_synchronize: None,
-            last_sync_time_ms: AtomicU64::new(get_current_millis()),
+            last_sync_time_ms: AtomicU64::new(current_millis()),
             broker_pre_online_service: None,
             min_broker_id_in_group: AtomicU64::new(0),
             min_broker_addr_in_group: Default::default(),
@@ -786,7 +786,7 @@ impl BrokerRuntime {
 
     #[allow(clippy::incompatible_msrv)]
     async fn initialize_scheduled_tasks(&mut self) {
-        let initial_delay = compute_next_morning_time_millis() - get_current_millis();
+        let initial_delay = compute_next_morning_time_millis() - current_millis();
         let period = Duration::from_secs(24 * 60 * 60);
         let broker_stats_ = self.inner.clone();
         self.scheduled_task_manager.add_fixed_rate_task_async(
@@ -888,13 +888,11 @@ impl BrokerRuntime {
                     Duration::from_secs(10),
                     Duration::from_secs(3),
                     async move |_ctx| {
-                        if get_current_millis() - inner_clone.last_sync_time_ms.load(Ordering::Relaxed) > 10_000 {
+                        if current_millis() - inner_clone.last_sync_time_ms.load(Ordering::Relaxed) > 10_000 {
                             if let Some(slave_synchronize) = &inner_clone.slave_synchronize {
                                 slave_synchronize.sync_all().await;
                             }
-                            inner_clone
-                                .last_sync_time_ms
-                                .store(get_current_millis(), Ordering::Relaxed);
+                            inner_clone.last_sync_time_ms.store(current_millis(), Ordering::Relaxed);
                         }
                         if inner_clone.message_store_config.timer_wheel_enable {
                             if let Some(slave_synchronize) = &inner_clone.slave_synchronize {
@@ -1060,7 +1058,7 @@ impl BrokerRuntime {
 
     pub async fn start(&mut self) {
         self.inner.should_start_time.store(
-            (get_current_millis() as i64 + self.inner.message_store_config.disappear_time_after_start) as u64,
+            (current_millis() as i64 + self.inner.message_store_config.disappear_time_after_start) as u64,
             Ordering::Release,
         );
         if self.inner.message_store_config.total_replicas > 1 && self.inner.broker_config.enable_slave_acting_master {
@@ -1087,7 +1085,7 @@ impl BrokerRuntime {
         self.scheduled_task_manager
             .add_fixed_rate_task_async(initial_delay, period, async move |_ctx| {
                 let start_time = broker_runtime_inner.should_start_time.load(Ordering::Relaxed);
-                if get_current_millis() < start_time {
+                if current_millis() < start_time {
                     info!("Register to namesrv after {}", start_time);
                     return Ok(());
                 }

--- a/rocketmq-broker/src/client/client_channel_info.rs
+++ b/rocketmq-broker/src/client/client_channel_info.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::LanguageCode;
 
@@ -33,7 +33,7 @@ impl ClientChannelInfo {
             client_id,
             language,
             version,
-            last_update_timestamp: get_current_millis(),
+            last_update_timestamp: current_millis(),
         }
     }
 

--- a/rocketmq-broker/src/client/consumer_group_info.rs
+++ b/rocketmq-broker/src/client/consumer_group_info.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
@@ -54,7 +54,7 @@ impl ConsumerGroupInfo {
             consume_type,
             message_model,
             consume_from_where,
-            last_update_timestamp: get_current_millis(),
+            last_update_timestamp: current_millis(),
         }
     }
 
@@ -66,7 +66,7 @@ impl ConsumerGroupInfo {
             consume_type: ConsumeType::ConsumePassively,
             message_model: MessageModel::Clustering,
             consume_from_where: ConsumeFromWhere::ConsumeFromLastOffset,
-            last_update_timestamp: get_current_millis(),
+            last_update_timestamp: current_millis(),
         }
     }
 
@@ -158,7 +158,7 @@ impl ConsumerGroupInfo {
                 );
                 *info_old = info_new;
             }
-            info_old.set_last_update_timestamp(get_current_millis());
+            info_old.set_last_update_timestamp(current_millis());
         } else {
             self.channel_info_table
                 .insert(info_new.channel().clone(), info_new.clone());
@@ -170,7 +170,7 @@ impl ConsumerGroupInfo {
             updated = true;
         }
 
-        self.last_update_timestamp = get_current_millis();
+        self.last_update_timestamp = current_millis();
 
         updated
     }
@@ -212,7 +212,7 @@ impl ConsumerGroupInfo {
                 true
             }
         });
-        self.last_update_timestamp = get_current_millis();
+        self.last_update_timestamp = current_millis();
         updated
     }
 

--- a/rocketmq-broker/src/client/manager/consumer_manager.rs
+++ b/rocketmq-broker/src/client/manager/consumer_manager.rs
@@ -22,7 +22,7 @@ use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
@@ -511,7 +511,7 @@ impl ConsumerManager {
 
             // Find expired subscriptions
             for subscription_data in subscription_table.iter() {
-                let diff = get_current_millis() as i64 - subscription_data.sub_version;
+                let diff = current_millis() as i64 - subscription_data.sub_version;
                 if diff > self.subscription_expired_timeout as i64 {
                     topics_to_remove.push(subscription_data.key().clone());
                 }
@@ -550,7 +550,7 @@ impl ConsumerManager {
             // Collect expired channels
             let mut channels_to_remove = Vec::new();
             for client_channel_info in channel_info_table.iter() {
-                let diff = get_current_millis() as i64 - client_channel_info.last_update_timestamp() as i64;
+                let diff = current_millis() as i64 - client_channel_info.last_update_timestamp() as i64;
 
                 if diff > self.channel_expired_timeout as i64 {
                     warn!(

--- a/rocketmq-broker/src/client/manager/producer_manager.rs
+++ b/rocketmq-broker/src/client/manager/producer_manager.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::connection::ConnectionState;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::producer_info::ProducerInfo;
@@ -214,7 +214,7 @@ impl ProducerManager {
             // Check if this channel is already registered
             if let Some(mut existing_info) = channel_table.get_mut(client_channel_info.channel()) {
                 // Update timestamp for existing producer
-                existing_info.set_last_update_timestamp(get_current_millis());
+                existing_info.set_last_update_timestamp(current_millis());
                 return;
             }
 
@@ -338,7 +338,7 @@ impl ProducerManager {
     /// Producers that haven't sent heartbeat for more than CHANNEL_EXPIRED_TIMEOUT (120 seconds)
     /// will be removed.
     pub fn scan_not_active_channel(&self) {
-        let current_time = get_current_millis();
+        let current_time = current_millis();
 
         // Collect all expired channels without holding locks during modification
         // Structure: (group_name, channel, client_info)

--- a/rocketmq-broker/src/client/rebalance/rebalance_lock_manager.rs
+++ b/rocketmq-broker/src/client/rebalance/rebalance_lock_manager.rs
@@ -20,7 +20,7 @@ use std::sync::LazyLock;
 
 use parking_lot::RwLock;
 use rocketmq_common::common::message::message_queue::MessageQueue;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use tracing::info;
 use tracing::warn;
 
@@ -68,7 +68,7 @@ impl RebalanceLockManager {
                     mq.clone(),
                     LockEntry {
                         client_id: client_id.to_string(),
-                        last_update_timestamp: AtomicI64::new(get_current_millis() as i64),
+                        last_update_timestamp: AtomicI64::new(current_millis() as i64),
                     },
                 );
                 info!(
@@ -82,7 +82,7 @@ impl RebalanceLockManager {
                 if lock_entry.is_locked(client_id) {
                     lock_entry
                         .last_update_timestamp
-                        .store(get_current_millis() as i64, std::sync::atomic::Ordering::Relaxed);
+                        .store(current_millis() as i64, std::sync::atomic::Ordering::Relaxed);
                     return true;
                 }
 
@@ -92,7 +92,7 @@ impl RebalanceLockManager {
                     lock_entry.client_id = client_id.to_string();
                     lock_entry
                         .last_update_timestamp
-                        .store(get_current_millis() as i64, std::sync::atomic::Ordering::Relaxed);
+                        .store(current_millis() as i64, std::sync::atomic::Ordering::Relaxed);
                     warn!(
                         "RebalanceLockManager#tryLock: try to lock a expired message queue, group={}, mq={:?}, old \
                          client id={}, new client id={}",
@@ -136,13 +136,13 @@ impl RebalanceLockManager {
                     );
                     LockEntry {
                         client_id: client_id.to_string(),
-                        last_update_timestamp: AtomicI64::new(get_current_millis() as i64),
+                        last_update_timestamp: AtomicI64::new(current_millis() as i64),
                     }
                 });
                 if lock_entry.is_locked(client_id) {
                     lock_entry
                         .last_update_timestamp
-                        .store(get_current_millis() as i64, std::sync::atomic::Ordering::Relaxed);
+                        .store(current_millis() as i64, std::sync::atomic::Ordering::Relaxed);
                     lock_mqs.insert(mq);
                     continue;
                 }
@@ -151,7 +151,7 @@ impl RebalanceLockManager {
                     lock_entry.client_id = client_id.to_string();
                     lock_entry
                         .last_update_timestamp
-                        .store(get_current_millis() as i64, std::sync::atomic::Ordering::Relaxed);
+                        .store(current_millis() as i64, std::sync::atomic::Ordering::Relaxed);
                     warn!(
                         "RebalanceLockManager#tryLockBatch: try to lock a expired message queue, group={} mq={:?}, \
                          old client id={}, new client id={}",
@@ -214,7 +214,7 @@ impl RebalanceLockManager {
                 if locked {
                     lock_entry
                         .last_update_timestamp
-                        .store(get_current_millis() as i64, std::sync::atomic::Ordering::Relaxed);
+                        .store(current_millis() as i64, std::sync::atomic::Ordering::Relaxed);
                 }
                 return locked;
             }
@@ -231,7 +231,7 @@ struct LockEntry {
 impl LockEntry {
     #[inline]
     pub fn is_expired(&self) -> bool {
-        let now = get_current_millis() as i64;
+        let now = current_millis() as i64;
         let last_update_timestamp = self.last_update_timestamp.load(std::sync::atomic::Ordering::Relaxed);
         (now - last_update_timestamp) > *REBALANCE_LOCK_MAX_LIVE_TIME
     }

--- a/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
+++ b/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::common::filter::expression_type::ExpressionType;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_filter::utils::bloom_filter::BloomFilter;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
 
@@ -93,7 +93,7 @@ impl ConsumerFilterManager {
         let mut consumer_filter_data = ConsumerFilterData::default();
         consumer_filter_data.set_topic(topic);
         consumer_filter_data.set_consumer_group(consumer_group);
-        consumer_filter_data.set_born_time(get_current_millis());
+        consumer_filter_data.set_born_time(current_millis());
         consumer_filter_data.set_dead_time(0);
         consumer_filter_data.set_expression(expression);
         consumer_filter_data.set_expression_type(type_);

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -24,7 +24,7 @@ use crossbeam_skiplist::SkipSet;
 use dashmap::DashMap;
 use rocketmq_common::common::key_builder::KeyBuilder;
 use rocketmq_common::common::pop_ack_constants::PopAckConstants;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
@@ -101,7 +101,7 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
                     }
                 }
 
-                if this.last_clean_time == 0 || get_current_millis() - this.last_clean_time > 5 * 60 * 1000 {
+                if this.last_clean_time == 0 || current_millis() - this.last_clean_time > 5 * 60 * 1000 {
                     this.mut_from_ref().clean_unused_resource();
                 }
             }
@@ -211,7 +211,7 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
                 self.polling_map.remove(&key);
             }
         }
-        self.last_clean_time = get_current_millis();
+        self.last_clean_time = current_millis();
     }
 
     pub fn notify_message_arriving(

--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::consume_queue::cq_ext_unit::CqExtUnit;
@@ -183,7 +183,7 @@ where
                         }
                     }
 
-                    if get_current_millis() >= (request.suspend_timestamp() + request.timeout_millis()) {
+                    if current_millis() >= (request.suspend_timestamp() + request.timeout_millis()) {
                         let pull_message_this = self.pull_message_processor.clone();
                         self.pull_message_processor.execute_request_when_wakeup(
                             pull_message_this,

--- a/rocketmq-broker/src/long_polling/pop_request.rs
+++ b/rocketmq-broker/src/long_polling/pop_request.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
@@ -78,7 +78,7 @@ impl PopRequest {
     }
 
     pub fn is_timeout(&self) -> bool {
-        let now = get_current_millis();
+        let now = current_millis();
         now > (self.expired - 50)
     }
 

--- a/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
@@ -22,7 +22,7 @@ use std::ops::Deref;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use serde::Deserialize;
@@ -348,7 +348,7 @@ impl OrderInfo {
         if self.invisible_time.is_none() || self.invisible_time.unwrap_or(0) == 0 {
             self.invisible_time = Some(current_invisible_time);
         }
-        let current_time = get_current_millis();
+        let current_time = current_millis();
         for (i, _) in (0..num).enumerate() {
             if self.is_not_ack(i) {
                 let mut next_visible_time = self.pop_time + self.invisible_time.unwrap_or(0);
@@ -372,7 +372,7 @@ impl OrderInfo {
         if self.offset_list.is_empty() {
             return None;
         }
-        let current_time = get_current_millis();
+        let current_time = current_millis();
         for i in 0..self.offset_list.len() {
             if self.is_not_ack(i) {
                 if self.invisible_time.is_none() || self.invisible_time.unwrap_or(0) == 0 {

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -38,7 +38,7 @@ use rocketmq_common::utils::crc32_utils;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::clients::rocketmq_tokio_client::RocketmqDefaultClient;
 use rocketmq_remoting::clients::RemotingClient;
@@ -791,7 +791,7 @@ impl BrokerOuterAPI {
             commit_offset: 0,
             suspend_timeout_millis: 0,
             subscription: Some(CheetahString::from_static_str(SubscriptionData::SUB_ALL)),
-            sub_version: get_current_millis() as i64,
+            sub_version: current_millis() as i64,
             expression_type: Some(CheetahString::from_static_str(ExpressionType::TAG)),
             max_msg_bytes: Some(i32::MAX),
             topic_request: Some(TopicRequestHeader {

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -23,7 +23,7 @@ use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::mix_all::MASTER_ID;
 use rocketmq_common::common::pop_ack_constants::PopAckConstants;
 use rocketmq_common::common::FAQUrl;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
@@ -420,7 +420,7 @@ where
                 CheetahString::from(PopMessageProcessor::<MS>::gen_ack_unique_id(ack_msg as &dyn AckMessage)),
             );
         }
-        inner.message_ext_inner.born_timestamp = get_current_millis() as i64;
+        inner.message_ext_inner.born_timestamp = current_millis() as i64;
         inner.message_ext_inner.store_host = self.broker_runtime_inner.store_host();
         inner.message_ext_inner.born_host = self.broker_runtime_inner.store_host();
         inner.set_delay_time_ms((pop_time + invisible_time) as u64);

--- a/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use bytes::Bytes;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -47,7 +47,7 @@ impl<MS: MessageStore> SubscriptionGroupHandler<MS> {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let start_time = get_current_millis() as i64;
+        let start_time = current_millis() as i64;
 
         let mut response = RemotingCommand::create_response_command();
 
@@ -62,7 +62,7 @@ impl<MS: MessageStore> SubscriptionGroupHandler<MS> {
                 .update_subscription_group_config(config)
         }
         response.set_code_ref(ResponseCode::Success);
-        let execution_time = get_current_millis() as i64 - start_time;
+        let execution_time = current_millis() as i64 - start_time;
 
         if let Ok(config) = config.as_ref() {
             info!(

--- a/rocketmq-broker/src/processor/change_invisible_time_processor.rs
+++ b/rocketmq-broker/src/processor/change_invisible_time_processor.rs
@@ -20,7 +20,7 @@ use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::pop_ack_constants::PopAckConstants;
 use rocketmq_common::common::FAQUrl;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -195,7 +195,7 @@ where
                 .await;
         }
         // add new ck
-        let now = get_current_millis();
+        let now = current_millis();
         let revive_qid = ExtraInfoUtil::get_revive_qid(extra_info.as_slice())?;
         let ck_result = self
             .append_check_point(
@@ -270,7 +270,7 @@ where
         inner.set_body(Bytes::from(ack_msg.encode()?));
         inner.message_ext_inner.queue_id = rq_id;
         inner.set_tags(CheetahString::from_static_str(PopAckConstants::ACK_TAG));
-        inner.message_ext_inner.born_timestamp = get_current_millis() as i64;
+        inner.message_ext_inner.born_timestamp = current_millis() as i64;
         inner.message_ext_inner.born_host = self.broker_runtime_inner.store_host();
         inner.message_ext_inner.store_host = self.broker_runtime_inner.store_host();
         let deliver_time_ms = ExtraInfoUtil::get_pop_time(extra_info)? + ExtraInfoUtil::get_invisible_time(extra_info)?;
@@ -329,7 +329,7 @@ where
         inner.set_body(Bytes::from(ck.encode()?));
         inner.message_ext_inner.queue_id = revive_qid;
         inner.set_tags(CheetahString::from_static_str(PopAckConstants::ACK_TAG));
-        inner.message_ext_inner.born_timestamp = get_current_millis() as i64;
+        inner.message_ext_inner.born_timestamp = current_millis() as i64;
         inner.message_ext_inner.born_host = self.broker_runtime_inner.store_host();
         inner.message_ext_inner.store_host = self.broker_runtime_inner.store_host();
         let deliver_time_ms = ck.get_revive_time() - PopAckConstants::ACK_TIME_INTERVAL;
@@ -393,7 +393,7 @@ where
         if old_offset > request_header.offset {
             return Ok(Some(RemotingCommand::create_response_command()));
         }
-        let next_visible_time = get_current_millis() + request_header.invisible_time as u64;
+        let next_visible_time = current_millis() + request_header.invisible_time as u64;
         self.broker_runtime_inner
             .consumer_order_info_manager()
             .update_next_visible_time(

--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -25,7 +25,7 @@ use rocketmq_common::common::mix_all::MASTER_ID;
 use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_common::common::sys_flag::pull_sys_flag::PullSysFlag;
 use rocketmq_common::MessageDecoder;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::response_code::RemotingSysResponseCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -191,7 +191,7 @@ impl<MS: MessageStore> PullMessageResultHandler for DefaultPullMessageResultHand
                         request_header.queue_id,
                     );
                     // Record group get latency
-                    let latency = (get_current_millis() - _begin_time_mills) as i32;
+                    let latency = (current_millis() - _begin_time_mills) as i32;
                     self.broker_runtime_inner.broker_stats_manager().inc_group_get_latency(
                         request_header.consumer_group.as_str(),
                         request_header.topic.as_str(),
@@ -239,7 +239,7 @@ impl<MS: MessageStore> PullMessageResultHandler for DefaultPullMessageResultHand
                         channel,
                         ctx,
                         polling_time_mills,
-                        get_current_millis(),
+                        current_millis(),
                         offset,
                         subscription_data,
                         message_filter,
@@ -369,7 +369,7 @@ impl<MS: MessageStore> DefaultPullMessageResultHandler<MS> {
 
         // Record disk fall behind time
         if store_timestamp > 0 {
-            let fall_behind_time = get_current_millis() as i64 - store_timestamp;
+            let fall_behind_time = current_millis() as i64 - store_timestamp;
             self.broker_runtime_inner
                 .broker_stats_manager()
                 .record_disk_fall_behind_time(group, topic, queue_id, fall_behind_time);

--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -22,7 +22,7 @@ use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_common::common::TopicFilterType;
 use rocketmq_common::MessageAccessor::MessageAccessor;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -216,7 +216,7 @@ where
                             metrics.inc_commit_messages(&topic, 1);
 
                             // Record transaction finish latency (in seconds)
-                            let commit_latency_secs = (get_current_millis() - born_timestamp) / 1000;
+                            let commit_latency_secs = (current_millis() - born_timestamp) / 1000;
                             metrics.record_transaction_finish_latency(&topic, commit_latency_secs);
                         }
 
@@ -298,7 +298,7 @@ where
             MessageConst::PROPERTY_CHECK_IMMUNITY_TIME_IN_SECONDS,
         )) {
             if !check_immunity_time_str.is_empty() {
-                let value_of_current_minus_born = get_current_millis() - (message_ext.born_timestamp as u64);
+                let value_of_current_minus_born = current_millis() - (message_ext.born_timestamp as u64);
                 let check_immunity_time = TransactionalMessageUtil::get_immunity_time(
                     &check_immunity_time_str,
                     self.broker_runtime_inner.broker_config().transaction_timeout,

--- a/rocketmq-broker/src/processor/notification_processor.rs
+++ b/rocketmq-broker/src/processor/notification_processor.rs
@@ -20,7 +20,7 @@ use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::key_builder::KeyBuilder;
 use rocketmq_common::common::FAQUrl;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::notification_request_header::NotificationRequestHeader;
@@ -193,7 +193,7 @@ where
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let now = get_current_millis();
+        let now = current_millis();
         request.add_ext_field_if_not_exist(NotificationProcessor::<MS>::BORN_TIME, now.to_string());
         if request
             .ext_fields()

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -39,7 +39,7 @@ use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::pop_ack_constants::PopAckConstants;
 use rocketmq_common::common::FAQUrl;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -176,7 +176,7 @@ where
         request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let begin_time_mills = get_current_millis();
+        let begin_time_mills = current_millis();
         request.add_ext_field_if_not_exist(CheetahString::from_static_str(BORN_TIME), begin_time_mills.to_string());
 
         if request
@@ -352,7 +352,7 @@ where
                     request_header.topic.clone(),
                     request_header.exp.clone(),
                     request_header.exp_type.clone(),
-                    get_current_millis(),
+                    current_millis(),
                 );
                 if consumer_filter_data.is_none() {
                     warn!(
@@ -456,7 +456,7 @@ where
         } else {
             String::new()
         };
-        let pop_time = get_current_millis();
+        let pop_time = current_millis();
 
         let mut rest_num = 0; // remaining number of messages to be fetched
         if need_retry && !request_header.order.unwrap_or(false) {
@@ -1446,7 +1446,7 @@ impl<MS: MessageStore> PopMessageProcessor<MS> {
         msg.set_body(Bytes::from(ck.serialize_json().unwrap()));
         msg.message_ext_inner.queue_id = revive_qid;
         msg.set_tags(CheetahString::from_static_str(PopAckConstants::CK_TAG));
-        msg.message_ext_inner.born_timestamp = get_current_millis() as i64;
+        msg.message_ext_inner.born_timestamp = current_millis() as i64;
         msg.message_ext_inner.born_host = store_host;
         msg.message_ext_inner.store_host = store_host;
         msg.set_delay_time_ms((ck.get_revive_time() - PopAckConstants::ACK_TIME_INTERVAL) as u64);
@@ -1468,7 +1468,7 @@ impl TimedLock {
     pub fn new() -> Self {
         TimedLock {
             lock: AtomicBool::new(false),
-            lock_time: AtomicU64::new(get_current_millis()),
+            lock_time: AtomicU64::new(current_millis()),
         }
     }
 
@@ -1478,7 +1478,7 @@ impl TimedLock {
             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
         {
             Ok(_) => {
-                self.lock_time.store(get_current_millis(), Ordering::Relaxed);
+                self.lock_time.store(current_millis(), Ordering::Relaxed);
                 true
             }
             Err(_) => false,
@@ -1555,7 +1555,7 @@ impl QueueLockManager {
     pub async fn clean_unused_locks(&self, used_expire_millis: u64) -> usize {
         let mut cache = self.expired_local_cache.write().await;
         let count = cache.len();
-        cache.retain(|_, lock| get_current_millis() - lock.get_lock_time() <= used_expire_millis);
+        cache.retain(|_, lock| current_millis() - lock.get_lock_time() <= used_expire_millis);
         count
     }
 

--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -34,7 +34,7 @@ use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::pop_ack_constants::PopAckConstants;
 use rocketmq_common::utils::data_converter::DataConverter;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::RemotingSerializable;
@@ -129,7 +129,7 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
             });
         }
 
-        let now = get_current_millis();
+        let now = current_millis();
         if point.get_revive_time() - (now as i64) < broker_config.pop_ck_stay_buffer_time_out as i64 + 1500 {
             if broker_config.enable_pop_log {
                 warn!("[PopBuffer]add ck, timeout, {:?}, {}", point, now);
@@ -286,7 +286,7 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
             return false;
         }
         let point = point_wrapper.get_ck();
-        let now = get_current_millis();
+        let now = current_millis();
         let revive_time = point.get_revive_time() as u64;
         let pop_time = point.pop_time as u64;
 
@@ -408,7 +408,7 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
         let pop_ck_stay_buffer_time = broker_config.pop_ck_stay_buffer_time as i64;
         let enable_pop_log = broker_config.enable_pop_log;
 
-        let now = get_current_millis() as i64;
+        let now = current_millis() as i64;
         let mut remove_keys = HashSet::with_capacity(256);
 
         for entry in self.buffer.iter() {
@@ -541,7 +541,7 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
         }
     }
     fn scan_garbage(&mut self) {
-        let current_millis = get_current_millis();
+        let current_millis = current_millis();
         let timeout_threshold = self.minute5;
 
         self.commit_offsets.retain(|key, value| {
@@ -880,7 +880,7 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
         msg.set_body(Bytes::from(batch_ack_msg.serialize_json().unwrap()));
         msg.message_ext_inner.queue_id = point_wrapper.revive_queue_id;
         msg.set_tags(CheetahString::from_static_str(PopAckConstants::BATCH_ACK_TAG));
-        msg.message_ext_inner.born_timestamp = get_current_millis() as i64;
+        msg.message_ext_inner.born_timestamp = current_millis() as i64;
         msg.message_ext_inner.born_host = self.broker_runtime_inner.store_host();
         msg.message_ext_inner.store_host = self.broker_runtime_inner.store_host();
         msg.set_delay_time_ms(point.get_revive_time() as u64);
@@ -920,7 +920,7 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
         msg.set_body(Bytes::from(ack_msg.serialize_json().unwrap()));
         msg.message_ext_inner.queue_id = point_wrapper.revive_queue_id;
         msg.set_tags(CheetahString::from_static_str(PopAckConstants::ACK_TAG));
-        msg.message_ext_inner.born_timestamp = get_current_millis() as i64;
+        msg.message_ext_inner.born_timestamp = current_millis() as i64;
         msg.message_ext_inner.born_host = self.broker_runtime_inner.store_host();
         msg.message_ext_inner.store_host = self.broker_runtime_inner.store_host();
         msg.set_delay_time_ms(point.get_revive_time() as u64);
@@ -975,7 +975,7 @@ impl<T> QueueWithTime<T> {
     pub fn new() -> Self {
         Self {
             queue: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
-            time: get_current_millis(),
+            time: current_millis(),
         }
     }
 

--- a/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
@@ -39,7 +39,7 @@ use rocketmq_common::common::TopicFilterType;
 use rocketmq_common::utils::data_converter::DataConverter;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_common::MessageAccessor::MessageAccessor;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::get_message_result::GetMessageResult;
 use rocketmq_store::base::message_status_enum::AppendMessageStatus;
@@ -318,7 +318,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
                     break;
                 }
 
-                if get_current_millis() < this.broker_runtime_inner.should_start_time().load(Relaxed) {
+                if current_millis() < this.broker_runtime_inner.should_start_time().load(Relaxed) {
                     info!(
                         "PopReviveService Ready to run after {}",
                         this.broker_runtime_inner.should_start_time().load(Relaxed)
@@ -366,12 +366,12 @@ impl<MS: MessageStore> PopReviveService<MS> {
                 let mut delay = 0;
                 if let Some(ref sort_list) = consume_revive_obj.sort_list {
                     if !sort_list.is_empty() {
-                        delay = (get_current_millis() - (sort_list[0].get_revive_time() as u64)) / 1000;
+                        delay = (current_millis() - (sort_list[0].get_revive_time() as u64)) / 1000;
                         this.current_revive_message_timestamp = sort_list[0].get_revive_time();
                         slow = 1;
                     }
                 } else {
-                    this.current_revive_message_timestamp = get_current_millis() as i64;
+                    this.current_revive_message_timestamp = current_millis() as i64;
                 }
                 if this.broker_runtime_inner.broker_config().enable_pop_log {
                     info!(
@@ -400,7 +400,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
     async fn consume_revive_message(&self, consume_revive_obj: &mut ConsumeReviveObj) {
         let map = &mut consume_revive_obj.map;
         let mut mock_point_map = HashMap::new();
-        let _start_scan_time = get_current_millis();
+        let _start_scan_time = current_millis();
         let mut end_time = 0;
         let consume_offset = self.broker_runtime_inner.consumer_offset_manager().query_offset(
             &CheetahString::from_static_str(PopAckConstants::REVIVE_GROUP),
@@ -436,11 +436,11 @@ impl<MS: MessageStore> PopReviveService<MS> {
                     .map(|timer_store| (timer_store.get_dequeue_behind(), timer_store.get_enqueue_behind()))
                     .unwrap_or((0, 0));
                 if end_time != 0
-                    && get_current_millis() - end_time > (3 * PopAckConstants::SECOND) as u64
+                    && current_millis() - end_time > (3 * PopAckConstants::SECOND) as u64
                     && timer_delay <= 0
                     && commit_log_delay <= 0
                 {
-                    end_time = get_current_millis();
+                    end_time = current_millis();
                 }
                 if self.broker_runtime_inner.broker_config().enable_pop_log {
                     info!(
@@ -464,7 +464,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
                 no_msg_count = 0;
             }
 
-            if get_current_millis() > self.broker_runtime_inner.broker_config().revive_scan_time {
+            if current_millis() > self.broker_runtime_inner.broker_config().revive_scan_time {
                 info!("reviveQueueId={}, scan timeout", self.queue_id);
                 break;
             }
@@ -649,7 +649,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
         merge_key: &CheetahString,
         mock_point_map: &mut HashMap<CheetahString, PopCheckPoint>,
     ) -> bool {
-        let now = get_current_millis();
+        let now = current_millis();
         let ack_wait_time = now - message_ext.get_deliver_time_ms();
         let revive_ack_wait_ms = self.broker_runtime_inner.broker_config().revive_ack_wait_ms;
         if ack_wait_time > revive_ack_wait_ms {
@@ -753,7 +753,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
                     let len = inflight_map.len();
 
                     // Find first timeout request
-                    let now = get_current_millis();
+                    let now = current_millis();
                     let timeout = inflight_map
                         .iter()
                         .find(|(_, (timestamp, completed))| {
@@ -843,7 +843,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
         new_ck.add_diff(0);
         new_ck.set_re_put_times(Some(CheetahString::from_string((re_put_times + 1).to_string())));
 
-        if old_ck.get_revive_time() <= get_current_millis() as i64 {
+        if old_ck.get_revive_time() <= current_millis() as i64 {
             let interval_index = if re_put_times >= self.ck_rewrite_intervals_in_seconds.len() as i32 {
                 self.ck_rewrite_intervals_in_seconds.len() - 1
             } else {
@@ -876,7 +876,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
             );
             return;
         }
-        let now = get_current_millis() as i64;
+        let now = current_millis() as i64;
         this.inflight_revive_request_map
             .lock()
             .await
@@ -994,7 +994,7 @@ impl<MS: MessageStore> PopReviveService<MS> {
             .get_max_offset_in_queue(&self.revive_topic, self.queue_id);
         let revive_offset = self.revive_offset.load(Ordering::Acquire);
         if max_offset - revive_offset > 1 {
-            let now = get_current_millis() as i64;
+            let now = current_millis() as i64;
             return std::cmp::max(0, now - self.current_revive_message_timestamp);
         }
         0
@@ -1087,7 +1087,7 @@ mod tests {
     use rocketmq_common::common::key_builder::KeyBuilder;
     use rocketmq_common::common::mix_all;
     use rocketmq_common::common::pop_ack_constants::PopAckConstants;
-    use rocketmq_common::TimeUtils::get_current_millis;
+    use rocketmq_common::TimeUtils::current_millis;
     use rocketmq_store::pop::ack_msg::AckMsg;
     use rocketmq_store::pop::pop_check_point::PopCheckPoint;
 
@@ -1320,7 +1320,7 @@ mod tests {
         });
 
         // Reader task: polls flag until it becomes true
-        let start = get_current_millis();
+        let start = current_millis();
         loop {
             if flag.load(Ordering::Acquire) {
                 break;
@@ -1328,7 +1328,7 @@ mod tests {
             tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
             // Timeout after 1 second
-            if get_current_millis() - start > 1000 {
+            if current_millis() - start > 1000 {
                 panic!("Flag was never set to true - visibility issue!");
             }
         }

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -20,7 +20,7 @@ use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::filter::expression_type::ExpressionType;
 use rocketmq_common::common::sys_flag::pull_sys_flag::PullSysFlag;
 use rocketmq_common::common::FAQUrl;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::RemotingSysResponseCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
@@ -628,7 +628,7 @@ where
         broker_allow_suspend: bool,
         broker_allow_flow_ctr_suspend: bool,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let begin_time_mills = get_current_millis();
+        let begin_time_mills = current_millis();
         let mut response = RemotingCommand::create_response_command();
         response.set_opaque_mut(request.opaque());
         let mut request_header = request

--- a/rocketmq-broker/src/processor/recall_message_processor.rs
+++ b/rocketmq-broker/src/processor/recall_message_processor.rs
@@ -23,7 +23,7 @@ use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::producer::recall_message_handle::RecallMessageHandle;
 use rocketmq_common::MessageDecoder;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
@@ -129,7 +129,7 @@ where
             .broker_runtime_inner
             .broker_config()
             .start_accept_send_request_time_stamp;
-        if get_current_millis() < start_timestamp as u64 {
+        if current_millis() < start_timestamp as u64 {
             return Ok(response.set_code(ResponseCode::ServiceNotAvailable).set_remark(
                 CheetahString::from_static_str("recall failed, broker service not available"),
             ));
@@ -191,7 +191,7 @@ where
         }
 
         let timestamp = handle_timestamp_str.parse::<i64>().unwrap_or(-1);
-        let current_time_millis = get_current_millis() as i64;
+        let current_time_millis = current_millis() as i64;
         let time_left = timestamp - current_time_millis;
         let timer_max_delay_sec = self.broker_runtime_inner.message_store_config().timer_max_delay_sec as i64;
 
@@ -209,7 +209,7 @@ where
             handle_message_id,
         );
 
-        let begin_time_millis = get_current_millis();
+        let begin_time_millis = current_millis();
         let put_message_result = self
             .broker_runtime_inner
             .message_store_mut()
@@ -258,7 +258,7 @@ where
         );
         properties.insert(
             CheetahString::from_static_str(MessageConst::PROPERTY_BORN_TIMESTAMP),
-            CheetahString::from_string(get_current_millis().to_string()),
+            CheetahString::from_string(current_millis().to_string()),
         );
         properties.insert(
             CheetahString::from_static_str(MessageConst::PROPERTY_TRACE_CONTEXT),
@@ -294,7 +294,7 @@ where
             store_size: 0,
             queue_offset: 0,
             sys_flag: 0,
-            born_timestamp: get_current_millis() as i64,
+            born_timestamp: current_millis() as i64,
             born_host,
             store_timestamp: 0,
             store_host,
@@ -348,7 +348,7 @@ where
                     .broker_stats_manager()
                     .inc_broker_put_nums(&topic, msg_num);
 
-                let latency = (get_current_millis() - begin_time_millis) as i32;
+                let latency = (current_millis() - begin_time_millis) as i32;
                 self.broker_runtime_inner
                     .broker_stats_manager()
                     .inc_topic_put_latency(&topic, 0, latency);

--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -19,7 +19,7 @@ use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -186,7 +186,7 @@ where
             .add_ext_field(MessageConst::PROPERTY_MSG_REGION, region_id.as_str())
             .add_ext_field(MessageConst::PROPERTY_TRACE_SWITCH, trace_on.to_string());
 
-        if get_current_millis() < start_timstamp {
+        if current_millis() < start_timstamp {
             return response
                 .set_code(ResponseCode::SystemError)
                 .set_remark(format!("broker unable to service, until, {start_timstamp}"));
@@ -452,7 +452,7 @@ where
         // Add PROPERTY_PUSH_REPLY_TIME to message properties BEFORE building header
         msg.put_property(
             CheetahString::from_static_str(MessageConst::PROPERTY_PUSH_REPLY_TIME),
-            CheetahString::from_string(get_current_millis().to_string()),
+            CheetahString::from_string(current_millis().to_string()),
         );
 
         // Build reply message request header with properties (including PROPERTY_PUSH_REPLY_TIME)
@@ -523,7 +523,7 @@ where
         ReplyMessageRequestHeader {
             born_host,
             store_host,
-            store_timestamp: get_current_millis() as i64,
+            store_timestamp: current_millis() as i64,
             producer_group: request_header.producer_group.clone(),
             topic: request_header.topic.clone(),
             default_topic: request_header.default_topic.clone(),

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -1377,7 +1377,7 @@ where
         send_message_context.queue_id(Some(request_header.queue_id));
         send_message_context.broker_region_id(CheetahString::from_string(region_id.clone()));
         send_message_context.born_time_stamp(request_header.born_timestamp);
-        send_message_context.request_time_stamp(TimeUtils::get_current_millis() as i64);
+        send_message_context.request_time_stamp(TimeUtils::current_millis() as i64);
 
         if let Some(owner) = request.ext_fields() {
             if let Some(value) = owner.get(BrokerStatsManager::COMMERCIAL_OWNER) {

--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -39,7 +39,7 @@ use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_common::FileUtils;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_rust::ArcMut;
@@ -880,7 +880,7 @@ impl<MS: MessageStore> DeliverDelayedMessageTimerTask<MS> {
             }
 
             // Check if it's time to deliver the message
-            let now = get_current_millis() as i64;
+            let now = current_millis() as i64;
             let deliver_timestamp = self.correct_deliver_timestamp(now, tags_code);
 
             let curr_offset = cq_unit.queue_offset;

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
@@ -28,7 +28,7 @@ use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::topic::TopicValidator;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
 use rocketmq_rust::ArcMut;
@@ -115,7 +115,7 @@ where
     }
 
     pub async fn batch_send_op_message(&self) -> u64 {
-        let start_time = get_current_millis();
+        let start_time = current_millis();
         let broker_config = self.transactional_message_bridge.broker_runtime_inner.broker_config();
         let interval = broker_config.transaction_op_batch_interval;
         let max_size = broker_config.transaction_op_msg_max_size as usize;
@@ -233,7 +233,7 @@ where
         debug!("Check topic={}, queues={:?}", topic, msg_queues);
 
         for message_queue in msg_queues {
-            let start_time = get_current_millis() as i64;
+            let start_time = current_millis() as i64;
             let op_queue = self.get_op_queue(&message_queue).await;
 
             let half_offset = self.transactional_message_bridge.fetch_consume_offset(&message_queue);
@@ -323,7 +323,7 @@ where
         let listener = &mut listener;
 
         loop {
-            let current_time = get_current_millis() as i64;
+            let current_time = current_millis() as i64;
             if current_time - start_time > MAX_PROCESS_TIME_LIMIT as i64 {
                 info!(
                     "Queue={:?} process time reach max={}",
@@ -426,7 +426,7 @@ where
                 }
 
                 // Handle immunity time logic
-                let current_time = get_current_millis() as i64;
+                let current_time = current_millis() as i64;
                 let value_of_current_minus_born = current_time - msg_ext.born_timestamp();
                 let mut check_immunity_time = transaction_timeout as i64;
 
@@ -558,7 +558,7 @@ where
         let msg_time = get_result
             .get_msg()
             .map(|msg| msg.store_timestamp())
-            .unwrap_or_else(|| get_current_millis() as i64);
+            .unwrap_or_else(|| current_millis() as i64);
 
         info!(
             "After check, {:?} opOffset={} opOffsetDiff={} msgOffset={} msgOffsetDiff={} msgTime={} \
@@ -569,7 +569,7 @@ where
             new_offset,
             max_msg_offset - new_offset as u64,
             msg_time,
-            get_current_millis() as i64 - msg_time,
+            current_millis() as i64 - msg_time,
             put_in_queue_count
         );
 
@@ -717,7 +717,7 @@ where
 
     /// Check if message needs to be skipped
     fn need_skip(&self, msg_ext: &MessageExt) -> bool {
-        let value_of_current_minus_born = get_current_millis() as i64 - msg_ext.born_timestamp();
+        let value_of_current_minus_born = current_millis() as i64 - msg_ext.born_timestamp();
 
         let file_reserved_time = self
             .transactional_message_bridge
@@ -977,7 +977,7 @@ where
         let mut delete_context = self.delete_context.lock().await;
         let mq_context = delete_context
             .entry(queue_id)
-            .or_insert(MessageQueueOpContext::new(get_current_millis(), 20000));
+            .or_insert(MessageQueueOpContext::new(current_millis(), 20000));
         let data = format!(
             "{}{}",
             message_ext.queue_offset,

--- a/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_message_bridge.rs
@@ -34,7 +34,7 @@ use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::get_message_result::GetMessageResult;
@@ -337,7 +337,7 @@ where
         msg_inner.message_ext_inner.sys_flag = 0;
         msg_inner.properties_string = MessageDecoder::message_properties_to_string(msg_inner.get_properties());
 
-        msg_inner.message_ext_inner.born_timestamp = get_current_millis() as i64;
+        msg_inner.message_ext_inner.born_timestamp = current_millis() as i64;
         msg_inner.message_ext_inner.born_host = self.store_host;
         msg_inner.message_ext_inner.store_host = self.store_host;
         msg_inner.set_wait_store_msg_ok(false);

--- a/rocketmq-broker/src/transaction/queue/transactional_op_batch_service.rs
+++ b/rocketmq-broker/src/transaction/queue/transactional_op_batch_service.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::task::service_task::ServiceContext;
 use rocketmq_rust::task::service_task::ServiceTask;
 use rocketmq_rust::task::ServiceManager;
@@ -86,12 +86,12 @@ where
         info!("TransactionalOpBatchService started");
         let transaction_op_batch_interval = self.broker_config.transaction_op_batch_interval;
         self.wakeup_timestamp.store(
-            get_current_millis() + transaction_op_batch_interval,
+            current_millis() + transaction_op_batch_interval,
             std::sync::atomic::Ordering::Relaxed,
         );
         while !context.is_stopped() {
             let mut interval =
-                self.wakeup_timestamp.load(std::sync::atomic::Ordering::Relaxed) as i64 - get_current_millis() as i64;
+                self.wakeup_timestamp.load(std::sync::atomic::Ordering::Relaxed) as i64 - current_millis() as i64;
             if interval <= 0 {
                 interval = 0;
                 context.wakeup();

--- a/rocketmq-broker/src/util/hook_utils.rs
+++ b/rocketmq-broker/src/util/hook_utils.rs
@@ -29,7 +29,7 @@ use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::utils::queue_type_utils::QueueTypeUtils;
 use rocketmq_common::MessageDecoder::message_properties_to_string;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
@@ -235,9 +235,9 @@ impl HookUtils {
     ) -> Option<PutMessageResult> {
         let delay_level = msg.message_ext_inner.message.get_delay_time_level();
         let deliver_ms = match msg.property(MessageConst::PROPERTY_TIMER_DELAY_SEC) {
-            Some(delay_sec) => get_current_millis() + delay_sec.parse::<u64>().unwrap() * 1000,
+            Some(delay_sec) => current_millis() + delay_sec.parse::<u64>().unwrap() * 1000,
             None => match msg.property(MessageConst::PROPERTY_TIMER_DELAY_MS) {
-                Some(delay_ms) => get_current_millis() + delay_ms.parse::<u64>().unwrap(),
+                Some(delay_ms) => current_millis() + delay_ms.parse::<u64>().unwrap(),
                 None => match msg.property(MessageConst::PROPERTY_TIMER_DELIVER_MS) {
                     Some(deliver_ms) => deliver_ms.parse::<u64>().unwrap(),
                     None => return Some(PutMessageResult::new_default(PutMessageStatus::WheelTimerMsgIllegal)),
@@ -245,8 +245,8 @@ impl HookUtils {
             },
         };
 
-        if deliver_ms > get_current_millis() {
-            if delay_level <= 0 && deliver_ms - get_current_millis() > message_store_config.timer_max_delay_sec * 1000 {
+        if deliver_ms > current_millis() {
+            if delay_level <= 0 && deliver_ms - current_millis() > message_store_config.timer_max_delay_sec * 1000 {
                 return Some(PutMessageResult::new_default(PutMessageStatus::WheelTimerMsgIllegal));
             }
 

--- a/rocketmq-client/src/base/client_config.rs
+++ b/rocketmq-client/src/base/client_config.rs
@@ -24,7 +24,7 @@ use rocketmq_common::utils::name_server_address_utils::NameServerAddressUtils;
 use rocketmq_common::utils::name_server_address_utils::NAMESRV_ENDPOINT_PATTERN;
 use rocketmq_common::utils::network_util::NetworkUtil;
 use rocketmq_common::utils::string_utils::StringUtils;
-use rocketmq_common::TimeUtils::get_current_nano;
+use rocketmq_common::TimeUtils::current_nano;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::protocol::request_type::RequestType;
 use rocketmq_remoting::protocol::LanguageCode;
@@ -209,7 +209,7 @@ impl ClientConfig {
     #[inline]
     pub fn change_instance_name_to_pid(&mut self) {
         if self.instance_name == "DEFAULT" {
-            self.instance_name = format!("{}#{}", std::process::id(), get_current_nano()).into();
+            self.instance_name = format!("{}#{}", std::process::id(), current_nano()).into();
         }
     }
     #[inline]

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -22,7 +22,7 @@ use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::MessageAccessor::MessageAccessor;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::body::cm_result::CMResult;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
@@ -432,7 +432,7 @@ impl ConsumeRequest {
         let mut status = None;
 
         if !self.msgs.is_empty() {
-            let start_ts = CheetahString::from_string(get_current_millis().to_string());
+            let start_ts = CheetahString::from_string(current_millis().to_string());
             for msg in self.msgs.iter_mut() {
                 MessageAccessor::set_consume_start_time_stamp(msg.as_mut(), start_ts.clone());
             }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -27,7 +27,7 @@ use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::MessageAccessor::MessageAccessor;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::body::cm_result::CMResult;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::header::extra_info_util::ExtraInfoUtil;
@@ -378,7 +378,7 @@ impl ConsumeMessagePopConcurrentlyService {
             .pop_delay_level
             .as_ref();
         let delay_time = delay_level_table[delay_level_table.len() - 1] * 1000 * 2;
-        let msg_delay_time = get_current_millis() - message.born_timestamp as u64;
+        let msg_delay_time = current_millis() - message.born_timestamp as u64;
         if msg_delay_time > delay_time as u64 {
             warn!("Consume too many times, ack message async. message {}", message);
             self.default_mqpush_consumer_impl
@@ -515,7 +515,7 @@ impl ConsumeRequest {
         if self.msgs.is_empty() || self.pop_time == 0 || self.invisible_time == 0 {
             return true;
         }
-        get_current_millis().saturating_sub(self.pop_time) >= self.invisible_time
+        current_millis().saturating_sub(self.pop_time) >= self.invisible_time
     }
 
     pub async fn run(mut self, mut consume_message_concurrently_service: ArcMut<ConsumeMessagePopConcurrentlyService>) {
@@ -573,7 +573,7 @@ impl ConsumeRequest {
             for msg in self.msgs.iter_mut() {
                 MessageAccessor::set_consume_start_time_stamp(
                     msg.as_mut(),
-                    CheetahString::from_string(get_current_millis().to_string()),
+                    CheetahString::from_string(current_millis().to_string()),
                 );
             }
         }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -33,7 +33,7 @@ use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mix_all::DEFAULT_CONSUMER_GROUP;
 use rocketmq_common::common::sys_flag::pull_sys_flag::PullSysFlag;
 use rocketmq_common::MessageAccessor::MessageAccessor;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::ClientErr;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInfo;
@@ -696,7 +696,7 @@ impl DefaultMQPushConsumerImpl {
             info!("the pop request[{}] is dropped.", pop_request);
             return;
         }
-        process_queue.set_last_pop_timestamp(get_current_millis());
+        process_queue.set_last_pop_timestamp(current_millis());
 
         if let Err(e) = self.make_sure_state_ok() {
             warn!("pop_message exception, consumer state not ok {}", e);
@@ -780,7 +780,7 @@ impl DefaultMQPushConsumerImpl {
             info!("the pull request[{}] is dropped.", pull_request);
             return;
         }
-        pull_request.process_queue.set_last_pull_timestamp(get_current_millis());
+        pull_request.process_queue.set_last_pull_timestamp(current_millis());
         if let Err(e) = self.make_sure_state_ok() {
             warn!("pullMessage exception, consumer state not ok {}", e);
             self.execute_pull_request_later(pull_request, self.pull_time_delay_mills_when_exception);

--- a/rocketmq-client/src/consumer/consumer_impl/pop_process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pop_process_queue.rs
@@ -22,7 +22,7 @@ use std::sync::atomic::Ordering::Acquire;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
 
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::body::pop_process_queue_info::PopProcessQueueInfo;
 
 use crate::consumer::consumer_impl::PULL_MAX_IDLE_TIME;
@@ -46,7 +46,7 @@ impl Hash for PopProcessQueue {
 impl Default for PopProcessQueue {
     fn default() -> Self {
         PopProcessQueue {
-            last_pop_timestamp: Arc::new(AtomicU64::new(get_current_millis())),
+            last_pop_timestamp: Arc::new(AtomicU64::new(current_millis())),
             wait_ack_counter: Arc::new(AtomicUsize::new(0)),
             dropped: Arc::new(AtomicBool::new(false)),
         }
@@ -108,7 +108,7 @@ impl PopProcessQueue {
 
     #[inline]
     pub(crate) fn is_pull_expired(&self) -> bool {
-        let current_time = get_current_millis();
+        let current_time = current_millis();
         current_time.saturating_sub(self.last_pop_timestamp.load(Acquire)) > *PULL_MAX_IDLE_TIME
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -25,7 +25,7 @@ use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::MessageAccessor::MessageAccessor;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::body::process_queue_info::ProcessQueueInfo;
 use rocketmq_rust::ArcMut;
 use tokio::sync::RwLock;
@@ -90,7 +90,7 @@ impl Default for ProcessQueue {
 
 impl ProcessQueue {
     pub fn new() -> Self {
-        let now = get_current_millis();
+        let now = current_millis();
         ProcessQueue {
             store: RwLock::new(ProcessQueueStore::new()),
             consume_lock: Arc::new(RwLock::new(())),
@@ -129,11 +129,11 @@ impl ProcessQueue {
     }
 
     pub(crate) fn is_pull_expired(&self) -> bool {
-        (get_current_millis() - self.last_pull_timestamp.load(Ordering::Acquire)) > *PULL_MAX_IDLE_TIME
+        (current_millis() - self.last_pull_timestamp.load(Ordering::Acquire)) > *PULL_MAX_IDLE_TIME
     }
 
     pub(crate) fn is_lock_expired(&self) -> bool {
-        (get_current_millis() - self.last_lock_timestamp.load(Ordering::Acquire)) > *REBALANCE_LOCK_MAX_LIVE_TIME
+        (current_millis() - self.last_lock_timestamp.load(Ordering::Acquire)) > *REBALANCE_LOCK_MAX_LIVE_TIME
     }
 
     pub(crate) fn inc_try_unlock_times(&self) {
@@ -158,7 +158,7 @@ impl ProcessQueue {
                     let consume_start_time_stamp = MessageAccessor::get_consume_start_time_stamp(value.as_ref());
                     if let Some(ts_str) = consume_start_time_stamp {
                         if let Ok(ts) = ts_str.parse::<u64>() {
-                            if get_current_millis() - ts > push_consumer.consumer_config.consume_timeout * 1000 * 60 {
+                            if current_millis() - ts > push_consumer.consumer_config.consume_timeout * 1000 * 60 {
                                 Some(value.clone())
                             } else {
                                 None
@@ -258,7 +258,7 @@ impl ProcessQueue {
     }
 
     pub(crate) async fn remove_message(&self, messages: &[ArcMut<MessageExt>]) -> i64 {
-        let now = get_current_millis();
+        let now = current_millis();
         let mut store = self.store.write().await;
 
         self.last_consume_timestamp.store(now, Ordering::Release);
@@ -334,7 +334,7 @@ impl ProcessQueue {
 
     pub(crate) async fn take_messages(&self, batch_size: u32) -> Vec<ArcMut<MessageExt>> {
         let mut messages = Vec::with_capacity(batch_size as usize);
-        let now = get_current_millis();
+        let now = current_millis();
         let mut store = self.store.write().await;
 
         self.last_consume_timestamp.store(now, Ordering::Release);
@@ -696,7 +696,7 @@ mod tests {
         assert!(consume_ts > 0);
         assert!(lock_ts > 0);
 
-        let new_ts = get_current_millis() + 1000;
+        let new_ts = current_millis() + 1000;
         pq.set_last_pull_timestamp(new_ts);
         assert_eq!(pq.get_last_pull_timestamp(), new_ts);
 

--- a/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
@@ -28,7 +28,7 @@ use rocketmq_common::common::mq_version::RocketMqVersion;
 use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_common::common::sys_flag::pull_sys_flag::PullSysFlag;
 use rocketmq_common::MessageAccessor::MessageAccessor;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 use rocketmq_remoting::protocol::header::pop_message_request_header::PopMessageRequestHeader;
 use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
@@ -410,7 +410,7 @@ impl PullAPIWrapper {
             };
             if poll {
                 request_header.poll_time = timeout;
-                request_header.born_time = get_current_millis();
+                request_header.born_time = current_millis();
             }
             self.client_instance
                 .mq_client_api_impl

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
@@ -23,7 +23,7 @@ use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_queue_assignment::MessageQueueAssignment;
 use rocketmq_common::common::mix_all;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
 use rocketmq_remoting::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
 use rocketmq_remoting::protocol::filter::filter_api::FilterAPI;
@@ -1011,7 +1011,7 @@ where
                     for mq in &locked_mq {
                         if let Some(pq) = process_queue_table.get(mq) {
                             pq.set_locked(true);
-                            pq.set_last_pull_timestamp(get_current_millis());
+                            pq.set_last_pull_timestamp(current_millis());
                         }
                     }
                     let lock_ok = locked_mq.contains(mq);
@@ -1071,7 +1071,7 @@ where
                                                 );
                                             }
                                             pq.set_locked(true);
-                                            pq.set_last_lock_timestamp(get_current_millis());
+                                            pq.set_last_lock_timestamp(current_millis());
                                         } else {
                                             pq.set_locked(false);
                                             warn!(
@@ -1126,7 +1126,7 @@ where
                                         );
                                     }
                                     pq.set_locked(true);
-                                    pq.set_last_lock_timestamp(get_current_millis());
+                                    pq.set_last_lock_timestamp(current_millis());
                                 } else {
                                     pq.set_locked(false);
                                     warn!(

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_push_impl.rs
@@ -23,7 +23,7 @@ use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::utils::util_all;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
 use rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType;
@@ -123,7 +123,7 @@ impl RebalancePushImpl {
         };
 
         let force_unlock =
-            pq.is_dropped() && (get_current_millis() > pq.get_last_lock_timestamp() + *UNLOCK_DELAY_TIME_MILLS);
+            pq.is_dropped() && (current_millis() > pq.get_last_lock_timestamp() + *UNLOCK_DELAY_TIME_MILLS);
         let consume_lock = tokio::time::timeout(Duration::from_millis(500), pq.consume_lock.write())
             .await
             .ok();
@@ -163,7 +163,7 @@ impl Rebalance for RebalancePushImpl {
             warn!("Subscription data not found for topic: {}", topic);
             return;
         };
-        let new_version = get_current_millis() as i64;
+        let new_version = current_millis() as i64;
         info!(
             "{} Rebalance changed, also update version: {}, {}",
             topic, subscription_data.sub_version, new_version
@@ -610,7 +610,7 @@ async fn lock_all_impl(
                                             info!("the message queue locked OK, Group: {:?} {}", consumer_group, mq);
                                         }
                                         pq.set_locked(true);
-                                        pq.set_last_lock_timestamp(get_current_millis());
+                                        pq.set_last_lock_timestamp(current_millis());
                                     } else {
                                         pq.set_locked(false);
                                         warn!("the message queue locked Failed, Group: {:?} {}", consumer_group, mq);

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::Shutdown;
 use tokio::select;
@@ -229,14 +229,14 @@ impl RebalanceService {
             let mut last_rebalance_timestamp = tokio::time::Instant::now();
             let min_interval = config.min_interval();
             let mut real_wait_interval = config.wait_interval();
-            info!("RebalanceService started, timestamp={}", get_current_millis());
+            info!("RebalanceService started, timestamp={}", current_millis());
             loop {
                 select! {
                     _ = notify.notified() => {
                         info!("RebalanceService wakeup triggered");
                     }
                     _ = shutdown.recv() => {
-                        info!("RebalanceService shutdown signal received, timestamp={}", get_current_millis());
+                        info!("RebalanceService shutdown signal received, timestamp={}", current_millis());
                         started_clone.store(false, Ordering::SeqCst);
                         return;
                     }
@@ -258,7 +258,7 @@ impl RebalanceService {
                     let balanced = match instance.do_rebalance().await {
                         Ok(result) => {
                             success_count_clone.fetch_add(1, Ordering::Relaxed);
-                            last_success_ts.store(get_current_millis(), Ordering::Relaxed);
+                            last_success_ts.store(current_millis(), Ordering::Relaxed);
                             result
                         }
                         Err(e) => {
@@ -266,7 +266,7 @@ impl RebalanceService {
                             error!(
                                 "RebalanceService: do_rebalance error: {:?}, timestamp={}",
                                 e,
-                                get_current_millis()
+                                current_millis()
                             );
                             false // Treat as unbalanced on exception, retry with min interval
                         }
@@ -289,7 +289,7 @@ impl RebalanceService {
                         balanced,
                         duration_ms,
                         next_interval.as_millis(),
-                        get_current_millis()
+                        current_millis()
                     );
 
                     real_wait_interval = next_interval;
@@ -367,7 +367,7 @@ impl RebalanceService {
             return true;
         }
 
-        let now = get_current_millis();
+        let now = current_millis();
         now - last_success < max_idle_ms
     }
 

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -20,7 +20,7 @@ use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::utils::util_all;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::runtime::RPCHook;
@@ -359,7 +359,7 @@ impl Default for ConsumerConfig {
             message_model: MessageModel::Clustering,
             consume_from_where: ConsumeFromWhere::ConsumeFromLastOffset,
             consume_timestamp: Some(CheetahString::from_string(util_all::time_millis_to_human_string3(
-                (get_current_millis() - (1000 * 60 * 30)) as i64,
+                (current_millis() - (1000 * 60 * 30)) as i64,
             ))),
             allocate_message_queue_strategy: Some(Arc::new(AllocateMessageQueueAveragely)),
             subscription: ArcMut::new(HashMap::new()),

--- a/rocketmq-client/src/consumer/pull_callback.rs
+++ b/rocketmq-client/src/consumer/pull_callback.rs
@@ -62,7 +62,7 @@ impl PullCallback for DefaultPullCallback {
             PullStatus::Found => {
                 let prev_request_offset = pull_request.next_offset;
                 pull_request.set_next_offset(pull_result_ext.pull_result.next_begin_offset as i64);
-                /*let pull_rt = get_current_millis() - begin_timestamp.elapsed().as_millis() as u64;
+                /*let pull_rt = current_millis() - begin_timestamp.elapsed().as_millis() as u64;
                 self.client_instance.as_mut().unwrap().*/
                 let mut first_msg_offset = i64::MAX;
                 if pull_result_ext

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -30,7 +30,7 @@ use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_queue_assignment::MessageQueueAssignment;
 use rocketmq_common::common::mix_all;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::base::connection_net_event::ConnectionNetEvent;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::heartbeat::consumer_data::ConsumerData;
@@ -135,7 +135,7 @@ impl MQClientInstance {
         let mut instance = ArcMut::new(MQClientInstance {
             client_config: shared_config,
             client_id,
-            boot_timestamp: get_current_millis(),
+            boot_timestamp: current_millis(),
             producer_table,
             consumer_table,
             admin_ext_table,

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -23,7 +23,7 @@ use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -94,7 +94,7 @@ impl ClientRemotingProcessor {
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let receive_time = get_current_millis();
+        let receive_time = current_millis();
         let response = RemotingCommand::create_response_command();
         let request_header = request
             .decode_command_custom_header::<ReplyMessageRequestHeader>()

--- a/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
@@ -145,13 +145,12 @@ where
 
         for entry in self.fault_item_table.iter() {
             let (name, fault_item) = (entry.key(), entry.value());
-            if get_current_millis() as i64 - (fault_item.check_stamp.load(std::sync::atomic::Ordering::Relaxed) as i64)
-                < 0
+            if current_millis() as i64 - (fault_item.check_stamp.load(std::sync::atomic::Ordering::Relaxed) as i64) < 0
             {
                 continue;
             }
             fault_item.check_stamp.store(
-                get_current_millis() + self.detect_interval as u64,
+                current_millis() + self.detect_interval as u64,
                 std::sync::atomic::Ordering::Release,
             );
 
@@ -209,7 +208,7 @@ use std::hash::Hash;
 use std::sync::atomic::AtomicBool;
 
 use cheetah_string::CheetahString;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use tracing::info;
 
@@ -238,7 +237,7 @@ impl FaultItem {
     }
 
     pub fn update_not_available_duration(&self, not_available_duration: u64) {
-        let now = get_current_millis();
+        let now = current_millis();
         if not_available_duration > 0
             && now + not_available_duration > self.start_timestamp.load(std::sync::atomic::Ordering::Relaxed)
         {
@@ -259,7 +258,7 @@ impl FaultItem {
     }
 
     pub fn is_available(&self) -> bool {
-        let now = get_current_millis();
+        let now = current_millis();
         now >= self.start_timestamp.load(std::sync::atomic::Ordering::Relaxed)
     }
 

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -27,7 +27,7 @@ use dashmap::DashMap;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageTrait;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use tokio::sync::Mutex;
 
@@ -464,7 +464,7 @@ impl MessageAccumulation {
             aggregate_key,
             messages_size: Arc::new(AtomicI32::new(0)),
             count: 0,
-            create_time: get_current_millis(),
+            create_time: current_millis(),
             completion_notify: Arc::new(tokio::sync::Notify::new()),
         }
     }
@@ -478,7 +478,7 @@ impl MessageAccumulation {
         }
 
         // Condition 2: Time threshold
-        let elapsed = get_current_millis() - self.create_time;
+        let elapsed = current_millis() - self.create_time;
         if elapsed >= hold_ms {
             return true;
         }

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -44,7 +44,7 @@ use rocketmq_common::utils::correlation_id_util::CorrelationIdUtil;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
 use rocketmq_common::RecallMessageHandle;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::ClientErr;
 use rocketmq_error::RocketmqError::RemotingTooMuchRequestError;
 use rocketmq_remoting::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
@@ -1212,7 +1212,7 @@ impl DefaultMQProducerImpl {
             default_topic_queue_nums: self.producer_config.default_topic_queue_nums() as i32,
             queue_id: mq.queue_id(),
             sys_flag,
-            born_timestamp: get_current_millis() as i64,
+            born_timestamp: current_millis() as i64,
             flag: msg.get_flag(),
             properties: Some(MessageDecoder::message_properties_to_string(msg.get_properties())),
             reconsume_times: Some(0),
@@ -2755,7 +2755,7 @@ where
         default_topic_queue_nums: producer_config.default_topic_queue_nums() as i32,
         queue_id: mq.queue_id(),
         sys_flag: 0,
-        born_timestamp: get_current_millis() as i64,
+        born_timestamp: current_millis() as i64,
         flag: msg.get_flag(),
         properties: Some(MessageDecoder::message_properties_to_string(msg.get_properties())),
         reconsume_times: Some(0),

--- a/rocketmq-client/src/trace/trace_context.rs
+++ b/rocketmq-client/src/trace/trace_context.rs
@@ -16,7 +16,7 @@ use std::cmp::Ordering;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_client_id_setter::MessageClientIDSetter;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 
 use crate::base::access_channel::AccessChannel;
 use crate::trace::trace_bean::TraceBean;
@@ -41,7 +41,7 @@ impl TraceContext {
     pub fn new() -> Self {
         TraceContext {
             trace_type: None,
-            time_stamp: get_current_millis(),
+            time_stamp: current_millis(),
             region_id: CheetahString::new(),
             region_name: CheetahString::new(),
             group_name: CheetahString::new(),
@@ -95,7 +95,7 @@ impl std::fmt::Display for TraceContext {
 mod tests {
     use cheetah_string::CheetahString;
     use rocketmq_common::common::message::message_client_id_setter::MessageClientIDSetter;
-    use rocketmq_common::TimeUtils::get_current_millis;
+    use rocketmq_common::TimeUtils::current_millis;
 
     use super::*;
 
@@ -119,7 +119,7 @@ mod tests {
     fn trace_context_with_values() {
         let trace_context = TraceContext {
             trace_type: Some(TraceType::Pub),
-            time_stamp: get_current_millis(),
+            time_stamp: current_millis(),
             region_id: CheetahString::from("region_id"),
             region_name: CheetahString::from("region_name"),
             group_name: CheetahString::from("group_name"),

--- a/rocketmq-common/src/common/coldctr/acc_and_time_stamp.rs
+++ b/rocketmq-common/src/common/coldctr/acc_and_time_stamp.rs
@@ -18,7 +18,7 @@ use std::fmt;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
-use crate::TimeUtils::get_current_millis;
+use crate::TimeUtils::current_millis;
 
 /// Accumulator and timestamp structure for tracking cold read operations
 ///
@@ -45,7 +45,7 @@ impl AccAndTimeStamp {
     /// # Returns
     /// A new AccAndTimeStamp instance with current timestamp
     pub fn new(cold_acc: u64) -> Self {
-        let current_time = get_current_millis();
+        let current_time = current_millis();
         Self {
             cold_acc: AtomicU64::new(cold_acc),
             last_cold_read_time_millis: AtomicU64::new(current_time),
@@ -123,7 +123,7 @@ impl AccAndTimeStamp {
     /// Update the last cold read timestamp to the current time
     #[inline]
     pub fn update_last_cold_read_time(&self) {
-        self.set_last_cold_read_time_millis(get_current_millis());
+        self.set_last_cold_read_time_millis(current_millis());
     }
 
     /// Get the creation timestamp of this structure

--- a/rocketmq-common/src/common/consumer/receipt_handle.rs
+++ b/rocketmq-common/src/common/consumer/receipt_handle.rs
@@ -166,7 +166,7 @@ impl ReceiptHandle {
     /// let expired = handle.is_expired();
     /// ```
     pub fn is_expired(&self) -> bool {
-        self.next_visible_time <= TimeUtils::get_current_millis() as i64
+        self.next_visible_time <= TimeUtils::current_millis() as i64
     }
 
     /// Decode a receipt handle from its string representation

--- a/rocketmq-common/src/common/message/message_client_id_setter.rs
+++ b/rocketmq-common/src/common/message/message_client_id_setter.rs
@@ -31,7 +31,7 @@ use crate::common::message::message_single::Message;
 use crate::common::message::MessageConst;
 use crate::common::message::MessageTrait;
 use crate::utils::util_all;
-use crate::TimeUtils::get_current_millis;
+use crate::TimeUtils::current_millis;
 use crate::UtilAll::bytes_to_string;
 use crate::UtilAll::write_int;
 use crate::UtilAll::write_short;
@@ -56,7 +56,7 @@ static FIX_STRING: LazyLock<Vec<char>> = LazyLock::new(|| {
 });
 
 pub fn create_fake_ip() -> Vec<u8> {
-    get_current_millis().to_be_bytes()[4..].to_vec()
+    current_millis().to_be_bytes()[4..].to_vec()
 }
 
 pub struct MessageClientIDSetter;
@@ -85,7 +85,7 @@ impl MessageClientIDSetter {
         let mut sb = vec!['\0'; *LEN * 2];
         sb[..FIX_STRING.len()].copy_from_slice(&FIX_STRING);
 
-        let current = get_current_millis() as i64;
+        let current = current_millis() as i64;
         if current >= *NEXT_START_TIME.lock() {
             Self::set_start_time(current);
         }

--- a/rocketmq-common/src/common/statistics/statistics_item.rs
+++ b/rocketmq-common/src/common/statistics/statistics_item.rs
@@ -21,7 +21,7 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use crate::common::statistics::interceptor::Interceptor;
-use crate::TimeUtils::get_current_millis;
+use crate::TimeUtils::current_millis;
 
 pub struct StatisticsItem {
     stat_kind: String,
@@ -41,7 +41,7 @@ impl StatisticsItem {
 
         let item_accumulates = item_names.iter().map(|_| AtomicI64::new(0)).collect();
         let invoke_times = AtomicI64::new(0);
-        let last_timestamp = AtomicU64::new(get_current_millis());
+        let last_timestamp = AtomicU64::new(current_millis());
 
         Self {
             stat_kind: stat_kind.to_string(),
@@ -61,7 +61,7 @@ impl StatisticsItem {
         }
 
         self.invoke_times.fetch_add(1, Ordering::SeqCst);
-        self.last_timestamp.store(get_current_millis(), Ordering::SeqCst);
+        self.last_timestamp.store(current_millis(), Ordering::SeqCst);
 
         if let Some(ref interceptor) = self.interceptor {
             interceptor.inc(item_incs);

--- a/rocketmq-common/src/common/statistics/statistics_manager.rs
+++ b/rocketmq-common/src/common/statistics/statistics_manager.rs
@@ -24,7 +24,7 @@ use tokio::time::interval;
 use crate::common::statistics::statistics_item::StatisticsItem;
 use crate::common::statistics::statistics_item_state_getter::StatisticsItemStateGetter;
 use crate::common::statistics::statistics_kind_meta::StatisticsKindMeta;
-use crate::TimeUtils::get_current_millis;
+use crate::TimeUtils::current_millis;
 
 type StatsTable = Arc<RwLock<HashMap<String, HashMap<String, Arc<StatisticsItem>>>>>;
 
@@ -94,7 +94,7 @@ impl StatisticsManager {
 
                     for item in tmp_item_map.values() {
                         let last_time_stamp = item.last_timestamp();
-                        if get_current_millis() - last_time_stamp > Self::MAX_IDLE_TIME
+                        if current_millis() - last_time_stamp > Self::MAX_IDLE_TIME
                             && (statistics_item_state_getter.is_none()
                                 || !statistics_item_state_getter.as_ref().unwrap().online(item))
                         {

--- a/rocketmq-common/src/common/stats/moment_stats_item.rs
+++ b/rocketmq-common/src/common/stats/moment_stats_item.rs
@@ -22,7 +22,7 @@ use tokio::task;
 use tokio::time;
 use tracing::info;
 
-use crate::TimeUtils::get_current_millis;
+use crate::TimeUtils::current_millis;
 use crate::UtilAll::compute_next_minutes_time_millis;
 
 #[derive(Clone)]
@@ -45,7 +45,7 @@ impl MomentStatsItem {
         let self_clone = self;
         tokio::spawn(async move {
             let initial_delay = Duration::from_millis(
-                (compute_next_minutes_time_millis() as i64 - get_current_millis() as i64).unsigned_abs(),
+                (compute_next_minutes_time_millis() as i64 - current_millis() as i64).unsigned_abs(),
             );
             time::sleep(initial_delay).await;
             let interval = time::interval(Duration::from_secs(300));

--- a/rocketmq-common/src/common/stats/moment_stats_item_set.rs
+++ b/rocketmq-common/src/common/stats/moment_stats_item_set.rs
@@ -21,7 +21,7 @@ use tokio::time::interval;
 use tokio::time::Duration;
 
 use crate::common::stats::moment_stats_item::MomentStatsItem;
-use crate::TimeUtils::get_current_millis;
+use crate::TimeUtils::current_millis;
 use crate::UtilAll::compute_next_minutes_time_millis;
 
 #[derive(Clone)]
@@ -54,9 +54,8 @@ impl MomentStatsItemSet {
 
     pub fn init(&self) {
         let stats_item_table = Arc::clone(&self.stats_item_table);
-        let initial_delay = Duration::from_millis(
-            (compute_next_minutes_time_millis() as i64 - get_current_millis() as i64).unsigned_abs(),
-        );
+        let initial_delay =
+            Duration::from_millis((compute_next_minutes_time_millis() as i64 - current_millis() as i64).unsigned_abs());
 
         let mut interval = tokio::time::interval(Duration::from_secs(300));
 

--- a/rocketmq-common/src/utils/http_tiny_client.rs
+++ b/rocketmq-common/src/utils/http_tiny_client.rs
@@ -29,7 +29,7 @@ use rocketmq_error::RocketMQResult;
 
 use crate::common::mq_version::RocketMqVersion;
 use crate::common::mq_version::CURRENT_VERSION;
-use crate::TimeUtils::get_current_millis;
+use crate::TimeUtils::current_millis;
 
 /// Global HTTP client with connection pool
 /// Reuses connections across requests for better performance
@@ -401,7 +401,7 @@ impl HttpTinyClient {
             format!("application/x-www-form-urlencoded;charset={encoding}"),
         );
 
-        let timestamp = get_current_millis();
+        let timestamp = current_millis();
         request_builder = request_builder.header("Metaq-Client-RequestTS", timestamp.to_string());
 
         Ok(request_builder)

--- a/rocketmq-common/src/utils/time_utils.rs
+++ b/rocketmq-common/src/utils/time_utils.rs
@@ -12,6 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Time utility functions for obtaining the current wall-clock time.
+//!
+//! All functions query [`std::time::SystemTime::now`] and return the elapsed
+//! duration since the Unix epoch in the requested unit.
+
+/// Returns the current Unix timestamp in milliseconds.
+///
+/// # Panics
+///
+/// Panics if the system clock is set to a time before the Unix epoch.
+#[deprecated(since = "0.8.0", note = "use `current_millis` instead")]
 #[inline(always)]
 pub fn get_current_millis() -> u64 {
     std::time::SystemTime::now()
@@ -20,12 +31,57 @@ pub fn get_current_millis() -> u64 {
         .as_millis() as u64
 }
 
+/// Returns the current Unix timestamp in nanoseconds.
+///
+/// # Panics
+///
+/// Panics if the system clock is set to a time before the Unix epoch.
+#[deprecated(since = "0.8.0", note = "use `current_nano` instead")]
 #[inline(always)]
 pub fn get_current_nano() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos() as u64
+}
+
+/// Returns the current Unix timestamp in milliseconds.
+///
+/// # Panics
+///
+/// Panics if the system clock is set to a time before the Unix epoch.
+#[inline(always)]
+pub fn current_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+/// Returns the current Unix timestamp in nanoseconds.
+///
+/// # Panics
+///
+/// Panics if the system clock is set to a time before the Unix epoch.
+#[inline(always)]
+pub fn current_nano() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+}
+
+/// Returns the current Unix timestamp in whole seconds.
+///
+/// # Panics
+///
+/// Panics if the system clock is set to a time before the Unix epoch.
+#[inline(always)]
+pub fn current_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
 }
 
 #[cfg(test)]
@@ -36,6 +92,7 @@ mod tests {
 
     use super::*;
 
+    #[allow(deprecated)]
     #[test]
     fn get_current_millis_returns_correct_value() {
         let before = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
@@ -44,11 +101,73 @@ mod tests {
         assert!(current >= before && current <= after);
     }
 
+    #[allow(deprecated)]
     #[test]
     fn get_current_nano_returns_correct_value() {
         let before = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
         let current = get_current_nano();
         let after = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
         assert!(current >= before && current <= after);
+    }
+
+    #[test]
+    fn current_millis_returns_correct_value() {
+        let before = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+        let current = current_millis();
+        let after = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+        assert!(current >= before && current <= after);
+    }
+
+    #[test]
+    fn current_nano_returns_correct_value() {
+        let before = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
+        let current = current_nano();
+        let after = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
+        assert!(current >= before && current <= after);
+    }
+
+    #[test]
+    fn current_secs_returns_correct_value() {
+        let before = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let current = current_secs();
+        let after = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        assert!(current >= before && current <= after);
+    }
+
+    #[test]
+    fn all_timestamps_are_positive() {
+        assert!(current_millis() > 0);
+        assert!(current_nano() > 0);
+        assert!(current_secs() > 0);
+    }
+
+    #[test]
+    fn millis_greater_than_secs() {
+        let secs = current_secs();
+        let millis = current_millis();
+        assert!(millis > secs);
+    }
+
+    #[test]
+    fn nanos_greater_than_millis() {
+        let millis = current_millis();
+        let nanos = current_nano();
+        assert!(nanos > millis);
+    }
+
+    #[test]
+    fn timestamps_are_non_decreasing() {
+        let t1 = current_millis();
+        std::thread::sleep(Duration::from_millis(5));
+        let t2 = current_millis();
+        assert!(t2 >= t1);
+    }
+
+    #[test]
+    fn secs_consistent_with_millis() {
+        let secs = current_secs();
+        let millis_as_secs = current_millis() / 1000;
+        // millis is sampled after secs; millis_as_secs is equal to secs or one ahead.
+        assert!(millis_as_secs == secs || millis_as_secs == secs + 1);
     }
 }

--- a/rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs
+++ b/rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::DashMap;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_rust::ArcMut;
 use tokio::task::JoinHandle;
@@ -111,7 +111,7 @@ impl DefaultBrokerHeartbeatManager {
     ) {
         info!("start scanNotActiveBroker");
 
-        let now_millis = get_current_millis();
+        let now_millis = current_millis();
         let mut to_remove = Vec::new();
 
         // Collect brokers to remove

--- a/rocketmq-controller/src/task/check_not_active_broker_request.rs
+++ b/rocketmq-controller/src/task/check_not_active_broker_request.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -24,7 +24,7 @@ pub struct CheckNotActiveBrokerRequest {
 impl Default for CheckNotActiveBrokerRequest {
     fn default() -> Self {
         Self {
-            check_time_millis: get_current_millis(),
+            check_time_millis: current_millis(),
         }
     }
 }

--- a/rocketmq-namesrv/src/processor/client_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/client_request_processor.rs
@@ -72,7 +72,7 @@ impl ClientRequestProcessor {
 
         Self {
             need_check_namesrv_ready: AtomicBool::new(true),
-            startup_time_millis: TimeUtils::get_current_millis(),
+            startup_time_millis: TimeUtils::current_millis(),
             wait_seconds_millis,
             need_wait_for_service,
             order_message_enable,
@@ -90,7 +90,7 @@ impl ClientRequestProcessor {
 
         // Early return: Check if nameserver is ready (using cached config)
         if self.need_wait_for_service {
-            let elapsed_millis = TimeUtils::get_current_millis().saturating_sub(self.startup_time_millis);
+            let elapsed_millis = TimeUtils::current_millis().saturating_sub(self.startup_time_millis);
             let namesrv_ready =
                 !self.need_check_namesrv_ready.load(Ordering::Relaxed) || elapsed_millis >= self.wait_seconds_millis;
 

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -64,7 +64,7 @@ use rocketmq_common::common::mix_all;
 use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::common::TopicSysFlag;
 use rocketmq_common::TimeUtils;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::clients::RemotingClient;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -328,7 +328,7 @@ impl RouteInfoManager {
         self.broker_live_table.mut_from_ref().insert(
             broker_addr_info.clone(),
             BrokerLiveInfo::new(
-                get_current_millis() as i64,
+                current_millis() as i64,
                 timeout_millis.unwrap_or(DEFAULT_BROKER_CHANNEL_EXPIRED_TIME),
                 topic_config_serialize_wrapper
                     .topic_config_serialize_wrapper
@@ -663,7 +663,7 @@ impl RouteInfoManager {
     ) {
         let broker_addr_info = BrokerAddrInfo::new(cluster_name, broker_addr);
         if let Some(value) = self.broker_live_table.get_mut(broker_addr_info.as_ref()) {
-            value.last_update_timestamp = TimeUtils::get_current_millis() as i64;
+            value.last_update_timestamp = TimeUtils::current_millis() as i64;
         }
     }
 
@@ -875,7 +875,7 @@ impl RouteInfoManager {
     pub fn scan_not_active_broker(&mut self) {
         for (broker_addr_info, broker_live_info) in self.broker_live_table.clone().iter() {
             if broker_live_info.heartbeat_timeout_millis + broker_live_info.last_update_timestamp
-                < TimeUtils::get_current_millis() as i64
+                < TimeUtils::current_millis() as i64
             {
                 self.on_connection_disconnected(broker_addr_info);
             }

--- a/rocketmq-namesrv/src/route/route_info_manager_v2.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_v2.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::mix_all;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::clients::RemotingClient;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -713,7 +713,7 @@ impl RouteInfoManagerV2 {
         let broker_addr_info = Arc::new(BrokerAddrInfo::new(cluster_name, broker_addr));
 
         let timeout = timeout_millis.unwrap_or(DEFAULT_BROKER_CHANNEL_EXPIRED_TIME);
-        let current_time = get_current_millis();
+        let current_time = current_millis();
 
         let live_info = BrokerLiveInfo::new(
             current_time,
@@ -1554,7 +1554,7 @@ impl RouteInfoManagerV2 {
     /// - This reduces lock contention on the global route tables
     pub fn scan_not_active_broker(&self) -> RouteResult<usize> {
         debug!("start scanNotActiveBroker");
-        let current_time = get_current_millis();
+        let current_time = current_millis();
 
         // Get expired brokers by checking heartbeat timeout
         let expired_brokers = self.broker_live_table.get_expired_brokers(current_time);

--- a/rocketmq-namesrv/src/route/tables/live_table.rs
+++ b/rocketmq-namesrv/src/route/tables/live_table.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::net::channel::ChannelId;
 use rocketmq_remoting::protocol::DataVersion;
@@ -368,7 +368,7 @@ impl BrokerLiveTable {
     /// * `broker_addr_info` - BrokerAddrInfo containing cluster name and broker address
     pub fn update_last_update_timestamp_by_addr_info(&self, broker_addr_info: &BrokerAddrInfo) {
         if let Some(mut entry) = self.inner.get_mut(broker_addr_info) {
-            let current_time = get_current_millis();
+            let current_time = current_millis();
             let old_info = entry.value();
             let new_info = BrokerLiveInfo {
                 last_update_timestamp: current_time,

--- a/rocketmq-remoting/src/base/request_task.rs
+++ b/rocketmq-remoting/src/base/request_task.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 
 use crate::net::channel::Channel;
 use crate::protocol::remoting_command::RemotingCommand;
@@ -35,7 +35,7 @@ impl RequestTask {
     pub fn new(runnable: Arc<dyn Fn() + Send + Sync>, channel: Channel, request: RemotingCommand) -> Self {
         Self {
             runnable,
-            create_timestamp: get_current_millis(),
+            create_timestamp: current_millis(),
             channel,
             request,
             stop_run: Arc::new(parking_lot::Mutex::new(false)),

--- a/rocketmq-remoting/src/protocol.rs
+++ b/rocketmq-remoting/src/protocol.rs
@@ -340,7 +340,7 @@ impl Default for DataVersion {
 
 impl DataVersion {
     pub fn new() -> Self {
-        let timestamp = time_utils::get_current_millis() as i64;
+        let timestamp = time_utils::current_millis() as i64;
 
         DataVersion {
             state_version: 0,
@@ -400,7 +400,7 @@ impl DataVersion {
     }
 
     pub fn next_version_with(&mut self, state_version: i64) {
-        self.timestamp = time_utils::get_current_millis() as i64;
+        self.timestamp = time_utils::current_millis() as i64;
         self.state_version = state_version;
         self.counter.fetch_add(1, Ordering::SeqCst);
     }

--- a/rocketmq-remoting/src/protocol/body/consumer_running_info.rs
+++ b/rocketmq-remoting/src/protocol/body/consumer_running_info.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeSet;
 use std::fmt::Display;
 
 use rocketmq_common::common::message::message_queue::MessageQueue;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 
@@ -133,7 +133,7 @@ impl ConsumerRunningInfo {
 
         let push = matches!(prev.consume_type, ConsumeType::ConsumePassively);
 
-        let start_for_a_while = (get_current_millis() - prev.prop_consumer_start_timestamp) > (1000 * 60 * 2);
+        let start_for_a_while = (current_millis() - prev.prop_consumer_start_timestamp) > (1000 * 60 * 2);
 
         if push && start_for_a_while {
             let mut prev = prev.clone();
@@ -165,7 +165,7 @@ impl ConsumerRunningInfo {
                             "{} {} can't lock for a while, {}ms\n",
                             client_id,
                             k,
-                            get_current_millis() - v.last_lock_timestamp
+                            current_millis() - v.last_lock_timestamp
                         ));
                     } else if v.droped && v.try_unlock_times > 0 {
                         sb.push_str(&format!(
@@ -174,7 +174,7 @@ impl ConsumerRunningInfo {
                         ));
                     }
                 } else {
-                    let diff = get_current_millis() - v.last_consume_timestamp;
+                    let diff = current_millis() - v.last_consume_timestamp;
 
                     if diff > (1000 * 60) && v.cached_msg_count > 0 {
                         sb.push_str(&format!(

--- a/rocketmq-remoting/src/protocol/body/timer_metrics_serialize_wrapper.rs
+++ b/rocketmq-remoting/src/protocol/body/timer_metrics_serialize_wrapper.rs
@@ -17,7 +17,7 @@ use std::fmt::Display;
 use std::sync::atomic::AtomicU64;
 
 use cheetah_string::CheetahString;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 
 use crate::protocol::DataVersion;
 
@@ -92,7 +92,7 @@ impl Default for Metric {
     fn default() -> Self {
         Metric {
             count: AtomicU64::new(0),
-            time_stamp: get_current_millis(),
+            time_stamp: current_millis(),
         }
     }
 }

--- a/rocketmq-remoting/src/protocol/header/controller/elect_master_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/controller/elect_master_request_header.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_macros::RequestHeaderCodecV2;
 use serde::Deserialize;
 use serde::Serialize;
@@ -61,7 +61,7 @@ impl Default for ElectMasterRequestHeader {
             broker_name: CheetahString::new(),
             broker_id: 0,
             designate_elect: false,
-            invoke_time: get_current_millis(),
+            invoke_time: current_millis(),
         }
     }
 }

--- a/rocketmq-remoting/src/protocol/header/controller/register_broker_to_controller_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/controller/register_broker_to_controller_request_header.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_macros::RequestHeaderCodecV2;
 use serde::Deserialize;
 use serde::Serialize;
@@ -35,7 +35,7 @@ impl Default for RegisterBrokerToControllerRequestHeader {
             broker_name: None,
             broker_id: None,
             broker_address: None,
-            invoke_time: get_current_millis(),
+            invoke_time: current_millis(),
         }
     }
 }

--- a/rocketmq-remoting/src/protocol/header/pop_message_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/pop_message_request_header.rs
@@ -15,7 +15,7 @@
 use std::fmt::Display;
 
 use cheetah_string::CheetahString;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_macros::RequestHeaderCodecV2;
 use serde::Deserialize;
 use serde::Serialize;
@@ -52,7 +52,7 @@ pub struct PopMessageRequestHeader {
 
 impl PopMessageRequestHeader {
     pub fn is_timeout_too_much(&self) -> bool {
-        get_current_millis() as i64 - self.born_time as i64 - self.poll_time as i64 > 500
+        current_millis() as i64 - self.born_time as i64 - self.poll_time as i64 > 500
     }
 }
 

--- a/rocketmq-remoting/src/protocol/heartbeat/subscription_data.rs
+++ b/rocketmq-remoting/src/protocol/heartbeat/subscription_data.rs
@@ -18,7 +18,7 @@ use std::hash::Hasher;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::filter::expression_type::ExpressionType;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -46,7 +46,7 @@ impl Default for SubscriptionData {
             sub_string: CheetahString::new(),
             tags_set: BTreeSet::new(),
             code_set: BTreeSet::new(),
-            sub_version: get_current_millis() as i64,
+            sub_version: current_millis() as i64,
             expression_type: CheetahString::from_static_str(ExpressionType::TAG),
             filter_class_source: CheetahString::new(),
         }
@@ -77,9 +77,9 @@ mod tests {
 
     #[test]
     fn subscription_data_default() {
-        let before = get_current_millis() as i64;
+        let before = current_millis() as i64;
         let data = SubscriptionData::default();
-        let after = get_current_millis() as i64;
+        let after = current_millis() as i64;
 
         assert!(!data.class_filter_mode);
         assert!(data.topic.is_empty());

--- a/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_utils.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_utils.rs
@@ -22,7 +22,7 @@ use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::EnvUtils::EnvUtils;
 use rocketmq_common::FileUtils::string_to_file;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_rust::ArcMut;
@@ -463,7 +463,7 @@ impl TopicQueueMappingUtils {
     ) -> RocketMQResult<TopicRemappingDetailWrapper> {
         TopicQueueMappingUtils::check_target_brokers_complete(target_brokers, broker_config_map)?;
         let mut global_id_map = HashMap::new();
-        let mut max_epoch_and_num = (get_current_millis(), queue_num);
+        let mut max_epoch_and_num = (current_millis(), queue_num);
         if !broker_config_map.is_empty() {
             let new_max_epoch_and_num = TopicQueueMappingUtils::check_name_epoch_num_consistence(
                 &CheetahString::from(topic),
@@ -513,7 +513,7 @@ impl TopicQueueMappingUtils {
         let new_id_to_broker = allocator.id_to_broker();
 
         //construct the topic configAndMapping
-        let new_epoch = (max_epoch_and_num.0 + 1000).max(get_current_millis());
+        let new_epoch = (max_epoch_and_num.0 + 1000).max(current_millis());
         for e in new_id_to_broker {
             let queue_id = e.0;
             let broker = e.1;
@@ -530,7 +530,7 @@ impl TopicQueueMappingUtils {
                             topic.into(),
                             0,
                             broker.into(),
-                            get_current_millis() as i64,
+                            current_millis() as i64,
                         ),
                         hosted_queues: None,
                     })),
@@ -777,7 +777,7 @@ impl TopicQueueMappingUtils {
             }
         }
 
-        let new_epoch = ((max_epoch_and_num.0 as u64 + 1000).max(get_current_millis())) as i64;
+        let new_epoch = ((max_epoch_and_num.0 as u64 + 1000).max(current_millis())) as i64;
 
         // construct the remapping info
         let mut brokers_to_map_out: HashSet<CheetahString> = HashSet::new();

--- a/rocketmq-store/benches/delivery.rs
+++ b/rocketmq-store/benches/delivery.rs
@@ -15,17 +15,17 @@
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 
 pub static A: std::sync::LazyLock<Vec<i32>> = std::sync::LazyLock::new(|| vec![1; 64]);
 
 pub fn delivery1() -> i32 {
-    let a = A.get((get_current_millis() % 64) as usize);
+    let a = A.get((current_millis() % 64) as usize);
     *a.unwrap()
 }
 
 pub fn delivery2() -> i32 {
-    let a = A.get((get_current_millis() & 63) as usize);
+    let a = A.get((current_millis() & 63) as usize);
     *a.unwrap()
 }
 

--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -27,7 +27,7 @@ use rocketmq_common::common::message::message_batch::MessageExtBatch;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use rocketmq_common::common::system_clock::SystemClock;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 
 use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
 use crate::base::commit_log_dispatcher::CommitLogDispatcher;
@@ -316,7 +316,7 @@ pub trait MessageStoreInner: Sync + 'static {
     /// Return the current timestamp of the store.
     #[inline(always)]
     fn now(&self) -> u64 {
-        get_current_millis()
+        current_millis()
     }
 
     /// Delete topic's consume queue file and unused stats.

--- a/rocketmq-store/src/base/store_stats_service.rs
+++ b/rocketmq-store/src/base/store_stats_service.rs
@@ -26,7 +26,7 @@ use parking_lot::Mutex;
 use parking_lot::RwLock;
 use rocketmq_common::common::broker::broker_config::BrokerIdentity;
 use rocketmq_common::common::system_clock::SystemClock;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use tracing::error;
 
 const FREQUENCY_OF_SAMPLING: u64 = 1000;
@@ -103,12 +103,12 @@ impl StoreStatsService {
             transferred_msg_count_list: Mutex::new(LinkedList::new()),
             put_message_distribute_time: Arc::new((0..13).map(|_| AtomicUsize::new(0)).collect()),
             last_put_message_distribute_time: Arc::new((0..13).map(|_| AtomicUsize::new(0)).collect()),
-            message_store_boot_timestamp: get_current_millis(),
+            message_store_boot_timestamp: current_millis(),
             put_message_entire_time_max: Arc::new(AtomicUsize::new(0)),
             get_message_entire_time_max: Arc::new(AtomicUsize::new(0)),
             dispatch_max_buffer: Arc::new(AtomicUsize::new(0)),
             sampling_lock: Mutex::new(()),
-            last_print_timestamp: get_current_millis(),
+            last_print_timestamp: current_millis(),
             broker_identity,
         }
     }

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -23,7 +23,7 @@ use arc_swap::ArcSwap;
 use cheetah_string::CheetahString;
 use parking_lot::Mutex;
 use rocketmq_common::common::boundary_type::BoundaryType;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::offset_to_file_name;
 use tracing::error;
 use tracing::info;
@@ -453,7 +453,7 @@ impl MappedFileQueue {
         for (i, mapped_file) in mfs.iter().enumerate().take(mfs_length) {
             let live_max_timestamp = mapped_file.get_last_modified_timestamp() as i64 + expired_time;
 
-            if get_current_millis() as i64 >= live_max_timestamp || clean_immediately {
+            if current_millis() as i64 >= live_max_timestamp || clean_immediately {
                 if mapped_file.destroy(interval_forcibly as u64) {
                     files.push(mapped_file.clone());
                     delete_count += 1;
@@ -890,7 +890,7 @@ impl MappedFileQueue {
             }
 
             let mapped_file = &files[i as usize];
-            let current_time = get_current_millis() as i64;
+            let current_time = current_millis() as i64;
             let recent_swap_time = mapped_file.get_recent_swap_map_time();
 
             // Force swap if interval exceeded
@@ -944,7 +944,7 @@ impl MappedFileQueue {
             }
 
             let mapped_file = &files[i as usize];
-            let current_time = get_current_millis() as i64;
+            let current_time = current_millis() as i64;
             let recent_swap_time = mapped_file.get_recent_swap_map_time();
 
             if current_time - recent_swap_time > force_clean_swap_interval_ms {

--- a/rocketmq-store/src/ha/default_ha_client.rs
+++ b/rocketmq-store/src/ha/default_ha_client.rs
@@ -24,7 +24,7 @@ use bytes::BufMut;
 use bytes::BytesMut;
 use futures_util::SinkExt;
 use futures_util::StreamExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::net::tcp::OwnedWriteHalf;
@@ -162,7 +162,7 @@ impl Inner {
                     // Initialize current reported offset
                     let max_offset = self.default_message_store.get_max_phy_offset();
                     self.current_reported_offset.store(max_offset, Ordering::Release);
-                    let now = get_current_millis();
+                    let now = current_millis();
                     self.last_read_timestamp.store(now, Ordering::SeqCst);
                     Ok(Some(stream))
                 }
@@ -209,7 +209,7 @@ impl DefaultHAClient {
     pub fn new(default_message_store: ArcMut<LocalFileMessageStore>) -> Result<Self, HAClientError> {
         let flow_monitor = Arc::new(FlowMonitor::new(default_message_store.message_store_config()));
 
-        let now = get_current_millis();
+        let now = current_millis();
 
         Ok(Self {
             inner: ArcMut::new(Inner {
@@ -390,7 +390,7 @@ impl HAClient for DefaultHAClient {
                                     }
                                     // housekeeping
                                     _ = house.tick() => {
-                                        let interval = get_current_millis().saturating_sub(client.last_read_timestamp.load(Ordering::SeqCst));
+                                        let interval = current_millis().saturating_sub(client.last_read_timestamp.load(Ordering::SeqCst));
                                         // If the interval exceeds the configured value, it indicates that the connection may have been disconnected.
                                         if interval > client.default_message_store.message_store_config_ref().ha_housekeeping_interval {
                                             warn!(
@@ -542,7 +542,7 @@ impl ReaderTask {
                     if !self.dispatch_read().await? {
                         bail!("dispatchReadRequest error");
                     }
-                    self.last_read_timestamp.store(get_current_millis(), Ordering::SeqCst);
+                    self.last_read_timestamp.store(current_millis(), Ordering::SeqCst);
                 }
                 Some(Err(e)) => {
                     bail!(e);
@@ -657,7 +657,7 @@ impl WriterTask {
         self.report_offset.put_i64(max_off);
         let bytes = self.report_offset.split().freeze();
         self.wr.send(bytes).await?;
-        self.last_write_timestamp.store(get_current_millis(), Ordering::Release);
+        self.last_write_timestamp.store(current_millis(), Ordering::Release);
         Ok(())
     }
 }

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -26,7 +26,7 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use futures_util::SinkExt;
 use futures_util::StreamExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::WeakArcMut;
 use tokio::net::tcp::OwnedReadHalf;
@@ -347,7 +347,7 @@ impl ReadSocketService {
             buffer: BytesMut::with_capacity(READ_MAX_BUFFER_SIZE),
             process_position: 0,
             message_store_config,
-            last_read_timestamp: AtomicU64::new(get_current_millis()),
+            last_read_timestamp: AtomicU64::new(current_millis()),
             connection,
         })
     }
@@ -372,7 +372,7 @@ impl ReadSocketService {
                     break;
                 }
                 Some(Ok(OffsetFrame(offset))) => {
-                    self.last_read_timestamp.store(get_current_millis(), Ordering::Relaxed);
+                    self.last_read_timestamp.store(current_millis(), Ordering::Relaxed);
                     self.slave_ack_offset.store(offset, Ordering::Relaxed);
 
                     if self.slave_request_offset.load(Ordering::Acquire) < 0 {
@@ -387,7 +387,7 @@ impl ReadSocketService {
                 }
             }
 
-            let current_time = get_current_millis();
+            let current_time = current_millis();
             let last_read = self.last_read_timestamp.load(Ordering::Relaxed);
             let interval = current_time - last_read;
 
@@ -528,8 +528,8 @@ impl WriteSocketService {
             next_transfer_from_where,
             message_store_config,
             connection,
-            last_write_timestamp: AtomicU64::new(get_current_millis()),
-            last_print_timestamp: AtomicU64::new(get_current_millis()),
+            last_write_timestamp: AtomicU64::new(current_millis()),
+            last_print_timestamp: AtomicU64::new(current_millis()),
             byte_buffer_header: BytesMut::with_capacity(TRANSFER_HEADER_SIZE),
             last_write_over: AtomicBool::new(true),
         })
@@ -611,7 +611,7 @@ impl WriteSocketService {
         }
 
         if self.last_write_over.load(Ordering::Relaxed) {
-            let current_time = get_current_millis();
+            let current_time = current_millis();
             let last_write = self.last_write_timestamp.load(Ordering::Relaxed);
             let interval = current_time - last_write;
 
@@ -655,7 +655,7 @@ impl WriteSocketService {
 
             let can_transfer_max_bytes = self.flow_monitor.can_transfer_max_byte_num();
             if size > can_transfer_max_bytes as usize {
-                let current_time = get_current_millis();
+                let current_time = current_millis();
                 let last_print = self.last_print_timestamp.load(Ordering::Relaxed);
 
                 if current_time - last_print > 1000 {
@@ -690,7 +690,7 @@ impl WriteSocketService {
         let bytes = self.byte_buffer_header.split().freeze();
         self.writer.send(bytes).await?;
 
-        self.last_write_timestamp.store(get_current_millis(), Ordering::Relaxed);
+        self.last_write_timestamp.store(current_millis(), Ordering::Relaxed);
         self.flow_monitor
             .add_byte_count_transferred(TRANSFER_HEADER_SIZE as i64);
         self.last_write_over.store(true, Ordering::Relaxed);
@@ -716,7 +716,7 @@ impl WriteSocketService {
             warn!("No data to send for offset {}", offset);
         }
 
-        self.last_write_timestamp.store(get_current_millis(), Ordering::Relaxed);
+        self.last_write_timestamp.store(current_millis(), Ordering::Relaxed);
         self.flow_monitor
             .add_byte_count_transferred((TRANSFER_HEADER_SIZE + size) as i64);
         self.last_write_over.store(true, Ordering::Relaxed);

--- a/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
+++ b/rocketmq-store/src/ha/ha_connection_state_notification_service.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rocketmq_common::common::broker::broker_role::BrokerRole;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::task::service_task::ServiceContext;
 use rocketmq_rust::task::service_task::ServiceTask;
 use rocketmq_rust::task::ServiceManager;
@@ -66,7 +66,7 @@ impl Inner {
             if connection_state == request.expect_state() {
                 request.complete(true).await;
             } else if connection_state == HAConnectionState::Ready {
-                if get_current_millis() - self.last_check_time_stamp.load(std::sync::atomic::Ordering::Relaxed)
+                if current_millis() - self.last_check_time_stamp.load(std::sync::atomic::Ordering::Relaxed)
                     > CONNECTION_ESTABLISH_TIMEOUT
                 {
                     error!("Wait HA connection establish with {} timeout", request.remote_addr());
@@ -74,7 +74,7 @@ impl Inner {
                 }
             } else {
                 self.last_check_time_stamp
-                    .store(get_current_millis(), std::sync::atomic::Ordering::Relaxed);
+                    .store(current_millis(), std::sync::atomic::Ordering::Relaxed);
             }
         } else {
             let mut connection_found = false;
@@ -86,10 +86,10 @@ impl Inner {
 
             if connection_found {
                 self.last_check_time_stamp
-                    .store(get_current_millis(), std::sync::atomic::Ordering::Relaxed);
+                    .store(current_millis(), std::sync::atomic::Ordering::Relaxed);
             }
             if !connection_found
-                && (get_current_millis() - self.last_check_time_stamp.load(std::sync::atomic::Ordering::Relaxed)
+                && (current_millis() - self.last_check_time_stamp.load(std::sync::atomic::Ordering::Relaxed)
                     > CONNECTION_ESTABLISH_TIMEOUT)
             {
                 error!("Wait HA connection establish with {} timeout", request.remote_addr());
@@ -173,6 +173,6 @@ impl HAConnectionStateNotificationService {
         *guard = Some(request);
         self.inner
             .last_check_time_stamp
-            .store(get_current_millis(), std::sync::atomic::Ordering::Relaxed);
+            .store(current_millis(), std::sync::atomic::Ordering::Relaxed);
     }
 }

--- a/rocketmq-store/src/index/index_service.rs
+++ b/rocketmq-store/src/index/index_service.rs
@@ -22,7 +22,7 @@ use cheetah_string::CheetahString;
 use parking_lot::RwLock;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::time_millis_to_human_string;
 use tracing::error;
 use tracing::info;
@@ -392,7 +392,7 @@ impl IndexService {
                 "{}{}{}",
                 self.store_path,
                 std::path::MAIN_SEPARATOR,
-                time_millis_to_human_string(get_current_millis() as i64)
+                time_millis_to_human_string(current_millis() as i64)
             );
 
             let new_index_file = Arc::new(IndexFile::new(

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -46,7 +46,7 @@ use rocketmq_common::MessageDecoder::string_to_message_properties;
 use rocketmq_common::MessageDecoder::MESSAGE_MAGIC_CODE_POSITION;
 use rocketmq_common::MessageDecoder::MESSAGE_MAGIC_CODE_V2;
 use rocketmq_common::MessageDecoder::SYSFLAG_POSITION;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::time_millis_to_human_string;
 use rocketmq_rust::ArcMut;
 use tokio::time::Instant;
@@ -411,7 +411,7 @@ impl CommitLog {
     }
 
     pub async fn put_messages(&mut self, mut msg_batch: MessageExtBatch) -> PutMessageResult {
-        msg_batch.message_ext_broker_inner.message_ext_inner.store_timestamp = get_current_millis() as i64;
+        msg_batch.message_ext_broker_inner.message_ext_inner.store_timestamp = current_millis() as i64;
         let tran_type = MessageSysFlag::get_transaction_value(msg_batch.message_ext_broker_inner.sys_flag());
         if MessageSysFlag::TRANSACTION_NOT_TYPE != tran_type {
             return PutMessageResult::new_default(PutMessageStatus::MessageIllegal);
@@ -466,10 +466,10 @@ impl CommitLog {
 
         let _put_message_lock = self.put_message_lock.lock().await;
         self.begin_time_in_lock
-            .store(time_utils::get_current_millis(), std::sync::atomic::Ordering::Release);
+            .store(time_utils::current_millis(), std::sync::atomic::Ordering::Release);
         let start_time = Instant::now();
         // Here settings are stored timestamp, in order to ensure an orderly global
-        msg_batch.message_ext_broker_inner.message_ext_inner.store_timestamp = time_utils::get_current_millis() as i64;
+        msg_batch.message_ext_broker_inner.message_ext_inner.store_timestamp = time_utils::current_millis() as i64;
 
         if mapped_file.is_none() || mapped_file.as_ref().unwrap().is_full() {
             mapped_file = self.mapped_file_queue.get_last_mapped_file_mut_start_offset(0, true);
@@ -646,7 +646,7 @@ impl CommitLog {
         };
 
         let _put_message_lock = self.put_message_lock.lock().await;
-        let begin_lock_timestamp = time_utils::get_current_millis();
+        let begin_lock_timestamp = time_utils::current_millis();
         self.begin_time_in_lock
             .store(begin_lock_timestamp, std::sync::atomic::Ordering::Release);
         let start_time = Instant::now();

--- a/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::WeakArcMut;
 use tokio::sync::Notify;
@@ -253,7 +253,7 @@ impl FlushRealTimeService {
                 let flush_physic_queue_thorough_interval = message_store_config.flush_commit_log_thorough_interval;
                 //let mut print_flush_progress = false;
 
-                let current_time_millis = get_current_millis();
+                let current_time_millis = current_millis();
                 if current_time_millis >= last_flush_timestamp + flush_physic_queue_thorough_interval as u64 {
                     last_flush_timestamp = current_time_millis;
                     flush_physic_queue_least_pages = 0;
@@ -316,7 +316,7 @@ impl CommitRealTimeService {
                 let commit_data_thorough_interval = message_store_config.commit_commit_log_thorough_interval;
                 //let mut print_flush_progress = false;
 
-                let begin = get_current_millis();
+                let begin = current_millis();
                 if begin >= last_commit_timestamp + commit_data_thorough_interval {
                     last_commit_timestamp = begin;
                     commit_data_least_pages = 0;
@@ -324,7 +324,7 @@ impl CommitRealTimeService {
 
                 let result = mapped_file_queue.commit(commit_data_least_pages);
                 if !result {
-                    last_commit_timestamp = get_current_millis();
+                    last_commit_timestamp = current_millis();
                     if let Some(flush_manager) = flush_manager.as_ref().unwrap().upgrade() {
                         flush_manager.wake_up_flush();
                     }

--- a/rocketmq-store/src/log_file/flush_manager_impl/group_commit_request.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/group_commit_request.rs
@@ -14,7 +14,7 @@
 
 use std::sync::atomic::AtomicI32;
 
-use rocketmq_common::TimeUtils::get_current_nano;
+use rocketmq_common::TimeUtils::current_nano;
 
 use crate::base::message_status_enum::PutMessageStatus;
 
@@ -39,7 +39,7 @@ impl Default for GroupCommitRequest {
 
 impl GroupCommitRequest {
     pub(crate) fn new(next_offset: i64, timeout_millis: u64) -> Self {
-        let dead_line = get_current_nano() + timeout_millis * 1_000_000;
+        let dead_line = current_nano() + timeout_millis * 1_000_000;
         Self {
             next_offset,
             dead_line,

--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -31,7 +31,7 @@ use cheetah_string::CheetahString;
 use memmap2::MmapMut;
 use rocketmq_common::common::message::message_batch::MessageExtBatch;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::ensure_dir_ok;
 use rocketmq_rust::ArcMut;
 use tracing::debug;
@@ -557,7 +557,7 @@ impl MappedFile for DefaultMappedFile {
                         };
 
                         if flush_result > 0 {
-                            self.last_flush_time.store(get_current_millis(), Ordering::Relaxed);
+                            self.last_flush_time.store(current_millis(), Ordering::Relaxed);
 
                             if let Some(metrics) = &self.metrics {
                                 let flush_duration = flush_start.elapsed();

--- a/rocketmq-store/src/log_file/mapped_file/reference_resource.rs
+++ b/rocketmq-store/src/log_file/mapped_file/reference_resource.rs
@@ -73,17 +73,16 @@ pub trait ReferenceResource: Send + Sync {
     /// # Parameters
     /// * `interval_forcibly` - The interval in milliseconds to forcibly shut down the resource.
     fn shutdown(&self, interval_forcibly: u64) {
-        use rocketmq_common::TimeUtils::get_current_millis;
+        use rocketmq_common::TimeUtils::current_millis;
 
         if self.base().available.load(Ordering::Acquire) {
             self.base().available.store(false, Ordering::Release);
             self.base()
                 .first_shutdown_timestamp
-                .store(get_current_millis(), Ordering::Release);
+                .store(current_millis(), Ordering::Release);
             self.release();
         } else if self.get_ref_count() > 0 {
-            let elapsed =
-                get_current_millis().saturating_sub(self.base().first_shutdown_timestamp.load(Ordering::Acquire));
+            let elapsed = current_millis().saturating_sub(self.base().first_shutdown_timestamp.load(Ordering::Acquire));
 
             if elapsed >= interval_forcibly {
                 let current_count = self.get_ref_count();

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -64,7 +64,7 @@ use rocketmq_common::CleanupPolicyUtils::get_delete_policy;
 use rocketmq_common::CleanupPolicyUtils::get_delete_policy_arc_mut;
 use rocketmq_common::FileUtils::string_to_file;
 use rocketmq_common::MessageDecoder;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::ensure_dir_ok;
 use rocketmq_error::RocketMQResult;
 use rocketmq_rust::ArcMut;
@@ -1550,7 +1550,7 @@ impl MessageStore for LocalFileMessageStore {
 
     fn is_os_page_cache_busy(&self) -> bool {
         let begin = self.commit_log.begin_time_in_lock().load(Ordering::Relaxed);
-        let diff = get_current_millis() - begin;
+        let diff = current_millis() - begin;
         diff < 10000000 && diff > self.message_store_config.os_page_cache_busy_timeout_mills
     }
 

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::AtomicI64;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::system_clock::SystemClock;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use tracing::error;
 use tracing::warn;
@@ -91,8 +91,8 @@ impl TimerMessageStore {
     }
 
     pub fn get_enqueue_behind_millis(&self) -> i64 {
-        if get_current_millis() - self.last_enqueue_but_expired_time < 2000 {
-            ((get_current_millis() - self.last_enqueue_but_expired_store_time) / 1000) as i64
+        if current_millis() - self.last_enqueue_but_expired_time < 2000 {
+            ((current_millis() - self.last_enqueue_but_expired_store_time) / 1000) as i64
         } else {
             0
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/copy_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/copy_acl_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
@@ -114,7 +114,7 @@ impl CommandExecute for CopyAclSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/copy_users_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/copy_users_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::user_info::UserInfo;
@@ -114,7 +114,7 @@ impl CommandExecute for CopyUsersSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/create_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/create_acl_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
@@ -208,7 +208,7 @@ impl CommandExecute for CreateAclSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/create_user_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/create_user_sub_command.rs
@@ -19,7 +19,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -132,7 +132,7 @@ impl CommandExecute for CreateUserSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/delete_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/delete_acl_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -133,7 +133,7 @@ impl CommandExecute for DeleteAclSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/delete_user_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/delete_user_sub_command.rs
@@ -19,7 +19,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -101,7 +101,7 @@ impl CommandExecute for DeleteUserSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/get_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/get_acl_sub_command.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
@@ -81,7 +81,7 @@ impl CommandExecute for GetAclSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/get_user_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/get_user_sub_command.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::user_info::UserInfo;
@@ -81,7 +81,7 @@ impl CommandExecute for GetUserSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/list_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/list_acl_sub_command.rs
@@ -20,7 +20,7 @@ use clap::Parser;
 
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
@@ -96,7 +96,7 @@ impl CommandExecute for ListAclSubCommand {
 
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             default_mqadmin_ext.set_namesrv_addr(addr.trim());
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/list_users_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/list_users_sub_command.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::user_info::UserInfo;
@@ -79,7 +79,7 @@ impl CommandExecute for ListUsersSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/update_acl_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/update_acl_sub_command.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -164,7 +164,7 @@ impl CommandExecute for UpdateAclSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/update_user_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth/update_user_sub_command.rs
@@ -19,7 +19,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -116,7 +116,7 @@ impl CommandExecute for UpdateUserSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext)
             .await

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/broker_consume_stats_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/broker_consume_stats_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -84,7 +84,7 @@ impl CommandExecute for BrokerConsumeStatsSubCommand {
 
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let broker_addr = self.broker_addr.trim().to_string();
         let is_order = self.is_order.trim().parse::<bool>().unwrap_or(false);

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/broker_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/broker_status_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -81,7 +81,7 @@ impl CommandExecute for BrokerStatusSubCommand {
 
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/clean_expired_cq_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/clean_expired_cq_sub_command.rs
@@ -19,7 +19,7 @@ use clap::ArgGroup;
 use clap::Parser;
 use futures::future::join_all;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -75,7 +75,7 @@ impl CommandExecute for CleanExpiredCQSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
             RocketMQError::Internal(format!("CleanExpiredCQSubCommand: Failed to start MQAdminExt: {}", e))

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/clean_unused_topic_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/clean_unused_topic_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -48,7 +48,7 @@ impl CommandExecute for CleanUnusedTopicSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
             RocketMQError::Internal(format!("CleanUnusedTopicSubCommand: Failed to start MQAdminExt: {}", e))

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/commit_log_set_read_ahead_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/commit_log_set_read_ahead_sub_command.rs
@@ -19,7 +19,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -350,7 +350,7 @@ impl CommandExecute for CommitLogSetReadAheadSubCommand {
 
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/delete_expired_commit_log_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/delete_expired_commit_log_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -48,7 +48,7 @@ impl CommandExecute for DeleteExpiredCommitLogSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
             RocketMQError::Internal(format!(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/get_broker_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/get_broker_config_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::Parser;
 use regex::Regex;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -132,7 +132,7 @@ impl CommandExecute for GetBrokerConfigSubCommand {
 
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         let key_pattern_regex = self.key_pattern_regex()?;
 
         let operation_result = async {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/get_broker_epoch_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/get_broker_epoch_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -58,7 +58,7 @@ impl CommandExecute for GetBrokerEpochSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
             RocketMQError::Internal(format!("GetBrokerEpochSubCommand: Failed to start MQAdminExt: {}", e))

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/get_cold_data_flow_ctr_info_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/get_cold_data_flow_ctr_info_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::utils::util_all::time_millis_to_human_string2;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -122,7 +122,7 @@ impl CommandExecute for GetColdDataFlowCtrInfoSubCommand {
 
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/remove_cold_data_flow_ctr_group_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/remove_cold_data_flow_ctr_group_config_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -85,7 +85,7 @@ impl CommandExecute for RemoveColdDataFlowCtrGroupConfigSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
             RocketMQError::Internal(format!(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/reset_master_flush_offset_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/reset_master_flush_offset_sub_command.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -42,7 +42,7 @@ impl CommandExecute for ResetMasterFlushOffsetSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
             RocketMQError::Internal(format!(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/send_msg_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/send_msg_status_sub_command.rs
@@ -19,7 +19,7 @@ use rocketmq_client_rust::base::client_config::ClientConfig;
 use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
 use rocketmq_client_rust::producer::mq_producer::MQProducer;
 use rocketmq_common::common::message::message_single::Message;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -73,7 +73,7 @@ pub struct SendMsgStatusSubCommand {
 
 impl CommandExecute for SendMsgStatusSubCommand {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
-        let instance_name = format!("PID_SMSC_{}", get_current_millis());
+        let instance_name = format!("PID_SMSC_{}", current_millis());
         let mut client_config = ClientConfig::default();
         client_config.set_instance_name(instance_name.into());
 
@@ -102,10 +102,10 @@ impl CommandExecute for SendMsgStatusSubCommand {
         }
 
         for _i in 0..self.count {
-            let begin = get_current_millis();
+            let begin = current_millis();
             match producer.send(build_message(broker_name, self.message_size)).await {
                 Ok(result) => {
-                    let rt = get_current_millis() - begin;
+                    let rt = current_millis() - begin;
                     println!(
                         "rt={}ms, SendResult={}",
                         rt,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/switch_timer_engine_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/switch_timer_engine_sub_command.rs
@@ -18,7 +18,7 @@ use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::message::MessageConst;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -60,7 +60,7 @@ impl CommandExecute for SwitchTimerEngineSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let engine_type = self.engine_type.trim().to_string();
         if engine_type.is_empty()

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/update_broker_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/update_broker_config_sub_command.rs
@@ -22,7 +22,7 @@ use clap::ArgAction;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -323,7 +323,7 @@ impl CommandExecute for UpdateBrokerConfigSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/update_cold_data_flow_ctr_group_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/broker/update_cold_data_flow_ctr_group_config_sub_command.rs
@@ -19,7 +19,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -99,7 +99,7 @@ impl CommandExecute for UpdateColdDataFlowCtrGroupConfigSubCommand {
         };
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
             RocketMQError::Internal(format!(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/cluster/cluster_list_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/cluster/cluster_list_sub_command.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
@@ -61,7 +61,7 @@ impl CommandExecute for ClusterListSubCommand {
 
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let print_interval = self.interval.map(|i| i * 1000);
         let cluster_name = self
@@ -342,7 +342,7 @@ async fn print_cluster_base_info(
 
                 if !earliest_message_time_stamp.is_empty() {
                     if let Ok(ts) = earliest_message_time_stamp.parse::<u64>() {
-                        let mills = get_current_millis() - ts;
+                        let mills = current_millis() - ts;
                         hour = mills as f64 / 1000.0 / 60.0 / 60.0;
                     }
                 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/cluster/cluster_send_msg_rt_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/cluster/cluster_send_msg_rt_sub_command.rs
@@ -23,7 +23,7 @@ use rocketmq_client_rust::base::client_config::ClientConfig;
 use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
 use rocketmq_client_rust::producer::mq_producer::MQProducer;
 use rocketmq_common::common::message::message_single::Message;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -107,14 +107,14 @@ impl CommandExecute for ClusterSendMsgRTSubCommand {
 
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
-        let instance_name = format!("PID_ClusterRTCommand_{}", get_current_millis());
+        let instance_name = format!("PID_ClusterRTCommand_{}", current_millis());
         let mut client_config = ClientConfig::default();
         client_config.set_instance_name(instance_name.into());
 
         let mut builder = DefaultMQProducer::builder()
-            .producer_group(get_current_millis().to_string())
+            .producer_group(current_millis().to_string())
             .client_config(client_config);
         if let Some(ref hook) = rpc_hook {
             builder = builder.rpc_hook(hook.clone());
@@ -178,7 +178,7 @@ impl CommandExecute for ClusterSendMsgRTSubCommand {
                         let mut fail_count: u64 = 0;
 
                         for i in 0..self.amount {
-                            let start = get_current_millis();
+                            let start = current_millis();
                             match producer.send(msg.clone()).await {
                                 Ok(_) => {
                                     success_count += 1;
@@ -187,7 +187,7 @@ impl CommandExecute for ClusterSendMsgRTSubCommand {
                                     fail_count += 1;
                                 }
                             }
-                            let end = get_current_millis();
+                            let end = current_millis();
 
                             if i != 0 {
                                 elapsed += end - start;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection/consumer_connection_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection/consumer_connection_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::mq_version::RocketMqVersion;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
@@ -43,7 +43,7 @@ impl CommandExecute for ConsumerConnectionSubCommand {
 
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         default_mq_admin_ext.start().await?;
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection/producer_connection_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/connection/producer_connection_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::mq_version::RocketMqVersion;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
@@ -42,7 +42,7 @@ impl CommandExecute for ProducerConnectionSubCommand {
 
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         default_mq_admin_ext.start().await?;
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/consumer_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/consumer_status_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::FileUtils::string_to_file;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInfo;
 
@@ -64,7 +64,7 @@ impl CommandExecute for ConsumerStatusSubCommand {
 
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         if let Some(namesrv) = &self.namesrv_addr {
             default_mq_admin_ext.set_namesrv_addr(namesrv.trim());
@@ -91,7 +91,7 @@ impl CommandExecute for ConsumerStatusSubCommand {
             }
         } else {
             let mut i = 1;
-            let now = get_current_millis();
+            let now = current_millis();
             let mut cri_table = BTreeMap::new();
             println!("#Index #ClientId #Version #ConsumerRunningInfoFile");
             for conn in cc.get_connection_set() {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/consumer_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/consumer_sub_command.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::mq_version::RocketMqVersion;
 use rocketmq_common::FileUtils::string_to_file;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInfo;
 use rocketmq_remoting::runtime::RPCHook;
@@ -62,7 +62,7 @@ impl CommandExecute for ConsumerSubCommand {
 
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         if let Some(namesrv) = &self.namesrv_addr {
             default_mq_admin_ext.set_namesrv_addr(namesrv.trim());
@@ -87,7 +87,7 @@ impl CommandExecute for ConsumerSubCommand {
             }
         } else {
             let mut i = 1;
-            let now = get_current_millis();
+            let now = current_millis();
             let mut cri_table: BTreeMap<String, ConsumerRunningInfo> = BTreeMap::new();
 
             for conn in cc.get_connection_set() {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/delete_subscription_group_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/delete_subscription_group_sub_command.rs
@@ -18,7 +18,7 @@ use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::mix_all::get_dlq_topic;
 use rocketmq_common::common::mix_all::get_retry_topic;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -139,7 +139,7 @@ impl CommandExecute for DeleteSubscriptionGroupSubCommand {
         let mut admin_ext = DefaultMQAdminExt::new();
         admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         if let Some(addr) = &self.common_args.namesrv_addr {
             admin_ext.set_namesrv_addr(addr.trim());

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/set_consume_mode_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/set_consume_mode_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -106,7 +106,7 @@ impl CommandExecute for SetConsumeModeSubCommand {
         };
         admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         if let Some(addr) = &self.common_args.namesrv_addr {
             admin_ext.set_namesrv_addr(addr.trim());

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/update_sub_group_list_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/update_sub_group_list_sub_command.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
@@ -81,7 +81,7 @@ impl CommandExecute for UpdateSubGroupListSubCommand {
         };
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         MQAdminExt::start(&mut default_mq_admin_ext).await.map_err(|e| {
             RocketMQError::Internal(format!(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/update_sub_group_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/update_sub_group_sub_command.rs
@@ -19,7 +19,7 @@ use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::attribute::attribute_parser::AttributeParser;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::subscription::group_retry_policy::GroupRetryPolicy;
@@ -131,7 +131,7 @@ impl CommandExecute for UpdateSubGroupSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller/clean_broker_metadata_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller/clean_broker_metadata_sub_command.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -105,7 +105,7 @@ impl CommandExecute for CleanBrokerMetadataSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller/get_controller_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller/get_controller_config_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -42,7 +42,7 @@ impl CommandExecute for GetControllerConfigSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let controller_servers: Vec<CheetahString> = self
             .controller_address

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller/get_controller_metadata_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller/get_controller_metadata_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -42,7 +42,7 @@ impl CommandExecute for GetControllerMetadataSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let controller_address: CheetahString = self.controller_address.as_str().into();
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller/update_controller_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller/update_controller_config_sub_command.rs
@@ -3,7 +3,7 @@ use crate::commands::CommandExecute;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -33,7 +33,7 @@ impl CommandExecute for UpdateControllerConfigSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let controller_address: CheetahString = self.controller_address.trim().into();
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/export/export_configs_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/export/export_configs_sub_command.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -96,7 +96,7 @@ impl CommandExecute for ExportConfigsSubCommand {
         };
         admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         if let Some(addr) = &self.common_args.namesrv_addr {
             admin_ext.set_namesrv_addr(addr.trim());

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/export/export_metadata_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/export/export_metadata_sub_command.rs
@@ -19,7 +19,7 @@ use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::config::TopicConfig;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
@@ -214,7 +214,7 @@ impl ExportMetadataSubCommand {
 
         result.insert(
             "exportTime".to_string(),
-            serde_json::Value::Number(serde_json::Number::from(get_current_millis())),
+            serde_json::Value::Number(serde_json::Number::from(current_millis())),
         );
 
         let json_content = serde_json::to_string_pretty(&result)
@@ -238,7 +238,7 @@ impl CommandExecute for ExportMetadataSubCommand {
         let mut admin_ext = DefaultMQAdminExt::new();
         admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         if let Some(addr) = &self.common_args.namesrv_addr {
             admin_ext.set_namesrv_addr(addr.trim());

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/export/export_pop_record_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/export/export_pop_record_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -105,7 +105,7 @@ impl CommandExecute for ExportPopRecordSubCommand {
         };
         admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         if let Some(addr) = &self.common_args.namesrv_addr {
             admin_ext.set_namesrv_addr(addr.trim());

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha/get_sync_state_set_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha/get_sync_state_set_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
@@ -71,7 +71,7 @@ impl CommandExecute for GetSyncStateSetSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha/ha_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/ha/ha_status_sub_command.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::time_millis_to_human_string2;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
@@ -63,7 +63,7 @@ impl CommandExecute for HAStatusSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/get_broker_lite_info_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/get_broker_lite_info_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::ArgGroup;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::get_broker_lite_info_response_body::GetBrokerLiteInfoResponseBody;
@@ -55,7 +55,7 @@ impl CommandExecute for GetBrokerLiteInfoSubCommand {
 
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/add_write_perm_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/add_write_perm_sub_command.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -39,7 +39,7 @@ impl CommandExecute for AddWritePermSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/delete_kv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/delete_kv_config_sub_command.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -38,7 +38,7 @@ impl CommandExecute for DeleteKvConfigSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/get_namesrv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/get_namesrv_config_sub_command.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 use tabled::settings::object::Rows;
@@ -68,7 +68,7 @@ impl CommandExecute for GetNamesrvConfigSubCommand {
             return Ok(());
         }
         let mut admin = DefaultMQAdminExt::new();
-        admin.client_config_mut().instance_name = get_current_millis().to_string().into();
+        admin.client_config_mut().instance_name = current_millis().to_string().into();
 
         let server_list = self.parse_server_list();
         if let Some(server_list) = server_list {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/update_kv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/update_kv_config_sub_command.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -45,7 +45,7 @@ impl CommandExecute for UpdateKvConfigSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             if let Some(addr) = &self.common_args.namesrv_addr {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/update_namesrv_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/update_namesrv_config_sub_command.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -44,7 +44,7 @@ impl CommandExecute for UpdateNamesrvConfigSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             // key name

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/wipe_write_perm_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/namesrv/wipe_write_perm_sub_command.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -39,7 +39,7 @@ impl CommandExecute for WipeWritePermSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset/reset_offset_by_time_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset/reset_offset_by_time_sub_command.rs
@@ -19,7 +19,7 @@ use chrono::NaiveDateTime;
 use chrono::TimeZone;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -38,7 +38,7 @@ const TIMESTAMP_FORMAT: &str = "%Y-%m-%d#%H:%M:%S:%3f";
 fn parse_timestamp(s: &str) -> RocketMQResult<u64> {
     let s = s.trim();
     if s.eq_ignore_ascii_case("now") {
-        return Ok(get_current_millis());
+        return Ok(current_millis());
     }
     // Try parsing as plain milliseconds integer first.
     if let Ok(ms) = s.parse::<u64>() {
@@ -239,7 +239,7 @@ impl CommandExecute for ResetOffsetByTimeSubCommand {
         let mut admin = DefaultMQAdminExt::new();
         admin
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         if let Some(addr) = &self.common_args.namesrv_addr {
             admin.set_namesrv_addr(addr.trim());

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/delete_topic_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/delete_topic_sub_command.rs
@@ -15,7 +15,7 @@
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::topic::TopicValidator;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 
@@ -84,7 +84,7 @@ impl CommandExecute for DeleteTopicSubCommand {
         let mut admin_ext = DefaultMQAdminExt::new();
         admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             admin_ext.set_namesrv_addr(addr.trim());
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/remapping_static_topic_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/remapping_static_topic_sub_command.rs
@@ -19,7 +19,7 @@ use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::FileUtils::file_to_string;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_utils::TopicQueueMappingUtils;
@@ -76,7 +76,7 @@ impl RemappingStaticTopicSubCommand {
         let mut default_mq_admin_ext = DefaultMQAdminExt::new();
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             default_mq_admin_ext.set_namesrv_addr(addr.trim());
         }
@@ -135,7 +135,7 @@ impl CommandExecute for RemappingStaticTopicSubCommand {
         let mut default_mq_admin_ext = DefaultMQAdminExt::new();
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             default_mq_admin_ext.set_namesrv_addr(addr.trim());
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/topic_cluster_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/topic_cluster_sub_command.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -41,7 +41,7 @@ impl TopicClusterSubCommand {
         let mut admin_ext = DefaultMQAdminExt::new();
         admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             admin_ext.set_namesrv_addr(addr.trim());
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/topic_list_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/topic_list_sub_command.rs
@@ -17,7 +17,7 @@ use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::mix_all::DLQ_GROUP_TOPIC_PREFIX;
 use rocketmq_common::common::mix_all::RETRY_GROUP_TOPIC_PREFIX;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
@@ -76,7 +76,7 @@ impl CommandExecute for TopicListSubCommand {
         let mut default_mq_admin_ext = DefaultMQAdminExt::new();
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             default_mq_admin_ext.set_namesrv_addr(addr.trim());
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/topic_route_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/topic_route_sub_command.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_remoting::protocol::RemotingSerializable;
@@ -98,7 +98,7 @@ impl CommandExecute for TopicRouteSubCommand {
         let mut default_mq_admin_ext = DefaultMQAdminExt::new();
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             default_mq_admin_ext.set_namesrv_addr(addr.trim());
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/topic_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/topic_status_sub_command.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::time_millis_to_human_string2;
 use rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable;
 
@@ -48,7 +48,7 @@ impl CommandExecute for TopicStatusSubCommand {
         let mut default_mq_admin_ext = DefaultMQAdminExt::new();
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             default_mq_admin_ext.set_namesrv_addr(addr.trim());
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/update_order_conf_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/update_order_conf_sub_command.rs
@@ -14,7 +14,7 @@
 
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
@@ -54,7 +54,7 @@ impl CommandExecute for UpdateOrderConfSubCommand {
         let mut default_mq_admin_ext = DefaultMQAdminExt::new();
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             default_mq_admin_ext.set_namesrv_addr(addr.trim());
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/update_static_topic_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/update_static_topic_sub_command.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::FileUtils::file_to_string;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_utils::TopicQueueMappingUtils;
@@ -73,7 +73,7 @@ impl UpdateStaticTopicSubCommand {
         let mut default_mq_admin_ext = DefaultMQAdminExt::new();
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             default_mq_admin_ext.set_namesrv_addr(addr.trim());
         }
@@ -124,7 +124,7 @@ impl CommandExecute for UpdateStaticTopicSubCommand {
         let mut default_mq_admin_ext = DefaultMQAdminExt::new();
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         if let Some(addr) = &self.common_args.namesrv_addr {
             default_mq_admin_ext.set_namesrv_addr(addr.trim());
         }
@@ -172,7 +172,7 @@ impl CommandExecute for UpdateStaticTopicSubCommand {
             .parse::<i32>()
             .map_err(|_e| RocketMQError::Internal("queue num parse to i32 failed".to_string()))?;
 
-        let mut max_epoch_and_num = (get_current_millis(), queue_num);
+        let mut max_epoch_and_num = (current_millis(), queue_num);
         if !broker_config_map.is_empty() {
             let new_max_epoch_and_num = TopicQueueMappingUtils::check_name_epoch_num_consistence(
                 &CheetahString::from(topic),

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/update_topic_list_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/update_topic_list_sub_command.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::config::TopicConfig;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
@@ -52,7 +52,7 @@ impl CommandExecute for UpdateTopicListSubCommand {
         let mut default_mq_admin_ext = DefaultMQAdminExt::new();
         default_mq_admin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         default_mq_admin_ext.start().await?;
 
         if !self.file.is_file() {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/update_topic_perm_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/update_topic_perm_sub_command.rs
@@ -19,7 +19,7 @@ use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::topic::TopicValidator;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -82,7 +82,7 @@ impl CommandExecute for UpdateTopicPermSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
         let operation_result = async {
             MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
                 RocketMQError::Internal(format!("UpdateTopicPermSubCommand: Failed to start MQAdminExt: {}", e))

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/update_topic_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/topic/update_topic_sub_command.rs
@@ -19,7 +19,7 @@ use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::common::TopicSysFlag;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
@@ -123,7 +123,7 @@ impl CommandExecute for UpdateTopicSubCommand {
         let mut default_mqadmin_ext = DefaultMQAdminExt::new();
         default_mqadmin_ext
             .client_config_mut()
-            .set_instance_name(get_current_millis().to_string().into());
+            .set_instance_name(current_millis().to_string().into());
 
         let operation_result = async {
             if let Some(addr) = &self.common_args.namesrv_addr {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/admin.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/admin.rs
@@ -19,7 +19,7 @@
 //! - [`AdminGuard`] - RAII wrapper for automatic resource cleanup
 
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::get_current_millis;
+use rocketmq_common::TimeUtils::current_millis;
 
 use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::RocketMQResult;
@@ -118,7 +118,7 @@ impl AdminBuilder {
         // Apply instance name (default: "tools-{timestamp}")
         let instance_name = self
             .instance_name
-            .unwrap_or_else(|| format!("tools-{}", get_current_millis()));
+            .unwrap_or_else(|| format!("tools-{}", current_millis()));
         admin.client_config_mut().set_instance_name(instance_name.into());
 
         // Note: timeout_millis and unit_name are stored but not currently applied


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6539

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->
