### PR TITLE
[ISSUE #6683]✨Add benchmarks for MessageUtil and optimize property handling in create_reply_message

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -71,6 +71,10 @@ harness = false
 name    = "thread_local_index_bench"
 harness = false
 
+[[bench]]
+name    = "message_util_bench"
+harness = false
+
 [[example]]
 name = "simple-producer"
 path = "examples/producer/simple_producer.rs"

--- a/rocketmq-client/benches/message_util_bench.rs
+++ b/rocketmq-client/benches/message_util_bench.rs
@@ -1,0 +1,264 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hint::black_box;
+
+use cheetah_string::CheetahString;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use rocketmq_client_rust::utils::message_util::MessageUtil;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_common::common::message::MessageConst;
+use rocketmq_common::MessageAccessor::MessageAccessor;
+
+// ============================================================================
+// Helper functions to create test messages
+// ============================================================================
+
+fn create_test_message_with_all_properties() -> Message {
+    let mut msg = Message::default();
+    MessageAccessor::put_property(
+        &mut msg,
+        CheetahString::from_static_str(MessageConst::PROPERTY_CLUSTER),
+        CheetahString::from_static_str("DefaultCluster"),
+    );
+    MessageAccessor::put_property(
+        &mut msg,
+        CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT),
+        CheetahString::from_static_str("client-123"),
+    );
+    MessageAccessor::put_property(
+        &mut msg,
+        CheetahString::from_static_str(MessageConst::PROPERTY_CORRELATION_ID),
+        CheetahString::from_static_str("correlation-456"),
+    );
+    MessageAccessor::put_property(
+        &mut msg,
+        CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_TTL),
+        CheetahString::from_static_str("60000"),
+    );
+    msg
+}
+
+fn create_test_message_without_cluster() -> Message {
+    let mut msg = Message::default();
+    MessageAccessor::put_property(
+        &mut msg,
+        CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT),
+        CheetahString::from_static_str("client-123"),
+    );
+    msg
+}
+
+fn create_test_message_minimal() -> Message {
+    let mut msg = Message::default();
+    MessageAccessor::put_property(
+        &mut msg,
+        CheetahString::from_static_str(MessageConst::PROPERTY_CLUSTER),
+        CheetahString::from_static_str("DefaultCluster"),
+    );
+    msg
+}
+
+// ============================================================================
+// Benchmark: create_reply_message - Success Path (All Properties)
+// ============================================================================
+
+fn bench_create_reply_message_success_full(c: &mut Criterion) {
+    let mut group = c.benchmark_group("create_reply_message_success_full");
+    group.throughput(Throughput::Elements(1));
+
+    let request_message = create_test_message_with_all_properties();
+    let body = b"test response body";
+
+    group.bench_function("with_all_properties", |b| {
+        b.iter(|| {
+            let result = MessageUtil::create_reply_message(&request_message, body);
+            assert!(result.is_ok());
+            black_box(result)
+        });
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// Benchmark: create_reply_message - Success Path (Minimal Properties)
+// ============================================================================
+
+fn bench_create_reply_message_success_minimal(c: &mut Criterion) {
+    let mut group = c.benchmark_group("create_reply_message_success_minimal");
+    group.throughput(Throughput::Elements(1));
+
+    let request_message = create_test_message_minimal();
+    let body = b"test response body";
+
+    group.bench_function("with_minimal_properties", |b| {
+        b.iter(|| {
+            let result = MessageUtil::create_reply_message(&request_message, body);
+            assert!(result.is_ok());
+            black_box(result)
+        });
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// Benchmark: create_reply_message - Failure Path (Missing Cluster)
+// ============================================================================
+
+fn bench_create_reply_message_failure(c: &mut Criterion) {
+    let mut group = c.benchmark_group("create_reply_message_failure");
+    group.throughput(Throughput::Elements(1));
+
+    let request_message = create_test_message_without_cluster();
+    let body = b"test response body";
+
+    group.bench_function("missing_cluster_early_return", |b| {
+        b.iter(|| {
+            let result = MessageUtil::create_reply_message(&request_message, body);
+            assert!(result.is_err());
+            black_box(result)
+        });
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// Benchmark: get_reply_to_client
+// ============================================================================
+
+fn bench_get_reply_to_client(c: &mut Criterion) {
+    let mut group = c.benchmark_group("get_reply_to_client");
+    group.throughput(Throughput::Elements(1));
+
+    let message_with_property = create_test_message_with_all_properties();
+    let message_without_property = create_test_message_minimal();
+
+    group.bench_function("with_property", |b| {
+        b.iter(|| {
+            let result = MessageUtil::get_reply_to_client(&message_with_property);
+            assert!(result.is_some());
+            black_box(result)
+        });
+    });
+
+    group.bench_function("without_property", |b| {
+        b.iter(|| {
+            let result = MessageUtil::get_reply_to_client(&message_without_property);
+            assert!(result.is_none());
+            black_box(result)
+        });
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// Benchmark: Throughput Test - High Concurrency Simulation
+// ============================================================================
+
+fn bench_high_throughput(c: &mut Criterion) {
+    let mut group = c.benchmark_group("high_throughput");
+
+    for batch_size in [10, 100, 1000, 10000] {
+        group.throughput(Throughput::Elements(batch_size));
+
+        let request_message = create_test_message_with_all_properties();
+        let body = b"test response body";
+
+        group.bench_with_input(BenchmarkId::from_parameter(batch_size), &batch_size, |b, &size| {
+            b.iter(|| {
+                for _ in 0..size {
+                    let _ = black_box(MessageUtil::create_reply_message(&request_message, body));
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ============================================================================
+// Benchmark: Memory Allocation Comparison
+// ============================================================================
+
+fn bench_memory_pattern(c: &mut Criterion) {
+    let mut group = c.benchmark_group("memory_pattern");
+    group.throughput(Throughput::Elements(1000));
+
+    let request_message = create_test_message_with_all_properties();
+    let body = b"test response body";
+
+    group.bench_function("repeated_calls", |b| {
+        b.iter(|| {
+            // Simulate high-frequency calls in production
+            for _ in 0..1000 {
+                let _ = black_box(MessageUtil::create_reply_message(&request_message, body));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// Benchmark: Static String Cache Hit Rate
+// ============================================================================
+
+fn bench_static_cache_effectiveness(c: &mut Criterion) {
+    let mut group = c.benchmark_group("static_cache_effectiveness");
+
+    // Create messages with different property combinations
+    let messages = vec![
+        create_test_message_with_all_properties(),
+        create_test_message_minimal(),
+        create_test_message_with_all_properties(),
+        create_test_message_minimal(),
+    ];
+
+    let body = b"test response body";
+
+    group.bench_function("mixed_property_patterns", |b| {
+        b.iter(|| {
+            for msg in &messages {
+                let _ = black_box(MessageUtil::create_reply_message(msg, body));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+// ============================================================================
+// Register all benchmarks
+// ============================================================================
+
+criterion_group!(
+    benches,
+    bench_create_reply_message_success_full,
+    bench_create_reply_message_success_minimal,
+    bench_create_reply_message_failure,
+    bench_get_reply_to_client,
+    bench_high_throughput,
+    bench_memory_pattern,
+    bench_static_cache_effectiveness,
+);
+
+criterion_main!(benches);

--- a/rocketmq-client/src/utils/message_util.rs
+++ b/rocketmq-client/src/utils/message_util.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::LazyLock;
+
 use bytes::Bytes;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_single::Message;
@@ -21,66 +23,79 @@ use rocketmq_common::MessageAccessor::MessageAccessor;
 
 use crate::common::client_error_code::ClientErrorCode;
 
+// Cached static strings to avoid repeated allocations
+static PROPERTY_CLUSTER: LazyLock<CheetahString> =
+    LazyLock::new(|| CheetahString::from_static_str(MessageConst::PROPERTY_CLUSTER));
+static PROPERTY_MESSAGE_TYPE: LazyLock<CheetahString> =
+    LazyLock::new(|| CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_TYPE));
+static REPLY_MESSAGE_FLAG: LazyLock<CheetahString> =
+    LazyLock::new(|| CheetahString::from_static_str(mix_all::REPLY_MESSAGE_FLAG));
+static PROPERTY_MESSAGE_REPLY_TO_CLIENT: LazyLock<CheetahString> =
+    LazyLock::new(|| CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT));
+static PROPERTY_CORRELATION_ID: LazyLock<CheetahString> =
+    LazyLock::new(|| CheetahString::from_static_str(MessageConst::PROPERTY_CORRELATION_ID));
+static PROPERTY_MESSAGE_TTL: LazyLock<CheetahString> =
+    LazyLock::new(|| CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_TTL));
+
 pub struct MessageUtil;
 
 impl MessageUtil {
     pub fn create_reply_message(request_message: &Message, body: &[u8]) -> rocketmq_error::RocketMQResult<Message> {
-        let mut reply_message = Message::default();
-        let cluster = request_message.property(&CheetahString::from_static_str(MessageConst::PROPERTY_CLUSTER));
-        if let Some(cluster) = cluster {
-            reply_message.set_body(Some(Bytes::copy_from_slice(body)));
-            let reply_topic = mix_all::get_retry_topic(cluster);
-            reply_message.set_topic(CheetahString::from_string(reply_topic));
-            MessageAccessor::put_property(
-                &mut reply_message,
-                CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_TYPE),
-                CheetahString::from_static_str(mix_all::REPLY_MESSAGE_FLAG),
-            );
-            if let Some(reply_to) = request_message.property(&CheetahString::from_static_str(
-                MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT,
-            )) {
-                MessageAccessor::put_property(
-                    &mut reply_message,
-                    CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT),
-                    reply_to.into(),
-                );
-            }
-            if let Some(correlation_id) =
-                request_message.property(&CheetahString::from_static_str(MessageConst::PROPERTY_CORRELATION_ID))
-            {
-                MessageAccessor::put_property(
-                    &mut reply_message,
-                    CheetahString::from_static_str(MessageConst::PROPERTY_CORRELATION_ID),
-                    correlation_id.into(),
-                );
-            }
-            if let Some(ttl) =
-                request_message.property(&CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_TTL))
-            {
-                MessageAccessor::put_property(
-                    &mut reply_message,
-                    CheetahString::from_static_str(MessageConst::PROPERTY_MESSAGE_TTL),
-                    ttl.into(),
-                );
-            }
-            Ok(reply_message)
-        } else {
-            let error = mq_client_err!(
+        // Early return: check required cluster property
+        let Some(cluster) = request_message.property(&PROPERTY_CLUSTER) else {
+            return Err(mq_client_err!(
                 ClientErrorCode::CREATE_REPLY_MESSAGE_EXCEPTION,
                 format!(
                     "create reply message fail, requestMessage error, property[{}] is null.",
                     MessageConst::PROPERTY_CLUSTER
                 )
+            ));
+        };
+
+        let mut reply_message = Message::default();
+        reply_message.set_body(Some(Bytes::copy_from_slice(body)));
+
+        let reply_topic = mix_all::get_retry_topic(cluster);
+        reply_message.set_topic(CheetahString::from_string(reply_topic));
+
+        // Set message type using cached static string
+        MessageAccessor::put_property(
+            &mut reply_message,
+            PROPERTY_MESSAGE_TYPE.clone(),
+            REPLY_MESSAGE_FLAG.clone(),
+        );
+
+        // Copy optional properties if present
+        if let Some(reply_to) = request_message.property(&PROPERTY_MESSAGE_REPLY_TO_CLIENT) {
+            MessageAccessor::put_property(
+                &mut reply_message,
+                PROPERTY_MESSAGE_REPLY_TO_CLIENT.clone(),
+                CheetahString::from_slice(reply_to),
             );
-            Err(error)
         }
+
+        if let Some(correlation_id) = request_message.property(&PROPERTY_CORRELATION_ID) {
+            MessageAccessor::put_property(
+                &mut reply_message,
+                PROPERTY_CORRELATION_ID.clone(),
+                CheetahString::from_slice(correlation_id),
+            );
+        }
+
+        if let Some(ttl) = request_message.property(&PROPERTY_MESSAGE_TTL) {
+            MessageAccessor::put_property(
+                &mut reply_message,
+                PROPERTY_MESSAGE_TTL.clone(),
+                CheetahString::from_slice(ttl),
+            );
+        }
+
+        Ok(reply_message)
     }
 
     pub fn get_reply_to_client(reply_message: &Message) -> Option<CheetahString> {
         reply_message
-            .property(&CheetahString::from_static_str(
-                MessageConst::PROPERTY_MESSAGE_REPLY_TO_CLIENT,
-            ))
-            .map(Into::into)
+            .property(&PROPERTY_MESSAGE_REPLY_TO_CLIENT)
+            .map(CheetahString::from_slice)
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6683

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive benchmark suite for message utility operations, including high-throughput scenarios and memory allocation patterns.

* **Refactor**
  * Optimized message utility functions with centralized caching of commonly used string constants to improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->