### PR TITLE
[ISSUE #6413]🚀Implement CloneGroupOffset Command for Consumer Group Offset Migration

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -474,6 +474,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Offset",
+                command: "cloneGroupOffset",
+                remark: "Clone offset from other group.",
+            },
+            Command {
+                category: "Offset",
                 command: "resetOffsetByTime",
                 remark: "Reset consumer group offsets to a specific timestamp (no restart required).",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod clone_group_offset_sub_command;
 mod reset_offset_by_time_sub_command;
 
 use std::sync::Arc;
@@ -20,11 +21,19 @@ use clap::Subcommand;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
+use crate::commands::offset::clone_group_offset_sub_command::CloneGroupOffsetSubCommand;
 use crate::commands::offset::reset_offset_by_time_sub_command::ResetOffsetByTimeSubCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
 pub enum OffsetCommands {
+    #[command(
+        name = "cloneGroupOffset",
+        about = "Clone offset from other group.",
+        long_about = None,
+    )]
+    CloneGroupOffset(CloneGroupOffsetSubCommand),
+
     #[command(
         name = "resetOffsetByTime",
         about = "Reset consumer group offsets to a specific timestamp without requiring client restart.",
@@ -57,6 +66,7 @@ EXAMPLES:
 impl CommandExecute for OffsetCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
+            OffsetCommands::CloneGroupOffset(cmd) => cmd.execute(rpc_hook).await,
             OffsetCommands::ResetOffsetByTime(cmd) => cmd.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset/clone_group_offset_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset/clone_group_offset_sub_command.rs
@@ -1,0 +1,120 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct CloneGroupOffsetSubCommand {
+    #[arg(short = 's', long = "srcGroup", required = true, help = "set source consumer group")]
+    src_group: String,
+
+    #[arg(
+        short = 'd',
+        long = "destGroup",
+        required = true,
+        help = "set destination consumer group"
+    )]
+    dest_group: String,
+
+    #[arg(short = 't', long = "topic", required = true, help = "set the topic")]
+    topic: String,
+
+    #[arg(
+        short = 'o',
+        long = "offline",
+        required = false,
+        help = "the group or the topic is offline"
+    )]
+    offline: bool,
+}
+
+impl CommandExecute for CloneGroupOffsetSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("CloneGroupOffsetSubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            let src_group = self.src_group.trim();
+            let dest_group = self.dest_group.trim();
+            let topic = self.topic.trim();
+
+            let consume_stats = default_mqadmin_ext
+                .examine_consume_stats(src_group.into(), None, None, None, None)
+                .await?;
+
+            let mqs = consume_stats.offset_table.keys().cloned().collect::<Vec<_>>();
+            if !mqs.is_empty() {
+                let topic_route = default_mqadmin_ext
+                    .examine_topic_route_info(topic.into())
+                    .await?
+                    .ok_or_else(|| {
+                        RocketMQError::Internal(format!(
+                            "CloneGroupOffsetSubCommand: Topic route not found for: {}",
+                            topic
+                        ))
+                    })?;
+
+                for mq in &mqs {
+                    let mut addr = None;
+                    for broker_data in &topic_route.broker_datas {
+                        if broker_data.broker_name() == mq.broker_name() {
+                            addr = broker_data.select_broker_addr();
+                            break;
+                        }
+                    }
+
+                    let offset = consume_stats.offset_table[mq].get_consumer_offset();
+                    if offset >= 0 {
+                        if let Some(broker_addr) = addr {
+                            default_mqadmin_ext
+                                .update_consume_offset(broker_addr, dest_group.into(), mq.clone(), offset as u64)
+                                .await?;
+                        }
+                    }
+                }
+            }
+
+            println!(
+                "clone group offset success. srcGroup[{}], destGroup=[{}], topic[{}]",
+                src_group, dest_group, topic
+            );
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6413 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new `cloneGroupOffset` command to clone message offsets from one consumer group to another for a specified topic, supporting both online and offline offset cloning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->