### PR TITLE
[ISSUE #6636]♻️Refactor send callback to use ArcSendCallback for improved async handling

### DIFF
--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -38,7 +38,7 @@ use crate::implementation::communication_mode::CommunicationMode;
 use crate::latency::mq_fault_strategy::MQFaultStrategy;
 use crate::producer::producer_impl::default_mq_producer_impl::DefaultMQProducerImpl;
 use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
-use crate::producer::send_callback::SendMessageCallback;
+use crate::producer::send_callback::ArcSendCallback;
 use crate::producer::send_result::SendResult;
 use crate::producer::send_status::SendStatus;
 use cheetah_string::CheetahString;
@@ -901,7 +901,7 @@ impl MQClientAPIImpl {
         request_header: SendMessageRequestHeader,
         timeout_millis: u64,
         communication_mode: CommunicationMode,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         topic_publish_info: Option<&TopicPublishInfo>,
         instance: Option<ArcMut<MQClientInstance>>,
         retry_times_when_send_failed: u32,
@@ -1082,7 +1082,7 @@ impl MQClientAPIImpl {
         msg: &T,
         timeout_millis: u64,
         request: RemotingCommand,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         topic_publish_info: Option<&TopicPublishInfo>,
         instance: Option<ArcMut<MQClientInstance>>,
         retry_times_when_send_failed: u32,
@@ -1122,7 +1122,7 @@ impl MQClientAPIImpl {
                             producer.execute_send_message_hook_after(context);
                         }
                         let duration = (Instant::now() - begin_start_time).as_millis() as u64;
-                        send_callback.as_ref().unwrap()(Some(&result), None);
+                        send_callback.as_ref().unwrap().on_success(&result);
                         producer
                             .update_fault_item(&broker_name, duration, false, true)
                             .await;
@@ -1164,7 +1164,7 @@ impl MQClientAPIImpl {
         msg: &T,
         timeout_millis: u64,
         request: RemotingCommand,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         topic_publish_info: Option<&TopicPublishInfo>,
         instance: Option<ArcMut<MQClientInstance>>,
         retry_times_when_send_failed: u32,
@@ -1264,7 +1264,7 @@ impl MQClientAPIImpl {
         is_batch_message: bool,
         timeout_millis: u64,
         current_request: RemotingCommand,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         _topic_publish_info: Option<TopicPublishInfo>,
         _instance: Option<ArcMut<MQClientInstance>>,
         _retry_times_when_send_failed: u32,
@@ -1308,7 +1308,7 @@ impl MQClientAPIImpl {
                                 response.code(),
                                 response.remark().map_or("".to_string(), |s| s.to_string())
                             );
-                            callback(None, Some(&err_obj as &dyn std::error::Error));
+                            callback.on_exception(&err_obj as &dyn std::error::Error);
                         }
                         return;
                     }
@@ -1354,7 +1354,7 @@ impl MQClientAPIImpl {
                             .update_fault_item(current_broker_name.clone(), cost, false, true)
                             .await;
                         if let Some(callback) = send_callback {
-                            callback(Some(&send_result), None);
+                            callback.on_success(&send_result);
                         }
                     }
                     Err(_) => {
@@ -1363,7 +1363,7 @@ impl MQClientAPIImpl {
                             .await;
                         if let Some(callback) = send_callback {
                             let err_obj = mq_client_err!("decode SendMessageResponseHeader failed".to_string());
-                            callback(None, Some(&err_obj as &dyn std::error::Error));
+                            callback.on_exception(&err_obj as &dyn std::error::Error);
                         }
                     }
                 }
@@ -1374,7 +1374,7 @@ impl MQClientAPIImpl {
                     .update_fault_item(current_broker_name.clone(), cost, true, true)
                     .await;
                 if let Some(callback) = send_callback {
-                    callback(None, Some(&e as &dyn std::error::Error));
+                    callback.on_exception(&e as &dyn std::error::Error);
                 }
             }
         }
@@ -1457,7 +1457,7 @@ impl MQClientAPIImpl {
         msg: &T,
         timeout_millis: u64,
         mut request: RemotingCommand,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         topic_publish_info: Option<&TopicPublishInfo>,
         instance: Option<ArcMut<MQClientInstance>>,
         times_total: u32,

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -41,7 +41,7 @@ use crate::producer::default_mq_produce_builder::DefaultMQProducerBuilder;
 use crate::producer::mq_producer::MQProducer;
 use crate::producer::produce_accumulator::ProduceAccumulator;
 use crate::producer::producer_impl::default_mq_producer_impl::DefaultMQProducerImpl;
-use crate::producer::send_callback::SendMessageCallback;
+use crate::producer::send_callback::ArcSendCallback;
 use crate::producer::send_result::SendResult;
 use crate::producer::transaction_send_result::TransactionSendResult;
 use crate::trace::async_trace_dispatcher::AsyncTraceDispatcher;
@@ -598,7 +598,7 @@ impl DefaultMQProducer {
         &mut self,
         mut msg: M,
         mq: Option<MessageQueue>,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
     ) -> rocketmq_error::RocketMQResult<Option<SendResult>>
     where
         M: MessageTrait + Send + Sync,
@@ -626,7 +626,7 @@ impl DefaultMQProducer {
         &mut self,
         mut msg: M,
         mq: Option<MessageQueue>,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
     ) -> rocketmq_error::RocketMQResult<Option<SendResult>>
     where
         M: MessageTrait + Send + std::marker::Sync + 'static,
@@ -973,7 +973,7 @@ impl MQProducer for DefaultMQProducer {
         mut msg: M,
         selector: S,
         arg: T,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
@@ -1001,7 +1001,7 @@ impl MQProducer for DefaultMQProducer {
         mut msg: M,
         selector: S,
         arg: T,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where

--- a/rocketmq-client/src/producer/mq_producer.rs
+++ b/rocketmq-client/src/producer/mq_producer.rs
@@ -18,7 +18,7 @@ use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::MessageTrait;
 
-use crate::producer::send_callback::SendMessageCallback;
+use crate::producer::send_callback::ArcSendCallback;
 use crate::producer::send_result::SendResult;
 use crate::producer::transaction_send_result::TransactionSendResult;
 
@@ -349,7 +349,7 @@ pub trait MQProducer {
         msg: M,
         selector: S,
         arg: T,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
@@ -381,7 +381,7 @@ pub trait MQProducer {
         msg: M,
         selector: S,
         arg: T,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -32,7 +32,7 @@ use rocketmq_rust::ArcMut;
 use tokio::sync::Mutex;
 
 use crate::producer::default_mq_producer::DefaultMQProducer;
-use crate::producer::send_callback::SendMessageCallback;
+use crate::producer::send_callback::ArcSendCallback;
 use crate::producer::send_result::SendResult;
 
 #[derive(Default)]
@@ -174,7 +174,7 @@ impl ProduceAccumulator {
         &mut self,
         message: M,
         mq: Option<MessageQueue>,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         default_mq_producer: DefaultMQProducer,
     ) -> rocketmq_error::RocketMQResult<()>
     where
@@ -360,7 +360,11 @@ impl ProduceAccumulator {
         let combined_callback = move |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
             // Invoke all registered callbacks
             for callback in &callbacks {
-                callback(result, error);
+                if let Some(result) = result {
+                    callback.on_success(result);
+                } else if let Some(error) = error {
+                    callback.on_exception(error);
+                }
             }
         };
 
@@ -441,7 +445,7 @@ impl Hash for AggregateKey {
 struct MessageAccumulation {
     default_mq_producer: ArcMut<DefaultMQProducer>,
     messages: Vec<Box<dyn MessageTrait + Send + Sync + 'static>>,
-    send_callbacks: Vec<SendMessageCallback>,
+    send_callbacks: Vec<ArcSendCallback>,
     keys: HashSet<String>,
     closed: Arc<AtomicBool>,
     send_results: Option<Vec<SendResult>>, // Stores results for sync send
@@ -489,7 +493,7 @@ impl MessageAccumulation {
     pub fn add<M: MessageTrait + Send + Sync + 'static>(
         &mut self,
         msg: M,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
     ) -> rocketmq_error::RocketMQResult<bool> {
         // Check if batch is already closed
         if self.closed.load(Ordering::Acquire) {
@@ -722,7 +726,11 @@ impl GuardForAsyncSendService {
         // Create combined callback
         let combined_callback = move |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
             for callback in &callbacks {
-                callback(result, error);
+                if let Some(result) = result {
+                    callback.on_success(result);
+                } else if let Some(error) = error {
+                    callback.on_exception(error);
+                }
             }
         };
 

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -84,7 +84,7 @@ use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
 use crate::producer::request_callback::RequestCallbackFn;
 use crate::producer::request_future_holder::REQUEST_FUTURE_HOLDER;
 use crate::producer::request_response_future::RequestResponseFuture;
-use crate::producer::send_callback::SendMessageCallback;
+use crate::producer::send_callback::ArcSendCallback;
 use crate::producer::send_result::SendResult;
 use crate::producer::send_status::SendStatus;
 use crate::producer::transaction_listener::ArcTransactionListener;
@@ -331,7 +331,7 @@ impl DefaultMQProducerImpl {
     pub async fn async_send_with_callback<T>(
         &mut self,
         msg: T,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
     ) -> rocketmq_error::RocketMQResult<()>
     where
         T: MessageTrait + Send + Sync,
@@ -539,7 +539,7 @@ impl DefaultMQProducerImpl {
         &mut self,
         msg: T,
         mq: MessageQueue,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
     ) -> rocketmq_error::RocketMQResult<()>
     where
         T: MessageTrait + Send + Sync,
@@ -558,7 +558,7 @@ impl DefaultMQProducerImpl {
         msg: M,
         selector: S,
         arg: T,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
@@ -585,10 +585,10 @@ impl DefaultMQProducerImpl {
         let future = async move {
             let cost_time = begin_start_time.elapsed().as_millis() as u64;
             if timeout <= cost_time {
-                send_callback_clone.as_ref().unwrap()(
-                    None,
-                    Some(&RemotingTooMuchRequestError("call timeout".to_string()) as &dyn std::error::Error),
-                );
+                send_callback_clone
+                    .as_ref()
+                    .unwrap()
+                    .on_exception(&RemotingTooMuchRequestError("call timeout".to_string()) as &dyn std::error::Error);
             }
 
             producer_impl
@@ -635,7 +635,7 @@ impl DefaultMQProducerImpl {
         selector: S,
         arg: T,
         communication_mode: CommunicationMode,
-        send_message_callback: Option<SendMessageCallback>,
+        send_message_callback: Option<ArcSendCallback>,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<Option<SendResult>>
     where
@@ -696,7 +696,7 @@ impl DefaultMQProducerImpl {
         &mut self,
         mut msg: T,
         mq: MessageQueue,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
@@ -720,27 +720,30 @@ impl DefaultMQProducerImpl {
         };
         let future = async move {
             if let Err(err) = producer_impl.make_sure_state_ok() {
-                send_callback_inner.as_ref().unwrap()(None, Some(&err as &dyn std::error::Error));
+                send_callback_inner
+                    .as_ref()
+                    .unwrap()
+                    .on_exception(&err as &dyn std::error::Error);
                 return;
             }
             if msg.topic() != mq.topic_str() {
-                send_callback_inner.as_ref().unwrap()(
-                    None,
-                    Some(&rocketmq_error::RocketmqError::MQClientErr(ClientErr::new(format!(
+                send_callback_inner
+                    .as_ref()
+                    .unwrap()
+                    .on_exception(&rocketmq_error::RocketmqError::MQClientErr(ClientErr::new(format!(
                         "message topic [{}] is not equal with message queue topic [{}]",
                         msg.topic(),
                         mq.topic_str()
-                    ))) as &dyn std::error::Error),
-                );
+                    ))) as &dyn std::error::Error);
                 return;
             }
 
             let cost_time = (Instant::now() - begin_start_time).as_millis() as u64;
             if timeout <= cost_time {
-                send_callback_inner.as_ref().unwrap()(
-                    None,
-                    Some(&RemotingTooMuchRequestError("call timeout".to_string()) as &dyn std::error::Error),
-                );
+                send_callback_inner
+                    .as_ref()
+                    .unwrap()
+                    .on_exception(&RemotingTooMuchRequestError("call timeout".to_string()) as &dyn std::error::Error);
             }
             let result = producer_impl
                 .send_kernel_impl(
@@ -755,7 +758,10 @@ impl DefaultMQProducerImpl {
             match result {
                 Ok(_) => {}
                 Err(err) => {
-                    send_callback_inner.as_ref().unwrap()(None, Some(&err as &dyn std::error::Error));
+                    send_callback_inner
+                        .as_ref()
+                        .unwrap()
+                        .on_exception(&err as &dyn std::error::Error);
                 }
             }
         };
@@ -767,7 +773,7 @@ impl DefaultMQProducerImpl {
     pub async fn async_send_with_callback_timeout<T>(
         &mut self,
         mut msg: T,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where
@@ -792,10 +798,12 @@ impl DefaultMQProducerImpl {
         let future = async move {
             let cost_time = (Instant::now() - begin_start_time).as_millis() as u64;
             if timeout <= cost_time {
-                send_callback_inner.as_ref().unwrap()(
-                    None,
-                    Some(&RemotingTooMuchRequestError("asyncSend call timeout".to_string()) as &dyn std::error::Error),
-                );
+                send_callback_inner
+                    .as_ref()
+                    .unwrap()
+                    .on_exception(
+                        &RemotingTooMuchRequestError("asyncSend call timeout".to_string()) as &dyn std::error::Error
+                    );
             }
 
             let result = producer_impl
@@ -804,7 +812,10 @@ impl DefaultMQProducerImpl {
             match result {
                 Ok(_) => {}
                 Err(err) => {
-                    send_callback_inner.as_ref().unwrap()(None, Some(&err as &dyn std::error::Error));
+                    send_callback_inner
+                        .as_ref()
+                        .unwrap()
+                        .on_exception(&err as &dyn std::error::Error);
                 }
             }
         };
@@ -816,7 +827,7 @@ impl DefaultMQProducerImpl {
     async fn execute_async_message_send<F>(
         &mut self,
         f: F,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         timeout: u64,
         begin_start_time: Instant,
         msg_len: usize,
@@ -827,93 +838,92 @@ impl DefaultMQProducerImpl {
     {
         let is_enable_backpressure_for_async_mode = self.producer_config.enable_backpressure_for_async_mode();
 
-        let (acquire_value_num, acquire_value_size) =
-            if is_enable_backpressure_for_async_mode {
-                //back pressure
-                let cost_time = (Instant::now() - begin_start_time).as_millis() as u64;
-                let is_semaphore_async_numb_acquired = (timeout - cost_time) > 0;
-                if !is_semaphore_async_numb_acquired {
-                    send_callback.as_ref().unwrap()(
-                        None,
-                        Some(&RemotingTooMuchRequestError(
-                            "send message tryAcquire semaphoreAsyncNum timeout".to_string(),
-                        ) as &dyn std::error::Error),
-                    );
-                    return Ok(());
-                }
-                let result = tokio::time::timeout(
-                    Duration::from_millis(timeout - cost_time),
-                    self.semaphore_async_send_num.acquire(),
-                )
-                .await;
-                let acquire_value_num = match result {
-                    Ok(acquire_value) => match acquire_value {
-                        Ok(value) => Some(value),
-                        Err(_) => {
-                            send_callback.as_ref().unwrap()(
-                                None,
-                                Some(&RemotingTooMuchRequestError(
-                                    "send message tryAcquire semaphoreAsyncNum timeout".to_string(),
-                                ) as &dyn std::error::Error),
-                            );
-                            return Ok(());
-                        }
-                    },
+        let (acquire_value_num, acquire_value_size) = if is_enable_backpressure_for_async_mode {
+            //back pressure
+            let cost_time = (Instant::now() - begin_start_time).as_millis() as u64;
+            let is_semaphore_async_numb_acquired = (timeout - cost_time) > 0;
+            if !is_semaphore_async_numb_acquired {
+                send_callback
+                    .as_ref()
+                    .unwrap()
+                    .on_exception(&RemotingTooMuchRequestError(
+                        "send message tryAcquire semaphoreAsyncNum timeout".to_string(),
+                    ) as &dyn std::error::Error);
+                return Ok(());
+            }
+            let result = tokio::time::timeout(
+                Duration::from_millis(timeout - cost_time),
+                self.semaphore_async_send_num.acquire(),
+            )
+            .await;
+            let acquire_value_num = match result {
+                Ok(acquire_value) => match acquire_value {
+                    Ok(value) => Some(value),
                     Err(_) => {
-                        send_callback.as_ref().unwrap()(
-                            None,
-                            Some(&RemotingTooMuchRequestError(
+                        send_callback
+                            .as_ref()
+                            .unwrap()
+                            .on_exception(&RemotingTooMuchRequestError(
                                 "send message tryAcquire semaphoreAsyncNum timeout".to_string(),
-                            ) as &dyn std::error::Error),
-                        );
+                            ) as &dyn std::error::Error);
                         return Ok(());
                     }
-                };
-
-                //message size
-                let cost_time = (Instant::now() - begin_start_time).as_millis() as u64;
-                let is_semaphore_async_size_acquired = (timeout - cost_time) > 0;
-                if !is_semaphore_async_size_acquired {
-                    send_callback.as_ref().unwrap()(
-                        None,
-                        Some(&RemotingTooMuchRequestError(
-                            "send message tryAcquire semaphoreAsyncSize timeout".to_string(),
-                        ) as &dyn std::error::Error),
-                    );
+                },
+                Err(_) => {
+                    send_callback
+                        .as_ref()
+                        .unwrap()
+                        .on_exception(&RemotingTooMuchRequestError(
+                            "send message tryAcquire semaphoreAsyncNum timeout".to_string(),
+                        ) as &dyn std::error::Error);
                     return Ok(());
                 }
-                let result = tokio::time::timeout(
-                    Duration::from_millis(timeout - cost_time),
-                    self.semaphore_async_send_size.acquire_many(msg_len as u32),
-                )
-                .await;
-                let acquire_value_size = match result {
-                    Ok(acquire_value) => match acquire_value {
-                        Ok(value) => Some(value),
-                        Err(_) => {
-                            send_callback.as_ref().unwrap()(
-                                None,
-                                Some(&RemotingTooMuchRequestError(
-                                    "send message tryAcquire semaphoreAsyncSize timeout".to_string(),
-                                ) as &dyn std::error::Error),
-                            );
-                            return Ok(());
-                        }
-                    },
+            };
+
+            //message size
+            let cost_time = (Instant::now() - begin_start_time).as_millis() as u64;
+            let is_semaphore_async_size_acquired = (timeout - cost_time) > 0;
+            if !is_semaphore_async_size_acquired {
+                send_callback
+                    .as_ref()
+                    .unwrap()
+                    .on_exception(&RemotingTooMuchRequestError(
+                        "send message tryAcquire semaphoreAsyncSize timeout".to_string(),
+                    ) as &dyn std::error::Error);
+                return Ok(());
+            }
+            let result = tokio::time::timeout(
+                Duration::from_millis(timeout - cost_time),
+                self.semaphore_async_send_size.acquire_many(msg_len as u32),
+            )
+            .await;
+            let acquire_value_size = match result {
+                Ok(acquire_value) => match acquire_value {
+                    Ok(value) => Some(value),
                     Err(_) => {
-                        send_callback.as_ref().unwrap()(
-                            None,
-                            Some(&RemotingTooMuchRequestError(
+                        send_callback
+                            .as_ref()
+                            .unwrap()
+                            .on_exception(&RemotingTooMuchRequestError(
                                 "send message tryAcquire semaphoreAsyncSize timeout".to_string(),
-                            ) as &dyn std::error::Error),
-                        );
+                            ) as &dyn std::error::Error);
                         return Ok(());
                     }
-                };
-                (acquire_value_num, acquire_value_size)
-            } else {
-                (None, None)
+                },
+                Err(_) => {
+                    send_callback
+                        .as_ref()
+                        .unwrap()
+                        .on_exception(&RemotingTooMuchRequestError(
+                            "send message tryAcquire semaphoreAsyncSize timeout".to_string(),
+                        ) as &dyn std::error::Error);
+                    return Ok(());
+                }
             };
+            (acquire_value_num, acquire_value_size)
+        } else {
+            (None, None)
+        };
         tokio::spawn(f);
         drop((acquire_value_num, acquire_value_size));
         Ok(())
@@ -923,7 +933,7 @@ impl DefaultMQProducerImpl {
         &mut self,
         msg: &mut T,
         communication_mode: CommunicationMode,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<Option<SendResult>>
     where
@@ -960,7 +970,7 @@ impl DefaultMQProducerImpl {
         msg: &mut T,
         topic: &CheetahString,
         topic_publish_info: &TopicPublishInfo,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         ctx: SendContext,
     ) -> rocketmq_error::RocketMQResult<Option<SendResult>>
     where
@@ -1128,7 +1138,7 @@ impl DefaultMQProducerImpl {
         msg: &mut T,
         mq: &MessageQueue,
         communication_mode: CommunicationMode,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         topic_publish_info: Option<&TopicPublishInfo>,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<Option<SendResult>>

--- a/rocketmq-client/src/producer/send_callback.rs
+++ b/rocketmq-client/src/producer/send_callback.rs
@@ -12,159 +12,126 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Callback abstractions for asynchronous message send operations.
+//!
+//! This module provides the [`SendCallback`] trait and related types for handling
+//! results of asynchronous message send operations. Callbacks can be implemented
+//! directly as trait implementations or provided as closures through automatic
+//! blanket implementation.
+
 use std::sync::Arc;
 
 use crate::producer::send_result::SendResult;
 
-/// Callback function type for asynchronous message sending operations.
+/// Callback trait for handling asynchronous message send results.
 ///
-/// This type represents a callback that will be invoked when an asynchronous send operation
-/// completes, either successfully or with an error. Following the original Java RocketMQ API
-/// design, the callback receives two `Option` parameters to indicate success or failure.
-///
-/// # Parameters
-///
-/// * First parameter: `Option<&SendResult>` - Contains the send result on success, `None` on
-///   failure
-/// * Second parameter: `Option<&dyn std::error::Error>` - Contains the error on failure, `None` on
-///   success
-///
-/// # Callback Contract
-///
-/// Implementations must handle two mutually exclusive states:
-/// - **Success**: `(Some(result), None)` - The message was sent successfully
-/// - **Failure**: `(None, Some(error))` - The send operation failed
-///
-/// The state `(Some(_), Some(_))` and `(None, None)` should never occur in normal operation.
-///
-/// # Thread Safety
-///
-/// The callback must be `Send + Sync` as it may be invoked from different threads in the
-/// async runtime.
+/// Implementors of this trait can respond to successful message delivery or
+/// send failures. Closures that match the expected signature automatically
+/// implement this trait through blanket implementation.
 ///
 /// # Examples
 ///
-/// Basic usage with error handling:
+/// Using a closure as callback:
 ///
 /// ```rust,ignore
-/// use rocketmq_client::producer::SendMessageCallback;
-/// use std::sync::Arc;
-///
-/// let callback: SendMessageCallback = Arc::new(|result, error| {
+/// producer.send_with_callback(message, |result, error| {
 ///     match (result, error) {
 ///         (Some(send_result), None) => {
-///             println!("Message sent successfully: {:?}", send_result);
+///             println!("Sent: {:?}", send_result.msg_id);
 ///         }
 ///         (None, Some(err)) => {
-///             eprintln!("Failed to send message: {}", err);
-///         }
-///         _ => {
-///             eprintln!("Invalid callback state");
-///         }
-///     }
-/// });
-///
-/// producer.send_with_callback(message, callback).await?;
-/// ```
-///
-/// With state capture:
-///
-/// ```rust,ignore
-/// use std::sync::Arc;
-/// use std::sync::atomic::{AtomicUsize, Ordering};
-///
-/// let success_count = Arc::new(AtomicUsize::new(0));
-/// let failure_count = Arc::new(AtomicUsize::new(0));
-///
-/// let success_cnt = Arc::clone(&success_count);
-/// let failure_cnt = Arc::clone(&failure_count);
-///
-/// let callback = Arc::new(move |result, error| {
-///     match (result, error) {
-///         (Some(_), None) => {
-///             success_cnt.fetch_add(1, Ordering::Relaxed);
-///         }
-///         (None, Some(_)) => {
-///             failure_cnt.fetch_add(1, Ordering::Relaxed);
+///             eprintln!("Failed: {}", err);
 ///         }
 ///         _ => {}
 ///     }
-/// });
-/// ```
-pub type SendMessageCallback = Arc<dyn Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync>;
-
-/// Alternative Result-based callback type for more idiomatic Rust code.
-///
-/// This callback type uses `Result<SendResult, E>` instead of separate `Option` parameters,
-/// providing a more Rust-idiomatic API while maintaining the same functionality.
-///
-/// # Type Parameters
-///
-/// * `E` - The error type, typically `Box<dyn std::error::Error>`
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// use rocketmq_client::producer::SendResultCallback;
-/// use std::sync::Arc;
-///
-/// let callback: SendResultCallback<Box<dyn std::error::Error>> =
-///     Arc::new(|result| match result {
-///         Ok(send_result) => {
-///             println!("Success: {:?}", send_result);
-///         }
-///         Err(error) => {
-///             eprintln!("Error: {}", error);
-///         }
-///     });
+/// }).await?;
 /// ```
 ///
-/// Note: This type is provided for future API evolution. The primary callback type
-/// remains `SendMessageCallback` to maintain compatibility with the existing codebase.
-pub type SendResultCallback<E> = Arc<dyn Fn(Result<&SendResult, E>) + Send + Sync>;
-
-/// Trait-based callback interface for message sending operations.
-///
-/// This trait provides an object-oriented callback interface similar to Java's `SendCallback`.
-/// It allows implementing custom callback logic as a type rather than a closure.
-///
-/// # Note
-///
-/// This trait is currently not actively used in the codebase. The preferred callback mechanism
-/// is the `SendMessageCallback` function type, which is more flexible and idiomatic in Rust.
-/// This trait is provided for API completeness and potential future extensions.
-///
-/// # Examples
+/// Implementing the trait:
 ///
 /// ```rust,ignore
-/// use rocketmq_client::producer::{SendCallback, SendResult};
+/// struct LoggingCallback;
 ///
-/// struct LoggingSendCallback;
-///
-/// impl SendCallback for LoggingSendCallback {
+/// impl SendCallback for LoggingCallback {
 ///     fn on_success(&self, send_result: &SendResult) {
-///         println!("Message sent: {:?}", send_result);
+///         log::info!("Message sent: {:?}", send_result.msg_id);
 ///     }
 ///
 ///     fn on_exception(&self, error: &dyn std::error::Error) {
-///         eprintln!("Send failed: {}", error);
+///         log::error!("Send failed: {}", error);
 ///     }
 /// }
 /// ```
-pub trait SendCallback: Send + Sync + 'static {
-    /// Called when the message is sent successfully.
+pub trait SendCallback: Send + Sync {
+    /// Invoked when a message is successfully sent.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// * `send_result` - The result of the send operation containing message ID, queue information,
-    ///   and other metadata
+    /// * `send_result` - Contains the message ID, queue information, and send metadata.
     fn on_success(&self, send_result: &SendResult);
 
-    /// Called when the send operation fails.
+    /// Invoked when a message send operation fails.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// * `error` - The error that caused the send operation to fail. Can be any error type
-    ///   implementing the standard `Error` trait.
+    /// * `error` - The error that caused the send failure.
     fn on_exception(&self, error: &dyn std::error::Error);
 }
+
+// Blanket implementation allowing closures to act as callbacks.
+//
+// Closures receive `Option<&SendResult>` and `Option<&dyn Error>` parameters,
+// where exactly one is `Some` and the other is `None`.
+impl<F> SendCallback for F
+where
+    F: Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync,
+{
+    fn on_success(&self, send_result: &SendResult) {
+        self(Some(send_result), None)
+    }
+
+    fn on_exception(&self, error: &dyn std::error::Error) {
+        self(None, Some(error))
+    }
+}
+
+/// Type alias for dynamically dispatched send callbacks.
+///
+/// Use this type when storing callbacks in struct fields or when the callback
+/// type cannot be determined at compile time. For function parameters, prefer
+/// generic bounds over `SendCallback` to enable monomorphization.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// struct ProducerState {
+///     pending: Vec<ArcSendCallback>,
+/// }
+///
+/// impl ProducerState {
+///     fn add<CB: SendCallback + 'static>(&mut self, callback: CB) {
+///         self.pending.push(Arc::new(callback));
+///     }
+/// }
+/// ```
+pub type ArcSendCallback = Arc<dyn SendCallback>;
+
+/// Legacy type alias for backward compatibility.
+///
+/// This type is deprecated in favor of the trait-based approach.
+/// Use `ArcSendCallback` for storage or generic `SendCallback` bound for parameters.
+///
+/// # Migration
+///
+/// ```rust,ignore
+/// // Old style (still works)
+/// let callback: SendMessageCallback = Arc::new(|result, error| { /* ... */ });
+///
+/// // New style (recommended)
+/// let callback: ArcSendCallback = Arc::new(|result, error| { /* ... */ });
+///
+/// // Or use generic parameter (best performance)
+/// fn my_function<CB: SendCallback + 'static>(callback: CB) { /* ... */ }
+/// ```
+#[deprecated(since = "0.8.0", note = "Use ArcSendCallback or generic SendCallback bound instead")]
+pub type SendMessageCallback = Arc<dyn Fn(Option<&SendResult>, Option<&dyn std::error::Error>) + Send + Sync>;

--- a/rocketmq-client/src/producer/transaction_mq_producer.rs
+++ b/rocketmq-client/src/producer/transaction_mq_producer.rs
@@ -22,7 +22,7 @@ use rocketmq_error::RocketMQError;
 
 use crate::producer::default_mq_producer::DefaultMQProducer;
 use crate::producer::mq_producer::MQProducer;
-use crate::producer::send_callback::SendMessageCallback;
+use crate::producer::send_callback::ArcSendCallback;
 use crate::producer::send_result::SendResult;
 use crate::producer::transaction_listener::ArcTransactionListener;
 use crate::producer::transaction_listener::TransactionListener;
@@ -266,7 +266,7 @@ impl MQProducer for TransactionMQProducer {
         msg: M,
         selector: S,
         arg: T,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
     ) -> rocketmq_error::RocketMQResult<()>
     where
         M: MessageTrait + Send + Sync,
@@ -283,7 +283,7 @@ impl MQProducer for TransactionMQProducer {
         msg: M,
         selector: S,
         arg: T,
-        send_callback: Option<SendMessageCallback>,
+        send_callback: Option<ArcSendCallback>,
         timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()>
     where


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6636

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated message send callback API to use trait-based approach with dedicated `on_success()` and `on_exception()` methods
  * Legacy callback type deprecated; migrate to new callback interface for all send operations using callbacks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->