### PR TITLE
[ISSUE #6419]Implement `checkRocksdbCqWriteProgress` admin command for validating RocksDB consume queue consistency

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -52,6 +52,7 @@ use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
+use rocketmq_remoting::protocol::body::check_rocksdb_cqwrite_progress_response_body::CheckRocksdbCqWriteResult;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::body::consumer_connection::ConsumerConnection;
 use rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInfo;
@@ -476,10 +477,21 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn check_rocksdb_cq_write_progress(
         &self,
-        _broker_addr: CheetahString,
-        _topic: CheetahString,
-    ) -> rocketmq_error::RocketMQResult<CheetahString> {
-        unimplemented!("check_rocksdb_cq_write_progress not implemented yet")
+        broker_addr: CheetahString,
+        topic: CheetahString,
+        check_store_time: i64,
+    ) -> rocketmq_error::RocketMQResult<CheckRocksdbCqWriteResult> {
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .check_rocksdb_cq_write_progress(
+                &broker_addr,
+                topic,
+                check_store_time,
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await
     }
 
     async fn examine_broker_cluster_info(&self) -> rocketmq_error::RocketMQResult<ClusterInfo> {

--- a/rocketmq-client/src/admin/mq_admin_ext_async.rs
+++ b/rocketmq-client/src/admin/mq_admin_ext_async.rs
@@ -33,6 +33,7 @@ use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
+use rocketmq_remoting::protocol::body::check_rocksdb_cqwrite_progress_response_body::CheckRocksdbCqWriteResult;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::body::consumer_connection::ConsumerConnection;
 use rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInfo;
@@ -175,7 +176,8 @@ pub trait MQAdminExt: Send {
         &self,
         broker_addr: CheetahString,
         topic: CheetahString,
-    ) -> rocketmq_error::RocketMQResult<CheetahString>;
+        check_store_time: i64,
+    ) -> rocketmq_error::RocketMQResult<CheckRocksdbCqWriteResult>;
 
     async fn examine_broker_cluster_info(&self) -> rocketmq_error::RocketMQResult<ClusterInfo>;
 

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -74,6 +74,7 @@ use rocketmq_remoting::protocol::body::batch_ack_message_request_body::BatchAckM
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
 use rocketmq_remoting::protocol::body::check_client_request_body::CheckClientRequestBody;
+use rocketmq_remoting::protocol::body::check_rocksdb_cqwrite_progress_response_body::CheckRocksdbCqWriteResult;
 use rocketmq_remoting::protocol::body::epoch_entry_cache::EpochEntryCache;
 use rocketmq_remoting::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
 use rocketmq_remoting::protocol::body::get_lite_group_info_response_body::GetLiteGroupInfoResponseBody;
@@ -92,6 +93,7 @@ use rocketmq_remoting::protocol::body::user_info::UserInfo;
 use rocketmq_remoting::protocol::header::ack_message_request_header::AckMessageRequestHeader;
 use rocketmq_remoting::protocol::header::change_invisible_time_request_header::ChangeInvisibleTimeRequestHeader;
 use rocketmq_remoting::protocol::header::change_invisible_time_response_header::ChangeInvisibleTimeResponseHeader;
+use rocketmq_remoting::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader;
 use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequestHeader;
 use rocketmq_remoting::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
 use rocketmq_remoting::protocol::header::create_user_request_header::CreateUserRequestHeader;
@@ -607,6 +609,37 @@ impl MQClientAPIImpl {
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
                 return GetBrokerLiteInfoResponseBody::decode(body.as_ref());
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn check_rocksdb_cq_write_progress(
+        &self,
+        addr: &CheetahString,
+        topic: CheetahString,
+        check_store_time: i64,
+        timeout_millis: u64,
+    ) -> RocketMQResult<CheckRocksdbCqWriteResult> {
+        let request_header = CheckRocksdbCqWriteProgressRequestHeader {
+            topic,
+            check_store_time,
+            rpc: None,
+        };
+        let request = RemotingCommand::create_request_command(RequestCode::CheckRocksdbCqWriteProgress, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                let result: CheckRocksdbCqWriteResult = serde_json::from_slice(body.as_ref()).map_err(|e| {
+                    mq_client_err!(-1, format!("Failed to deserialize CheckRocksdbCqWriteResult: {}", e))
+                })?;
+                return Ok(result);
             }
         }
         Err(mq_client_err!(

--- a/rocketmq-remoting/src/protocol/body/check_rocksdb_cqwrite_progress_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/check_rocksdb_cqwrite_progress_response_body.rs
@@ -16,10 +16,40 @@ use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(i32)]
+pub enum CheckStatus {
+    CheckOk = 0,
+    CheckNotOk = 1,
+    CheckInProgress = 2,
+    CheckError = 3,
+}
+
+impl From<i32> for CheckStatus {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => CheckStatus::CheckOk,
+            1 => CheckStatus::CheckNotOk,
+            2 => CheckStatus::CheckInProgress,
+            3 => CheckStatus::CheckError,
+            _ => CheckStatus::CheckError,
+        }
+    }
+}
+
+/// Result of checking RocksDB consume queue write progress.
+/// Corresponds to Java's `CheckRocksdbCqWriteResult`.
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ClusterAclVersionInfo {
-    pub diff_result: Option<CheetahString>,
+pub struct CheckRocksdbCqWriteResult {
+    pub check_result: Option<CheetahString>,
+    pub check_status: i32,
+}
+
+impl CheckRocksdbCqWriteResult {
+    pub fn get_check_status(&self) -> CheckStatus {
+        CheckStatus::from(self.check_status)
+    }
 }
 
 #[cfg(test)]
@@ -29,39 +59,55 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cluster_acl_version_info_default_values() {
-        let info = ClusterAclVersionInfo::default();
-        assert!(info.diff_result.is_none());
+    fn check_rocksdb_cq_write_result_default_values() {
+        let result = CheckRocksdbCqWriteResult::default();
+        assert!(result.check_result.is_none());
+        assert_eq!(result.check_status, 0);
     }
 
     #[test]
-    fn cluster_acl_version_info_with_diff_result() {
-        let info = ClusterAclVersionInfo {
-            diff_result: Some(CheetahString::from("diff")),
+    fn check_rocksdb_cq_write_result_with_values() {
+        let result = CheckRocksdbCqWriteResult {
+            check_result: Some(CheetahString::from("all topic is ready")),
+            check_status: 0,
         };
-        assert_eq!(info.diff_result, Some(CheetahString::from("diff")));
+        assert_eq!(result.check_result, Some(CheetahString::from("all topic is ready")));
+        assert_eq!(result.get_check_status(), CheckStatus::CheckOk);
     }
 
     #[test]
-    fn serialize_cluster_acl_version_info() {
-        let info = ClusterAclVersionInfo {
-            diff_result: Some(CheetahString::from("diff")),
+    fn serialize_check_rocksdb_cq_write_result() {
+        let result = CheckRocksdbCqWriteResult {
+            check_result: Some(CheetahString::from("check doing")),
+            check_status: 2,
         };
-        let serialized = serde_json::to_string(&info).unwrap();
-        assert_eq!(serialized, r#"{"diffResult":"diff"}"#);
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(serialized.contains("\"checkResult\":\"check doing\""));
+        assert!(serialized.contains("\"checkStatus\":2"));
     }
 
     #[test]
-    fn deserialize_cluster_acl_version_info() {
-        let json = r#"{"diffResult":"diff"}"#;
-        let deserialized: ClusterAclVersionInfo = serde_json::from_str(json).unwrap();
-        assert_eq!(deserialized.diff_result, Some(CheetahString::from("diff")));
+    fn deserialize_check_rocksdb_cq_write_result() {
+        let json = r#"{"checkResult":"all ok","checkStatus":0}"#;
+        let result: CheckRocksdbCqWriteResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.check_result, Some(CheetahString::from("all ok")));
+        assert_eq!(result.check_status, 0);
+        assert_eq!(result.get_check_status(), CheckStatus::CheckOk);
     }
 
     #[test]
-    fn deserialize_cluster_acl_version_info_missing_diff_result() {
-        let json = r#"{}"#;
-        let deserialized: ClusterAclVersionInfo = serde_json::from_str(json).unwrap();
-        assert!(deserialized.diff_result.is_none());
+    fn deserialize_check_rocksdb_cq_write_result_error() {
+        let json = r#"{"checkResult":"error info","checkStatus":3}"#;
+        let result: CheckRocksdbCqWriteResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.get_check_status(), CheckStatus::CheckError);
+    }
+
+    #[test]
+    fn check_status_from_i32() {
+        assert_eq!(CheckStatus::from(0), CheckStatus::CheckOk);
+        assert_eq!(CheckStatus::from(1), CheckStatus::CheckNotOk);
+        assert_eq!(CheckStatus::from(2), CheckStatus::CheckInProgress);
+        assert_eq!(CheckStatus::from(3), CheckStatus::CheckError);
+        assert_eq!(CheckStatus::from(99), CheckStatus::CheckError);
     }
 }

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -16,6 +16,7 @@ pub mod ack_message_request_header;
 pub mod broker;
 pub mod change_invisible_time_request_header;
 pub mod change_invisible_time_response_header;
+pub mod check_rocksdb_cq_write_progress_request_header;
 pub mod check_transaction_state_request_header;
 pub mod client_request_header;
 pub mod consume_message_directly_result_request_header;

--- a/rocketmq-remoting/src/protocol/header/check_rocksdb_cq_write_progress_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/check_rocksdb_cq_write_progress_request_header.rs
@@ -1,0 +1,33 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckRocksdbCqWriteProgressRequestHeader {
+    #[required]
+    pub topic: CheetahString,
+
+    #[required]
+    pub check_store_time: i64,
+
+    #[serde(flatten)]
+    pub rpc: Option<RpcRequestHeader>,
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -43,6 +43,7 @@ use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
+use rocketmq_remoting::protocol::body::check_rocksdb_cqwrite_progress_response_body::CheckRocksdbCqWriteResult;
 use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::protocol::body::consumer_connection::ConsumerConnection;
 use rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInfo;
@@ -1130,10 +1131,13 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn check_rocksdb_cq_write_progress(
         &self,
-        _broker_addr: CheetahString,
-        _topic: CheetahString,
-    ) -> rocketmq_error::RocketMQResult<CheetahString> {
-        unimplemented!("check_rocksdb_cq_write_progress not implemented yet")
+        broker_addr: CheetahString,
+        topic: CheetahString,
+        check_store_time: i64,
+    ) -> rocketmq_error::RocketMQResult<CheckRocksdbCqWriteResult> {
+        self.default_mqadmin_ext_impl
+            .check_rocksdb_cq_write_progress(broker_addr, topic, check_store_time)
+            .await
     }
 
     async fn get_all_producer_info(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -27,6 +27,7 @@ mod message;
 mod namesrv;
 mod offset;
 mod producer;
+mod queue;
 mod target;
 mod topic;
 
@@ -145,6 +146,11 @@ pub enum Commands {
     Producer(producer::ProducerCommands),
 
     #[command(subcommand)]
+    #[command(about = "Queue commands")]
+    #[command(name = "queue")]
+    Queue(queue::QueueCommands),
+
+    #[command(subcommand)]
     #[command(about = "Topic commands")]
     Topic(topic::TopicCommands),
 
@@ -168,6 +174,7 @@ impl CommandExecute for Commands {
             Commands::NameServer(value) => value.execute(rpc_hook).await,
             Commands::Offset(value) => value.execute(rpc_hook).await,
             Commands::Producer(value) => value.execute(rpc_hook).await,
+            Commands::Queue(value) => value.execute(rpc_hook).await,
             Commands::Topic(value) => value.execute(rpc_hook).await,
             Commands::Show(value) => value.execute(rpc_hook).await,
         }
@@ -498,6 +505,11 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "Producer",
                 command: "producer",
                 remark: "Query producer's instances, connection, status, etc.",
+            },
+            Command {
+                category: "Queue",
+                command: "checkRocksdbCqWriteProgress",
+                remark: "Check if rocksdb cq is same as file cq.",
             },
             Command {
                 category: "Topic",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/queue.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/queue.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod check_rocksdb_cq_write_progress_sub_command;
+
+use std::sync::Arc;
+
+use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::queue::check_rocksdb_cq_write_progress_sub_command::CheckRocksdbCqWriteProgressSubCommand;
+use crate::commands::CommandExecute;
+
+#[derive(Subcommand)]
+pub enum QueueCommands {
+    #[command(
+        name = "checkRocksdbCqWriteProgress",
+        about = "check if rocksdb cq is same as file cq.",
+        long_about = None,
+    )]
+    CheckRocksdbCqWriteProgress(CheckRocksdbCqWriteProgressSubCommand),
+}
+
+impl CommandExecute for QueueCommands {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self {
+            QueueCommands::CheckRocksdbCqWriteProgress(cmd) => cmd.execute(rpc_hook).await,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/queue/check_rocksdb_cq_write_progress_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/queue/check_rocksdb_cq_write_progress_sub_command.rs
@@ -1,0 +1,133 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::body::check_rocksdb_cqwrite_progress_response_body::CheckStatus;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+const THIRTY_DAYS_MILLIS: i64 = 30 * 24 * 60 * 60 * 1000;
+
+#[derive(Debug, Clone, Parser)]
+pub struct CheckRocksdbCqWriteProgressSubCommand {
+    #[arg(short = 'c', long = "cluster", required = true, help = "Cluster name")]
+    cluster_name: String,
+
+    #[arg(short = 'n', long = "nameserverAddr", required = true, help = "nameserver address")]
+    namesrv_addr: String,
+
+    #[arg(short = 't', long = "topic", help = "topic name")]
+    topic: Option<String>,
+
+    #[arg(long = "checkFrom", help = "check from time")]
+    check_from: Option<i64>,
+}
+
+impl CommandExecute for CheckRocksdbCqWriteProgressSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+        default_mqadmin_ext.set_namesrv_addr(self.namesrv_addr.trim());
+
+        let cluster_name = self.cluster_name.trim().to_string();
+        let topic = self.topic.as_deref().map(|t| t.trim().to_string()).unwrap_or_default();
+        let check_store_time = self
+            .check_from
+            .unwrap_or_else(|| current_millis() as i64 - THIRTY_DAYS_MILLIS);
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "CheckRocksdbCqWriteProgressSubCommand: Failed to start MQAdminExt: {}",
+                    e
+                ))
+            })?;
+
+            let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await.map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "CheckRocksdbCqWriteProgressSubCommand: Failed to examine broker cluster info: {}",
+                    e
+                ))
+            })?;
+
+            let cluster_addr_table = cluster_info
+                .cluster_addr_table
+                .as_ref()
+                .ok_or_else(|| RocketMQError::Internal("clusterAddrTable is empty".into()))?;
+
+            if cluster_addr_table.get(cluster_name.as_str()).is_none() {
+                println!("clusterAddrTable is empty");
+                return Ok(());
+            }
+
+            let broker_addr_table = cluster_info
+                .broker_addr_table
+                .as_ref()
+                .ok_or_else(|| RocketMQError::Internal("brokerAddrTable is empty".into()))?;
+
+            for (broker_name, broker_data) in broker_addr_table {
+                let broker_addr = match broker_data.broker_addrs().get(&0u64) {
+                    Some(addr) => addr.clone(),
+                    None => continue,
+                };
+
+                match default_mqadmin_ext
+                    .check_rocksdb_cq_write_progress(broker_addr, CheetahString::from(topic.as_str()), check_store_time)
+                    .await
+                {
+                    Ok(result) => {
+                        let check_status = result.get_check_status();
+                        let check_result = result.check_result.as_deref().unwrap_or("");
+                        if check_status == CheckStatus::CheckError {
+                            println!(
+                                "{} check error, please check log... errInfo: {}",
+                                broker_name, check_result
+                            );
+                        } else {
+                            println!(
+                                "{} check doing, please wait and get the result from log...",
+                                broker_name
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        println!("{} check error: {}", broker_name, e);
+                    }
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6419

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new Queue command `checkRocksdbCqWriteProgress` to verify RocksDB consume queue consistency against file-based consume queue. Accepts cluster name, nameserver address, topic, and optional time window parameters. Reports per-broker status and detailed error information to help diagnose synchronization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->