### PR TITLE
[ISSUE #6688]🚀Add TraceDispatcherType enum to categorize trace data sources

### DIFF
--- a/rocketmq-client/src/trace/trace_dispatcher_type.rs
+++ b/rocketmq-client/src/trace/trace_dispatcher_type.rs
@@ -12,13 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod async_trace_dispatcher;
-pub mod hook;
-pub mod trace_bean;
-pub mod trace_constants;
-pub mod trace_context;
-pub mod trace_dispatcher;
-pub mod trace_dispatcher_type;
-pub mod trace_transfer_bean;
-pub mod trace_type;
-pub mod trace_view;
+/// Type of trace dispatcher indicating the source of trace data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum TraceDispatcherType {
+    /// Trace data from message producers
+    #[default]
+    Producer,
+    /// Trace data from message consumers
+    Consumer,
+}
+
+impl TraceDispatcherType {
+    #[inline]
+    pub fn is_producer(&self) -> bool {
+        matches!(self, Self::Producer)
+    }
+
+    #[inline]
+    pub fn is_consumer(&self) -> bool {
+        matches!(self, Self::Consumer)
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6688

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced enhanced trace categorization capabilities to the RocketMQ client, enabling more granular identification and monitoring of trace sources within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->