### PR TITLE
[ISSUE #6399]🚀Implement TriggerLiteDispatch Command for Lite Topic Message Dispatch Management

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -391,6 +391,11 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Get broker lite info.",
             },
             Command {
+                category: "Lite",
+                command: "triggerLiteDispatch",
+                remark: "Trigger Lite Dispatch.",
+            },
+            Command {
                 category: "NameServer",
                 command: "addWritePerm",
                 remark: "Add write perm of broker in all name server.",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod get_broker_lite_info_sub_command;
+mod trigger_lite_dispatch_sub_command;
 
 use std::sync::Arc;
 
@@ -21,6 +22,7 @@ use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::lite::get_broker_lite_info_sub_command::GetBrokerLiteInfoSubCommand;
+use crate::commands::lite::trigger_lite_dispatch_sub_command::TriggerLiteDispatchSubCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
@@ -31,12 +33,20 @@ pub enum LiteCommands {
         long_about = None,
     )]
     GetBrokerLiteInfo(GetBrokerLiteInfoSubCommand),
+
+    #[command(
+        name = "triggerLiteDispatch",
+        about = "Trigger Lite Dispatch.",
+        long_about = None,
+    )]
+    TriggerLiteDispatch(TriggerLiteDispatchSubCommand),
 }
 
 impl CommandExecute for LiteCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             LiteCommands::GetBrokerLiteInfo(cmd) => cmd.execute(rpc_hook).await,
+            LiteCommands::TriggerLiteDispatch(cmd) => cmd.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/trigger_lite_dispatch_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/trigger_lite_dispatch_sub_command.rs
@@ -1,0 +1,109 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct TriggerLiteDispatchSubCommand {
+    #[arg(short = 'p', long = "parentTopic", required = true, help = "Parent topic name")]
+    parent_topic: String,
+
+    #[arg(short = 'g', long = "group", required = true, help = "Consumer group")]
+    group: String,
+
+    #[arg(short = 'c', long = "clientId", required = false, help = "clientId (optional)")]
+    client_id: Option<String>,
+
+    #[arg(short = 'b', long = "brokerName", required = false, help = "brokerName (optional)")]
+    broker_name: Option<String>,
+}
+
+impl CommandExecute for TriggerLiteDispatchSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "TriggerLiteDispatchSubCommand: Failed to start MQAdminExt: {}",
+                    e
+                ))
+            })?;
+
+            let parent_topic = self.parent_topic.trim();
+            let group = self.group.trim();
+            let client_id = self.client_id.as_deref().map(|s| s.trim());
+            let broker_name = self.broker_name.as_deref().map(|s| s.trim());
+
+            let topic_route_data = default_mqadmin_ext
+                .examine_topic_route_info(CheetahString::from(parent_topic))
+                .await?;
+
+            println!("Group And Topic Info: [{}] [{}]\n", group, parent_topic);
+
+            if let Some(topic_route_data) = topic_route_data {
+                for broker_data in &topic_route_data.broker_datas {
+                    let broker_addr = match broker_data.select_broker_addr() {
+                        Some(addr) => addr,
+                        None => continue,
+                    };
+
+                    if let Some(bn) = broker_name {
+                        if bn != broker_data.broker_name().as_str() {
+                            continue;
+                        }
+                    }
+
+                    let client_id_param = client_id.map(CheetahString::from).unwrap_or_default();
+
+                    let success = default_mqadmin_ext
+                        .trigger_lite_dispatch(broker_addr, CheetahString::from(group), client_id_param)
+                        .await
+                        .is_ok();
+
+                    println!(
+                        "{:<30} {:<12}",
+                        broker_data.broker_name(),
+                        if success { "dispatched" } else { "error" }
+                    );
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6399 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the "triggerLiteDispatch" command in RocketMQ Admin tools. Users can initiate lite dispatch operations by providing a parent topic and group name, with optional client ID and broker name parameters. The command retrieves topic route information and executes dispatch operations on applicable brokers, reporting success or error for each.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->