### PR TITLE
[ISSUE #6788]🚀Add consumer configuration query functionality with UI integration

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-common/src/consumer.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-common/src/consumer.rs
@@ -50,8 +50,17 @@ pub struct ConsumerTopicDetailQueryRequest {
     pub address: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerConfigQueryRequest {
+    pub consumer_group: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
+    use super::ConsumerConfigQueryRequest;
     use super::ConsumerConnectionQueryRequest;
     use super::ConsumerGroupListRequest;
     use super::ConsumerGroupRefreshRequest;
@@ -100,6 +109,18 @@ mod tests {
         };
 
         let json = serde_json::to_string(&request).expect("serialize consumer topic detail request");
+        assert!(json.contains("\"consumerGroup\""));
+        assert!(json.contains("\"address\""));
+    }
+
+    #[test]
+    fn consumer_config_query_request_uses_expected_field_names() {
+        let request = ConsumerConfigQueryRequest {
+            consumer_group: "group-a".to_string(),
+            address: Some("127.0.0.1:10911".to_string()),
+        };
+
+        let json = serde_json::to_string(&request).expect("serialize consumer config request");
         assert!(json.contains("\"consumerGroup\""));
         assert!(json.contains("\"address\""));
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 use crate::consumer::service::ConsumerManager;
+use crate::consumer::types::ConsumerConfigView;
 use crate::consumer::types::ConsumerConnectionView;
 use crate::consumer::types::ConsumerGroupListItem;
 use crate::consumer::types::ConsumerGroupListResponse;
 use crate::consumer::types::ConsumerTopicDetailView;
+use rocketmq_dashboard_common::ConsumerConfigQueryRequest;
 use rocketmq_dashboard_common::ConsumerConnectionQueryRequest;
 use rocketmq_dashboard_common::ConsumerGroupListRequest;
 use rocketmq_dashboard_common::ConsumerGroupRefreshRequest;
@@ -63,6 +65,17 @@ pub async fn query_consumer_topic_detail(
 ) -> Result<ConsumerTopicDetailView, String> {
     consumer_manager
         .query_consumer_topic_detail(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn query_consumer_config(
+    request: ConsumerConfigQueryRequest,
+    consumer_manager: State<'_, ConsumerManager>,
+) -> Result<ConsumerConfigView, String> {
+    consumer_manager
+        .query_consumer_config(request)
         .await
         .map_err(|error| error.to_string())
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use crate::consumer::admin::ManagedConsumerAdmin;
+use crate::consumer::types::ConsumerConfigAttributeItem;
+use crate::consumer::types::ConsumerConfigView;
 use crate::consumer::types::ConsumerConnectionItem;
 use crate::consumer::types::ConsumerConnectionView;
 use crate::consumer::types::ConsumerError;
@@ -32,6 +34,7 @@ use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mq_version::RocketMqVersion;
+use rocketmq_dashboard_common::ConsumerConfigQueryRequest;
 use rocketmq_dashboard_common::ConsumerConnectionQueryRequest;
 use rocketmq_dashboard_common::ConsumerGroupListRequest;
 use rocketmq_dashboard_common::ConsumerGroupRefreshRequest;
@@ -41,6 +44,10 @@ use rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats;
 use rocketmq_remoting::protocol::admin::offset_wrapper::OffsetWrapper;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_remoting::protocol::body::consumer_connection::ConsumerConnection;
+use rocketmq_remoting::protocol::subscription::group_retry_policy::GroupRetryPolicy;
+use rocketmq_remoting::protocol::subscription::group_retry_policy_type::GroupRetryPolicyType;
+use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+use serde_json::json;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -220,6 +227,43 @@ impl ConsumerManager {
         }
     }
 
+    pub(crate) async fn query_consumer_config(
+        &self,
+        request: ConsumerConfigQueryRequest,
+    ) -> ConsumerResult<ConsumerConfigView> {
+        let group_name = validate_consumer_group_name(&request.consumer_group)?;
+
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("consumer admin session should be initialized before use");
+                self.query_consumer_config_with_admin(&mut session.admin, &group_name, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "query_consumer_config failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `query_consumer_config` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
     async fn ensure_admin_session(&self, session_slot: &mut Option<ManagedConsumerAdmin>) -> ConsumerResult<()> {
         let generation = self.runtime.generation();
         let needs_reconnect = session_slot
@@ -366,6 +410,51 @@ impl ConsumerManager {
             raw_group_name,
             stats,
             &queue_client_map,
+        ))
+    }
+
+    async fn query_consumer_config_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        raw_group_name: &str,
+        request: ConsumerConfigQueryRequest,
+    ) -> ConsumerResult<ConsumerConfigView> {
+        let cluster_info = admin
+            .examine_broker_cluster_info()
+            .await
+            .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+
+        let broker_address = match normalize_address(request.address.as_deref()) {
+            Some(address) => address,
+            None => {
+                let group_map = collect_consumer_group_meta(admin, &cluster_info).await?;
+                let meta = group_map.get(raw_group_name).ok_or_else(|| {
+                    ConsumerError::Validation(format!(
+                        "Consumer group `{}` was not found in the current cluster view.",
+                        raw_group_name
+                    ))
+                })?;
+                resolve_first_consumer_broker_address(meta).ok_or_else(|| {
+                    ConsumerError::Validation(format!(
+                        "No broker address was found for consumer group `{}`.",
+                        raw_group_name
+                    ))
+                })?
+            }
+        };
+
+        let config = admin
+            .examine_subscription_group_config(broker_address.clone(), raw_group_name.into())
+            .await
+            .map_err(|error| ConsumerError::RocketMQ(error.to_string()))?;
+
+        let broker_name = resolve_broker_name_by_address(&cluster_info, broker_address.as_str()).unwrap_or_default();
+
+        Ok(build_consumer_config_view(
+            raw_group_name,
+            broker_name,
+            broker_address.to_string(),
+            &config,
         ))
     }
 }
@@ -538,6 +627,14 @@ fn parse_addresses(address: Option<&str>) -> Vec<CheetahString> {
         .collect()
 }
 
+fn resolve_first_consumer_broker_address(meta: &ConsumerGroupMeta) -> Option<CheetahString> {
+    let mut broker_addresses: Vec<&String> = meta.broker_addresses.iter().collect();
+    broker_addresses.sort();
+    broker_addresses
+        .first()
+        .map(|value| CheetahString::from(value.as_str()))
+}
+
 fn first_address(address: Option<&str>) -> Option<CheetahString> {
     parse_addresses(address).into_iter().next()
 }
@@ -650,6 +747,104 @@ fn build_consumer_connection_view(raw_group_name: &str, connection: ConsumerConn
     }
 }
 
+fn build_consumer_config_view(
+    raw_group_name: &str,
+    broker_name: String,
+    broker_address: String,
+    config: &SubscriptionGroupConfig,
+) -> ConsumerConfigView {
+    let mut subscription_topics: Vec<String> = config
+        .subscription_data_set()
+        .into_iter()
+        .flat_map(|items| items.iter())
+        .map(|item| item.topic().to_string())
+        .collect();
+    subscription_topics.sort();
+    subscription_topics.dedup();
+
+    let mut attributes: Vec<ConsumerConfigAttributeItem> = config
+        .attributes()
+        .iter()
+        .map(|(key, value)| ConsumerConfigAttributeItem {
+            key: key.to_string(),
+            value: value.to_string(),
+        })
+        .collect();
+    attributes.sort_by(|left, right| left.key.cmp(&right.key));
+
+    ConsumerConfigView {
+        consumer_group: raw_group_name.to_string(),
+        broker_name,
+        broker_address,
+        consume_enable: config.consume_enable(),
+        consume_from_min_enable: config.consume_from_min_enable(),
+        consume_broadcast_enable: config.consume_broadcast_enable(),
+        consume_message_orderly: config.consume_message_orderly(),
+        retry_queue_nums: config.retry_queue_nums(),
+        retry_max_times: config.retry_max_times(),
+        broker_id: config.broker_id(),
+        which_broker_when_consume_slowly: config.which_broker_when_consume_slowly(),
+        notify_consumer_ids_changed_enable: config.notify_consumer_ids_changed_enable(),
+        group_sys_flag: config.group_sys_flag(),
+        consume_timeout_minute: config.consume_timeout_minute(),
+        group_retry_policy_json: serialize_group_retry_policy_json(config.group_retry_policy())
+            .unwrap_or_else(|_| "{}".to_string()),
+        subscription_topic_count: subscription_topics.len(),
+        subscription_topics,
+        attributes,
+    }
+}
+
+fn resolve_broker_name_by_address(cluster_info: &ClusterInfo, broker_address: &str) -> Option<String> {
+    cluster_info.broker_addr_table.as_ref().and_then(|table| {
+        table.iter().find_map(|(broker_name, broker_data)| {
+            broker_data
+                .broker_addrs()
+                .values()
+                .any(|addr| addr.as_str() == broker_address)
+                .then(|| broker_name.to_string())
+        })
+    })
+}
+
+fn serialize_group_retry_policy_json(policy: &GroupRetryPolicy) -> Result<String, serde_json::Error> {
+    let effective_retry_policy = match policy.type_() {
+        GroupRetryPolicyType::Exponential => json!({
+            "type": "EXPONENTIAL",
+            "initial": policy
+                .exponential_retry_policy()
+                .map(|value| value.initial())
+                .unwrap_or(5_000),
+            "max": policy
+                .exponential_retry_policy()
+                .map(|value| value.max())
+                .unwrap_or(7_200_000),
+            "multiplier": policy
+                .exponential_retry_policy()
+                .map(|value| value.multiplier())
+                .unwrap_or(2),
+        }),
+        GroupRetryPolicyType::Customized => json!({
+            "type": "CUSTOMIZED",
+            "next": policy
+                .customized_retry_policy()
+                .map(|value| value.next().to_vec())
+                .unwrap_or_else(|| vec![
+                    1_000, 5_000, 10_000, 30_000, 60_000, 120_000, 180_000, 240_000, 300_000,
+                    360_000, 420_000, 480_000, 540_000, 600_000, 1_200_000, 1_800_000, 3_600_000,
+                    7_200_000,
+                ]),
+        }),
+    };
+
+    serde_json::to_string_pretty(&json!({
+        "type": policy.type_(),
+        "exponentialRetryPolicy": policy.exponential_retry_policy(),
+        "customizedRetryPolicy": policy.customized_retry_policy(),
+        "retryPolicy": effective_retry_policy,
+    }))
+}
+
 fn consume_from_where_label(value: ConsumeFromWhere) -> String {
     #[allow(deprecated)]
     match value {
@@ -759,12 +954,15 @@ fn build_consumer_topic_detail_view(
 #[cfg(test)]
 mod tests {
     use super::ConsumerGroupMeta;
+    use super::build_consumer_config_view;
     use super::build_consumer_connection_view;
     use super::build_consumer_topic_detail_view;
     use super::build_summary;
     use super::classify_consumer_group;
     use super::is_reconnect_worthy_error;
     use super::is_system_consumer_group;
+    use super::resolve_broker_name_by_address;
+    use super::resolve_first_consumer_broker_address;
     use super::strip_system_prefix;
     use crate::consumer::types::ConsumerGroupListItem;
     use cheetah_string::CheetahString;
@@ -773,12 +971,16 @@ mod tests {
     use rocketmq_remoting::protocol::LanguageCode;
     use rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats;
     use rocketmq_remoting::protocol::admin::offset_wrapper::OffsetWrapper;
+    use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
     use rocketmq_remoting::protocol::body::connection::Connection;
     use rocketmq_remoting::protocol::body::consumer_connection::ConsumerConnection;
     use rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType;
     use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
     use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
+    use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
+    use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
     use std::collections::HashMap;
+    use std::collections::HashSet;
 
     #[test]
     fn classify_consumer_group_marks_system_fifo_and_normal() {
@@ -916,6 +1118,93 @@ mod tests {
         assert!(is_reconnect_worthy_error("request timeout while talking to namesrv"));
         assert!(!is_reconnect_worthy_error("consumer group not found"));
         assert!(!is_reconnect_worthy_error("subscription group metadata is empty"));
+    }
+
+    #[test]
+    fn resolve_first_consumer_broker_address_returns_sorted_first_value() {
+        let meta = ConsumerGroupMeta {
+            broker_addresses: HashSet::from(["172.19.80.2:10911".to_string(), "172.19.80.1:10911".to_string()]),
+            orderly_flags: Vec::new(),
+        };
+
+        let resolved = resolve_first_consumer_broker_address(&meta).expect("expected a broker address");
+
+        assert_eq!(resolved.as_str(), "172.19.80.1:10911");
+    }
+
+    #[test]
+    fn build_consumer_config_view_maps_subscription_group_config_fields() {
+        let mut config = SubscriptionGroupConfig::default();
+        config.set_group_name("group-a".into());
+        config.set_consume_enable(false);
+        config.set_consume_from_min_enable(false);
+        config.set_consume_broadcast_enable(true);
+        config.set_consume_message_orderly(true);
+        config.set_retry_queue_nums(4);
+        config.set_retry_max_times(8);
+        config.set_broker_id(1);
+        config.set_which_broker_when_consume_slowly(2);
+        config.set_notify_consumer_ids_changed_enable(false);
+        config.set_group_sys_flag(7);
+        config.set_consume_timeout_minute(21);
+        config.set_attributes(HashMap::from([("a".into(), "1".into()), ("b".into(), "2".into())]));
+        config.set_subscription_data_set(Some(HashSet::from([
+            rocketmq_remoting::protocol::subscription::simple_subscription_data::SimpleSubscriptionData::new(
+                "TopicB".to_string(),
+                "TAG".to_string(),
+                "*".to_string(),
+                1,
+            ),
+            rocketmq_remoting::protocol::subscription::simple_subscription_data::SimpleSubscriptionData::new(
+                "TopicA".to_string(),
+                "TAG".to_string(),
+                "*".to_string(),
+                2,
+            ),
+        ])));
+
+        let view = build_consumer_config_view(
+            "group-a",
+            "broker-a".to_string(),
+            "172.19.80.1:10911".to_string(),
+            &config,
+        );
+
+        assert_eq!(view.consumer_group, "group-a");
+        assert_eq!(view.broker_name, "broker-a");
+        assert_eq!(view.broker_address, "172.19.80.1:10911");
+        assert!(!view.consume_enable);
+        assert!(!view.consume_from_min_enable);
+        assert!(view.consume_broadcast_enable);
+        assert!(view.consume_message_orderly);
+        assert_eq!(view.retry_queue_nums, 4);
+        assert_eq!(view.retry_max_times, 8);
+        assert_eq!(view.broker_id, 1);
+        assert_eq!(view.which_broker_when_consume_slowly, 2);
+        assert!(!view.notify_consumer_ids_changed_enable);
+        assert_eq!(view.group_sys_flag, 7);
+        assert_eq!(view.consume_timeout_minute, 21);
+        assert_eq!(view.subscription_topic_count, 2);
+        assert_eq!(
+            view.subscription_topics,
+            vec!["TopicA".to_string(), "TopicB".to_string()]
+        );
+        assert_eq!(view.attributes.len(), 2);
+        assert_eq!(view.attributes[0].key, "a");
+        assert!(view.group_retry_policy_json.contains("\"retryPolicy\""));
+        assert!(view.group_retry_policy_json.contains("\"CUSTOMIZED\""));
+    }
+
+    #[test]
+    fn resolve_broker_name_by_address_finds_matching_broker() {
+        let mut broker_addrs = HashMap::new();
+        broker_addrs.insert(0, "172.19.80.1:10911".into());
+        let broker_data = BrokerData::new("DefaultCluster".into(), "broker-a".into(), broker_addrs, None);
+
+        let cluster_info = ClusterInfo::new(Some(HashMap::from([("broker-a".into(), broker_data)])), None);
+
+        let resolved = resolve_broker_name_by_address(&cluster_info, "172.19.80.1:10911");
+        assert_eq!(resolved.as_deref(), Some("broker-a"));
     }
 
     const fn ordinal_for_v5_4_0() -> i32 {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/types.rs
@@ -135,3 +135,33 @@ pub(crate) struct ConsumerTopicDetailView {
     pub(crate) total_diff: i64,
     pub(crate) topics: Vec<ConsumerTopicDetailItem>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConsumerConfigAttributeItem {
+    pub(crate) key: String,
+    pub(crate) value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConsumerConfigView {
+    pub(crate) consumer_group: String,
+    pub(crate) broker_name: String,
+    pub(crate) broker_address: String,
+    pub(crate) consume_enable: bool,
+    pub(crate) consume_from_min_enable: bool,
+    pub(crate) consume_broadcast_enable: bool,
+    pub(crate) consume_message_orderly: bool,
+    pub(crate) retry_queue_nums: i32,
+    pub(crate) retry_max_times: i32,
+    pub(crate) broker_id: u64,
+    pub(crate) which_broker_when_consume_slowly: u64,
+    pub(crate) notify_consumer_ids_changed_enable: bool,
+    pub(crate) group_sys_flag: i32,
+    pub(crate) consume_timeout_minute: i32,
+    pub(crate) group_retry_policy_json: String,
+    pub(crate) subscription_topic_count: usize,
+    pub(crate) subscription_topics: Vec<String>,
+    pub(crate) attributes: Vec<ConsumerConfigAttributeItem>,
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -103,6 +103,7 @@ pub fn run() {
             consumer::commands::refresh_consumer_group,
             consumer::commands::query_consumer_connection,
             consumer::commands::query_consumer_topic_detail,
+            consumer::commands::query_consumer_config,
             producer::commands::get_producer_topic_options,
             producer::commands::query_producer_connections,
             topic::commands::get_topic_list,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/ConsumerView.tsx
@@ -26,6 +26,7 @@ import { toast } from 'sonner@2.0.3';
 import { Pagination } from './Pagination';
 import { useConsumerCatalog } from '../features/consumer/hooks/useConsumerCatalog';
 import { ConsumerClientModal } from '../features/consumer/components/ConsumerClientModal';
+import { ConsumerConfigModal } from '../features/consumer/components/ConsumerConfigModal';
 import { ConsumerDetailModal } from '../features/consumer/components/ConsumerDetailModal';
 import type { ConsumerGroupListItem } from '../features/consumer/types/consumer.types';
 
@@ -187,7 +188,7 @@ const LegacyConsumerDetailModal = ({ isOpen, onClose, consumer }: any) => {
   );
 };
 
-const ConsumerConfigModal = ({ isOpen, onClose, consumer }: any) => {
+const LegacyConsumerConfigModal = ({ isOpen, onClose, consumer }: any) => {
   if (!isOpen) return null;
 
   return (

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerConfigModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/components/ConsumerConfigModal.tsx
@@ -1,0 +1,349 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
+import {
+    Activity,
+    AlertCircle,
+    Cpu,
+    Hash,
+    LoaderCircle,
+    Network,
+    RotateCcw,
+    Settings,
+    X,
+} from 'lucide-react';
+import { ConsumerService } from '../../../services/consumer.service';
+import type {
+    ConsumerConfigView,
+    ConsumerGroupListItem,
+} from '../types/consumer.types';
+
+interface ConsumerConfigModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    consumer: ConsumerGroupListItem | null;
+}
+
+const getConsumerLabel = (consumer: ConsumerGroupListItem | null) =>
+    consumer?.displayGroupName ?? consumer?.rawGroupName ?? '-';
+
+const getErrorMessage = (error: unknown, fallback: string) => {
+    if (typeof error === 'string' && error.trim().length > 0) {
+        return error;
+    }
+    if (error instanceof Error && error.message.trim().length > 0) {
+        return error.message;
+    }
+    if (error && typeof error === 'object' && 'message' in error) {
+        const message = (error as { message?: unknown }).message;
+        if (typeof message === 'string' && message.trim().length > 0) {
+            return message;
+        }
+    }
+    return fallback;
+};
+
+const formatBoolean = (value: boolean) => (value ? 'Enabled' : 'Disabled');
+
+export const ConsumerConfigModal = ({
+    isOpen,
+    onClose,
+    consumer,
+}: ConsumerConfigModalProps) => {
+    const brokerAddresses = useMemo(() => consumer?.brokerAddresses ?? [], [consumer]);
+    const [selectedBrokerAddress, setSelectedBrokerAddress] = useState('');
+    const [data, setData] = useState<ConsumerConfigView | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        if (!isOpen || !consumer) {
+            return;
+        }
+
+        setSelectedBrokerAddress((current) => {
+            if (current && brokerAddresses.includes(current)) {
+                return current;
+            }
+            return brokerAddresses[0] ?? '';
+        });
+    }, [brokerAddresses, consumer, isOpen]);
+
+    useEffect(() => {
+        if (!isOpen || !consumer || !selectedBrokerAddress) {
+            return;
+        }
+
+        let cancelled = false;
+        setIsLoading(true);
+        setError('');
+        setData(null);
+
+        void ConsumerService.queryConsumerConfig({
+            consumerGroup: consumer.rawGroupName,
+            address: selectedBrokerAddress,
+        })
+            .then((response) => {
+                if (!cancelled) {
+                    setData(response);
+                }
+            })
+            .catch((loadError) => {
+                if (!cancelled) {
+                    setError(getErrorMessage(loadError, 'Failed to load consumer configuration.'));
+                }
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setIsLoading(false);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [consumer, isOpen, selectedBrokerAddress]);
+
+    if (!isOpen) {
+        return null;
+    }
+
+    const consumerLabel = getConsumerLabel(consumer);
+
+    return (
+        <AnimatePresence>
+            <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+                <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 0.3 }}
+                    exit={{ opacity: 0 }}
+                    onClick={onClose}
+                    className="absolute inset-0 bg-black"
+                />
+                <motion.div
+                    initial={{ opacity: 0, scale: 0.95, y: 10 }}
+                    animate={{ opacity: 1, scale: 1, y: 0 }}
+                    exit={{ opacity: 0, scale: 0.95, y: 10 }}
+                    className="relative flex max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-xl border border-gray-100 bg-white shadow-2xl dark:border-gray-800 dark:bg-gray-900"
+                >
+                    <div className="z-10 flex shrink-0 items-center justify-between border-b border-gray-100 bg-white px-6 py-5 dark:border-gray-800 dark:bg-gray-900">
+                        <div>
+                            <h3 className="flex items-center text-xl font-bold text-gray-800 dark:text-white">
+                                <Settings className="mr-2 h-5 w-5 text-blue-500" />
+                                Configuration
+                            </h3>
+                            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                <span className="font-mono font-medium text-gray-700 dark:text-gray-300">
+                                    {consumerLabel}
+                                </span>
+                            </p>
+                        </div>
+                        <button
+                            onClick={onClose}
+                            className="rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+                        >
+                            <X className="h-5 w-5" />
+                        </button>
+                    </div>
+
+                    <div className="flex-1 overflow-y-auto bg-gray-50/50 p-6 dark:bg-gray-950/50">
+                        <div className="mb-6 flex flex-col gap-3 rounded-2xl border border-gray-100 bg-white/80 p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900/80 md:flex-row md:items-center md:justify-between">
+                            <div>
+                                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-gray-400 dark:text-gray-500">
+                                    Broker Address
+                                </div>
+                                <div className="mt-2 font-mono text-sm text-gray-700 dark:text-gray-300">
+                                    {selectedBrokerAddress || '-'}
+                                </div>
+                            </div>
+                            <label className="flex items-center gap-3 text-sm text-gray-600 dark:text-gray-300">
+                                <Network className="h-4 w-4 text-blue-500" />
+                                <select
+                                    value={selectedBrokerAddress}
+                                    onChange={(event) => setSelectedBrokerAddress(event.target.value)}
+                                    className="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                                >
+                                    {brokerAddresses.map((address) => (
+                                        <option key={address} value={address}>
+                                            {address}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
+                        </div>
+
+                        {isLoading ? (
+                            <div className="flex min-h-[320px] items-center justify-center">
+                                <div className="flex items-center gap-3 rounded-full bg-white px-4 py-2 text-sm text-gray-600 shadow-sm dark:bg-gray-900 dark:text-gray-300">
+                                    <LoaderCircle className="h-4 w-4 animate-spin" />
+                                    Loading consumer configuration...
+                                </div>
+                            </div>
+                        ) : error ? (
+                            <div className="flex items-start gap-3 rounded-2xl border border-red-200/70 bg-red-50/80 px-4 py-3 text-sm text-red-700 shadow-sm dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+                                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                                <span>{error}</span>
+                            </div>
+                        ) : data ? (
+                            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                                <section className="space-y-4 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+                                    <div className="flex items-center gap-2">
+                                        <div className="rounded-lg bg-blue-50 p-1.5 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400">
+                                            <Hash className="h-4 w-4" />
+                                        </div>
+                                        <h4 className="font-semibold text-gray-900 dark:text-white">Basic Information</h4>
+                                    </div>
+                                    <ConfigField label="Group Name" value={data.consumerGroup} mono />
+                                    <ConfigField label="Broker Name" value={data.brokerName || '-'} mono />
+                                    <ConfigField label="Broker Address" value={data.brokerAddress} mono />
+                                    <ConfigField label="Broker ID" value={String(data.brokerId)} mono />
+                                    <ConfigField label="System Flag" value={String(data.groupSysFlag)} mono />
+                                </section>
+
+                                <section className="space-y-4 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+                                    <div className="flex items-center gap-2">
+                                        <div className="rounded-lg bg-green-50 p-1.5 text-green-600 dark:bg-green-900/30 dark:text-green-400">
+                                            <Activity className="h-4 w-4" />
+                                        </div>
+                                        <h4 className="font-semibold text-gray-900 dark:text-white">Control Settings</h4>
+                                    </div>
+                                    <ConfigField label="Consume Enable" value={formatBoolean(data.consumeEnable)} />
+                                    <ConfigField
+                                        label="Consume From Min"
+                                        value={formatBoolean(data.consumeFromMinEnable)}
+                                    />
+                                    <ConfigField
+                                        label="Broadcast Mode"
+                                        value={formatBoolean(data.consumeBroadcastEnable)}
+                                    />
+                                    <ConfigField
+                                        label="Orderly Consumption"
+                                        value={formatBoolean(data.consumeMessageOrderly)}
+                                    />
+                                    <ConfigField
+                                        label="Notify Client Change"
+                                        value={formatBoolean(data.notifyConsumerIdsChangedEnable)}
+                                    />
+                                </section>
+
+                                <section className="space-y-4 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+                                    <div className="flex items-center gap-2">
+                                        <div className="rounded-lg bg-orange-50 p-1.5 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400">
+                                            <RotateCcw className="h-4 w-4" />
+                                        </div>
+                                        <h4 className="font-semibold text-gray-900 dark:text-white">Retry & Throttling</h4>
+                                    </div>
+                                    <ConfigField label="Retry Queues" value={String(data.retryQueueNums)} mono />
+                                    <ConfigField label="Max Retries" value={String(data.retryMaxTimes)} mono />
+                                    <ConfigField
+                                        label="Slow Consume Broker"
+                                        value={String(data.whichBrokerWhenConsumeSlowly)}
+                                        mono
+                                    />
+                                    <ConfigField
+                                        label="Consume Timeout"
+                                        value={`${data.consumeTimeoutMinute} minutes`}
+                                        mono
+                                    />
+                                    <ConfigField
+                                        label="Subscription Topics"
+                                        value={String(data.subscriptionTopicCount)}
+                                        mono
+                                    />
+                                </section>
+
+                                <section className="space-y-4 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+                                    <div className="flex items-center gap-2">
+                                        <div className="rounded-lg bg-purple-50 p-1.5 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400">
+                                            <Cpu className="h-4 w-4" />
+                                        </div>
+                                        <h4 className="font-semibold text-gray-900 dark:text-white">System Config</h4>
+                                    </div>
+                                    <div className="space-y-1">
+                                        <label className="block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                            Retry Policy (JSON)
+                                        </label>
+                                        <div className="overflow-hidden rounded-lg border border-gray-800 bg-gray-900 p-3">
+                                            <pre className="overflow-x-auto font-mono text-[10px] text-gray-300">
+                                                {data.groupRetryPolicyJson}
+                                            </pre>
+                                        </div>
+                                    </div>
+                                    <div className="space-y-1">
+                                        <label className="block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                            Subscription Topics
+                                        </label>
+                                        <div className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-2 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                                            {data.subscriptionTopics.length > 0
+                                                ? data.subscriptionTopics.join(', ')
+                                                : 'No subscription topics declared in the group config.'}
+                                        </div>
+                                    </div>
+                                    <div className="space-y-1">
+                                        <label className="block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                            Attributes
+                                        </label>
+                                        <div className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-2 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                                            {data.attributes.length > 0 ? (
+                                                <div className="space-y-2">
+                                                    {data.attributes.map((attribute) => (
+                                                        <div
+                                                            key={attribute.key}
+                                                            className="flex items-start justify-between gap-3 font-mono text-xs"
+                                                        >
+                                                            <span className="text-gray-500 dark:text-gray-400">
+                                                                {attribute.key}
+                                                            </span>
+                                                            <span className="break-all text-right text-gray-800 dark:text-gray-200">
+                                                                {attribute.value}
+                                                            </span>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            ) : (
+                                                'No custom attributes are configured.'
+                                            )}
+                                        </div>
+                                    </div>
+                                </section>
+                            </div>
+                        ) : (
+                            <div className="rounded-2xl border border-dashed border-gray-200 bg-white/70 px-6 py-16 text-center text-sm text-gray-500 shadow-sm dark:border-gray-800 dark:bg-gray-900/70 dark:text-gray-400">
+                                No consumer configuration was returned.
+                            </div>
+                        )}
+                    </div>
+
+                    <div className="z-10 flex shrink-0 justify-end border-t border-gray-100 bg-white px-6 py-4 dark:border-gray-800 dark:bg-gray-900">
+                        <button
+                            onClick={onClose}
+                            className="rounded-lg bg-gray-900 px-6 py-2 text-sm font-medium text-white shadow-md transition-all hover:bg-gray-800 hover:shadow-lg dark:border dark:border-gray-700 dark:!bg-gray-900 dark:!text-white dark:hover:!bg-gray-800"
+                        >
+                            Close
+                        </button>
+                    </div>
+                </motion.div>
+            </div>
+        </AnimatePresence>
+    );
+};
+
+interface ConfigFieldProps {
+    label: string;
+    value: string;
+    mono?: boolean;
+}
+
+const ConfigField = ({ label, value, mono = false }: ConfigFieldProps) => (
+    <div className="space-y-1">
+        <label className="block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {label}
+        </label>
+        <div
+            className={`rounded-lg border border-gray-100 bg-gray-50 px-3 py-2 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 ${
+                mono ? 'font-mono' : ''
+            }`}
+        >
+            {value}
+        </div>
+    </div>
+);

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/types/consumer.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/types/consumer.types.ts
@@ -18,6 +18,11 @@ export interface ConsumerTopicDetailQueryRequest {
     address?: string;
 }
 
+export interface ConsumerConfigQueryRequest {
+    consumerGroup: string;
+    address?: string;
+}
+
 export interface ConsumerGroupListSummary {
     totalGroups: number;
     normalGroups: number;
@@ -97,4 +102,30 @@ export interface ConsumerTopicDetailView {
     topicCount: number;
     totalDiff: number;
     topics: ConsumerTopicDetailItem[];
+}
+
+export interface ConsumerConfigAttributeItem {
+    key: string;
+    value: string;
+}
+
+export interface ConsumerConfigView {
+    consumerGroup: string;
+    brokerName: string;
+    brokerAddress: string;
+    consumeEnable: boolean;
+    consumeFromMinEnable: boolean;
+    consumeBroadcastEnable: boolean;
+    consumeMessageOrderly: boolean;
+    retryQueueNums: number;
+    retryMaxTimes: number;
+    brokerId: number;
+    whichBrokerWhenConsumeSlowly: number;
+    notifyConsumerIdsChangedEnable: boolean;
+    groupSysFlag: number;
+    consumeTimeoutMinute: number;
+    groupRetryPolicyJson: string;
+    subscriptionTopicCount: number;
+    subscriptionTopics: string[];
+    attributes: ConsumerConfigAttributeItem[];
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/consumer.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/consumer.service.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import type {
+    ConsumerConfigQueryRequest,
+    ConsumerConfigView,
     ConsumerConnectionQueryRequest,
     ConsumerConnectionView,
     ConsumerGroupListItem,
@@ -25,5 +27,9 @@ export class ConsumerService {
 
     static async queryConsumerTopicDetail(request: ConsumerTopicDetailQueryRequest): Promise<ConsumerTopicDetailView> {
         return invoke<ConsumerTopicDetailView>('query_consumer_topic_detail', { request });
+    }
+
+    static async queryConsumerConfig(request: ConsumerConfigQueryRequest): Promise<ConsumerConfigView> {
+        return invoke<ConsumerConfigView>('query_consumer_config', { request });
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6788

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consumer configuration viewer: Users can now query and view detailed consumer group settings including broker information, consumption modes, retry policies, subscription topics, and custom attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->