### PR TITLE
[ISSUE #6160][Test🧪] Add unit tests for LockBatchMqRequestHeader

### DIFF
--- a/rocketmq-remoting/src/protocol/header/lock_batch_mq_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/lock_batch_mq_request_header.rs
@@ -47,27 +47,13 @@ mod tests {
             )),
         };
 
-        assert!(header.rpc_request_header.is_some());
-        assert!(header.rpc_request_header.as_ref().unwrap().namespace.is_some());
-        assert_eq!(
-            header.rpc_request_header.as_ref().unwrap().namespace.as_ref().unwrap(),
-            "some_value"
-        );
-        assert!(header.rpc_request_header.as_ref().unwrap().namespaced.is_some());
-        assert!(header.rpc_request_header.as_ref().unwrap().namespaced.unwrap());
-        assert!(header.rpc_request_header.as_ref().unwrap().broker_name.is_some());
-        assert_eq!(
-            header
-                .rpc_request_header
-                .as_ref()
-                .unwrap()
-                .broker_name
-                .as_ref()
-                .unwrap(),
-            "brokerName"
-        );
-        assert!(header.rpc_request_header.as_ref().unwrap().oneway.is_some());
-        assert!(header.rpc_request_header.as_ref().unwrap().oneway.unwrap());
+        let json_str = serde_json::to_string(&header).unwrap();
+
+        // Verify the serialized JSON contains expected fields with camelCase naming
+        assert!(json_str.contains("\"namespace\":\"some_value\""));
+        assert!(json_str.contains("\"namespaced\":true"));
+        assert!(json_str.contains("\"brokerName\":\"brokerName\""));
+        assert!(json_str.contains("\"oneway\":true"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6160

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for LockBatchMqRequestHeader to validate its default state, serialization and deserialization behavior, and correct handling of nested header data and field naming conventions. These tests are test-only and do not change any public APIs or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->