### PR TITLE
[ISSUE #6630]🚀Add random-selector-producer example for load-balanced message delivery

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -113,6 +113,10 @@ name = "hash-selector-producer"
 path = "examples/ordermessage/hash_selector_producer.rs"
 
 [[example]]
+name = "random-selector-producer"
+path = "examples/ordermessage/random_selector_producer.rs"
+
+[[example]]
 name = "ordermessage-consumer"
 path = "examples/ordermessage/ordermessage_consumer.rs"
 

--- a/rocketmq-client/examples/ordermessage/random_selector_producer.rs
+++ b/rocketmq-client/examples/ordermessage/random_selector_producer.rs
@@ -1,0 +1,60 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Example demonstrating the use of SelectMessageQueueByRandom for load-balanced message delivery.
+//!
+//! This example shows how to use random queue selection to distribute messages
+//! evenly across available queues without ordering guarantees.
+
+use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
+use rocketmq_client_rust::producer::message_queue_selector::MessageQueueSelector;
+use rocketmq_client_rust::producer::mq_producer::MQProducer;
+use rocketmq_client_rust::producer::queue_selector::SelectMessageQueueByRandom;
+use rocketmq_common::common::message::message_single::Message;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut producer = DefaultMQProducer::builder()
+        .producer_group("random_producer_group")
+        .name_server_addr("127.0.0.1:9876")
+        .build();
+
+    producer.start().await?;
+    println!("Producer started successfully");
+
+    let selector = SelectMessageQueueByRandom;
+
+    for i in 0..10 {
+        let message = Message::builder()
+            .topic("RandomTopic")
+            .body(format!("Message {}", i).as_bytes().to_vec())
+            .keys(vec![format!("MSG_{}", i)])
+            .build()?;
+
+        let send_result = producer
+            .send_with_selector(message, |mqs, msg, arg| selector.select(mqs, msg, arg), &())
+            .await?;
+
+        if let Some(result) = send_result {
+            if let (Some(queue), Some(msg_id)) = (&result.message_queue, &result.msg_id) {
+                println!("Sent message {} to queue {}: {}", i, queue.queue_id(), msg_id);
+            }
+        }
+    }
+
+    producer.shutdown().await;
+    println!("Producer shutdown");
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6630

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new example illustrating random queue selection for load-balanced message delivery, demonstrating how to distribute messages across available producer queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->