### PR TITLE
[ISSUE #6415]🚀Implement ResetOffsetByTimeOld Command for Legacy Offset Reset

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1902,12 +1902,21 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
 
     async fn reset_offset_by_timestamp_old(
         &self,
+        cluster_name: Option<CheetahString>,
         consumer_group: CheetahString,
         topic: CheetahString,
         timestamp: u64,
         force: bool,
     ) -> rocketmq_error::RocketMQResult<Vec<RollbackStats>> {
-        let topic_route_data = self.examine_topic_route_info(topic.clone()).await?;
+        let mut route_topic = topic.clone();
+        if !topic.is_empty()
+            && (mix_all::is_lmq(Some(topic.as_str()))
+                || topic.as_str() == format!("{}wheel_timer", TopicValidator::SYSTEM_TOPIC_PREFIX))
+            && cluster_name.as_ref().is_some_and(|name| !name.is_empty())
+        {
+            route_topic = cluster_name.unwrap();
+        }
+        let topic_route_data = self.examine_topic_route_info(route_topic).await?;
         let mut rollback_stats_list = Vec::new();
 
         if let Some(route_data) = topic_route_data {

--- a/rocketmq-client/src/admin/mq_admin_ext_async.rs
+++ b/rocketmq-client/src/admin/mq_admin_ext_async.rs
@@ -274,6 +274,7 @@ pub trait MQAdminExt: Send {
 
     async fn reset_offset_by_timestamp_old(
         &self,
+        cluster_name: Option<CheetahString>,
         consumer_group: CheetahString,
         topic: CheetahString,
         timestamp: u64,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -495,6 +495,7 @@ impl TopicManager {
                     let rollback_stats = managed
                         .admin
                         .reset_offset_by_timestamp_old(
+                            None,
                             consumer_group.clone().into(),
                             request.topic.clone().into(),
                             request.reset_time as u64,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1240,13 +1240,14 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn reset_offset_by_timestamp_old(
         &self,
+        cluster_name: Option<CheetahString>,
         consumer_group: CheetahString,
         topic: CheetahString,
         timestamp: u64,
         force: bool,
     ) -> rocketmq_error::RocketMQResult<Vec<RollbackStats>> {
         self.default_mqadmin_ext_impl
-            .reset_offset_by_timestamp_old(consumer_group, topic, timestamp, force)
+            .reset_offset_by_timestamp_old(cluster_name, consumer_group, topic, timestamp, force)
             .await
     }
     #[allow(deprecated)]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -529,6 +529,11 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Reset consumer group offsets to a specific timestamp (no restart required).",
             },
             Command {
+                category: "Offset",
+                command: "resetOffsetByTimeOld",
+                remark: "Reset consumer offset by timestamp (execute this command required client restart).",
+            },
+            Command {
                 category: "Producer",
                 command: "producer",
                 remark: "Query producer's instances, connection, status, etc.",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset.rs
@@ -14,6 +14,7 @@
 
 mod clone_group_offset_sub_command;
 mod get_consumer_status_sub_command;
+mod reset_offset_by_time_old_sub_command;
 mod reset_offset_by_time_sub_command;
 
 use std::sync::Arc;
@@ -24,6 +25,7 @@ use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::offset::clone_group_offset_sub_command::CloneGroupOffsetSubCommand;
 use crate::commands::offset::get_consumer_status_sub_command::GetConsumerStatusSubCommand;
+use crate::commands::offset::reset_offset_by_time_old_sub_command::ResetOffsetByTimeOldSubCommand;
 use crate::commands::offset::reset_offset_by_time_sub_command::ResetOffsetByTimeSubCommand;
 use crate::commands::CommandExecute;
 
@@ -70,6 +72,13 @@ EXAMPLES:
   resetOffsetByTime -g orderGroup -t orderTopic -s 1708330800000"#
     )]
     ResetOffsetByTime(ResetOffsetByTimeSubCommand),
+
+    #[command(
+        name = "resetOffsetByTimeOld",
+        about = "Reset consumer offset by timestamp(execute this command required client restart).",
+        long_about = None,
+    )]
+    ResetOffsetByTimeOld(ResetOffsetByTimeOldSubCommand),
 }
 
 impl CommandExecute for OffsetCommands {
@@ -78,6 +87,7 @@ impl CommandExecute for OffsetCommands {
             OffsetCommands::CloneGroupOffset(cmd) => cmd.execute(rpc_hook).await,
             OffsetCommands::GetConsumerStatus(cmd) => cmd.execute(rpc_hook).await,
             OffsetCommands::ResetOffsetByTime(cmd) => cmd.execute(rpc_hook).await,
+            OffsetCommands::ResetOffsetByTimeOld(cmd) => cmd.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset/reset_offset_by_time_old_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset/reset_offset_by_time_old_sub_command.rs
@@ -1,0 +1,181 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_common::UtilAll::parse_date;
+use rocketmq_common::UtilAll::YYYY_MM_DD_HH_MM_SS_SSS;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct ResetOffsetByTimeOldSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(short = 'g', long = "group", required = true, help = "set the consumer group")]
+    group: String,
+
+    #[arg(short = 't', long = "topic", required = true, help = "set the topic")]
+    topic: String,
+
+    #[arg(
+        short = 's',
+        long = "timestamp",
+        required = true,
+        help = "set the timestamp[currentTimeMillis|yyyy-MM-dd#HH:mm:ss:SSS]"
+    )]
+    timestamp: String,
+
+    #[arg(
+        short = 'f',
+        long = "force",
+        required = false,
+        help = "set the force rollback by timestamp switch[true|false]"
+    )]
+    force: Option<bool>,
+
+    #[arg(
+        short = 'c',
+        long = "cluster",
+        required = false,
+        help = "Cluster name or lmq parent topic, lmq is used to find the route."
+    )]
+    cluster: Option<String>,
+}
+
+impl ResetOffsetByTimeOldSubCommand {
+    async fn reset_offset(
+        admin: &DefaultMQAdminExt,
+        cluster_name: Option<&str>,
+        consumer_group: &str,
+        topic: &str,
+        timestamp: u64,
+        force: bool,
+        timestamp_str: &str,
+    ) -> RocketMQResult<()> {
+        let rollback_stats_list = admin
+            .reset_offset_by_timestamp_old(
+                cluster_name.map(|value| value.into()),
+                consumer_group.into(),
+                topic.into(),
+                timestamp,
+                force,
+            )
+            .await?;
+
+        println!(
+            "reset consumer offset by specified consumerGroup[{}], topic[{}], force[{}], timestamp(string)[{}], \
+             timestamp(long)[{}]",
+            consumer_group, topic, force, timestamp_str, timestamp
+        );
+        println!(
+            "{:<20}  {:<20}  {:<20}  {:<20}  {:<20}  {:<20}",
+            "#brokerName", "#queueId", "#brokerOffset", "#consumerOffset", "#timestampOffset", "#resetOffset"
+        );
+
+        for rollback_stats in rollback_stats_list {
+            let broker_name = rollback_stats.broker_name.to_string();
+            let broker_name = if broker_name.chars().count() > 32 {
+                broker_name.chars().take(32).collect::<String>()
+            } else {
+                broker_name
+            };
+
+            println!(
+                "{:<20}  {:<20}  {:<20}  {:<20}  {:<20}  {:<20}",
+                broker_name,
+                rollback_stats.queue_id,
+                rollback_stats.broker_offset,
+                rollback_stats.consumer_offset,
+                rollback_stats.timestamp_offset,
+                rollback_stats.rollback_offset
+            );
+        }
+
+        Ok(())
+    }
+}
+
+impl CommandExecute for ResetOffsetByTimeOldSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let consumer_group = self.group.trim();
+        let topic = self.topic.trim();
+        let timestamp_str = self.timestamp.trim();
+        let cluster_name = self.cluster.as_deref().map(str::trim).filter(|value| !value.is_empty());
+        let force = self.force.unwrap_or(true);
+
+        let timestamp = match timestamp_str.parse::<u64>() {
+            Ok(timestamp) => timestamp,
+            Err(_) => {
+                if let Some(date) = parse_date(timestamp_str, YYYY_MM_DD_HH_MM_SS_SSS) {
+                    let millis = date.and_utc().timestamp_millis();
+                    if millis < 0 {
+                        println!("specified timestamp invalid.");
+                        return Ok(());
+                    }
+                    millis as u64
+                } else {
+                    println!("specified timestamp invalid.");
+                    return Ok(());
+                }
+            }
+        };
+
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        if let Some(namesrv_addr) = &self.common_args.namesrv_addr {
+            default_mqadmin_ext.set_namesrv_addr(namesrv_addr.trim());
+        }
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
+                RocketMQError::Internal(format!(
+                    "ResetOffsetByTimeOldSubCommand: Failed to start MQAdminExt: {}",
+                    e
+                ))
+            })?;
+
+            Self::reset_offset(
+                &default_mqadmin_ext,
+                cluster_name,
+                consumer_group,
+                topic,
+                timestamp,
+                force,
+                timestamp_str,
+            )
+            .await
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset/reset_offset_by_time_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/offset/reset_offset_by_time_sub_command.rs
@@ -189,7 +189,7 @@ impl ResetOffsetByTimeSubCommand {
         println!();
 
         let rollback_stats = admin
-            .reset_offset_by_timestamp_old(group.into(), topic.into(), timestamp, false)
+            .reset_offset_by_timestamp_old(None, group.into(), topic.into(), timestamp, false)
             .await?;
 
         println!(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6415 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "reset offset by timestamp (old)" command with optional cluster specification.
  * Accepts timestamps as milliseconds or date strings (yyyy-MM-dd HH:mm:ss:SSS).
  * Shows results in a formatted table with broker and offset details.

* **Bug Fixes**
  * Improved handling when a consumer is not online during offset reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->