### PR TITLE
enhancement: Rename get_delay_time_level to delay_time_level for consistency in MessageTrait

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -528,7 +528,7 @@ where
         message_ext.properties_string =
             MessageDecoder::message_properties_to_string(message_ext.message_ext_inner.message.properties().as_map());
         let send_transaction_prepare_message = if tra_flag
-            && !(message_ext.reconsume_times() > 0 && message_ext.message_ext_inner.message.get_delay_time_level() > 0)
+            && !(message_ext.reconsume_times() > 0 && message_ext.message_ext_inner.message.delay_time_level() > 0)
         {
             if self
                 .inner

--- a/rocketmq-broker/src/util/hook_utils.rs
+++ b/rocketmq-broker/src/util/hook_utils.rs
@@ -159,7 +159,7 @@ impl HookUtils {
                 }
             }
             // Delay Delivery
-            if msg.message_ext_inner.message.get_delay_time_level() > 0 {
+            if msg.message_ext_inner.message.delay_time_level() > 0 {
                 Self::transform_delay_level_message(broker_runtime_inner, msg);
             }
         }
@@ -171,7 +171,7 @@ impl HookUtils {
     }
 
     pub fn check_if_timer_message(msg: &mut MessageExtBrokerInner) -> bool {
-        if msg.message_ext_inner.message.get_delay_time_level() > 0 {
+        if msg.message_ext_inner.message.delay_time_level() > 0 {
             if msg
                 .message_ext_inner
                 .properties()
@@ -233,7 +233,7 @@ impl HookUtils {
         message_store_config: &MessageStoreConfig,
         msg: &mut MessageExtBrokerInner,
     ) -> Option<PutMessageResult> {
-        let delay_level = msg.message_ext_inner.message.get_delay_time_level();
+        let delay_level = msg.message_ext_inner.message.delay_time_level();
         let deliver_ms = match msg.property(MessageConst::PROPERTY_TIMER_DELAY_SEC) {
             Some(delay_sec) => current_millis() + delay_sec.parse::<u64>().unwrap() * 1000,
             None => match msg.property(MessageConst::PROPERTY_TIMER_DELAY_MS) {
@@ -313,7 +313,7 @@ impl HookUtils {
         msg: &mut MessageExtBrokerInner,
     ) {
         let schedule_message_service = broker_runtime_inner.schedule_message_service();
-        if msg.message_ext_inner.message.get_delay_time_level() > schedule_message_service.get_max_delay_level() {
+        if msg.message_ext_inner.message.delay_time_level() > schedule_message_service.get_max_delay_level() {
             msg.message_ext_inner
                 .message
                 .set_delay_time_level(schedule_message_service.get_max_delay_level());
@@ -334,7 +334,7 @@ impl HookUtils {
         msg.message_ext_inner
             .message
             .set_topic(CheetahString::from_static_str(TopicValidator::RMQ_SYS_SCHEDULE_TOPIC));
-        msg.message_ext_inner.queue_id = delay_level_to_queue_id(msg.message_ext_inner.message.get_delay_time_level());
+        msg.message_ext_inner.queue_id = delay_level_to_queue_id(msg.message_ext_inner.message.delay_time_level());
     }
 
     pub fn send_message_back(

--- a/rocketmq-client/src/producer/default_mq_producer.rs
+++ b/rocketmq-client/src/producer/default_mq_producer.rs
@@ -664,7 +664,7 @@ impl DefaultMQProducer {
             return false;
         }
         // delay message do not support batch processing
-        if msg.get_delay_time_level() > 0
+        if msg.delay_time_level() > 0
             || msg.get_delay_time_ms() > 0
             || msg.get_delay_time_sec() > 0
             || msg.get_deliver_time_ms() > 0

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -2042,7 +2042,7 @@ impl DefaultMQProducerImpl {
         self.ensure_not_delayed_for_transactional(&msg)?;
 
         // ignore DelayTimeLevel parameter
-        if msg.get_delay_time_level() != 0 {
+        if msg.delay_time_level() != 0 {
             MessageAccessor::clear_property(&mut msg, MessageConst::PROPERTY_DELAY_TIME_LEVEL);
         }
         Validators::check_message(Some(&msg), self.producer_config.as_ref())?;

--- a/rocketmq-common/src/common/message.rs
+++ b/rocketmq-common/src/common/message.rs
@@ -141,7 +141,7 @@ pub trait MessageTrait: Any + Display + Debug {
     }
 
     /// Returns the delay time level of the message, or 0 if not set.
-    fn get_delay_time_level(&self) -> i32 {
+    fn delay_time_level(&self) -> i32 {
         self.property(&CheetahString::from_static_str(MessageConst::PROPERTY_DELAY_TIME_LEVEL))
             .and_then(|v| v.parse().ok())
             .unwrap_or(0)

--- a/rocketmq-common/src/common/message/message_batch.rs
+++ b/rocketmq-common/src/common/message/message_batch.rs
@@ -96,7 +96,7 @@ impl MessageBatch {
 
         let mut first: Option<&Message> = None;
         for message in &message_list {
-            if message.get_delay_time_level() > 0 {
+            if message.delay_time_level() > 0 {
                 return Err(RocketMQError::illegal_argument(
                     "TimeDelayLevel is not supported for batching",
                 ));

--- a/rocketmq-common/src/common/message/message_batch_v2.rs
+++ b/rocketmq-common/src/common/message/message_batch_v2.rs
@@ -105,7 +105,7 @@ impl MessageBatchV2 {
     fn validate_batch_messages(messages: &[Message], first: &Message) -> RocketMQResult<()> {
         for message in messages {
             // Delayed messages not supported
-            if message.get_delay_time_level() > 0 {
+            if message.delay_time_level() > 0 {
                 return Err(RocketMQError::illegal_argument(
                     "TimeDelayLevel is not supported for batching",
                 ));

--- a/rocketmq-common/src/common/message/message_builder.rs
+++ b/rocketmq-common/src/common/message/message_builder.rs
@@ -301,7 +301,7 @@ mod tests {
             .delay_level(3)
             .build_unchecked();
 
-        assert_eq!(msg.get_delay_time_level(), 3);
+        assert_eq!(msg.delay_time_level(), 3);
     }
 
     #[test]

--- a/rocketmq-common/src/common/message/message_single.rs
+++ b/rocketmq-common/src/common/message/message_single.rs
@@ -361,7 +361,7 @@ impl Message {
     }
 
     #[inline]
-    pub fn get_delay_time_level(&self) -> i32 {
+    pub fn delay_time_level(&self) -> i32 {
         self.properties.delay_level().unwrap_or(0)
     }
 
@@ -440,7 +440,7 @@ impl Message {
     /// Returns the delay time level.
     #[inline]
     pub fn delay_level(&self) -> i32 {
-        self.get_delay_time_level()
+        self.delay_time_level()
     }
 
     /// Returns the buyer ID.

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -420,7 +420,7 @@ impl CommitLog {
             .message_ext_broker_inner
             .message_ext_inner
             .message
-            .get_delay_time_level()
+            .delay_time_level()
             > 0
         {
             return PutMessageResult::new_default(PutMessageStatus::MessageIllegal);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6623 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized method naming conventions across message handling APIs for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->