### PR TITLE
[ISSUE #6682]🧪Add test case for ConsumeMessageContext and MessageSelector

### DIFF
--- a/rocketmq-client/src/consumer/message_selector.rs
+++ b/rocketmq-client/src/consumer/message_selector.rs
@@ -109,3 +109,24 @@ impl MessageSelector {
         &self.expression
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_selector_by_sql() {
+        let sql = "a > 10";
+        let selector = MessageSelector::by_sql(sql);
+        assert_eq!(selector.get_expression_type(), ExpressionType::SQL92);
+        assert_eq!(selector.get_expression(), sql);
+    }
+
+    #[test]
+    fn message_selector_by_tag() {
+        let tag = "TagA || TagB";
+        let selector = MessageSelector::by_tag(tag);
+        assert_eq!(selector.get_expression_type(), ExpressionType::TAG);
+        assert_eq!(selector.get_expression(), tag);
+    }
+}

--- a/rocketmq-client/src/hook/consume_message_context.rs
+++ b/rocketmq-client/src/hook/consume_message_context.rs
@@ -172,3 +172,77 @@ impl<'a> fmt::Debug for ConsumeMessageContext<'a> {
             .finish()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consume_message_context_new() {
+        let group = CheetahString::from("test_group");
+        let msg_list = vec![ArcMut::new(MessageExt::default())];
+        let context = ConsumeMessageContext::new(group.clone(), &msg_list);
+
+        assert_eq!(context.consumer_group, group);
+        assert_eq!(context.message_count(), 1);
+        assert!(context.mq.is_none());
+        assert!(!context.success);
+    }
+
+    #[test]
+    fn consume_message_context_builder_methods() {
+        let group = CheetahString::from("test_group");
+        let msg_list = vec![];
+        let mq = MessageQueue::from_parts("topic", "broker", 1);
+
+        let context = ConsumeMessageContext::new(group, &msg_list)
+            .with_mq(mq.clone())
+            .with_success(true)
+            .with_status("SUCCESS")
+            .with_namespace("test_ns")
+            .with_access_channel(AccessChannel::Cloud);
+
+        assert_eq!(context.mq.unwrap(), mq);
+        assert!(context.success);
+        assert_eq!(context.status, "SUCCESS");
+        assert_eq!(context.namespace, "test_ns");
+        assert_eq!(context.access_channel.unwrap(), AccessChannel::Cloud);
+    }
+
+    #[test]
+    fn consume_message_context_add_prop() {
+        let mut context = ConsumeMessageContext::<'static>::default();
+        context.add_prop("key1", "value1");
+        assert_eq!(context.props.get(&CheetahString::from("key1")).unwrap(), "value1");
+    }
+
+    #[test]
+    fn consume_message_context_display() {
+        let group = CheetahString::from("test_group");
+        let msg_list = vec![];
+        let context = ConsumeMessageContext::new(group, &msg_list)
+            .with_success(true)
+            .with_status("OK");
+
+        let display = format!("{}", context);
+        assert!(display.contains("consumer_group: test_group"));
+        assert!(display.contains("msg_count: 0"));
+        assert!(display.contains("success: true"));
+        assert!(display.contains("status: OK"));
+    }
+
+    #[test]
+    fn consume_message_context_debug() {
+        let context = ConsumeMessageContext::<'static>::default();
+        let debug = format!("{:?}", context);
+        assert!(debug.contains("ConsumeMessageContext"));
+        assert!(debug.contains("consumer_group"));
+    }
+
+    #[test]
+    fn consume_message_context_with_trace_context() {
+        let context =
+            ConsumeMessageContext::<'static>::default().with_trace_context(Arc::new("trace_data".to_string()));
+        assert!(context.mq_trace_context.is_some());
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6665
- Fixes #6682 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for message selector and message consumption context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->