### PR TITLE
[Enhancement✨] Add buyer_id_ref method for MessageTrait

### DIFF
--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -205,6 +205,11 @@ pub trait MessageTrait: Any + Display + Debug {
         self.property(&CheetahString::from_static_str(MessageConst::PROPERTY_BUYER_ID))
     }
 
+    /// Returns a reference to the buyer ID associated with the message.
+    fn buyer_id_ref(&self) -> Option<&CheetahString> {
+        self.property_ref(&CheetahString::from_static_str(MessageConst::PROPERTY_BUYER_ID))
+    }
+
     /// Sets the buyer ID for the message.
     fn set_buyer_id(&mut self, buyer_id: CheetahString) {
         self.put_property(


### PR DESCRIPTION
## Motivation
Closes #6588

## Modification
Added `buyer_id_ref()` method to `MessageTrait` that returns `Option<&CheetahString>` instead of cloning. This is consistent with existing `_ref` methods like `tags_ref()`, `get_keys_ref()`, and `user_property_ref()`.

## Result
Zero-copy access to buyer ID property, avoiding unnecessary string cloning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced buyer ID property access in the messaging system, allowing more efficient retrieval and handling of buyer information data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->