### PR TITLE
[ISSUE ##6710]Remove commented-out error handling in cleanup

### DIFF
--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -727,10 +727,6 @@ impl WriteSocketService {
     async fn cleanup(&mut self) {
         *self.current_state.write().await = HAConnectionState::Shutdown;
 
-        /*        if let Err(e) = self.writer.close().await {
-            error!("Error closing sink: {}", e);
-        }*/
-
         if let Some(connection) = self.connection.upgrade() {
             self.ha_service.remove_connection(connection).await;
         }


### PR DESCRIPTION
Remove useless code from default_ha_connection.rs Fix #6710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal connection cleanup logic by removing unnecessary sink closure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->