### PR TITLE
[ISSUE #6418]Implement `producer` admin command for querying producer instances and status

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -258,7 +258,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .get_producer_connection_list(ctx, request)
                     .await
             }
-            RequestCode::GetAllProducerInfo => Ok(get_unknown_cmd_response(request_code)),
+            RequestCode::GetAllProducerInfo => self.producer_request_handler.get_all_producer_info(ctx, request).await,
             RequestCode::GetConsumeStats => {
                 self.consumer_request_handler
                     .get_consume_stats(channel, ctx, request_code, request)

--- a/rocketmq-broker/src/processor/admin_broker_processor/producer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/producer_request_handler.rs
@@ -54,4 +54,16 @@ impl<MS: MessageStore> ProducerRequestHandler<MS> {
         ));
         Ok(Some(response))
     }
+
+    pub async fn get_all_producer_info(
+        &self,
+        _ctx: ConnectionHandlerContext,
+        _request: &RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let mut response = RemotingCommand::create_response_command();
+        let producer_table_info = self.broker_runtime_inner.producer_manager().get_producer_table();
+        let body = producer_table_info.encode()?;
+        response = response.set_body(body).set_code(ResponseCode::Success);
+        Ok(Some(response))
+    }
 }

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -569,9 +569,14 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn get_all_producer_info(
         &self,
-        _broker_addr: CheetahString,
+        broker_addr: CheetahString,
     ) -> rocketmq_error::RocketMQResult<ProducerTableInfo> {
-        unimplemented!("get_all_producer_info not implemented yet")
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_all_producer_info(broker_addr.as_str(), self.timeout_millis.as_millis() as u64)
+            .await
     }
 
     async fn get_name_server_address_list(&self) -> Vec<CheetahString> {

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -80,6 +80,7 @@ use rocketmq_remoting::protocol::body::get_lite_group_info_response_body::GetLit
 use rocketmq_remoting::protocol::body::get_lite_topic_info_response_body::GetLiteTopicInfoResponseBody;
 use rocketmq_remoting::protocol::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
+use rocketmq_remoting::protocol::body::producer_table_info::ProducerTableInfo;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
 use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
@@ -1769,6 +1770,41 @@ impl MQClientAPIImpl {
                 )
             )),
         }
+    }
+
+    pub async fn get_all_producer_info(
+        &mut self,
+        addr: &str,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<ProducerTableInfo> {
+        let request = RemotingCommand::create_request_command(RequestCode::GetAllProducerInfo, EmptyHeader {});
+        let response = self
+            .remoting_client
+            .invoke_request(
+                Some(mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr).as_ref()),
+                request,
+                timeout_millis,
+            )
+            .await?;
+        match ResponseCode::from(response.code()) {
+            ResponseCode::Success => {
+                if let Some(body) = response.body() {
+                    return ProducerTableInfo::decode(body);
+                }
+            }
+            _ => {
+                return Err(client_broker_err!(
+                    response.code(),
+                    response.remark().map_or("".to_string(), |s| s.to_string()),
+                    addr.to_string()
+                ));
+            }
+        }
+        Err(client_broker_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string()),
+            addr.to_string()
+        ))
     }
 
     pub async fn update_consumer_offset_oneway(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1138,9 +1138,9 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn get_all_producer_info(
         &self,
-        _broker_addr: CheetahString,
+        broker_addr: CheetahString,
     ) -> rocketmq_error::RocketMQResult<ProducerTableInfo> {
-        unimplemented!("get_all_producer_info not implemented yet")
+        self.default_mqadmin_ext_impl.get_all_producer_info(broker_addr).await
     }
     #[allow(deprecated)]
     async fn delete_topic_in_broker_concurrent(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -26,6 +26,7 @@ mod lite;
 mod message;
 mod namesrv;
 mod offset;
+mod producer;
 mod target;
 mod topic;
 
@@ -139,6 +140,11 @@ pub enum Commands {
     Offset(offset::OffsetCommands),
 
     #[command(subcommand)]
+    #[command(about = "Producer commands")]
+    #[command(name = "producer")]
+    Producer(producer::ProducerCommands),
+
+    #[command(subcommand)]
     #[command(about = "Topic commands")]
     Topic(topic::TopicCommands),
 
@@ -161,6 +167,7 @@ impl CommandExecute for Commands {
             Commands::Message(value) => value.execute(rpc_hook).await,
             Commands::NameServer(value) => value.execute(rpc_hook).await,
             Commands::Offset(value) => value.execute(rpc_hook).await,
+            Commands::Producer(value) => value.execute(rpc_hook).await,
             Commands::Topic(value) => value.execute(rpc_hook).await,
             Commands::Show(value) => value.execute(rpc_hook).await,
         }
@@ -486,6 +493,11 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "Offset",
                 command: "resetOffsetByTime",
                 remark: "Reset consumer group offsets to a specific timestamp (no restart required).",
+            },
+            Command {
+                category: "Producer",
+                command: "producer",
+                remark: "Query producer's instances, connection, status, etc.",
             },
             Command {
                 category: "Topic",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/producer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/producer.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod producer_sub_command;
+
+use std::sync::Arc;
+
+use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::producer::producer_sub_command::ProducerSubCommand;
+use crate::commands::CommandExecute;
+
+#[derive(Subcommand)]
+pub enum ProducerCommands {
+    #[command(
+        name = "producer",
+        about = "Query producer's instances, connection, status, etc.",
+        long_about = None,
+    )]
+    Producer(ProducerSubCommand),
+}
+
+impl CommandExecute for ProducerCommands {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self {
+            ProducerCommands::Producer(cmd) => cmd.execute(rpc_hook).await,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/producer/producer_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/producer/producer_sub_command.rs
@@ -1,0 +1,82 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct ProducerSubCommand {
+    #[arg(short = 'b', long = "broker", required = true, help = "broker address")]
+    broker_addr: String,
+}
+
+impl CommandExecute for ProducerSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("ProducerSubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            let broker_addr = self.broker_addr.trim();
+            let producer_table_info = default_mqadmin_ext
+                .get_all_producer_info(CheetahString::from(broker_addr))
+                .await
+                .map_err(|e| {
+                    RocketMQError::Internal(format!("ProducerSubCommand: Failed to get all producer info: {}", e))
+                })?;
+
+            let data = producer_table_info.data();
+            if data.is_empty() {
+                println!("No producer groups found on broker {}", broker_addr);
+                return Ok(());
+            }
+
+            for (group, producers) in data {
+                if producers.is_empty() {
+                    println!("producer group ({}) instances are empty", group);
+                    continue;
+                }
+                for producer in producers {
+                    println!("producer group ({}) instance : {}", group, producer);
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6418

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "producer" command to the admin CLI for querying producer instances by broker address.
  * Implemented end-to-end retrieval and display of producer information (broker → client → admin), including informative messages when no data is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->