### PR TITLE
[ISSUE #6753]♻️Simplify DefaultMQAdminExt initialization and enhance TopicView with data fetching and filtering

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -167,6 +167,10 @@ impl DefaultMQAdminExtImpl {
         self.inner = Some(inner);
     }
 
+    pub fn has_inner(&self) -> bool {
+        self.inner.is_some()
+    }
+
     pub async fn create_acl_with_acl_info(
         &self,
         broker_addr: CheetahString,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -222,14 +222,15 @@ impl TopicManager {
             });
         }
 
-        Ok(TopicListResponse {
+        let response = TopicListResponse {
             total: items.len(),
             items,
             targets,
             current_namesrv: snapshot.current_namesrv.clone().unwrap_or_default(),
             use_vip_channel: snapshot.use_vip_channel,
             use_tls: snapshot.use_tls,
-        })
+        };
+        Ok(response)
     }
 
     async fn get_topic_route_with_admin(

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
@@ -1,4 +1,4 @@
-import React, {useState, ReactNode} from 'react';
+import React, {useEffect, useState, ReactNode} from 'react';
 import {motion, AnimatePresence} from 'motion/react';
 import {
     Activity,
@@ -36,12 +36,64 @@ import {
 import {toast} from 'sonner@2.0.3';
 import {Button} from '../components/ui/LegacyButton';
 import {Pagination} from './Pagination';
+import {useTopicCatalog} from '../features/topic/hooks/useTopicCatalog';
+import type {TopicCategory, TopicListItem} from '../features/topic/types/topic.types';
 
 interface Topic {
     name: string;
     type: string;
     operations: string[];
 }
+
+const TOPIC_PAGE_SIZE = 10;
+
+const TOPIC_FILTER_ORDER: TopicCategory[] = [
+    'NORMAL',
+    'DELAY',
+    'FIFO',
+    'TRANSACTION',
+    'UNSPECIFIED',
+    'RETRY',
+    'DLQ',
+    'SYSTEM',
+];
+
+const buildDefaultTopicFilters = (): Record<TopicCategory, boolean> => ({
+    NORMAL: true,
+    DELAY: false,
+    FIFO: true,
+    TRANSACTION: true,
+    UNSPECIFIED: true,
+    RETRY: true,
+    DLQ: true,
+    SYSTEM: true,
+});
+
+const buildTopicOperations = (item: TopicListItem): string[] => {
+    const baseOperations = ['Status', 'Router', 'Consumer Manage', 'Topic Config'];
+
+    if (item.systemTopic) {
+        return baseOperations;
+    }
+
+    if (item.category === 'RETRY' || item.category === 'DLQ') {
+        return [...baseOperations, 'Delete'];
+    }
+
+    return [
+        ...baseOperations,
+        'Send Message',
+        'Reset Consumer Offset',
+        'Skip Message Accumulate',
+        'Delete',
+    ];
+};
+
+const mapTopicListItem = (item: TopicListItem): Topic => ({
+    name: item.topic,
+    type: item.category,
+    operations: buildTopicOperations(item),
+});
 
 interface TopicRouterModalProps {
     isOpen: boolean;
@@ -1109,17 +1161,9 @@ const TopicSkipMessageAccumulateModal = ({isOpen, onClose, topic}: TopicRouterMo
 };
 
 export const TopicView = () => {
+    const {data, error, isLoading, isRefreshing, refresh} = useTopicCatalog();
     const [searchTerm, setSearchTerm] = useState('');
-    const [selectedFilters, setSelectedFilters] = useState<any>({
-        NORMAL: true,
-        Delay: false,
-        FIFO: true,
-        TRANSACTION: true,
-        UNSPECIFIED: true,
-        RETRY: true,
-        DLQ: true,
-        SYSTEM: true
-    });
+    const [selectedFilters, setSelectedFilters] = useState<Record<TopicCategory, boolean>>(buildDefaultTopicFilters);
     const [currentPage, setCurrentPage] = useState(1);
     const [statusModal, setStatusModal] = useState<{ isOpen: boolean, topic: Topic | null }>({isOpen: false, topic: null});
     const [routerModal, setRouterModal] = useState<{ isOpen: boolean, topic: Topic | null }>({isOpen: false, topic: null});
@@ -1129,31 +1173,43 @@ export const TopicView = () => {
     const [resetOffsetModal, setResetOffsetModal] = useState<{ isOpen: boolean, topic: Topic | null }>({isOpen: false, topic: null});
     const [skipAccumulateModal, setSkipAccumulateModal] = useState<{ isOpen: boolean, topic: Topic | null }>({isOpen: false, topic: null});
 
-    // Mock Topic Data
-    const topics = [
-        {name: 'SELF_TEST_TOPIC', type: 'SYSTEM', operations: ['Status', 'Router', 'Consumer Manage', 'Topic Config']},
-        {
-            name: 'DefaultCluster',
-            type: 'SYSTEM',
-            operations: ['Status', 'Router', 'Consumer Manage', 'Topic Config', 'Send Message', 'Reset Consumer Offset', 'Skip Message Accumulate', 'Delete']
-        },
-        {
-            name: 'OrderPlaced_TOPIC',
-            type: 'NORMAL',
-            operations: ['Status', 'Router', 'Consumer Manage', 'Topic Config', 'Send Message', 'Reset Consumer Offset', 'Skip Message Accumulate', 'Delete']
-        },
-        {name: 'UserSignup_EVENT', type: 'NORMAL', operations: ['Status', 'Router', 'Consumer Manage', 'Topic Config', 'Send Message']},
-        {name: 'rmq_sys_wheel_timer', type: 'SYSTEM', operations: ['Status', 'Router', 'Consumer Manage', 'Topic Config']},
-        {
-            name: 'benchmark',
-            type: 'NORMAL',
-            operations: ['Status', 'Router', 'Consumer Manage', 'Topic Config', 'Send Message', 'Reset Consumer Offset', 'Delete']
-        },
-        {name: 'RMQ_SYS_TRANS_HALF_TOPIC', type: 'SYSTEM', operations: ['Status', 'Router', 'Consumer Manage', 'Topic Config']},
-        {name: 'Payment_RETRY_TOPIC', type: 'RETRY', operations: ['Status', 'Router', 'Consumer Manage', 'Topic Config', 'Delete']},
-    ];
+    useEffect(() => {
+        if (error) {
+            toast.error(error);
+        }
+    }, [error]);
 
-    const toggleFilter = (key: string) => {
+    const topics = (data?.items ?? []).map(mapTopicListItem);
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+    const filteredTopics = topics.filter((topic) => {
+        const matchesType = selectedFilters[topic.type as TopicCategory] ?? true;
+        if (!matchesType) {
+            return false;
+        }
+
+        if (!normalizedSearch) {
+            return true;
+        }
+
+        return topic.name.toLowerCase().includes(normalizedSearch) || topic.type.toLowerCase().includes(normalizedSearch);
+    });
+    const totalPages = Math.max(1, Math.ceil(filteredTopics.length / TOPIC_PAGE_SIZE));
+    const pagedTopics = filteredTopics.slice(
+        (currentPage - 1) * TOPIC_PAGE_SIZE,
+        currentPage * TOPIC_PAGE_SIZE,
+    );
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [normalizedSearch, selectedFilters]);
+
+    useEffect(() => {
+        if (currentPage > totalPages) {
+            setCurrentPage(totalPages);
+        }
+    }, [currentPage, totalPages]);
+
+    const toggleFilter = (key: TopicCategory) => {
         setSelectedFilters((prev) => ({...prev, [key]: !prev[key]}));
     };
 
@@ -1211,7 +1267,7 @@ export const TopicView = () => {
         switch (key) {
             case 'NORMAL':
                 return FileBox;
-            case 'Delay':
+            case 'DELAY':
                 return Clock;
             case 'FIFO':
                 return Layers;
@@ -1294,9 +1350,11 @@ export const TopicView = () => {
                         <Button
                             variant="secondary"
                             icon={RefreshCw}
+                            onClick={() => void refresh()}
+                            disabled={isRefreshing || isLoading}
                             className="dark:bg-gray-900 dark:text-white dark:border dark:border-gray-700 dark:hover:bg-gray-800"
                         >
-                            Refresh
+                            {isRefreshing ? 'Refreshing...' : 'Refresh'}
                         </Button>
                     </div>
                 </div>
@@ -1306,7 +1364,8 @@ export const TopicView = () => {
                         <Filter className="w-3 h-3 mr-1"/>
                         Types:
                     </div>
-                    {Object.entries(selectedFilters).map(([key, checked]) => {
+                    {TOPIC_FILTER_ORDER.map((key) => {
+                        const checked = selectedFilters[key];
                         const Icon = getFilterIcon(key);
                         return (
                             <button
@@ -1329,7 +1388,7 @@ export const TopicView = () => {
             {/* Topic Grid */}
             <div className="grid grid-cols-1 xl:grid-cols-2 gap-5">
                 <AnimatePresence mode="popLayout">
-                    {topics.map((topic, index) => (
+                    {pagedTopics.map((topic, index) => (
                         <motion.div
                             layout
                             key={topic.name}
@@ -1409,11 +1468,19 @@ export const TopicView = () => {
                 </AnimatePresence>
             </div>
 
+            {filteredTopics.length === 0 && (
+                <div className="rounded-2xl border border-dashed border-gray-200 bg-white/70 px-6 py-10 text-center text-sm text-gray-500 shadow-sm dark:border-gray-800 dark:bg-gray-900/70 dark:text-gray-400">
+                    {isLoading
+                        ? 'Loading topics from the current NameServer...'
+                        : 'No topics matched the current search keyword or type filters.'}
+                </div>
+            )}
+
             {/* Pagination */}
             <div className="flex items-center justify-center pt-6">
                 <Pagination
                     currentPage={currentPage}
-                    totalPages={5}
+                    totalPages={totalPages}
                     onPageChange={setCurrentPage}
                 />
             </div>

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -89,6 +89,30 @@ pub struct DefaultMQAdminExt {
 }
 
 impl DefaultMQAdminExt {
+    fn build(
+        client_config: ArcMut<ClientConfig>,
+        admin_ext_group: CheetahString,
+        timeout_millis: Duration,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> Self {
+        let mut default_mqadmin_ext_impl = ArcMut::new(DefaultMQAdminExtImpl::new(
+            rpc_hook,
+            timeout_millis,
+            client_config.clone(),
+            admin_ext_group.clone(),
+        ));
+        let inner = default_mqadmin_ext_impl.clone();
+        default_mqadmin_ext_impl.set_inner(inner);
+
+        Self {
+            client_config,
+            default_mqadmin_ext_impl,
+            admin_ext_group,
+            create_topic_key: CheetahString::from_static_str(TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC),
+            timeout_millis,
+        }
+    }
+
     pub(crate) fn set_namesrv_addr(&mut self, name_serv_addr: &str) {
         self.client_config.set_namesrv_addr(name_serv_addr.into());
     }
@@ -98,101 +122,36 @@ impl DefaultMQAdminExt {
     pub fn new() -> Self {
         let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
         let client_config = ArcMut::new(ClientConfig::new());
-        let mut default_mqadmin_ext_impl = ArcMut::new(DefaultMQAdminExtImpl::new(
-            None,
-            Duration::from_millis(5000),
-            client_config.clone(),
-            admin_ext_group.clone(),
-        ));
-        let inner = default_mqadmin_ext_impl.clone();
-        default_mqadmin_ext_impl.set_inner(inner);
-        Self {
-            client_config,
-            default_mqadmin_ext_impl,
-            admin_ext_group,
-            create_topic_key: CheetahString::from_static_str(TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC),
-            timeout_millis: Duration::from_millis(5000),
-        }
+        Self::build(client_config, admin_ext_group, Duration::from_millis(5000), None)
     }
 
     pub fn with_timeout(timeout_millis: Duration) -> Self {
         let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
         let client_config = ArcMut::new(ClientConfig::new());
-        let mut default_mqadmin_ext_impl = ArcMut::new(DefaultMQAdminExtImpl::new(
-            None,
-            timeout_millis,
-            client_config.clone(),
-            admin_ext_group.clone(),
-        ));
-        let inner = default_mqadmin_ext_impl.clone();
-        default_mqadmin_ext_impl.set_inner(inner);
-        Self {
-            client_config,
-            default_mqadmin_ext_impl,
-            admin_ext_group,
-            create_topic_key: CheetahString::from_static_str(TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC),
-            timeout_millis,
-        }
+        Self::build(client_config, admin_ext_group, timeout_millis, None)
     }
 
     pub fn with_rpc_hook(rpc_hook: Arc<dyn RPCHook>) -> Self {
         let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
         let client_config = ArcMut::new(ClientConfig::new());
-        let mut default_mqadmin_ext_impl = ArcMut::new(DefaultMQAdminExtImpl::new(
-            Some(rpc_hook),
-            Duration::from_millis(5000),
-            client_config.clone(),
-            admin_ext_group.clone(),
-        ));
-        let inner = default_mqadmin_ext_impl.clone();
-        default_mqadmin_ext_impl.set_inner(inner);
-        Self {
+        Self::build(
             client_config,
-            default_mqadmin_ext_impl,
             admin_ext_group,
-            create_topic_key: CheetahString::from_static_str(TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC),
-            timeout_millis: Duration::from_millis(5000),
-        }
+            Duration::from_millis(5000),
+            Some(rpc_hook),
+        )
     }
 
     pub fn with_rpc_hook_and_timeout(rpc_hook: Arc<dyn RPCHook>, timeout_millis: Duration) -> Self {
         let admin_ext_group = CheetahString::from_static_str(ADMIN_EXT_GROUP);
         let client_config = ArcMut::new(ClientConfig::new());
-        let mut default_mqadmin_ext_impl = ArcMut::new(DefaultMQAdminExtImpl::new(
-            Some(rpc_hook),
-            timeout_millis,
-            client_config.clone(),
-            admin_ext_group.clone(),
-        ));
-        let inner = default_mqadmin_ext_impl.clone();
-        default_mqadmin_ext_impl.set_inner(inner);
-        Self {
-            client_config,
-            default_mqadmin_ext_impl,
-            admin_ext_group,
-            create_topic_key: CheetahString::from_static_str(TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC),
-            timeout_millis,
-        }
+        Self::build(client_config, admin_ext_group, timeout_millis, Some(rpc_hook))
     }
 
     pub fn with_admin_ext_group(admin_ext_group: impl Into<CheetahString>) -> Self {
         let admin_ext_group = admin_ext_group.into();
         let client_config = ArcMut::new(ClientConfig::new());
-        let mut default_mqadmin_ext_impl = ArcMut::new(DefaultMQAdminExtImpl::new(
-            None,
-            Duration::from_millis(5000),
-            client_config.clone(),
-            admin_ext_group.clone(),
-        ));
-        let inner = default_mqadmin_ext_impl.clone();
-        default_mqadmin_ext_impl.set_inner(inner);
-        Self {
-            client_config,
-            default_mqadmin_ext_impl,
-            admin_ext_group,
-            create_topic_key: CheetahString::from_static_str(TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC),
-            timeout_millis: Duration::from_millis(5000),
-        }
+        Self::build(client_config, admin_ext_group, Duration::from_millis(5000), None)
     }
 
     pub fn with_admin_ext_group_and_timeout(
@@ -201,21 +160,7 @@ impl DefaultMQAdminExt {
     ) -> Self {
         let admin_ext_group = admin_ext_group.into();
         let client_config = ArcMut::new(ClientConfig::new());
-        let mut default_mqadmin_ext_impl = ArcMut::new(DefaultMQAdminExtImpl::new(
-            None,
-            timeout_millis,
-            client_config.clone(),
-            admin_ext_group.clone(),
-        ));
-        let inner = default_mqadmin_ext_impl.clone();
-        default_mqadmin_ext_impl.set_inner(inner);
-        Self {
-            client_config,
-            default_mqadmin_ext_impl,
-            admin_ext_group,
-            create_topic_key: CheetahString::from_static_str(TopicValidator::AUTO_CREATE_TOPIC_KEY_TOPIC),
-            timeout_millis,
-        }
+        Self::build(client_config, admin_ext_group, timeout_millis, None)
     }
 
     #[inline]
@@ -305,6 +250,28 @@ impl DefaultMQAdminExt {
                 last_key,
             )
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DefaultMQAdminExt;
+    use std::time::Duration;
+
+    #[test]
+    fn admin_ext_builders_initialize_inner_impl() {
+        let default_admin = DefaultMQAdminExt::new();
+        assert!(default_admin.default_mqadmin_ext_impl.inner.is_some());
+
+        let timed_admin = DefaultMQAdminExt::with_timeout(Duration::from_secs(3));
+        assert!(timed_admin.default_mqadmin_ext_impl.inner.is_some());
+
+        let grouped_admin = DefaultMQAdminExt::with_admin_ext_group("dashboard-test");
+        assert!(grouped_admin.default_mqadmin_ext_impl.inner.is_some());
+
+        let grouped_timed_admin =
+            DefaultMQAdminExt::with_admin_ext_group_and_timeout("dashboard-test", Duration::from_secs(3));
+        assert!(grouped_timed_admin.default_mqadmin_ext_impl.inner.is_some());
     }
 }
 
@@ -1364,13 +1331,11 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn query_message(
         &self,
-        cluster_name: CheetahString,
-        topic: CheetahString,
-        msg_id: CheetahString,
+        _cluster_name: CheetahString,
+        _topic: CheetahString,
+        _msg_id: CheetahString,
     ) -> rocketmq_error::RocketMQResult<MessageExt> {
-        self.default_mqadmin_ext_impl
-            .query_message(cluster_name, topic, msg_id)
-            .await
+        unimplemented!("query_message not implemented yet")
     }
 
     async fn get_broker_ha_status(&self, broker_addr: CheetahString) -> rocketmq_error::RocketMQResult<HARuntimeInfo> {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -253,28 +253,6 @@ impl DefaultMQAdminExt {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::DefaultMQAdminExt;
-    use std::time::Duration;
-
-    #[test]
-    fn admin_ext_builders_initialize_inner_impl() {
-        let default_admin = DefaultMQAdminExt::new();
-        assert!(default_admin.default_mqadmin_ext_impl.inner.is_some());
-
-        let timed_admin = DefaultMQAdminExt::with_timeout(Duration::from_secs(3));
-        assert!(timed_admin.default_mqadmin_ext_impl.inner.is_some());
-
-        let grouped_admin = DefaultMQAdminExt::with_admin_ext_group("dashboard-test");
-        assert!(grouped_admin.default_mqadmin_ext_impl.inner.is_some());
-
-        let grouped_timed_admin =
-            DefaultMQAdminExt::with_admin_ext_group_and_timeout("dashboard-test", Duration::from_secs(3));
-        assert!(grouped_timed_admin.default_mqadmin_ext_impl.inner.is_some());
-    }
-}
-
 impl Default for DefaultMQAdminExt {
     fn default() -> Self {
         Self::new()
@@ -1494,5 +1472,27 @@ impl MQAdminExt for DefaultMQAdminExt {
         _config_types: Vec<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<()> {
         unimplemented!("export_rocksdb_config_to_json not implemented yet")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DefaultMQAdminExt;
+    use std::time::Duration;
+
+    #[test]
+    fn admin_ext_builders_initialize_inner_impl() {
+        let default_admin = DefaultMQAdminExt::new();
+        assert!(default_admin.default_mqadmin_ext_impl.has_inner());
+
+        let timed_admin = DefaultMQAdminExt::with_timeout(Duration::from_secs(3));
+        assert!(timed_admin.default_mqadmin_ext_impl.has_inner());
+
+        let grouped_admin = DefaultMQAdminExt::with_admin_ext_group("dashboard-test");
+        assert!(grouped_admin.default_mqadmin_ext_impl.has_inner());
+
+        let grouped_timed_admin =
+            DefaultMQAdminExt::with_admin_ext_group_and_timeout("dashboard-test", Duration::from_secs(3));
+        assert!(grouped_timed_admin.default_mqadmin_ext_impl.has_inner());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6753

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pagination and search-based filtering for topics; refreshed topics load and empty-state messaging.

* **Improvements**
  * Visual feedback during refresh/load operations and disabled refresh while loading.
  * Consolidated admin initialization and added runtime NameServer address setter.

* **Bug Fixes**
  * Improved error handling with toast notifications.
  * Standardized topic type handling and normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->