### PR TITLE
[ISSUE #6542]✨Enhance consumer statistics tracking by updating throughput counters and recording round-trip times for message consumption

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -121,6 +121,28 @@ impl ConsumeMessageConcurrentlyService {
             }
         }
 
+        // Update per-topic/group consume throughput counters, split by ack index.
+        if let Some(impl_) = self.default_mqpush_consumer_impl.as_ref() {
+            if let Some(client_instance) = impl_.client_instance.as_ref() {
+                let mgr = client_instance.consumer_stats_manager();
+                let topic = consume_request.message_queue.topic().as_str();
+                let group = self.consumer_group.as_str();
+                let total = consume_request.msgs.len() as u64;
+                match status {
+                    ConsumeConcurrentlyStatus::ConsumeSuccess => {
+                        let ok = (ack_index + 1).max(0) as u64;
+                        mgr.inc_consume_ok_tps(group, topic, ok);
+                        if total > ok {
+                            mgr.inc_consume_failed_tps(group, topic, total - ok);
+                        }
+                    }
+                    ConsumeConcurrentlyStatus::ReconsumeLater => {
+                        mgr.inc_consume_failed_tps(group, topic, total);
+                    }
+                }
+            }
+        }
+
         match self.consumer_config.message_model {
             MessageModel::Broadcasting => {
                 for i in ((ack_index + 1) as usize)..consume_request.msgs.len() {
@@ -533,6 +555,15 @@ impl ConsumeRequest {
             cmc.success = s == ConsumeConcurrentlyStatus::ConsumeSuccess;
             cmc.access_channel = Some(default_mqpush_consumer_impl.client_config.access_channel);
             default_mqpush_consumer_impl.execute_hook_after(&mut consume_message_context);
+        }
+
+        // Record message consume round-trip time.
+        if let Some(client_instance) = default_mqpush_consumer_impl.client_instance.as_ref() {
+            client_instance.consumer_stats_manager().inc_consume_rt(
+                self.consumer_group.as_str(),
+                self.message_queue.topic().as_str(),
+                consume_rt,
+            );
         }
 
         if self.process_queue.is_dropped() {

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -284,6 +284,7 @@ impl ConsumeMessageOrderlyService {
         context: &ConsumeOrderlyContext,
         consume_request: &mut ConsumeRequest,
     ) -> bool {
+        let msg_count = msgs.len() as u64;
         let (continue_consume, commit_offset) = if context.is_auto_commit() {
             match status {
                 ConsumeOrderlyStatus::Success => (true, consume_request.process_queue.commit().await),
@@ -340,6 +341,28 @@ impl ConsumeMessageOrderlyService {
                 }
             }
         };
+
+        // Update per-topic/group consume throughput counters based on the orderly consume result.
+        if let Some(impl_) = self.default_mqpush_consumer_impl.as_ref() {
+            if let Some(client_instance) = impl_.client_instance.as_ref() {
+                let mgr = client_instance.consumer_stats_manager();
+                let topic = consume_request.message_queue.topic().as_str();
+                let group = self.consumer_group.as_str();
+                let is_ok = if context.is_auto_commit() {
+                    matches!(
+                        status,
+                        ConsumeOrderlyStatus::Success | ConsumeOrderlyStatus::Rollback | ConsumeOrderlyStatus::Commit
+                    )
+                } else {
+                    matches!(status, ConsumeOrderlyStatus::Success)
+                };
+                if is_ok {
+                    mgr.inc_consume_ok_tps(group, topic, msg_count);
+                } else if matches!(status, ConsumeOrderlyStatus::SuspendCurrentQueueAMoment) {
+                    mgr.inc_consume_failed_tps(group, topic, msg_count);
+                }
+            }
+        }
 
         if commit_offset >= 0 && !consume_request.process_queue.is_dropped() {
             let mut default_mqpush_consumer_impl = self.default_mqpush_consumer_impl.as_ref().unwrap().clone();
@@ -728,6 +751,14 @@ impl ConsumeRequest {
                         status == ConsumeOrderlyStatus::Success || status == ConsumeOrderlyStatus::Commit;
                     consume_message_context.as_mut().unwrap().status = status.to_string().into();
                     default_mqpush_consumer_impl.execute_hook_after(&mut consume_message_context);
+                }
+                // Record message consume round-trip time.
+                if let Some(client_instance) = default_mqpush_consumer_impl.client_instance.as_ref() {
+                    client_instance.consumer_stats_manager().inc_consume_rt(
+                        consume_message_orderly_service_inner.consumer_group.as_str(),
+                        self.message_queue.topic().as_str(),
+                        consume_rt,
+                    );
                 }
                 let continue_consume = consume_message_orderly_service_inner
                     .process_consume_result(

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -344,6 +344,28 @@ impl ConsumeMessagePopConcurrentlyService {
             }
         }
 
+        // Update per-topic/group consume throughput counters, split by ack index.
+        if let Some(impl_) = self.default_mqpush_consumer_impl.as_ref() {
+            if let Some(client_instance) = impl_.client_instance.as_ref() {
+                let mgr = client_instance.consumer_stats_manager();
+                let topic = consume_request.message_queue.topic().as_str();
+                let group = self.consumer_group.as_str();
+                let total = consume_request.msgs.len() as u64;
+                match status {
+                    ConsumeConcurrentlyStatus::ConsumeSuccess => {
+                        let ok = (ack_index + 1).max(0) as u64;
+                        mgr.inc_consume_ok_tps(group, topic, ok);
+                        if total > ok {
+                            mgr.inc_consume_failed_tps(group, topic, total - ok);
+                        }
+                    }
+                    ConsumeConcurrentlyStatus::ReconsumeLater => {
+                        mgr.inc_consume_failed_tps(group, topic, total);
+                    }
+                }
+            }
+        }
+
         if ack_index >= 0 {
             for i in 0..=ack_index {
                 let msg = &consume_request.msgs[i as usize];
@@ -679,6 +701,15 @@ impl ConsumeRequest {
             cmc.success = status.unwrap() == ConsumeConcurrentlyStatus::ConsumeSuccess;
             cmc.access_channel = Some(default_mqpush_consumer_impl.client_config.access_channel);
             default_mqpush_consumer_impl.execute_hook_after(&mut consume_message_context);
+        }
+
+        // Record message consume round-trip time.
+        if let Some(client_instance) = default_mqpush_consumer_impl.client_instance.as_ref() {
+            client_instance.consumer_stats_manager().inc_consume_rt(
+                self.consumer_group.as_str(),
+                self.message_queue.topic().as_str(),
+                consume_rt,
+            );
         }
 
         if self.process_queue.is_dropped() {

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -63,6 +63,7 @@ use crate::producer::default_mq_producer::DefaultMQProducer;
 use crate::producer::default_mq_producer::ProducerConfig;
 use crate::producer::producer_impl::mq_producer_inner::MQProducerInnerImpl;
 use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
+use crate::stat::consumer_stats_manager::ConsumerStatsManager;
 
 const LOCK_TIMEOUT_MILLIS: u64 = 3000;
 
@@ -104,6 +105,7 @@ pub struct MQClientInstance {
     broker_heartbeat_fingerprint_table: BrokerHeartbeatFingerprintTable,
     /// HeartbeatV2: Set of brokers that support V2 protocol
     broker_support_v2_heartbeat_set: BrokerSupportV2HeartbeatSet,
+    consumer_stats_manager: ConsumerStatsManager,
 }
 
 impl MQClientInstance {
@@ -155,6 +157,7 @@ impl MQClientInstance {
             scheduled_task_manager: ScheduledTaskManager::new(),
             broker_heartbeat_fingerprint_table,
             broker_support_v2_heartbeat_set,
+            consumer_stats_manager: ConsumerStatsManager::new(),
         });
 
         // Clone instance first to avoid borrow checker issues
@@ -223,6 +226,11 @@ impl MQClientInstance {
         instance
     }
 
+    /// Returns a reference to the [`ConsumerStatsManager`] held by this instance.
+    pub fn consumer_stats_manager(&self) -> &ConsumerStatsManager {
+        &self.consumer_stats_manager
+    }
+
     pub fn re_balance_immediately(&self) {
         self.rebalance_service.wakeup();
     }
@@ -276,6 +284,8 @@ impl MQClientInstance {
                     .unwrap()
                     .start_with_factory(false)
                     .await?;
+                // Start consumer stats manager
+                self.consumer_stats_manager.start();
                 info!("the client factory[{}] start OK", self.client_id);
                 self.service_state = ServiceState::Running;
             }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6542

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consumer performance metrics tracking to monitor per-topic/group consumption throughput and round-trip times across concurrent and orderly consumer implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->