### PR TITLE
[ISSUE #6406]🚀Implement QueryMsgByKey Command for Key-Based Message Lookup

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -334,6 +334,72 @@ impl DefaultMQAdminExtImpl {
 
         Ok(result.pull_result)
     }
+
+    pub async fn query_message_by_key(
+        &self,
+        cluster_name: Option<CheetahString>,
+        topic: CheetahString,
+        key: CheetahString,
+        max_num: i32,
+        begin_timestamp: i64,
+        end_timestamp: i64,
+        _key_type: CheetahString,
+        _last_key: Option<CheetahString>,
+    ) -> rocketmq_error::RocketMQResult<crate::base::query_result::QueryResult> {
+        let route_topic = cluster_name.unwrap_or_else(|| topic.clone());
+        let topic_route_data = self
+            .examine_topic_route_info(route_topic.clone())
+            .await?
+            .ok_or_else(|| {
+                rocketmq_error::RocketMQError::Internal(format!("Topic route not found for: {}", route_topic))
+            })?;
+
+        let mut message_list: Vec<MessageExt> = Vec::new();
+        let mut index_last_update_timestamp: u64 = 0;
+
+        let api_impl = self.client_instance.as_ref().unwrap().get_mq_client_api_impl();
+        let timeout = self.timeout_millis.as_millis() as u64;
+
+        for broker_data in &topic_route_data.broker_datas {
+            let broker_addr = match broker_data.select_broker_addr() {
+                Some(addr) => addr,
+                None => continue,
+            };
+
+            let request_header =
+                rocketmq_remoting::protocol::header::query_message_request_header::QueryMessageRequestHeader {
+                    topic: topic.clone(),
+                    key: key.clone(),
+                    max_num,
+                    begin_timestamp,
+                    end_timestamp,
+                    topic_request_header: None,
+                };
+
+            match MQClientAPIImpl::query_message(&api_impl, &broker_addr, request_header, timeout).await {
+                Ok(Some((response_header, body))) => {
+                    if let Some(mut body_bytes) = body {
+                        let msgs = message_decoder::decodes_batch(&mut body_bytes, true, true);
+                        message_list.extend(msgs);
+                    }
+                    if response_header.index_last_update_timestamp as u64 > index_last_update_timestamp {
+                        index_last_update_timestamp = response_header.index_last_update_timestamp as u64;
+                    }
+                }
+                Ok(None) => {
+                    // No messages found on this broker, continue
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to query message by key from broker {}: {}", broker_addr, e);
+                }
+            }
+        }
+
+        Ok(crate::base::query_result::QueryResult::new(
+            index_last_update_timestamp,
+            message_list,
+        ))
+    }
 }
 
 #[allow(unused_variables)]

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -135,6 +135,8 @@ use rocketmq_remoting::protocol::header::pull_message_response_header::PullMessa
 use rocketmq_remoting::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
 use rocketmq_remoting::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::query_consumer_offset_response_header::QueryConsumerOffsetResponseHeader;
+use rocketmq_remoting::protocol::header::query_message_request_header::QueryMessageRequestHeader;
+use rocketmq_remoting::protocol::header::query_message_response_header::QueryMessageResponseHeader;
 use rocketmq_remoting::protocol::header::recall_message_request_header::RecallMessageRequestHeader;
 use rocketmq_remoting::protocol::header::recall_message_response_header::RecallMessageResponseHeader;
 use rocketmq_remoting::protocol::header::reset_master_flush_offset_header::ResetMasterFlushOffsetHeader;
@@ -2050,6 +2052,39 @@ impl MQClientAPIImpl {
             response.remark().map_or("".to_string(), |s| s.to_string()),
             addr.to_string()
         ))
+    }
+
+    pub async fn query_message(
+        this: &ArcMut<Self>,
+        addr: &CheetahString,
+        request_header: QueryMessageRequestHeader,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<Option<(QueryMessageResponseHeader, Option<bytes::Bytes>)>> {
+        let request = RemotingCommand::create_request_command(RequestCode::QueryMessage, request_header);
+        let response = this
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        match ResponseCode::from(response.code()) {
+            ResponseCode::Success => {
+                let response_header = response
+                    .decode_command_custom_header::<QueryMessageResponseHeader>()
+                    .map_err(|e| {
+                        rocketmq_error::RocketMQError::Internal(format!(
+                            "decode QueryMessageResponseHeader failed: {}",
+                            e
+                        ))
+                    })?;
+                let body = response.body().cloned();
+                Ok(Some((response_header, body)))
+            }
+            ResponseCode::QueryNotFound => Ok(None),
+            _ => Err(client_broker_err!(
+                response.code(),
+                response.remark().map_or("".to_string(), |s| s.to_string()),
+                addr.to_string()
+            )),
+        }
     }
 
     pub async fn pull_message<PCB>(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -266,6 +266,31 @@ impl DefaultMQAdminExt {
             .pull_message_from_queue(broker_addr, mq, sub_expression, offset, max_nums, timeout_millis)
             .await
     }
+
+    pub async fn query_message_by_key(
+        &self,
+        cluster_name: Option<CheetahString>,
+        topic: CheetahString,
+        key: CheetahString,
+        max_num: i32,
+        begin_timestamp: i64,
+        end_timestamp: i64,
+        key_type: CheetahString,
+        last_key: Option<CheetahString>,
+    ) -> rocketmq_error::RocketMQResult<rocketmq_client_rust::base::query_result::QueryResult> {
+        self.default_mqadmin_ext_impl
+            .query_message_by_key(
+                cluster_name,
+                topic,
+                key,
+                max_num,
+                begin_timestamp,
+                end_timestamp,
+                key_type,
+                last_key,
+            )
+            .await
+    }
 }
 
 impl Default for DefaultMQAdminExt {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -470,6 +470,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Message",
+                command: "queryMsgByKey",
+                remark: "Query Message by Key.",
+            },
+            Command {
+                category: "Message",
                 command: "sendMessage",
                 remark: "Send a message.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message.rs
@@ -16,6 +16,7 @@ pub mod check_msg_send_rt_sub_command;
 pub mod decode_message_id_sub_command;
 pub mod dump_compaction_log_sub_command;
 pub mod print_msg_by_queue_sub_command;
+pub mod query_msg_by_key_sub_command;
 pub mod send_message_sub_command;
 
 use std::sync::Arc;
@@ -28,6 +29,7 @@ use crate::commands::message::check_msg_send_rt_sub_command::CheckMsgSendRTSubCo
 use crate::commands::message::decode_message_id_sub_command::DecodeMessageIdSubCommand;
 use crate::commands::message::dump_compaction_log_sub_command::DumpCompactionLogSubCommand;
 use crate::commands::message::print_msg_by_queue_sub_command::PrintMsgByQueueSubCommand;
+use crate::commands::message::query_msg_by_key_sub_command::QueryMsgByKeySubCommand;
 use crate::commands::message::send_message_sub_command::SendMessageSubCommand;
 use crate::commands::CommandExecute;
 
@@ -62,6 +64,13 @@ pub enum MessageCommands {
     PrintMsgByQueue(PrintMsgByQueueSubCommand),
 
     #[command(
+        name = "queryMsgByKey",
+        about = "Query Message by Key.",
+        long_about = None,
+    )]
+    QueryMsgByKey(QueryMsgByKeySubCommand),
+
+    #[command(
         name = "sendMessage",
         about = "Send a message.",
         long_about = None,
@@ -76,6 +85,7 @@ impl CommandExecute for MessageCommands {
             MessageCommands::DecodeMessageId(value) => value.execute(rpc_hook).await,
             MessageCommands::DumpCompactionLog(value) => value.execute(rpc_hook).await,
             MessageCommands::PrintMsgByQueue(value) => value.execute(rpc_hook).await,
+            MessageCommands::QueryMsgByKey(value) => value.execute(rpc_hook).await,
             MessageCommands::SendMessage(value) => value.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message/query_msg_by_key_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message/query_msg_by_key_sub_command.rs
@@ -1,0 +1,171 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::message::MessageConst;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+#[derive(Debug, Clone, Parser)]
+pub struct QueryMsgByKeySubCommand {
+    #[arg(short = 't', long = "topic", required = true, help = "Topic name")]
+    topic: String,
+
+    #[arg(short = 'k', long = "msgKey", required = true, help = "Message Key")]
+    msg_key: String,
+
+    #[arg(
+        short = 'b',
+        long = "beginTimestamp",
+        required = false,
+        help = "Begin timestamp(ms). default:0, eg:1676730526212"
+    )]
+    begin_timestamp: Option<i64>,
+
+    #[arg(
+        short = 'e',
+        long = "endTimestamp",
+        required = false,
+        help = "End timestamp(ms). default:Long.MAX_VALUE, eg:1676730526212"
+    )]
+    end_timestamp: Option<i64>,
+
+    #[arg(
+        short = 'm',
+        long = "maxNum",
+        required = false,
+        default_value = "64",
+        help = "The maximum number of messages returned by the query, default:64"
+    )]
+    max_num: i32,
+
+    #[arg(
+        short = 'c',
+        long = "cluster",
+        required = false,
+        help = "Cluster name or lmq parent topic, lmq is used to find the route."
+    )]
+    cluster: Option<String>,
+
+    #[arg(
+        short = 'p',
+        long = "keyType",
+        required = false,
+        help = "Index key type, default index key type is K, you can use K for keys OR T for tags"
+    )]
+    key_type: Option<String>,
+
+    #[arg(short = 'l', long = "lastKey", required = false, help = "Last Key")]
+    last_key: Option<String>,
+}
+
+fn deal_time_to_hour_stamps(timestamp: i64) -> i64 {
+    const HOUR_MS: i64 = 1000 * 60 * 60;
+    timestamp / HOUR_MS * HOUR_MS
+}
+
+impl CommandExecute for QueryMsgByKeySubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!("QueryMsgByKeySubCommand: Failed to start MQAdminExt: {}", e))
+            })?;
+
+            let topic = self.topic.trim();
+            let key = self.msg_key.trim();
+
+            let mut key_type = CheetahString::from_static_str(MessageConst::INDEX_KEY_TYPE);
+            if let Some(ref kt) = self.key_type {
+                let kt = kt.trim();
+                if kt != MessageConst::INDEX_KEY_TYPE && kt != MessageConst::INDEX_TAG_TYPE {
+                    println!("index type error, just support K for keys or T for tags");
+                    return Ok(());
+                }
+                key_type = CheetahString::from(kt);
+            }
+
+            let begin_timestamp = self.begin_timestamp.unwrap_or(0);
+            let end_timestamp = self.end_timestamp.unwrap_or(i64::MAX);
+            let max_num = self.max_num;
+            let cluster_name = self.cluster.as_deref().map(|s| CheetahString::from(s.trim()));
+            let last_key = self.last_key.as_deref().map(|s| CheetahString::from(s.trim()));
+
+            let query_result = default_mqadmin_ext
+                .query_message_by_key(
+                    cluster_name,
+                    CheetahString::from(topic),
+                    CheetahString::from(key),
+                    max_num,
+                    begin_timestamp,
+                    end_timestamp,
+                    key_type.clone(),
+                    last_key,
+                )
+                .await
+                .map_err(|e| RocketMQError::Internal(format!("Failed to query message by key: {}", e)))?;
+
+            println!(
+                "{:<50} {:>4} {:>40} {:<200}",
+                "#Message ID", "#QID", "#Offset", "#IndexKey"
+            );
+            for msg in query_result.message_list() {
+                if !key_type.is_empty() {
+                    let store_timestamp = deal_time_to_hour_stamps(msg.store_timestamp());
+                    let index_last_key = format!(
+                        "{}@{}@{}@{}@{}@{}",
+                        store_timestamp,
+                        topic,
+                        key_type,
+                        key,
+                        msg.msg_id(),
+                        msg.commit_log_offset()
+                    );
+                    println!(
+                        "{:<50} {:>4} {:>40} {:<200}",
+                        msg.msg_id(),
+                        msg.queue_id(),
+                        msg.queue_offset(),
+                        index_last_key
+                    );
+                } else {
+                    println!("{:<50} {:>4} {:>40}", msg.msg_id(), msg.queue_id(), msg.queue_offset(),);
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6406 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message query by key capability to admin tools, enabling users to search and retrieve messages using a message key within a specified time range
  * New CLI command available for querying messages by key with customizable parameters including timestamp bounds and maximum result count

<!-- end of auto-generated comment: release notes by coderabbit.ai -->