### PR TITLE
[ISSUE #6624]🚀Add hash-selector-producer example and fix message topic in benchmarks

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -109,6 +109,10 @@ name = "ordermessage-producer"
 path = "examples/ordermessage/ordermessage_producer.rs"
 
 [[example]]
+name = "hash-selector-producer"
+path = "examples/ordermessage/hash_selector_producer.rs"
+
+[[example]]
 name = "ordermessage-consumer"
 path = "examples/ordermessage/ordermessage_consumer.rs"
 

--- a/rocketmq-client/benches/select_queue_benchmark.rs
+++ b/rocketmq-client/benches/select_queue_benchmark.rs
@@ -59,7 +59,7 @@ fn bench_select_original(c: &mut Criterion) {
         MessageQueue::from_parts("test_topic", "broker-a", 2),
         MessageQueue::from_parts("test_topic", "broker-a", 3),
     ];
-    let msg = Message::builder().build().unwrap();
+    let msg = Message::builder().topic("test_topic").build().unwrap();
 
     c.bench_function("select_original", |b| {
         b.iter(|| {
@@ -77,7 +77,7 @@ fn bench_select_cached(c: &mut Criterion) {
         MessageQueue::from_parts("test_topic", "broker-a", 2),
         MessageQueue::from_parts("test_topic", "broker-a", 3),
     ];
-    let msg = Message::builder().build().unwrap();
+    let msg = Message::builder().topic("test_topic").build().unwrap();
 
     c.bench_function("select_cached", |b| {
         b.iter(|| {

--- a/rocketmq-client/examples/ordermessage/hash_selector_producer.rs
+++ b/rocketmq-client/examples/ordermessage/hash_selector_producer.rs
@@ -1,0 +1,68 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Example demonstrating the use of SelectMessageQueueByHash for ordered message delivery.
+//!
+//! This example shows how to use hash-based queue selection to ensure that messages
+//! with the same key (e.g., order ID) are always sent to the same queue, maintaining
+//! ordering guarantees.
+
+use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
+use rocketmq_client_rust::producer::message_queue_selector::MessageQueueSelector;
+use rocketmq_client_rust::producer::mq_producer::MQProducer;
+use rocketmq_client_rust::producer::queue_selector::SelectMessageQueueByHash;
+use rocketmq_common::common::message::message_single::Message;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut producer = DefaultMQProducer::builder()
+        .producer_group("order_producer_group")
+        .name_server_addr("127.0.0.1:9876")
+        .build();
+
+    producer.start().await?;
+    println!("Producer started successfully");
+
+    let selector = SelectMessageQueueByHash;
+
+    for i in 0..10 {
+        let order_id = i % 3;
+
+        let message = Message::builder()
+            .topic("OrderTopic")
+            .body(format!("Order {} - Item {}", order_id, i).as_bytes().to_vec())
+            .keys(vec![format!("ORDER_{}", order_id)])
+            .build()?;
+
+        let send_result = producer
+            .send_with_selector(message, |mqs, msg, arg| selector.select(mqs, msg, arg), &order_id)
+            .await?;
+
+        if let Some(result) = send_result {
+            if let (Some(queue), Some(msg_id)) = (&result.message_queue, &result.msg_id) {
+                println!(
+                    "Sent order {} message to queue {}: {}",
+                    order_id,
+                    queue.queue_id(),
+                    msg_id
+                );
+            }
+        }
+    }
+
+    producer.shutdown().await;
+    println!("Producer shutdown");
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6624

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example demonstrating ordered message delivery using hash-based queue selection for message ordering patterns.

* **Tests**
  * Enhanced queue selection benchmarks with topic configuration for improved test accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->