### PR TITLE
[ISSUE #6583]🚀Implement search_offset and search_offset_by_timestamp methods for queue offset retrieval

### DIFF
--- a/rocketmq-client/src/implementation/mq_admin_impl.rs
+++ b/rocketmq-client/src/implementation/mq_admin_impl.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_common::common::boundary_type::BoundaryType;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
@@ -112,7 +113,41 @@ impl MQAdminImpl {
         Err(mq_client_err!(format!("The broker[{}] not exist", mq.broker_name())))
     }
 
+    /// Searches for the queue offset whose store timestamp is closest to `timestamp`.
+    ///
+    /// Defaults to [`BoundaryType::Lower`], returning the earliest offset whose store
+    /// timestamp is greater than or equal to `timestamp`, matching the behaviour of
+    /// `MQAdminImpl.searchOffset(MessageQueue, long)` in the Java implementation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the broker address cannot be resolved or the remote call fails.
     pub async fn search_offset(&mut self, mq: &MessageQueue, timestamp: u64) -> rocketmq_error::RocketMQResult<i64> {
-        unimplemented!("search_offset is not implemented yet")
+        let client = self
+            .client
+            .as_mut()
+            .ok_or_else(|| RocketMQError::not_initialized("MQClientInstance"))?;
+        let broker_name = client.get_broker_name_from_message_queue(mq).await;
+        let mut broker_addr = client.find_broker_address_in_publish(broker_name.as_ref());
+        if broker_addr.is_none() {
+            client.update_topic_route_info_from_name_server_topic(mq.topic()).await;
+            let broker_name = client.get_broker_name_from_message_queue(mq).await;
+            broker_addr = client.find_broker_address_in_publish(broker_name.as_ref());
+        }
+        if let Some(ref broker_addr) = broker_addr {
+            return client
+                .mq_client_api_impl
+                .as_mut()
+                .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?
+                .search_offset_by_timestamp(
+                    broker_addr,
+                    mq,
+                    timestamp as i64,
+                    BoundaryType::Lower,
+                    self.timeout_millis,
+                )
+                .await;
+        }
+        Err(mq_client_err!(format!("The broker[{}] not exist", mq.broker_name())))
     }
 }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -130,11 +130,14 @@ use rocketmq_remoting::protocol::header::recall_message_request_header::RecallMe
 use rocketmq_remoting::protocol::header::recall_message_response_header::RecallMessageResponseHeader;
 use rocketmq_remoting::protocol::header::reset_master_flush_offset_header::ResetMasterFlushOffsetHeader;
 
+use rocketmq_common::common::boundary_type::BoundaryType;
 use rocketmq_remoting::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader;
 use rocketmq_remoting::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader;
 use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::update_user_request_header::UpdateUserRequestHeader;
 use rocketmq_remoting::protocol::headers::client::GetConsumerConnectionListRequestHeader;
+use rocketmq_remoting::protocol::headers::view::SearchOffsetRequestHeader;
+use rocketmq_remoting::protocol::headers::view::SearchOffsetResponseHeader;
 use rocketmq_remoting::protocol::heartbeat::heartbeat_data::HeartbeatData;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
@@ -2121,6 +2124,63 @@ impl MQClientAPIImpl {
             let response_header = response
                 .decode_command_custom_header::<GetMaxOffsetResponseHeader>()
                 .expect("decode error");
+            return Ok(response_header.offset);
+        }
+        Err(client_broker_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string()),
+            addr.to_string()
+        ))
+    }
+
+    /// Searches for the queue offset whose store timestamp is closest to `timestamp`.
+    ///
+    /// When `boundary_type` is [`BoundaryType::Lower`], the returned offset is the earliest one
+    /// whose store timestamp is greater than or equal to `timestamp`.  When
+    /// [`BoundaryType::Upper`], the latest such offset is returned.
+    ///
+    /// Mirrors `MQClientAPIImpl.searchOffset` in the Java implementation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the broker returns a non-success response code or is unreachable.
+    pub async fn search_offset_by_timestamp(
+        &mut self,
+        addr: &str,
+        message_queue: &MessageQueue,
+        timestamp: i64,
+        boundary_type: BoundaryType,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<i64> {
+        let request_header = SearchOffsetRequestHeader {
+            topic: message_queue.topic().clone(),
+            queue_id: message_queue.queue_id(),
+            timestamp,
+            boundary_type,
+            topic_request_header: Some(TopicRequestHeader {
+                rpc_request_header: Some(RpcRequestHeader {
+                    broker_name: Some(message_queue.broker_name().clone()),
+                    ..Default::default()
+                }),
+                lo: None,
+            }),
+        };
+        let request = RemotingCommand::create_request_command(RequestCode::SearchOffsetByTimestamp, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(
+                Some(&mix_all::broker_vip_channel(
+                    self.client_config.vip_channel_enabled,
+                    addr,
+                )),
+                request,
+                timeout_millis,
+            )
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            let response_header = response
+                .decode_command_custom_header::<SearchOffsetResponseHeader>()
+                .expect("decode SearchOffsetResponseHeader error");
             return Ok(response_header.offset);
         }
         Err(client_broker_err!(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6583

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added timestamp-based queue offset search capability, enabling you to locate message offsets at or near a specific point in time for more precise message retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->