### PR TITLE
[ISSUE #6699]🚀Refactor send callback to use ArcSendCallback in send_with_selector.rs

### DIFF
--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -2974,9 +2974,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",

--- a/rocketmq-example/examples/producer/send_with_selector.rs
+++ b/rocketmq-example/examples/producer/send_with_selector.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
 use rocketmq_client_rust::producer::mq_producer::MQProducer;
-use rocketmq_client_rust::producer::send_callback::SendMessageCallback;
+use rocketmq_client_rust::producer::send_callback::ArcSendCallback;
 use rocketmq_client_rust::producer::send_result::SendResult;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_single::Message;
@@ -157,7 +157,7 @@ async fn send_with_selector_callback(producer: &mut DefaultMQProducer) -> Rocket
 
     let arg = "selector-arg";
 
-    let callback: SendMessageCallback = Arc::new(
+    let callback: ArcSendCallback = Arc::new(
         |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
             (Some(r), None) => println!("   Callback: Success - {:?}", r),
             (None, Some(e)) => println!("   Callback: Error - {}", e),
@@ -195,7 +195,7 @@ async fn send_with_selector_callback_timeout(producer: &mut DefaultMQProducer) -
 
     let arg = "selector-arg";
 
-    let callback: SendMessageCallback = Arc::new(
+    let callback: ArcSendCallback = Arc::new(
         |result: Option<&SendResult>, error: Option<&dyn std::error::Error>| match (result, error) {
             (Some(r), None) => println!("   Callback: Success - {:?}", r),
             (None, Some(e)) => println!("   Callback: Error - {}", e),


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6699

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated callback type handling in the message producer example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->