### PR TITLE
[ISSUE #6402]🚀Implement PrintMessageByQueue Command for Queue-Level Message Inspection

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -24,7 +24,12 @@ use crate::admin::mq_admin_ext_async::MQAdminExt;
 use crate::admin::mq_admin_ext_async_inner::MQAdminExtInnerImpl;
 use crate::base::client_config::ClientConfig;
 use crate::common::admin_tool_result::AdminToolResult;
+use crate::consumer::consumer_impl::pull_request_ext::PullResultExt;
+use crate::consumer::pull_callback::PullCallback;
+use crate::consumer::pull_status::PullStatus;
 use crate::factory::mq_client_instance::MQClientInstance;
+use crate::implementation::communication_mode::CommunicationMode;
+use crate::implementation::mq_client_api_impl::MQClientAPIImpl;
 use crate::implementation::mq_client_manager::MQClientManager;
 use cheetah_string::CheetahString;
 use rand::seq::IndexedRandom;
@@ -32,12 +37,14 @@ use rocketmq_common::common::base::plain_access_config::PlainAccessConfig;
 use rocketmq_common::common::base::service_state::ServiceState;
 use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::constant::PermName;
+use rocketmq_common::common::message::message_decoder;
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mix_all::DLQ_GROUP_TOPIC_PREFIX;
 use rocketmq_common::common::mix_all::RETRY_GROUP_TOPIC_PREFIX;
+use rocketmq_common::common::sys_flag::pull_sys_flag::PullSysFlag;
 #[allow(deprecated)]
 use rocketmq_common::common::tools::broker_operator_result::BrokerOperatorResult;
 #[allow(deprecated)]
@@ -76,6 +83,7 @@ use rocketmq_remoting::protocol::body::user_info::UserInfo;
 use rocketmq_remoting::protocol::header::elect_master_response_header::ElectMasterResponseHeader;
 use rocketmq_remoting::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader;
 use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
+use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_remoting::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
 use rocketmq_remoting::protocol::header::view_broker_stats_data_request_header::ViewBrokerStatsDataRequestHeader;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
@@ -267,6 +275,64 @@ impl DefaultMQAdminExtImpl {
 
         self.update_user(broker_addr, username, password, user_type, user_status)
             .await
+    }
+
+    pub async fn pull_message_from_queue(
+        &self,
+        broker_addr: &str,
+        mq: &MessageQueue,
+        sub_expression: &str,
+        offset: i64,
+        max_nums: i32,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<crate::consumer::pull_result::PullResult> {
+        let sys_flag = PullSysFlag::build_sys_flag(false, false, true, false);
+
+        let request_header = PullMessageRequestHeader {
+            consumer_group: CheetahString::from_static_str(mix_all::TOOLS_CONSUMER_GROUP),
+            topic: mq.topic().clone(),
+            queue_id: mq.queue_id(),
+            queue_offset: offset,
+            max_msg_nums: max_nums,
+            sys_flag: sys_flag as i32,
+            commit_offset: 0,
+            suspend_timeout_millis: 0,
+            sub_version: 0,
+            subscription: Some(CheetahString::from(sub_expression)),
+            expression_type: None,
+            max_msg_bytes: None,
+            request_source: None,
+            proxy_forward_client_id: None,
+            topic_request: None,
+        };
+
+        struct NoopPullCallback;
+        impl PullCallback for NoopPullCallback {
+            async fn on_success(&mut self, _pull_result: PullResultExt) {}
+            fn on_exception(&mut self, _e: Box<dyn std::error::Error + Send>) {}
+        }
+
+        let api_impl = self.client_instance.as_ref().unwrap().get_mq_client_api_impl();
+
+        let mut result = MQClientAPIImpl::pull_message(
+            api_impl,
+            CheetahString::from(broker_addr),
+            request_header,
+            timeout_millis,
+            CommunicationMode::Sync,
+            NoopPullCallback,
+        )
+        .await?
+        .ok_or_else(|| rocketmq_error::RocketMQError::Internal("pull_message returned None in sync mode".into()))?;
+
+        if result.pull_result.pull_status == PullStatus::Found {
+            if let Some(mut message_binary) = result.message_binary.take() {
+                let msg_vec = message_decoder::decodes_batch(&mut message_binary, true, true);
+                result.pull_result.msg_found_list = Some(msg_vec.into_iter().map(ArcMut::new).collect());
+            }
+        }
+
+        Ok(result.pull_result)
     }
 }
 
@@ -1921,12 +1987,54 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn search_offset(
         &self,
-        _broker_addr: CheetahString,
-        _topic_name: CheetahString,
-        _queue_id: i32,
-        _timestamp: u64,
-        _timeout_millis: u64,
+        broker_addr: CheetahString,
+        topic_name: CheetahString,
+        queue_id: i32,
+        timestamp: u64,
+        timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<u64> {
-        unimplemented!("search_offset not implemented yet (deprecated)")
+        let mq = MessageQueue::from_parts(&topic_name, "", queue_id);
+        let offset = self
+            .client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .search_offset_by_timestamp(
+                broker_addr.as_str(),
+                &mq,
+                timestamp as i64,
+                rocketmq_common::common::boundary_type::BoundaryType::Lower,
+                timeout_millis,
+            )
+            .await?;
+        Ok(offset as u64)
+    }
+
+    async fn min_offset(
+        &self,
+        broker_addr: CheetahString,
+        message_queue: MessageQueue,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<i64> {
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_min_offset(broker_addr.as_str(), &message_queue, timeout_millis)
+            .await
+    }
+
+    async fn max_offset(
+        &self,
+        broker_addr: CheetahString,
+        message_queue: MessageQueue,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<i64> {
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_max_offset(broker_addr.as_str(), &message_queue, timeout_millis)
+            .await
     }
 }

--- a/rocketmq-client/src/admin/mq_admin_ext_async.rs
+++ b/rocketmq-client/src/admin/mq_admin_ext_async.rs
@@ -892,4 +892,18 @@ pub trait MQAdminExt: Send {
         timestamp: u64,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<u64>;
+
+    async fn min_offset(
+        &self,
+        broker_addr: CheetahString,
+        message_queue: MessageQueue,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<i64>;
+
+    async fn max_offset(
+        &self,
+        broker_addr: CheetahString,
+        message_queue: MessageQueue,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<i64>;
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -252,6 +252,20 @@ impl DefaultMQAdminExt {
             .update_user_with_user_info(broker_addr, user_info)
             .await
     }
+
+    pub async fn pull_message_from_queue(
+        &self,
+        broker_addr: &str,
+        mq: &MessageQueue,
+        sub_expression: &str,
+        offset: i64,
+        max_nums: i32,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<rocketmq_client_rust::consumer::pull_result::PullResult> {
+        self.default_mqadmin_ext_impl
+            .pull_message_from_queue(broker_addr, mq, sub_expression, offset, max_nums, timeout_millis)
+            .await
+    }
 }
 
 impl Default for DefaultMQAdminExt {
@@ -1124,13 +1138,37 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn search_offset(
         &self,
-        _broker_addr: CheetahString,
-        _topic_name: CheetahString,
-        _queue_id: i32,
-        _timestamp: u64,
-        _timeout_millis: u64,
+        broker_addr: CheetahString,
+        topic_name: CheetahString,
+        queue_id: i32,
+        timestamp: u64,
+        timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<u64> {
-        unimplemented!("search_offset not implemented yet (deprecated)")
+        self.default_mqadmin_ext_impl
+            .search_offset(broker_addr, topic_name, queue_id, timestamp, timeout_millis)
+            .await
+    }
+
+    async fn min_offset(
+        &self,
+        broker_addr: CheetahString,
+        message_queue: MessageQueue,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<i64> {
+        self.default_mqadmin_ext_impl
+            .min_offset(broker_addr, message_queue, timeout_millis)
+            .await
+    }
+
+    async fn max_offset(
+        &self,
+        broker_addr: CheetahString,
+        message_queue: MessageQueue,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<i64> {
+        self.default_mqadmin_ext_impl
+            .max_offset(broker_addr, message_queue, timeout_millis)
+            .await
     }
 
     async fn check_rocksdb_cq_write_progress(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -465,6 +465,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Message",
+                command: "printMsgByQueue",
+                remark: "Print Message Detail by queueId.",
+            },
+            Command {
+                category: "Message",
                 command: "sendMessage",
                 remark: "Send a message.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message.rs
@@ -15,6 +15,7 @@
 pub mod check_msg_send_rt_sub_command;
 pub mod decode_message_id_sub_command;
 pub mod dump_compaction_log_sub_command;
+pub mod print_msg_by_queue_sub_command;
 pub mod send_message_sub_command;
 
 use std::sync::Arc;
@@ -26,6 +27,7 @@ use rocketmq_remoting::runtime::RPCHook;
 use crate::commands::message::check_msg_send_rt_sub_command::CheckMsgSendRTSubCommand;
 use crate::commands::message::decode_message_id_sub_command::DecodeMessageIdSubCommand;
 use crate::commands::message::dump_compaction_log_sub_command::DumpCompactionLogSubCommand;
+use crate::commands::message::print_msg_by_queue_sub_command::PrintMsgByQueueSubCommand;
 use crate::commands::message::send_message_sub_command::SendMessageSubCommand;
 use crate::commands::CommandExecute;
 
@@ -53,6 +55,13 @@ pub enum MessageCommands {
     DumpCompactionLog(DumpCompactionLogSubCommand),
 
     #[command(
+        name = "printMsgByQueue",
+        about = "Print Message Detail by queueId.",
+        long_about = None,
+    )]
+    PrintMsgByQueue(PrintMsgByQueueSubCommand),
+
+    #[command(
         name = "sendMessage",
         about = "Send a message.",
         long_about = None,
@@ -66,6 +75,7 @@ impl CommandExecute for MessageCommands {
             MessageCommands::CheckMsgSendRT(value) => value.execute(rpc_hook).await,
             MessageCommands::DecodeMessageId(value) => value.execute(rpc_hook).await,
             MessageCommands::DumpCompactionLog(value) => value.execute(rpc_hook).await,
+            MessageCommands::PrintMsgByQueue(value) => value.execute(rpc_hook).await,
             MessageCommands::SendMessage(value) => value.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message/print_msg_by_queue_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message/print_msg_by_queue_sub_command.rs
@@ -1,0 +1,305 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_client_rust::consumer::pull_status::PullStatus;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_common::common::message::message_queue::MessageQueue;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_common::UtilAll::parse_date;
+use rocketmq_common::UtilAll::YYYY_MM_DD_HH_MM_SS_SSS;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+const PULL_BATCH_SIZE: i32 = 32;
+
+#[derive(Debug, Clone, Parser)]
+pub struct PrintMsgByQueueSubCommand {
+    #[arg(short = 't', long = "topic", required = true, help = "Topic name")]
+    topic: String,
+
+    #[arg(short = 'a', long = "brokerName", required = true, help = "Broker name")]
+    broker_name: String,
+
+    #[arg(short = 'i', long = "queueId", required = true, help = "Queue id")]
+    queue_id: i32,
+
+    #[arg(
+        short = 'c',
+        long = "charsetName",
+        required = false,
+        default_value = "UTF-8",
+        help = "CharsetName(eg: UTF-8, GBK)"
+    )]
+    charset_name: String,
+
+    #[arg(
+        short = 's',
+        long = "subExpression",
+        required = false,
+        default_value = "*",
+        help = "Subscribe Expression(eg: TagA || TagB)"
+    )]
+    sub_expression: String,
+
+    #[arg(
+        short = 'b',
+        long = "beginTimestamp",
+        required = false,
+        help = "Begin timestamp[currentTimeMillis|yyyy-MM-dd#HH:mm:ss:SSS]"
+    )]
+    begin_timestamp: Option<String>,
+
+    #[arg(
+        short = 'e',
+        long = "endTimestamp",
+        required = false,
+        help = "End timestamp[currentTimeMillis|yyyy-MM-dd#HH:mm:ss:SSS]"
+    )]
+    end_timestamp: Option<String>,
+
+    #[arg(
+        short = 'p',
+        long = "print",
+        required = false,
+        default_value = "false",
+        help = "Print msg. eg: true | false(default)"
+    )]
+    print_msg: bool,
+
+    #[arg(
+        short = 'd',
+        long = "printBody",
+        required = false,
+        default_value = "false",
+        help = "Print body. eg: true | false(default)"
+    )]
+    print_body: bool,
+
+    #[arg(
+        short = 'f',
+        long = "calculate",
+        required = false,
+        default_value = "false",
+        help = "Calculate by tag. eg: true | false(default)"
+    )]
+    calculate_by_tag: bool,
+}
+
+fn timestamp_format(value: &str) -> u64 {
+    if let Ok(ts) = value.parse::<u64>() {
+        return ts;
+    }
+    let date_str = value.replace('#', " ");
+    if let Some(dt) = parse_date(&date_str, YYYY_MM_DD_HH_MM_SS_SSS) {
+        return dt.and_utc().timestamp_millis() as u64;
+    }
+    0
+}
+
+impl CommandExecute for PrintMsgByQueueSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext)
+                .await
+                .map_err(|e| RocketMQError::Internal(format!("Failed to start MQAdminExt: {}", e)))?;
+
+            let topic = self.topic.trim();
+            let broker_name = self.broker_name.trim();
+            let queue_id = self.queue_id;
+            let charset_name = self.charset_name.trim();
+            let sub_expression = self.sub_expression.trim();
+            let print_msg = self.print_msg;
+            let print_body = self.print_body;
+            let cal_by_tag = self.calculate_by_tag;
+
+            // Resolve broker address via topic route
+            let topic_route = default_mqadmin_ext
+                .examine_topic_route_info(CheetahString::from(topic))
+                .await
+                .map_err(|e| RocketMQError::Internal(format!("Failed to get topic route info: {}", e)))?
+                .ok_or_else(|| RocketMQError::Internal(format!("Topic route not found for: {}", topic)))?;
+
+            let broker_data = topic_route
+                .broker_datas
+                .iter()
+                .find(|bd| bd.broker_name().as_str() == broker_name)
+                .ok_or_else(|| {
+                    RocketMQError::Internal(format!(
+                        "Broker '{}' not found in topic route for '{}'",
+                        broker_name, topic
+                    ))
+                })?;
+
+            let broker_addr = broker_data
+                .select_broker_addr()
+                .ok_or_else(|| RocketMQError::Internal(format!("No available address for broker '{}'", broker_name)))?;
+
+            let mq = MessageQueue::from_parts(topic, broker_name, queue_id);
+            let timeout = 3000u64;
+
+            let mut min_offset = default_mqadmin_ext
+                .min_offset(broker_addr.clone(), mq.clone(), timeout)
+                .await
+                .map_err(|e| RocketMQError::Internal(format!("Failed to get min offset: {}", e)))?;
+
+            let mut max_offset = default_mqadmin_ext
+                .max_offset(broker_addr.clone(), mq.clone(), timeout)
+                .await
+                .map_err(|e| RocketMQError::Internal(format!("Failed to get max offset: {}", e)))?;
+
+            if let Some(ref begin_ts) = self.begin_timestamp {
+                let time_value = timestamp_format(begin_ts.trim());
+                min_offset = default_mqadmin_ext
+                    .search_offset(
+                        broker_addr.clone(),
+                        CheetahString::from(topic),
+                        queue_id,
+                        time_value,
+                        timeout,
+                    )
+                    .await
+                    .map_err(|e| RocketMQError::Internal(format!("Failed to search begin offset: {}", e)))?
+                    as i64;
+            }
+
+            if let Some(ref end_ts) = self.end_timestamp {
+                let time_value = timestamp_format(end_ts.trim());
+                max_offset = default_mqadmin_ext
+                    .search_offset(
+                        broker_addr.clone(),
+                        CheetahString::from(topic),
+                        queue_id,
+                        time_value,
+                        timeout,
+                    )
+                    .await
+                    .map_err(|e| RocketMQError::Internal(format!("Failed to search end offset: {}", e)))?
+                    as i64;
+            }
+
+            let mut tag_cal_map: HashMap<String, AtomicI64> = HashMap::new();
+            let mut offset = min_offset;
+
+            'read_queue: while offset < max_offset {
+                let pull_result = default_mqadmin_ext
+                    .pull_message_from_queue(
+                        broker_addr.as_str(),
+                        &mq,
+                        sub_expression,
+                        offset,
+                        PULL_BATCH_SIZE,
+                        timeout,
+                    )
+                    .await;
+
+                match pull_result {
+                    Ok(result) => {
+                        offset = result.next_begin_offset() as i64;
+                        match result.pull_status() {
+                            PullStatus::Found => {
+                                if let Some(msg_list) = result.msg_found_list() {
+                                    if cal_by_tag {
+                                        calculate_by_tag(msg_list, &mut tag_cal_map);
+                                    }
+                                    if print_msg {
+                                        print_messages(msg_list, charset_name, print_body);
+                                    }
+                                }
+                            }
+                            PullStatus::NoMatchedMsg | PullStatus::NoNewMsg | PullStatus::OffsetIllegal => {
+                                break 'read_queue;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Pull message error: {}", e);
+                        break;
+                    }
+                }
+            }
+
+            if cal_by_tag {
+                print_calculate_by_tag(&tag_cal_map);
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}
+
+fn calculate_by_tag(msgs: &[rocketmq_rust::ArcMut<MessageExt>], tag_cal_map: &mut HashMap<String, AtomicI64>) {
+    for msg in msgs {
+        if let Some(tag) = msg.tags() {
+            let tag_str = tag.to_string();
+            if !tag_str.is_empty() {
+                tag_cal_map
+                    .entry(tag_str)
+                    .or_insert_with(|| AtomicI64::new(0))
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+fn print_calculate_by_tag(tag_cal_map: &HashMap<String, AtomicI64>) {
+    let mut list: Vec<(&String, i64)> = tag_cal_map
+        .iter()
+        .map(|(tag, count)| (tag, count.load(Ordering::Relaxed)))
+        .collect();
+    list.sort_by_key(|b| std::cmp::Reverse(b.1));
+    for (tag, count) in list {
+        println!("Tag: {:<30} Count: {}", tag, count);
+    }
+}
+
+fn print_messages(msgs: &[rocketmq_rust::ArcMut<MessageExt>], _charset_name: &str, print_body: bool) {
+    for msg in msgs {
+        let body_str = if print_body {
+            if let Some(body) = msg.body() {
+                String::from_utf8(body.to_vec()).unwrap_or_else(|_| "BINARY".to_string())
+            } else {
+                "EMPTY".to_string()
+            }
+        } else {
+            "NOT PRINT BODY".to_string()
+        };
+        let msg_ref: &MessageExt = msg;
+        println!("MSGID: {} {} BODY: {}", msg.msg_id(), msg_ref, body_str);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6402 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull messages directly from a broker queue with synchronous batching and timeout control.
  * Query minimum and maximum offsets and perform offset searches by timestamp for precise navigation.
  * New admin command to print message details by queue ID, with timestamp-range filtering, optional body display, and tag-based counting.

* **Bug Fixes**
  * Implemented previously placeholder offset search for correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->