### PR TITLE
[ISSUE #6552] Remove useless code from escape_bridge.rs

### DIFF
--- a/rocketmq-broker/src/failover/escape_bridge.rs
+++ b/rocketmq-broker/src/failover/escape_bridge.rs
@@ -396,14 +396,7 @@ where
         if self.broker_runtime_inner.broker_config().broker_identity.broker_name == broker_name {
             async move {
                 let result = message_store
-                    .get_message(
-                        &inner_consumer_group_name,
-                        &topic,
-                        queue_id,
-                        offset,
-                        1,
-                        None,
-                    )
+                    .get_message(&inner_consumer_group_name, &topic, queue_id, offset, 1, None)
                     .await;
                 if result.is_none() {
                     warn!(
@@ -419,10 +412,7 @@ where
                     let need_retry = status.unwrap() == GetMessageStatus::OffsetFoundNull;
                     warn!(
                         "Can not get msg, topic {}, offset {}, queueId {}, needRetry {},",
-                        topic,
-                        offset,
-                        queue_id,
-                        need_retry,
+                        topic, offset, queue_id, need_retry,
                     );
                     return (None, "Can not get msg".to_string(), need_retry);
                 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6552 https://github.com/mxsm/rocketmq-rust/issues/6552

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

test pr

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed commented-out code and unused local variables in the failover escape bridge to reduce dead code and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->