### PR TITLE
[ISSUE #6580]🚀Implement max_offset  method for improved message queue offset retrieval

### DIFF
--- a/rocketmq-client/src/implementation/mq_admin_impl.rs
+++ b/rocketmq-client/src/implementation/mq_admin_impl.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use rocketmq_common::common::message::message_queue::MessageQueue;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_rust::ArcMut;
 
@@ -81,8 +82,18 @@ impl MQAdminImpl {
         )))
     }
 
+    /// Queries the maximum offset of the given message queue from the broker.
+    ///
+    /// Retries the broker address lookup via the name server when it is not cached locally.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the broker address cannot be resolved or the remote call fails.
     pub async fn max_offset(&mut self, mq: &MessageQueue) -> rocketmq_error::RocketMQResult<i64> {
-        let client = self.client.as_mut().expect("client is None");
+        let client = self
+            .client
+            .as_mut()
+            .ok_or_else(|| RocketMQError::not_initialized("MQClientInstance"))?;
         let broker_name = client.get_broker_name_from_message_queue(mq).await;
         let mut broker_addr = client.find_broker_address_in_publish(broker_name.as_ref());
         if broker_addr.is_none() {
@@ -91,18 +102,17 @@ impl MQAdminImpl {
             broker_addr = client.find_broker_address_in_publish(broker_name.as_ref());
         }
         if let Some(ref broker_addr) = broker_addr {
-            let offset = client
+            return client
                 .mq_client_api_impl
                 .as_mut()
-                .expect("mq_client_api_impl is None")
+                .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?
                 .get_max_offset(broker_addr, mq, self.timeout_millis)
-                .await?;
-            return Ok(offset);
+                .await;
         }
-
-        unimplemented!("max_offset")
+        Err(mq_client_err!(format!("The broker[{}] not exist", mq.broker_name())))
     }
+
     pub async fn search_offset(&mut self, mq: &MessageQueue, timestamp: u64) -> rocketmq_error::RocketMQResult<i64> {
-        unimplemented!("max_offset")
+        unimplemented!("search_offset is not implemented yet")
     }
 }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -42,6 +42,7 @@ use crate::producer::send_callback::SendMessageCallback;
 use crate::producer::send_result::SendResult;
 use crate::producer::send_status::SendStatus;
 use cheetah_string::CheetahString;
+
 use rocketmq_common::common::message::message_batch::MessageBatch;
 use rocketmq_common::common::message::message_client_id_setter::MessageClientIDSetter;
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
@@ -128,6 +129,7 @@ use rocketmq_remoting::protocol::header::query_consumer_offset_response_header::
 use rocketmq_remoting::protocol::header::recall_message_request_header::RecallMessageRequestHeader;
 use rocketmq_remoting::protocol::header::recall_message_response_header::RecallMessageResponseHeader;
 use rocketmq_remoting::protocol::header::reset_master_flush_offset_header::ResetMasterFlushOffsetHeader;
+
 use rocketmq_remoting::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader;
 use rocketmq_remoting::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader;
 use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6580

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for offset lookup operations with more descriptive error messages when broker addresses cannot be resolved.
  * Added automatic retry logic to update topic routing information when broker addresses are not cached, improving reliability during dynamic broker scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->