### PR TITLE
[ISSUE #6405]🚀Implement DumpCompactionLog Command for Compaction Log Inspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,6 +3428,7 @@ version = "0.8.0"
 name = "rocketmq-admin-core"
 version = "0.8.0"
 dependencies = [
+ "bytes",
  "cheetah-string",
  "chrono",
  "clap",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/Cargo.toml
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/Cargo.toml
@@ -40,6 +40,8 @@ rocketmq-rust        = { workspace = true }
 rocketmq-client-rust = { workspace = true }
 rocketmq-error       = { workspace = true }
 
+bytes                = { workspace = true }
+
 serde.workspace      = true
 serde_json.workspace = true
 serde_yaml           = "0.9"

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -433,6 +433,11 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Decode unique message ID.",
             },
             Command {
+                category: "Message",
+                command: "dumpCompactionLog",
+                remark: "Parse compaction log to message.",
+            },
+            Command {
                 category: "NameServer",
                 command: "addWritePerm",
                 remark: "Add write perm of broker in all name server.",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message.rs
@@ -14,6 +14,7 @@
 
 pub mod check_msg_send_rt_sub_command;
 pub mod decode_message_id_sub_command;
+pub mod dump_compaction_log_sub_command;
 
 use std::sync::Arc;
 
@@ -23,6 +24,7 @@ use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::message::check_msg_send_rt_sub_command::CheckMsgSendRTSubCommand;
 use crate::commands::message::decode_message_id_sub_command::DecodeMessageIdSubCommand;
+use crate::commands::message::dump_compaction_log_sub_command::DumpCompactionLogSubCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
@@ -40,6 +42,13 @@ pub enum MessageCommands {
         long_about = None,
     )]
     DecodeMessageId(DecodeMessageIdSubCommand),
+
+    #[command(
+        name = "dumpCompactionLog",
+        about = "Parse compaction log to message.",
+        long_about = None,
+    )]
+    DumpCompactionLog(DumpCompactionLogSubCommand),
 }
 
 impl CommandExecute for MessageCommands {
@@ -47,6 +56,7 @@ impl CommandExecute for MessageCommands {
         match self {
             MessageCommands::CheckMsgSendRT(value) => value.execute(rpc_hook).await,
             MessageCommands::DecodeMessageId(value) => value.execute(rpc_hook).await,
+            MessageCommands::DumpCompactionLog(value) => value.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message/dump_compaction_log_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message/dump_compaction_log_sub_command.rs
@@ -1,0 +1,87 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use clap::Parser;
+use rocketmq_common::common::message::message_decoder;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct DumpCompactionLogSubCommand {
+    #[arg(short = 'f', long = "file", required = false, help = "to dump file name")]
+    file: Option<String>,
+}
+
+impl CommandExecute for DumpCompactionLogSubCommand {
+    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        if let Some(file_name) = &self.file {
+            let file_path = Path::new(file_name);
+
+            if !file_path.exists() {
+                return Err(RocketMQError::Internal(format!("file {} not exist.", file_name)));
+            }
+
+            if file_path.is_dir() {
+                return Err(RocketMQError::Internal(format!("file {} is a directory.", file_name)));
+            }
+
+            let data = fs::read(file_name)
+                .map_err(|e| RocketMQError::Internal(format!("Failed to read file {}: {}", file_name, e)))?;
+
+            let file_size = data.len();
+            let mut buf = Bytes::from(data);
+            let mut current = 0usize;
+
+            while current < file_size {
+                if buf.len() < 4 {
+                    break;
+                }
+
+                let size = i32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+
+                if size <= 0 || size as usize > file_size {
+                    break;
+                }
+
+                if buf.len() < size as usize {
+                    break;
+                }
+
+                let mut msg_bytes = buf.split_to(size as usize);
+
+                match message_decoder::decode(&mut msg_bytes, false, false, false, false, false) {
+                    Some(message_ext) => {
+                        current += size as usize;
+                        println!("{}", message_ext);
+                    }
+                    None => {
+                        break;
+                    }
+                }
+            }
+        } else {
+            println!("miss dump log file name");
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6405 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "dumpCompactionLog" command to parse and display messages from compaction log files in the message administration tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->