### PR TITLE
[ISSUE #6674]♻️Refactor consume message hooks to use immutable context and improve safety

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -474,7 +474,7 @@ impl ConsumeRequest {
                         .unwrap_or_default(),
                     access_channel: Default::default(),
                 });
-                default_mqpush_consumer_impl.execute_hook_before(&mut consume_message_context);
+                default_mqpush_consumer_impl.execute_hook_before(consume_message_context.as_ref().unwrap());
             }
 
             let listener = self.message_listener.clone();
@@ -554,7 +554,7 @@ impl ConsumeRequest {
             cmc.status = s.to_string().into();
             cmc.success = s == ConsumeConcurrentlyStatus::ConsumeSuccess;
             cmc.access_channel = Some(default_mqpush_consumer_impl.client_config.access_channel);
-            default_mqpush_consumer_impl.execute_hook_after(&mut consume_message_context);
+            default_mqpush_consumer_impl.execute_hook_after(consume_message_context.as_ref().unwrap());
         }
 
         // Record message consume round-trip time.

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -660,7 +660,7 @@ impl ConsumeRequest {
                             .unwrap_or_default(),
                         access_channel: Default::default(),
                     });
-                    default_mqpush_consumer_impl.execute_hook_before(&mut consume_message_context);
+                    default_mqpush_consumer_impl.execute_hook_before(consume_message_context.as_ref().unwrap());
                 }
                 let begin_timestamp = Instant::now();
                 let mut has_exception = false;
@@ -750,7 +750,7 @@ impl ConsumeRequest {
                     consume_message_context.as_mut().unwrap().success =
                         status == ConsumeOrderlyStatus::Success || status == ConsumeOrderlyStatus::Commit;
                     consume_message_context.as_mut().unwrap().status = status.to_string().into();
-                    default_mqpush_consumer_impl.execute_hook_after(&mut consume_message_context);
+                    default_mqpush_consumer_impl.execute_hook_after(consume_message_context.as_ref().unwrap());
                 }
                 // Record message consume round-trip time.
                 if let Some(client_instance) = default_mqpush_consumer_impl.client_instance.as_ref() {

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -616,7 +616,7 @@ impl ConsumeRequest {
                     .unwrap_or_default(),
                 access_channel: Default::default(),
             });
-            default_mqpush_consumer_impl.execute_hook_before(&mut consume_message_context);
+            default_mqpush_consumer_impl.execute_hook_before(consume_message_context.as_ref().unwrap());
         }
 
         let listener = self.message_listener.clone();
@@ -700,7 +700,7 @@ impl ConsumeRequest {
             cmc.status = status.unwrap().to_string().into();
             cmc.success = status.unwrap() == ConsumeConcurrentlyStatus::ConsumeSuccess;
             cmc.access_channel = Some(default_mqpush_consumer_impl.client_config.access_channel);
-            default_mqpush_consumer_impl.execute_hook_after(&mut consume_message_context);
+            default_mqpush_consumer_impl.execute_hook_after(consume_message_context.as_ref().unwrap());
         }
 
         // Record message consume round-trip time.

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -925,7 +925,7 @@ impl DefaultLitePullConsumerImpl {
                 // Execute hook before with panic protection
                 for hook in &self.consume_message_hook_list {
                     if let Err(err) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        hook.consume_message_before(Some(&mut context));
+                        hook.consume_message_before(&context);
                     })) {
                         tracing::error!(
                             "consumeMessageHook {} executeHookBefore panicked: {:?}",
@@ -942,7 +942,7 @@ impl DefaultLitePullConsumerImpl {
                 // Execute hook after with panic protection
                 for hook in &self.consume_message_hook_list {
                     if let Err(err) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        hook.consume_message_after(Some(&mut context));
+                        hook.consume_message_after(&context);
                     })) {
                         tracing::error!(
                             "consumeMessageHook {} executeHookAfter panicked: {:?}",

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -610,7 +610,7 @@ impl DefaultMQPushConsumerImpl {
         Ok(())
     }
 
-    pub fn register_consume_message_hook(&mut self, hook: impl ConsumeMessageHook + Send + Sync + 'static) {
+    pub fn register_consume_message_hook(&mut self, hook: impl ConsumeMessageHook + 'static) {
         self.consume_message_hook_list
             .push(Arc::new(hook) as ConsumeMessageHookArc);
     }
@@ -1083,15 +1083,15 @@ impl DefaultMQPushConsumerImpl {
         !self.consume_message_hook_list.is_empty()
     }
 
-    pub fn execute_hook_before(&self, context: &mut Option<ConsumeMessageContext>) {
+    pub fn execute_hook_before(&self, context: &ConsumeMessageContext) {
         for hook in self.consume_message_hook_list.iter() {
-            hook.consume_message_before(context.as_mut());
+            hook.consume_message_before(context);
         }
     }
 
-    pub fn execute_hook_after(&self, context: &mut Option<ConsumeMessageContext>) {
+    pub fn execute_hook_after(&self, context: &ConsumeMessageContext) {
         for hook in self.consume_message_hook_list.iter() {
-            hook.consume_message_after(context.as_mut());
+            hook.consume_message_after(context);
         }
     }
 

--- a/rocketmq-client/src/hook/consume_message_context.rs
+++ b/rocketmq-client/src/hook/consume_message_context.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
@@ -22,15 +24,151 @@ use rocketmq_rust::ArcMut;
 
 use crate::base::access_channel::AccessChannel;
 
+/// Context information for message consumption operations.
+///
+/// Contains metadata about a message consumption attempt, including the consumer group,
+/// message list, target queue, and consumption result. This context is passed to
+/// consumption hooks for monitoring and tracing purposes.
+///
+/// # Examples
+///
+/// ```ignore
+/// use rocketmq_client::hook::consume_message_context::ConsumeMessageContext;
+/// use cheetah_string::CheetahString;
+///
+/// let context = ConsumeMessageContext::new(
+///     CheetahString::from("test_group"),
+///     &messages
+/// ).with_success(true)
+///   .with_status("CONSUME_SUCCESS");
+/// ```
 #[derive(Default)]
 pub struct ConsumeMessageContext<'a> {
+    /// Consumer group name
     pub consumer_group: CheetahString,
+    /// List of messages being consumed
     pub msg_list: &'a [ArcMut<MessageExt>],
+    /// Target message queue
     pub mq: Option<MessageQueue>,
+    /// Whether consumption succeeded
     pub success: bool,
+    /// Consumption status description
     pub status: CheetahString,
-    pub mq_trace_context: Option<Arc<Box<dyn std::any::Any + Send + Sync>>>,
+    /// Trace context for distributed tracing
+    pub mq_trace_context: Option<Arc<dyn Any + Send + Sync>>,
+    /// Additional properties
     pub props: HashMap<CheetahString, CheetahString>,
+    /// Namespace
     pub namespace: CheetahString,
+    /// Access channel
     pub access_channel: Option<AccessChannel>,
+}
+
+impl<'a> ConsumeMessageContext<'a> {
+    /// Creates a new consumption context.
+    #[inline]
+    pub fn new(consumer_group: CheetahString, msg_list: &'a [ArcMut<MessageExt>]) -> Self {
+        Self {
+            consumer_group,
+            msg_list,
+            ..Default::default()
+        }
+    }
+
+    /// Sets the message queue.
+    #[inline]
+    pub fn with_mq(mut self, mq: MessageQueue) -> Self {
+        self.mq = Some(mq);
+        self
+    }
+
+    /// Sets the success flag.
+    #[inline]
+    pub fn with_success(mut self, success: bool) -> Self {
+        self.success = success;
+        self
+    }
+
+    /// Sets the status description.
+    #[inline]
+    pub fn with_status(mut self, status: impl Into<CheetahString>) -> Self {
+        self.status = status.into();
+        self
+    }
+
+    /// Sets the trace context.
+    #[inline]
+    pub fn with_trace_context(mut self, context: Arc<dyn Any + Send + Sync>) -> Self {
+        self.mq_trace_context = Some(context);
+        self
+    }
+
+    /// Sets the namespace.
+    #[inline]
+    pub fn with_namespace(mut self, namespace: impl Into<CheetahString>) -> Self {
+        self.namespace = namespace.into();
+        self
+    }
+
+    /// Sets the access channel.
+    #[inline]
+    pub fn with_access_channel(mut self, channel: AccessChannel) -> Self {
+        self.access_channel = Some(channel);
+        self
+    }
+
+    /// Adds a property.
+    #[inline]
+    pub fn add_prop(&mut self, key: impl Into<CheetahString>, value: impl Into<CheetahString>) {
+        self.props.insert(key.into(), value.into());
+    }
+
+    /// Gets the number of messages in this context.
+    #[inline]
+    pub fn message_count(&self) -> usize {
+        self.msg_list.len()
+    }
+}
+
+impl<'a> fmt::Display for ConsumeMessageContext<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ConsumeMessageContext {{ consumer_group: {}, msg_count: {}, ",
+            self.consumer_group,
+            self.msg_list.len()
+        )?;
+
+        if let Some(ref mq) = self.mq {
+            write!(f, "mq: {}, ", mq)?;
+        }
+
+        write!(f, "success: {}, status: {}", self.success, self.status)?;
+
+        if !self.namespace.is_empty() {
+            write!(f, ", namespace: {}", self.namespace)?;
+        }
+
+        if let Some(ref channel) = self.access_channel {
+            write!(f, ", access_channel: {:?}", channel)?;
+        }
+
+        write!(f, " }}")
+    }
+}
+
+impl<'a> fmt::Debug for ConsumeMessageContext<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConsumeMessageContext")
+            .field("consumer_group", &self.consumer_group)
+            .field("msg_list_len", &self.msg_list.len())
+            .field("mq", &self.mq)
+            .field("success", &self.success)
+            .field("status", &self.status)
+            .field("mq_trace_context", &self.mq_trace_context.as_ref().map(|_| "Some(_)"))
+            .field("props_count", &self.props.len())
+            .field("namespace", &self.namespace)
+            .field("access_channel", &self.access_channel)
+            .finish()
+    }
 }

--- a/rocketmq-client/src/hook/consume_message_hook.rs
+++ b/rocketmq-client/src/hook/consume_message_hook.rs
@@ -16,38 +16,48 @@ use std::sync::Arc;
 
 use crate::hook::consume_message_context::ConsumeMessageContext;
 
-/// A shared, thread-safe reference to a [`ConsumeMessageHook`] implementation.
-pub type ConsumeMessageHookArc = Arc<dyn ConsumeMessageHook + Send + Sync>;
+/// Type alias for a thread-safe hook reference.
+pub type ConsumeMessageHookArc = Arc<dyn ConsumeMessageHook>;
 
-/// Defines lifecycle callbacks invoked around the message consumption process.
+/// Hook for message consumption lifecycle events.
 ///
-/// Implementations are registered with a push consumer and called synchronously on the
-/// consumer's processing thread before and after each batch of messages is consumed.
-/// Multiple hooks may be registered; they are invoked in registration order.
+/// Implementations are invoked synchronously before and after each batch of messages
+/// is consumed by a push consumer. Multiple hooks may be registered and are executed
+/// in registration order.
 ///
-/// Both callbacks receive an optional mutable reference to a [`ConsumeMessageContext`]
-/// that carries metadata about the current consumption attempt, including the consumer
-/// group, topic, message list, and the final consumption result.
-pub trait ConsumeMessageHook {
-    /// Returns the name that uniquely identifies this hook implementation.
-    fn hook_name(&self) -> &str;
+/// # Examples
+///
+/// ```ignore
+/// use rocketmq_client::hook::consume_message_hook::ConsumeMessageHook;
+/// use rocketmq_client::hook::consume_message_context::ConsumeMessageContext;
+///
+/// struct LoggingHook;
+///
+/// impl ConsumeMessageHook for LoggingHook {
+///     fn hook_name(&self) -> &'static str {
+///         "LoggingHook"
+///     }
+///
+///     fn consume_message_before(&self, context: &ConsumeMessageContext) {
+///         println!("Before consuming {} messages from {}",
+///                  context.msg_list.len(), context.consumer_group);
+///     }
+///
+///     fn consume_message_after(&self, context: &ConsumeMessageContext) {
+///         println!("After consuming, success: {}", context.success);
+///     }
+/// }
+/// ```
+pub trait ConsumeMessageHook: Send + Sync {
+    /// Returns the unique name of this hook.
+    fn hook_name(&self) -> &'static str;
 
-    /// Invoked immediately before message consumption begins.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - Mutable reference to the consumption context, or `None` if no context is
-    ///   available for the current invocation.
-    fn consume_message_before(&self, context: Option<&mut ConsumeMessageContext>);
+    /// Invoked before message consumption begins.
+    fn consume_message_before(&self, context: &ConsumeMessageContext);
 
-    /// Invoked immediately after message consumption completes.
+    /// Invoked after message consumption completes.
     ///
-    /// The [`ConsumeMessageContext`] reflects the final consumption status at this point,
-    /// including whether the messages were consumed successfully or encountered an error.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - Mutable reference to the consumption context, or `None` if no context is
-    ///   available for the current invocation.
-    fn consume_message_after(&self, context: Option<&mut ConsumeMessageContext>);
+    /// The context reflects the final consumption status, including whether
+    /// the messages were consumed successfully.
+    fn consume_message_after(&self, context: &ConsumeMessageContext);
 }

--- a/rocketmq-client/src/trace/hook/consume_message_trace_hook_impl.rs
+++ b/rocketmq-client/src/trace/hook/consume_message_trace_hook_impl.rs
@@ -27,15 +27,15 @@ impl ConsumeMessageTraceHookImpl {
 }
 
 impl ConsumeMessageHook for ConsumeMessageTraceHookImpl {
-    fn hook_name(&self) -> &str {
-        todo!()
+    fn hook_name(&self) -> &'static str {
+        "ConsumeMessageTraceHook"
     }
 
-    fn consume_message_before(&self, context: Option<&mut ConsumeMessageContext>) {
-        todo!()
+    fn consume_message_before(&self, _context: &ConsumeMessageContext) {
+        // TODO: Implement trace logic before consumption
     }
 
-    fn consume_message_after(&self, context: Option<&mut ConsumeMessageContext>) {
-        todo!()
+    fn consume_message_after(&self, _context: &ConsumeMessageContext) {
+        // TODO: Implement trace logic after consumption
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6674

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified message consumption hook API by updating method signatures to use immutable, non-optional context parameters
  * Relaxed thread-safety constraints for hook registration to increase flexibility
  * Enhanced context structure with improved builder methods for configuring message consumption behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->