### PR TITLE
[ISSUE #6544]Clean up commented async handling code  Closes

### DIFF
--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -1235,33 +1235,6 @@ impl<MS: MessageStore> PutResultProcess<MS> {
         }
 
         self
-        /*let this = Arc::new(self);
-        let this_clone = Arc::clone(&this);
-
-        // Handle the future completion
-        tokio::spawn(async move {
-            if let Some(mut future) = this_clone.future.clone() {
-                match future.await {
-                    Ok(result) => {
-                        this_clone.handle_result(result);
-                    }
-                    Err(e) => {
-                        error!(
-                            "ScheduleMessageService put message exceptionally, info: {}",
-                            this_clone,
-                        );
-                        this_clone.on_exception();
-                    }
-                }
-            }
-        });
-
-        // Unwrap the Arc to return self
-        // This is safe because we're the only owner at this point
-        match Arc::try_unwrap(this) {
-            Ok(this) => this,
-            Err(_) => panic!("Failed to unwrap Arc in then_process"),
-        }*/
     }
 
     /// Handle the result of a put operation


### PR DESCRIPTION
Removed commented-out code for handling async message scheduling.

<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6544

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified scheduled message result processing in the broker by converting asynchronous task handling to synchronous immediate processing, reducing code complexity and removing redundant memory management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->