### PR TITLE
[ISSUE #6766]🚀Refactor TopicManager to use persistent admin session for improved topic management operations

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.21"
+version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5feec195269515c4722937cd7ffcfe7b4205d18d2e6577b7223ecb159ab00"
+checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -722,7 +722,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "toml 1.0.6+spec-1.1.0",
- "winnow 0.7.15",
+ "winnow 1.0.0",
  "yaml-rust2",
 ]
 
@@ -2614,9 +2614,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 
 [[package]]
 name = "mac"
@@ -4135,6 +4135,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tokio",
  "uuid",
 ]
 
@@ -4590,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json_any_key"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c409ca1209f6c4741028b9e1e56d973c868ffaef25ffbaf2471e486c2a74b3"
+checksum = "b82e4b1d3a2cb67817b8c403eac7b98225c2e1c855a13ef9b80b9bac63a06c20"
 dependencies = [
  "serde",
  "serde_json",
@@ -6740,6 +6741,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ password-hash    = "0.5"
 rand_core        = { version = "0.6", features = ["getrandom"] }
 uuid             = { version = "1", features = ["v4", "serde"] }
 chrono           = { version = "0.4", features = ["serde"] }
+tokio            = { version = "1", features = ["sync"] }
 rocketmq-dashboard-common = { path = "../../rocketmq-dashboard-common" }
 anyhow           = "1.0"
 cheetah-string   = "1"

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/runtime.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/runtime.rs
@@ -66,6 +66,11 @@ impl NameServerRuntimeState {
             .clone()
     }
 
+    pub(crate) fn snapshot_and_generation(&self) -> (NameServerConfigSnapshot, u64) {
+        let state = self.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        (state.snapshot.clone(), state.generation)
+    }
+
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn generation(&self) -> u64 {
         self.state

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/admin.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/admin.rs
@@ -25,11 +25,12 @@ use uuid::Uuid;
 pub(crate) struct ManagedTopicAdmin {
     pub(crate) admin: DefaultMQAdminExt,
     pub(crate) snapshot: NameServerConfigSnapshot,
+    pub(crate) generation: u64,
 }
 
 impl ManagedTopicAdmin {
     pub(crate) async fn connect(runtime: &Arc<NameServerRuntimeState>) -> TopicResult<Self> {
-        let snapshot = runtime.snapshot();
+        let (snapshot, generation) = runtime.snapshot_and_generation();
         let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
             TopicError::Configuration("No active NameServer is configured. Add and select a NameServer first.".into())
         })?;
@@ -50,7 +51,15 @@ impl ManagedTopicAdmin {
             .await
             .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
 
-        Ok(Self { admin, snapshot })
+        Ok(Self {
+            admin,
+            snapshot,
+            generation,
+        })
+    }
+
+    pub(crate) fn matches_generation(&self, generation: u64) -> bool {
+        self.generation == generation
     }
 
     pub(crate) async fn shutdown(&mut self) {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -225,7 +225,8 @@ impl TopicManager {
             let session = session_guard
                 .as_mut()
                 .expect("topic admin session should be initialized before use");
-            self.create_or_update_topic_with_admin(&mut session.admin, request).await
+            self.create_or_update_topic_with_admin(&mut session.admin, request)
+                .await
         };
 
         if Self::should_reset_session(&result) {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -60,11 +60,13 @@ use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
 #[derive(Clone)]
 pub(crate) struct TopicManager {
     runtime: Arc<NameServerRuntimeState>,
+    admin_session: Arc<Mutex<Option<ManagedTopicAdmin>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -76,52 +78,182 @@ struct TopicBrokerConfigSnapshot {
 
 impl TopicManager {
     pub(crate) fn new(runtime: Arc<NameServerRuntimeState>) -> Self {
-        Self { runtime }
+        Self {
+            runtime,
+            admin_session: Arc::new(Mutex::new(None)),
+        }
     }
 
     pub(crate) async fn get_topic_list(&self, request: TopicListRequest) -> TopicResult<TopicListResponse> {
-        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
-        let result = self
-            .get_topic_list_with_admin(&mut managed.admin, &managed.snapshot, request)
-            .await;
-        managed.shutdown().await;
-        result
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let snapshot = session_guard
+                .as_ref()
+                .expect("topic admin session should be initialized before use")
+                .snapshot
+                .clone();
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("topic admin session should be initialized before use");
+                self.get_topic_list_with_admin(&mut session.admin, &snapshot, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "get_topic_list failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `get_topic_list` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     pub(crate) async fn get_topic_route(&self, request: TopicQueryRequest) -> TopicResult<TopicRouteView> {
-        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
-        let result = self.get_topic_route_with_admin(&mut managed.admin, request).await;
-        managed.shutdown().await;
-        result
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("topic admin session should be initialized before use");
+                self.get_topic_route_with_admin(&mut session.admin, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "get_topic_route failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `get_topic_route` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     pub(crate) async fn get_topic_stats(&self, request: TopicQueryRequest) -> TopicResult<TopicStatusView> {
-        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
-        let result = self.get_topic_stats_with_admin(&mut managed.admin, request).await;
-        managed.shutdown().await;
-        result
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("topic admin session should be initialized before use");
+                self.get_topic_stats_with_admin(&mut session.admin, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "get_topic_stats failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `get_topic_stats` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     pub(crate) async fn get_topic_config(&self, request: TopicConfigQueryRequest) -> TopicResult<TopicConfigView> {
-        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
-        let result = self.get_topic_config_with_admin(&mut managed.admin, request).await;
-        managed.shutdown().await;
-        result
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("topic admin session should be initialized before use");
+                self.get_topic_config_with_admin(&mut session.admin, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "get_topic_config failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `get_topic_config` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     pub(crate) async fn create_or_update_topic(&self, request: TopicConfigRequest) -> TopicResult<TopicMutationResult> {
-        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
-        let result = self
-            .create_or_update_topic_with_admin(&mut managed.admin, request)
-            .await;
-        managed.shutdown().await;
+        let mut session_guard = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session_guard).await?;
+
+        let result = {
+            let session = session_guard
+                .as_mut()
+                .expect("topic admin session should be initialized before use");
+            self.create_or_update_topic_with_admin(&mut session.admin, request).await
+        };
+
+        if Self::should_reset_session(&result) {
+            self.reset_admin_session(&mut session_guard, "create_or_update_topic failed")
+                .await;
+        }
+        drop(session_guard);
+
         result
     }
 
     pub(crate) async fn delete_topic(&self, request: DeleteTopicRequest) -> TopicResult<TopicMutationResult> {
-        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
-        let result = self.delete_topic_with_admin(&mut managed.admin, request).await;
-        managed.shutdown().await;
+        let mut session_guard = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session_guard).await?;
+
+        let result = {
+            let session = session_guard
+                .as_mut()
+                .expect("topic admin session should be initialized before use");
+            self.delete_topic_with_admin(&mut session.admin, request).await
+        };
+
+        if Self::should_reset_session(&result) {
+            self.reset_admin_session(&mut session_guard, "delete_topic failed")
+                .await;
+        }
+        drop(session_guard);
+
         result
     }
 
@@ -129,22 +261,70 @@ impl TopicManager {
         &self,
         request: TopicQueryRequest,
     ) -> TopicResult<TopicConsumerGroupListResponse> {
-        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
-        let result = self
-            .get_topic_consumer_groups_with_admin(&mut managed.admin, request)
-            .await;
-        managed.shutdown().await;
-        result
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("topic admin session should be initialized before use");
+                self.get_topic_consumer_groups_with_admin(&mut session.admin, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "get_topic_consumer_groups failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `get_topic_consumer_groups` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     pub(crate) async fn get_topic_consumers(
         &self,
         request: TopicQueryRequest,
     ) -> TopicResult<TopicConsumerInfoResponse> {
-        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
-        let result = self.get_topic_consumers_with_admin(&mut managed.admin, request).await;
-        managed.shutdown().await;
-        result
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("topic admin session should be initialized before use");
+                self.get_topic_consumers_with_admin(&mut session.admin, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "get_topic_consumers failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `get_topic_consumers` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     pub(crate) async fn reset_consumer_offset(&self, request: ResetOffsetRequest) -> TopicResult<TopicMutationResult> {
@@ -162,12 +342,65 @@ impl TopicManager {
         &self,
         request: SendTopicMessageRequest,
     ) -> TopicResult<TopicSendMessageResult> {
-        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
-        let result = self
-            .send_topic_message_with_admin(&mut managed.admin, &managed.snapshot, request)
-            .await;
-        managed.shutdown().await;
+        let mut session_guard = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session_guard).await?;
+
+        let snapshot = session_guard
+            .as_ref()
+            .expect("topic admin session should be initialized before use")
+            .snapshot
+            .clone();
+        let result = {
+            let session = session_guard
+                .as_mut()
+                .expect("topic admin session should be initialized before use");
+            self.send_topic_message_with_admin(&mut session.admin, &snapshot, request)
+                .await
+        };
+
+        if Self::should_reset_session(&result) {
+            self.reset_admin_session(&mut session_guard, "send_topic_message failed")
+                .await;
+        }
+        drop(session_guard);
+
         result
+    }
+
+    async fn ensure_admin_session(&self, session_slot: &mut Option<ManagedTopicAdmin>) -> TopicResult<()> {
+        let generation = self.runtime.generation();
+        let needs_reconnect = session_slot
+            .as_ref()
+            .is_none_or(|session| !session.matches_generation(generation));
+
+        if needs_reconnect {
+            self.reset_admin_session(session_slot, "refreshing topic admin session")
+                .await;
+            let session = ManagedTopicAdmin::connect(&self.runtime).await?;
+            log::info!(
+                "Connected topic admin session for namesrv `{}` at generation {}",
+                session.snapshot.current_namesrv.as_deref().unwrap_or_default(),
+                session.generation
+            );
+            *session_slot = Some(session);
+        }
+
+        Ok(())
+    }
+
+    async fn reset_admin_session(&self, session_slot: &mut Option<ManagedTopicAdmin>, reason: &str) {
+        if let Some(mut session) = session_slot.take() {
+            log::info!(
+                "Shutting down topic admin session for namesrv `{}`: {}",
+                session.snapshot.current_namesrv.as_deref().unwrap_or_default(),
+                reason
+            );
+            session.shutdown().await;
+        }
+    }
+
+    fn should_reset_session<T>(result: &TopicResult<T>) -> bool {
+        matches!(result, Err(TopicError::RocketMQ(_)))
     }
 
     async fn get_topic_list_with_admin(
@@ -230,6 +463,8 @@ impl TopicManager {
             use_vip_channel: snapshot.use_vip_channel,
             use_tls: snapshot.use_tls,
         };
+
+        //log::info!("get_topic_list_with_admin response: {:?}", response);
         Ok(response)
     }
 
@@ -474,59 +709,78 @@ impl TopicManager {
         if request.consumer_group_list.is_empty() {
             return Err(TopicError::Validation("Select at least one consumer group.".into()));
         }
+        let operation_name = if skip_accumulate {
+            "skip_message_accumulate"
+        } else {
+            "reset_consumer_offset"
+        };
 
-        let mut managed = ManagedTopicAdmin::connect(&self.runtime).await?;
-        let mut affected_queues = 0usize;
-        for consumer_group in &request.consumer_group_list {
-            let offsets = managed
-                .admin
-                .reset_offset_by_timestamp(
-                    None,
-                    request.topic.clone().into(),
-                    consumer_group.clone().into(),
-                    request.reset_time as u64,
-                    request.force,
-                )
-                .await;
-            match offsets {
-                Ok(offsets) => {
-                    affected_queues += offsets.len();
+        let mut session_guard = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session_guard).await?;
+
+        let result = {
+            let session = session_guard
+                .as_mut()
+                .expect("topic admin session should be initialized before use");
+            let mut affected_queues = 0usize;
+            for consumer_group in &request.consumer_group_list {
+                let offsets = session
+                    .admin
+                    .reset_offset_by_timestamp(
+                        None,
+                        request.topic.clone().into(),
+                        consumer_group.clone().into(),
+                        request.reset_time as u64,
+                        request.force,
+                    )
+                    .await;
+                match offsets {
+                    Ok(offsets) => {
+                        affected_queues += offsets.len();
+                    }
+                    Err(error) if is_consumer_not_online_error(&error) => {
+                        let rollback_stats = session
+                            .admin
+                            .reset_offset_by_timestamp_old(
+                                None,
+                                consumer_group.clone().into(),
+                                request.topic.clone().into(),
+                                request.reset_time as u64,
+                                request.force,
+                            )
+                            .await
+                            .map_err(|fallback_error| TopicError::RocketMQ(fallback_error.to_string()))?;
+                        affected_queues += rollback_stats.len();
+                    }
+                    Err(error) => return Err(TopicError::RocketMQ(error.to_string())),
                 }
-                Err(error) if is_consumer_not_online_error(&error) => {
-                    let rollback_stats = managed
-                        .admin
-                        .reset_offset_by_timestamp_old(
-                            None,
-                            consumer_group.clone().into(),
-                            request.topic.clone().into(),
-                            request.reset_time as u64,
-                            request.force,
-                        )
-                        .await
-                        .map_err(|fallback_error| TopicError::RocketMQ(fallback_error.to_string()))?;
-                    affected_queues += rollback_stats.len();
-                }
-                Err(error) => return Err(TopicError::RocketMQ(error.to_string())),
             }
-        }
-        managed.shutdown().await;
 
-        Ok(TopicMutationResult {
-            success: true,
-            message: if skip_accumulate {
-                format!(
-                    "Skipped accumulated messages for {} consumer group(s).",
-                    request.consumer_group_list.len()
-                )
-            } else {
-                format!(
-                    "Reset offsets for {} consumer group(s).",
-                    request.consumer_group_list.len()
-                )
-            },
-            topic_name: Some(request.topic),
-            affected_queues: Some(affected_queues),
-        })
+            Ok(TopicMutationResult {
+                success: true,
+                message: if skip_accumulate {
+                    format!(
+                        "Skipped accumulated messages for {} consumer group(s).",
+                        request.consumer_group_list.len()
+                    )
+                } else {
+                    format!(
+                        "Reset offsets for {} consumer group(s).",
+                        request.consumer_group_list.len()
+                    )
+                },
+                topic_name: Some(request.topic.clone()),
+                affected_queues: Some(affected_queues),
+            })
+        };
+
+        if Self::should_reset_session(&result) {
+            self.reset_admin_session(&mut session_guard, &format!("{operation_name} failed"))
+                .await;
+        }
+        drop(session_guard);
+
+        result
     }
 
     async fn send_topic_message_with_admin(

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.21"
+version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5feec195269515c4722937cd7ffcfe7b4205d18d2e6577b7223ecb159ab00"
+checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
 dependencies = [
  "async-trait",
  "convert_case",
@@ -421,7 +421,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "toml",
- "winnow 0.7.15",
+ "winnow 1.0.0",
  "yaml-rust2",
 ]
 
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 
 [[package]]
 name = "md-5"
@@ -2621,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json_any_key"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c409ca1209f6c4741028b9e1e56d973c868ffaef25ffbaf2471e486c2a74b3"
+checksum = "b82e4b1d3a2cb67817b8c403eac7b98225c2e1c855a13ef9b80b9bac63a06c20"
 dependencies = [
  "serde",
  "serde_json",
@@ -3784,6 +3784,12 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6766

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added async runtime dependency to support background concurrency.

* **Refactor**
  * Centralized and reused admin sessions to reduce per-request connection overhead.
  * Added generation-aware session handling to avoid stale connections.
  * Improved error handling with selective automatic reconnects and one-retry behavior for transient failures.

* **Bug Fixes**
  * Ensured sessions are reset on protocol errors to prevent repeated failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->