### PR TITLE
[ISSUE #6646]✨Enhance consumer manager to use Arc<RwLock<Vec>> for dynamic listener registration and add benchmark for RwLock overhead

### DIFF
--- a/rocketmq-broker/benches/listener_lock_overhead.rs
+++ b/rocketmq-broker/benches/listener_lock_overhead.rs
@@ -1,0 +1,102 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Benchmark to measure RwLock overhead for consumer listener list access
+//!
+//! Compares:
+//! - Direct Vec access (baseline)
+//! - Arc<RwLock<Vec>> read access (P5 optimization)
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use parking_lot::RwLock;
+
+struct DummyListener;
+
+impl DummyListener {
+    fn handle(&self, _value: u64) {
+        // Simulate minimal work
+        black_box(_value);
+    }
+}
+
+/// Baseline: Direct Vec access
+fn vec_direct_access(listeners: &[DummyListener], value: u64) {
+    for listener in listeners {
+        listener.handle(value);
+    }
+}
+
+/// P5 implementation: Arc<RwLock<Vec>> with read lock
+fn rwlock_read_access(listeners: &Arc<RwLock<Vec<DummyListener>>>, value: u64) {
+    let guard = listeners.read();
+    for listener in guard.iter() {
+        listener.handle(value);
+    }
+}
+
+fn benchmark_listener_access(c: &mut Criterion) {
+    let mut group = c.benchmark_group("listener_lock_overhead");
+
+    // Setup: 1 listener (typical case)
+    let vec_listeners = vec![DummyListener];
+    let rwlock_listeners = Arc::new(RwLock::new(vec![DummyListener]));
+
+    group.bench_function("vec_direct_1_listener", |b| {
+        b.iter(|| vec_direct_access(black_box(&vec_listeners), black_box(42)))
+    });
+
+    group.bench_function("rwlock_read_1_listener", |b| {
+        b.iter(|| rwlock_read_access(black_box(&rwlock_listeners), black_box(42)))
+    });
+
+    // Setup: 2 listeners (common case)
+    let vec_listeners_2 = vec![DummyListener, DummyListener];
+    let rwlock_listeners_2 = Arc::new(RwLock::new(vec![DummyListener, DummyListener]));
+
+    group.bench_function("vec_direct_2_listeners", |b| {
+        b.iter(|| vec_direct_access(black_box(&vec_listeners_2), black_box(42)))
+    });
+
+    group.bench_function("rwlock_read_2_listeners", |b| {
+        b.iter(|| rwlock_read_access(black_box(&rwlock_listeners_2), black_box(42)))
+    });
+
+    group.finish();
+}
+
+/// Benchmark concurrent read access under RwLock
+fn benchmark_concurrent_reads(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_listener_access");
+
+    let rwlock_listeners = Arc::new(RwLock::new(vec![DummyListener]));
+
+    // Simulate concurrent access by multiple threads
+    group.bench_function("single_threaded_reads", |b| {
+        b.iter(|| {
+            for _ in 0..10 {
+                rwlock_read_access(black_box(&rwlock_listeners), black_box(42));
+            }
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_listener_access, benchmark_concurrent_reads);
+criterion_main!(benches);

--- a/rocketmq-broker/src/client/manager/consumer_manager.rs
+++ b/rocketmq-broker/src/client/manager/consumer_manager.rs
@@ -21,6 +21,7 @@ use std::time::Instant;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
+use parking_lot::RwLock;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_common::TimeUtils::current_millis;
@@ -51,6 +52,9 @@ use crate::client::consumer_ids_change_listener::ConsumerIdsChangeListener;
 static CHANNEL_CONSUMER_GROUPS: LazyLock<DashMap<CheetahString, HashSet<CheetahString>>> =
     LazyLock::new(|| DashMap::with_capacity_and_shard_amount(4096, 64));
 
+/// Type alias for consumer change listener to reduce complexity
+type ConsumerListener = Arc<Box<dyn ConsumerIdsChangeListener + Send + Sync + 'static>>;
+
 /// Manages consumer client connections and their lifecycle.
 ///
 /// This manager maintains:
@@ -69,7 +73,8 @@ pub struct ConsumerManager {
     /// Topic -> Set<Group> reverse index for fast topic-to-group lookup
     topic_group_table: Arc<DashMap<CheetahString, HashSet<CheetahString>>>,
     /// Listeners notified on consumer registration/unregistration events
-    consumer_ids_change_listener_list: Vec<Arc<Box<dyn ConsumerIdsChangeListener + Send + Sync + 'static>>>,
+    /// Uses Arc<RwLock<Vec>> to support dynamic listener registration at runtime
+    consumer_ids_change_listener_list: Arc<RwLock<Vec<ConsumerListener>>>,
     /// Optional broker statistics manager (set once during initialization)
     broker_stats_manager: Option<Weak<BrokerStatsManager>>,
     /// Broker configuration (used for enable_fast_channel_event_process flag)
@@ -86,11 +91,8 @@ impl ConsumerManager {
     /// # Arguments
     /// * `consumer_ids_change_listener` - Listener for consumer change events
     /// * `expired_timeout` - Timeout for channel and subscription expiration (milliseconds)
-    pub fn new(
-        consumer_ids_change_listener: Arc<Box<dyn ConsumerIdsChangeListener + Send + Sync + 'static>>,
-        expired_timeout: u64,
-    ) -> Self {
-        let consumer_ids_change_listener_list = vec![consumer_ids_change_listener];
+    pub fn new(consumer_ids_change_listener: ConsumerListener, expired_timeout: u64) -> Self {
+        let consumer_ids_change_listener_list = Arc::new(RwLock::new(vec![consumer_ids_change_listener]));
         ConsumerManager {
             // Uses 64 shards for improved concurrency under high load
             consumer_table: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
@@ -111,10 +113,10 @@ impl ConsumerManager {
     /// * `consumer_ids_change_listener` - Listener for consumer change events
     /// * `broker_config` - Broker configuration containing timeout settings
     pub fn new_with_broker_stats(
-        consumer_ids_change_listener: Arc<Box<dyn ConsumerIdsChangeListener + Send + Sync + 'static>>,
+        consumer_ids_change_listener: ConsumerListener,
         broker_config: Arc<BrokerConfig>,
     ) -> Self {
-        let consumer_ids_change_listener_list = vec![consumer_ids_change_listener];
+        let consumer_ids_change_listener_list = Arc::new(RwLock::new(vec![consumer_ids_change_listener]));
         ConsumerManager {
             // Uses 64 shards for improved concurrency under high load
             consumer_table: Arc::new(DashMap::with_capacity_and_shard_amount(1024, 64)),
@@ -505,9 +507,26 @@ impl ConsumerManager {
     /// * `group` - The affected consumer group
     /// * `args` - Additional event arguments
     pub fn call_consumer_ids_change_listener(&self, event: ConsumerGroupEvent, group: &str, args: &[&dyn Any]) {
-        for listener in self.consumer_ids_change_listener_list.iter() {
+        let listeners = self.consumer_ids_change_listener_list.read();
+        for listener in listeners.iter() {
             listener.handle(event, group, args);
         }
+    }
+
+    /// Dynamically appends a new consumer change listener to the list.
+    ///
+    /// This enables runtime registration of listeners for plugin-like extensibility.
+    ///
+    /// # Arguments
+    /// * `listener` - The listener to register
+    ///
+    /// # Example
+    /// ```ignore
+    /// let custom_listener = Arc::new(Box::new(MyCustomListener::new()));
+    /// consumer_manager.append_consumer_ids_change_listener(custom_listener);
+    /// ```
+    pub fn append_consumer_ids_change_listener(&self, listener: ConsumerListener) {
+        self.consumer_ids_change_listener_list.write().push(listener);
     }
 
     /// Clears topic-group reverse index entries for a removed consumer group.


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6646

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled dynamic registration of consumer ID change listeners at runtime, allowing listeners to be added without recompilation.

* **Tests**
  * Added comprehensive performance benchmarks to evaluate listener access patterns, measure synchronization overhead, and assess concurrent read scenarios across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->