### PR TITLE
[ISSUE #6411]🚀Implement QueryMsgByOffset Command for Offset-Based Message Lookup

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -485,6 +485,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Message",
+                command: "queryMsgByOffset",
+                remark: "Query Message by offset.",
+            },
+            Command {
+                category: "Message",
                 command: "sendMessage",
                 remark: "Send a message.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message.rs
@@ -19,6 +19,7 @@ pub mod print_message_sub_command;
 pub mod print_msg_by_queue_sub_command;
 pub mod query_msg_by_id_sub_command;
 pub mod query_msg_by_key_sub_command;
+pub mod query_msg_by_offset_sub_command;
 pub mod send_message_sub_command;
 
 use std::sync::Arc;
@@ -34,6 +35,7 @@ use crate::commands::message::print_message_sub_command::PrintMessageSubCommand;
 use crate::commands::message::print_msg_by_queue_sub_command::PrintMsgByQueueSubCommand;
 use crate::commands::message::query_msg_by_id_sub_command::QueryMsgByIdSubCommand;
 use crate::commands::message::query_msg_by_key_sub_command::QueryMsgByKeySubCommand;
+use crate::commands::message::query_msg_by_offset_sub_command::QueryMsgByOffsetSubCommand;
 use crate::commands::message::send_message_sub_command::SendMessageSubCommand;
 use crate::commands::CommandExecute;
 
@@ -88,6 +90,13 @@ pub enum MessageCommands {
     QueryMsgByKey(QueryMsgByKeySubCommand),
 
     #[command(
+        name = "queryMsgByOffset",
+        about = "Query Message by offset.",
+        long_about = None,
+    )]
+    QueryMsgByOffset(QueryMsgByOffsetSubCommand),
+
+    #[command(
         name = "sendMessage",
         about = "Send a message.",
         long_about = None,
@@ -105,6 +114,7 @@ impl CommandExecute for MessageCommands {
             MessageCommands::PrintMsgByQueue(value) => value.execute(rpc_hook).await,
             MessageCommands::QueryMsgById(value) => value.execute(rpc_hook).await,
             MessageCommands::QueryMsgByKey(value) => value.execute(rpc_hook).await,
+            MessageCommands::QueryMsgByOffset(value) => value.execute(rpc_hook).await,
             MessageCommands::SendMessage(value) => value.execute(rpc_hook).await,
         }
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message/query_msg_by_offset_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message/query_msg_by_offset_sub_command.rs
@@ -1,0 +1,172 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_client_rust::consumer::pull_status::PullStatus;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_common::common::message::message_queue::MessageQueue;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+const PULL_TIMEOUT_MILLIS: u64 = 3000;
+
+#[derive(Debug, Clone, Parser)]
+pub struct QueryMsgByOffsetSubCommand {
+    #[arg(short = 't', long = "topic", required = true, help = "Topic name")]
+    topic: String,
+
+    #[arg(short = 'b', long = "brokerName", required = true, help = "Broker name")]
+    broker_name: String,
+
+    #[arg(short = 'i', long = "queueId", required = true, help = "Queue Id")]
+    queue_id: i32,
+
+    #[arg(short = 'o', long = "offset", required = true, help = "Queue Offset")]
+    offset: i64,
+
+    #[arg(
+        short = 'f',
+        long = "bodyFormat",
+        required = false,
+        help = "print message body by the specified format"
+    )]
+    body_format: Option<String>,
+
+    #[arg(
+        short = 'r',
+        long = "routeTopic",
+        required = false,
+        help = "the topic which is used to find route info"
+    )]
+    route_topic: Option<String>,
+}
+
+impl CommandExecute for QueryMsgByOffsetSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext)
+                .await
+                .map_err(|e| RocketMQError::Internal(format!("Failed to start MQAdminExt: {}", e)))?;
+
+            let topic = self.topic.trim();
+            let broker_name = self.broker_name.trim();
+            let queue_id = self.queue_id;
+            let requested_offset = self.offset;
+            let route_topic = self.route_topic.as_deref().map(str::trim).unwrap_or(topic);
+
+            let topic_route = default_mqadmin_ext
+                .examine_topic_route_info(CheetahString::from(route_topic))
+                .await
+                .map_err(|e| RocketMQError::Internal(format!("Failed to get topic route info: {}", e)))?
+                .ok_or_else(|| RocketMQError::Internal(format!("Topic route not found for: {}", route_topic)))?;
+
+            let broker_data = topic_route
+                .broker_datas
+                .iter()
+                .find(|bd| bd.broker_name().as_str() == broker_name)
+                .ok_or_else(|| {
+                    RocketMQError::IllegalArgument(format!(
+                        "Broker '{}' not found in topic route for '{}'",
+                        broker_name, route_topic
+                    ))
+                })?;
+
+            let broker_addr = broker_data
+                .select_broker_addr()
+                .ok_or_else(|| RocketMQError::Internal(format!("No available address for broker '{}'", broker_name)))?;
+
+            if route_topic != topic {
+                let route_mq = MessageQueue::from_parts(route_topic, broker_name, 0);
+                default_mqadmin_ext
+                    .pull_message_from_queue(broker_addr.as_str(), &route_mq, "*", 0, 1, PULL_TIMEOUT_MILLIS)
+                    .await
+                    .map_err(|e| RocketMQError::Internal(format!("Failed to warm up route topic pull: {}", e)))?;
+            }
+
+            let mq = MessageQueue::from_parts(topic, broker_name, queue_id);
+
+            let pull_result = default_mqadmin_ext
+                .pull_message_from_queue(broker_addr.as_str(), &mq, "*", requested_offset, 1, PULL_TIMEOUT_MILLIS)
+                .await
+                .map_err(|e| RocketMQError::Internal(format!("Failed to pull message by offset: {}", e)))?;
+
+            match pull_result.pull_status() {
+                PullStatus::Found => {
+                    if let Some(msg_list) = pull_result.msg_found_list() {
+                        if let Some(first_msg) = msg_list.first() {
+                            let msg: &MessageExt = first_msg;
+                            let body_format = self.body_format.as_deref().map(str::trim).unwrap_or("UTF-8");
+                            let body = match msg.body() {
+                                Some(bytes) => {
+                                    if body_format.eq_ignore_ascii_case("UTF-8")
+                                        || body_format.eq_ignore_ascii_case("UTF8")
+                                    {
+                                        String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| "BINARY".to_string())
+                                    } else if body_format.eq_ignore_ascii_case("ISO-8859-1")
+                                        || body_format.eq_ignore_ascii_case("LATIN1")
+                                        || body_format.eq_ignore_ascii_case("LATIN-1")
+                                    {
+                                        bytes.iter().map(|&b| b as char).collect()
+                                    } else if body_format.eq_ignore_ascii_case("ASCII") {
+                                        if bytes.is_ascii() {
+                                            String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| "BINARY".to_string())
+                                        } else {
+                                            return Err(RocketMQError::IllegalArgument(format!(
+                                                "Unsupported body bytes for ASCII bodyFormat: {}",
+                                                body_format
+                                            )));
+                                        }
+                                    } else {
+                                        return Err(RocketMQError::IllegalArgument(format!(
+                                            "Unsupported bodyFormat: {}",
+                                            body_format
+                                        )));
+                                    }
+                                }
+                                None => "EMPTY".to_string(),
+                            };
+                            println!("MSGID: {} {} BODY: {}", msg.msg_id(), msg, body);
+                            return Ok(());
+                        }
+                    }
+                }
+                PullStatus::NoMatchedMsg | PullStatus::NoNewMsg | PullStatus::OffsetIllegal => {}
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6411 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command to query a single message by topic, broker, queue ID, and offset. Returns message ID and a human-readable body (with configurable format detection and fallbacks). If no message is found the command exits quietly; errors are reported for startup, routing, pull failures, or unsupported body formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->