### PR TITLE
[Test🧪] Add test case for GetLiteTopicInfoRequestHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_lite_topic_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_lite_topic_info_request_header.rs
@@ -26,3 +26,82 @@ pub struct GetLiteTopicInfoRequestHeader {
     #[required]
     pub lite_topic: CheetahString,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn get_lite_topic_info_request_header_creation() {
+        let header = GetLiteTopicInfoRequestHeader {
+            parent_topic: CheetahString::from("parent_topic"),
+            lite_topic: CheetahString::from("lite_topic"),
+        };
+
+        assert_eq!(header.parent_topic, CheetahString::from("parent_topic"));
+        assert_eq!(header.lite_topic, CheetahString::from("lite_topic"));
+    }
+
+    #[test]
+    fn get_lite_topic_info_request_header_serializes_to_map() {
+        let header = GetLiteTopicInfoRequestHeader {
+            parent_topic: CheetahString::from("test_parent"),
+            lite_topic: CheetahString::from("test_lite"),
+        };
+
+        let map = header.to_map().unwrap();
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("parentTopic")).unwrap(),
+            "test_parent"
+        );
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("liteTopic")).unwrap(),
+            "test_lite"
+        );
+    }
+
+    #[test]
+    fn get_lite_topic_info_request_header_deserializes_from_map() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("parentTopic"),
+            CheetahString::from("deserialized_parent"),
+        );
+        map.insert(
+            CheetahString::from_static_str("liteTopic"),
+            CheetahString::from("deserialized_lite"),
+        );
+
+        let header = <GetLiteTopicInfoRequestHeader as FromMap>::from(&map).unwrap();
+        assert_eq!(header.parent_topic, CheetahString::from("deserialized_parent"));
+        assert_eq!(header.lite_topic, CheetahString::from("deserialized_lite"));
+    }
+
+    #[test]
+    fn get_lite_topic_info_request_header_clone() {
+        let header = GetLiteTopicInfoRequestHeader {
+            parent_topic: CheetahString::from("parent"),
+            lite_topic: CheetahString::from("lite"),
+        };
+
+        let cloned = header.clone();
+        assert_eq!(header.parent_topic, cloned.parent_topic);
+        assert_eq!(header.lite_topic, cloned.lite_topic);
+    }
+
+    #[test]
+    fn get_lite_topic_info_request_header_debug() {
+        let header = GetLiteTopicInfoRequestHeader {
+            parent_topic: CheetahString::from("parent"),
+            lite_topic: CheetahString::from("lite"),
+        };
+
+        let debug_str = format!("{:?}", header);
+        assert!(debug_str.contains("parent"));
+        assert!(debug_str.contains("lite"));
+    }
+}


### PR DESCRIPTION
## Motivation
Closes #6572

## Modification
Added unit tests for `GetLiteTopicInfoRequestHeader` covering:
- Header creation with field values
- Serialization to map (`to_map`)
- Deserialization from map (`from_map`)
- Clone behavior
- Debug formatting

## Result
All 5 tests pass. Improves test coverage for the remoting protocol headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for request header components, including validation of serialization and deserialization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->