### PR TITLE
[ISSUE #6397]🚀Implement GetLiteTopicInfo Command for Lite Topic Subscription Monitoring

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1676,12 +1676,14 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         &self,
         broker_addr: CheetahString,
     ) -> rocketmq_error::RocketMQResult<GetBrokerLiteInfoResponseBody> {
-        self.client_instance
-            .as_ref()
-            .unwrap()
-            .get_mq_client_api_impl()
-            .get_broker_lite_info(&broker_addr, self.timeout_millis.as_millis() as u64)
-            .await
+        if let Some(ref mq_client_instance) = self.client_instance {
+            mq_client_instance
+                .get_mq_client_api_impl()
+                .get_broker_lite_info(&broker_addr, self.timeout_millis.as_millis() as u64)
+                .await
+        } else {
+            Err(rocketmq_error::RocketMQError::ClientNotStarted)
+        }
     }
 
     async fn get_parent_topic_info(
@@ -1699,11 +1701,23 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn get_lite_topic_info(
         &self,
-        _broker_addr: CheetahString,
-        _parent_topic: CheetahString,
-        _lite_topic: CheetahString,
+        broker_addr: CheetahString,
+        parent_topic: CheetahString,
+        lite_topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<GetLiteTopicInfoResponseBody> {
-        unimplemented!("get_lite_topic_info not implemented yet")
+        if let Some(ref mq_client_instance) = self.client_instance {
+            mq_client_instance
+                .get_mq_client_api_impl()
+                .get_lite_topic_info(
+                    &broker_addr,
+                    &parent_topic,
+                    &lite_topic,
+                    self.timeout_millis.as_millis() as u64,
+                )
+                .await
+        } else {
+            Err(rocketmq_error::RocketMQError::ClientNotStarted)
+        }
     }
 
     async fn get_lite_client_info(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -76,6 +76,7 @@ use rocketmq_remoting::protocol::body::check_client_request_body::CheckClientReq
 use rocketmq_remoting::protocol::body::epoch_entry_cache::EpochEntryCache;
 use rocketmq_remoting::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
 use rocketmq_remoting::protocol::body::get_lite_group_info_response_body::GetLiteGroupInfoResponseBody;
+use rocketmq_remoting::protocol::body::get_lite_topic_info_response_body::GetLiteTopicInfoResponseBody;
 use rocketmq_remoting::protocol::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
@@ -99,6 +100,7 @@ use rocketmq_remoting::protocol::header::end_transaction_request_header::EndTran
 use rocketmq_remoting::protocol::header::extra_info_util::ExtraInfoUtil;
 use rocketmq_remoting::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
 use rocketmq_remoting::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader;
+use rocketmq_remoting::protocol::header::get_lite_topic_info_request_header::GetLiteTopicInfoRequestHeader;
 use rocketmq_remoting::protocol::header::get_max_offset_request_header::GetMaxOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
 use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
@@ -625,6 +627,33 @@ impl MQClientAPIImpl {
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
                 return GetLiteGroupInfoResponseBody::decode(body.as_ref());
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn get_lite_topic_info(
+        &self,
+        addr: &CheetahString,
+        parent_topic: &CheetahString,
+        lite_topic: &CheetahString,
+        timeout_millis: u64,
+    ) -> RocketMQResult<GetLiteTopicInfoResponseBody> {
+        let request_header = GetLiteTopicInfoRequestHeader {
+            parent_topic: parent_topic.clone(),
+            lite_topic: lite_topic.clone(),
+        };
+        let request = RemotingCommand::create_request_command(RequestCode::GetLiteTopicInfo, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return GetLiteTopicInfoResponseBody::decode(body.as_ref());
             }
         }
         Err(mq_client_err!(

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -42,6 +42,7 @@ pub mod get_consumer_running_info_request_header;
 pub mod get_consumer_status_request_header;
 pub mod get_earliest_msg_storetime_response_header;
 pub mod get_lite_group_info_request_header;
+pub mod get_lite_topic_info_request_header;
 pub mod get_max_offset_request_header;
 pub mod get_max_offset_response_header;
 pub mod get_meta_data_response_header;

--- a/rocketmq-remoting/src/protocol/header/get_lite_topic_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_lite_topic_info_request_header.rs
@@ -1,0 +1,28 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct GetLiteTopicInfoRequestHeader {
+    #[required]
+    pub parent_topic: CheetahString,
+
+    #[required]
+    pub lite_topic: CheetahString,
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1380,11 +1380,13 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn get_lite_topic_info(
         &self,
-        _broker_addr: CheetahString,
-        _parent_topic: CheetahString,
-        _lite_topic: CheetahString,
+        broker_addr: CheetahString,
+        parent_topic: CheetahString,
+        lite_topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<GetLiteTopicInfoResponseBody> {
-        unimplemented!("get_lite_topic_info not implemented yet")
+        self.default_mqadmin_ext_impl
+            .get_lite_topic_info(broker_addr, parent_topic, lite_topic)
+            .await
     }
 
     async fn get_lite_client_info(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -402,6 +402,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Lite",
+                command: "getLiteTopicInfo",
+                remark: "Get lite topic info.",
+            },
+            Command {
+                category: "Lite",
                 command: "getParentTopicInfo",
                 remark: "Get parent topic info.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite.rs
@@ -15,6 +15,7 @@
 mod get_broker_lite_info_sub_command;
 mod get_lite_client_info_sub_command;
 mod get_lite_group_info_sub_command;
+mod get_lite_topic_info_sub_command;
 mod get_parent_topic_info_sub_command;
 mod trigger_lite_dispatch_sub_command;
 
@@ -27,6 +28,7 @@ use rocketmq_remoting::runtime::RPCHook;
 use crate::commands::lite::get_broker_lite_info_sub_command::GetBrokerLiteInfoSubCommand;
 use crate::commands::lite::get_lite_client_info_sub_command::GetLiteClientInfoSubCommand;
 use crate::commands::lite::get_lite_group_info_sub_command::GetLiteGroupInfoSubCommand;
+use crate::commands::lite::get_lite_topic_info_sub_command::GetLiteTopicInfoSubCommand;
 use crate::commands::lite::get_parent_topic_info_sub_command::GetParentTopicInfoSubCommand;
 use crate::commands::lite::trigger_lite_dispatch_sub_command::TriggerLiteDispatchSubCommand;
 use crate::commands::CommandExecute;
@@ -55,6 +57,13 @@ pub enum LiteCommands {
     GetLiteGroupInfo(GetLiteGroupInfoSubCommand),
 
     #[command(
+        name = "getLiteTopicInfo",
+        about = "Get lite topic info.",
+        long_about = None,
+    )]
+    GetLiteTopicInfo(GetLiteTopicInfoSubCommand),
+
+    #[command(
         name = "getParentTopicInfo",
         about = "Get parent topic info.",
         long_about = None,
@@ -75,6 +84,7 @@ impl CommandExecute for LiteCommands {
             LiteCommands::GetBrokerLiteInfo(cmd) => cmd.execute(rpc_hook).await,
             LiteCommands::GetLiteClientInfo(cmd) => cmd.execute(rpc_hook).await,
             LiteCommands::GetLiteGroupInfo(cmd) => cmd.execute(rpc_hook).await,
+            LiteCommands::GetLiteTopicInfo(cmd) => cmd.execute(rpc_hook).await,
             LiteCommands::GetParentTopicInfo(cmd) => cmd.execute(rpc_hook).await,
             LiteCommands::TriggerLiteDispatch(cmd) => cmd.execute(rpc_hook).await,
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/get_lite_topic_info_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/lite/get_lite_topic_info_sub_command.rs
@@ -1,0 +1,157 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::lite;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_common::UtilAll::time_millis_to_human_string2;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct GetLiteTopicInfoSubCommand {
+    #[arg(short = 'p', long = "parentTopic", required = true, help = "Parent topic name")]
+    parent_topic: String,
+
+    #[arg(short = 'l', long = "liteTopic", required = true, help = "Lite topic name")]
+    lite_topic: String,
+
+    #[arg(short = 's', long = "showClientId", help = "Show all clientId")]
+    show_client_id: bool,
+}
+
+impl CommandExecute for GetLiteTopicInfoSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("GetLiteTopicInfoSubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            let parent_topic = self.parent_topic.trim();
+            let lite_topic = self.lite_topic.trim();
+            let show_client_id = self.show_client_id;
+
+            let lmq_name = lite::to_lmq_name(parent_topic, lite_topic).unwrap_or_default();
+
+            let topic_route_data = default_mqadmin_ext
+                .examine_topic_route_info(CheetahString::from(parent_topic))
+                .await
+                .map_err(|e| {
+                    RocketMQError::Internal(format!(
+                        "GetLiteTopicInfoSubCommand: Failed to examine topic route info: {}",
+                        e
+                    ))
+                })?
+                .ok_or_else(|| {
+                    RocketMQError::Internal(format!(
+                        "GetLiteTopicInfoSubCommand: Topic route not found for: {}",
+                        parent_topic
+                    ))
+                })?;
+
+            println!("Lite Topic Info: [{}] [{}] [{}]", parent_topic, lite_topic, lmq_name);
+            println!(
+                "{:<50} {:<14} {:<14} {:<30} {:<12} {:<18}",
+                "#Broker Name", "#MinOffset", "#MaxOffset", "#LastUpdate", "#Sharding", "#SubClientCount"
+            );
+
+            for broker_data in &topic_route_data.broker_datas {
+                let broker_addr = match broker_data.select_broker_addr() {
+                    Some(addr) => addr,
+                    None => continue,
+                };
+
+                match default_mqadmin_ext
+                    .get_lite_topic_info(
+                        broker_addr.clone(),
+                        CheetahString::from(parent_topic),
+                        CheetahString::from(lite_topic),
+                    )
+                    .await
+                {
+                    Ok(body) => {
+                        let (min_offset, max_offset, last_update) = if let Some(topic_offset) = body.topic_offset() {
+                            (
+                                topic_offset.get_min_offset(),
+                                topic_offset.get_max_offset(),
+                                topic_offset.get_last_update_timestamp(),
+                            )
+                        } else {
+                            (0, 0, 0)
+                        };
+
+                        let last_update_str = if last_update > 0 {
+                            time_millis_to_human_string2(last_update)
+                        } else {
+                            "-".to_string()
+                        };
+
+                        let broker_name = broker_data.broker_name();
+                        let display_name: String = if broker_name.chars().count() > 40 {
+                            broker_name.chars().take(40).collect()
+                        } else {
+                            broker_name.to_string()
+                        };
+
+                        println!(
+                            "{:<50} {:<14} {:<14} {:<30} {:<12} {:<18}",
+                            display_name,
+                            min_offset,
+                            max_offset,
+                            last_update_str,
+                            body.sharding_to_broker(),
+                            body.subscriber().len()
+                        );
+
+                        if show_client_id {
+                            let display_list: Vec<String> = body
+                                .subscriber()
+                                .iter()
+                                .map(|client_group| format!("{}@{}", client_group.client_id, client_group.group))
+                                .collect();
+                            println!("{:?}", display_list);
+                        }
+                    }
+                    Err(e) => {
+                        println!("[{}] error: {}", broker_data.broker_name(), e);
+                    }
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6397 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin command to query lite topic information across brokers; shows min/max offsets, last update timestamps, sharding and subscriber counts.
  * Optional flag to display client ID and group details for subscribers.
  * Added support for fetching lite topic info from brokers so the command returns live data.

* **Bug Fixes**
  * Commands now report a clear "client not started" error instead of panicking when the internal client is uninitialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->