### PR TITLE
[ISSUE #6738]🚀Implement NameServer management with CRUD operations and UI integration

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod auth;
+mod nameserver;
 
 use tauri::Manager;
 
@@ -38,6 +39,16 @@ pub fn run() {
             let auth_service = auth::AuthService::new(auth_db);
             let bootstrap_status = auth_service.bootstrap_default_admin()?;
 
+            let nameserver_db = nameserver::NameServerDb::new(app.handle())?;
+            nameserver_db.init()?;
+            log::info!(
+                "Local NameServer SQLite database initialized at: {}",
+                nameserver_db.db_path().display()
+            );
+
+            let nameserver_service = nameserver::NameServerService::new(nameserver_db);
+            nameserver_service.bootstrap_defaults()?;
+
             if bootstrap_status.created {
                 log::warn!(
                     "Initialized local dashboard admin account `{}` with the bootstrap password. The password must be \
@@ -47,6 +58,7 @@ pub fn run() {
             }
 
             app.manage(auth_service);
+            app.manage(nameserver_service);
             app.manage(auth::SessionState::default());
 
             Ok(())
@@ -56,7 +68,13 @@ pub fn run() {
             auth::commands::logout,
             auth::commands::restore_session,
             auth::commands::change_password,
-            auth::commands::get_auth_bootstrap_status
+            auth::commands::get_auth_bootstrap_status,
+            nameserver::commands::get_name_server_home_page,
+            nameserver::commands::add_name_server,
+            nameserver::commands::switch_name_server,
+            nameserver::commands::delete_name_server,
+            nameserver::commands::update_vip_channel,
+            nameserver::commands::update_use_tls
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver.rs
@@ -1,0 +1,21 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) mod commands;
+pub(crate) mod db;
+pub(crate) mod service;
+pub(crate) mod types;
+
+pub(crate) use db::NameServerDb;
+pub(crate) use service::NameServerService;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
@@ -19,9 +19,7 @@ use crate::nameserver::types::NameServerResult;
 use tauri::State;
 
 #[tauri::command]
-pub fn get_name_server_home_page(
-    nameserver_service: State<'_, NameServerService>,
-) -> NameServerHomePageResponse {
+pub fn get_name_server_home_page(nameserver_service: State<'_, NameServerService>) -> NameServerHomePageResponse {
     match nameserver_service.get_home_page() {
         Ok(response) => response,
         Err(error) => {
@@ -74,10 +72,7 @@ pub fn update_vip_channel(
 }
 
 #[tauri::command]
-pub fn update_use_tls(
-    enabled: bool,
-    nameserver_service: State<'_, NameServerService>,
-) -> NameServerMutationResponse {
+pub fn update_use_tls(enabled: bool, nameserver_service: State<'_, NameServerService>) -> NameServerMutationResponse {
     handle_mutation("update TLS setting", || nameserver_service.update_use_tls(enabled))
 }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
@@ -1,0 +1,101 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::nameserver::service::NameServerService;
+use crate::nameserver::types::NameServerHomePageResponse;
+use crate::nameserver::types::NameServerMutationResponse;
+use crate::nameserver::types::NameServerResult;
+use tauri::State;
+
+#[tauri::command]
+pub fn get_name_server_home_page(
+    nameserver_service: State<'_, NameServerService>,
+) -> NameServerHomePageResponse {
+    match nameserver_service.get_home_page() {
+        Ok(response) => response,
+        Err(error) => {
+            log::error!("Failed to load NameServer settings: {}", error);
+            NameServerHomePageResponse {
+                success: false,
+                message: error
+                    .to_string()
+                    .replace("Validation error: ", "")
+                    .replace("Database error: ", ""),
+                namesrv_addr_list: Vec::new(),
+                current_namesrv: None,
+                use_vip_channel: true,
+                use_tls: false,
+            }
+        }
+    }
+}
+
+#[tauri::command]
+pub fn add_name_server(
+    address: String,
+    nameserver_service: State<'_, NameServerService>,
+) -> NameServerMutationResponse {
+    handle_mutation("add Name Server", || nameserver_service.add_name_server(&address))
+}
+
+#[tauri::command]
+pub fn switch_name_server(
+    address: String,
+    nameserver_service: State<'_, NameServerService>,
+) -> NameServerMutationResponse {
+    handle_mutation("switch Name Server", || nameserver_service.switch_name_server(&address))
+}
+
+#[tauri::command]
+pub fn delete_name_server(
+    address: String,
+    nameserver_service: State<'_, NameServerService>,
+) -> NameServerMutationResponse {
+    handle_mutation("delete Name Server", || nameserver_service.delete_name_server(&address))
+}
+
+#[tauri::command]
+pub fn update_vip_channel(
+    enabled: bool,
+    nameserver_service: State<'_, NameServerService>,
+) -> NameServerMutationResponse {
+    handle_mutation("update VIP channel", || nameserver_service.update_vip_channel(enabled))
+}
+
+#[tauri::command]
+pub fn update_use_tls(
+    enabled: bool,
+    nameserver_service: State<'_, NameServerService>,
+) -> NameServerMutationResponse {
+    handle_mutation("update TLS setting", || nameserver_service.update_use_tls(enabled))
+}
+
+fn handle_mutation(
+    operation: &str,
+    action: impl FnOnce() -> NameServerResult<NameServerMutationResponse>,
+) -> NameServerMutationResponse {
+    match action() {
+        Ok(response) => response,
+        Err(error) => {
+            log::warn!("Failed to {}: {}", operation, error);
+            NameServerMutationResponse {
+                success: false,
+                message: error
+                    .to_string()
+                    .replace("Validation error: ", "")
+                    .replace("Database error: ", ""),
+            }
+        }
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/db.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/db.rs
@@ -1,0 +1,136 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::nameserver::types::NameServerError;
+use crate::nameserver::types::NameServerResult;
+use rusqlite::Connection;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+use tauri::AppHandle;
+use tauri::Manager;
+
+const DB_FILE_NAME: &str = "dashboard.db";
+const NAMESERVER_TABLES_SCHEMA: &str = "
+    CREATE TABLE IF NOT EXISTS nameserver_addresses (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        address TEXT NOT NULL UNIQUE,
+        is_active INTEGER NOT NULL DEFAULT 0,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS nameserver_settings (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        use_vip_channel INTEGER NOT NULL DEFAULT 1,
+        use_tls INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_nameserver_addresses_single_active
+    ON nameserver_addresses(is_active)
+    WHERE is_active = 1;
+";
+
+#[derive(Debug, Clone)]
+pub(crate) struct NameServerDb {
+    db_path: PathBuf,
+}
+
+impl NameServerDb {
+    pub(crate) fn new(app: &AppHandle) -> NameServerResult<Self> {
+        let app_config_dir = app
+            .path()
+            .app_config_dir()
+            .map_err(|error| NameServerError::AppPath(error.to_string()))?;
+
+        Ok(Self::from_path(app_config_dir.join(DB_FILE_NAME)))
+    }
+
+    pub(crate) fn from_path(db_path: impl Into<PathBuf>) -> Self {
+        Self {
+            db_path: db_path.into(),
+        }
+    }
+
+    pub(crate) fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    pub(crate) fn init(&self) -> NameServerResult<()> {
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction()?;
+        transaction.execute_batch(NAMESERVER_TABLES_SCHEMA)?;
+        if table_exists(&transaction, "ops_name_servers")? {
+            transaction.execute(
+                "
+                INSERT OR IGNORE INTO nameserver_addresses (id, address, is_active, sort_order, created_at, updated_at)
+                SELECT id, address, is_active, sort_order, created_at, updated_at
+                FROM ops_name_servers
+                ",
+                [],
+            )?;
+        }
+
+        if table_exists(&transaction, "ops_settings")? {
+            transaction.execute(
+                "
+                INSERT OR IGNORE INTO nameserver_settings (id, use_vip_channel, use_tls, created_at, updated_at)
+                SELECT id, use_vip_channel, use_tls, created_at, updated_at
+                FROM ops_settings
+                ",
+                [],
+            )?;
+        }
+        transaction.execute(
+            "
+            INSERT INTO nameserver_settings (id, use_vip_channel, use_tls, created_at, updated_at)
+            SELECT 1, 1, 0, datetime('now'), datetime('now')
+            WHERE NOT EXISTS (SELECT 1 FROM nameserver_settings WHERE id = 1)
+            ",
+            [],
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    pub(crate) fn connection(&self) -> NameServerResult<Connection> {
+        self.ensure_parent_dir()?;
+
+        let connection = Connection::open(&self.db_path)?;
+        connection.busy_timeout(Duration::from_secs(5))?;
+        Ok(connection)
+    }
+
+    fn ensure_parent_dir(&self) -> NameServerResult<()> {
+        if let Some(parent) = self.db_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn table_exists(connection: &Connection, table_name: &str) -> NameServerResult<bool> {
+    let table_count: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        [table_name],
+        |row| row.get(0),
+    )?;
+
+    Ok(table_count > 0)
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
@@ -1,0 +1,439 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::nameserver::db::NameServerDb;
+use crate::nameserver::types::NameServerError;
+use crate::nameserver::types::NameServerHomePageResponse;
+use crate::nameserver::types::NameServerMutationResponse;
+use crate::nameserver::types::NameServerRecord;
+use crate::nameserver::types::NameServerResult;
+use chrono::Utc;
+use rusqlite::OptionalExtension;
+use rusqlite::params;
+
+const DEFAULT_NAME_SERVER: &str = "127.0.0.1:9876";
+
+#[derive(Debug, Clone)]
+pub(crate) struct NameServerService {
+    db: NameServerDb,
+}
+
+impl NameServerService {
+    pub(crate) fn new(db: NameServerDb) -> Self {
+        Self { db }
+    }
+
+    pub(crate) fn bootstrap_defaults(&self) -> NameServerResult<()> {
+        let connection = self.db.connection()?;
+        let name_server_count: i64 =
+            connection.query_row("SELECT COUNT(*) FROM nameserver_addresses", [], |row| row.get(0))?;
+
+        if name_server_count == 0 {
+            let now = Utc::now().to_rfc3339();
+            connection.execute(
+                "
+                INSERT INTO nameserver_addresses (address, is_active, sort_order, created_at, updated_at)
+                VALUES (?1, 1, 0, ?2, ?2)
+                ",
+                params![DEFAULT_NAME_SERVER, now],
+            )?;
+            return Ok(());
+        }
+
+        let active_count: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM nameserver_addresses WHERE is_active = 1",
+            [],
+            |row| row.get(0),
+        )?;
+
+        if active_count == 0 {
+            connection.execute(
+                "
+                UPDATE nameserver_addresses
+                SET is_active = 1,
+                    updated_at = ?1
+                WHERE id = (
+                    SELECT id
+                    FROM nameserver_addresses
+                    ORDER BY sort_order ASC, id ASC
+                    LIMIT 1
+                )
+                ",
+                params![Utc::now().to_rfc3339()],
+            )?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn get_home_page(&self) -> NameServerResult<NameServerHomePageResponse> {
+        let connection = self.db.connection()?;
+        let name_servers = self.list_name_servers(&connection)?;
+        let current_namesrv = name_servers
+            .iter()
+            .find(|record| record.is_active)
+            .map(|record| record.address.clone());
+
+        let (use_vip_channel, use_tls) = connection.query_row(
+            "
+            SELECT use_vip_channel, use_tls
+            FROM nameserver_settings
+            WHERE id = 1
+            ",
+            [],
+            |row| Ok((row.get::<_, i64>(0)? != 0, row.get::<_, i64>(1)? != 0)),
+        )?;
+
+        Ok(NameServerHomePageResponse {
+            success: true,
+            message: "NameServer settings loaded".to_string(),
+            namesrv_addr_list: name_servers.into_iter().map(|record| record.address).collect(),
+            current_namesrv,
+            use_vip_channel,
+            use_tls,
+        })
+    }
+
+    pub(crate) fn add_name_server(&self, address: &str) -> NameServerResult<NameServerMutationResponse> {
+        let normalized_address = normalize_address(address)?;
+        let now = Utc::now().to_rfc3339();
+        let mut connection = self.db.connection()?;
+        let transaction = connection.transaction()?;
+
+        let existing = transaction
+            .query_row(
+                "SELECT 1 FROM nameserver_addresses WHERE address = ?1",
+                params![normalized_address],
+                |_| Ok(()),
+            )
+            .optional()?;
+
+        if existing.is_some() {
+            return Err(NameServerError::Validation("Address already exists".to_string()));
+        }
+
+        let next_sort_order: i64 = transaction.query_row(
+            "SELECT COALESCE(MAX(sort_order), -1) + 1 FROM nameserver_addresses",
+            [],
+            |row| row.get(0),
+        )?;
+        let has_active = transaction
+            .query_row(
+                "SELECT 1 FROM nameserver_addresses WHERE is_active = 1 LIMIT 1",
+                [],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some();
+
+        transaction.execute(
+            "
+            INSERT INTO nameserver_addresses (address, is_active, sort_order, created_at, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?4)
+            ",
+            params![
+                normalized_address,
+                if has_active { 0 } else { 1 },
+                next_sort_order,
+                now
+            ],
+        )?;
+        transaction.commit()?;
+
+        Ok(NameServerMutationResponse {
+            success: true,
+            message: "Name Server added".to_string(),
+        })
+    }
+
+    pub(crate) fn switch_name_server(&self, address: &str) -> NameServerResult<NameServerMutationResponse> {
+        let normalized_address = normalize_address(address)?;
+        let now = Utc::now().to_rfc3339();
+        let mut connection = self.db.connection()?;
+        let transaction = connection.transaction()?;
+
+        let target = transaction
+            .query_row(
+                "
+                SELECT id, address, is_active
+                FROM nameserver_addresses
+                WHERE address = ?1
+                ",
+                params![normalized_address],
+                map_name_server_record,
+            )
+            .optional()?;
+
+        let Some(target_record) = target else {
+            return Err(NameServerError::Validation("Name Server address not found".to_string()));
+        };
+
+        if target_record.is_active {
+            return Ok(NameServerMutationResponse {
+                success: true,
+                message: "Name Server is already active".to_string(),
+            });
+        }
+
+        transaction.execute(
+            "
+            UPDATE nameserver_addresses
+            SET is_active = 0,
+                updated_at = ?1
+            WHERE is_active = 1
+            ",
+            params![now],
+        )?;
+        transaction.execute(
+            "
+            UPDATE nameserver_addresses
+            SET is_active = 1,
+                updated_at = ?1
+            WHERE id = ?2
+            ",
+            params![now, target_record.id],
+        )?;
+        transaction.commit()?;
+
+        Ok(NameServerMutationResponse {
+            success: true,
+            message: format!("Switched to Name Server: {}", target_record.address),
+        })
+    }
+
+    pub(crate) fn delete_name_server(&self, address: &str) -> NameServerResult<NameServerMutationResponse> {
+        let normalized_address = normalize_address(address)?;
+        let mut connection = self.db.connection()?;
+        let transaction = connection.transaction()?;
+
+        let target = transaction
+            .query_row(
+                "
+                SELECT id, address, is_active
+                FROM nameserver_addresses
+                WHERE address = ?1
+                ",
+                params![normalized_address],
+                map_name_server_record,
+            )
+            .optional()?;
+
+        let Some(target_record) = target else {
+            return Err(NameServerError::Validation("Name Server address not found".to_string()));
+        };
+
+        if target_record.is_active {
+            return Err(NameServerError::Validation(
+                "Cannot remove the active Name Server".to_string(),
+            ));
+        }
+
+        let name_server_count: i64 =
+            transaction.query_row("SELECT COUNT(*) FROM nameserver_addresses", [], |row| row.get(0))?;
+        if name_server_count <= 1 {
+            return Err(NameServerError::Validation(
+                "Cannot remove the last Name Server".to_string(),
+            ));
+        }
+
+        transaction.execute(
+            "DELETE FROM nameserver_addresses WHERE id = ?1",
+            params![target_record.id],
+        )?;
+        transaction.commit()?;
+
+        Ok(NameServerMutationResponse {
+            success: true,
+            message: "Name Server removed".to_string(),
+        })
+    }
+
+    pub(crate) fn update_vip_channel(&self, enabled: bool) -> NameServerResult<NameServerMutationResponse> {
+        self.update_settings_flag("use_vip_channel", enabled, "VIP Channel updated")
+    }
+
+    pub(crate) fn update_use_tls(&self, enabled: bool) -> NameServerResult<NameServerMutationResponse> {
+        self.update_settings_flag("use_tls", enabled, "TLS setting updated")
+    }
+
+    fn update_settings_flag(
+        &self,
+        column_name: &str,
+        enabled: bool,
+        success_message: &str,
+    ) -> NameServerResult<NameServerMutationResponse> {
+        let connection = self.db.connection()?;
+        let now = Utc::now().to_rfc3339();
+        let sql = format!(
+            "
+            UPDATE nameserver_settings
+            SET {column_name} = ?1,
+                updated_at = ?2
+            WHERE id = 1
+            "
+        );
+
+        connection.execute(&sql, params![if enabled { 1 } else { 0 }, now])?;
+
+        Ok(NameServerMutationResponse {
+            success: true,
+            message: success_message.to_string(),
+        })
+    }
+
+    fn list_name_servers(&self, connection: &rusqlite::Connection) -> NameServerResult<Vec<NameServerRecord>> {
+        let mut statement = connection.prepare(
+            "
+            SELECT id, address, is_active
+            FROM nameserver_addresses
+            ORDER BY sort_order ASC, id ASC
+            ",
+        )?;
+        let rows = statement.query_map([], map_name_server_record)?;
+        let name_servers = rows.collect::<Result<Vec<_>, _>>()?;
+        Ok(name_servers)
+    }
+}
+
+fn normalize_address(address: &str) -> NameServerResult<String> {
+    let normalized = address.trim();
+    if normalized.is_empty() {
+        return Err(NameServerError::Validation("Please enter a valid address".to_string()));
+    }
+
+    let Some((host, port)) = normalized.rsplit_once(':') else {
+        return Err(NameServerError::Validation(
+            "Name Server address must use host:port format".to_string(),
+        ));
+    };
+
+    let normalized_host = host.trim();
+    let normalized_port = port.trim();
+
+    if normalized_host.is_empty() || normalized_port.is_empty() {
+        return Err(NameServerError::Validation(
+            "Name Server address must use host:port format".to_string(),
+        ));
+    }
+
+    normalized_port.parse::<u16>().map_err(|_| {
+        NameServerError::Validation("Name Server port must be a valid number".to_string())
+    })?;
+
+    Ok(format!("{normalized_host}:{normalized_port}"))
+}
+
+fn map_name_server_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<NameServerRecord> {
+    Ok(NameServerRecord {
+        id: row.get(0)?,
+        address: row.get(1)?,
+        is_active: row.get::<_, i64>(2)? != 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NameServerService;
+    use crate::nameserver::db::NameServerDb;
+    use std::env;
+    use std::fs;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new() -> Self {
+            let path = env::temp_dir().join(format!("rocketmq-dashboard-tauri-nameserver-service-tests-{}", Uuid::new_v4()));
+            fs::create_dir_all(&path).expect("failed to create test directory");
+            Self { path }
+        }
+
+        fn db_path(&self) -> PathBuf {
+            self.path.join("dashboard.db")
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    struct TestContext {
+        _test_dir: TestDir,
+        service: NameServerService,
+    }
+
+    fn setup_service() -> TestContext {
+        let test_dir = TestDir::new();
+        let db = NameServerDb::from_path(test_dir.db_path());
+        db.init().expect("database initialization should succeed");
+        let service = NameServerService::new(db);
+        service.bootstrap_defaults().expect("bootstrap should succeed");
+
+        TestContext {
+            _test_dir: test_dir,
+            service,
+        }
+    }
+
+    #[test]
+    fn bootstrap_creates_default_name_server() {
+        let context = setup_service();
+        let service = &context.service;
+
+        let response = service.get_home_page().expect("home page should load");
+
+        assert_eq!(response.namesrv_addr_list, vec!["127.0.0.1:9876".to_string()]);
+        assert_eq!(response.current_namesrv.as_deref(), Some("127.0.0.1:9876"));
+        assert!(response.use_vip_channel);
+        assert!(!response.use_tls);
+    }
+
+    #[test]
+    fn add_and_switch_name_server_updates_current_selection() {
+        let context = setup_service();
+        let service = &context.service;
+
+        service
+            .add_name_server("192.168.1.20:9876")
+            .expect("second address should be added");
+        service
+            .switch_name_server("192.168.1.20:9876")
+            .expect("switch should succeed");
+
+        let response = service.get_home_page().expect("home page should load");
+        assert_eq!(response.current_namesrv.as_deref(), Some("192.168.1.20:9876"));
+        assert_eq!(response.namesrv_addr_list.len(), 2);
+    }
+
+    #[test]
+    fn delete_active_name_server_is_rejected() {
+        let context = setup_service();
+        let service = &context.service;
+
+        let error = service
+            .delete_name_server("127.0.0.1:9876")
+            .expect_err("active address removal should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Cannot remove the active Name Server")
+        );
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
@@ -142,12 +142,7 @@ impl NameServerService {
             INSERT INTO nameserver_addresses (address, is_active, sort_order, created_at, updated_at)
             VALUES (?1, ?2, ?3, ?4, ?4)
             ",
-            params![
-                normalized_address,
-                if has_active { 0 } else { 1 },
-                next_sort_order,
-                now
-            ],
+            params![normalized_address, if has_active { 0 } else { 1 }, next_sort_order, now],
         )?;
         transaction.commit()?;
 
@@ -327,9 +322,9 @@ fn normalize_address(address: &str) -> NameServerResult<String> {
         ));
     }
 
-    normalized_port.parse::<u16>().map_err(|_| {
-        NameServerError::Validation("Name Server port must be a valid number".to_string())
-    })?;
+    normalized_port
+        .parse::<u16>()
+        .map_err(|_| NameServerError::Validation("Name Server port must be a valid number".to_string()))?;
 
     Ok(format!("{normalized_host}:{normalized_port}"))
 }
@@ -357,7 +352,10 @@ mod tests {
 
     impl TestDir {
         fn new() -> Self {
-            let path = env::temp_dir().join(format!("rocketmq-dashboard-tauri-nameserver-service-tests-{}", Uuid::new_v4()));
+            let path = env::temp_dir().join(format!(
+                "rocketmq-dashboard-tauri-nameserver-service-tests-{}",
+                Uuid::new_v4()
+            ));
             fs::create_dir_all(&path).expect("failed to create test directory");
             Self { path }
         }
@@ -430,10 +428,6 @@ mod tests {
             .delete_name_server("127.0.0.1:9876")
             .expect_err("active address removal should fail");
 
-        assert!(
-            error
-                .to_string()
-                .contains("Cannot remove the active Name Server")
-        );
+        assert!(error.to_string().contains("Cannot remove the active Name Server"));
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/types.rs
@@ -1,0 +1,77 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt;
+
+pub(crate) type NameServerResult<T> = Result<T, NameServerError>;
+
+#[derive(Debug)]
+pub(crate) enum NameServerError {
+    Io(std::io::Error),
+    Database(rusqlite::Error),
+    AppPath(String),
+    Validation(String),
+}
+
+impl fmt::Display for NameServerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "I/O error: {error}"),
+            Self::Database(error) => write!(f, "Database error: {error}"),
+            Self::AppPath(message) => write!(f, "Application path error: {message}"),
+            Self::Validation(message) => write!(f, "Validation error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for NameServerError {}
+
+impl From<std::io::Error> for NameServerError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<rusqlite::Error> for NameServerError {
+    fn from(error: rusqlite::Error) -> Self {
+        Self::Database(error)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct NameServerRecord {
+    pub(crate) id: i64,
+    pub(crate) address: String,
+    pub(crate) is_active: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NameServerHomePageResponse {
+    pub(crate) success: bool,
+    pub(crate) message: String,
+    pub(crate) namesrv_addr_list: Vec<String>,
+    pub(crate) current_namesrv: Option<String>,
+    pub(crate) use_vip_channel: bool,
+    pub(crate) use_tls: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NameServerMutationResponse {
+    pub(crate) success: bool,
+    pub(crate) message: String,
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/layout/MainLayout.tsx
@@ -50,7 +50,7 @@ export const MainLayout = ({children}: MainLayoutProps) => {
                 <div className="flex-1 overflow-y-auto px-4 py-2 space-y-8">
                     <div>
                         <div className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3 px-3">Platform</div>
-                        <SidebarItem icon={Settings} label="NameServer" active={activeTab === 'OPS'} onClick={() => setActiveTab('OPS')}/>
+                        <SidebarItem icon={Settings} label="NameServer" active={activeTab === 'NameServer'} onClick={() => setActiveTab('NameServer')}/>
                         <SidebarItem icon={LayoutDashboard} label="Dashboard" active={activeTab === 'Dashboard'} onClick={() => setActiveTab('Dashboard')}/>
                         <SidebarItem icon={Network} label="Proxy" active={activeTab === 'Proxy'} onClick={() => setActiveTab('Proxy')}/>
                         <SidebarItem icon={Server} label="Cluster" active={activeTab === 'Cluster'} onClick={() => setActiveTab('Cluster')}/>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/app/router/AppRouter.tsx
@@ -4,7 +4,7 @@ import {DashboardPage} from '../../pages/dashboard/DashboardPage';
 
 // Import Views
 import {ACLView} from '../../components/ACLView';
-import {OpsView} from '../../components/OpsView';
+import {NameServerView} from '../../components/NameServerView';
 import {ProxyView} from '../../components/ProxyView';
 import {ClusterView} from '../../components/ClusterView';
 import {TopicView} from '../../components/TopicView';
@@ -19,8 +19,8 @@ export const AppRouter = () => {
     const {activeTab} = useAppStore();
 
     switch (activeTab) {
-        case 'OPS':
-            return <OpsView/>;
+        case 'NameServer':
+            return <NameServerView/>;
         case 'Proxy':
             return <ProxyView/>;
         case 'Dashboard':

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/NameServerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/NameServerView.tsx
@@ -6,33 +6,87 @@ import {Card} from '../components/ui/LegacyCard';
 import {Button} from '../components/ui/LegacyButton';
 import {Input} from '../components/ui/LegacyInput';
 import {Toggle} from '../components/ui/LegacyToggle';
+import {useNameServer} from '../features/nameserver/hooks/useNameServer';
 
-export const OpsView = () => {
-    const [nameServers, setNameServers] = useState(['127.0.0.1:9876', '192.168.1.20:9876']);
+export const NameServerView = () => {
     const [newNameServer, setNewNameServer] = useState('');
-    const [selectedNameServer, setSelectedNameServer] = useState('127.0.0.1:9876');
-    const [isVIPChannel, setIsVIPChannel] = useState(true);
-    const [useTLS, setUseTLS] = useState(false);
+    const {
+        nameServers,
+        selectedNameServer,
+        isVIPChannel,
+        useTLS,
+        isLoading,
+        pendingAction,
+        addNameServer,
+        switchNameServer,
+        deleteNameServer,
+        updateVIPChannel,
+        updateUseTLS,
+    } = useNameServer();
 
-    const handleAddNameServer = () => {
-        if (!newNameServer) return toast.error('Please enter a valid address');
-        if (nameServers.includes(newNameServer)) return toast.error('Address already exists');
-        setNameServers([...nameServers, newNameServer]);
+    const normalizedAddresses = new Set(nameServers.map((address) => address.trim().toLowerCase()));
+
+    const handleAddNameServer = async () => {
+        const nextAddress = newNameServer.trim();
+
+        if (!nextAddress) {
+            toast.error('Please enter a valid address');
+            return;
+        }
+
+        if (normalizedAddresses.has(nextAddress.toLowerCase())) {
+            toast.error('Address already exists');
+            return;
+        }
+
+        const response = await addNameServer(nextAddress);
+        if (!response.success) {
+            toast.error(response.message);
+            return;
+        }
+
         setNewNameServer('');
-        toast.success('Name Server added');
+        toast.success(response.message);
     };
 
-    const handleRemoveNameServer = (ns: string) => {
-        if (nameServers.length <= 1) return toast.error('Cannot remove the last Name Server');
-        if (ns === selectedNameServer) return toast.error('Cannot remove the active Name Server');
+    const handleRemoveNameServer = async (ns: string) => {
+        const response = await deleteNameServer(ns);
+        if (!response.success) {
+            toast.error(response.message);
+            return;
+        }
 
-        setNameServers(nameServers.filter(s => s !== ns));
-        toast.success('Name Server removed');
+        toast.success(response.message);
     };
 
-    const handleSwitchServer = (ns: string) => {
-        setSelectedNameServer(ns);
-        toast.success(`Switched to Name Server: ${ns}`);
+    const handleSwitchServer = async (ns: string) => {
+        const response = await switchNameServer(ns);
+        if (!response.success) {
+            toast.error(response.message);
+            return;
+        }
+
+        toast.success(response.message);
+    };
+
+    const handleVIPChannelChange = async (checked: boolean) => {
+        const response = await updateVIPChannel(checked);
+        if (!response.success) {
+            toast.error(response.message);
+            return;
+        }
+
+        toast.success(response.message);
+    };
+
+    const handleUseTLSChange = async (checked: boolean) => {
+        const response = await updateUseTLS(checked);
+        if (!response.success) {
+            toast.error(response.message);
+            return;
+        }
+
+        toast.success(response.message);
     };
 
     return (
@@ -40,12 +94,13 @@ export const OpsView = () => {
             <Card title="Name Server Configuration" description="Manage your Name Server addresses and connection status.">
                 <div className="space-y-6">
 
-                    <div className="flex gap-3 items-start">
+                    <div className="flex items-stretch gap-3">
                         <div className="flex-1">
                             <Input
                                 placeholder="Enter new Name Server address (e.g. 192.168.1.50:9876)"
                                 value={newNameServer}
                                 onChange={(e) => setNewNameServer(e.target.value)}
+                                disabled={isLoading || pendingAction === 'add'}
                                 className="bg-white dark:bg-gray-800 dark:text-white dark:border-gray-700 shadow-sm"
                             />
                         </div>
@@ -53,13 +108,14 @@ export const OpsView = () => {
                             variant="primary"
                             onClick={handleAddNameServer}
                             icon={Plus}
-                            className="dark:!bg-gray-900 dark:!text-white dark:border dark:border-gray-700 dark:hover:!bg-gray-800"
+                            disabled={isLoading || pendingAction === 'add'}
+                            className="h-[46px] w-[164px] shrink-0 px-5 dark:!bg-gray-900 dark:!text-white dark:border dark:border-gray-700 dark:hover:!bg-gray-800"
                         >
                             Add Server
                         </Button>
                     </div>
 
-                    <div className="border border-gray-200 rounded-xl overflow-hidden bg-white shadow-sm">
+                    <div className="border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden bg-white dark:bg-gray-900 shadow-sm">
                         <div className="min-w-full">
                             <div
                                 className="bg-gray-100 dark:bg-gray-800 border-b border-gray-100 dark:border-gray-800 px-6 py-3 flex items-center text-xs font-medium text-gray-900 dark:text-gray-200 uppercase tracking-wider">
@@ -83,6 +139,15 @@ export const OpsView = () => {
                                 }}
                             >
                                 <AnimatePresence mode="popLayout">
+                                    {isLoading && nameServers.length === 0 && (
+                                        <motion.div
+                                            initial={{opacity: 0}}
+                                            animate={{opacity: 1}}
+                                            className="px-6 py-8 text-sm text-gray-500 dark:text-gray-400"
+                                        >
+                                            Loading local NameServer settings...
+                                        </motion.div>
+                                    )}
                                     {nameServers.map((ns) => (
                                         <motion.div
                                             layout
@@ -94,7 +159,7 @@ export const OpsView = () => {
                                             exit={{opacity: 0, height: 0, marginBottom: 0, transition: {duration: 0.2}}}
                                             whileHover={{scale: 1.002}}
                                             transition={{type: "spring", stiffness: 400, damping: 30}}
-                                            className={`flex items-center px-6 py-4 transition-colors relative group hover:bg-gray-50 dark:hover:bg-gray-800/50 ${ns === selectedNameServer ? 'bg-gray-100 dark:bg-gray-800' : 'bg-white dark:bg-gray-900'}`}
+                                            className={`flex items-center px-6 py-4 transition-colors relative group hover:bg-gray-50 dark:hover:bg-gray-800/60 ${ns === selectedNameServer ? 'bg-gray-100 dark:bg-gray-800' : 'bg-white dark:bg-gray-900'}`}
                                         >
                                             {ns === selectedNameServer && (
                                                 <motion.div
@@ -129,13 +194,18 @@ export const OpsView = () => {
                                             </div>
 
                                             <div
-                                                className="w-32 flex justify-end items-center space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                                                className="w-32 flex justify-end items-center space-x-2 opacity-100 md:opacity-70 md:group-hover:opacity-100 transition-opacity duration-200">
                                                 {ns !== selectedNameServer && (
                                                     <motion.button
                                                         whileHover={{scale: 1.05}}
                                                         whileTap={{scale: 0.95}}
                                                         onClick={() => handleSwitchServer(ns)}
-                                                        className="text-xs font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 px-3 py-1.5 rounded-md hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+                                                        disabled={isLoading || pendingAction === `switch:${ns}`}
+                                                        className={`text-xs font-semibold px-3 py-1.5 rounded-md border shadow-sm transition-colors ${
+                                                            isLoading || pendingAction === `switch:${ns}`
+                                                                ? 'text-slate-400 border-slate-700 bg-slate-800/60 cursor-not-allowed'
+                                                                : 'text-blue-700 dark:text-slate-100 border-blue-200/80 bg-blue-50/80 hover:bg-blue-100 dark:border-slate-700 dark:bg-slate-800/88 dark:hover:bg-slate-700/92 dark:hover:border-slate-600'
+                                                        }`}
                                                     >
                                                         Switch
                                                     </motion.button>
@@ -144,12 +214,12 @@ export const OpsView = () => {
                                                     whileHover={{scale: 1.1, color: "#ef4444"}}
                                                     whileTap={{scale: 0.9}}
                                                     onClick={() => handleRemoveNameServer(ns)}
+                                                    disabled={ns === selectedNameServer || isLoading || pendingAction === `delete:${ns}`}
                                                     className={`p-1.5 rounded-md transition-colors ${
-                                                        ns === selectedNameServer
-                                                            ? 'text-gray-300 dark:text-gray-700 cursor-not-allowed'
-                                                            : 'text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800'
+                                                        ns === selectedNameServer || isLoading || pendingAction === `delete:${ns}`
+                                                            ? 'text-gray-300 dark:text-gray-600 bg-transparent cursor-not-allowed'
+                                                            : 'text-gray-500 dark:text-slate-200 border border-gray-200 bg-white hover:bg-gray-50 dark:border-slate-700 dark:bg-slate-800/88 dark:hover:bg-rose-500/14 dark:hover:border-rose-400/30 dark:hover:text-rose-100 shadow-sm'
                                                     }`}
-                                                    disabled={ns === selectedNameServer}
                                                 >
                                                     <Trash2 className="w-4 h-4"/>
                                                 </motion.button>
@@ -168,11 +238,19 @@ export const OpsView = () => {
                 <div className="divide-y divide-gray-100 dark:divide-gray-800">
                     <div className="flex items-center justify-between py-4">
                         <span className="text-sm font-medium text-gray-900 dark:text-gray-300">VIP Channel</span>
-                        <Toggle checked={isVIPChannel} onChange={setIsVIPChannel}/>
+                        <Toggle
+                            checked={isVIPChannel}
+                            onChange={handleVIPChannelChange}
+                            disabled={isLoading || pendingAction === 'vip'}
+                        />
                     </div>
                     <div className="flex items-center justify-between py-4">
                         <span className="text-sm font-medium text-gray-900 dark:text-gray-300">TLS Encryption</span>
-                        <Toggle checked={useTLS} onChange={setUseTLS}/>
+                        <Toggle
+                            checked={useTLS}
+                            onChange={handleUseTLSChange}
+                            disabled={isLoading || pendingAction === 'tls'}
+                        />
                     </div>
                 </div>
             </Card>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/hooks/useNameServer.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/hooks/useNameServer.ts
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react';
+import { NameServerService } from '../../../services/nameserver.service';
+
+export const useNameServer = () => {
+    const [nameServers, setNameServers] = useState<string[]>([]);
+    const [selectedNameServer, setSelectedNameServer] = useState('');
+    const [isVIPChannel, setIsVIPChannel] = useState(true);
+    const [useTLS, setUseTLS] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+    const [pendingAction, setPendingAction] = useState<string | null>(null);
+
+    const loadNameServerSettings = async () => {
+        setIsLoading(true);
+
+        try {
+            const response = await NameServerService.getHomePage();
+
+            if (!response.success) {
+                return {
+                    success: false,
+                    message: response.message || 'Failed to load NameServer settings',
+                };
+            }
+
+            setNameServers(response.namesrvAddrList);
+            setSelectedNameServer(response.currentNamesrv ?? '');
+            setIsVIPChannel(response.useVIPChannel);
+            setUseTLS(response.useTLS);
+
+            return {
+                success: true,
+                message: response.message,
+            };
+        } catch (error) {
+            return {
+                success: false,
+                message: error instanceof Error ? error.message : 'Failed to load NameServer settings',
+            };
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        void loadNameServerSettings();
+    }, []);
+
+    const addNameServer = async (address: string) => {
+        setPendingAction('add');
+        try {
+            const response = await NameServerService.addNameServer(address);
+            if (!response.success) {
+                return response;
+            }
+
+            const refreshResult = await loadNameServerSettings();
+            return refreshResult.success ? response : refreshResult;
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    const switchNameServer = async (address: string) => {
+        setPendingAction(`switch:${address}`);
+        try {
+            const response = await NameServerService.switchNameServer(address);
+            if (!response.success) {
+                return response;
+            }
+
+            const refreshResult = await loadNameServerSettings();
+            return refreshResult.success ? response : refreshResult;
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    const deleteNameServer = async (address: string) => {
+        setPendingAction(`delete:${address}`);
+        try {
+            const response = await NameServerService.deleteNameServer(address);
+            if (!response.success) {
+                return response;
+            }
+
+            const refreshResult = await loadNameServerSettings();
+            return refreshResult.success ? response : refreshResult;
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    const updateVIPChannel = async (enabled: boolean) => {
+        const previousValue = isVIPChannel;
+        setPendingAction('vip');
+        setIsVIPChannel(enabled);
+
+        try {
+            const response = await NameServerService.updateVIPChannel(enabled);
+            if (!response.success) {
+                setIsVIPChannel(previousValue);
+            }
+            return response;
+        } catch (error) {
+            setIsVIPChannel(previousValue);
+            return {
+                success: false,
+                message: error instanceof Error ? error.message : 'Failed to update VIP Channel',
+            };
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    const updateUseTLS = async (enabled: boolean) => {
+        const previousValue = useTLS;
+        setPendingAction('tls');
+        setUseTLS(enabled);
+
+        try {
+            const response = await NameServerService.updateUseTLS(enabled);
+            if (!response.success) {
+                setUseTLS(previousValue);
+            }
+            return response;
+        } catch (error) {
+            setUseTLS(previousValue);
+            return {
+                success: false,
+                message: error instanceof Error ? error.message : 'Failed to update TLS',
+            };
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    return {
+        nameServers,
+        selectedNameServer,
+        isVIPChannel,
+        useTLS,
+        isLoading,
+        pendingAction,
+        reload: loadNameServerSettings,
+        addNameServer,
+        switchNameServer,
+        deleteNameServer,
+        updateVIPChannel,
+        updateUseTLS,
+    };
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/types/nameserver.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/types/nameserver.types.ts
@@ -1,0 +1,13 @@
+export interface NameServerHomePageResponse {
+    success: boolean;
+    message: string;
+    namesrvAddrList: string[];
+    currentNamesrv: string | null;
+    useVIPChannel: boolean;
+    useTLS: boolean;
+}
+
+export interface NameServerMutationResponse {
+    success: boolean;
+    message: string;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/nameserver.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/nameserver.service.ts
@@ -1,0 +1,28 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { NameServerHomePageResponse, NameServerMutationResponse } from '../features/nameserver/types/nameserver.types';
+
+export class NameServerService {
+    static async getHomePage(): Promise<NameServerHomePageResponse> {
+        return invoke<NameServerHomePageResponse>('get_name_server_home_page');
+    }
+
+    static async addNameServer(address: string): Promise<NameServerMutationResponse> {
+        return invoke<NameServerMutationResponse>('add_name_server', { address });
+    }
+
+    static async switchNameServer(address: string): Promise<NameServerMutationResponse> {
+        return invoke<NameServerMutationResponse>('switch_name_server', { address });
+    }
+
+    static async deleteNameServer(address: string): Promise<NameServerMutationResponse> {
+        return invoke<NameServerMutationResponse>('delete_name_server', { address });
+    }
+
+    static async updateVIPChannel(enabled: boolean): Promise<NameServerMutationResponse> {
+        return invoke<NameServerMutationResponse>('update_vip_channel', { enabled });
+    }
+
+    static async updateUseTLS(enabled: boolean): Promise<NameServerMutationResponse> {
+        return invoke<NameServerMutationResponse>('update_use_tls', { enabled });
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/stores/app.store.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useState, ReactNode } from 'react';
 import type { SessionUser } from '../features/auth/types/auth.types';
 
 type Tab =
-  | 'OPS'
+  | 'NameServer'
   | 'Proxy'
   | 'Dashboard'
   | 'Cluster'
@@ -42,7 +42,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   const getPageTitle = (tab: Tab) => {
     switch (tab) {
-      case 'OPS':
+      case 'NameServer':
         return 'NameServer Management';
       case 'Proxy':
         return 'Proxy Management';

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,9 +49,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -346,18 +346,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.66"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1987,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2756,9 +2756,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6738

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * NameServer management UI: add, delete, and switch nameservers with loading states and toast feedback.
  * Persisted settings for VIP Channel and TLS with toggle controls.
  * Automatic bootstrap of default nameserver and consistent list/sort behavior.
* **Integrations**
  * Backend commands and a local database ensure settings and server list are saved and retrievable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->