### PR TITLE
[ISSUE #6777]🚀Add delete topic by broker functionality with UI integration and error handling

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -99,6 +99,7 @@ pub fn run() {
             topic::commands::get_topic_config,
             topic::commands::create_or_update_topic,
             topic::commands::delete_topic,
+            topic::commands::delete_topic_by_broker,
             topic::commands::get_topic_consumer_groups,
             topic::commands::get_topic_consumers,
             topic::commands::reset_consumer_offset,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/commands.rs
@@ -21,6 +21,7 @@ use crate::topic::types::TopicMutationResult;
 use crate::topic::types::TopicRouteView;
 use crate::topic::types::TopicSendMessageResult;
 use crate::topic::types::TopicStatusView;
+use rocketmq_dashboard_common::DeleteTopicByBrokerRequest;
 use rocketmq_dashboard_common::DeleteTopicRequest;
 use rocketmq_dashboard_common::ResetOffsetRequest;
 use rocketmq_dashboard_common::SendTopicMessageRequest;
@@ -92,6 +93,17 @@ pub async fn delete_topic(
 ) -> Result<TopicMutationResult, String> {
     topic_manager
         .delete_topic(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn delete_topic_by_broker(
+    request: DeleteTopicByBrokerRequest,
+    topic_manager: State<'_, TopicManager>,
+) -> Result<TopicMutationResult, String> {
+    topic_manager
+        .delete_topic_by_broker(request)
         .await
         .map_err(|error| error.to_string())
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -36,13 +36,18 @@ use rocketmq_admin_core::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_client_rust::base::client_config::ClientConfig;
 use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
+use rocketmq_client_rust::producer::local_transaction_state::LocalTransactionState;
 use rocketmq_client_rust::producer::mq_producer::MQProducer;
+use rocketmq_client_rust::producer::transaction_listener::TransactionListener;
+use rocketmq_client_rust::producer::transaction_mq_producer::TransactionMQProducer;
 use rocketmq_common::common::attribute::Attribute;
 use rocketmq_common::common::attribute::topic_attributes::TopicAttributes;
 use rocketmq_common::common::config::TopicConfig as RocketMqTopicConfig;
+use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::topic::TopicValidator;
+use rocketmq_dashboard_common::DeleteTopicByBrokerRequest;
 use rocketmq_dashboard_common::DeleteTopicRequest;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
 use rocketmq_dashboard_common::ResetOffsetRequest;
@@ -57,6 +62,7 @@ use rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use std::any::Any;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -74,6 +80,22 @@ struct TopicBrokerConfigSnapshot {
     broker_name: String,
     cluster_name: Option<String>,
     config: RocketMqTopicConfig,
+}
+
+struct DashboardTransactionListener;
+
+impl TransactionListener for DashboardTransactionListener {
+    fn execute_local_transaction(
+        &self,
+        _msg: &dyn rocketmq_common::common::message::MessageTrait,
+        _arg: Option<&(dyn Any + Send + Sync)>,
+    ) -> LocalTransactionState {
+        LocalTransactionState::CommitMessage
+    }
+
+    fn check_local_transaction(&self, _msg: &MessageExt) -> LocalTransactionState {
+        LocalTransactionState::CommitMessage
+    }
 }
 
 impl TopicManager {
@@ -251,6 +273,30 @@ impl TopicManager {
 
         if Self::should_reset_session(&result) {
             self.reset_admin_session(&mut session_guard, "delete_topic failed")
+                .await;
+        }
+        drop(session_guard);
+
+        result
+    }
+
+    pub(crate) async fn delete_topic_by_broker(
+        &self,
+        request: DeleteTopicByBrokerRequest,
+    ) -> TopicResult<TopicMutationResult> {
+        let mut session_guard = self.admin_session.lock().await;
+        self.ensure_admin_session(&mut session_guard).await?;
+
+        let result = {
+            let session = session_guard
+                .as_mut()
+                .expect("topic admin session should be initialized before use");
+            self.delete_topic_by_broker_with_admin(&mut session.admin, request)
+                .await
+        };
+
+        if Self::should_reset_session(&result) {
+            self.reset_admin_session(&mut session_guard, "delete_topic_by_broker failed")
                 .await;
         }
         drop(session_guard);
@@ -608,6 +654,11 @@ impl TopicManager {
             format!("+{}", TopicAttributes::topic_message_type_attribute().name()).into(),
             normalize_message_type(request.message_type.as_deref()).into(),
         );
+        let attributes_log = attributes
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<_>>()
+            .join(",");
 
         let topic_config = RocketMqTopicConfig {
             topic_name: Some(request.topic_name.clone().into()),
@@ -618,6 +669,23 @@ impl TopicManager {
             attributes,
             ..RocketMqTopicConfig::default()
         };
+
+        let mut sorted_brokers: Vec<String> = target_broker_names.iter().cloned().collect();
+        sorted_brokers.sort();
+        let mut sorted_addrs: Vec<String> = target_addrs.iter().map(|addr| addr.to_string()).collect();
+        sorted_addrs.sort();
+        log::info!(
+            "create_or_update_topic topic=`{}` clusters={:?} brokers={:?} resolved_brokers={:?} resolved_addrs={:?} \
+             order={} message_type={} attributes={}",
+            request.topic_name,
+            request.cluster_name_list,
+            request.broker_name_list,
+            sorted_brokers,
+            sorted_addrs,
+            request.order,
+            normalize_message_type(request.message_type.as_deref()),
+            attributes_log
+        );
 
         for broker_addr in &target_addrs {
             admin
@@ -683,6 +751,50 @@ impl TopicManager {
         Ok(TopicMutationResult {
             success: true,
             message: format!("Topic `{topic}` was deleted from {} cluster(s).", clusters.len()),
+            topic_name: Some(topic),
+            affected_queues: None,
+        })
+    }
+
+    async fn delete_topic_by_broker_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: DeleteTopicByBrokerRequest,
+    ) -> TopicResult<TopicMutationResult> {
+        let topic = request.topic.trim().to_string();
+        if topic.is_empty() {
+            return Err(TopicError::Validation("Topic name is required.".into()));
+        }
+
+        let broker_name = request.broker_name.trim().to_string();
+        if broker_name.is_empty() {
+            return Err(TopicError::Validation("Broker name is required.".into()));
+        }
+
+        let cluster_info = admin
+            .examine_broker_cluster_info()
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+        let broker_addr = find_master_addr_by_broker_name(&cluster_info, &broker_name).ok_or_else(|| {
+            TopicError::Validation(format!(
+                "Broker `{broker_name}` was not found in the current cluster view."
+            ))
+        })?;
+        log::info!(
+            "delete_topic_by_broker topic=`{}` broker=`{}` addr=`{}`",
+            topic,
+            broker_name,
+            broker_addr
+        );
+
+        admin
+            .delete_topic_in_broker(HashSet::from([broker_addr]), topic.clone().into())
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+
+        Ok(TopicMutationResult {
+            success: true,
+            message: format!("Topic `{topic}` was deleted from broker `{broker_name}`."),
             topic_name: Some(topic),
             affected_queues: None,
         })
@@ -841,11 +953,19 @@ impl TopicManager {
                 },
             )
             .await?;
-        if !matches!(topic_config.message_type.as_str(), "NORMAL" | "UNSPECIFIED") {
-            return Err(TopicError::Validation(format!(
-                "Desktop send is currently limited to NORMAL topics. `{}` is `{}`.",
-                request.topic, topic_config.message_type
-            )));
+        log::info!(
+            "send_topic_message topic=`{}` message_type=`{}` trace_enabled={} key_present={} tag_present={}",
+            request.topic,
+            topic_config.message_type,
+            request.trace_enabled,
+            !request.key.trim().is_empty(),
+            !request.tag.trim().is_empty()
+        );
+
+        let normalized_message_body = normalize_topic_message_body(&request.message_body)?;
+
+        if topic_config.message_type == "TRANSACTION" {
+            return send_transaction_message_with_runtime(snapshot.clone(), request, normalized_message_body).await;
         }
 
         let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
@@ -867,40 +987,117 @@ impl TopicManager {
             .await
             .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
 
-        let normalized_message_body = normalize_topic_message_body(&request.message_body)?;
-        let mut builder = Message::builder()
-            .topic(request.topic.clone())
-            .body_slice(normalized_message_body.as_bytes())
-            .trace_switch(request.trace_enabled);
-        if !request.tag.trim().is_empty() {
-            builder = builder.tags(request.tag.clone());
-        }
-        if !request.key.trim().is_empty() {
-            builder = builder.key(request.key.clone());
-        }
-
+        let message = build_send_message(&request, &normalized_message_body);
         let send_result = producer
-            .send_with_timeout(builder.build_unchecked(), 5_000)
+            .send_with_timeout(message, 5_000)
             .await
             .map_err(|error| TopicError::RocketMQ(error.to_string()));
         producer.shutdown().await;
         let send_result = send_result?
             .ok_or_else(|| TopicError::RocketMQ("Broker acknowledged send without returning a result.".into()))?;
 
-        Ok(TopicSendMessageResult {
-            topic: request.topic,
-            send_status: format!("{:?}", send_result.send_status),
-            message_id: send_result.msg_id.map(|message_id| message_id.to_string()),
-            broker_name: send_result
-                .message_queue
-                .as_ref()
-                .map(|queue| queue.broker_name().to_string()),
-            queue_id: send_result.message_queue.as_ref().map(|queue| queue.queue_id()),
-            queue_offset: send_result.queue_offset,
-            transaction_id: send_result.transaction_id,
-            region_id: send_result.region_id,
-        })
+        Ok(map_send_result(request.topic, send_result))
     }
+}
+
+async fn send_transaction_message_with_runtime(
+    snapshot: NameServerConfigSnapshot,
+    request: SendTopicMessageRequest,
+    normalized_message_body: String,
+) -> TopicResult<TopicSendMessageResult> {
+    tokio::task::spawn_blocking(move || -> TopicResult<TopicSendMessageResult> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+
+        runtime.block_on(async move {
+            let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
+                TopicError::Configuration(
+                    "No active NameServer is configured. Add and select a NameServer first.".into(),
+                )
+            })?;
+
+            let mut client_config = ClientConfig::new();
+            client_config.set_namesrv_addr(current_namesrv.into());
+            client_config.set_vip_channel_enabled(snapshot.use_vip_channel);
+            client_config.set_use_tls(snapshot.use_tls);
+
+            let mut producer = TransactionMQProducer::builder()
+                .producer_group(format!("dashboard-topic-tx-sender-{}", Uuid::new_v4()))
+                .client_config(client_config)
+                .transaction_listener(DashboardTransactionListener)
+                .build();
+
+            producer
+                .start()
+                .await
+                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+
+            let message = build_send_message(&request, &normalized_message_body);
+            let tx_result = producer
+                .send_message_in_transaction::<(), _>(message, None)
+                .await
+                .map_err(|error| TopicError::RocketMQ(error.to_string()));
+            producer.shutdown().await;
+            let tx_result = tx_result?;
+
+            map_transaction_send_result(request.topic, tx_result)
+        })
+    })
+    .await
+    .map_err(|error| TopicError::RocketMQ(error.to_string()))?
+}
+
+fn build_send_message(request: &SendTopicMessageRequest, normalized_message_body: &str) -> Message {
+    let mut builder = Message::builder()
+        .topic(request.topic.clone())
+        .body_slice(normalized_message_body.as_bytes())
+        .trace_switch(request.trace_enabled);
+    if !request.tag.trim().is_empty() {
+        builder = builder.tags(request.tag.clone());
+    }
+    if !request.key.trim().is_empty() {
+        builder = builder.key(request.key.clone());
+    }
+    builder.build_unchecked()
+}
+
+fn map_send_result(
+    topic: String,
+    send_result: rocketmq_client_rust::producer::send_result::SendResult,
+) -> TopicSendMessageResult {
+    TopicSendMessageResult {
+        topic,
+        send_status: format!("{:?}", send_result.send_status),
+        message_id: send_result.msg_id.map(|message_id| message_id.to_string()),
+        broker_name: send_result
+            .message_queue
+            .as_ref()
+            .map(|queue| queue.broker_name().to_string()),
+        queue_id: send_result.message_queue.as_ref().map(|queue| queue.queue_id()),
+        queue_offset: send_result.queue_offset,
+        transaction_id: send_result.transaction_id,
+        region_id: send_result.region_id,
+        local_transaction_state: None,
+    }
+}
+
+fn map_transaction_send_result(
+    topic: String,
+    transaction_result: rocketmq_client_rust::producer::transaction_send_result::TransactionSendResult,
+) -> TopicResult<TopicSendMessageResult> {
+    let send_result = transaction_result.send_result.ok_or_else(|| {
+        TopicError::RocketMQ("Transaction producer completed without returning a send result.".into())
+    })?;
+    let mut result = map_send_result(topic, send_result);
+    result.local_transaction_state = transaction_result
+        .local_transaction_state
+        .map(|state| state.to_string());
+    if let Some(local_state) = result.local_transaction_state.as_deref() {
+        result.send_status = format!("{} ({local_state})", result.send_status);
+    }
+    Ok(result)
 }
 
 fn classify_topic(topic: &str, configs: Option<&[TopicBrokerConfigSnapshot]>) -> (String, String, bool) {
@@ -1514,13 +1711,26 @@ fn quote_numeric_object_keys(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::TopicBrokerConfigSnapshot;
+    use super::build_send_message;
     use super::classify_topic;
     use super::cluster_targets_from_cluster_info;
+    use super::find_master_addr_by_broker_name;
     use super::is_reconnect_worthy_error;
+    use super::map_send_result;
+    use super::map_transaction_send_result;
+    use super::master_targets_by_cluster_name;
     use super::normalize_message_type;
     use super::normalize_topic_message_body;
     use super::quote_numeric_object_keys;
+    use cheetah_string::CheetahString;
+    use rocketmq_client_rust::producer::local_transaction_state::LocalTransactionState;
+    use rocketmq_client_rust::producer::send_result::SendResult;
+    use rocketmq_client_rust::producer::send_status::SendStatus;
+    use rocketmq_client_rust::producer::transaction_send_result::TransactionSendResult;
     use rocketmq_common::common::config::TopicConfig as RocketMqTopicConfig;
+    use rocketmq_common::common::message::message_queue::MessageQueue;
+    use rocketmq_common::common::mix_all;
+    use rocketmq_dashboard_common::SendTopicMessageRequest;
     use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
     use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
     use std::collections::HashMap;
@@ -1586,6 +1796,84 @@ mod tests {
     }
 
     #[test]
+    fn find_master_addr_by_broker_name_returns_master_address() {
+        let mut broker_addrs = HashMap::new();
+        broker_addrs.insert(mix_all::MASTER_ID, CheetahString::from("10.0.0.1:10911"));
+
+        let mut broker_addr_table = HashMap::new();
+        broker_addr_table.insert(
+            "broker-a".into(),
+            BrokerData::new("cluster-a".into(), "broker-a".into(), broker_addrs, None),
+        );
+
+        let cluster_info = ClusterInfo::new(Some(broker_addr_table), Some(HashMap::new()));
+
+        assert_eq!(
+            find_master_addr_by_broker_name(&cluster_info, "broker-a"),
+            Some(CheetahString::from("10.0.0.1:10911"))
+        );
+    }
+
+    #[test]
+    fn find_master_addr_by_broker_name_returns_none_for_unknown_broker() {
+        let cluster_info = ClusterInfo::new(Some(HashMap::new()), Some(HashMap::new()));
+
+        assert_eq!(find_master_addr_by_broker_name(&cluster_info, "missing-broker"), None);
+    }
+
+    #[test]
+    fn master_targets_by_cluster_name_returns_sorted_master_targets() {
+        let mut broker_addr_table = HashMap::new();
+
+        let mut broker_b_addrs = HashMap::new();
+        broker_b_addrs.insert(mix_all::MASTER_ID, CheetahString::from("10.0.0.2:10911"));
+        broker_addr_table.insert(
+            "broker-b".into(),
+            BrokerData::new("cluster-a".into(), "broker-b".into(), broker_b_addrs, None),
+        );
+
+        let mut broker_a_addrs = HashMap::new();
+        broker_a_addrs.insert(mix_all::MASTER_ID, CheetahString::from("10.0.0.1:10911"));
+        broker_addr_table.insert(
+            "broker-a".into(),
+            BrokerData::new("cluster-a".into(), "broker-a".into(), broker_a_addrs, None),
+        );
+
+        let cluster_addr_table = HashMap::from([(
+            CheetahString::from("cluster-a"),
+            HashSet::from_iter([CheetahString::from("broker-b"), CheetahString::from("broker-a")]),
+        )]);
+        let cluster_info = ClusterInfo::new(Some(broker_addr_table), Some(cluster_addr_table));
+
+        let targets = master_targets_by_cluster_name(&cluster_info, "cluster-a").expect("cluster targets");
+
+        assert_eq!(
+            targets,
+            vec![
+                ("broker-a".to_string(), CheetahString::from("10.0.0.1:10911")),
+                ("broker-b".to_string(), CheetahString::from("10.0.0.2:10911")),
+            ]
+        );
+    }
+
+    #[test]
+    fn master_targets_by_cluster_name_skips_brokers_without_master_addr() {
+        let broker_addr_table = HashMap::from([(
+            CheetahString::from("broker-a"),
+            BrokerData::new("cluster-a".into(), "broker-a".into(), HashMap::new(), None),
+        )]);
+        let cluster_addr_table = HashMap::from([(
+            CheetahString::from("cluster-a"),
+            HashSet::from_iter([CheetahString::from("broker-a")]),
+        )]);
+        let cluster_info = ClusterInfo::new(Some(broker_addr_table), Some(cluster_addr_table));
+
+        let targets = master_targets_by_cluster_name(&cluster_info, "cluster-a").expect("cluster targets");
+
+        assert!(targets.is_empty());
+    }
+
+    #[test]
     fn reconnect_error_detection_only_matches_transport_failures() {
         assert!(is_reconnect_worthy_error("connection refused by broker"));
         assert!(is_reconnect_worthy_error("request timeout while talking to namesrv"));
@@ -1622,6 +1910,89 @@ mod tests {
         assert_eq!(
             normalize_topic_message_body("plain text body").unwrap(),
             "plain text body"
+        );
+    }
+
+    #[test]
+    fn build_send_message_carries_key_tag_and_trace_switch() {
+        let request = SendTopicMessageRequest {
+            topic: "TopicTest".to_string(),
+            key: "order-1".to_string(),
+            tag: "TagA".to_string(),
+            message_body: "payload".to_string(),
+            trace_enabled: true,
+        };
+
+        let message = build_send_message(&request, "payload");
+
+        assert_eq!(message.topic().to_string(), "TopicTest");
+        assert_eq!(message.tags(), Some("TagA"));
+        assert_eq!(message.keys(), Some(vec!["order-1".to_string()]));
+        assert!(message.properties().trace_switch());
+    }
+
+    #[test]
+    fn map_send_result_preserves_queue_and_transaction_metadata() {
+        let mut queue = MessageQueue::new();
+        queue.set_topic("TopicTest".into());
+        queue.set_broker_name("broker-a".into());
+        queue.set_queue_id(3);
+
+        let result = map_send_result(
+            "TopicTest".to_string(),
+            SendResult::new_with_additional_fields(
+                SendStatus::SendOk,
+                Some(CheetahString::from("msg-1")),
+                Some(queue),
+                42,
+                Some("tx-1".to_string()),
+                None,
+                Some("region-a".to_string()),
+            ),
+        );
+
+        assert_eq!(result.topic, "TopicTest");
+        assert_eq!(result.send_status, "SendOk");
+        assert_eq!(result.message_id.as_deref(), Some("msg-1"));
+        assert_eq!(result.broker_name.as_deref(), Some("broker-a"));
+        assert_eq!(result.queue_id, Some(3));
+        assert_eq!(result.queue_offset, 42);
+        assert_eq!(result.transaction_id.as_deref(), Some("tx-1"));
+        assert_eq!(result.region_id.as_deref(), Some("region-a"));
+        assert_eq!(result.local_transaction_state, None);
+    }
+
+    #[test]
+    fn map_transaction_send_result_includes_local_transaction_state() {
+        let result = map_transaction_send_result(
+            "TopicTest".to_string(),
+            TransactionSendResult {
+                local_transaction_state: Some(LocalTransactionState::CommitMessage),
+                send_result: Some(SendResult::default()),
+            },
+        )
+        .expect("transaction send result should map");
+
+        assert_eq!(result.topic, "TopicTest");
+        assert_eq!(result.send_status, "SendOk (COMMIT_MESSAGE)");
+        assert_eq!(result.local_transaction_state.as_deref(), Some("COMMIT_MESSAGE"));
+    }
+
+    #[test]
+    fn map_transaction_send_result_requires_nested_send_result() {
+        let error = map_transaction_send_result(
+            "TopicTest".to_string(),
+            TransactionSendResult {
+                local_transaction_state: Some(LocalTransactionState::CommitMessage),
+                send_result: None,
+            },
+        )
+        .expect_err("missing send result should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Transaction producer completed without returning a send result.")
         );
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/types.rs
@@ -182,4 +182,5 @@ pub(crate) struct TopicSendMessageResult {
     pub(crate) queue_offset: u64,
     pub(crate) transaction_id: Option<String>,
     pub(crate) region_id: Option<String>,
+    pub(crate) local_transaction_state: Option<String>,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/TopicView.tsx
@@ -348,240 +348,6 @@ const TopicRouterModal = ({isOpen, onClose, topic}: TopicRouterModalProps) => {
     );
 };
 
-const LegacyTopicConfigModal = ({isOpen, onClose, topic}: TopicRouterModalProps) => {
-    const [selectedBrokers, setSelectedBrokers] = useState(['mxsm']);
-    const [isBrokerDropdownOpen, setIsBrokerDropdownOpen] = useState(false);
-    // Mock broker data
-    const brokers = ['mxsm', 'broker-a', 'broker-b', 'broker-c'];
-
-    const toggleBroker = (broker: string) => {
-        if (selectedBrokers.includes(broker)) {
-            setSelectedBrokers(selectedBrokers.filter(b => b !== broker));
-        } else {
-            setSelectedBrokers([...selectedBrokers, broker]);
-        }
-    };
-
-    if (!isOpen) return null;
-
-    return (
-        <AnimatePresence>
-            <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-                <motion.div
-                    initial={{opacity: 0}}
-                    animate={{opacity: 0.3}}
-                    exit={{opacity: 0}}
-                    onClick={onClose}
-                    className="absolute inset-0 bg-black"
-                />
-                <motion.div
-                    initial={{opacity: 0, scale: 0.95, y: 10}}
-                    animate={{opacity: 1, scale: 1, y: 0}}
-                    exit={{opacity: 0, scale: 0.95, y: 10}}
-                    className="relative w-full max-w-2xl bg-white dark:bg-gray-900 rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh] border border-gray-100 dark:border-gray-800"
-                >
-                    {/* Header */}
-                    <div className="px-6 py-5 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between bg-white dark:bg-gray-900 z-10">
-                        <div>
-                            <h3 className="text-xl font-bold text-gray-800 dark:text-white flex items-center">
-                                <Settings className="w-5 h-5 mr-2 text-blue-500"/>
-                                Topic Configuration
-                            </h3>
-                            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                                Manage settings for <span className="font-mono text-gray-700 dark:text-gray-300 font-medium">{topic?.name || 'undefined'}</span>
-                            </p>
-                        </div>
-                        <button
-                            onClick={onClose}
-                            className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
-                        >
-                            <X className="w-5 h-5"/>
-                        </button>
-                    </div>
-
-                    {/* Content - Scrollable */}
-                    <div className="p-6 overflow-y-auto bg-gray-50/50 dark:bg-gray-950/50 space-y-6" onClick={() => setIsBrokerDropdownOpen(false)}>
-
-                        {/* Card 1: Deployment Target */}
-                        <div className="bg-white dark:bg-gray-900 p-5 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm">
-                            <h4 className="text-sm font-bold text-gray-900 dark:text-white mb-4 flex items-center uppercase tracking-wider">
-                                <Server className="w-4 h-4 mr-2 text-gray-400 dark:text-gray-500"/> Deployment Target
-                            </h4>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-                                <div>
-                                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1.5">Cluster Name</label>
-                                    <div className="relative">
-                                        <select
-                                            className="w-full px-3 py-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all appearance-none cursor-pointer hover:bg-white dark:hover:bg-gray-750 hover:shadow-sm">
-                                            <option>DefaultCluster</option>
-                                        </select>
-                                        <ChevronDown className="absolute right-3 top-3 w-4 h-4 text-gray-400 dark:text-gray-500 pointer-events-none"/>
-                                    </div>
-                                </div>
-                                <div className="relative">
-                                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1.5">Broker Name (Multi-select)</label>
-                                    <div
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            setIsBrokerDropdownOpen(!isBrokerDropdownOpen);
-                                        }}
-                                        className="w-full min-h-[42px] px-3 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-700 dark:text-gray-200 cursor-pointer hover:border-blue-500 dark:hover:border-blue-500 hover:shadow-sm flex flex-wrap gap-1.5 items-center transition-all relative"
-                                    >
-                                        {selectedBrokers.length === 0 ? (
-                                            <span className="text-gray-400 dark:text-gray-500">Select brokers...</span>
-                                        ) : (
-                                            selectedBrokers.map(b => (
-                                                <span key={b}
-                                                      className="bg-blue-50 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded text-xs border border-blue-100 dark:border-blue-800 flex items-center font-medium">
-                               {b}
-                                                    <X
-                                                        className="w-3 h-3 ml-1 hover:text-blue-900 dark:hover:text-blue-100 cursor-pointer"
-                                                        onClick={(e) => {
-                                                            e.stopPropagation();
-                                                            toggleBroker(b);
-                                                        }}
-                                                    />
-                             </span>
-                                            ))
-                                        )}
-                                        <ChevronDown
-                                            className={`absolute right-3 top-3 w-4 h-4 text-gray-400 dark:text-gray-500 pointer-events-none transition-transform duration-200 ${isBrokerDropdownOpen ? 'rotate-180' : ''}`}/>
-                                    </div>
-
-                                    {/* Dropdown Menu */}
-                                    <AnimatePresence>
-                                        {isBrokerDropdownOpen && (
-                                            <motion.div
-                                                initial={{opacity: 0, y: 5}}
-                                                animate={{opacity: 1, y: 0}}
-                                                exit={{opacity: 0, y: 5}}
-                                                className="absolute z-20 top-full left-0 right-0 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-xl max-h-48 overflow-y-auto"
-                                                onClick={(e) => e.stopPropagation()}
-                                            >
-                                                {brokers.map(broker => (
-                                                    <div
-                                                        key={broker}
-                                                        onClick={() => toggleBroker(broker)}
-                                                        className="px-3 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer flex items-center space-x-3 border-b border-gray-50 dark:border-gray-700 last:border-0"
-                                                    >
-                                                        <div
-                                                            className={`w-4 h-4 border rounded flex items-center justify-center transition-colors ${selectedBrokers.includes(broker) ? 'bg-blue-600 border-blue-600 dark:bg-blue-500 dark:border-blue-500' : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900'}`}>
-                                                            {selectedBrokers.includes(broker) && <Check className="w-3 h-3 text-white"/>}
-                                                        </div>
-                                                        <span
-                                                            className={`text-sm ${selectedBrokers.includes(broker) ? 'text-gray-900 dark:text-white font-medium' : 'text-gray-600 dark:text-gray-300'}`}>
-                                {broker}
-                              </span>
-                                                    </div>
-                                                ))}
-                                            </motion.div>
-                                        )}
-                                    </AnimatePresence>
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Card 2: Topic Definition */}
-                        <div className="bg-white dark:bg-gray-900 p-5 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm">
-                            <h4 className="text-sm font-bold text-gray-900 dark:text-white mb-4 flex items-center uppercase tracking-wider">
-                                <FileText className="w-4 h-4 mr-2 text-gray-400 dark:text-gray-500"/> Topic Definition
-                            </h4>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-                                <div className="md:col-span-2">
-                                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1.5">
-                                        Topic Name <span className="text-red-500">*</span>
-                                    </label>
-                                    <input
-                                        type="text"
-                                        value={topic?.name || 'TopicTest'}
-                                        readOnly
-                                        className="w-full px-3 py-2.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-500 dark:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all font-mono"
-                                    />
-                                </div>
-                                <div className="md:col-span-2">
-                                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1.5">Message Type</label>
-                                    <div className="relative">
-                                        <select
-                                            className="w-full px-3 py-2.5 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all appearance-none cursor-pointer shadow-sm">
-                                            <option>UNSPECIFIED</option>
-                                            <option>NORMAL</option>
-                                            <option>FIFO</option>
-                                            <option>DELAY</option>
-                                            <option>TRANSACTION</option>
-                                        </select>
-                                        <ChevronDown className="absolute right-3 top-3 w-4 h-4 text-gray-400 dark:text-gray-500 pointer-events-none"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Card 3: Queue Configuration */}
-                        <div className="bg-white dark:bg-gray-900 p-5 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm">
-                            <h4 className="text-sm font-bold text-gray-900 dark:text-white mb-4 flex items-center uppercase tracking-wider">
-                                <Database className="w-4 h-4 mr-2 text-gray-400 dark:text-gray-500"/> Queue Configuration
-                            </h4>
-                            <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
-                                <div>
-                                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1.5">
-                                        Write Queues <span className="text-red-500">*</span>
-                                    </label>
-                                    <input
-                                        type="number"
-                                        defaultValue={4}
-                                        className="w-full px-3 py-2.5 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all shadow-sm"
-                                    />
-                                </div>
-                                <div>
-                                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1.5">
-                                        Read Queues <span className="text-red-500">*</span>
-                                    </label>
-                                    <input
-                                        type="number"
-                                        defaultValue={4}
-                                        className="w-full px-3 py-2.5 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all shadow-sm"
-                                    />
-                                </div>
-                                <div>
-                                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1.5">
-                                        Permission (Perm) <span className="text-red-500">*</span>
-                                    </label>
-                                    <input
-                                        type="number"
-                                        defaultValue={6}
-                                        className="w-full px-3 py-2.5 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all shadow-sm"
-                                    />
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-
-                    {/* Footer */}
-                    <div className="px-6 py-4 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex justify-end space-x-3 z-10">
-                        <button
-                            onClick={onClose}
-                            className="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shadow-sm"
-                        >
-                            Cancel
-                        </button>
-                        <button
-                            onClick={() => {
-                                toast.success(`Topic changes committed for ${selectedBrokers.length} brokers`);
-                                onClose();
-                            }}
-                            className="px-6 py-2 bg-gray-900 text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-all shadow-md hover:shadow-lg flex items-center dark:!bg-gray-900 dark:!text-white dark:border dark:border-gray-700 dark:hover:!bg-gray-800"
-                        >
-                            <Save className="w-4 h-4 mr-2"/>
-                            Commit Changes
-                        </button>
-                    </div>
-
-                </motion.div>
-            </div>
-        </AnimatePresence>
-    );
-};
-
 const TOPIC_CONFIG_FIELD_LABELS: Record<string, string> = {
     readQueueNums: 'Read Queues',
     writeQueueNums: 'Write Queues',
@@ -599,13 +365,16 @@ const formatAttributeLabel = (key: string) =>
 
 interface TopicConfigModalProps extends TopicRouterModalProps {
     onEdit: (seed: TopicEditorSeed) => void;
+    onRefresh: () => Promise<void>;
 }
 
-const TopicConfigModal = ({isOpen, onClose, topic, onEdit}: TopicConfigModalProps) => {
+const TopicConfigModal = ({isOpen, onClose, topic, onEdit, onRefresh}: TopicConfigModalProps) => {
     const [configData, setConfigData] = useState<TopicConfigView | null>(null);
     const [selectedBroker, setSelectedBroker] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
+    const [actionError, setActionError] = useState('');
+    const [isDeletingBroker, setIsDeletingBroker] = useState(false);
 
     useEffect(() => {
         if (!isOpen || !topic?.name) {
@@ -652,6 +421,8 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit}: TopicConfigModalProp
         setSelectedBroker(null);
         setConfigData(null);
         setError('');
+        setActionError('');
+        setIsDeletingBroker(false);
     }, [isOpen, topic?.name]);
 
     if (!isOpen) return null;
@@ -661,6 +432,36 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit}: TopicConfigModalProp
     const attributes = Object.entries(configData?.attributes ?? {}).sort(([left], [right]) => left.localeCompare(right));
     const inconsistentFields = configData?.inconsistentFields ?? [];
     const activeBroker = selectedBroker ?? configData?.brokerName ?? '';
+
+    const handleDeleteByBroker = async () => {
+        if (!configData || !activeBroker) {
+            return;
+        }
+
+        const confirmed = window.confirm(
+            `Delete topic "${configData.topicName}" from broker "${activeBroker}" only? This will not remove the NameServer topic mapping.`,
+        );
+        if (!confirmed) {
+            return;
+        }
+
+        setIsDeletingBroker(true);
+        setActionError('');
+
+        try {
+            const result = await TopicService.deleteTopicByBroker({
+                brokerName: activeBroker,
+                topic: configData.topicName,
+            });
+            toast.success(result.message || `Deleted ${configData.topicName} from ${activeBroker}`);
+            await onRefresh();
+            onClose();
+        } catch (deleteError) {
+            setActionError(getErrorMessage(deleteError, 'Failed to delete topic from the selected broker.'));
+        } finally {
+            setIsDeletingBroker(false);
+        }
+    };
 
     return (
         <AnimatePresence>
@@ -892,6 +693,12 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit}: TopicConfigModalProp
                                         </div>
                                     )}
                                 </div>
+
+                                {actionError && (
+                                    <div className="rounded-xl border border-red-200 bg-red-50/80 px-5 py-4 text-sm text-red-600 shadow-sm dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+                                        {actionError}
+                                    </div>
+                                )}
                             </>
                         )}
                     </div>
@@ -902,6 +709,14 @@ const TopicConfigModal = ({isOpen, onClose, topic, onEdit}: TopicConfigModalProp
                             className="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shadow-sm"
                         >
                             Close
+                        </button>
+                        <button
+                            onClick={() => void handleDeleteByBroker()}
+                            disabled={!configData || isLoading || isDeletingBroker || !activeBroker}
+                            className="px-6 py-2 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-500 transition-all shadow-md hover:shadow-lg flex items-center disabled:cursor-not-allowed disabled:opacity-50 dark:bg-red-600 dark:text-white dark:hover:bg-red-500"
+                        >
+                            <Trash2 className="w-4 h-4 mr-2"/>
+                            {isDeletingBroker ? 'Deleting...' : 'Delete This Broker'}
                         </button>
                         <button
                             onClick={() => {
@@ -1375,11 +1190,13 @@ const TopicSendMessageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) 
     const [messageBody, setMessageBody] = useState('');
     const [traceEnabled, setTraceEnabled] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isLoadingConfig, setIsLoadingConfig] = useState(false);
     const [error, setError] = useState('');
     const [sendResult, setSendResult] = useState<TopicSendMessageResult | null>(null);
+    const [topicMessageType, setTopicMessageType] = useState('UNSPECIFIED');
 
     useEffect(() => {
-        if (!isOpen) {
+        if (!isOpen || !topic?.name) {
             return;
         }
 
@@ -1390,6 +1207,36 @@ const TopicSendMessageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) 
         setIsSubmitting(false);
         setError('');
         setSendResult(null);
+        setIsLoadingConfig(true);
+        setTopicMessageType('UNSPECIFIED');
+
+        let cancelled = false;
+
+        const loadTopicConfig = async () => {
+            try {
+                const result = await TopicService.getTopicConfig({
+                    topic: topic.name,
+                    brokerName: null,
+                });
+                if (!cancelled) {
+                    setTopicMessageType(result.messageType || 'UNSPECIFIED');
+                }
+            } catch (loadError) {
+                if (!cancelled) {
+                    setError(getErrorMessage(loadError, 'Failed to load topic configuration before sending.'));
+                }
+            } finally {
+                if (!cancelled) {
+                    setIsLoadingConfig(false);
+                }
+            }
+        };
+
+        void loadTopicConfig();
+
+        return () => {
+            cancelled = true;
+        };
     }, [isOpen, topic?.name]);
 
     const handleSubmit = async () => {
@@ -1477,6 +1324,19 @@ const TopicSendMessageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) 
                                 />
                             </div>
 
+                            <div className="grid grid-cols-[120px_1fr] items-center gap-4">
+                                <label className="flex items-center justify-end gap-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+                                    <Layers className="w-4 h-4 text-gray-400 dark:text-gray-500"/>
+                                    Message Type:
+                                </label>
+                                <input
+                                    type="text"
+                                    value={isLoadingConfig ? 'Loading...' : topicMessageType}
+                                    disabled
+                                    className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-500 dark:text-gray-400 cursor-not-allowed font-mono"
+                                />
+                            </div>
+
                             {/* Tag */}
                             <div className="grid grid-cols-[120px_1fr] items-center gap-4">
                                 <label className="flex items-center justify-end gap-2 text-sm font-medium text-gray-600 dark:text-gray-400">
@@ -1526,6 +1386,11 @@ const TopicSendMessageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) 
                             <div className="col-start-2 rounded-lg border border-blue-100 bg-blue-50/80 px-3 py-2 text-xs text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/30 dark:text-blue-300">
                                 Standard JSON and relaxed JSON are both supported here. Numeric keys like <span className="font-mono">{`{ 1: 'value' }`}</span> will be normalized before sending.
                             </div>
+                            <div className="col-start-2 rounded-lg border border-gray-200 bg-gray-50/90 px-3 py-2 text-xs text-gray-600 dark:border-gray-800 dark:bg-gray-800/80 dark:text-gray-300">
+                                {topicMessageType === 'TRANSACTION'
+                                    ? 'This topic uses TRANSACTION semantics. The desktop sender will use a transaction producer and commit the local transaction immediately, matching the Java dashboard test-send flow.'
+                                    : `This topic will be sent through the standard producer path for ${topicMessageType}.`}
+                            </div>
 
                             {/* Enable Message Trace */}
                             <div className="grid grid-cols-[120px_1fr] items-center gap-4 pt-1">
@@ -1562,6 +1427,16 @@ const TopicSendMessageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) 
                                     <div className="mt-1 font-mono text-xs break-all">
                                         {sendResult.messageId ? `Message ID: ${sendResult.messageId}` : 'Broker accepted the message without returning a message id.'}
                                     </div>
+                                    {sendResult.localTransactionState && (
+                                        <div className="mt-1 text-xs">
+                                            Local transaction: {sendResult.localTransactionState}
+                                        </div>
+                                    )}
+                                    {sendResult.transactionId && (
+                                        <div className="mt-1 font-mono text-xs break-all">
+                                            Transaction ID: {sendResult.transactionId}
+                                        </div>
+                                    )}
                                     <div className="mt-1 text-xs">
                                         Queue: {sendResult.brokerName ?? '-'} / {sendResult.queueId ?? '-'} / offset {sendResult.queueOffset}
                                     </div>
@@ -1580,11 +1455,11 @@ const TopicSendMessageModal = ({isOpen, onClose, topic}: TopicRouterModalProps) 
                         </button>
                         <button
                             onClick={() => void handleSubmit()}
-                            disabled={isSubmitting}
+                            disabled={isSubmitting || isLoadingConfig}
                             className="px-6 py-2 bg-gray-900 text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-all shadow-md hover:shadow-lg flex items-center dark:!bg-gray-900 dark:!text-white dark:border dark:border-gray-700 dark:hover:!bg-gray-800"
                         >
                             <Send className="w-4 h-4 mr-2"/>
-                            {isSubmitting ? 'Sending...' : 'Commit'}
+                            {isLoadingConfig ? 'Preparing...' : isSubmitting ? 'Sending...' : 'Commit'}
                         </button>
                     </div>
                 </motion.div>
@@ -2496,7 +2371,7 @@ const TopicDeleteModal = ({isOpen, onClose, topic, onDeleted}: TopicDeleteModalP
 };
 
 export const TopicView = () => {
-    const {data, error, isLoading, isRefreshing, refresh} = useTopicCatalog();
+    const {data, error, isLoading, isRefreshPending, isRefreshing, refresh} = useTopicCatalog();
     const [searchTerm, setSearchTerm] = useState('');
     const [selectedFilters, setSelectedFilters] = useState<Record<TopicCategory, boolean>>(buildDefaultTopicFilters);
     const [currentPage, setCurrentPage] = useState(1);
@@ -2645,6 +2520,7 @@ export const TopicView = () => {
                 isOpen={configModal.isOpen}
                 onClose={() => setConfigModal({isOpen: false, topic: null})}
                 topic={configModal.topic}
+                onRefresh={refresh}
                 onEdit={(seed) => {
                     setConfigModal({isOpen: false, topic: null});
                     setEditorModal({isOpen: true, mode: 'update', seed});
@@ -2712,8 +2588,9 @@ export const TopicView = () => {
                         <Button
                             variant="secondary"
                             icon={RefreshCw}
+                            iconClassName={isRefreshPending ? 'rotate-180' : 'rotate-0'}
                             onClick={() => void refresh()}
-                            disabled={isRefreshing || isLoading}
+                            disabled={isRefreshPending || isLoading}
                             className="dark:bg-gray-900 dark:text-white dark:border dark:border-gray-700 dark:hover:bg-gray-800"
                         >
                             {isRefreshing ? 'Refreshing...' : 'Refresh'}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ui/LegacyButton.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ui/LegacyButton.tsx
@@ -6,11 +6,20 @@ interface ButtonProps {
     variant?: 'primary' | 'secondary' | 'ghost' | 'accent' | 'danger' | 'outline';
     onClick?: () => void;
     icon?: React.ElementType;
+    iconClassName?: string;
     className?: string;
     disabled?: boolean;
 }
 
-export const Button = ({children, variant = 'primary', onClick, icon: Icon, className = "", disabled}: ButtonProps) => {
+export const Button = ({
+    children,
+    variant = 'primary',
+    onClick,
+    icon: Icon,
+    iconClassName = "",
+    className = "",
+    disabled
+}: ButtonProps) => {
     const baseStyle = "inline-flex items-center justify-center px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-1 dark:focus:ring-offset-gray-900 disabled:opacity-50 disabled:cursor-not-allowed";
 
     const variants = {
@@ -29,7 +38,7 @@ export const Button = ({children, variant = 'primary', onClick, icon: Icon, clas
             disabled={disabled}
             className={`${baseStyle} ${variants[variant]} ${className}`}
         >
-            {Icon && <Icon className="w-4 h-4 mr-2"/>}
+            {Icon && <Icon className={`w-4 h-4 mr-2 transition-transform duration-300 ${iconClassName}`}/>}
             {children}
         </motion.button>
     );

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/hooks/useTopicCatalog.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/hooks/useTopicCatalog.ts
@@ -7,17 +7,24 @@ const defaultListRequest = {
     skipRetryAndDlq: false,
 };
 
+const REFRESH_INDICATOR_DELAY_MS = 180;
+
 export const useTopicCatalog = () => {
     const [data, setData] = useState<TopicListResponse | null>(null);
     const [isLoading, setIsLoading] = useState(true);
+    const [isRefreshPending, setIsRefreshPending] = useState(false);
     const [isRefreshing, setIsRefreshing] = useState(false);
     const [error, setError] = useState('');
 
     const load = async (mode: 'initial' | 'refresh' = 'refresh') => {
+        let refreshIndicatorTimer: number | null = null;
         if (mode === 'initial') {
             setIsLoading(true);
         } else {
-            setIsRefreshing(true);
+            setIsRefreshPending(true);
+            refreshIndicatorTimer = window.setTimeout(() => {
+                setIsRefreshing(true);
+            }, REFRESH_INDICATOR_DELAY_MS);
         }
         setError('');
 
@@ -27,7 +34,11 @@ export const useTopicCatalog = () => {
         } catch (loadError) {
             setError(loadError instanceof Error ? loadError.message : 'Failed to load topics');
         } finally {
+            if (refreshIndicatorTimer !== null) {
+                window.clearTimeout(refreshIndicatorTimer);
+            }
             setIsLoading(false);
+            setIsRefreshPending(false);
             setIsRefreshing(false);
         }
     };
@@ -39,6 +50,7 @@ export const useTopicCatalog = () => {
     return {
         data,
         isLoading,
+        isRefreshPending,
         isRefreshing,
         error,
         refresh: () => load('refresh'),

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/types/topic.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/topic/types/topic.types.ts
@@ -124,6 +124,7 @@ export interface TopicSendMessageResult {
     queueOffset: number;
     transactionId?: string | null;
     regionId?: string | null;
+    localTransactionState?: string | null;
 }
 
 export interface TopicListRequest {
@@ -154,6 +155,11 @@ export interface TopicConfigRequest {
 export interface DeleteTopicRequest {
     topic: string;
     clusterName?: string | null;
+}
+
+export interface DeleteTopicByBrokerRequest {
+    brokerName: string;
+    topic: string;
 }
 
 export interface ResetOffsetRequest {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/topic.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/topic.service.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import type {
+    DeleteTopicByBrokerRequest,
     DeleteTopicRequest,
     ResetOffsetRequest,
     SendTopicMessageRequest,
@@ -40,6 +41,10 @@ export class TopicService {
 
     static async deleteTopic(request: DeleteTopicRequest): Promise<TopicMutationResult> {
         return invoke<TopicMutationResult>('delete_topic', { request });
+    }
+
+    static async deleteTopicByBroker(request: DeleteTopicByBrokerRequest): Promise<TopicMutationResult> {
+        return invoke<TopicMutationResult>('delete_topic_by_broker', { request });
     }
 
     static async getTopicConsumerGroups(request: TopicQueryRequest): Promise<TopicConsumerGroupListResponse> {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6777

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delete topics scoped to specific brokers with confirmation dialog.
  * Display local transaction state in message send results.
  * Auto-load topic configuration when opening send message modal.

* **Improvements**
  * Enhanced transaction message sending flow.
  * Better visual feedback for refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->