### PR TITLE
[ISSUE #6751]🚀Add Topic management module with CRUD operations and UI integration

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -53,7 +53,9 @@ use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::common::FAQUrl;
 use rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats;
 use rocketmq_remoting::protocol::admin::consume_stats_list::ConsumeStatsList;
+use rocketmq_remoting::protocol::admin::offset_wrapper::OffsetWrapper;
 use rocketmq_remoting::protocol::admin::rollback_stats::RollbackStats;
+use rocketmq_remoting::protocol::admin::topic_offset::TopicOffset;
 use rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable;
 use rocketmq_remoting::protocol::body::acl_info::AclInfo;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
@@ -80,14 +82,23 @@ use rocketmq_remoting::protocol::body::subscription_group_wrapper::SubscriptionG
 use rocketmq_remoting::protocol::body::topic::topic_list::TopicList;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
 use rocketmq_remoting::protocol::body::user_info::UserInfo;
+use rocketmq_remoting::protocol::header::create_topic_request_header::CreateTopicRequestHeader;
+use rocketmq_remoting::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader;
 use rocketmq_remoting::protocol::header::elect_master_response_header::ElectMasterResponseHeader;
 use rocketmq_remoting::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader;
+use rocketmq_remoting::protocol::header::get_topic_config_request_header::GetTopicConfigRequestHeader;
+use rocketmq_remoting::protocol::header::get_topic_stats_info_request_header::GetTopicStatsInfoRequestHeader;
 use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
 use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_remoting::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
+use rocketmq_remoting::protocol::header::reset_offset_request_header::ResetOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
 use rocketmq_remoting::protocol::header::view_broker_stats_data_request_header::ViewBrokerStatsDataRequestHeader;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use rocketmq_remoting::protocol::route::route_data_view::QueueData;
+use rocketmq_remoting::protocol::static_topic::topic_config_and_queue_mapping::TopicConfigAndQueueMapping;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
 use rocketmq_remoting::protocol::subscription::broker_stats_data::BrokerStatsData;
 use rocketmq_remoting::protocol::subscription::group_forbidden::GroupForbidden;
@@ -503,7 +514,38 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         addr: CheetahString,
         config: TopicConfig,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        let topic = config
+            .topic_name
+            .clone()
+            .ok_or_else(|| rocketmq_error::RocketMQError::IllegalArgument("Topic name is required".into()))?;
+        let attributes = if config.attributes.is_empty() {
+            None
+        } else {
+            Some(CheetahString::from(
+                serde_json::to_string(&config.attributes)
+                    .map_err(|error| rocketmq_error::RocketMQError::Internal(error.to_string()))?,
+            ))
+        };
+        let request_header = CreateTopicRequestHeader {
+            topic,
+            default_topic: CheetahString::from_static_str(TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC),
+            read_queue_nums: config.read_queue_nums as i32,
+            write_queue_nums: config.write_queue_nums as i32,
+            perm: config.perm as i32,
+            topic_filter_type: config.topic_filter_type.to_string().into(),
+            topic_sys_flag: Some(config.topic_sys_flag as i32),
+            order: config.order,
+            attributes,
+            force: Some(false),
+            topic_request_header: None,
+        };
+
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .update_or_create_topic(&addr, request_header, self.timeout_millis.as_millis() as u64)
+            .await
     }
 
     async fn create_and_update_topic_config_list(
@@ -511,7 +553,10 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         addr: CheetahString,
         topic_config_list: Vec<TopicConfig>,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        for config in topic_config_list {
+            self.create_and_update_topic_config(addr.clone(), config).await?;
+        }
+        Ok(())
     }
 
     async fn create_and_update_plain_access_config(
@@ -580,11 +625,49 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         topic: CheetahString,
         broker_addr: Option<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<TopicStatsTable> {
-        todo!()
+        let timeout = self.timeout_millis.as_millis() as u64;
+        let request_header = GetTopicStatsInfoRequestHeader {
+            topic: topic.clone(),
+            topic_request_header: None,
+        };
+        if let Some(addr) = broker_addr {
+            return self
+                .client_instance
+                .as_ref()
+                .unwrap()
+                .get_mq_client_api_impl()
+                .get_topic_stats_info(&addr, request_header, timeout)
+                .await;
+        }
+
+        let topic_route = self.examine_topic_route_info(topic).await?;
+        let mut result = TopicStatsTable::new();
+        if let Some(route_data) = topic_route {
+            for broker_data in &route_data.broker_datas {
+                if let Some(master_addr) = broker_data.broker_addrs().get(&mix_all::MASTER_ID) {
+                    let stats = self
+                        .client_instance
+                        .as_ref()
+                        .unwrap()
+                        .get_mq_client_api_impl()
+                        .get_topic_stats_info(master_addr, request_header.clone(), timeout)
+                        .await?;
+                    result.get_offset_table_mut().extend(stats.into_offset_table());
+                }
+            }
+        }
+
+        Ok(result)
     }
 
     async fn examine_topic_stats_concurrent(&self, topic: CheetahString) -> AdminToolResult<TopicStatsTable> {
-        todo!()
+        match self.examine_topic_stats(topic, None).await {
+            Ok(stats) => AdminToolResult::success(stats),
+            Err(error) => AdminToolResult::failure(
+                crate::common::admin_tools_result_code_enum::AdminToolsResultCodeEnum::RemotingError,
+                error.to_string(),
+            ),
+        }
     }
 
     async fn fetch_all_topic_list(&self) -> rocketmq_error::RocketMQResult<TopicList> {
@@ -834,7 +917,14 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         namespace: CheetahString,
         key: CheetahString,
     ) -> rocketmq_error::RocketMQResult<CheetahString> {
-        todo!()
+        Ok(self
+            .client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_kvconfig_value(namespace, key, self.timeout_millis.as_millis() as u64)
+            .await?
+            .unwrap_or_default())
     }
 
     async fn get_kv_list_by_namespace(&self, namespace: CheetahString) -> rocketmq_error::RocketMQResult<KVTable> {
@@ -846,7 +936,24 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         topic_name: CheetahString,
         cluster_name: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        let cluster_info = self.examine_broker_cluster_info().await?;
+        let mut broker_addrs = HashSet::new();
+        if let Some(cluster_addr_table) = cluster_info.cluster_addr_table.as_ref() {
+            if let Some(broker_names) = cluster_addr_table.get(&cluster_name) {
+                if let Some(broker_addr_table) = cluster_info.broker_addr_table.as_ref() {
+                    for broker_name in broker_names {
+                        if let Some(broker_data) = broker_addr_table.get(broker_name) {
+                            broker_addrs.extend(broker_data.broker_addrs().values().cloned());
+                        }
+                    }
+                }
+            }
+        }
+        self.delete_topic_in_broker(broker_addrs, topic_name.clone()).await?;
+
+        let namesrv_addrs: HashSet<CheetahString> = self.get_name_server_address_list().await.into_iter().collect();
+        self.delete_topic_in_name_server(namesrv_addrs, Some(cluster_name), topic_name)
+            .await
     }
 
     async fn delete_topic_in_broker(
@@ -854,7 +961,24 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         addrs: HashSet<CheetahString>,
         topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        let request_header = DeleteTopicRequestHeader {
+            topic: topic.clone(),
+            topic_request_header: None,
+        };
+        let api = self.client_instance.as_ref().unwrap().get_mq_client_api_impl();
+        let timeout = self.timeout_millis.as_millis() as u64;
+        for addr in addrs {
+            api.delete_topic_in_broker(
+                &addr,
+                DeleteTopicRequestHeader {
+                    topic: request_header.topic.clone(),
+                    topic_request_header: None,
+                },
+                timeout,
+            )
+            .await?;
+        }
+        Ok(())
     }
 
     async fn delete_topic_in_name_server(
@@ -863,7 +987,13 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         cluster_name: Option<CheetahString>,
         topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        let request_header = DeleteTopicFromNamesrvRequestHeader::new(topic, cluster_name);
+        let api = self.client_instance.as_ref().unwrap().get_mq_client_api_impl();
+        let timeout = self.timeout_millis.as_millis() as u64;
+        for addr in addrs {
+            api.delete_topic_in_nameserver(&addr, request_header.clone(), timeout).await?;
+        }
+        Ok(())
     }
 
     async fn delete_subscription_group(
@@ -920,7 +1050,40 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         timestamp: u64,
         is_force: bool,
     ) -> rocketmq_error::RocketMQResult<HashMap<MessageQueue, u64>> {
-        todo!()
+        let topic_route = self.examine_topic_route_info(topic.clone()).await?;
+        let mut offset_table = HashMap::new();
+        let timeout = self.timeout_millis.as_millis() as u64;
+
+        if let Some(route_data) = topic_route {
+            for broker_data in &route_data.broker_datas {
+                if let Some(expected_cluster) = cluster_name.as_ref() {
+                    if broker_data.cluster() != expected_cluster {
+                        continue;
+                    }
+                }
+                if let Some(master_addr) = broker_data.broker_addrs().get(&mix_all::MASTER_ID) {
+                    let request_header = ResetOffsetRequestHeader {
+                        topic: topic.clone(),
+                        group: group.clone(),
+                        queue_id: -1,
+                        offset: None,
+                        timestamp: timestamp as i64,
+                        is_force,
+                        topic_request_header: None,
+                    };
+                    let offsets = self
+                        .client_instance
+                        .as_ref()
+                        .unwrap()
+                        .get_mq_client_api_impl()
+                        .invoke_broker_to_reset_offset(master_addr, request_header, timeout)
+                        .await?;
+                    offset_table.extend(offsets.into_iter().map(|(mq, offset)| (mq, offset as u64)));
+                }
+            }
+        }
+
+        Ok(offset_table)
     }
 
     async fn reset_offset_new(
@@ -976,7 +1139,47 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         value: CheetahString,
         is_cluster: bool,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        if is_cluster {
+            return self
+                .client_instance
+                .as_ref()
+                .unwrap()
+                .get_mq_client_api_impl()
+                .put_kvconfig_value(
+                    CheetahString::from_static_str(NAMESPACE_ORDER_TOPIC_CONFIG),
+                    key,
+                    value,
+                    self.timeout_millis.as_millis() as u64,
+                )
+                .await;
+        }
+
+        let existing = self
+            .client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_kvconfig_value(
+                CheetahString::from_static_str(NAMESPACE_ORDER_TOPIC_CONFIG),
+                key.clone(),
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await?
+            .unwrap_or_default();
+
+        let merged_order_conf = merge_order_conf_entries(existing.as_str(), value.as_str());
+
+        self.client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .put_kvconfig_value(
+                CheetahString::from_static_str(NAMESPACE_ORDER_TOPIC_CONFIG),
+                key,
+                merged_order_conf.into(),
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await
     }
 
     async fn query_topic_consume_by_who(&self, topic: CheetahString) -> rocketmq_error::RocketMQResult<GroupList> {
@@ -1247,7 +1450,19 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         addr: CheetahString,
         topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<TopicConfig> {
-        todo!()
+        let request_header = GetTopicConfigRequestHeader {
+            topic,
+            topic_request_header: None,
+        };
+        let mapping: TopicConfigAndQueueMapping = self
+            .client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_topic_config(&addr, request_header, self.timeout_millis.as_millis() as u64)
+            .await?;
+
+        Ok(mapping.topic_config)
     }
 
     async fn create_static_topic(
@@ -1687,12 +1902,40 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn reset_offset_by_timestamp_old(
         &self,
-        _consumer_group: CheetahString,
-        _topic: CheetahString,
-        _timestamp: u64,
-        _force: bool,
+        consumer_group: CheetahString,
+        topic: CheetahString,
+        timestamp: u64,
+        force: bool,
     ) -> rocketmq_error::RocketMQResult<Vec<RollbackStats>> {
-        unimplemented!("reset_offset_by_timestamp_old not implemented yet")
+        let topic_route_data = self.examine_topic_route_info(topic.clone()).await?;
+        let mut rollback_stats_list = Vec::new();
+
+        if let Some(route_data) = topic_route_data {
+            let mut topic_route_map = HashMap::new();
+            for queue_data in &route_data.queue_datas {
+                topic_route_map.insert(queue_data.broker_name().to_string(), queue_data.clone());
+            }
+
+            for broker_data in &route_data.broker_datas {
+                if let Some(addr) = broker_data.select_broker_addr() {
+                    if let Some(queue_data) = topic_route_map.get(broker_data.broker_name().as_str()) {
+                        let mut rollback_stats = self
+                            .reset_offset_by_timestamp_old_on_broker(
+                                addr,
+                                queue_data,
+                                consumer_group.clone(),
+                                topic.clone(),
+                                timestamp as i64,
+                                force,
+                            )
+                            .await?;
+                        rollback_stats_list.append(&mut rollback_stats);
+                    }
+                }
+            }
+        }
+
+        Ok(rollback_stats_list)
     }
     #[allow(deprecated)]
     async fn reset_offset_new_concurrent(
@@ -2102,5 +2345,197 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
             .get_mq_client_api_impl()
             .get_max_offset(broker_addr.as_str(), &message_queue, timeout_millis)
             .await
+    }
+}
+
+impl DefaultMQAdminExtImpl {
+    async fn reset_offset_by_timestamp_old_on_broker(
+        &self,
+        broker_addr: CheetahString,
+        queue_data: &QueueData,
+        consumer_group: CheetahString,
+        topic: CheetahString,
+        timestamp: i64,
+        force: bool,
+    ) -> rocketmq_error::RocketMQResult<Vec<RollbackStats>> {
+        let consume_stats = self
+            .client_instance
+            .as_ref()
+            .unwrap()
+            .get_mq_client_api_impl()
+            .get_consume_stats(
+                &broker_addr,
+                GetConsumeStatsRequestHeader {
+                    consumer_group: consumer_group.clone(),
+                    topic: CheetahString::empty(),
+                    topic_request_header: None,
+                },
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await?;
+
+        let mut rollback_stats_list = Vec::new();
+        let mut has_consumed = false;
+
+        for (queue, offset_wrapper) in &consume_stats.offset_table {
+            if queue.topic() == &topic {
+                has_consumed = true;
+                rollback_stats_list.push(
+                    self.reset_offset_consume_offset(
+                        broker_addr.clone(),
+                        consumer_group.clone(),
+                        queue.clone(),
+                        offset_wrapper,
+                        timestamp,
+                        force,
+                    )
+                    .await?,
+                );
+            }
+        }
+
+        if !has_consumed {
+            let topic_status = self
+                .client_instance
+                .as_ref()
+                .unwrap()
+                .get_mq_client_api_impl()
+                .get_topic_stats_info(
+                    &broker_addr,
+                    GetTopicStatsInfoRequestHeader {
+                        topic: topic.clone(),
+                        topic_request_header: None,
+                    },
+                    self.timeout_millis.as_millis() as u64,
+                )
+                .await?;
+
+            for queue_id in 0..queue_data.read_queue_nums() {
+                let queue = MessageQueue::from_parts(topic.clone(), queue_data.broker_name().clone(), queue_id as i32);
+                let mut offset_wrapper = OffsetWrapper::new();
+                let topic_offset = topic_status
+                    .get_offset_table()
+                    .get(&queue)
+                    .cloned()
+                    .unwrap_or_else(TopicOffset::new);
+                offset_wrapper.set_broker_offset(topic_offset.get_max_offset());
+                offset_wrapper.set_consumer_offset(topic_offset.get_min_offset());
+                rollback_stats_list.push(
+                    self.reset_offset_consume_offset(
+                        broker_addr.clone(),
+                        consumer_group.clone(),
+                        queue,
+                        &offset_wrapper,
+                        timestamp,
+                        force,
+                    )
+                    .await?,
+                );
+            }
+        }
+
+        Ok(rollback_stats_list)
+    }
+
+    async fn reset_offset_consume_offset(
+        &self,
+        broker_addr: CheetahString,
+        consumer_group: CheetahString,
+        queue: MessageQueue,
+        offset_wrapper: &OffsetWrapper,
+        timestamp: i64,
+        force: bool,
+    ) -> rocketmq_error::RocketMQResult<RollbackStats> {
+        let reset_offset = if timestamp == -1 {
+            self.client_instance
+                .as_ref()
+                .unwrap()
+                .get_mq_client_api_impl()
+                .get_max_offset(broker_addr.as_str(), &queue, self.timeout_millis.as_millis() as u64)
+                .await?
+        } else {
+            self.client_instance
+                .as_ref()
+                .unwrap()
+                .get_mq_client_api_impl()
+                .search_offset_by_timestamp(
+                    broker_addr.as_str(),
+                    &queue,
+                    timestamp,
+                    rocketmq_common::common::boundary_type::BoundaryType::Lower,
+                    self.timeout_millis.as_millis() as u64,
+                )
+                .await?
+        };
+
+        let mut rollback_stats = RollbackStats {
+            broker_name: queue.broker_name().clone(),
+            queue_id: queue.queue_id() as i64,
+            broker_offset: offset_wrapper.get_broker_offset(),
+            consumer_offset: offset_wrapper.get_consumer_offset(),
+            timestamp_offset: reset_offset,
+            rollback_offset: offset_wrapper.get_consumer_offset(),
+        };
+
+        if force || reset_offset <= offset_wrapper.get_consumer_offset() {
+            rollback_stats.rollback_offset = reset_offset;
+            self.client_instance
+                .as_ref()
+                .unwrap()
+                .get_mq_client_api_impl()
+                .update_consumer_offset(
+                    &broker_addr,
+                    UpdateConsumerOffsetRequestHeader {
+                        consumer_group,
+                        topic: queue.topic().clone(),
+                        queue_id: queue.queue_id(),
+                        commit_offset: reset_offset,
+                        topic_request_header: None,
+                    },
+                    self.timeout_millis.as_millis() as u64,
+                )
+                .await?;
+        }
+
+        Ok(rollback_stats)
+    }
+}
+
+fn merge_order_conf_entries(existing: &str, value: &str) -> String {
+    let mut entries = HashMap::new();
+    for item in existing.split(';').filter(|item| !item.trim().is_empty()) {
+        if let Some((broker_name, _)) = item.split_once(':') {
+            entries.insert(broker_name.to_string(), item.to_string());
+        }
+    }
+    if let Some((broker_name, _)) = value.split_once(':') {
+        entries.insert(broker_name.to_string(), value.to_string());
+    } else if !value.trim().is_empty() {
+        entries.insert(value.to_string(), value.to_string());
+    }
+
+    let mut broker_names: Vec<String> = entries.keys().cloned().collect();
+    broker_names.sort();
+    broker_names
+        .into_iter()
+        .filter_map(|broker_name| entries.remove(&broker_name))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_order_conf_entries;
+
+    #[test]
+    fn merge_order_conf_entries_replaces_existing_broker_value() {
+        let merged = merge_order_conf_entries("broker-a:4;broker-b:4", "broker-a:8");
+        assert_eq!(merged, "broker-a:8;broker-b:4");
+    }
+
+    #[test]
+    fn merge_order_conf_entries_adds_new_broker_value() {
+        let merged = merge_order_conf_entries("broker-a:4", "broker-b:8");
+        assert_eq!(merged, "broker-a:4;broker-b:8");
     }
 }

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -86,18 +86,18 @@ use rocketmq_remoting::protocol::header::create_topic_request_header::CreateTopi
 use rocketmq_remoting::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader;
 use rocketmq_remoting::protocol::header::elect_master_response_header::ElectMasterResponseHeader;
 use rocketmq_remoting::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader;
+use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
 use rocketmq_remoting::protocol::header::get_topic_config_request_header::GetTopicConfigRequestHeader;
 use rocketmq_remoting::protocol::header::get_topic_stats_info_request_header::GetTopicStatsInfoRequestHeader;
-use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
+use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
 use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_remoting::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
 use rocketmq_remoting::protocol::header::reset_offset_request_header::ResetOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
-use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
 use rocketmq_remoting::protocol::header::view_broker_stats_data_request_header::ViewBrokerStatsDataRequestHeader;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
-use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_remoting::protocol::route::route_data_view::QueueData;
+use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_remoting::protocol::static_topic::topic_config_and_queue_mapping::TopicConfigAndQueueMapping;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
 use rocketmq_remoting::protocol::subscription::broker_stats_data::BrokerStatsData;
@@ -521,10 +521,9 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         let attributes = if config.attributes.is_empty() {
             None
         } else {
-            Some(CheetahString::from(
-                serde_json::to_string(&config.attributes)
-                    .map_err(|error| rocketmq_error::RocketMQError::Internal(error.to_string()))?,
-            ))
+            Some(CheetahString::from(serde_json::to_string(&config.attributes).map_err(
+                |error| rocketmq_error::RocketMQError::Internal(error.to_string()),
+            )?))
         };
         let request_header = CreateTopicRequestHeader {
             topic,
@@ -991,7 +990,8 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         let api = self.client_instance.as_ref().unwrap().get_mq_client_api_impl();
         let timeout = self.timeout_millis.as_millis() as u64;
         for addr in addrs {
-            api.delete_topic_in_nameserver(&addr, request_header.clone(), timeout).await?;
+            api.delete_topic_in_nameserver(&addr, request_header.clone(), timeout)
+                .await?;
         }
         Ok(())
     }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -88,6 +88,7 @@ use rocketmq_remoting::protocol::body::query_consume_queue_response_body::QueryC
 use rocketmq_remoting::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
 use rocketmq_remoting::protocol::body::response::get_consumer_status_body::GetConsumerStatusBody;
 use rocketmq_remoting::protocol::body::response::lock_batch_response_body::LockBatchResponseBody;
+use rocketmq_remoting::protocol::body::response::reset_offset_body::ResetOffsetBody;
 use rocketmq_remoting::protocol::body::set_message_request_mode_request_body::SetMessageRequestModeRequestBody;
 use rocketmq_remoting::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
 use rocketmq_remoting::protocol::body::user_info::UserInfo;
@@ -97,8 +98,10 @@ use rocketmq_remoting::protocol::header::change_invisible_time_response_header::
 use rocketmq_remoting::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader;
 use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequestHeader;
 use rocketmq_remoting::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
+use rocketmq_remoting::protocol::header::create_topic_request_header::CreateTopicRequestHeader;
 use rocketmq_remoting::protocol::header::create_user_request_header::CreateUserRequestHeader;
 use rocketmq_remoting::protocol::header::delete_acl_request_header::DeleteAclRequestHeader;
+use rocketmq_remoting::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader;
 use rocketmq_remoting::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
 use rocketmq_remoting::protocol::header::delete_user_request_header::DeleteUserRequestHeader;
 use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
@@ -114,6 +117,8 @@ use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaD
 use rocketmq_remoting::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::get_min_offset_response_header::GetMinOffsetResponseHeader;
 use rocketmq_remoting::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader;
+use rocketmq_remoting::protocol::header::get_topic_config_request_header::GetTopicConfigRequestHeader;
+use rocketmq_remoting::protocol::header::get_topic_stats_info_request_header::GetTopicStatsInfoRequestHeader;
 use rocketmq_remoting::protocol::header::get_user_request_headers::GetUserRequestHeader;
 use rocketmq_remoting::protocol::header::heartbeat_request_header::HeartbeatRequestHeader;
 use rocketmq_remoting::protocol::header::list_acl_request_header::ListAclRequestHeader;
@@ -123,7 +128,10 @@ use rocketmq_remoting::protocol::header::message_operation_header::send_message_
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::DeleteKVConfigRequestHeader;
+use rocketmq_remoting::protocol::header::namesrv::kv_config_header::GetKVConfigRequestHeader;
+use rocketmq_remoting::protocol::header::namesrv::kv_config_header::GetKVConfigResponseHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::PutKVConfigRequestHeader;
+use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::perm_broker_header::AddWritePermOfBrokerRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::perm_broker_header::AddWritePermOfBrokerResponseHeader;
 use rocketmq_remoting::protocol::header::namesrv::perm_broker_header::WipeWritePermOfBrokerRequestHeader;
@@ -140,6 +148,7 @@ use rocketmq_remoting::protocol::header::query_message_response_header::QueryMes
 use rocketmq_remoting::protocol::header::recall_message_request_header::RecallMessageRequestHeader;
 use rocketmq_remoting::protocol::header::recall_message_response_header::RecallMessageResponseHeader;
 use rocketmq_remoting::protocol::header::reset_master_flush_offset_header::ResetMasterFlushOffsetHeader;
+use rocketmq_remoting::protocol::header::reset_offset_request_header::ResetOffsetRequestHeader;
 
 use rocketmq_common::common::boundary_type::BoundaryType;
 use rocketmq_remoting::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader;
@@ -156,6 +165,7 @@ use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::protocol::remoting_command;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use rocketmq_remoting::protocol::static_topic::topic_config_and_queue_mapping::TopicConfigAndQueueMapping;
 use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::remoting::RemotingService;
@@ -186,6 +196,44 @@ pub struct MQClientAPIImpl {
 }
 
 impl MQClientAPIImpl {
+    pub(crate) async fn get_kvconfig_value(
+        &self,
+        namespace: CheetahString,
+        key: CheetahString,
+        timeout_millis: u64,
+    ) -> RocketMQResult<Option<CheetahString>> {
+        let request_header = GetKVConfigRequestHeader::new(namespace, key);
+        let request = RemotingCommand::create_request_command(RequestCode::GetKvConfig, request_header);
+
+        let name_server_address_list = self.remoting_client.get_name_server_address_list();
+        let mut err_response = None;
+        for name_srv_addr in name_server_address_list {
+            let response = self
+                .remoting_client
+                .invoke_request(Some(name_srv_addr), request.clone(), timeout_millis)
+                .await?;
+            match ResponseCode::from(response.code()) {
+                ResponseCode::Success => {
+                    let response_header = response
+                        .decode_command_custom_header::<GetKVConfigResponseHeader>()
+                        .map_err(|error| mq_client_err!(format!("decode GetKVConfigResponseHeader failed: {error}")))?;
+                    return Ok(response_header.value);
+                }
+                ResponseCode::QueryNotFound => return Ok(None),
+                _ => err_response = Some(response),
+            }
+        }
+
+        if let Some(err_response) = err_response {
+            return Err(mq_client_err!(
+                err_response.code(),
+                err_response.remark().map_or("".to_string(), |s| s.to_string())
+            ));
+        }
+
+        Ok(None)
+    }
+
     pub(crate) async fn delete_kvconfig_value(
         &self,
         namespace: CheetahString,
@@ -874,6 +922,52 @@ impl MQClientAPIImpl {
         ))
     }
 
+    pub(crate) async fn get_topic_stats_info(
+        &self,
+        addr: &CheetahString,
+        request_header: GetTopicStatsInfoRequestHeader,
+        timeout_millis: u64,
+    ) -> RocketMQResult<rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable> {
+        let request = RemotingCommand::create_request_command(RequestCode::GetTopicStatsInfo, request_header);
+        let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
+        let response = self
+            .remoting_client
+            .invoke_request(Some(&broker_addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable::decode(body.as_ref());
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn get_topic_config(
+        &self,
+        addr: &CheetahString,
+        request_header: GetTopicConfigRequestHeader,
+        timeout_millis: u64,
+    ) -> RocketMQResult<TopicConfigAndQueueMapping> {
+        let request = RemotingCommand::create_request_command(RequestCode::GetTopicConfig, request_header);
+        let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
+        let response = self
+            .remoting_client
+            .invoke_request(Some(&broker_addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                return serde_json::from_slice(body.as_ref()).map_err(Into::into);
+            }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
     pub(crate) async fn query_topic_consume_by_who(
         &self,
         addr: &CheetahString,
@@ -889,6 +983,94 @@ impl MQClientAPIImpl {
             if let Some(body) = response.get_body() {
                 return rocketmq_remoting::protocol::body::group_list::GroupList::decode(body.as_ref());
             }
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn update_or_create_topic(
+        &self,
+        addr: &CheetahString,
+        request_header: CreateTopicRequestHeader,
+        timeout_millis: u64,
+    ) -> RocketMQResult<()> {
+        let request = RemotingCommand::create_request_command(RequestCode::UpdateAndCreateTopic, request_header);
+        let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
+        let response = self
+            .remoting_client
+            .invoke_request(Some(&broker_addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            return Ok(());
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn delete_topic_in_broker(
+        &self,
+        addr: &CheetahString,
+        request_header: DeleteTopicRequestHeader,
+        timeout_millis: u64,
+    ) -> RocketMQResult<()> {
+        let request = RemotingCommand::create_request_command(RequestCode::DeleteTopicInBroker, request_header);
+        let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
+        let response = self
+            .remoting_client
+            .invoke_request(Some(&broker_addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            return Ok(());
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn delete_topic_in_nameserver(
+        &self,
+        addr: &CheetahString,
+        request_header: DeleteTopicFromNamesrvRequestHeader,
+        timeout_millis: u64,
+    ) -> RocketMQResult<()> {
+        let request = RemotingCommand::create_request_command(RequestCode::DeleteTopicInNamesrv, request_header);
+        let response = self
+            .remoting_client
+            .invoke_request(Some(addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            return Ok(());
+        }
+        Err(mq_client_err!(
+            response.code(),
+            response.remark().map_or("".to_string(), |s| s.to_string())
+        ))
+    }
+
+    pub(crate) async fn invoke_broker_to_reset_offset(
+        &self,
+        addr: &CheetahString,
+        request_header: ResetOffsetRequestHeader,
+        timeout_millis: u64,
+    ) -> RocketMQResult<HashMap<MessageQueue, i64>> {
+        let request = RemotingCommand::create_request_command(RequestCode::InvokeBrokerToResetOffset, request_header);
+        let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
+        let response = self
+            .remoting_client
+            .invoke_request(Some(&broker_addr), request, timeout_millis)
+            .await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.get_body() {
+                if let Some(reset_body) = ResetOffsetBody::decode(body.as_ref()) {
+                    return Ok(reset_body.offset_table);
+                }
+            }
+            return Ok(HashMap::new());
         }
         Err(mq_client_err!(
             response.code(),

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -101,8 +101,8 @@ use rocketmq_remoting::protocol::header::consumer_send_msg_back_request_header::
 use rocketmq_remoting::protocol::header::create_topic_request_header::CreateTopicRequestHeader;
 use rocketmq_remoting::protocol::header::create_user_request_header::CreateUserRequestHeader;
 use rocketmq_remoting::protocol::header::delete_acl_request_header::DeleteAclRequestHeader;
-use rocketmq_remoting::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader;
 use rocketmq_remoting::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
+use rocketmq_remoting::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader;
 use rocketmq_remoting::protocol::header::delete_user_request_header::DeleteUserRequestHeader;
 use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
 use rocketmq_remoting::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
@@ -131,11 +131,11 @@ use rocketmq_remoting::protocol::header::namesrv::kv_config_header::DeleteKVConf
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::GetKVConfigRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::GetKVConfigResponseHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::PutKVConfigRequestHeader;
-use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::perm_broker_header::AddWritePermOfBrokerRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::perm_broker_header::AddWritePermOfBrokerResponseHeader;
 use rocketmq_remoting::protocol::header::namesrv::perm_broker_header::WipeWritePermOfBrokerRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::perm_broker_header::WipeWritePermOfBrokerResponseHeader;
+use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
 use rocketmq_remoting::protocol::header::pop_message_request_header::PopMessageRequestHeader;
 use rocketmq_remoting::protocol::header::pop_message_response_header::PopMessageResponseHeader;
 use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -82,6 +82,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,7 +169,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -198,6 +248,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,7 +339,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -336,6 +404,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +428,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -442,6 +526,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,12 +613,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -556,6 +724,18 @@ dependencies = [
  "toml 1.0.6+spec-1.1.0",
  "winnow 0.7.15",
  "yaml-rust2",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -761,7 +941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -771,7 +951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -805,7 +985,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -819,7 +999,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -830,7 +1010,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -841,7 +1021,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -856,6 +1036,7 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "serde",
 ]
 
 [[package]]
@@ -886,7 +1067,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -896,7 +1077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -909,7 +1090,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -968,7 +1161,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -991,7 +1184,7 @@ checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1066,6 +1259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1327,9 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1175,6 +1377,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,7 +1418,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1246,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1261,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1271,56 +1485,55 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1330,7 +1543,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1513,7 +1725,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1582,7 +1794,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1661,7 +1873,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2055,6 +2267,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,6 +2302,21 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2238,7 +2478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2259,6 +2499,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,6 +2516,21 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -2338,6 +2603,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,7 +2646,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2410,6 +2685,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2509,7 +2790,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2523,6 +2804,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2577,7 +2868,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2808,6 +3099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,6 +3163,17 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2944,7 +3252,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3070,7 +3378,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3154,6 +3462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,7 +3504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3265,7 +3579,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3370,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3565,7 +3879,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3693,6 +4007,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocketmq-admin-core"
+version = "0.8.0"
+dependencies = [
+ "bytes",
+ "cheetah-string",
+ "chrono",
+ "clap",
+ "clap_complete",
+ "colored",
+ "dialoguer",
+ "futures",
+ "indicatif",
+ "regex",
+ "rocketmq-client-rust",
+ "rocketmq-common",
+ "rocketmq-error",
+ "rocketmq-remoting",
+ "rocketmq-rust",
+ "rocksdb",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tabled",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "rocketmq-client-rust"
+version = "0.8.0"
+dependencies = [
+ "bytes",
+ "cheetah-string",
+ "dashmap",
+ "futures",
+ "num_cpus",
+ "parking_lot",
+ "rand 0.10.0",
+ "rocketmq-common",
+ "rocketmq-error",
+ "rocketmq-remoting",
+ "rocketmq-runtime",
+ "rocketmq-rust",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "trait-variant",
+]
+
+[[package]]
 name = "rocketmq-common"
 version = "0.8.0"
 dependencies = [
@@ -3751,12 +4118,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argon2",
+ "cheetah-string",
  "chrono",
  "log",
  "password-hash",
  "rand_core 0.6.4",
+ "rocketmq-admin-core",
+ "rocketmq-client-rust",
  "rocketmq-common",
  "rocketmq-dashboard-common",
+ "rocketmq-error",
+ "rocketmq-remoting",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3777,6 +4149,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocketmq-macros"
+version = "0.8.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "rocketmq-remoting"
+version = "0.8.0"
+dependencies = [
+ "anyhow",
+ "bitvec",
+ "bytemuck",
+ "bytes",
+ "cheetah-string",
+ "dashmap",
+ "flate2",
+ "flume",
+ "futures",
+ "futures-util",
+ "num_cpus",
+ "parking_lot",
+ "rand 0.10.0",
+ "rocketmq-common",
+ "rocketmq-error",
+ "rocketmq-macros",
+ "rocketmq-rust",
+ "serde",
+ "serde_json",
+ "serde_json_any_key",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "trait-variant",
+ "uuid",
+]
+
+[[package]]
+name = "rocketmq-runtime"
+version = "0.8.0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "rocketmq-rust"
 version = "0.8.0"
 dependencies = [
@@ -3790,6 +4209,16 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -3956,6 +4385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4021,7 +4456,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4126,7 +4561,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4137,7 +4572,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4154,6 +4589,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_any_key"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c409ca1209f6c4741028b9e1e56d973c868ffaef25ffbaf2471e486c2a74b3"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,7 +4606,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4210,7 +4655,20 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4232,7 +4690,7 @@ checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4264,6 +4722,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -4376,6 +4840,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4442,9 +4915,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4468,7 +4941,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4503,6 +4976,30 @@ dependencies = [
  "pkg-config",
  "toml 0.8.2",
  "version-compare",
+]
+
+[[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4553,7 +5050,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4659,7 +5156,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
  "time",
@@ -4677,7 +5174,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -4829,7 +5326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4844,6 +5341,15 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -4872,7 +5378,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4883,7 +5389,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4987,7 +5493,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5211,7 +5717,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5258,7 +5764,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5361,10 +5867,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -5414,6 +5938,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -5573,7 +6103,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5728,7 +6258,7 @@ checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5855,7 +6385,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5866,7 +6396,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6254,7 +6784,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6270,7 +6800,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6423,7 +6953,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6444,7 +6974,7 @@ checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6464,7 +6994,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6504,7 +7034,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
@@ -51,4 +51,9 @@ uuid             = { version = "1", features = ["v4", "serde"] }
 chrono           = { version = "0.4", features = ["serde"] }
 rocketmq-dashboard-common = { path = "../../rocketmq-dashboard-common" }
 anyhow           = "1.0"
+cheetah-string   = "1"
 rocketmq-common  = { path = "../../../rocketmq-common" }
+rocketmq-admin-core = { path = "../../../rocketmq-tools/rocketmq-admin/rocketmq-admin-core" }
+rocketmq-client-rust = { path = "../../../rocketmq-client" }
+rocketmq-remoting = { path = "../../../rocketmq-remoting" }
+rocketmq-error = { path = "../../../rocketmq-error" }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "512"]
+
 mod auth;
 mod nameserver;
+mod topic;
 
 use rocketmq_dashboard_common::NameServerConfigStore;
 use std::sync::Arc;
@@ -61,11 +64,13 @@ pub fn run() {
                 nameserver_store.load_snapshot()?,
             ));
             let nameserver_manager = nameserver::NameServerManager::new(nameserver_db, nameserver_runtime.clone())?;
+            let topic_manager = topic::TopicManager::new(nameserver_runtime.clone());
 
             app.manage(auth_service);
             app.manage(auth::SessionState::default());
             app.manage(nameserver_runtime);
             app.manage(nameserver_manager);
+            app.manage(topic_manager);
 
             Ok(())
         })
@@ -81,7 +86,18 @@ pub fn run() {
             nameserver::commands::switch_name_server,
             nameserver::commands::delete_name_server,
             nameserver::commands::update_vip_channel,
-            nameserver::commands::update_use_tls
+            nameserver::commands::update_use_tls,
+            topic::commands::get_topic_list,
+            topic::commands::get_topic_route,
+            topic::commands::get_topic_stats,
+            topic::commands::get_topic_config,
+            topic::commands::create_or_update_topic,
+            topic::commands::delete_topic,
+            topic::commands::get_topic_consumer_groups,
+            topic::commands::get_topic_consumers,
+            topic::commands::reset_consumer_offset,
+            topic::commands::skip_message_accumulate,
+            topic::commands::send_topic_message
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic.rs
@@ -1,0 +1,20 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) mod admin;
+pub(crate) mod commands;
+pub(crate) mod service;
+pub(crate) mod types;
+
+pub(crate) use service::TopicManager;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/admin.rs
@@ -1,0 +1,59 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::nameserver::NameServerRuntimeState;
+use crate::topic::types::TopicError;
+use crate::topic::types::TopicResult;
+use rocketmq_admin_core::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_dashboard_common::NameServerConfigSnapshot;
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+pub(crate) struct ManagedTopicAdmin {
+    pub(crate) admin: DefaultMQAdminExt,
+    pub(crate) snapshot: NameServerConfigSnapshot,
+}
+
+impl ManagedTopicAdmin {
+    pub(crate) async fn connect(runtime: &Arc<NameServerRuntimeState>) -> TopicResult<Self> {
+        let snapshot = runtime.snapshot();
+        let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
+            TopicError::Configuration("No active NameServer is configured. Add and select a NameServer first.".into())
+        })?;
+
+        let mut admin = DefaultMQAdminExt::with_admin_ext_group_and_timeout(
+            format!("dashboard-topic-admin-{}", Uuid::new_v4()),
+            Duration::from_millis(5_000),
+        );
+        admin
+            .client_config_mut()
+            .set_namesrv_addr(current_namesrv.clone().into());
+        admin
+            .client_config_mut()
+            .set_vip_channel_enabled(snapshot.use_vip_channel);
+        admin.client_config_mut().set_use_tls(snapshot.use_tls);
+        admin
+            .start()
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+
+        Ok(Self { admin, snapshot })
+    }
+
+    pub(crate) async fn shutdown(&mut self) {
+        self.admin.shutdown().await;
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
@@ -1,0 +1,152 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::topic::service::TopicManager;
+use crate::topic::types::TopicConfigView;
+use crate::topic::types::TopicConsumerGroupListResponse;
+use crate::topic::types::TopicConsumerInfoResponse;
+use crate::topic::types::TopicListResponse;
+use crate::topic::types::TopicMutationResult;
+use crate::topic::types::TopicRouteView;
+use crate::topic::types::TopicSendMessageResult;
+use crate::topic::types::TopicStatusView;
+use rocketmq_dashboard_common::DeleteTopicRequest;
+use rocketmq_dashboard_common::ResetOffsetRequest;
+use rocketmq_dashboard_common::SendTopicMessageRequest;
+use rocketmq_dashboard_common::TopicConfigQueryRequest;
+use rocketmq_dashboard_common::TopicConfigRequest;
+use rocketmq_dashboard_common::TopicListRequest;
+use rocketmq_dashboard_common::TopicQueryRequest;
+use tauri::State;
+
+#[tauri::command]
+pub async fn get_topic_list(
+    request: TopicListRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicListResponse, String> {
+    topic_manager
+        .get_topic_list(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn get_topic_route(
+    request: TopicQueryRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicRouteView, String> {
+    topic_manager
+        .get_topic_route(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn get_topic_stats(
+    request: TopicQueryRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicStatusView, String> {
+    topic_manager
+        .get_topic_stats(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn get_topic_config(
+    request: TopicConfigQueryRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicConfigView, String> {
+    topic_manager
+        .get_topic_config(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn create_or_update_topic(
+    request: TopicConfigRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicMutationResult, String> {
+    topic_manager
+        .create_or_update_topic(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn delete_topic(
+    request: DeleteTopicRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicMutationResult, String> {
+    topic_manager
+        .delete_topic(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn get_topic_consumer_groups(
+    request: TopicQueryRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicConsumerGroupListResponse, String> {
+    topic_manager
+        .get_topic_consumer_groups(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn get_topic_consumers(
+    request: TopicQueryRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicConsumerInfoResponse, String> {
+    topic_manager
+        .get_topic_consumers(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn reset_consumer_offset(
+    request: ResetOffsetRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicMutationResult, String> {
+    topic_manager
+        .reset_consumer_offset(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn skip_message_accumulate(
+    request: ResetOffsetRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicMutationResult, String> {
+    topic_manager
+        .skip_message_accumulate(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn send_topic_message(
+    request: SendTopicMessageRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicSendMessageResult, String> {
+    topic_manager
+        .send_topic_message(request)
+        .await
+        .map_err(|error| error.to_string())
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -1,0 +1,1135 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::nameserver::NameServerRuntimeState;
+use crate::topic::admin::ManagedTopicAdmin;
+use crate::topic::types::TopicBrokerAddressView;
+use crate::topic::types::TopicConfigView;
+use crate::topic::types::TopicConsumerGroupListResponse;
+use crate::topic::types::TopicConsumerInfoResponse;
+use crate::topic::types::TopicConsumerInfoView;
+use crate::topic::types::TopicError;
+use crate::topic::types::TopicListItem;
+use crate::topic::types::TopicListResponse;
+use crate::topic::types::TopicMutationResult;
+use crate::topic::types::TopicResult;
+use crate::topic::types::TopicRouteBrokerView;
+use crate::topic::types::TopicRouteQueueView;
+use crate::topic::types::TopicRouteView;
+use crate::topic::types::TopicSendMessageResult;
+use crate::topic::types::TopicStatusOffsetView;
+use crate::topic::types::TopicStatusView;
+use crate::topic::types::TopicTargetOption;
+use cheetah_string::CheetahString;
+use rocketmq_admin_core::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_client_rust::base::client_config::ClientConfig;
+use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
+use rocketmq_client_rust::producer::mq_producer::MQProducer;
+use rocketmq_common::common::attribute::Attribute;
+use rocketmq_common::common::attribute::topic_attributes::TopicAttributes;
+use rocketmq_common::common::config::TopicConfig as RocketMqTopicConfig;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_common::common::mix_all;
+use rocketmq_common::common::topic::TopicValidator;
+use rocketmq_dashboard_common::DeleteTopicRequest;
+use rocketmq_dashboard_common::NameServerConfigSnapshot;
+use rocketmq_dashboard_common::ResetOffsetRequest;
+use rocketmq_dashboard_common::SendTopicMessageRequest;
+use rocketmq_dashboard_common::TopicConfigQueryRequest;
+use rocketmq_dashboard_common::TopicConfigRequest;
+use rocketmq_dashboard_common::TopicListRequest;
+use rocketmq_dashboard_common::TopicQueryRequest;
+use rocketmq_error::RocketMQError;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable;
+use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
+use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
+use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub(crate) struct TopicManager {
+    runtime: Arc<NameServerRuntimeState>,
+}
+
+#[derive(Clone, Debug)]
+struct TopicBrokerConfigSnapshot {
+    broker_name: String,
+    cluster_name: Option<String>,
+    config: RocketMqTopicConfig,
+}
+
+impl TopicManager {
+    pub(crate) fn new(runtime: Arc<NameServerRuntimeState>) -> Self {
+        Self { runtime }
+    }
+
+    pub(crate) async fn get_topic_list(&self, request: TopicListRequest) -> TopicResult<TopicListResponse> {
+        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
+        let result = self
+            .get_topic_list_with_admin(&mut managed.admin, &managed.snapshot, request)
+            .await;
+        managed.shutdown().await;
+        result
+    }
+
+    pub(crate) async fn get_topic_route(&self, request: TopicQueryRequest) -> TopicResult<TopicRouteView> {
+        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
+        let result = self.get_topic_route_with_admin(&mut managed.admin, request).await;
+        managed.shutdown().await;
+        result
+    }
+
+    pub(crate) async fn get_topic_stats(&self, request: TopicQueryRequest) -> TopicResult<TopicStatusView> {
+        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
+        let result = self.get_topic_stats_with_admin(&mut managed.admin, request).await;
+        managed.shutdown().await;
+        result
+    }
+
+    pub(crate) async fn get_topic_config(&self, request: TopicConfigQueryRequest) -> TopicResult<TopicConfigView> {
+        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
+        let result = self.get_topic_config_with_admin(&mut managed.admin, request).await;
+        managed.shutdown().await;
+        result
+    }
+
+    pub(crate) async fn create_or_update_topic(&self, request: TopicConfigRequest) -> TopicResult<TopicMutationResult> {
+        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
+        let result = self
+            .create_or_update_topic_with_admin(&mut managed.admin, request)
+            .await;
+        managed.shutdown().await;
+        result
+    }
+
+    pub(crate) async fn delete_topic(&self, request: DeleteTopicRequest) -> TopicResult<TopicMutationResult> {
+        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
+        let result = self.delete_topic_with_admin(&mut managed.admin, request).await;
+        managed.shutdown().await;
+        result
+    }
+
+    pub(crate) async fn get_topic_consumer_groups(
+        &self,
+        request: TopicQueryRequest,
+    ) -> TopicResult<TopicConsumerGroupListResponse> {
+        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
+        let result = self
+            .get_topic_consumer_groups_with_admin(&mut managed.admin, request)
+            .await;
+        managed.shutdown().await;
+        result
+    }
+
+    pub(crate) async fn get_topic_consumers(
+        &self,
+        request: TopicQueryRequest,
+    ) -> TopicResult<TopicConsumerInfoResponse> {
+        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
+        let result = self.get_topic_consumers_with_admin(&mut managed.admin, request).await;
+        managed.shutdown().await;
+        result
+    }
+
+    pub(crate) async fn reset_consumer_offset(&self, request: ResetOffsetRequest) -> TopicResult<TopicMutationResult> {
+        self.apply_offset_reset(request, false).await
+    }
+
+    pub(crate) async fn skip_message_accumulate(
+        &self,
+        request: ResetOffsetRequest,
+    ) -> TopicResult<TopicMutationResult> {
+        self.apply_offset_reset(request, true).await
+    }
+
+    pub(crate) async fn send_topic_message(
+        &self,
+        request: SendTopicMessageRequest,
+    ) -> TopicResult<TopicSendMessageResult> {
+        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
+        let result = self
+            .send_topic_message_with_admin(&mut managed.admin, &managed.snapshot, request)
+            .await;
+        managed.shutdown().await;
+        result
+    }
+
+    async fn get_topic_list_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        snapshot: &NameServerConfigSnapshot,
+        request: TopicListRequest,
+    ) -> TopicResult<TopicListResponse> {
+        let topic_list = admin
+            .fetch_all_topic_list()
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        let cluster_info = admin
+            .examine_broker_cluster_info()
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        let targets = cluster_targets_from_cluster_info(&cluster_info);
+        let topic_configs = collect_topic_configs(admin, &cluster_info).await?;
+
+        let mut topics: Vec<String> = topic_list.topic_list.iter().map(|topic| topic.to_string()).collect();
+        topics.sort();
+
+        let mut items = Vec::new();
+        for topic in topics {
+            let config_snapshots = topic_configs.get(&topic).map(Vec::as_slice);
+            let (category, message_type, system_topic) = classify_topic(&topic, config_snapshots);
+            if request.skip_sys_process && system_topic {
+                continue;
+            }
+            if request.skip_retry_and_dlq && matches!(category.as_str(), "RETRY" | "DLQ") {
+                continue;
+            }
+
+            let route = admin
+                .examine_topic_route_info(topic.clone().into())
+                .await
+                .map_err(|error| TopicError::RocketMQ(error.to_string()))?
+                .unwrap_or_default();
+            let (clusters, brokers, read_queue_count, write_queue_count, perm) = summarize_route(&route);
+
+            items.push(TopicListItem {
+                topic,
+                category,
+                message_type,
+                clusters,
+                brokers,
+                read_queue_count,
+                write_queue_count,
+                perm,
+                order: summarize_order(config_snapshots),
+                system_topic,
+            });
+        }
+
+        Ok(TopicListResponse {
+            total: items.len(),
+            items,
+            targets,
+            current_namesrv: snapshot.current_namesrv.clone().unwrap_or_default(),
+            use_vip_channel: snapshot.use_vip_channel,
+            use_tls: snapshot.use_tls,
+        })
+    }
+
+    async fn get_topic_route_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: TopicQueryRequest,
+    ) -> TopicResult<TopicRouteView> {
+        let route = require_topic_route(admin, &request.topic).await?;
+        Ok(map_route_view(&request.topic, &route))
+    }
+
+    async fn get_topic_stats_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: TopicQueryRequest,
+    ) -> TopicResult<TopicStatusView> {
+        let stats = admin
+            .examine_topic_stats(request.topic.clone().into(), None)
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        Ok(map_status_view(&request.topic, &stats))
+    }
+
+    async fn get_topic_config_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: TopicConfigQueryRequest,
+    ) -> TopicResult<TopicConfigView> {
+        let cluster_info = admin
+            .examine_broker_cluster_info()
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        let route = require_topic_route(admin, &request.topic).await?;
+        let broker_configs = collect_route_topic_configs(admin, &route, &request.topic).await?;
+        let selected_config = match request.broker_name.as_deref() {
+            Some(name) => broker_configs
+                .iter()
+                .find(|config| config.broker_name == name)
+                .ok_or_else(|| TopicError::Validation(format!("Broker `{name}` was not found.")))?,
+            None => broker_configs
+                .first()
+                .ok_or_else(|| TopicError::Validation(format!("Topic `{}` has no online broker.", request.topic)))?,
+        };
+
+        Ok(build_topic_config_view(
+            &request.topic,
+            &cluster_info,
+            selected_config,
+            &broker_configs,
+        ))
+    }
+
+    async fn create_or_update_topic_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: TopicConfigRequest,
+    ) -> TopicResult<TopicMutationResult> {
+        if request.topic_name.trim().is_empty() {
+            return Err(TopicError::Validation("Topic name is required.".into()));
+        }
+        if request.cluster_name_list.is_empty() && request.broker_name_list.is_empty() {
+            return Err(TopicError::Validation(
+                "Select at least one cluster or broker before saving the topic.".into(),
+            ));
+        }
+
+        let cluster_info = admin
+            .examine_broker_cluster_info()
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        let mut target_addrs = HashSet::new();
+        let mut target_broker_names = HashSet::new();
+        for cluster_name in &request.cluster_name_list {
+            for (broker_name, broker_addr) in master_targets_by_cluster_name(&cluster_info, cluster_name)? {
+                target_broker_names.insert(broker_name);
+                target_addrs.insert(broker_addr);
+            }
+        }
+        for broker_name in &request.broker_name_list {
+            let addr = find_master_addr_by_broker_name(&cluster_info, broker_name).ok_or_else(|| {
+                TopicError::Validation(format!(
+                    "Broker `{broker_name}` was not found in the current cluster view."
+                ))
+            })?;
+            target_broker_names.insert(broker_name.clone());
+            target_addrs.insert(addr);
+        }
+
+        if target_addrs.is_empty() {
+            return Err(TopicError::Validation(
+                "No writable broker target could be resolved.".into(),
+            ));
+        }
+
+        let mut attributes = HashMap::new();
+        attributes.insert(
+            TopicAttributes::topic_message_type_attribute().name().clone(),
+            normalize_message_type(request.message_type.as_deref()).into(),
+        );
+
+        let topic_config = RocketMqTopicConfig {
+            topic_name: Some(request.topic_name.clone().into()),
+            read_queue_nums: request.read_queue_nums.max(1) as u32,
+            write_queue_nums: request.write_queue_nums.max(1) as u32,
+            perm: request.perm.max(0) as u32,
+            order: request.order,
+            attributes,
+            ..RocketMqTopicConfig::default()
+        };
+
+        for broker_addr in &target_addrs {
+            admin
+                .create_and_update_topic_config(broker_addr.clone(), topic_config.clone())
+                .await
+                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        }
+
+        if request.order {
+            let order_conf = build_order_conf(&target_broker_names, topic_config.write_queue_nums);
+            admin
+                .create_or_update_order_conf(request.topic_name.clone().into(), order_conf.into(), true)
+                .await
+                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        }
+
+        Ok(TopicMutationResult {
+            success: true,
+            message: format!("Topic `{}` was saved successfully.", request.topic_name),
+            topic_name: Some(request.topic_name),
+            affected_queues: None,
+        })
+    }
+
+    async fn delete_topic_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: DeleteTopicRequest,
+    ) -> TopicResult<TopicMutationResult> {
+        let topic = request.topic.trim().to_string();
+        if topic.is_empty() {
+            return Err(TopicError::Validation("Topic name is required.".into()));
+        }
+
+        let clusters = if let Some(cluster_name) = request.cluster_name {
+            vec![cluster_name]
+        } else {
+            let route = require_topic_route(admin, &topic).await?;
+            let mut unique_clusters: Vec<String> = route
+                .broker_datas
+                .iter()
+                .map(|broker| broker.cluster().to_string())
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
+            unique_clusters.sort();
+            unique_clusters
+        };
+
+        if clusters.is_empty() {
+            return Err(TopicError::Validation(format!(
+                "Topic `{topic}` has no cluster mapping to delete."
+            )));
+        }
+
+        for cluster_name in &clusters {
+            admin
+                .delete_topic(topic.clone().into(), cluster_name.clone().into())
+                .await
+                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        }
+
+        Ok(TopicMutationResult {
+            success: true,
+            message: format!("Topic `{topic}` was deleted from {} cluster(s).", clusters.len()),
+            topic_name: Some(topic),
+            affected_queues: None,
+        })
+    }
+
+    async fn get_topic_consumer_groups_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: TopicQueryRequest,
+    ) -> TopicResult<TopicConsumerGroupListResponse> {
+        let groups = admin
+            .query_topic_consume_by_who(request.topic.clone().into())
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        let mut consumer_groups: Vec<String> = groups.group_list.into_iter().map(|group| group.to_string()).collect();
+        consumer_groups.sort();
+        Ok(TopicConsumerGroupListResponse {
+            topic: request.topic,
+            consumer_groups,
+        })
+    }
+
+    async fn get_topic_consumers_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: TopicQueryRequest,
+    ) -> TopicResult<TopicConsumerInfoResponse> {
+        let groups = self
+            .get_topic_consumer_groups_with_admin(
+                admin,
+                TopicQueryRequest {
+                    topic: request.topic.clone(),
+                },
+            )
+            .await?;
+        let mut items = Vec::new();
+        for consumer_group in groups.consumer_groups {
+            let stats = admin
+                .examine_consume_stats(
+                    consumer_group.clone().into(),
+                    Some(request.topic.clone().into()),
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+            items.push(TopicConsumerInfoView {
+                consumer_group,
+                total_diff: stats.compute_total_diff(),
+                inflight_diff: stats.compute_inflight_total_diff(),
+                consume_tps: stats.get_consume_tps(),
+            });
+        }
+
+        Ok(TopicConsumerInfoResponse {
+            topic: request.topic,
+            items,
+        })
+    }
+
+    async fn apply_offset_reset(
+        &self,
+        request: ResetOffsetRequest,
+        skip_accumulate: bool,
+    ) -> TopicResult<TopicMutationResult> {
+        if request.consumer_group_list.is_empty() {
+            return Err(TopicError::Validation("Select at least one consumer group.".into()));
+        }
+
+        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
+        let mut affected_queues = 0usize;
+        for consumer_group in &request.consumer_group_list {
+            let offsets = managed
+                .admin
+                .reset_offset_by_timestamp(
+                    None,
+                    request.topic.clone().into(),
+                    consumer_group.clone().into(),
+                    request.reset_time as u64,
+                    request.force,
+                )
+                .await;
+            match offsets {
+                Ok(offsets) => {
+                    affected_queues += offsets.len();
+                }
+                Err(error) if is_consumer_not_online_error(&error) => {
+                    let rollback_stats = managed
+                        .admin
+                        .reset_offset_by_timestamp_old(
+                            consumer_group.clone().into(),
+                            request.topic.clone().into(),
+                            request.reset_time as u64,
+                            request.force,
+                        )
+                        .await
+                        .map_err(|fallback_error| TopicError::RocketMQ(fallback_error.to_string()))?;
+                    affected_queues += rollback_stats.len();
+                }
+                Err(error) => return Err(TopicError::RocketMQ(error.to_string())),
+            }
+        }
+        managed.shutdown().await;
+
+        Ok(TopicMutationResult {
+            success: true,
+            message: if skip_accumulate {
+                format!(
+                    "Skipped accumulated messages for {} consumer group(s).",
+                    request.consumer_group_list.len()
+                )
+            } else {
+                format!(
+                    "Reset offsets for {} consumer group(s).",
+                    request.consumer_group_list.len()
+                )
+            },
+            topic_name: Some(request.topic),
+            affected_queues: Some(affected_queues),
+        })
+    }
+
+    async fn send_topic_message_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        snapshot: &NameServerConfigSnapshot,
+        request: SendTopicMessageRequest,
+    ) -> TopicResult<TopicSendMessageResult> {
+        let topic_config = self
+            .get_topic_config_with_admin(
+                admin,
+                TopicConfigQueryRequest {
+                    topic: request.topic.clone(),
+                    broker_name: None,
+                },
+            )
+            .await?;
+        if !matches!(topic_config.message_type.as_str(), "NORMAL" | "UNSPECIFIED") {
+            return Err(TopicError::Validation(format!(
+                "Desktop send is currently limited to NORMAL topics. `{}` is `{}`.",
+                request.topic, topic_config.message_type
+            )));
+        }
+
+        let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
+            TopicError::Configuration("No active NameServer is configured. Add and select a NameServer first.".into())
+        })?;
+
+        let mut client_config = ClientConfig::new();
+        client_config.set_namesrv_addr(current_namesrv.into());
+        client_config.set_vip_channel_enabled(snapshot.use_vip_channel);
+        client_config.set_use_tls(snapshot.use_tls);
+
+        let mut producer = DefaultMQProducer::builder()
+            .producer_group(format!("dashboard-topic-sender-{}", Uuid::new_v4()))
+            .client_config(client_config)
+            .build();
+
+        producer
+            .start()
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+
+        let mut builder = Message::builder()
+            .topic(request.topic.clone())
+            .body_slice(request.message_body.as_bytes())
+            .trace_switch(request.trace_enabled);
+        if !request.tag.trim().is_empty() {
+            builder = builder.tags(request.tag.clone());
+        }
+        if !request.key.trim().is_empty() {
+            builder = builder.key(request.key.clone());
+        }
+
+        let send_result = producer
+            .send_with_timeout(builder.build_unchecked(), 5_000)
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()));
+        producer.shutdown().await;
+        let send_result = send_result?
+            .ok_or_else(|| TopicError::RocketMQ("Broker acknowledged send without returning a result.".into()))?;
+
+        Ok(TopicSendMessageResult {
+            topic: request.topic,
+            send_status: format!("{:?}", send_result.send_status),
+            message_id: send_result.msg_id.map(|message_id| message_id.to_string()),
+            broker_name: send_result
+                .message_queue
+                .as_ref()
+                .map(|queue| queue.broker_name().to_string()),
+            queue_id: send_result.message_queue.as_ref().map(|queue| queue.queue_id()),
+            queue_offset: send_result.queue_offset,
+            transaction_id: send_result.transaction_id,
+            region_id: send_result.region_id,
+        })
+    }
+}
+
+fn classify_topic(topic: &str, configs: Option<&[TopicBrokerConfigSnapshot]>) -> (String, String, bool) {
+    if topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
+        return ("RETRY".into(), "RETRY".into(), false);
+    }
+    if topic.starts_with(mix_all::DLQ_GROUP_TOPIC_PREFIX) {
+        return ("DLQ".into(), "DLQ".into(), false);
+    }
+    if TopicValidator::is_system_topic(topic) {
+        return ("SYSTEM".into(), "SYSTEM".into(), true);
+    }
+
+    let message_type = configs
+        .and_then(summarize_message_type)
+        .unwrap_or_else(|| "UNSPECIFIED".into());
+    (message_type.clone(), message_type, false)
+}
+
+fn normalize_message_type(message_type: Option<&str>) -> String {
+    match message_type.unwrap_or("NORMAL").trim().to_uppercase().as_str() {
+        "FIFO" => "FIFO".into(),
+        "DELAY" => "DELAY".into(),
+        "TRANSACTION" => "TRANSACTION".into(),
+        "UNSPECIFIED" => "UNSPECIFIED".into(),
+        _ => "NORMAL".into(),
+    }
+}
+
+async fn require_topic_route(admin: &mut DefaultMQAdminExt, topic: &str) -> TopicResult<TopicRouteData> {
+    admin
+        .examine_topic_route_info(topic.to_string().into())
+        .await
+        .map_err(|error| TopicError::RocketMQ(error.to_string()))?
+        .ok_or_else(|| TopicError::Validation(format!("Topic `{topic}` was not found.")))
+}
+
+fn summarize_route(route: &TopicRouteData) -> (Vec<String>, Vec<String>, u32, u32, i32) {
+    let mut clusters: Vec<String> = route
+        .broker_datas
+        .iter()
+        .map(|broker| broker.cluster().to_string())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    clusters.sort();
+
+    let mut brokers: Vec<String> = route
+        .broker_datas
+        .iter()
+        .map(|broker| broker.broker_name().to_string())
+        .collect();
+    brokers.sort();
+    brokers.dedup();
+
+    let read_queue_count = route.queue_datas.iter().map(|queue| queue.read_queue_nums()).sum();
+    let write_queue_count = route.queue_datas.iter().map(|queue| queue.write_queue_nums()).sum();
+    let perm = route
+        .queue_datas
+        .first()
+        .map(|queue| queue.perm() as i32)
+        .unwrap_or_default();
+
+    (clusters, brokers, read_queue_count, write_queue_count, perm)
+}
+
+fn summarize_message_type(configs: &[TopicBrokerConfigSnapshot]) -> Option<String> {
+    let message_types: HashSet<String> = configs
+        .iter()
+        .map(|item| item.config.get_topic_message_type().to_string())
+        .collect();
+    if message_types.len() == 1 {
+        message_types.into_iter().next()
+    } else {
+        Some("UNSPECIFIED".into())
+    }
+}
+
+fn summarize_order(configs: Option<&[TopicBrokerConfigSnapshot]>) -> bool {
+    configs
+        .map(|items| items.iter().all(|item| item.config.order))
+        .unwrap_or(false)
+}
+
+async fn collect_topic_configs(
+    admin: &mut DefaultMQAdminExt,
+    cluster_info: &ClusterInfo,
+) -> TopicResult<HashMap<String, Vec<TopicBrokerConfigSnapshot>>> {
+    let mut topic_configs = HashMap::new();
+    for (broker_name, broker_addr) in collect_master_broker_targets(cluster_info) {
+        let wrapper: TopicConfigSerializeWrapper = admin
+            .get_all_topic_config(broker_addr, 5_000)
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        if let Some(config_table) = wrapper.topic_config_table() {
+            for (topic, config) in config_table {
+                topic_configs
+                    .entry(topic.to_string())
+                    .or_insert_with(Vec::new)
+                    .push(TopicBrokerConfigSnapshot {
+                        broker_name: broker_name.clone(),
+                        cluster_name: find_cluster_name_by_broker_name(cluster_info, &broker_name),
+                        config: config.clone(),
+                    });
+            }
+        }
+    }
+    for snapshots in topic_configs.values_mut() {
+        snapshots.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+    }
+    Ok(topic_configs)
+}
+
+fn collect_master_broker_targets(cluster_info: &ClusterInfo) -> Vec<(String, CheetahString)> {
+    let mut targets = Vec::new();
+    if let Some(broker_addr_table) = cluster_info.broker_addr_table.as_ref() {
+        for (broker_name, broker_data) in broker_addr_table {
+            if let Some(master_addr) = broker_data.broker_addrs().get(&mix_all::MASTER_ID) {
+                targets.push((broker_name.to_string(), master_addr.clone()));
+            }
+        }
+    }
+    targets.sort_by(|left, right| left.0.cmp(&right.0));
+    targets
+}
+
+fn cluster_targets_from_cluster_info(cluster_info: &ClusterInfo) -> Vec<TopicTargetOption> {
+    let mut items = Vec::new();
+    if let Some(cluster_addr_table) = cluster_info.cluster_addr_table.as_ref() {
+        for (cluster_name, broker_names) in cluster_addr_table {
+            let mut brokers: Vec<String> = broker_names.iter().map(|item| item.to_string()).collect();
+            brokers.sort();
+            items.push(TopicTargetOption {
+                cluster_name: cluster_name.to_string(),
+                broker_names: brokers,
+            });
+        }
+    }
+    items.sort_by(|left, right| left.cluster_name.cmp(&right.cluster_name));
+    items
+}
+
+fn find_master_addr_by_broker_name(cluster_info: &ClusterInfo, broker_name: &str) -> Option<CheetahString> {
+    cluster_info
+        .broker_addr_table
+        .as_ref()
+        .and_then(|table| table.get(broker_name))
+        .and_then(|broker_data| broker_data.broker_addrs().get(&mix_all::MASTER_ID).cloned())
+}
+
+fn find_cluster_name_by_broker_name(cluster_info: &ClusterInfo, broker_name: &str) -> Option<String> {
+    cluster_info.cluster_addr_table.as_ref().and_then(|table| {
+        table
+            .iter()
+            .find(|(_, broker_names)| broker_names.iter().any(|item| item.as_str() == broker_name))
+            .map(|(cluster_name, _)| cluster_name.to_string())
+    })
+}
+
+fn master_targets_by_cluster_name(
+    cluster_info: &ClusterInfo,
+    cluster_name: &str,
+) -> TopicResult<Vec<(String, CheetahString)>> {
+    let cluster_addr_table = cluster_info
+        .cluster_addr_table
+        .as_ref()
+        .ok_or_else(|| TopicError::RocketMQ("NameServer did not return cluster address data.".into()))?;
+    let broker_addr_table = cluster_info
+        .broker_addr_table
+        .as_ref()
+        .ok_or_else(|| TopicError::RocketMQ("NameServer did not return broker address data.".into()))?;
+    let broker_names = cluster_addr_table.get(cluster_name).ok_or_else(|| {
+        TopicError::Validation(format!(
+            "Cluster `{cluster_name}` was not found in the current NameServer view."
+        ))
+    })?;
+    let mut addrs = Vec::new();
+    for broker_name in broker_names {
+        if let Some(master_addr) = broker_addr_table
+            .get(broker_name)
+            .and_then(|broker_data| broker_data.broker_addrs().get(&mix_all::MASTER_ID))
+        {
+            addrs.push((broker_name.to_string(), master_addr.clone()));
+        }
+    }
+    addrs.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(addrs)
+}
+
+async fn collect_route_topic_configs(
+    admin: &mut DefaultMQAdminExt,
+    route: &TopicRouteData,
+    topic: &str,
+) -> TopicResult<Vec<TopicBrokerConfigSnapshot>> {
+    let mut snapshots = Vec::new();
+    for broker in &route.broker_datas {
+        if let Some(master_addr) = broker.broker_addrs().get(&mix_all::MASTER_ID) {
+            let config = admin
+                .examine_topic_config(master_addr.clone(), topic.to_string().into())
+                .await
+                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+            snapshots.push(TopicBrokerConfigSnapshot {
+                broker_name: broker.broker_name().to_string(),
+                cluster_name: Some(broker.cluster().to_string()),
+                config,
+            });
+        }
+    }
+    snapshots.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+    Ok(snapshots)
+}
+
+fn build_topic_config_view(
+    topic: &str,
+    cluster_info: &ClusterInfo,
+    selected_config: &TopicBrokerConfigSnapshot,
+    all_configs: &[TopicBrokerConfigSnapshot],
+) -> TopicConfigView {
+    let mut broker_name_list: Vec<String> = all_configs.iter().map(|item| item.broker_name.clone()).collect();
+    broker_name_list.sort();
+    broker_name_list.dedup();
+
+    let mut cluster_name_list: Vec<String> = all_configs
+        .iter()
+        .filter_map(|item| {
+            item.cluster_name
+                .clone()
+                .or_else(|| find_cluster_name_by_broker_name(cluster_info, &item.broker_name))
+        })
+        .collect();
+    cluster_name_list.sort();
+    cluster_name_list.dedup();
+
+    TopicConfigView {
+        topic_name: topic.to_string(),
+        broker_name: selected_config.broker_name.clone(),
+        cluster_name: selected_config
+            .cluster_name
+            .clone()
+            .or_else(|| find_cluster_name_by_broker_name(cluster_info, &selected_config.broker_name)),
+        broker_name_list,
+        cluster_name_list,
+        read_queue_nums: selected_config.config.read_queue_nums as i32,
+        write_queue_nums: selected_config.config.write_queue_nums as i32,
+        perm: selected_config.config.perm as i32,
+        order: selected_config.config.order,
+        message_type: selected_config.config.get_topic_message_type().to_string(),
+        attributes: selected_config
+            .config
+            .attributes
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect(),
+        inconsistent_fields: detect_inconsistent_topic_fields(all_configs),
+    }
+}
+
+fn detect_inconsistent_topic_fields(configs: &[TopicBrokerConfigSnapshot]) -> Vec<String> {
+    if configs.len() <= 1 {
+        return Vec::new();
+    }
+
+    let baseline = &configs[0].config;
+    let baseline_attributes: HashMap<String, String> = baseline
+        .attributes
+        .iter()
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect();
+    let baseline_message_type = baseline.get_topic_message_type().to_string();
+    let mut inconsistent_fields = Vec::new();
+
+    if configs
+        .iter()
+        .any(|item| item.config.read_queue_nums != baseline.read_queue_nums)
+    {
+        inconsistent_fields.push("readQueueNums".into());
+    }
+    if configs
+        .iter()
+        .any(|item| item.config.write_queue_nums != baseline.write_queue_nums)
+    {
+        inconsistent_fields.push("writeQueueNums".into());
+    }
+    if configs.iter().any(|item| item.config.perm != baseline.perm) {
+        inconsistent_fields.push("perm".into());
+    }
+    if configs.iter().any(|item| item.config.order != baseline.order) {
+        inconsistent_fields.push("order".into());
+    }
+    if configs
+        .iter()
+        .any(|item| item.config.get_topic_message_type().to_string() != baseline_message_type)
+    {
+        inconsistent_fields.push("messageType".into());
+    }
+    if configs.iter().any(|item| {
+        item.config
+            .attributes
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect::<HashMap<_, _>>()
+            != baseline_attributes
+    }) {
+        inconsistent_fields.push("attributes".into());
+    }
+
+    inconsistent_fields
+}
+
+fn build_order_conf(broker_names: &HashSet<String>, write_queue_nums: u32) -> String {
+    let mut ordered_brokers: Vec<String> = broker_names.iter().cloned().collect();
+    ordered_brokers.sort();
+    ordered_brokers
+        .into_iter()
+        .map(|broker_name| format!("{broker_name}:{write_queue_nums}"))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+fn is_consumer_not_online_error(error: &RocketMQError) -> bool {
+    matches!(
+        error,
+        RocketMQError::BrokerOperationFailed { code, .. }
+            if ResponseCode::from(*code) == ResponseCode::ConsumerNotOnline
+    )
+}
+
+#[cfg(test)]
+mod topic_config_tests {
+    use super::*;
+
+    fn snapshot(
+        broker_name: &str,
+        cluster_name: &str,
+        read_queue_nums: u32,
+        write_queue_nums: u32,
+        perm: u32,
+        order: bool,
+        message_type: &str,
+    ) -> TopicBrokerConfigSnapshot {
+        let mut config = RocketMqTopicConfig {
+            read_queue_nums,
+            write_queue_nums,
+            perm,
+            order,
+            ..RocketMqTopicConfig::default()
+        };
+        config.attributes.insert(
+            TopicAttributes::topic_message_type_attribute().name().clone(),
+            message_type.into(),
+        );
+        TopicBrokerConfigSnapshot {
+            broker_name: broker_name.to_string(),
+            cluster_name: Some(cluster_name.to_string()),
+            config,
+        }
+    }
+
+    #[test]
+    fn detect_inconsistent_topic_fields_reports_divergence() {
+        let snapshots = vec![
+            snapshot("broker-a", "DefaultCluster", 8, 8, 6, false, "NORMAL"),
+            snapshot("broker-b", "DefaultCluster", 16, 8, 6, true, "FIFO"),
+        ];
+
+        let fields = detect_inconsistent_topic_fields(&snapshots);
+
+        assert!(fields.contains(&"readQueueNums".to_string()));
+        assert!(fields.contains(&"order".to_string()));
+        assert!(fields.contains(&"messageType".to_string()));
+    }
+
+    #[test]
+    fn summarize_message_type_returns_unspecified_for_mixed_configs() {
+        let snapshots = vec![
+            snapshot("broker-a", "DefaultCluster", 8, 8, 6, false, "NORMAL"),
+            snapshot("broker-b", "DefaultCluster", 8, 8, 6, false, "FIFO"),
+        ];
+
+        assert_eq!(summarize_message_type(&snapshots), Some("UNSPECIFIED".to_string()));
+    }
+
+    #[test]
+    fn build_order_conf_is_sorted_and_stable() {
+        let broker_names = HashSet::from(["broker-b".to_string(), "broker-a".to_string()]);
+
+        assert_eq!(build_order_conf(&broker_names, 8), "broker-a:8;broker-b:8");
+    }
+}
+
+fn map_route_view(topic: &str, route: &TopicRouteData) -> TopicRouteView {
+    let mut brokers = route
+        .broker_datas
+        .iter()
+        .map(|broker| {
+            let mut addresses = broker
+                .broker_addrs()
+                .iter()
+                .map(|(broker_id, address)| TopicBrokerAddressView {
+                    broker_id: *broker_id as i64,
+                    address: address.to_string(),
+                })
+                .collect::<Vec<_>>();
+            addresses.sort_by_key(|left| left.broker_id);
+            TopicRouteBrokerView {
+                cluster_name: broker.cluster().to_string(),
+                broker_name: broker.broker_name().to_string(),
+                addresses,
+            }
+        })
+        .collect::<Vec<_>>();
+    brokers.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+
+    let mut queues = route
+        .queue_datas
+        .iter()
+        .map(|queue| TopicRouteQueueView {
+            broker_name: queue.broker_name().to_string(),
+            read_queue_nums: queue.read_queue_nums(),
+            write_queue_nums: queue.write_queue_nums(),
+            perm: queue.perm() as i32,
+        })
+        .collect::<Vec<_>>();
+    queues.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+
+    TopicRouteView {
+        topic: topic.to_string(),
+        brokers,
+        queues,
+    }
+}
+
+fn map_status_view(topic: &str, stats: &TopicStatsTable) -> TopicStatusView {
+    let mut offsets = stats
+        .get_offset_table()
+        .iter()
+        .map(|(queue, offset)| TopicStatusOffsetView {
+            broker_name: queue.broker_name().to_string(),
+            queue_id: queue.queue_id(),
+            min_offset: offset.get_min_offset(),
+            max_offset: offset.get_max_offset(),
+            last_update_timestamp: offset.get_last_update_timestamp(),
+        })
+        .collect::<Vec<_>>();
+    offsets.sort_by(|left, right| {
+        left.broker_name
+            .cmp(&right.broker_name)
+            .then(left.queue_id.cmp(&right.queue_id))
+    });
+
+    TopicStatusView {
+        topic: topic.to_string(),
+        total_message_count: offsets
+            .iter()
+            .map(|item| (item.max_offset - item.min_offset).max(0))
+            .sum(),
+        queue_count: offsets.len(),
+        offsets,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TopicBrokerConfigSnapshot;
+    use super::classify_topic;
+    use super::cluster_targets_from_cluster_info;
+    use super::normalize_message_type;
+    use rocketmq_common::common::config::TopicConfig as RocketMqTopicConfig;
+    use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
+    use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    #[test]
+    fn classify_special_topics_matches_dashboard_rules() {
+        let retry = classify_topic("%RETRY%group-a", None);
+        let dlq = classify_topic("%DLQ%group-a", None);
+        let system = classify_topic("TBW102", None);
+
+        assert_eq!(retry.0, "RETRY");
+        assert_eq!(dlq.0, "DLQ");
+        assert_eq!(system.0, "SYSTEM");
+        assert!(system.2);
+    }
+
+    #[test]
+    fn classify_regular_topics_uses_message_type_attribute() {
+        let mut config = RocketMqTopicConfig::new("TopicTest");
+        config.attributes.insert("message.type".into(), "FIFO".into());
+        let snapshots = vec![TopicBrokerConfigSnapshot {
+            broker_name: "broker-a".to_string(),
+            cluster_name: Some("cluster-a".to_string()),
+            config,
+        }];
+
+        let (category, message_type, system_topic) = classify_topic("TopicTest", Some(&snapshots));
+
+        assert_eq!(category, "FIFO");
+        assert_eq!(message_type, "FIFO");
+        assert!(!system_topic);
+    }
+
+    #[test]
+    fn normalize_message_type_defaults_to_normal() {
+        assert_eq!(normalize_message_type(None), "NORMAL");
+        assert_eq!(normalize_message_type(Some("delay")), "DELAY");
+        assert_eq!(normalize_message_type(Some("unknown")), "NORMAL");
+    }
+
+    #[test]
+    fn cluster_targets_are_sorted_for_forms() {
+        let mut broker_addr_table = HashMap::new();
+        broker_addr_table.insert(
+            "broker-a".into(),
+            BrokerData::new("cluster-a".into(), "broker-a".into(), HashMap::new(), None),
+        );
+        let mut cluster_addr_table = HashMap::new();
+        cluster_addr_table.insert(
+            "cluster-a".into(),
+            HashSet::from_iter(["broker-b".into(), "broker-a".into()]),
+        );
+
+        let items =
+            cluster_targets_from_cluster_info(&ClusterInfo::new(Some(broker_addr_table), Some(cluster_addr_table)));
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].broker_names,
+            vec!["broker-a".to_string(), "broker-b".to_string()]
+        );
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/types.rs
@@ -1,0 +1,185 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fmt;
+
+pub(crate) type TopicResult<T> = Result<T, TopicError>;
+
+#[derive(Debug)]
+pub(crate) enum TopicError {
+    Configuration(String),
+    Validation(String),
+    RocketMQ(String),
+}
+
+impl fmt::Display for TopicError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Configuration(message) => write!(f, "Configuration error: {message}"),
+            Self::Validation(message) => write!(f, "Validation error: {message}"),
+            Self::RocketMQ(message) => write!(f, "RocketMQ error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for TopicError {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicTargetOption {
+    pub(crate) cluster_name: String,
+    pub(crate) broker_names: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicListItem {
+    pub(crate) topic: String,
+    pub(crate) category: String,
+    pub(crate) message_type: String,
+    pub(crate) clusters: Vec<String>,
+    pub(crate) brokers: Vec<String>,
+    pub(crate) read_queue_count: u32,
+    pub(crate) write_queue_count: u32,
+    pub(crate) perm: i32,
+    pub(crate) order: bool,
+    pub(crate) system_topic: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicListResponse {
+    pub(crate) items: Vec<TopicListItem>,
+    pub(crate) total: usize,
+    pub(crate) targets: Vec<TopicTargetOption>,
+    pub(crate) current_namesrv: String,
+    pub(crate) use_vip_channel: bool,
+    pub(crate) use_tls: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicBrokerAddressView {
+    pub(crate) broker_id: i64,
+    pub(crate) address: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicRouteBrokerView {
+    pub(crate) cluster_name: String,
+    pub(crate) broker_name: String,
+    pub(crate) addresses: Vec<TopicBrokerAddressView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicRouteQueueView {
+    pub(crate) broker_name: String,
+    pub(crate) read_queue_nums: u32,
+    pub(crate) write_queue_nums: u32,
+    pub(crate) perm: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicRouteView {
+    pub(crate) topic: String,
+    pub(crate) brokers: Vec<TopicRouteBrokerView>,
+    pub(crate) queues: Vec<TopicRouteQueueView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicStatusOffsetView {
+    pub(crate) broker_name: String,
+    pub(crate) queue_id: i32,
+    pub(crate) min_offset: i64,
+    pub(crate) max_offset: i64,
+    pub(crate) last_update_timestamp: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicStatusView {
+    pub(crate) topic: String,
+    pub(crate) total_message_count: i64,
+    pub(crate) queue_count: usize,
+    pub(crate) offsets: Vec<TopicStatusOffsetView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicConfigView {
+    pub(crate) topic_name: String,
+    pub(crate) broker_name: String,
+    pub(crate) cluster_name: Option<String>,
+    pub(crate) broker_name_list: Vec<String>,
+    pub(crate) cluster_name_list: Vec<String>,
+    pub(crate) read_queue_nums: i32,
+    pub(crate) write_queue_nums: i32,
+    pub(crate) perm: i32,
+    pub(crate) order: bool,
+    pub(crate) message_type: String,
+    pub(crate) attributes: HashMap<String, String>,
+    pub(crate) inconsistent_fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicMutationResult {
+    pub(crate) success: bool,
+    pub(crate) message: String,
+    pub(crate) topic_name: Option<String>,
+    pub(crate) affected_queues: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicConsumerGroupListResponse {
+    pub(crate) topic: String,
+    pub(crate) consumer_groups: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicConsumerInfoView {
+    pub(crate) consumer_group: String,
+    pub(crate) total_diff: i64,
+    pub(crate) inflight_diff: i64,
+    pub(crate) consume_tps: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicConsumerInfoResponse {
+    pub(crate) topic: String,
+    pub(crate) items: Vec<TopicConsumerInfoView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicSendMessageResult {
+    pub(crate) topic: String,
+    pub(crate) send_status: String,
+    pub(crate) message_id: Option<String>,
+    pub(crate) broker_name: Option<String>,
+    pub(crate) queue_id: Option<i32>,
+    pub(crate) queue_offset: u64,
+    pub(crate) transaction_id: Option<String>,
+    pub(crate) region_id: Option<String>,
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/components/topicStyles.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/components/topicStyles.ts
@@ -1,0 +1,14 @@
+export const topicGlassCardClass =
+    'border-black/10 bg-white/80 shadow-[0_18px_48px_rgba(15,23,42,0.08)] backdrop-blur-xl dark:border-white/10 dark:bg-[#0d1320]/90 dark:shadow-[0_24px_72px_rgba(0,0,0,0.38)]';
+
+export const topicMutedPanelClass =
+    'rounded-2xl border border-black/5 bg-black/[0.025] dark:border-white/8 dark:bg-white/[0.03]';
+
+export const topicOutlineButtonClass =
+    'h-10 rounded-2xl border-black/10 bg-white/70 text-slate-700 transition-all duration-200 hover:border-sky-300 hover:bg-white hover:text-slate-950 dark:border-white/12 dark:bg-white/[0.04] dark:text-slate-100 dark:hover:border-sky-400/40 dark:hover:bg-white/[0.1] dark:hover:text-white';
+
+export const topicDangerButtonClass =
+    'h-10 rounded-2xl border-rose-200/70 bg-rose-50 text-rose-700 transition-all duration-200 hover:border-rose-300 hover:bg-rose-100 hover:text-rose-900 dark:border-rose-400/20 dark:bg-rose-500/[0.08] dark:text-rose-200 dark:hover:border-rose-400/30 dark:hover:bg-rose-500/[0.14] dark:hover:text-rose-50';
+
+export const topicPrimaryButtonClass =
+    'h-10 rounded-2xl border border-sky-400/30 bg-sky-600 text-white shadow-[0_16px_40px_rgba(2,132,199,0.24)] transition-all duration-200 hover:bg-sky-500 dark:border-sky-300/20 dark:bg-sky-500 dark:text-slate-950 dark:hover:bg-sky-400';

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/hooks/useTopicCatalog.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/hooks/useTopicCatalog.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { TopicService } from '../../../services/topic.service';
+import type { TopicListResponse } from '../types/topic.types';
+
+const defaultListRequest = {
+    skipSysProcess: false,
+    skipRetryAndDlq: false,
+};
+
+export const useTopicCatalog = () => {
+    const [data, setData] = useState<TopicListResponse | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [error, setError] = useState('');
+
+    const load = async (mode: 'initial' | 'refresh' = 'refresh') => {
+        if (mode === 'initial') {
+            setIsLoading(true);
+        } else {
+            setIsRefreshing(true);
+        }
+        setError('');
+
+        try {
+            const result = await TopicService.getTopicList(defaultListRequest);
+            setData(result);
+        } catch (loadError) {
+            setError(loadError instanceof Error ? loadError.message : 'Failed to load topics');
+        } finally {
+            setIsLoading(false);
+            setIsRefreshing(false);
+        }
+    };
+
+    useEffect(() => {
+        void load('initial');
+    }, []);
+
+    return {
+        data,
+        isLoading,
+        isRefreshing,
+        error,
+        refresh: () => load('refresh'),
+    };
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/types/topic.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/types/topic.types.ts
@@ -1,0 +1,202 @@
+export type TopicCategory =
+    | 'SYSTEM'
+    | 'RETRY'
+    | 'DLQ'
+    | 'NORMAL'
+    | 'UNSPECIFIED'
+    | 'FIFO'
+    | 'DELAY'
+    | 'TRANSACTION';
+
+export type TopicMessageType = Exclude<TopicCategory, 'SYSTEM' | 'RETRY' | 'DLQ'>;
+
+export interface TopicTargetOption {
+    clusterName: string;
+    brokerNames: string[];
+}
+
+export interface TopicListItem {
+    topic: string;
+    category: TopicCategory;
+    messageType: string;
+    clusters: string[];
+    brokers: string[];
+    readQueueCount: number;
+    writeQueueCount: number;
+    perm: number;
+    order: boolean;
+    systemTopic: boolean;
+}
+
+export interface TopicListResponse {
+    items: TopicListItem[];
+    total: number;
+    targets: TopicTargetOption[];
+    currentNamesrv: string;
+    useVipChannel: boolean;
+    useTls: boolean;
+}
+
+export interface TopicBrokerAddressView {
+    brokerId: number;
+    address: string;
+}
+
+export interface TopicRouteBrokerView {
+    clusterName: string;
+    brokerName: string;
+    addresses: TopicBrokerAddressView[];
+}
+
+export interface TopicRouteQueueView {
+    brokerName: string;
+    readQueueNums: number;
+    writeQueueNums: number;
+    perm: number;
+}
+
+export interface TopicRouteView {
+    topic: string;
+    brokers: TopicRouteBrokerView[];
+    queues: TopicRouteQueueView[];
+}
+
+export interface TopicStatusOffsetView {
+    brokerName: string;
+    queueId: number;
+    minOffset: number;
+    maxOffset: number;
+    lastUpdateTimestamp: number;
+}
+
+export interface TopicStatusView {
+    topic: string;
+    totalMessageCount: number;
+    queueCount: number;
+    offsets: TopicStatusOffsetView[];
+}
+
+export interface TopicConfigView {
+    topicName: string;
+    brokerName: string;
+    clusterName: string | null;
+    brokerNameList: string[];
+    clusterNameList: string[];
+    readQueueNums: number;
+    writeQueueNums: number;
+    perm: number;
+    order: boolean;
+    messageType: string;
+    attributes: Record<string, string>;
+    inconsistentFields: string[];
+}
+
+export interface TopicMutationResult {
+    success: boolean;
+    message: string;
+    topicName?: string | null;
+    affectedQueues?: number | null;
+}
+
+export interface TopicConsumerGroupListResponse {
+    topic: string;
+    consumerGroups: string[];
+}
+
+export interface TopicConsumerInfoView {
+    consumerGroup: string;
+    totalDiff: number;
+    inflightDiff: number;
+    consumeTps: number;
+}
+
+export interface TopicConsumerInfoResponse {
+    topic: string;
+    items: TopicConsumerInfoView[];
+}
+
+export interface TopicSendMessageResult {
+    topic: string;
+    sendStatus: string;
+    messageId?: string | null;
+    brokerName?: string | null;
+    queueId?: number | null;
+    queueOffset: number;
+    transactionId?: string | null;
+    regionId?: string | null;
+}
+
+export interface TopicListRequest {
+    skipSysProcess: boolean;
+    skipRetryAndDlq: boolean;
+}
+
+export interface TopicQueryRequest {
+    topic: string;
+}
+
+export interface TopicConfigQueryRequest {
+    topic: string;
+    brokerName?: string | null;
+}
+
+export interface TopicConfigRequest {
+    clusterNameList: string[];
+    brokerNameList: string[];
+    topicName: string;
+    writeQueueNums: number;
+    readQueueNums: number;
+    perm: number;
+    order: boolean;
+    messageType?: string | null;
+}
+
+export interface DeleteTopicRequest {
+    topic: string;
+    clusterName?: string | null;
+}
+
+export interface ResetOffsetRequest {
+    consumerGroupList: string[];
+    topic: string;
+    resetTime: number;
+    force: boolean;
+}
+
+export interface SendTopicMessageRequest {
+    topic: string;
+    key: string;
+    tag: string;
+    messageBody: string;
+    traceEnabled: boolean;
+}
+
+export interface TopicEditorSeed {
+    topicName: string;
+    clusterNameList: string[];
+    brokerNameList: string[];
+    writeQueueNums: number;
+    readQueueNums: number;
+    perm: number;
+    order: boolean;
+    messageType: string;
+}
+
+export const TOPIC_CATEGORY_OPTIONS: TopicCategory[] = [
+    'NORMAL',
+    'FIFO',
+    'DELAY',
+    'TRANSACTION',
+    'UNSPECIFIED',
+    'RETRY',
+    'DLQ',
+    'SYSTEM',
+];
+
+export const TOPIC_MESSAGE_TYPE_OPTIONS: TopicMessageType[] = [
+    'NORMAL',
+    'FIFO',
+    'DELAY',
+    'TRANSACTION',
+    'UNSPECIFIED',
+];

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/topic.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/topic.service.ts
@@ -1,0 +1,64 @@
+import { invoke } from '@tauri-apps/api/core';
+import type {
+    DeleteTopicRequest,
+    ResetOffsetRequest,
+    SendTopicMessageRequest,
+    TopicConfigQueryRequest,
+    TopicConfigRequest,
+    TopicConfigView,
+    TopicConsumerGroupListResponse,
+    TopicConsumerInfoResponse,
+    TopicListRequest,
+    TopicListResponse,
+    TopicMutationResult,
+    TopicQueryRequest,
+    TopicRouteView,
+    TopicSendMessageResult,
+    TopicStatusView,
+} from '../features/topic/types/topic.types';
+
+export class TopicService {
+    static async getTopicList(request: TopicListRequest): Promise<TopicListResponse> {
+        return invoke<TopicListResponse>('get_topic_list', { request });
+    }
+
+    static async getTopicRoute(request: TopicQueryRequest): Promise<TopicRouteView> {
+        return invoke<TopicRouteView>('get_topic_route', { request });
+    }
+
+    static async getTopicStats(request: TopicQueryRequest): Promise<TopicStatusView> {
+        return invoke<TopicStatusView>('get_topic_stats', { request });
+    }
+
+    static async getTopicConfig(request: TopicConfigQueryRequest): Promise<TopicConfigView> {
+        return invoke<TopicConfigView>('get_topic_config', { request });
+    }
+
+    static async createOrUpdateTopic(request: TopicConfigRequest): Promise<TopicMutationResult> {
+        return invoke<TopicMutationResult>('create_or_update_topic', { request });
+    }
+
+    static async deleteTopic(request: DeleteTopicRequest): Promise<TopicMutationResult> {
+        return invoke<TopicMutationResult>('delete_topic', { request });
+    }
+
+    static async getTopicConsumerGroups(request: TopicQueryRequest): Promise<TopicConsumerGroupListResponse> {
+        return invoke<TopicConsumerGroupListResponse>('get_topic_consumer_groups', { request });
+    }
+
+    static async getTopicConsumers(request: TopicQueryRequest): Promise<TopicConsumerInfoResponse> {
+        return invoke<TopicConsumerInfoResponse>('get_topic_consumers', { request });
+    }
+
+    static async resetConsumerOffset(request: ResetOffsetRequest): Promise<TopicMutationResult> {
+        return invoke<TopicMutationResult>('reset_consumer_offset', { request });
+    }
+
+    static async skipMessageAccumulate(request: ResetOffsetRequest): Promise<TopicMutationResult> {
+        return invoke<TopicMutationResult>('skip_message_accumulate', { request });
+    }
+
+    static async sendTopicMessage(request: SendTopicMessageRequest): Promise<TopicSendMessageResult> {
+        return invoke<TopicSendMessageResult>('send_topic_message', { request });
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -548,9 +548,7 @@ impl MQAdminExt for DefaultMQAdminExt {
         addrs: HashSet<CheetahString>,
         topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        self.default_mqadmin_ext_impl
-            .delete_topic_in_broker(addrs, topic)
-            .await
+        self.default_mqadmin_ext_impl.delete_topic_in_broker(addrs, topic).await
     }
 
     async fn delete_topic_in_name_server(
@@ -820,9 +818,7 @@ impl MQAdminExt for DefaultMQAdminExt {
         addr: CheetahString,
         topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<TopicConfig> {
-        self.default_mqadmin_ext_impl
-            .examine_topic_config(addr, topic)
-            .await
+        self.default_mqadmin_ext_impl.examine_topic_config(addr, topic).await
     }
 
     async fn create_static_topic(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -348,7 +348,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         addr: CheetahString,
         config: TopicConfig,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .create_and_update_topic_config(addr, config)
+            .await
     }
 
     async fn create_and_update_topic_config_list(
@@ -356,7 +358,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         addr: CheetahString,
         topic_config_list: Vec<TopicConfig>,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .create_and_update_topic_config_list(addr, topic_config_list)
+            .await
     }
 
     async fn create_and_update_plain_access_config(
@@ -422,11 +426,15 @@ impl MQAdminExt for DefaultMQAdminExt {
         topic: CheetahString,
         broker_addr: Option<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<TopicStatsTable> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .examine_topic_stats(topic, broker_addr)
+            .await
     }
 
     async fn examine_topic_stats_concurrent(&self, topic: CheetahString) -> AdminToolResult<TopicStatsTable> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .examine_topic_stats_concurrent(topic)
+            .await
     }
 
     async fn fetch_all_topic_list(&self) -> rocketmq_error::RocketMQResult<TopicList> {
@@ -530,7 +538,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         topic_name: CheetahString,
         cluster_name: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .delete_topic(topic_name, cluster_name)
+            .await
     }
 
     async fn delete_topic_in_broker(
@@ -538,7 +548,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         addrs: HashSet<CheetahString>,
         topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .delete_topic_in_broker(addrs, topic)
+            .await
     }
 
     async fn delete_topic_in_name_server(
@@ -547,7 +559,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         cluster_name: Option<CheetahString>,
         topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .delete_topic_in_name_server(addrs, cluster_name, topic)
+            .await
     }
 
     async fn delete_subscription_group(
@@ -584,7 +598,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         timestamp: u64,
         is_force: bool,
     ) -> rocketmq_error::RocketMQResult<HashMap<MessageQueue, u64>> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .reset_offset_by_timestamp(cluster_name, topic, group, timestamp, is_force)
+            .await
     }
 
     async fn reset_offset_new(
@@ -613,7 +629,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         value: CheetahString,
         is_cluster: bool,
     ) -> rocketmq_error::RocketMQResult<()> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .create_or_update_order_conf(key, value, is_cluster)
+            .await
     }
 
     async fn query_topic_consume_by_who(&self, topic: CheetahString) -> rocketmq_error::RocketMQResult<GroupList> {
@@ -802,7 +820,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         addr: CheetahString,
         topic: CheetahString,
     ) -> rocketmq_error::RocketMQResult<TopicConfig> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .examine_topic_config(addr, topic)
+            .await
     }
 
     async fn create_static_topic(
@@ -1224,12 +1244,14 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn reset_offset_by_timestamp_old(
         &self,
-        _consumer_group: CheetahString,
-        _topic: CheetahString,
-        _timestamp: u64,
-        _force: bool,
+        consumer_group: CheetahString,
+        topic: CheetahString,
+        timestamp: u64,
+        force: bool,
     ) -> rocketmq_error::RocketMQResult<Vec<RollbackStats>> {
-        unimplemented!("reset_offset_by_timestamp_old not implemented yet")
+        self.default_mqadmin_ext_impl
+            .reset_offset_by_timestamp_old(consumer_group, topic, timestamp, force)
+            .await
     }
     #[allow(deprecated)]
     async fn reset_offset_new_concurrent(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6751

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topic management: create, update, and delete topics across clusters
  * Topic discovery: list topics with routing, broker, stats and configuration views
  * Consumer operations: list consumer groups and consumers for a topic
  * Offset management: reset offsets and skip message accumulation
  * Direct messaging: send test messages to topics
  * Dashboard UI: topic panel, commands, client-side hooks, types and styles added

* **Tests**
  * Unit tests for topic config/order and helper logic added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->