### PR TITLE
[ISSUE #6421]Implement `statsAll` admin command for comprehensive topic and consumer group statistics

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -16,6 +16,7 @@ use crate::broker_runtime::BrokerRuntimeInner;
 use crate::processor::admin_broker_processor::batch_mq_handler::BatchMqHandler;
 use crate::processor::admin_broker_processor::broker_config_request_handler::BrokerConfigRequestHandler;
 use crate::processor::admin_broker_processor::broker_epoch_cache_handler::BrokerEpochCacheHandler;
+use crate::processor::admin_broker_processor::broker_stats_handler::BrokerStatsHandler;
 use crate::processor::admin_broker_processor::consumer_request_handler::ConsumerRequestHandler;
 use crate::processor::admin_broker_processor::get_broker_ha_status_handler::GetBrokerHaStatusHandler;
 use crate::processor::admin_broker_processor::get_user_request_handler::GetUserRequestHandler;
@@ -44,6 +45,7 @@ use tracing::warn;
 mod batch_mq_handler;
 mod broker_config_request_handler;
 mod broker_epoch_cache_handler;
+mod broker_stats_handler;
 mod consumer_request_handler;
 mod get_broker_ha_status_handler;
 mod get_user_request_handler;
@@ -82,6 +84,7 @@ pub struct AdminBrokerProcessor<MS: MessageStore> {
     get_user_request_handler: GetUserRequestHandler<MS>,
     update_cold_data_flow_ctr_group_config_request_handler: UpdateColdDataFlowCtrGroupConfigRequestHandler<MS>,
     get_broker_ha_status_handler: GetBrokerHaStatusHandler<MS>,
+    broker_stats_handler: BrokerStatsHandler<MS>,
 }
 
 impl<MS> RequestProcessor for AdminBrokerProcessor<MS>
@@ -126,6 +129,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
         let update_cold_data_flow_ctr_group_config_request_handler =
             UpdateColdDataFlowCtrGroupConfigRequestHandler::new(broker_runtime_inner.clone());
         let get_broker_ha_status_handler = GetBrokerHaStatusHandler::new(broker_runtime_inner.clone());
+        let broker_stats_handler = BrokerStatsHandler::new(broker_runtime_inner.clone());
 
         AdminBrokerProcessor {
             topic_request_handler,
@@ -147,6 +151,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
             get_user_request_handler,
             update_cold_data_flow_ctr_group_config_request_handler,
             get_broker_ha_status_handler,
+            broker_stats_handler,
         }
     }
 }
@@ -305,7 +310,11 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
             RequestCode::QueryCorrectionOffset => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::ConsumeMessageDirectly => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::CloneGroupOffset => Ok(get_unknown_cmd_response(request_code)),
-            RequestCode::ViewBrokerStatsData => Ok(get_unknown_cmd_response(request_code)),
+            RequestCode::ViewBrokerStatsData => {
+                self.broker_stats_handler
+                    .view_broker_stats_data(channel, ctx, request_code, request)
+                    .await
+            }
             RequestCode::GetBrokerConsumeStats => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::QueryConsumeQueue => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::CheckRocksdbCqWriteProgress => Ok(get_unknown_cmd_response(request_code)),

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_stats_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_stats_handler.rs
@@ -1,0 +1,79 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::body::broker_stats_item::BrokerStatsItem;
+use rocketmq_remoting::protocol::header::view_broker_stats_data_request_header::ViewBrokerStatsDataRequestHeader;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::subscription::broker_stats_data::BrokerStatsData;
+use rocketmq_remoting::protocol::RemotingSerializable;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+
+use crate::broker_runtime::BrokerRuntimeInner;
+
+#[derive(Clone)]
+pub(super) struct BrokerStatsHandler<MS: MessageStore> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+}
+
+impl<MS: MessageStore> BrokerStatsHandler<MS> {
+    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        Self { broker_runtime_inner }
+    }
+
+    pub async fn view_broker_stats_data(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let mut response = RemotingCommand::create_response_command();
+        let request_header = request.decode_command_custom_header::<ViewBrokerStatsDataRequestHeader>()?;
+
+        let stats_name = request_header.stats_name.as_str();
+        let stats_key = request_header.stats_key.as_str();
+
+        let stats_item = self
+            .broker_runtime_inner
+            .broker_stats_manager()
+            .get_stats_item(stats_name, stats_key);
+
+        match stats_item {
+            Some(item) => {
+                let minute = item.get_stats_data_in_minute();
+                let hour = item.get_stats_data_in_hour();
+                let day = item.get_stats_data_in_day();
+
+                let broker_stats_data = BrokerStatsData::new(
+                    BrokerStatsItem::new(minute.get_sum(), minute.get_tps(), minute.get_avgpt()),
+                    BrokerStatsItem::new(hour.get_sum(), hour.get_tps(), hour.get_avgpt()),
+                    BrokerStatsItem::new(day.get_sum(), day.get_tps(), day.get_avgpt()),
+                );
+
+                let body = broker_stats_data.encode()?;
+                response.set_body_mut_ref(body);
+                Ok(Some(response))
+            }
+            None => Ok(Some(response.set_code(ResponseCode::SystemError).set_remark(format!(
+                "No stats data for statsName={}, statsKey={}",
+                stats_name, stats_key
+            )))),
+        }
+    }
+}

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -74,7 +74,10 @@ use rocketmq_remoting::protocol::body::topic::topic_list::TopicList;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
 use rocketmq_remoting::protocol::body::user_info::UserInfo;
 use rocketmq_remoting::protocol::header::elect_master_response_header::ElectMasterResponseHeader;
+use rocketmq_remoting::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader;
 use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
+use rocketmq_remoting::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
+use rocketmq_remoting::protocol::header::view_broker_stats_data_request_header::ViewBrokerStatsDataRequestHeader;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
@@ -448,7 +451,12 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
     }
 
     async fn fetch_all_topic_list(&self) -> rocketmq_error::RocketMQResult<TopicList> {
-        todo!()
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_all_topic_list_from_name_server(self.timeout_millis.as_millis() as u64)
+            .await
     }
 
     async fn fetch_topics_by_cluster(&self, cluster_name: CheetahString) -> rocketmq_error::RocketMQResult<TopicList> {
@@ -472,7 +480,61 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         broker_addr: Option<CheetahString>,
         timeout_millis: Option<u64>,
     ) -> rocketmq_error::RocketMQResult<ConsumeStats> {
-        todo!()
+        let timeout = timeout_millis.unwrap_or(self.timeout_millis.as_millis() as u64);
+        let topic_str = topic.clone().unwrap_or_default();
+
+        if let Some(addr) = broker_addr {
+            let request_header = GetConsumeStatsRequestHeader {
+                consumer_group,
+                topic: topic_str,
+                topic_request_header: None,
+            };
+            return self
+                .client_instance
+                .as_ref()
+                .unwrap()
+                .get_mq_client_api_impl()
+                .get_consume_stats(&addr, request_header, timeout)
+                .await;
+        }
+
+        let retry_topic: CheetahString = rocketmq_common::common::mix_all::get_retry_topic(&consumer_group).into();
+        let topic_route = self
+            .client_instance
+            .as_ref()
+            .unwrap()
+            .mq_client_api_impl
+            .as_ref()
+            .unwrap()
+            .get_topic_route_info_from_name_server(&retry_topic, timeout)
+            .await?;
+
+        let mut result = ConsumeStats::new();
+
+        if let Some(route_data) = topic_route {
+            for bd in &route_data.broker_datas {
+                if let Some(master_addr) = bd.broker_addrs().get(&rocketmq_common::common::mix_all::MASTER_ID) {
+                    let request_header = GetConsumeStatsRequestHeader {
+                        consumer_group: consumer_group.clone(),
+                        topic: topic_str.clone(),
+                        topic_request_header: None,
+                    };
+                    let cs = self
+                        .client_instance
+                        .as_ref()
+                        .unwrap()
+                        .get_mq_client_api_impl()
+                        .get_consume_stats(master_addr, request_header, timeout)
+                        .await?;
+
+                    result.get_offset_table_mut().extend(cs.offset_table);
+                    let new_tps = result.get_consume_tps() + cs.consume_tps;
+                    result.set_consume_tps(new_tps);
+                }
+            }
+        }
+
+        Ok(result)
     }
 
     async fn check_rocksdb_cq_write_progress(
@@ -781,7 +843,35 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
     }
 
     async fn query_topic_consume_by_who(&self, topic: CheetahString) -> rocketmq_error::RocketMQResult<GroupList> {
-        todo!()
+        let topic_route = self
+            .client_instance
+            .as_ref()
+            .unwrap()
+            .mq_client_api_impl
+            .as_ref()
+            .unwrap()
+            .get_topic_route_info_from_name_server(&topic, self.timeout_millis.as_millis() as u64)
+            .await?;
+
+        if let Some(route_data) = topic_route {
+            for bd in &route_data.broker_datas {
+                if let Some(master_addr) = bd.broker_addrs().get(&rocketmq_common::common::mix_all::MASTER_ID) {
+                    let request_header = QueryTopicConsumeByWhoRequestHeader {
+                        topic: topic.clone(),
+                        topic_request_header: None,
+                    };
+                    return self
+                        .client_instance
+                        .as_ref()
+                        .unwrap()
+                        .get_mq_client_api_impl()
+                        .query_topic_consume_by_who(master_addr, request_header, self.timeout_millis.as_millis() as u64)
+                        .await;
+                }
+            }
+        }
+
+        Ok(GroupList::default())
     }
 
     async fn query_topics_by_consumer(&self, group: CheetahString) -> rocketmq_error::RocketMQResult<TopicList> {
@@ -1503,11 +1593,17 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn view_broker_stats_data(
         &self,
-        _broker_addr: CheetahString,
-        _stats_name: CheetahString,
-        _stats_key: CheetahString,
+        broker_addr: CheetahString,
+        stats_name: CheetahString,
+        stats_key: CheetahString,
     ) -> rocketmq_error::RocketMQResult<BrokerStatsData> {
-        unimplemented!("view_broker_stats_data not implemented yet")
+        let request_header = ViewBrokerStatsDataRequestHeader { stats_name, stats_key };
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .view_broker_stats_data(&broker_addr, request_header, self.timeout_millis.as_millis() as u64)
+            .await
     }
 
     async fn fetch_consume_stats_in_broker(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -828,6 +828,95 @@ impl MQClientAPIImpl {
             response.remark().map_or("".to_string(), |s| s.to_string())
         ))
     }
+
+    pub(crate) async fn get_all_topic_list_from_name_server(
+        &self,
+        timeout_millis: u64,
+    ) -> RocketMQResult<rocketmq_remoting::protocol::body::topic::topic_list::TopicList> {
+        let request =
+            RemotingCommand::create_request_command(RequestCode::GetAllTopicListFromNameserver, EmptyHeader {});
+        let response = self
+            .remoting_client
+            .invoke_request(None, request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return rocketmq_remoting::protocol::body::topic::topic_list::TopicList::decode(body.as_ref());
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn get_consume_stats(
+        &self,
+        addr: &CheetahString,
+        request_header: rocketmq_remoting::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader,
+        timeout_millis: u64,
+    ) -> RocketMQResult<rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats> {
+        let request = RemotingCommand::create_request_command(RequestCode::GetConsumeStats, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats::decode(body.as_ref());
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn query_topic_consume_by_who(
+        &self,
+        addr: &CheetahString,
+        request_header: rocketmq_remoting::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader,
+        timeout_millis: u64,
+    ) -> RocketMQResult<rocketmq_remoting::protocol::body::group_list::GroupList> {
+        let request = RemotingCommand::create_request_command(RequestCode::QueryTopicConsumeByWho, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return rocketmq_remoting::protocol::body::group_list::GroupList::decode(body.as_ref());
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn view_broker_stats_data(
+        &self,
+        addr: &CheetahString,
+        request_header: rocketmq_remoting::protocol::header::view_broker_stats_data_request_header::ViewBrokerStatsDataRequestHeader,
+        timeout_millis: u64,
+    ) -> RocketMQResult<rocketmq_remoting::protocol::subscription::broker_stats_data::BrokerStatsData> {
+        let request = RemotingCommand::create_request_command(RequestCode::ViewBrokerStatsData, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return rocketmq_remoting::protocol::subscription::broker_stats_data::BrokerStatsData::decode(
+                    body.as_ref(),
+                );
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
 }
 
 impl NameServerUpdateCallback for MQClientAPIImpl {

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -92,5 +92,6 @@ pub mod unlock_batch_mq_request_header;
 pub mod unregister_client_request_header;
 pub mod update_consumer_offset_header;
 pub mod update_user_request_header;
+pub mod view_broker_stats_data_request_header;
 pub mod view_message_request_header;
 pub mod view_message_response_header;

--- a/rocketmq-remoting/src/protocol/header/view_broker_stats_data_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/view_broker_stats_data_request_header.rs
@@ -1,0 +1,29 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2)]
+pub struct ViewBrokerStatsDataRequestHeader {
+    #[required]
+    #[serde(rename = "statsName")]
+    pub stats_name: CheetahString,
+
+    #[required]
+    #[serde(rename = "statsKey")]
+    pub stats_key: CheetahString,
+}

--- a/rocketmq-remoting/src/protocol/subscription/broker_stats_data.rs
+++ b/rocketmq-remoting/src/protocol/subscription/broker_stats_data.rs
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use crate::protocol::body::broker_stats_item::BrokerStatsItem;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 /// Represents broker statistics over different time periods (minute, hour, day)
 pub struct BrokerStatsData {
     /// Statistics for the last minute

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -389,7 +389,7 @@ impl MQAdminExt for DefaultMQAdminExt {
     }
 
     async fn fetch_all_topic_list(&self) -> rocketmq_error::RocketMQResult<TopicList> {
-        todo!()
+        self.default_mqadmin_ext_impl.fetch_all_topic_list().await
     }
 
     async fn fetch_topics_by_cluster(&self, cluster_name: CheetahString) -> rocketmq_error::RocketMQResult<TopicList> {
@@ -410,7 +410,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         broker_addr: Option<CheetahString>,
         timeout_millis: Option<u64>,
     ) -> rocketmq_error::RocketMQResult<ConsumeStats> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .examine_consume_stats(consumer_group, topic, cluster_name, broker_addr, timeout_millis)
+            .await
     }
 
     async fn examine_broker_cluster_info(&self) -> rocketmq_error::RocketMQResult<ClusterInfo> {
@@ -574,7 +576,7 @@ impl MQAdminExt for DefaultMQAdminExt {
     }
 
     async fn query_topic_consume_by_who(&self, topic: CheetahString) -> rocketmq_error::RocketMQResult<GroupList> {
-        todo!()
+        self.default_mqadmin_ext_impl.query_topic_consume_by_who(topic).await
     }
 
     async fn query_topics_by_consumer(&self, group: CheetahString) -> rocketmq_error::RocketMQResult<TopicList> {
@@ -1200,11 +1202,13 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn view_broker_stats_data(
         &self,
-        _broker_addr: CheetahString,
-        _stats_name: CheetahString,
-        _stats_key: CheetahString,
+        broker_addr: CheetahString,
+        stats_name: CheetahString,
+        stats_key: CheetahString,
     ) -> rocketmq_error::RocketMQResult<BrokerStatsData> {
-        unimplemented!("view_broker_stats_data not implemented yet")
+        self.default_mqadmin_ext_impl
+            .view_broker_stats_data(broker_addr, stats_name, stats_key)
+            .await
     }
 
     async fn fetch_consume_stats_in_broker(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -28,6 +28,7 @@ mod namesrv;
 mod offset;
 mod producer;
 mod queue;
+mod stats;
 mod target;
 mod topic;
 
@@ -151,6 +152,11 @@ pub enum Commands {
     Queue(queue::QueueCommands),
 
     #[command(subcommand)]
+    #[command(about = "Stats commands")]
+    #[command(name = "stats")]
+    Stats(stats::StatsCommands),
+
+    #[command(subcommand)]
     #[command(about = "Topic commands")]
     Topic(topic::TopicCommands),
 
@@ -175,6 +181,7 @@ impl CommandExecute for Commands {
             Commands::Offset(value) => value.execute(rpc_hook).await,
             Commands::Producer(value) => value.execute(rpc_hook).await,
             Commands::Queue(value) => value.execute(rpc_hook).await,
+            Commands::Stats(value) => value.execute(rpc_hook).await,
             Commands::Topic(value) => value.execute(rpc_hook).await,
             Commands::Show(value) => value.execute(rpc_hook).await,
         }
@@ -515,6 +522,11 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "Queue",
                 command: "queryCq",
                 remark: "Query cq command.",
+            },
+            Command {
+                category: "Stats",
+                command: "statsAll",
+                remark: "Topic and Consumer tps stats.",
             },
             Command {
                 category: "Topic",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/stats.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/stats.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod stats_all_sub_command;
+
+use std::sync::Arc;
+
+use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::stats::stats_all_sub_command::StatsAllSubCommand;
+use crate::commands::CommandExecute;
+
+#[derive(Subcommand)]
+pub enum StatsCommands {
+    #[command(
+        name = "statsAll",
+        about = "Topic and Consumer tps stats.",
+        long_about = None,
+    )]
+    StatsAll(StatsAllSubCommand),
+}
+
+impl CommandExecute for StatsCommands {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self {
+            StatsCommands::StatsAll(cmd) => cmd.execute(rpc_hook).await,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/stats/stats_all_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/stats/stats_all_sub_command.rs
@@ -1,0 +1,208 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::mix_all;
+use rocketmq_common::common::mix_all::DLQ_GROUP_TOPIC_PREFIX;
+use rocketmq_common::common::mix_all::RETRY_GROUP_TOPIC_PREFIX;
+use rocketmq_common::common::stats::Stats;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::subscription::broker_stats_data::BrokerStatsData;
+use rocketmq_remoting::runtime::RPCHook;
+use tracing::warn;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct StatsAllSubCommand {
+    #[arg(
+        short = 'a',
+        long = "activeTopic",
+        help = "print active topic only",
+        required = false
+    )]
+    active_topic: bool,
+
+    #[arg(short = 't', long = "topic", required = false, help = "print select topic only")]
+    topic: Option<String>,
+}
+
+impl StatsAllSubCommand {
+    fn compute_24_hour_sum(bsd: &BrokerStatsData) -> u64 {
+        if bsd.get_stats_day().get_sum() != 0 {
+            return bsd.get_stats_day().get_sum();
+        }
+        if bsd.get_stats_hour().get_sum() != 0 {
+            return bsd.get_stats_hour().get_sum();
+        }
+        if bsd.get_stats_minute().get_sum() != 0 {
+            return bsd.get_stats_minute().get_sum();
+        }
+        0
+    }
+
+    async fn print_topic_detail(admin: &DefaultMQAdminExt, topic: &str, active_topic: bool) -> RocketMQResult<()> {
+        let topic_route_data = admin.examine_topic_route_info(CheetahString::from(topic)).await?;
+
+        let group_list = admin.query_topic_consume_by_who(CheetahString::from(topic)).await?;
+
+        let mut in_tps: f64 = 0.0;
+        let mut in_msg_cnt_today: u64 = 0;
+
+        if let Some(route_data) = &topic_route_data {
+            for bd in &route_data.broker_datas {
+                if let Some(master_addr) = bd.broker_addrs().get(&mix_all::MASTER_ID) {
+                    if let Ok(bsd) = admin
+                        .view_broker_stats_data(
+                            master_addr.clone(),
+                            CheetahString::from(Stats::TOPIC_PUT_NUMS),
+                            CheetahString::from(topic),
+                        )
+                        .await
+                    {
+                        in_tps += bsd.get_stats_minute().get_tps();
+                        in_msg_cnt_today += Self::compute_24_hour_sum(&bsd);
+                    }
+                }
+            }
+        }
+
+        if !group_list.group_list.is_empty() {
+            for group in &group_list.group_list {
+                let mut out_tps: f64 = 0.0;
+                let mut out_msg_cnt_today: u64 = 0;
+
+                if let Some(route_data) = &topic_route_data {
+                    for bd in &route_data.broker_datas {
+                        if let Some(master_addr) = bd.broker_addrs().get(&mix_all::MASTER_ID) {
+                            let stats_key = format!("{}@{}", topic, group);
+                            if let Ok(bsd) = admin
+                                .view_broker_stats_data(
+                                    master_addr.clone(),
+                                    CheetahString::from(Stats::GROUP_GET_NUMS),
+                                    CheetahString::from(stats_key.as_str()),
+                                )
+                                .await
+                            {
+                                out_tps += bsd.get_stats_minute().get_tps();
+                                out_msg_cnt_today += Self::compute_24_hour_sum(&bsd);
+                            }
+                        }
+                    }
+                }
+
+                let mut accumulate: i64 = 0;
+                if let Ok(consume_stats) = admin
+                    .examine_consume_stats(group.clone(), Some(CheetahString::from(topic)), None, None, None)
+                    .await
+                {
+                    accumulate = consume_stats.compute_total_diff();
+                    if accumulate < 0 {
+                        accumulate = 0;
+                    }
+                }
+
+                if !active_topic || in_msg_cnt_today > 0 || out_msg_cnt_today > 0 {
+                    println!(
+                        "{:<64}  {:<64} {:>12} {:>11.2} {:>11.2} {:>14} {:>14}",
+                        Self::front_string_at_least(topic, 64),
+                        Self::front_string_at_least(group.as_str(), 64),
+                        accumulate,
+                        in_tps,
+                        out_tps,
+                        in_msg_cnt_today,
+                        out_msg_cnt_today,
+                    );
+                }
+            }
+        } else if !active_topic || in_msg_cnt_today > 0 {
+            println!(
+                "{:<64}  {:<64} {:>12} {:>11.2} {:>11} {:>14} {:>14}",
+                Self::front_string_at_least(topic, 64),
+                "",
+                0,
+                in_tps,
+                "",
+                in_msg_cnt_today,
+                "NO_CONSUMER",
+            );
+        }
+
+        Ok(())
+    }
+
+    fn front_string_at_least(s: &str, size: usize) -> String {
+        s.chars().take(size).collect()
+    }
+}
+
+impl CommandExecute for StatsAllSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("StatsAllSubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            let topic_list = default_mqadmin_ext.fetch_all_topic_list().await?;
+
+            println!(
+                "{:<64}  {:<64} {:>12} {:>11} {:>11} {:>14} {:>14}",
+                "#Topic", "#Consumer Group", "#Accumulation", "#InTPS", "#OutTPS", "#InMsg24Hour", "#OutMsg24Hour",
+            );
+
+            let active_topic = self.active_topic;
+            let select_topic = self.topic.clone();
+
+            for topic in &topic_list.topic_list {
+                if topic.starts_with(RETRY_GROUP_TOPIC_PREFIX) || topic.starts_with(DLQ_GROUP_TOPIC_PREFIX) {
+                    continue;
+                }
+
+                if let Some(ref select) = select_topic {
+                    if !select.is_empty() && topic.as_str() != select.as_str() {
+                        continue;
+                    }
+                }
+
+                if let Err(e) = Self::print_topic_detail(&default_mqadmin_ext, topic.as_str(), active_topic).await {
+                    warn!("statsAll: failed to collect stats for topic '{}': {}", topic, e);
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6421 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Stats CLI group with statsAll to show per-topic and per-consumer 24‑hour counts and TPS.
  * Enabled broker statistics querying (view broker stats data) and made broker stats retrievable and serializable.
  * Implemented consume-stats and topic/consumer lookup flows to fetch and aggregate consumption metrics across brokers.
  * Replaced placeholder admin calls with working implementations to fetch topic lists and consume stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->