### PR TITLE
[ISSUE #6558]🚀Implement suspend and resume functionality for MQPushConsumer with async support

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -1398,6 +1398,23 @@ impl DefaultMQPushConsumerImpl {
             .await;
         write_guard.remove(topic);
     }
+
+    pub async fn suspend(&self) {
+        self.pause.store(true, Ordering::Release);
+        info!(
+            "Suspend the consumer, instanceName={}, group={}",
+            self.client_config.instance_name, self.consumer_config.consumer_group
+        );
+    }
+
+    pub async fn resume(&self) {
+        self.pause.store(false, Ordering::Release);
+        self.do_rebalance().await;
+        info!(
+            "Resume the consumer, instanceName={}, group={}",
+            self.client_config.instance_name, self.consumer_config.consumer_group
+        );
+    }
 }
 
 impl MQConsumerInner for DefaultMQPushConsumerImpl {
@@ -1431,8 +1448,17 @@ impl MQConsumerInner for DefaultMQPushConsumerImpl {
         .unwrap()
     }
 
-    fn do_rebalance(&self) {
-        todo!()
+    async fn do_rebalance(&self) {
+        if !self.pause.load(Ordering::Acquire) {
+            let orderly = self.is_consume_orderly();
+            let rebalance = self.rebalance_impl.mut_from_ref().do_rebalance(orderly).await;
+            if !rebalance {
+                warn!(
+                    "rebalance failed, maybe the consumer was paused during rebalance. instanceName={}, group={}",
+                    self.client_config.instance_name, self.consumer_config.consumer_group
+                );
+            }
+        }
     }
 
     async fn try_rebalance(&self) -> rocketmq_error::RocketMQResult<bool> {

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -513,12 +513,16 @@ impl MQPushConsumer for DefaultMQPushConsumer {
         }
     }
 
-    async fn suspend(&mut self) {
-        todo!()
+    async fn suspend(&self) {
+        if let Some(ref default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl {
+            default_mqpush_consumer_impl.suspend().await;
+        }
     }
 
-    async fn resume(&mut self) {
-        todo!()
+    async fn resume(&self) {
+        if let Some(ref default_mqpush_consumer_impl) = self.default_mqpush_consumer_impl {
+            default_mqpush_consumer_impl.resume().await;
+        }
     }
 }
 

--- a/rocketmq-client/src/consumer/mq_consumer_inner.rs
+++ b/rocketmq-client/src/consumer/mq_consumer_inner.rs
@@ -51,7 +51,7 @@ pub trait MQConsumerInnerLocal: MQConsumerInnerAny + Sync + 'static {
     fn subscriptions(&self) -> HashSet<SubscriptionData>;
 
     /// Performs the rebalancing of the consumer.
-    fn do_rebalance(&self);
+    async fn do_rebalance(&self);
 
     /// Attempts to perform rebalancing asynchronously and returns a `Result` indicating success or
     /// failure.
@@ -154,8 +154,8 @@ impl MQConsumerInner for MQConsumerInnerImpl {
     }
 
     #[inline]
-    fn do_rebalance(&self) {
-        MQConsumerInner::do_rebalance(self.default_mqpush_consumer_impl.as_ref())
+    async fn do_rebalance(&self) {
+        MQConsumerInner::do_rebalance(self.default_mqpush_consumer_impl.as_ref()).await
     }
 
     #[inline]

--- a/rocketmq-client/src/consumer/mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/mq_push_consumer.rs
@@ -19,18 +19,25 @@ use crate::consumer::listener::message_listener_orderly::MessageListenerOrderly;
 use crate::consumer::message_selector::MessageSelector;
 use crate::consumer::mq_consumer::MQConsumer;
 
-/// The `MQPushConsumer` trait defines the interface for a push consumer in RocketMQ.
-/// A push consumer receives messages from the broker and processes them using registered listeners.
+/// Defines the push-consumer interface for RocketMQ.
+///
+/// Implementations receive messages from brokers and dispatch them to the
+/// registered concurrent or orderly listener.
 #[allow(async_fn_in_trait)]
 pub trait MQPushConsumer: MQConsumer {
-    /// Starts the push consumer.
+    /// Asynchronously starts the consumer instance.
+    ///
+    /// This method does not block the calling thread.
     ///
     /// # Returns
     ///
-    /// * `rocketmq_error::RocketMQResult<()>` - An empty result indicating success or an error.
+    /// Returns `Ok(())` when startup succeeds, or an error when initialization
+    /// fails.
     async fn start(&mut self) -> rocketmq_error::RocketMQResult<()>;
 
-    /// Shuts down the push consumer.
+    /// Asynchronously shuts down the consumer instance.
+    ///
+    /// This method does not block the calling thread.
     async fn shutdown(&mut self);
 
     /// Registers a message listener for concurrent message consumption.
@@ -41,7 +48,7 @@ pub trait MQPushConsumer: MQConsumer {
     ///
     /// # Type Parameters
     ///
-    /// * `MLC` - The type of the message listener closure.
+    /// * `ML` - The listener type.
     fn register_message_listener_concurrently<ML>(&mut self, message_listener: ML)
     where
         ML: MessageListenerConcurrently + Send + Sync + 'static;
@@ -54,12 +61,14 @@ pub trait MQPushConsumer: MQConsumer {
     ///
     /// # Type Parameters
     ///
-    /// * `MLO` - The type of the message listener closure.
+    /// * `ML` - The listener type.
     fn register_message_listener_orderly<ML>(&mut self, message_listener: ML)
     where
         ML: MessageListenerOrderly + Send + Sync + 'static;
 
-    /// Subscribes to a topic with a subscription expression.
+    /// Asynchronously subscribes to a topic with a subscription expression.
+    ///
+    /// This method does not block the calling thread.
     ///
     /// # Parameters
     ///
@@ -69,7 +78,8 @@ pub trait MQPushConsumer: MQConsumer {
     ///
     /// # Returns
     ///
-    /// * `rocketmq_error::RocketMQResult<()>` - An empty result indicating success or an error.
+    /// Returns `Ok(())` when the subscription is accepted, or an error when the
+    /// subscription request is invalid or cannot be applied.
     ///
     /// # Examples
     ///
@@ -91,7 +101,9 @@ pub trait MQPushConsumer: MQConsumer {
         sub_expression: impl Into<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<()>;
 
-    /// Subscribes to a topic with an optional message selector.
+    /// Asynchronously subscribes to a topic with an optional selector.
+    ///
+    /// This method does not block the calling thread.
     ///
     /// # Parameters
     ///
@@ -100,23 +112,30 @@ pub trait MQPushConsumer: MQConsumer {
     ///
     /// # Returns
     ///
-    /// * `rocketmq_error::RocketMQResult<()>` - An empty result indicating success or an error.
+    /// Returns `Ok(())` when the subscription is accepted, or an error when the
+    /// selector is invalid or cannot be applied.
     async fn subscribe_with_selector(
         &mut self,
         topic: &str,
         selector: Option<MessageSelector>,
     ) -> rocketmq_error::RocketMQResult<()>;
 
-    /// Unsubscribes from a topic.
+    /// Asynchronously unsubscribes from a topic.
+    ///
+    /// This method does not block the calling thread.
     ///
     /// # Parameters
     ///
     /// * `topic` - The topic to unsubscribe from.
     async fn unsubscribe(&mut self, topic: &str);
 
-    /// Suspends the push consumer.
-    async fn suspend(&mut self);
+    /// Asynchronously suspends message consumption.
+    ///
+    /// This method does not block the calling thread.
+    async fn suspend(&self);
 
-    /// Resumes the push consumer.
-    async fn resume(&mut self);
+    /// Asynchronously resumes message consumption.
+    ///
+    /// This method does not block the calling thread.
+    async fn resume(&self);
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6558

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added suspend and resume controls for consumer lifecycle management, allowing consumers to pause and resume message consumption.

* **Refactor**
  * Improved consumer rebalancing with asynchronous operations for better responsiveness.
  * Simplified API by allowing suspend and resume operations without requiring mutable access to consumer instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->