### PR TITLE
[Test🧪] Add test case for GetLiteGroupInfoRequestHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/get_lite_group_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_lite_group_info_request_header.rs
@@ -68,18 +68,12 @@ mod tests {
         };
 
         let map = header.to_map().unwrap();
-        assert_eq!(
-            map.get(&CheetahString::from_static_str("group")).unwrap(),
-            "my_group"
-        );
+        assert_eq!(map.get(&CheetahString::from_static_str("group")).unwrap(), "my_group");
         assert_eq!(
             map.get(&CheetahString::from_static_str("liteTopic")).unwrap(),
             "my_lite_topic"
         );
-        assert_eq!(
-            map.get(&CheetahString::from_static_str("topK")).unwrap(),
-            "5"
-        );
+        assert_eq!(map.get(&CheetahString::from_static_str("topK")).unwrap(), "5");
     }
 
     #[test]
@@ -93,10 +87,7 @@ mod tests {
             CheetahString::from_static_str("liteTopic"),
             CheetahString::from("deserialized_lite"),
         );
-        map.insert(
-            CheetahString::from_static_str("topK"),
-            CheetahString::from("20"),
-        );
+        map.insert(CheetahString::from_static_str("topK"), CheetahString::from("20"));
 
         let header = <GetLiteGroupInfoRequestHeader as FromMap>::from(&map).unwrap();
         assert_eq!(header.group, CheetahString::from("deserialized_group"));


### PR DESCRIPTION
## Motivation
Closes #6569

## Modification
Added unit tests for `GetLiteGroupInfoRequestHeader` covering:
- Header creation with field values
- Serialization to map (`to_map`)
- Deserialization from map (`from_map`)
- Clone behavior
- Debug formatting
- Edge cases for `top_k` (zero, negative, i32::MAX)

## Result
All 6 tests pass. Improves test coverage for the remoting protocol headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for the Lite Group Info request header: validates creation, serialization/deserialization round-trips, cloning, debug formatting, and behavior with edge top_k values (0, negative, max). No public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->