### PR TITLE
[ISSUE #6570]♻️Refactor ConsumeMessageHook to use Arc for improved thread safety and simplify hook registration

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -83,6 +83,7 @@ use crate::consumer::store::remote_broker_offset_store::RemoteBrokerOffsetStore;
 use crate::factory::mq_client_instance::MQClientInstance;
 use crate::hook::consume_message_context::ConsumeMessageContext;
 use crate::hook::consume_message_hook::ConsumeMessageHook;
+use crate::hook::consume_message_hook::ConsumeMessageHookArc;
 use crate::hook::filter_message_context::FilterMessageContext;
 use crate::hook::filter_message_hook::FilterMessageHook;
 use crate::implementation::communication_mode::CommunicationMode;
@@ -107,7 +108,7 @@ pub struct DefaultMQPushConsumerImpl {
     pub(crate) consumer_config: ArcMut<ConsumerConfig>,
     pub(crate) rebalance_impl: ArcMut<RebalancePushImpl>,
     filter_message_hook_list: Vec<Arc<dyn FilterMessageHook + Send + Sync>>,
-    consume_message_hook_list: Vec<Arc<Box<dyn ConsumeMessageHook + Send + Sync>>>,
+    consume_message_hook_list: Vec<ConsumeMessageHookArc>,
     rpc_hook: Option<Arc<dyn RPCHook>>,
     service_state: ArcMut<ServiceState>,
     pub(crate) client_instance: Option<ArcMut<MQClientInstance>>,
@@ -609,8 +610,9 @@ impl DefaultMQPushConsumerImpl {
         Ok(())
     }
 
-    pub fn register_consume_message_hook(&mut self, hook: impl ConsumeMessageHook) {
-        unimplemented!("registerConsumeMessageHook");
+    pub fn register_consume_message_hook(&mut self, hook: impl ConsumeMessageHook + Send + Sync + 'static) {
+        self.consume_message_hook_list
+            .push(Arc::new(hook) as ConsumeMessageHookArc);
     }
 
     pub fn register_message_listener(&mut self, message_listener: Option<ArcMut<MessageListener>>) {

--- a/rocketmq-client/src/hook/consume_message_hook.rs
+++ b/rocketmq-client/src/hook/consume_message_hook.rs
@@ -12,12 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use crate::hook::consume_message_context::ConsumeMessageContext;
 
+/// A shared, thread-safe reference to a [`ConsumeMessageHook`] implementation.
+pub type ConsumeMessageHookArc = Arc<dyn ConsumeMessageHook + Send + Sync>;
+
+/// Defines lifecycle callbacks invoked around the message consumption process.
+///
+/// Implementations are registered with a push consumer and called synchronously on the
+/// consumer's processing thread before and after each batch of messages is consumed.
+/// Multiple hooks may be registered; they are invoked in registration order.
+///
+/// Both callbacks receive an optional mutable reference to a [`ConsumeMessageContext`]
+/// that carries metadata about the current consumption attempt, including the consumer
+/// group, topic, message list, and the final consumption result.
 pub trait ConsumeMessageHook {
+    /// Returns the name that uniquely identifies this hook implementation.
     fn hook_name(&self) -> &str;
 
+    /// Invoked immediately before message consumption begins.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - Mutable reference to the consumption context, or `None` if no context is
+    ///   available for the current invocation.
     fn consume_message_before(&self, context: Option<&mut ConsumeMessageContext>);
 
+    /// Invoked immediately after message consumption completes.
+    ///
+    /// The [`ConsumeMessageContext`] reflects the final consumption status at this point,
+    /// including whether the messages were consumed successfully or encountered an error.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - Mutable reference to the consumption context, or `None` if no context is
+    ///   available for the current invocation.
     fn consume_message_after(&self, context: Option<&mut ConsumeMessageContext>);
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6570

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified consume message hook storage mechanism with a new type alias for thread-safe hook objects.
  * Updated `register_consume_message_hook` method signature for more flexible hook registration.

* **Documentation**
  * Added documentation to consume message hook trait and its methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->