### PR TITLE
[ISSUE #6420]Implement `queryCq` admin command for querying consume queue data and metadata

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1549,14 +1549,27 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn query_consume_queue(
         &self,
-        _broker_addr: CheetahString,
-        _topic: CheetahString,
-        _queue_id: i32,
-        _index: u64,
-        _count: i32,
-        _consumer_group: CheetahString,
+        broker_addr: CheetahString,
+        topic: CheetahString,
+        queue_id: i32,
+        index: u64,
+        count: i32,
+        consumer_group: CheetahString,
     ) -> rocketmq_error::RocketMQResult<QueryConsumeQueueResponseBody> {
-        unimplemented!("query_consume_queue not implemented yet")
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .query_consume_queue(
+                &broker_addr,
+                topic,
+                queue_id,
+                index as i64,
+                count,
+                consumer_group,
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await
     }
 
     async fn update_and_get_group_read_forbidden(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -84,6 +84,7 @@ use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_remoting::protocol::body::producer_table_info::ProducerTableInfo;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
+use rocketmq_remoting::protocol::body::query_consume_queue_response_body::QueryConsumeQueueResponseBody;
 use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
 use rocketmq_remoting::protocol::body::response::get_consumer_status_body::GetConsumerStatusBody;
 use rocketmq_remoting::protocol::body::response::lock_batch_response_body::LockBatchResponseBody;
@@ -131,6 +132,7 @@ use rocketmq_remoting::protocol::header::pop_message_request_header::PopMessageR
 use rocketmq_remoting::protocol::header::pop_message_response_header::PopMessageResponseHeader;
 use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_remoting::protocol::header::pull_message_response_header::PullMessageResponseHeader;
+use rocketmq_remoting::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
 use rocketmq_remoting::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::query_consumer_offset_response_header::QueryConsumerOffsetResponseHeader;
 use rocketmq_remoting::protocol::header::recall_message_request_header::RecallMessageRequestHeader;
@@ -638,6 +640,50 @@ impl MQClientAPIImpl {
             if let Some(body) = response.get_body() {
                 let result: CheckRocksdbCqWriteResult = serde_json::from_slice(body.as_ref()).map_err(|e| {
                     mq_client_err!(-1, format!("Failed to deserialize CheckRocksdbCqWriteResult: {}", e))
+                })?;
+                return Ok(result);
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn query_consume_queue(
+        &self,
+        addr: &CheetahString,
+        topic: CheetahString,
+        queue_id: i32,
+        index: i64,
+        count: i32,
+        consumer_group: CheetahString,
+        timeout_millis: u64,
+    ) -> RocketMQResult<QueryConsumeQueueResponseBody> {
+        let request_header = QueryConsumeQueueRequestHeader {
+            topic,
+            queue_id,
+            index,
+            count,
+            consumer_group: if consumer_group.is_empty() {
+                None
+            } else {
+                Some(consumer_group)
+            },
+            rpc: None,
+        };
+        let request = RemotingCommand::create_request_command(RequestCode::QueryConsumeQueue, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                let result: QueryConsumeQueueResponseBody = serde_json::from_slice(body.as_ref()).map_err(|e| {
+                    mq_client_err!(
+                        -1,
+                        format!("Failed to deserialize QueryConsumeQueueResponseBody: {}", e)
+                    )
                 })?;
                 return Ok(result);
             }

--- a/rocketmq-remoting/src/protocol/body/query_consume_queue_response_body.rs
+++ b/rocketmq-remoting/src/protocol/body/query_consume_queue_response_body.rs
@@ -22,11 +22,11 @@ use crate::protocol::heartbeat::subscription_data::SubscriptionData;
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryConsumeQueueResponseBody {
-    subscription_data: SubscriptionData,
-    filter_data: CheetahString,
-    queue_data: Vec<ConsumeQueueData>,
-    max_queue_index: i64,
-    min_queue_index: i64,
+    pub subscription_data: Option<SubscriptionData>,
+    pub filter_data: Option<CheetahString>,
+    pub queue_data: Option<Vec<ConsumeQueueData>>,
+    pub max_queue_index: i64,
+    pub min_queue_index: i64,
 }
 
 #[cfg(test)]
@@ -36,9 +36,9 @@ mod tests {
     #[test]
     fn query_consume_queue_response_body_default_values() {
         let response_body: QueryConsumeQueueResponseBody = Default::default();
-        //assert_eq!(response_body.subscription_data, SubscriptionData::default());
-        assert_eq!(response_body.filter_data, "");
-        assert!(response_body.queue_data.is_empty());
+        assert!(response_body.subscription_data.is_none());
+        assert!(response_body.filter_data.is_none());
+        assert!(response_body.queue_data.is_none());
         assert_eq!(response_body.max_queue_index, 0);
         assert_eq!(response_body.min_queue_index, 0);
     }

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -72,6 +72,7 @@ pub mod pop_message_request_header;
 pub mod pop_message_response_header;
 pub mod pull_message_request_header;
 pub mod pull_message_response_header;
+pub mod query_consume_queue_request_header;
 pub mod query_consume_time_span_request_header;
 pub mod query_consumer_offset_request_header;
 pub mod query_consumer_offset_response_header;

--- a/rocketmq-remoting/src/protocol/header/query_consume_queue_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/query_consume_queue_request_header.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryConsumeQueueRequestHeader {
+    #[required]
+    pub topic: CheetahString,
+
+    #[required]
+    pub queue_id: i32,
+
+    #[required]
+    pub index: i64,
+
+    #[required]
+    pub count: i32,
+
+    pub consumer_group: Option<CheetahString>,
+
+    #[serde(flatten)]
+    pub rpc: Option<RpcRequestHeader>,
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1238,14 +1238,16 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn query_consume_queue(
         &self,
-        _broker_addr: CheetahString,
-        _topic: CheetahString,
-        _queue_id: i32,
-        _index: u64,
-        _count: i32,
-        _consumer_group: CheetahString,
+        broker_addr: CheetahString,
+        topic: CheetahString,
+        queue_id: i32,
+        index: u64,
+        count: i32,
+        consumer_group: CheetahString,
     ) -> rocketmq_error::RocketMQResult<QueryConsumeQueueResponseBody> {
-        unimplemented!("query_consume_queue not implemented yet")
+        self.default_mqadmin_ext_impl
+            .query_consume_queue(broker_addr, topic, queue_id, index, count, consumer_group)
+            .await
     }
 
     async fn update_and_get_group_read_forbidden(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -512,6 +512,11 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Check if rocksdb cq is same as file cq.",
             },
             Command {
+                category: "Queue",
+                command: "queryCq",
+                remark: "Query cq command.",
+            },
+            Command {
                 category: "Topic",
                 command: "allocateMQ",
                 remark: "Allocate MQ.",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/queue.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/queue.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod check_rocksdb_cq_write_progress_sub_command;
+mod query_consume_queue_sub_command;
 
 use std::sync::Arc;
 
@@ -21,6 +22,7 @@ use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::queue::check_rocksdb_cq_write_progress_sub_command::CheckRocksdbCqWriteProgressSubCommand;
+use crate::commands::queue::query_consume_queue_sub_command::QueryCqSubCommand;
 use crate::commands::CommandExecute;
 
 #[derive(Subcommand)]
@@ -31,12 +33,20 @@ pub enum QueueCommands {
         long_about = None,
     )]
     CheckRocksdbCqWriteProgress(CheckRocksdbCqWriteProgressSubCommand),
+
+    #[command(
+        name = "queryCq",
+        about = "Query cq command.",
+        long_about = None,
+    )]
+    QueryCq(QueryCqSubCommand),
 }
 
 impl CommandExecute for QueueCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             QueueCommands::CheckRocksdbCqWriteProgress(cmd) => cmd.execute(rpc_hook).await,
+            QueueCommands::QueryCq(cmd) => cmd.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/queue/query_consume_queue_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/queue/query_consume_queue_sub_command.rs
@@ -1,0 +1,163 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct QueryCqSubCommand {
+    #[arg(short = 't', long = "topic", required = true, help = "topic name")]
+    topic: String,
+
+    #[arg(short = 'q', long = "queue", required = true, help = "queue num, ie. 1")]
+    queue_id: i32,
+
+    #[arg(short = 'i', long = "index", required = true, help = "start queue index")]
+    index: u64,
+
+    #[arg(
+        short = 'c',
+        long = "count",
+        required = false,
+        default_value = "10",
+        help = "how many"
+    )]
+    count: i32,
+
+    #[arg(short = 'b', long = "broker", required = false, help = "broker addr")]
+    broker: Option<String>,
+
+    #[arg(short = 'g', long = "consumer", required = false, help = "consumer group")]
+    consumer_group: Option<String>,
+}
+
+impl CommandExecute for QueryCqSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let topic = self.topic.trim().to_string();
+        let queue_id = self.queue_id;
+        let index = self.index;
+        let count = self.count;
+        let consumer_group = self
+            .consumer_group
+            .as_deref()
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("QueryCqSubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            let broker_addr = if let Some(ref broker) = self.broker {
+                CheetahString::from_string(broker.trim().to_string())
+            } else {
+                let topic_route_data = default_mqadmin_ext
+                    .examine_topic_route_info(CheetahString::from_string(topic.clone()))
+                    .await
+                    .map_err(|e| {
+                        RocketMQError::Internal(format!("QueryCqSubCommand: Failed to examine topic route info: {}", e))
+                    })?;
+
+                let topic_route_data =
+                    topic_route_data.ok_or_else(|| RocketMQError::Internal("No topic route data!".into()))?;
+
+                if topic_route_data.broker_datas.is_empty() {
+                    return Err(RocketMQError::Internal(
+                        "No topic route data! broker_datas is empty".into(),
+                    ));
+                }
+
+                let broker_data = &topic_route_data.broker_datas[0];
+                broker_data.broker_addrs().get(&0u64).cloned().ok_or_else(|| {
+                    RocketMQError::Internal("No master broker address found in topic route data".into())
+                })?
+            };
+
+            let response_body = default_mqadmin_ext
+                .query_consume_queue(
+                    broker_addr,
+                    CheetahString::from_string(topic),
+                    queue_id,
+                    index,
+                    count,
+                    CheetahString::from_string(consumer_group),
+                )
+                .await
+                .map_err(|e| {
+                    RocketMQError::Internal(format!("QueryCqSubCommand: Failed to query consume queue: {}", e))
+                })?;
+
+            if let Some(ref subscription_data) = response_body.subscription_data {
+                println!("Subscription data:");
+                match serde_json::to_string_pretty(subscription_data) {
+                    Ok(json) => println!("{}", json),
+                    Err(_) => println!("{:?}", subscription_data),
+                }
+                println!("======================================");
+            }
+
+            if let Some(ref filter_data) = response_body.filter_data {
+                if !filter_data.is_empty() {
+                    println!("Filter data:");
+                    println!("{}", filter_data);
+                    println!("======================================");
+                }
+            }
+
+            println!("Queue data:");
+            println!(
+                "max: {}, min: {}",
+                response_body.max_queue_index, response_body.min_queue_index
+            );
+            println!("======================================");
+
+            if let Some(ref queue_data) = response_body.queue_data {
+                for (offset, data) in queue_data.iter().enumerate() {
+                    println!("idx: {}", index + offset as u64);
+                    match serde_json::to_string_pretty(data) {
+                        Ok(json) => println!("{}", json),
+                        Err(_) => println!("{}", data),
+                    }
+                    println!("======================================");
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6420 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consume-queue query end-to-end: admin API, remoting request header support, and a CLI subcommand to query and display consume-queue details (topic, queue ID, index, count, optional broker/consumer group).
* **Bug Fixes / Improvements**
  * Implemented API forwarding for query requests and made response fields optional and publicly accessible for safer, clearer output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->