### PR TITLE
fix: Remove `sync_unsafe_cell` and `fn_traits` feature flags due to C…

### DIFF
--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -14,9 +14,7 @@
 
 #![allow(dead_code)]
 #![allow(incomplete_features)]
-#![feature(sync_unsafe_cell)]
 #![feature(duration_constructors)]
-#![feature(fn_traits)]
 #![feature(impl_trait_in_assoc_type)]
 extern crate core;
 


### PR DESCRIPTION
# Which Issue(s) This PR Fixes / Closes
Addresses the CI compilation failure in `rocketmq-remoting` caused by unused feature flags.

# Brief Description
This PR removes the unused unstable feature flags `sync_unsafe_cell` and `fn_traits` from the `rocketmq-remoting` crate.

These features were declared in `src/lib.rs` but were **not actually used** within the codebase. Their presence triggered errors in CI environments where `-D unused-features` is enforced via warnings.

# How Did You Test This Change?
- `cargo check -p rocketmq-remoting`  
  Confirmed that the compilation errors are resolved.

- `cargo test -p rocketmq-remoting`  
  Verified that all tests pass (a 1ms timestamp flake in one test was confirmed as unrelated to these changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal compiler feature configurations to streamline the build process and reduce technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->