### PR TITLE
[ISSUE #6414]🚀Implement GetConsumerStatus Command for Real-Time Consumer Monitoring

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -722,7 +722,36 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         group: CheetahString,
         client_addr: CheetahString,
     ) -> rocketmq_error::RocketMQResult<HashMap<CheetahString, HashMap<MessageQueue, u64>>> {
-        todo!()
+        let topic_route_data = self.examine_topic_route_info(topic.clone()).await?;
+        if let Some(route_data) = topic_route_data {
+            if !route_data.broker_datas.is_empty() {
+                if let Some(addr) = route_data.broker_datas[0].select_broker_addr() {
+                    let result = self
+                        .client_instance
+                        .as_ref()
+                        .unwrap()
+                        .get_mq_client_api_impl()
+                        .invoke_broker_to_get_consumer_status(
+                            addr.as_str(),
+                            topic,
+                            group,
+                            client_addr,
+                            self.timeout_millis.as_millis() as u64,
+                        )
+                        .await?;
+                    let converted: HashMap<CheetahString, HashMap<MessageQueue, u64>> = result
+                        .into_iter()
+                        .map(|(k, v)| {
+                            let inner: HashMap<MessageQueue, u64> =
+                                v.into_iter().map(|(mq, off)| (mq, off as u64)).collect();
+                            (k, inner)
+                        })
+                        .collect();
+                    return Ok(converted);
+                }
+            }
+        }
+        Ok(HashMap::new())
     }
 
     async fn create_or_update_order_conf(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -83,6 +83,7 @@ use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
 use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
+use rocketmq_remoting::protocol::body::response::get_consumer_status_body::GetConsumerStatusBody;
 use rocketmq_remoting::protocol::body::response::lock_batch_response_body::LockBatchResponseBody;
 use rocketmq_remoting::protocol::body::set_message_request_mode_request_body::SetMessageRequestModeRequestBody;
 use rocketmq_remoting::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
@@ -100,6 +101,7 @@ use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
 use rocketmq_remoting::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
 use rocketmq_remoting::protocol::header::extra_info_util::ExtraInfoUtil;
 use rocketmq_remoting::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
+use rocketmq_remoting::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
 use rocketmq_remoting::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader;
 use rocketmq_remoting::protocol::header::get_lite_topic_info_request_header::GetLiteTopicInfoRequestHeader;
 use rocketmq_remoting::protocol::header::get_max_offset_request_header::GetMaxOffsetRequestHeader;
@@ -1720,6 +1722,53 @@ impl MQClientAPIImpl {
             response.remark().map_or("".to_string(), |s| s.to_string()),
             addr.to_string()
         ))
+    }
+
+    pub async fn invoke_broker_to_get_consumer_status(
+        &mut self,
+        addr: &str,
+        topic: CheetahString,
+        group: CheetahString,
+        client_addr: CheetahString,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<HashMap<CheetahString, HashMap<MessageQueue, i64>>> {
+        let request_header = GetConsumerStatusRequestHeader {
+            topic,
+            group,
+            client_addr: if client_addr.is_empty() {
+                None
+            } else {
+                Some(client_addr)
+            },
+            rpc_request_header: None,
+        };
+        let request =
+            RemotingCommand::create_request_command(RequestCode::InvokeBrokerToGetConsumerStatus, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(
+                Some(mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr).as_ref()),
+                request,
+                timeout_millis,
+            )
+            .await?;
+        match ResponseCode::from(response.code()) {
+            ResponseCode::Success => {
+                if let Some(body) = response.body() {
+                    if let Some(status_body) = GetConsumerStatusBody::decode(body) {
+                        return Ok(status_body.consumer_table);
+                    }
+                }
+                Ok(HashMap::new())
+            }
+            _ => Err(mq_client_err!(
+                response.code(),
+                format!(
+                    "invoke broker to get consumer status failed, remark={}",
+                    response.remark().map_or("".to_string(), |s| s.to_string()),
+                )
+            )),
+        }
     }
 
     pub async fn update_consumer_offset_oneway(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -558,7 +558,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         group: CheetahString,
         client_addr: CheetahString,
     ) -> rocketmq_error::RocketMQResult<HashMap<CheetahString, HashMap<MessageQueue, u64>>> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .get_consume_status(topic, group, client_addr)
+            .await
     }
 
     async fn create_or_update_order_conf(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -479,6 +479,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Offset",
+                command: "getConsumerStatus",
+                remark: "Get consumer status from client.",
+            },
+            Command {
+                category: "Offset",
                 command: "resetOffsetByTime",
                 remark: "Reset consumer group offsets to a specific timestamp (no restart required).",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod clone_group_offset_sub_command;
+mod get_consumer_status_sub_command;
 mod reset_offset_by_time_sub_command;
 
 use std::sync::Arc;
@@ -22,6 +23,7 @@ use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::offset::clone_group_offset_sub_command::CloneGroupOffsetSubCommand;
+use crate::commands::offset::get_consumer_status_sub_command::GetConsumerStatusSubCommand;
 use crate::commands::offset::reset_offset_by_time_sub_command::ResetOffsetByTimeSubCommand;
 use crate::commands::CommandExecute;
 
@@ -33,6 +35,13 @@ pub enum OffsetCommands {
         long_about = None,
     )]
     CloneGroupOffset(CloneGroupOffsetSubCommand),
+
+    #[command(
+        name = "getConsumerStatus",
+        about = "Get consumer status from client.",
+        long_about = None
+    )]
+    GetConsumerStatus(GetConsumerStatusSubCommand),
 
     #[command(
         name = "resetOffsetByTime",
@@ -67,6 +76,7 @@ impl CommandExecute for OffsetCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             OffsetCommands::CloneGroupOffset(cmd) => cmd.execute(rpc_hook).await,
+            OffsetCommands::GetConsumerStatus(cmd) => cmd.execute(rpc_hook).await,
             OffsetCommands::ResetOffsetByTime(cmd) => cmd.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset/get_consumer_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset/get_consumer_status_sub_command.rs
@@ -1,0 +1,108 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct GetConsumerStatusSubCommand {
+    #[arg(short = 'g', long = "group", required = true, help = "set the consumer group")]
+    group: String,
+
+    #[arg(short = 't', long = "topic", required = true, help = "set the topic")]
+    topic: String,
+
+    #[arg(
+        short = 'i',
+        long = "originClientId",
+        required = false,
+        help = "set the consumer clientId"
+    )]
+    origin_client_id: Option<String>,
+}
+
+impl CommandExecute for GetConsumerStatusSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "GetConsumerStatusSubCommand: Failed to start MQAdminExt: {}",
+                    e
+                ))
+            })?;
+
+            let group = self.group.trim();
+            let topic = self.topic.trim();
+            let origin_client_id = self.origin_client_id.as_deref().map(|s| s.trim()).unwrap_or("");
+
+            let consumer_status_table = default_mqadmin_ext
+                .get_consume_status(topic.into(), group.into(), origin_client_id.into())
+                .await?;
+
+            println!(
+                "get consumer status from client. group={}, topic={}, originClientId={}",
+                group, topic, origin_client_id
+            );
+
+            println!(
+                "{:<50}  {:<15}  {:<15}  {:<20}",
+                "#clientId", "#brokerName", "#queueId", "#offset"
+            );
+
+            for (client_id, mq_table) in &consumer_status_table {
+                let mut entries: Vec<_> = mq_table.iter().collect();
+                entries.sort_by(|(a, _), (b, _)| {
+                    a.broker_name()
+                        .cmp(b.broker_name())
+                        .then_with(|| a.queue_id().cmp(&b.queue_id()))
+                });
+
+                for (mq, offset) in entries {
+                    println!(
+                        "{:<50}  {:<15}  {:<15}  {:<20}",
+                        client_id,
+                        mq.broker_name(),
+                        mq.queue_id(),
+                        offset,
+                    );
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6414 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "getConsumerStatus" command to retrieve consumer status information for a specified consumer group and topic, with optional client ID filtering.
  * Results are displayed in a formatted table, organized by broker name and queue ID for easy analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->