### PR TITLE
[ISSUE #6423]Implement `getConsumerConfig` admin command for querying subscription group configuration

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -310,7 +310,11 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
             RequestCode::QueryConsumeQueue => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::CheckRocksdbCqWriteProgress => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::UpdateAndGetGroupForbidden => Ok(get_unknown_cmd_response(request_code)),
-            RequestCode::GetSubscriptionGroupConfig => Ok(get_unknown_cmd_response(request_code)),
+            RequestCode::GetSubscriptionGroupConfig => {
+                self.subscription_group_handler
+                    .get_subscription_group_config(channel, ctx, request_code, request)
+                    .await
+            }
             RequestCode::UpdateAndCreateAclConfig => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::DeleteAclConfig => Ok(get_unknown_cmd_response(request_code)),
             RequestCode::GetBrokerClusterAclInfo => Ok(get_unknown_cmd_response(request_code)),

--- a/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
@@ -18,6 +18,7 @@ use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
+use rocketmq_remoting::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 use rocketmq_remoting::protocol::RemotingDeserializable;
@@ -80,6 +81,34 @@ impl<MS: MessageStore> SubscriptionGroupHandler<MS> {
         // status.getName())     .build();
         // BrokerMetricsManager.consumerGroupCreateExecuteTime.record(executionTime, attributes);
         Ok(Some(response))
+    }
+
+    pub async fn get_subscription_group_config(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let mut response = RemotingCommand::create_response_command();
+        let request_header = request.decode_command_custom_header::<GetSubscriptionGroupConfigRequestHeader>()?;
+        let group = &request_header.group;
+        let group_config = self
+            .broker_runtime_inner
+            .subscription_group_manager()
+            .find_subscription_group_config(group);
+
+        match group_config {
+            Some(config) => {
+                response.set_body_mut_ref(config.encode()?);
+                Ok(Some(response.set_code(ResponseCode::Success)))
+            }
+            None => Ok(Some(
+                response
+                    .set_code(ResponseCode::SubscriptionGroupNotExist)
+                    .set_remark(format!("No group in this broker. group: {}", group)),
+            )),
+        }
     }
 
     pub async fn unlock_batch_mq(

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -432,7 +432,12 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         addr: CheetahString,
         group: CheetahString,
     ) -> rocketmq_error::RocketMQResult<SubscriptionGroupConfig> {
-        todo!()
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_subscription_group_config(&addr, group, self.timeout_millis.as_millis() as u64)
+            .await
     }
 
     async fn examine_topic_stats(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -3144,6 +3144,37 @@ impl MQClientAPIImpl {
         ))
     }
 
+    pub(crate) async fn get_subscription_group_config(
+        &self,
+        addr: &CheetahString,
+        group: CheetahString,
+        timeout_millis: u64,
+    ) -> RocketMQResult<rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig>
+    {
+        let request = RemotingCommand::create_request_command(
+            RequestCode::GetSubscriptionGroupConfig,
+            rocketmq_remoting::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader {
+                group,
+                rpc_request_header: None,
+            },
+        );
+        let mut response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.take_body() {
+                return rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig::decode(
+                    body.as_ref(),
+                );
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
     fn build_queue_offset_sorted_map(
         topic: &str,
         msg_found_list: &[MessageExt],

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -51,6 +51,7 @@ pub mod get_min_offset_request_header;
 pub mod get_min_offset_response_header;
 pub mod get_parent_topic_info_request_header;
 pub mod get_producer_connection_list_request_header;
+pub mod get_subscription_group_config_request_header;
 pub mod get_topic_config_request_header;
 pub mod get_topic_stats_info_request_header;
 pub mod get_topic_stats_request_header;

--- a/rocketmq-remoting/src/protocol/header/get_subscription_group_config_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_subscription_group_config_request_header.rs
@@ -1,0 +1,30 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct GetSubscriptionGroupConfigRequestHeader {
+    #[required]
+    pub group: CheetahString,
+
+    #[serde(flatten)]
+    pub rpc_request_header: Option<RpcRequestHeader>,
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -373,7 +373,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         addr: CheetahString,
         group: CheetahString,
     ) -> rocketmq_error::RocketMQResult<SubscriptionGroupConfig> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .examine_subscription_group_config(addr, group)
+            .await
     }
 
     async fn examine_topic_stats(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -347,6 +347,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Consumer",
+                command: "getConsumerConfig",
+                remark: "Get consumer config by subscription group name.",
+            },
+            Command {
+                category: "Consumer",
                 command: "updateSubGroup",
                 remark: "Update consumer sub group.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/auth.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 The RocketMQ Rust Authors
+// Copyright 2023 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 The RocketMQ Rust Authors
+// Copyright 2023 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 mod consumer_status_sub_command;
 mod consumer_sub_command;
 mod delete_subscription_group_sub_command;
+mod get_consumer_config_sub_command;
 mod set_consume_mode_sub_command;
 mod start_monitoring_sub_command;
 mod update_sub_group_list_sub_command;
@@ -28,6 +29,7 @@ use rocketmq_remoting::runtime::RPCHook;
 use crate::commands::consumer::consumer_status_sub_command::ConsumerStatusSubCommand;
 use crate::commands::consumer::consumer_sub_command::ConsumerSubCommand;
 use crate::commands::consumer::delete_subscription_group_sub_command::DeleteSubscriptionGroupSubCommand;
+use crate::commands::consumer::get_consumer_config_sub_command::GetConsumerConfigSubCommand;
 use crate::commands::consumer::set_consume_mode_sub_command::SetConsumeModeSubCommand;
 use crate::commands::consumer::start_monitoring_sub_command::StartMonitoringSubCommand;
 use crate::commands::consumer::update_sub_group_list_sub_command::UpdateSubGroupListSubCommand;
@@ -56,6 +58,13 @@ pub enum ConsumerCommands {
         long_about = r#"Delete subscription group from broker."#
     )]
     DeleteSubscriptionGroup(DeleteSubscriptionGroupSubCommand),
+
+    #[command(
+        name = "getConsumerConfig",
+        about = "Get consumer config by subscription group name.",
+        long_about = None,
+    )]
+    GetConsumerConfig(GetConsumerConfigSubCommand),
 
     #[command(
         name = "setConsumeMode",
@@ -92,6 +101,7 @@ impl CommandExecute for ConsumerCommands {
             ConsumerCommands::ConsumerStatus(cmd) => cmd.execute(rpc_hook).await,
             ConsumerCommands::Consumer(cmd) => cmd.execute(rpc_hook).await,
             ConsumerCommands::DeleteSubscriptionGroup(cmd) => cmd.execute(rpc_hook).await,
+            ConsumerCommands::GetConsumerConfig(cmd) => cmd.execute(rpc_hook).await,
             ConsumerCommands::SetConsumeMode(cmd) => cmd.execute(rpc_hook).await,
             ConsumerCommands::StartMonitoring(cmd) => cmd.execute(rpc_hook).await,
             ConsumerCommands::UpdateSubGroupList(cmd) => cmd.execute(rpc_hook).await,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/get_consumer_config_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/consumer/get_consumer_config_sub_command.rs
@@ -1,0 +1,155 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct GetConsumerConfigSubCommand {
+    #[arg(short = 'g', long = "groupName", required = true, help = "subscription group name")]
+    group_name: String,
+}
+
+struct ConsumerConfigInfo {
+    cluster_name: String,
+    broker_name: String,
+    subscription_group_config: SubscriptionGroupConfig,
+}
+
+impl CommandExecute for GetConsumerConfigSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let group_name = self.group_name.trim().to_string();
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "GetConsumerConfigSubCommand: Failed to start MQAdminExt: {}",
+                    e
+                ))
+            })?;
+
+            let mut consumer_config_info_list: Vec<ConsumerConfigInfo> = Vec::new();
+
+            let cluster_info = default_mqadmin_ext.examine_broker_cluster_info().await.map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "GetConsumerConfigSubCommand: Failed to examine broker cluster info: {}",
+                    e
+                ))
+            })?;
+
+            let broker_addr_table = cluster_info.broker_addr_table.unwrap_or_default();
+            let cluster_addr_table = cluster_info.cluster_addr_table.unwrap_or_default();
+
+            for (broker_name, broker_data) in &broker_addr_table {
+                let cluster_name = get_cluster_name(broker_name, &cluster_addr_table);
+                let broker_address = match broker_data.select_broker_addr() {
+                    Some(addr) => addr,
+                    None => continue,
+                };
+
+                match default_mqadmin_ext
+                    .examine_subscription_group_config(broker_address, CheetahString::from(group_name.as_str()))
+                    .await
+                {
+                    Ok(config) => {
+                        consumer_config_info_list.push(ConsumerConfigInfo {
+                            cluster_name: cluster_name.unwrap_or_default(),
+                            broker_name: broker_name.to_string(),
+                            subscription_group_config: config,
+                        });
+                    }
+                    Err(_) => {
+                        continue;
+                    }
+                }
+            }
+
+            if consumer_config_info_list.is_empty() {
+                return Ok(());
+            }
+
+            for info in &consumer_config_info_list {
+                println!(
+                    "============================={}:{}=============================",
+                    info.cluster_name, info.broker_name
+                );
+                let config = &info.subscription_group_config;
+                print_field("groupName", config.group_name());
+                print_field("consumeEnable", &config.consume_enable());
+                print_field("consumeFromMinEnable", &config.consume_from_min_enable());
+                print_field("consumeMessageOrderly", &config.consume_message_orderly());
+                print_field("consumeBroadcastEnable", &config.consume_broadcast_enable());
+                print_field("retryQueueNums", &config.retry_queue_nums());
+                print_field("retryMaxTimes", &config.retry_max_times());
+                print_field("brokerId", &config.broker_id());
+                print_field(
+                    "whichBrokerWhenConsumeSlowly",
+                    &config.which_broker_when_consume_slowly(),
+                );
+                print_field(
+                    "notifyConsumerIdsChangedEnable",
+                    &config.notify_consumer_ids_changed_enable(),
+                );
+                print_field("groupSysFlag", &config.group_sys_flag());
+                print_field("consumeTimeoutMinute", &config.consume_timeout_minute());
+                println!();
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+fn get_cluster_name(
+    broker_name: &CheetahString,
+    cluster_addr_table: &HashMap<CheetahString, HashSet<CheetahString>>,
+) -> Option<String> {
+    for (cluster_name, broker_name_set) in cluster_addr_table {
+        if broker_name_set.contains(broker_name) {
+            return Some(cluster_name.to_string());
+        }
+    }
+    None
+}
+
+fn print_field(name: &str, value: &dyn std::fmt::Display) {
+    println!("  {:<40}=  {}", name, value);
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/controller.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 The RocketMQ Rust Authors
+// Copyright 2023 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6423 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for querying subscription group configurations from brokers
* Introduced new "getConsumerConfig" CLI command to display detailed consumer configuration, including consumption settings, broker assignments, retry policies, and timeout parameters for a specified consumer group

<!-- end of auto-generated comment: release notes by coderabbit.ai -->