### PR TITLE
[ISSUE #6799]🚀Add initial implementation of RocketMQ Proxy with gRPC support and service management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3712,6 +3712,29 @@ dependencies = [
 [[package]]
 name = "rocketmq-proxy"
 version = "0.8.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cheetah-string",
+ "config",
+ "dashmap",
+ "futures",
+ "prost",
+ "prost-types",
+ "rocketmq-common",
+ "rocketmq-error",
+ "rocketmq-remoting",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
+ "uuid",
+]
 
 [[package]]
 name = "rocketmq-remoting"

--- a/rocketmq-proxy/Cargo.toml
+++ b/rocketmq-proxy/Cargo.toml
@@ -21,10 +21,37 @@ edition.workspace      = true
 homepage.workspace     = true
 repository.workspace   = true
 license.workspace      = true
-keywords.workspace     = true
-categories.workspace   = true
+keywords               = ["rocketmq", "proxy", "grpc", "messaging", "async"]
+categories             = ["network-programming", "asynchronous"]
 readme                 = "README.md"
-description.workspace  = true
+description            = "RocketMQ Proxy Module - gRPC proxy runtime for the Rust implementation"
 rust-version.workspace = true
 
 [dependencies]
+rocketmq-common   = { workspace = true }
+rocketmq-error    = { workspace = true }
+rocketmq-remoting = { workspace = true }
+
+tokio        = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util   = { workspace = true }
+
+serde  = { workspace = true }
+config = { workspace = true }
+
+dashmap        = { workspace = true }
+bytes          = { workspace = true }
+tracing        = { workspace = true }
+futures        = { workspace = true }
+uuid           = { workspace = true }
+cheetah-string = { workspace = true }
+thiserror      = { workspace = true }
+
+async-trait = "0.1"
+prost       = "0.14"
+prost-types = "0.14"
+tonic       = { version = "0.14.5", features = ["transport", "codegen"] }
+tonic-prost = "0.14"
+
+[build-dependencies]
+tonic-prost-build = "0.14.5"

--- a/rocketmq-proxy/build.rs
+++ b/rocketmq-proxy/build.rs
@@ -1,0 +1,21 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=proto/");
+
+    tonic_prost_build::configure().compile_protos(&["proto/service.proto"], &["proto"])?;
+
+    Ok(())
+}

--- a/rocketmq-proxy/proto/definition.proto
+++ b/rocketmq-proxy/proto/definition.proto
@@ -1,0 +1,624 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Source: https://github.com/apache/rocketmq-apis/tree/main/apache/rocketmq/v2
+// Copyright: The Apache Software Foundation (ASF)
+// Adapted for rocketmq-rust namespace and local build layout.
+
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+package rocketmq_rust_proxy.v2;
+
+option csharp_namespace = "Rocketmq.Rust.Proxy.V2";
+option java_multiple_files = true;
+option java_package = "rocketmq.rust.proxy.v2";
+option java_generate_equals_and_hash = true;
+option java_string_check_utf8 = true;
+option java_outer_classname = "RocketmqRustProxyDomain";
+
+enum TransactionResolution {
+  TRANSACTION_RESOLUTION_UNSPECIFIED = 0;
+  COMMIT = 1;
+  ROLLBACK = 2;
+}
+
+enum TransactionSource {
+  SOURCE_UNSPECIFIED = 0;
+  SOURCE_CLIENT = 1;
+  SOURCE_SERVER_CHECK = 2;
+}
+
+enum Permission {
+  PERMISSION_UNSPECIFIED = 0;
+  NONE = 1;
+  READ = 2;
+  WRITE = 3;
+  READ_WRITE = 4;
+}
+
+enum FilterType {
+  FILTER_TYPE_UNSPECIFIED = 0;
+  TAG = 1;
+  SQL = 2;
+}
+
+message FilterExpression {
+  FilterType type = 1;
+  string expression = 2;
+}
+
+message RetryPolicy {
+  int32 max_attempts = 1;
+  oneof strategy {
+    ExponentialBackoff exponential_backoff = 2;
+    CustomizedBackoff customized_backoff = 3;
+  }
+}
+
+// https://en.wikipedia.org/wiki/Exponential_backoff
+message ExponentialBackoff {
+  google.protobuf.Duration initial = 1;
+  google.protobuf.Duration max = 2;
+  float multiplier = 3;
+}
+
+message CustomizedBackoff {
+  // To support classic backoff strategy which is arbitrary defined by end users.
+  // Typical values are: `1s 5s 10s 30s 1m 2m 3m 4m 5m 6m 7m 8m 9m 10m 20m 30m 1h 2h`
+  repeated google.protobuf.Duration next = 1;
+}
+
+message Resource {
+  string resource_namespace = 1;
+
+  // Resource name identifier, which remains unique within the abstract resource
+  // namespace.
+  string name = 2;
+}
+
+message SubscriptionEntry {
+  Resource topic = 1;
+  FilterExpression expression = 2;
+}
+
+enum AddressScheme {
+  ADDRESS_SCHEME_UNSPECIFIED = 0;
+  IPv4 = 1;
+  IPv6 = 2;
+  DOMAIN_NAME = 3;
+}
+
+message Address {
+  string host = 1;
+  int32 port = 2;
+}
+
+message Endpoints {
+  AddressScheme scheme = 1;
+  repeated Address addresses = 2;
+}
+
+message Broker {
+  // Name of the broker
+  string name = 1;
+
+  // Broker index. Canonically, index = 0 implies that the broker is playing
+  // leader role while brokers with index > 0 play follower role.
+  int32 id = 2;
+
+  // Address of the broker, complying with the following scheme
+  // 1. dns:[//authority/]host[:port]
+  // 2. ipv4:address[:port][,address[:port],...] – IPv4 addresses
+  // 3. ipv6:address[:port][,address[:port],...] – IPv6 addresses
+  Endpoints endpoints = 3;
+}
+
+message MessageQueue {
+  Resource topic = 1;
+  int32 id = 2;
+  Permission permission = 3;
+  Broker broker = 4;
+  repeated MessageType accept_message_types = 5;
+}
+
+enum MessageType {
+  MESSAGE_TYPE_UNSPECIFIED = 0;
+
+  NORMAL = 1;
+
+  // Sequenced message
+  FIFO = 2;
+
+  // Messages that are delivered after the specified duration.
+  DELAY = 3;
+
+  // Messages that are transactional. Only committed messages are delivered to
+  // subscribers.
+  TRANSACTION = 4;
+
+  // lite topic
+  LITE = 5;
+
+  // Messages that lower prioritised ones may need to wait for higher priority messages to be processed first
+  PRIORITY = 6;
+}
+
+enum DigestType {
+  DIGEST_TYPE_UNSPECIFIED = 0;
+
+  // CRC algorithm achieves goal of detecting random data error with lowest
+  // computation overhead.
+  CRC32 = 1;
+
+  // MD5 algorithm achieves good balance between collision rate and computation
+  // overhead.
+  MD5 = 2;
+
+  // SHA-family has substantially fewer collision with fair amount of
+  // computation.
+  SHA1 = 3;
+}
+
+// When publishing messages to or subscribing messages from brokers, clients
+// shall include or validate digests of message body to ensure data integrity.
+//
+// For message publishing, when an invalid digest were detected, brokers need
+// respond client with BAD_REQUEST.
+//
+// For messages subscription, when an invalid digest were detected, consumers
+// need to handle this case according to message type:
+// 1) Standard messages should be negatively acknowledged instantly, causing
+// immediate re-delivery; 2) FIFO messages require special RPC, to re-fetch
+// previously acquired messages batch;
+message Digest {
+  DigestType type = 1;
+  string checksum = 2;
+}
+
+enum ClientType {
+  CLIENT_TYPE_UNSPECIFIED = 0;
+  PRODUCER = 1;
+  PUSH_CONSUMER = 2;
+  SIMPLE_CONSUMER = 3;
+  PULL_CONSUMER = 4;
+  LITE_PUSH_CONSUMER = 5;
+  LITE_SIMPLE_CONSUMER = 6;
+}
+
+enum Encoding {
+  ENCODING_UNSPECIFIED = 0;
+
+  IDENTITY = 1;
+
+  GZIP = 2;
+}
+
+message SystemProperties {
+  // Tag, which is optional.
+  optional string tag = 1;
+
+  // Message keys
+  repeated string keys = 2;
+
+  // Message identifier, client-side generated, remains unique.
+  // if message_id is empty, the send message request will be aborted with
+  // status `INVALID_ARGUMENT`
+  string message_id = 3;
+
+  // Message body digest
+  Digest body_digest = 4;
+
+  // Message body encoding. Candidate options are identity, gzip, snappy etc.
+  Encoding body_encoding = 5;
+
+  // Message type, normal, FIFO or transactional.
+  MessageType message_type = 6;
+
+  // Message born time-point.
+  google.protobuf.Timestamp born_timestamp = 7;
+
+  // Message born host. Valid options are IPv4, IPv6 or client host domain name.
+  string born_host = 8;
+
+  // Time-point at which the message is stored in the broker, which is absent
+  // for message publishing.
+  optional google.protobuf.Timestamp store_timestamp = 9;
+
+  // The broker that stores this message. It may be broker name, IP or arbitrary
+  // identifier that uniquely identify the server.
+  string store_host = 10;
+
+  // Time-point at which broker delivers to clients, which is optional.
+  optional google.protobuf.Timestamp delivery_timestamp = 11;
+
+  // If a message is acquired by way of POP, this field holds the receipt,
+  // which is absent for message publishing.
+  // Clients use the receipt to acknowledge or negatively acknowledge the
+  // message.
+  optional string receipt_handle = 12;
+
+  // Message queue identifier in which a message is physically stored.
+  int32 queue_id = 13;
+
+  // Message-queue offset at which a message is stored, which is absent for
+  // message publishing.
+  optional int64 queue_offset = 14;
+
+  // Period of time servers would remain invisible once a message is acquired.
+  optional google.protobuf.Duration invisible_duration = 15;
+
+  // Business code may failed to process messages for the moment. Hence, clients
+  // may request servers to deliver them again using certain back-off strategy,
+  // the attempt is 1 not 0 if message is delivered first time, and it is absent
+  // for message publishing.
+  optional int32 delivery_attempt = 16;
+
+  // Define the group name of message in the same topic, which is optional.
+  optional string message_group = 17;
+
+  // Trace context for each message, which is optional.
+  optional string trace_context = 18;
+
+  // If a transactional message stay unresolved for more than
+  // `transaction_orphan_threshold`, it would be regarded as an
+  // orphan. Servers that manages orphan messages would pick up
+  // a capable publisher to resolve
+  optional google.protobuf.Duration orphaned_transaction_recovery_duration = 19;
+
+  // Information to identify whether this message is from dead letter queue.
+  optional DeadLetterQueue dead_letter_queue = 20;
+
+  // lite topic
+  optional string lite_topic = 21;
+
+  // Priority of message, which is optional
+  optional int32 priority = 22;
+}
+
+message DeadLetterQueue {
+  // Original topic for this DLQ message.
+  string topic = 1;
+  // Original message id for this DLQ message.
+  string message_id = 2;
+}
+
+message Message {
+
+  Resource topic = 1;
+
+  // User defined key-value pairs.
+  // If user_properties contain the reserved keys by RocketMQ,
+  // the send message request will be aborted with status `INVALID_ARGUMENT`.
+  // See below links for the reserved keys
+  // https://github.com/apache/rocketmq/blob/master/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java#L58
+  map<string, string> user_properties = 2;
+
+  SystemProperties system_properties = 3;
+
+  bytes body = 4;
+}
+
+message Assignment {
+  MessageQueue message_queue = 1;
+}
+
+enum Code {
+  CODE_UNSPECIFIED = 0;
+
+  // Generic code for success.
+  OK = 20000;
+
+  // Generic code for multiple return results.
+  MULTIPLE_RESULTS = 30000;
+
+  // Generic code for bad request, indicating that required fields or headers are missing.
+  BAD_REQUEST = 40000;
+  // Format of access point is illegal.
+  ILLEGAL_ACCESS_POINT = 40001;
+  // Format of topic is illegal.
+  ILLEGAL_TOPIC = 40002;
+  // Format of consumer group is illegal.
+  ILLEGAL_CONSUMER_GROUP = 40003;
+  // Format of message tag is illegal.
+  ILLEGAL_MESSAGE_TAG = 40004;
+  // Format of message key is illegal.
+  ILLEGAL_MESSAGE_KEY = 40005;
+  // Format of message group is illegal.
+  ILLEGAL_MESSAGE_GROUP = 40006;
+  // Format of message property key is illegal.
+  ILLEGAL_MESSAGE_PROPERTY_KEY = 40007;
+  // Transaction id is invalid.
+  INVALID_TRANSACTION_ID = 40008;
+  // Format of message id is illegal.
+  ILLEGAL_MESSAGE_ID = 40009;
+  // Format of filter expression is illegal.
+  ILLEGAL_FILTER_EXPRESSION = 40010;
+  // The invisible time of request is invalid.
+  ILLEGAL_INVISIBLE_TIME = 40011;
+  // The delivery timestamp of message is invalid.
+  ILLEGAL_DELIVERY_TIME = 40012;
+  // Receipt handle of message is invalid.
+  INVALID_RECEIPT_HANDLE = 40013;
+  // Message property conflicts with its type.
+  MESSAGE_PROPERTY_CONFLICT_WITH_TYPE = 40014;
+  // Client type could not be recognized.
+  UNRECOGNIZED_CLIENT_TYPE = 40015;
+  // Message is corrupted.
+  MESSAGE_CORRUPTED = 40016;
+  // Request is rejected due to missing of x-mq-client-id header.
+  CLIENT_ID_REQUIRED = 40017;
+  // Polling time is illegal.
+  ILLEGAL_POLLING_TIME = 40018;
+  // Offset is illegal.
+  ILLEGAL_OFFSET = 40019;
+  // Format of lite topic is illegal.
+  ILLEGAL_LITE_TOPIC = 40020;
+
+  // Generic code indicates that the client request lacks valid authentication
+  // credentials for the requested resource.
+  UNAUTHORIZED = 40100;
+
+  // Generic code indicates that the account is suspended due to overdue of payment.
+  PAYMENT_REQUIRED = 40200;
+
+  // Generic code for the case that user does not have the permission to operate.
+  FORBIDDEN = 40300;
+
+  // Generic code for resource not found.
+  NOT_FOUND = 40400;
+  // Message not found from server.
+  MESSAGE_NOT_FOUND = 40401;
+  // Topic resource does not exist.
+  TOPIC_NOT_FOUND = 40402;
+  // Consumer group resource does not exist.
+  CONSUMER_GROUP_NOT_FOUND = 40403;
+  // Offset not found from server.
+  OFFSET_NOT_FOUND = 40404;
+
+  // Generic code representing client side timeout when connecting to, reading data from, or write data to server.
+  REQUEST_TIMEOUT = 40800;
+
+  // Generic code represents that the request entity is larger than limits defined by server.
+  PAYLOAD_TOO_LARGE = 41300;
+  // Message body size exceeds the threshold.
+  MESSAGE_BODY_TOO_LARGE = 41301;
+  // Message body is empty.
+  MESSAGE_BODY_EMPTY = 41302;
+
+  // Generic code for use cases where pre-conditions are not met.
+  // For example, if a producer instance is used to publish messages without prior start() invocation,
+  // this error code will be raised.
+  PRECONDITION_FAILED = 42800;
+
+  // Generic code indicates that too many requests are made in short period of duration.
+  // Requests are throttled.
+  TOO_MANY_REQUESTS = 42900;
+
+  // LiteTopic related quota exceeded
+  LITE_TOPIC_QUOTA_EXCEEDED = 42901;
+  LITE_SUBSCRIPTION_QUOTA_EXCEEDED = 42902;
+
+  // Generic code for the case that the server is unwilling to process the request because its header fields are too large.
+  // The request may be resubmitted after reducing the size of the request header fields.
+  REQUEST_HEADER_FIELDS_TOO_LARGE = 43100;
+  // Message properties total size exceeds the threshold.
+  MESSAGE_PROPERTIES_TOO_LARGE = 43101;
+
+  // Generic code indicates that server/client encountered an unexpected
+  // condition that prevented it from fulfilling the request.
+  INTERNAL_ERROR = 50000;
+  // Code indicates that the server encountered an unexpected condition
+  // that prevented it from fulfilling the request.
+  // This error response is a generic "catch-all" response.
+  // Usually, this indicates the server cannot find a better alternative
+  // error code to response. Sometimes, server administrators log error
+  // responses like the 500 status code with more details about the request
+  // to prevent the error from happening again in the future.
+  //
+  // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+  INTERNAL_SERVER_ERROR = 50001;
+  // The HA-mechanism is not working now.
+  HA_NOT_AVAILABLE = 50002;
+
+  // Generic code means that the server or client does not support the
+  // functionality required to fulfill the request.
+  NOT_IMPLEMENTED = 50100;
+
+  // Generic code represents that the server, which acts as a gateway or proxy,
+  // does not get an satisfied response in time from its upstream servers.
+  // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+  PROXY_TIMEOUT = 50400;
+  // Message persistence timeout.
+  MASTER_PERSISTENCE_TIMEOUT = 50401;
+  // Slave persistence timeout.
+  SLAVE_PERSISTENCE_TIMEOUT = 50402;
+
+  // Generic code for unsupported operation.
+  UNSUPPORTED = 50500;
+  // Operation is not allowed in current version.
+  VERSION_UNSUPPORTED = 50501;
+  // Not allowed to verify message. Chances are that you are verifying
+  // a FIFO message, as is violating FIFO semantics.
+  VERIFY_FIFO_MESSAGE_UNSUPPORTED = 50502;
+
+  // Generic code for failed message consumption.
+  FAILED_TO_CONSUME_MESSAGE = 60000;
+}
+
+message Status {
+  Code code = 1;
+  string message = 2;
+}
+
+enum Language {
+  LANGUAGE_UNSPECIFIED = 0;
+  JAVA = 1;
+  CPP = 2;
+  DOT_NET = 3;
+  GOLANG = 4;
+  RUST = 5;
+  PYTHON = 6;
+  PHP = 7;
+  NODE_JS = 8;
+  RUBY = 9;
+  OBJECTIVE_C = 10;
+  DART = 11;
+  KOTLIN = 12;
+}
+
+// User Agent
+message UA {
+  // SDK language
+  Language language = 1;
+
+  // SDK version
+  string version = 2;
+
+  // Platform details, including OS name, version, arch etc.
+  string platform = 3;
+
+  // Hostname of the node
+  string hostname = 4;
+}
+
+message Settings {
+  // Configurations for all clients.
+  optional ClientType client_type = 1;
+
+  optional Endpoints access_point = 2;
+
+  // If publishing of messages encounters throttling or server internal errors,
+  // publishers should implement automatic retries after progressive longer
+  // back-offs for consecutive errors.
+  //
+  // When processing message fails, `backoff_policy` describes an interval
+  // after which the message should be available to consume again.
+  //
+  // For FIFO messages, the interval should be relatively small because
+  // messages of the same message group would not be readily available until
+  // the prior one depletes its lifecycle.
+  optional RetryPolicy backoff_policy = 3;
+
+  // Request timeout for RPCs excluding long-polling.
+  optional google.protobuf.Duration request_timeout = 4;
+
+  oneof pub_sub {
+    Publishing publishing = 5;
+
+    Subscription subscription = 6;
+  }
+
+  // User agent details
+  UA user_agent = 7;
+
+  Metric metric = 8;
+}
+
+message Publishing {
+  // Publishing settings below here is appointed by client, thus it is
+  // unnecessary for server to push at present.
+  //
+  // List of topics to which messages will publish to.
+  repeated Resource topics = 1;
+
+  // If the message body size exceeds `max_body_size`, broker servers would
+  // reject the request. As a result, it is advisable that Producer performs
+  // client-side check validation.
+  int32 max_body_size = 2;
+
+  // When `validate_message_type` flag set `false`, no need to validate message's type
+  // with messageQueue's `accept_message_types` before publishing.
+  bool validate_message_type = 3;
+}
+
+message Subscription {
+  // Subscription settings below here is appointed by client, thus it is
+  // unnecessary for server to push at present.
+  //
+  // Consumer group.
+  optional Resource group = 1;
+
+  // Subscription for consumer.
+  repeated SubscriptionEntry subscriptions = 2;
+
+  // Subscription settings below here are from server, it is essential for
+  // server to push.
+  //
+  // When FIFO flag is `true`, messages of the same message group are processed
+  // in first-in-first-out manner.
+  //
+  // Brokers will not deliver further messages of the same group until prior
+  // ones are completely acknowledged.
+  optional bool fifo = 3;
+
+  // Message receive batch size here is essential for push consumer.
+  optional int32 receive_batch_size = 4;
+
+  // Long-polling timeout for `ReceiveMessageRequest`, which is essential for
+  // push consumer.
+  optional google.protobuf.Duration long_polling_timeout = 5;
+
+  // Only lite push consumer
+  // client-side lite subscription quota limit
+  optional int32 lite_subscription_quota = 6;
+
+  // Only lite push consumer
+  // Maximum length limit for lite topic
+  optional int32 max_lite_topic_size = 7;
+}
+
+enum LiteSubscriptionAction {
+  PARTIAL_ADD = 0;
+  PARTIAL_REMOVE = 1;
+  COMPLETE_ADD = 2;
+  COMPLETE_REMOVE = 3;
+}
+
+message Metric {
+  // Indicates that if client should export local metrics to server.
+  bool on = 1;
+
+  // The endpoint that client metrics should be exported to, which is required if the switch is on.
+  optional Endpoints endpoints = 2;
+}
+
+enum QueryOffsetPolicy {
+  // Use this option if client wishes to playback all existing messages.
+  BEGINNING = 0;
+
+  // Use this option if client wishes to skip all existing messages.
+  END = 1;
+
+  // Use this option if time-based seek is targeted.
+  TIMESTAMP = 2;
+}
+
+message OffsetOption {
+  oneof offset_type {
+    Policy policy = 1;
+    int64 offset = 2;
+    int64 tail_n = 3;
+    int64 timestamp = 4;
+  }
+
+  enum Policy {
+    LAST = 0;
+    MIN = 1;
+    MAX = 2;
+  }
+}

--- a/rocketmq-proxy/proto/service.proto
+++ b/rocketmq-proxy/proto/service.proto
@@ -1,0 +1,480 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Source: https://github.com/apache/rocketmq-apis/tree/main/apache/rocketmq/v2
+// Copyright: The Apache Software Foundation (ASF)
+// Adapted for rocketmq-rust namespace and local build layout.
+
+syntax = "proto3";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+import "definition.proto";
+
+package rocketmq_rust_proxy.v2;
+
+option csharp_namespace = "Rocketmq.Rust.Proxy.V2";
+option java_multiple_files = true;
+option java_package = "rocketmq.rust.proxy.v2";
+option java_generate_equals_and_hash = true;
+option java_string_check_utf8 = true;
+option java_outer_classname = "RocketmqRustProxyService";
+
+// Topics are destination of messages to publish to or subscribe from. Similar
+// to domain names, they will be addressable after resolution through the
+// provided access point.
+//
+// Access points are usually the addresses of name servers, which fulfill
+// service discovery, load-balancing and other auxiliary services. Name servers
+// receive periodic heartbeats from affiliate brokers and erase those which
+// failed to maintain alive status.
+//
+// Name servers answer queries of QueryRouteRequest, responding clients with
+// addressable message-queues, which they may directly publish messages to or
+// subscribe messages from.
+//
+// QueryRouteRequest shall include source endpoints, aka, configured
+// access-point, which annotates tenant-id, instance-id or other
+// vendor-specific settings. Purpose-built name servers may respond customized
+// results based on these particular requirements.
+message QueryRouteRequest {
+  Resource topic = 1;
+  Endpoints endpoints = 2;
+}
+
+message QueryRouteResponse {
+  Status status = 1;
+
+  repeated MessageQueue message_queues = 2;
+}
+
+message SendMessageRequest {
+  repeated Message messages = 1;
+}
+
+message SendResultEntry {
+  Status status = 1;
+  string message_id = 2;
+  string transaction_id = 3;
+  int64 offset = 4;
+  // Unique handle to identify message to recall, support delay message for now.
+  string recall_handle = 5;
+}
+
+message SendMessageResponse {
+  Status status = 1;
+
+  // Some implementation may have partial failure issues. Client SDK developers are expected to inspect
+  // each entry for best certainty.
+  repeated SendResultEntry entries = 2;
+}
+
+message QueryAssignmentRequest {
+  Resource topic = 1;
+  Resource group = 2;
+  Endpoints endpoints = 3;
+}
+
+message QueryAssignmentResponse {
+  Status status = 1;
+  repeated Assignment assignments = 2;
+}
+
+message ReceiveMessageRequest {
+  Resource group = 1;
+  MessageQueue message_queue = 2;
+  FilterExpression filter_expression = 3;
+  int32 batch_size = 4;
+  // Required if client type is simple consumer.
+  optional google.protobuf.Duration invisible_duration = 5;
+  // For message auto renew and clean
+  bool auto_renew = 6;
+  optional google.protobuf.Duration long_polling_timeout = 7;
+  optional string attempt_id = 8;
+}
+
+message ReceiveMessageResponse {
+  oneof content {
+    Status status = 1;
+    Message message = 2;
+    // The timestamp that brokers start to deliver status line or message.
+    google.protobuf.Timestamp delivery_timestamp = 3;
+  }
+}
+
+message AckMessageEntry {
+  string message_id = 1;
+  string receipt_handle = 2;
+  optional string lite_topic = 3;
+}
+
+message AckMessageRequest {
+  Resource group = 1;
+  Resource topic = 2;
+  repeated AckMessageEntry entries = 3;
+}
+
+message AckMessageResultEntry {
+  string message_id = 1;
+  string receipt_handle = 2;
+
+  // Acknowledge result may be acquired through inspecting
+  // `status.code`; In case acknowledgement failed, `status.message`
+  // is the explanation of the failure.
+  Status status = 3;
+}
+
+message AckMessageResponse {
+
+  // RPC tier status, which is used to represent RPC-level errors including
+  // authentication, authorization, throttling and other general failures.
+  Status status = 1;
+
+  repeated AckMessageResultEntry entries = 2;
+}
+
+message ForwardMessageToDeadLetterQueueRequest {
+  Resource group = 1;
+  Resource topic = 2;
+  string receipt_handle = 3;
+  string message_id = 4;
+  int32 delivery_attempt = 5;
+  int32 max_delivery_attempts = 6;
+  optional string lite_topic = 7;
+}
+
+message ForwardMessageToDeadLetterQueueResponse { Status status = 1; }
+
+message HeartbeatRequest {
+  optional Resource group = 1;
+  ClientType client_type = 2;
+}
+
+message HeartbeatResponse { Status status = 1; }
+
+message EndTransactionRequest {
+  Resource topic = 1;
+  string message_id = 2;
+  string transaction_id = 3;
+  TransactionResolution resolution = 4;
+  TransactionSource source = 5;
+  string trace_context = 6;
+}
+
+message EndTransactionResponse { Status status = 1; }
+
+message PrintThreadStackTraceCommand { string nonce = 1; }
+
+message ReconnectEndpointsCommand { string nonce = 1; }
+
+message ThreadStackTrace {
+  string nonce = 1;
+  optional string thread_stack_trace = 2;
+}
+
+message VerifyMessageCommand {
+  string nonce = 1;
+  Message message = 2;
+}
+
+message VerifyMessageResult {
+  string nonce = 1;
+}
+
+message RecoverOrphanedTransactionCommand {
+  Message message = 1;
+  string transaction_id = 2;
+}
+
+message NotifyUnsubscribeLiteCommand {
+  string lite_topic = 1;
+}
+
+message TelemetryCommand {
+  optional Status status = 1;
+
+  oneof command {
+    // Client settings
+    Settings settings = 2;
+
+    // These messages are from client.
+    //
+    // Report thread stack trace to server.
+    ThreadStackTrace thread_stack_trace = 3;
+
+    // Report message verify result to server.
+    VerifyMessageResult verify_message_result = 4;
+
+    // There messages are from server.
+    //
+    // Request client to recover the orphaned transaction message.
+    RecoverOrphanedTransactionCommand recover_orphaned_transaction_command = 5;
+
+    // Request client to print thread stack trace.
+    PrintThreadStackTraceCommand print_thread_stack_trace_command = 6;
+
+    // Request client to verify the consumption of the appointed message.
+    VerifyMessageCommand verify_message_command = 7;
+
+    // Request client to reconnect server use the latest endpoints.
+    ReconnectEndpointsCommand reconnect_endpoints_command = 8;
+
+    // Request client to unsubscribe lite topic.
+    NotifyUnsubscribeLiteCommand notify_unsubscribe_lite_command = 9;
+  }
+}
+
+message NotifyClientTerminationRequest {
+  // Consumer group, which is absent for producer.
+  optional Resource group = 1;
+}
+
+message NotifyClientTerminationResponse { Status status = 1; }
+
+message ChangeInvisibleDurationRequest {
+  Resource group = 1;
+  Resource topic = 2;
+
+  // Unique receipt handle to identify message to change
+  string receipt_handle = 3;
+
+  // New invisible duration
+  google.protobuf.Duration invisible_duration = 4;
+
+  // For message tracing
+  string message_id = 5;
+
+  optional string lite_topic = 6;
+  // If true, server will not increment the retry times for this message
+  optional bool suspend = 7;
+}
+
+message ChangeInvisibleDurationResponse {
+  Status status = 1;
+
+  // Server may generate a new receipt handle for the message.
+  string receipt_handle = 2;
+}
+
+message PullMessageRequest {
+  Resource group = 1;
+  MessageQueue message_queue = 2;
+  int64 offset = 3;
+  int32 batch_size = 4;
+  FilterExpression filter_expression = 5;
+  google.protobuf.Duration long_polling_timeout = 6;
+}
+
+message PullMessageResponse {
+  oneof content {
+    Status status = 1;
+    Message message = 2;
+    int64 next_offset = 3;
+  }
+}
+
+message UpdateOffsetRequest {
+  Resource group = 1;
+  MessageQueue message_queue = 2;
+  int64 offset = 3;
+}
+
+message UpdateOffsetResponse {
+  Status status = 1;
+}
+
+message GetOffsetRequest {
+  Resource group = 1;
+  MessageQueue message_queue = 2;
+}
+
+message GetOffsetResponse {
+  Status status = 1;
+  int64 offset = 2;
+}
+
+message QueryOffsetRequest {
+  MessageQueue message_queue = 1;
+  QueryOffsetPolicy query_offset_policy = 2;
+  optional google.protobuf.Timestamp timestamp = 3;
+}
+
+message QueryOffsetResponse {
+  Status status = 1;
+  int64 offset = 2;
+}
+
+message RecallMessageRequest {
+  Resource topic = 1;
+  // Refer to SendResultEntry.
+  string recall_handle = 2;
+}
+
+message RecallMessageResponse {
+  Status status = 1;
+  string message_id = 2;
+}
+
+message SyncLiteSubscriptionRequest {
+  LiteSubscriptionAction action = 1;
+  // bindTopic for lite push consumer
+  Resource topic = 2;
+  // consumer group
+  Resource group = 3;
+  // lite subscription set of lite topics
+  repeated string lite_topic_set = 4;
+  optional int64 version = 5;
+  optional OffsetOption offset_option = 6;
+}
+
+message SyncLiteSubscriptionResponse {
+  Status status = 1;
+}
+
+// For all the RPCs in MessagingService, the following error handling policies
+// apply:
+//
+// If the request doesn't bear a valid authentication credential, return a
+// response with common.status.code == `UNAUTHENTICATED`. If the authenticated
+// user is not granted with sufficient permission to execute the requested
+// operation, return a response with common.status.code == `PERMISSION_DENIED`.
+// If the per-user-resource-based quota is exhausted, return a response with
+// common.status.code == `RESOURCE_EXHAUSTED`. If any unexpected server-side
+// errors raise, return a response with common.status.code == `INTERNAL`.
+service MessagingService {
+
+  // Queries the route entries of the requested topic in the perspective of the
+  // given endpoints. On success, servers should return a collection of
+  // addressable message-queues. Note servers may return customized route
+  // entries based on endpoints provided.
+  //
+  // If the requested topic doesn't exist, returns `NOT_FOUND`.
+  // If the specific endpoints is empty, returns `INVALID_ARGUMENT`.
+  rpc QueryRoute(QueryRouteRequest) returns (QueryRouteResponse) {}
+
+  // Producer or consumer sends HeartbeatRequest to servers periodically to
+  // keep-alive. Additionally, it also reports client-side configuration,
+  // including topic subscription, load-balancing group name, etc.
+  //
+  // Returns `OK` if success.
+  //
+  // If a client specifies a language that is not yet supported by servers,
+  // returns `INVALID_ARGUMENT`
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse) {}
+
+  // Delivers messages to brokers.
+  // Clients may further:
+  // 1. Refine a message destination to message-queues which fulfills parts of
+  // FIFO semantic;
+  // 2. Flag a message as transactional, which keeps it invisible to consumers
+  // until it commits;
+  // 3. Time a message, making it invisible to consumers till specified
+  // time-point;
+  // 4. And more...
+  //
+  // Returns message-id or transaction-id with status `OK` on success.
+  //
+  // If the destination topic doesn't exist, returns `NOT_FOUND`.
+  rpc SendMessage(SendMessageRequest) returns (SendMessageResponse) {}
+
+  // Queries the assigned route info of a topic for current consumer,
+  // the returned assignment result is decided by server-side load balancer.
+  //
+  // If the corresponding topic doesn't exist, returns `NOT_FOUND`.
+  // If the specific endpoints is empty, returns `INVALID_ARGUMENT`.
+  rpc QueryAssignment(QueryAssignmentRequest) returns (QueryAssignmentResponse) {
+  }
+
+  // Receives messages from the server in batch manner, returns a set of
+  // messages if success. The received messages should be acked or redelivered
+  // after processed.
+  //
+  // If the pending concurrent receive requests exceed the quota of the given
+  // consumer group, returns `UNAVAILABLE`. If the upstream store server hangs,
+  // return `DEADLINE_EXCEEDED` in a timely manner. If the corresponding topic
+  // or consumer group doesn't exist, returns `NOT_FOUND`. If there is no new
+  // message in the specific topic, returns `OK` with an empty message set.
+  // Please note that client may suffer from false empty responses.
+  //
+  // If failed to receive message from remote, server must return only one
+  // `ReceiveMessageResponse` as the reply to the request, whose `Status` indicates
+  // the specific reason of failure, otherwise, the reply is considered successful.
+  rpc ReceiveMessage(ReceiveMessageRequest) returns (stream ReceiveMessageResponse) {
+  }
+
+  // Acknowledges the message associated with the `receipt_handle` or `offset`
+  // in the `AckMessageRequest`, it means the message has been successfully
+  // processed. Returns `OK` if the message server remove the relevant message
+  // successfully.
+  //
+  // If the given receipt_handle is illegal or out of date, returns
+  // `INVALID_ARGUMENT`.
+  rpc AckMessage(AckMessageRequest) returns (AckMessageResponse) {}
+
+  // Forwards one message to dead letter queue if the max delivery attempts is
+  // exceeded by this message at client-side, return `OK` if success.
+  rpc ForwardMessageToDeadLetterQueue(ForwardMessageToDeadLetterQueueRequest)
+      returns (ForwardMessageToDeadLetterQueueResponse) {}
+
+  // PullMessage and ReceiveMessage RPCs serve a similar purpose,
+  // which is to attempt to get messages from the server, but with different semantics.
+  rpc PullMessage(PullMessageRequest) returns (stream PullMessageResponse) {}
+
+  // Update the consumption progress of the designated queue of the
+  // consumer group to the remote.
+  rpc UpdateOffset(UpdateOffsetRequest) returns (UpdateOffsetResponse) {}
+
+  // Query the consumption progress of the designated queue of the
+  // consumer group to the remote.
+  rpc GetOffset(GetOffsetRequest) returns (GetOffsetResponse) {}
+
+  // Query the offset of the designated queue by the query offset policy.
+  rpc QueryOffset(QueryOffsetRequest) returns (QueryOffsetResponse) {}
+
+  // Commits or rollback one transactional message.
+  rpc EndTransaction(EndTransactionRequest) returns (EndTransactionResponse) {}
+
+  // Once a client starts, it would immediately establishes bi-lateral stream
+  // RPCs with brokers, reporting its settings as the initiative command.
+  //
+  // When servers have need of inspecting client status, they would issue
+  // telemetry commands to clients. After executing received instructions,
+  // clients shall report command execution results through client-side streams.
+  rpc Telemetry(stream TelemetryCommand) returns (stream TelemetryCommand) {}
+
+  // Notify the server that the client is terminated.
+  rpc NotifyClientTermination(NotifyClientTerminationRequest) returns (NotifyClientTerminationResponse) {
+  }
+
+  // Once a message is retrieved from consume queue on behalf of the group, it
+  // will be kept invisible to other clients of the same group for a period of
+  // time. The message is supposed to be processed within the invisible
+  // duration. If the client, which is in charge of the invisible message, is
+  // not capable of processing the message timely, it may use
+  // ChangeInvisibleDuration to lengthen invisible duration.
+  rpc ChangeInvisibleDuration(ChangeInvisibleDurationRequest) returns (ChangeInvisibleDurationResponse) {
+  }
+
+  // Recall a message,
+  // for delay message, should recall before delivery time, like the rollback operation of transaction message,
+  // for normal message, not supported for now.
+  rpc RecallMessage(RecallMessageRequest) returns (RecallMessageResponse) {
+  }
+
+  // Sync lite subscription info, lite push consumer only
+  rpc SyncLiteSubscription(SyncLiteSubscriptionRequest) returns (SyncLiteSubscriptionResponse) {}
+
+}

--- a/rocketmq-proxy/src/bootstrap.rs
+++ b/rocketmq-proxy/src/bootstrap.rs
@@ -1,0 +1,108 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future;
+use std::future::Future;
+use std::sync::Arc;
+
+use crate::config::ProxyConfig;
+use crate::config::ProxyMode;
+use crate::error::ProxyResult;
+use crate::grpc::server;
+use crate::grpc::ProxyGrpcService;
+use crate::processor::DefaultMessagingProcessor;
+use crate::processor::MessagingProcessor;
+use crate::service::ClusterServiceManager;
+use crate::service::LocalServiceManager;
+use crate::service::ServiceManager;
+use crate::session::ClientSessionRegistry;
+
+pub struct ProxyRuntimeBuilder {
+    config: ProxyConfig,
+    service_manager: Option<Arc<dyn ServiceManager>>,
+    session_registry: Option<ClientSessionRegistry>,
+}
+
+impl ProxyRuntimeBuilder {
+    pub fn with_service_manager(mut self, service_manager: Arc<dyn ServiceManager>) -> Self {
+        self.service_manager = Some(service_manager);
+        self
+    }
+
+    pub fn with_session_registry(mut self, session_registry: ClientSessionRegistry) -> Self {
+        self.session_registry = Some(session_registry);
+        self
+    }
+
+    pub fn build(self) -> ProxyRuntime<DefaultMessagingProcessor> {
+        let service_manager = self
+            .service_manager
+            .unwrap_or_else(|| default_service_manager(self.config.mode));
+        let session_registry = self.session_registry.unwrap_or_default();
+        let processor = Arc::new(DefaultMessagingProcessor::new(service_manager));
+        ProxyRuntime::from_processor(self.config, processor, session_registry)
+    }
+}
+
+pub struct ProxyRuntime<P = DefaultMessagingProcessor> {
+    config: Arc<ProxyConfig>,
+    grpc_service: ProxyGrpcService<P>,
+}
+
+impl ProxyRuntime<DefaultMessagingProcessor> {
+    pub fn builder(config: ProxyConfig) -> ProxyRuntimeBuilder {
+        ProxyRuntimeBuilder {
+            config,
+            service_manager: None,
+            session_registry: None,
+        }
+    }
+
+    pub fn new(config: ProxyConfig) -> Self {
+        Self::builder(config).build()
+    }
+}
+
+impl<P> ProxyRuntime<P>
+where
+    P: MessagingProcessor + 'static,
+{
+    pub fn from_processor(config: ProxyConfig, processor: Arc<P>, session_registry: ClientSessionRegistry) -> Self {
+        let config = Arc::new(config);
+        let grpc_service = ProxyGrpcService::new(Arc::clone(&config), processor, session_registry);
+        Self { config, grpc_service }
+    }
+
+    pub fn config(&self) -> &ProxyConfig {
+        self.config.as_ref()
+    }
+
+    pub async fn serve(self) -> ProxyResult<()> {
+        self.serve_with_shutdown(future::pending::<()>()).await
+    }
+
+    pub async fn serve_with_shutdown<F>(self, shutdown: F) -> ProxyResult<()>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        server::serve(self.config, self.grpc_service, shutdown).await
+    }
+}
+
+fn default_service_manager(mode: ProxyMode) -> Arc<dyn ServiceManager> {
+    match mode {
+        ProxyMode::Cluster => Arc::new(ClusterServiceManager::default()),
+        ProxyMode::Local => Arc::new(LocalServiceManager::default()),
+    }
+}

--- a/rocketmq-proxy/src/config.rs
+++ b/rocketmq-proxy/src/config.rs
@@ -1,0 +1,134 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::path::Path;
+
+use rocketmq_error::RocketMQError;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::error::ProxyResult;
+use crate::DEFAULT_PROXY_GRPC_PORT;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ProxyMode {
+    #[default]
+    Cluster,
+    Local,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct GrpcConfig {
+    pub listen_addr: String,
+    pub max_decoding_message_size: usize,
+    pub max_encoding_message_size: usize,
+    pub concurrency_limit_per_connection: usize,
+    pub use_endpoint_port_from_request: bool,
+}
+
+impl Default for GrpcConfig {
+    fn default() -> Self {
+        Self {
+            listen_addr: format!("0.0.0.0:{DEFAULT_PROXY_GRPC_PORT}"),
+            max_decoding_message_size: 8 * 1024 * 1024,
+            max_encoding_message_size: 8 * 1024 * 1024,
+            concurrency_limit_per_connection: 256,
+            use_endpoint_port_from_request: false,
+        }
+    }
+}
+
+impl GrpcConfig {
+    pub fn socket_addr(&self) -> ProxyResult<SocketAddr> {
+        self.listen_addr.parse().map_err(|error| {
+            RocketMQError::illegal_argument(format!(
+                "invalid proxy gRPC listen address '{}': {error}",
+                self.listen_addr
+            ))
+            .into()
+        })
+    }
+
+    pub fn listen_port(&self) -> ProxyResult<u16> {
+        Ok(self.socket_addr()?.port())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct RuntimeConfig {
+    pub route_permits: usize,
+    pub producer_permits: usize,
+    pub consumer_permits: usize,
+    pub client_manager_permits: usize,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            route_permits: 512,
+            producer_permits: 1024,
+            consumer_permits: 1024,
+            client_manager_permits: 512,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct SessionConfig {
+    pub client_ttl_ms: u64,
+    pub receipt_handle_ttl_ms: u64,
+    pub auto_renew_enabled: bool,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            client_ttl_ms: 60_000,
+            receipt_handle_ttl_ms: 5 * 60_000,
+            auto_renew_enabled: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ProxyConfig {
+    pub mode: ProxyMode,
+    pub grpc: GrpcConfig,
+    pub runtime: RuntimeConfig,
+    pub session: SessionConfig,
+}
+
+impl ProxyConfig {
+    pub fn load_from_file(path: impl AsRef<Path>) -> ProxyResult<Self> {
+        let path = path.as_ref();
+        let builder = config::Config::builder().add_source(config::File::from(path));
+        let config = builder.build().map_err(|error| {
+            RocketMQError::Internal(format!("failed to build proxy config from {}: {error}", path.display()))
+        })?;
+
+        config.try_deserialize().map_err(|error| {
+            RocketMQError::Internal(format!(
+                "failed to deserialize proxy config from {}: {error}",
+                path.display()
+            ))
+            .into()
+        })
+    }
+}

--- a/rocketmq-proxy/src/context.rs
+++ b/rocketmq-proxy/src/context.rs
@@ -1,0 +1,170 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+use std::time::Instant;
+
+use tonic::metadata::MetadataMap;
+use tonic::Request;
+use uuid::Uuid;
+
+use crate::error::ProxyError;
+use crate::error::ProxyResult;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResolvedAddressScheme {
+    Unspecified,
+    Ipv4,
+    Ipv6,
+    DomainName,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ResolvedEndpoint {
+    pub scheme: ResolvedAddressScheme,
+    pub host: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProxyContext {
+    request_id: String,
+    rpc_name: &'static str,
+    remote_addr: Option<String>,
+    local_addr: Option<String>,
+    client_id: Option<String>,
+    language: Option<String>,
+    client_version: Option<String>,
+    namespace: Option<String>,
+    connection_id: Option<String>,
+    deadline: Option<Duration>,
+    received_at: Instant,
+}
+
+impl ProxyContext {
+    pub fn from_grpc_request<T>(rpc_name: &'static str, request: &Request<T>) -> Self {
+        let metadata = request.metadata();
+        Self {
+            request_id: Uuid::new_v4().to_string(),
+            rpc_name,
+            remote_addr: request.remote_addr().map(|addr| addr.to_string()),
+            local_addr: None,
+            client_id: metadata_string(metadata, "x-mq-client-id"),
+            language: metadata_string(metadata, "x-mq-language"),
+            client_version: metadata_string(metadata, "x-mq-client-version"),
+            namespace: metadata_string(metadata, "x-mq-namespace"),
+            connection_id: metadata_string(metadata, "x-mq-channel-id"),
+            deadline: metadata
+                .get("grpc-timeout")
+                .and_then(|value| value.to_str().ok())
+                .and_then(parse_grpc_timeout),
+            received_at: Instant::now(),
+        }
+    }
+
+    pub fn require_client_id(&self) -> ProxyResult<&str> {
+        self.client_id.as_deref().ok_or(ProxyError::ClientIdRequired)
+    }
+
+    pub fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    pub fn rpc_name(&self) -> &'static str {
+        self.rpc_name
+    }
+
+    pub fn remote_addr(&self) -> Option<&str> {
+        self.remote_addr.as_deref()
+    }
+
+    pub fn local_addr(&self) -> Option<&str> {
+        self.local_addr.as_deref()
+    }
+
+    pub fn client_id(&self) -> Option<&str> {
+        self.client_id.as_deref()
+    }
+
+    pub fn namespace(&self) -> Option<&str> {
+        self.namespace.as_deref()
+    }
+
+    pub fn language(&self) -> Option<&str> {
+        self.language.as_deref()
+    }
+
+    pub fn client_version(&self) -> Option<&str> {
+        self.client_version.as_deref()
+    }
+
+    pub fn connection_id(&self) -> Option<&str> {
+        self.connection_id.as_deref()
+    }
+
+    pub fn deadline(&self) -> Option<Duration> {
+        self.deadline
+    }
+
+    pub fn received_at(&self) -> Instant {
+        self.received_at
+    }
+}
+
+fn metadata_string(metadata: &MetadataMap, key: &'static str) -> Option<String> {
+    metadata
+        .get(key)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned)
+}
+
+pub(crate) fn parse_grpc_timeout(raw: &str) -> Option<Duration> {
+    if raw.len() < 2 {
+        return None;
+    }
+
+    let (value, unit) = raw.split_at(raw.len() - 1);
+    let value = value.parse::<u64>().ok()?;
+
+    match unit {
+        "H" => Some(Duration::from_secs(value.saturating_mul(60).saturating_mul(60))),
+        "M" => Some(Duration::from_secs(value.saturating_mul(60))),
+        "S" => Some(Duration::from_secs(value)),
+        "m" => Some(Duration::from_millis(value)),
+        "u" => Some(Duration::from_micros(value)),
+        "n" => Some(Duration::from_nanos(value)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::parse_grpc_timeout;
+
+    #[test]
+    fn parse_grpc_timeout_supports_multiple_units() {
+        assert_eq!(parse_grpc_timeout("5S"), Some(Duration::from_secs(5)));
+        assert_eq!(parse_grpc_timeout("25m"), Some(Duration::from_millis(25)));
+        assert_eq!(parse_grpc_timeout("100u"), Some(Duration::from_micros(100)));
+    }
+
+    #[test]
+    fn parse_grpc_timeout_rejects_invalid_values() {
+        assert_eq!(parse_grpc_timeout(""), None);
+        assert_eq!(parse_grpc_timeout("abc"), None);
+        assert_eq!(parse_grpc_timeout("12X"), None);
+    }
+}

--- a/rocketmq-proxy/src/error.rs
+++ b/rocketmq-proxy/src/error.rs
@@ -1,0 +1,58 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::RocketMQError;
+use thiserror::Error;
+
+pub type ProxyResult<T> = std::result::Result<T, ProxyError>;
+
+#[derive(Debug, Error)]
+pub enum ProxyError {
+    #[error(transparent)]
+    RocketMQ(#[from] RocketMQError),
+
+    #[error("gRPC client id is required")]
+    ClientIdRequired,
+
+    #[error("unrecognized client type: {0}")]
+    UnrecognizedClientType(i32),
+
+    #[error("proxy capability is not implemented yet: {feature}")]
+    NotImplemented { feature: &'static str },
+
+    #[error("request was rejected because '{resource}' is saturated")]
+    TooManyRequests { resource: &'static str },
+
+    #[error("invalid gRPC metadata: {message}")]
+    InvalidMetadata { message: String },
+
+    #[error("transport error: {message}")]
+    Transport { message: String },
+}
+
+impl ProxyError {
+    pub fn not_implemented(feature: &'static str) -> Self {
+        Self::NotImplemented { feature }
+    }
+
+    pub fn too_many_requests(resource: &'static str) -> Self {
+        Self::TooManyRequests { resource }
+    }
+
+    pub fn invalid_metadata(message: impl Into<String>) -> Self {
+        Self::InvalidMetadata {
+            message: message.into(),
+        }
+    }
+}

--- a/rocketmq-proxy/src/grpc/adapter.rs
+++ b/rocketmq-proxy/src/grpc/adapter.rs
@@ -1,0 +1,474 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+use rocketmq_common::common::constant::PermName;
+use rocketmq_common::common::mix_all::MASTER_ID;
+use rocketmq_remoting::protocol::route::route_data_view::QueueData;
+use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+
+use crate::config::ProxyConfig;
+use crate::context::ResolvedAddressScheme;
+use crate::context::ResolvedEndpoint;
+use crate::error::ProxyResult;
+use crate::processor::QueryAssignmentPlan;
+use crate::processor::QueryAssignmentRequest;
+use crate::processor::QueryRoutePlan;
+use crate::processor::QueryRouteRequest;
+use crate::proto::v2;
+use crate::service::ProxyTopicMessageType;
+use crate::service::ResourceIdentity;
+use crate::status::ProxyStatusMapper;
+
+pub fn build_query_route_request(
+    config: &ProxyConfig,
+    request: &v2::QueryRouteRequest,
+) -> ProxyResult<QueryRouteRequest> {
+    Ok(QueryRouteRequest {
+        topic: resource_identity(request.topic.as_ref(), "topic")?,
+        endpoints: resolve_endpoints(config, request.endpoints.as_ref())?,
+    })
+}
+
+pub fn build_query_assignment_request(
+    config: &ProxyConfig,
+    request: &v2::QueryAssignmentRequest,
+) -> ProxyResult<QueryAssignmentRequest> {
+    Ok(QueryAssignmentRequest {
+        topic: resource_identity(request.topic.as_ref(), "topic")?,
+        group: resource_identity(request.group.as_ref(), "group")?,
+        endpoints: resolve_endpoints(config, request.endpoints.as_ref())?,
+    })
+}
+
+pub fn build_query_route_response(request: &v2::QueryRouteRequest, plan: &QueryRoutePlan) -> v2::QueryRouteResponse {
+    let broker_map = build_broker_map(&plan.route);
+    let topic = request.topic.clone().unwrap_or_default();
+    let message_queues = plan
+        .route
+        .queue_datas
+        .iter()
+        .flat_map(|queue_data| {
+            broker_map
+                .get(queue_data.broker_name.as_str())
+                .into_iter()
+                .flat_map(move |broker_id_map| broker_id_map.values())
+                .flat_map({
+                    let topic = topic.clone();
+                    move |broker| {
+                        gen_message_queue_from_queue_data(queue_data, &topic, plan.topic_message_type, broker.clone())
+                    }
+                })
+        })
+        .collect();
+
+    v2::QueryRouteResponse {
+        status: Some(ProxyStatusMapper::ok()),
+        message_queues,
+    }
+}
+
+pub fn build_query_assignment_response(
+    request: &v2::QueryAssignmentRequest,
+    plan: &QueryAssignmentPlan,
+) -> v2::QueryAssignmentResponse {
+    let broker_map = build_broker_map(&plan.route);
+    let topic = request.topic.clone().unwrap_or_default();
+    let is_fifo = plan
+        .subscription_group
+        .as_ref()
+        .map(|group| group.consume_message_orderly)
+        .unwrap_or(false);
+    let is_lite = plan
+        .subscription_group
+        .as_ref()
+        .and_then(|group| group.lite_bind_topic.as_ref())
+        .is_some();
+
+    let assignments: Vec<v2::Assignment> = plan
+        .route
+        .queue_datas
+        .iter()
+        .filter(|queue_data| PermName::is_readable(queue_data.perm) && queue_data.read_queue_nums > 0)
+        .filter_map(|queue_data| {
+            broker_map
+                .get(queue_data.broker_name.as_str())
+                .and_then(|id_map| id_map.get(&MASTER_ID))
+                .map(|broker| (queue_data, broker.clone()))
+        })
+        .flat_map(|(queue_data, broker)| {
+            let permission = convert_permission(queue_data.perm);
+            if is_fifo && !is_lite {
+                (0..queue_data.read_queue_nums)
+                    .map({
+                        let topic = topic.clone();
+                        move |queue_id| v2::Assignment {
+                            message_queue: Some(v2::MessageQueue {
+                                topic: Some(topic.clone()),
+                                id: queue_id as i32,
+                                permission,
+                                broker: Some(broker.clone()),
+                                accept_message_types: Vec::new(),
+                            }),
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                vec![v2::Assignment {
+                    message_queue: Some(v2::MessageQueue {
+                        topic: Some(topic.clone()),
+                        id: -1,
+                        permission,
+                        broker: Some(broker),
+                        accept_message_types: Vec::new(),
+                    }),
+                }]
+            }
+        })
+        .collect();
+
+    if assignments.is_empty() {
+        return v2::QueryAssignmentResponse {
+            status: Some(ProxyStatusMapper::from_code(v2::Code::Forbidden, "no readable queue")),
+            assignments,
+        };
+    }
+
+    v2::QueryAssignmentResponse {
+        status: Some(ProxyStatusMapper::ok()),
+        assignments,
+    }
+}
+
+pub fn error_query_route_response(status: v2::Status) -> v2::QueryRouteResponse {
+    v2::QueryRouteResponse {
+        status: Some(status),
+        message_queues: Vec::new(),
+    }
+}
+
+pub fn error_query_assignment_response(status: v2::Status) -> v2::QueryAssignmentResponse {
+    v2::QueryAssignmentResponse {
+        status: Some(status),
+        assignments: Vec::new(),
+    }
+}
+
+fn resource_identity(resource: Option<&v2::Resource>, field: &'static str) -> ProxyResult<ResourceIdentity> {
+    let resource = resource.ok_or_else(|| {
+        rocketmq_error::RocketMQError::illegal_argument(format!("{field} resource must not be empty"))
+    })?;
+    if resource.name.trim().is_empty() {
+        return Err(rocketmq_error::RocketMQError::illegal_argument(format!("{field} name must not be empty")).into());
+    }
+
+    Ok(ResourceIdentity::new(
+        resource.resource_namespace.clone(),
+        resource.name.clone(),
+    ))
+}
+
+fn resolve_endpoints(config: &ProxyConfig, endpoints: Option<&v2::Endpoints>) -> ProxyResult<Vec<ResolvedEndpoint>> {
+    let endpoints =
+        endpoints.ok_or_else(|| rocketmq_error::RocketMQError::illegal_argument("endpoints must not be empty"))?;
+
+    if endpoints.addresses.is_empty() {
+        return Err(rocketmq_error::RocketMQError::illegal_argument("endpoints must not be empty").into());
+    }
+
+    let fallback_port = config.grpc.listen_port()?;
+    let scheme = match v2::AddressScheme::try_from(endpoints.scheme) {
+        Ok(v2::AddressScheme::IPv4) => ResolvedAddressScheme::Ipv4,
+        Ok(v2::AddressScheme::IPv6) => ResolvedAddressScheme::Ipv6,
+        Ok(v2::AddressScheme::DomainName) => ResolvedAddressScheme::DomainName,
+        _ => ResolvedAddressScheme::Unspecified,
+    };
+
+    endpoints
+        .addresses
+        .iter()
+        .map(|address| {
+            if address.host.trim().is_empty() {
+                return Err(rocketmq_error::RocketMQError::illegal_argument("endpoint host must not be empty").into());
+            }
+
+            let port = if config.grpc.use_endpoint_port_from_request {
+                address.port
+            } else {
+                i32::from(fallback_port)
+            };
+
+            if !(0..=u16::MAX as i32).contains(&port) {
+                return Err(rocketmq_error::RocketMQError::illegal_argument(format!(
+                    "endpoint port out of range: {port}"
+                ))
+                .into());
+            }
+
+            Ok(ResolvedEndpoint {
+                scheme,
+                host: address.host.clone(),
+                port: port as u16,
+            })
+        })
+        .collect()
+}
+
+fn build_broker_map(route: &TopicRouteData) -> HashMap<String, HashMap<u64, v2::Broker>> {
+    let mut broker_map = HashMap::new();
+
+    for broker_data in &route.broker_datas {
+        let mut broker_id_map = HashMap::new();
+        let broker_name = broker_data.broker_name().to_string();
+        for (broker_id, broker_addr) in broker_data.broker_addrs() {
+            let (scheme, address) = parse_broker_address(broker_addr.as_str());
+            let broker = v2::Broker {
+                name: broker_name.clone(),
+                id: *broker_id as i32,
+                endpoints: Some(v2::Endpoints {
+                    scheme: scheme as i32,
+                    addresses: vec![address],
+                }),
+            };
+            broker_id_map.insert(*broker_id, broker);
+        }
+        broker_map.insert(broker_name, broker_id_map);
+    }
+
+    broker_map
+}
+
+fn gen_message_queue_from_queue_data(
+    queue_data: &QueueData,
+    topic: &v2::Resource,
+    topic_message_type: ProxyTopicMessageType,
+    broker: v2::Broker,
+) -> Vec<v2::MessageQueue> {
+    let mut read_only = 0;
+    let mut write_only = 0;
+    let mut read_write = 0;
+    let mut inaccessible = 0;
+
+    if PermName::is_writeable(queue_data.perm) && PermName::is_readable(queue_data.perm) {
+        read_write = queue_data.write_queue_nums.min(queue_data.read_queue_nums);
+        read_only = queue_data.read_queue_nums - read_write;
+        write_only = queue_data.write_queue_nums - read_write;
+    } else if PermName::is_writeable(queue_data.perm) {
+        write_only = queue_data.write_queue_nums;
+    } else if PermName::is_readable(queue_data.perm) {
+        read_only = queue_data.read_queue_nums;
+    } else {
+        inaccessible = queue_data.write_queue_nums.max(queue_data.read_queue_nums).max(1);
+    }
+
+    let mut queue_id = 0_i32;
+    let mut result = Vec::new();
+
+    for _ in 0..read_only {
+        result.push(v2::MessageQueue {
+            topic: Some(topic.clone()),
+            id: queue_id,
+            permission: v2::Permission::Read as i32,
+            broker: Some(broker.clone()),
+            accept_message_types: topic_message_types(topic_message_type),
+        });
+        queue_id += 1;
+    }
+
+    for _ in 0..write_only {
+        result.push(v2::MessageQueue {
+            topic: Some(topic.clone()),
+            id: queue_id,
+            permission: v2::Permission::Write as i32,
+            broker: Some(broker.clone()),
+            accept_message_types: topic_message_types(topic_message_type),
+        });
+        queue_id += 1;
+    }
+
+    for _ in 0..read_write {
+        result.push(v2::MessageQueue {
+            topic: Some(topic.clone()),
+            id: queue_id,
+            permission: v2::Permission::ReadWrite as i32,
+            broker: Some(broker.clone()),
+            accept_message_types: topic_message_types(topic_message_type),
+        });
+        queue_id += 1;
+    }
+
+    for _ in 0..inaccessible {
+        result.push(v2::MessageQueue {
+            topic: Some(topic.clone()),
+            id: queue_id,
+            permission: v2::Permission::None as i32,
+            broker: Some(broker.clone()),
+            accept_message_types: topic_message_types(topic_message_type),
+        });
+        queue_id += 1;
+    }
+
+    result
+}
+
+fn topic_message_types(topic_message_type: ProxyTopicMessageType) -> Vec<i32> {
+    match topic_message_type {
+        ProxyTopicMessageType::Normal => vec![v2::MessageType::Normal as i32],
+        ProxyTopicMessageType::Fifo => vec![v2::MessageType::Fifo as i32],
+        ProxyTopicMessageType::Delay => vec![v2::MessageType::Delay as i32],
+        ProxyTopicMessageType::Transaction => vec![v2::MessageType::Transaction as i32],
+        ProxyTopicMessageType::Mixed => vec![
+            v2::MessageType::Normal as i32,
+            v2::MessageType::Fifo as i32,
+            v2::MessageType::Delay as i32,
+            v2::MessageType::Transaction as i32,
+        ],
+        ProxyTopicMessageType::Lite => vec![v2::MessageType::Lite as i32],
+        ProxyTopicMessageType::Priority => vec![v2::MessageType::Priority as i32],
+        ProxyTopicMessageType::Unspecified => vec![v2::MessageType::Unspecified as i32],
+    }
+}
+
+fn convert_permission(perm: u32) -> i32 {
+    if PermName::is_readable(perm) && PermName::is_writeable(perm) {
+        return v2::Permission::ReadWrite as i32;
+    }
+    if PermName::is_readable(perm) {
+        return v2::Permission::Read as i32;
+    }
+    if PermName::is_writeable(perm) {
+        return v2::Permission::Write as i32;
+    }
+    v2::Permission::None as i32
+}
+
+fn parse_broker_address(address: &str) -> (v2::AddressScheme, v2::Address) {
+    if let Ok(parsed) = SocketAddr::from_str(address) {
+        let scheme = match parsed.ip() {
+            IpAddr::V4(_) => v2::AddressScheme::IPv4,
+            IpAddr::V6(_) => v2::AddressScheme::IPv6,
+        };
+        return (
+            scheme,
+            v2::Address {
+                host: parsed.ip().to_string(),
+                port: i32::from(parsed.port()),
+            },
+        );
+    }
+
+    if let Some((host, port)) = address.rsplit_once(':') {
+        if let Ok(port) = port.parse::<i32>() {
+            let scheme = if host.parse::<IpAddr>().map(|ip| ip.is_ipv4()).unwrap_or(false) {
+                v2::AddressScheme::IPv4
+            } else if host.parse::<IpAddr>().map(|ip| ip.is_ipv6()).unwrap_or(false) {
+                v2::AddressScheme::IPv6
+            } else {
+                v2::AddressScheme::DomainName
+            };
+
+            return (
+                scheme,
+                v2::Address {
+                    host: host.trim_matches(&['[', ']'][..]).to_owned(),
+                    port,
+                },
+            );
+        }
+    }
+
+    (
+        v2::AddressScheme::DomainName,
+        v2::Address {
+            host: address.to_owned(),
+            port: 0,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
+    use rocketmq_remoting::protocol::route::route_data_view::QueueData;
+    use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+
+    use super::build_query_route_response;
+    use super::gen_message_queue_from_queue_data;
+    use crate::processor::QueryRoutePlan;
+    use crate::proto::v2;
+    use crate::service::ProxyTopicMessageType;
+
+    #[test]
+    fn route_response_preserves_permission_split() {
+        let queue_data = QueueData::new(CheetahString::from("broker-a"), 2, 1, 6, 0);
+        let broker = v2::Broker {
+            name: "broker-a".to_owned(),
+            id: 0,
+            endpoints: None,
+        };
+
+        let generated = gen_message_queue_from_queue_data(
+            &queue_data,
+            &v2::Resource {
+                resource_namespace: String::new(),
+                name: "TopicA".to_owned(),
+            },
+            ProxyTopicMessageType::Normal,
+            broker,
+        );
+
+        assert_eq!(generated.len(), 2);
+        assert_eq!(generated[0].permission, v2::Permission::Read as i32);
+        assert_eq!(generated[1].permission, v2::Permission::ReadWrite as i32);
+    }
+
+    #[test]
+    fn route_response_builds_queue_entries() {
+        let mut broker_addrs = HashMap::new();
+        broker_addrs.insert(0_u64, CheetahString::from("127.0.0.1:10911"));
+        let route = TopicRouteData {
+            queue_datas: vec![QueueData::new(CheetahString::from("broker-a"), 1, 1, 6, 0)],
+            broker_datas: vec![BrokerData::new(
+                CheetahString::from("cluster-a"),
+                CheetahString::from("broker-a"),
+                broker_addrs,
+                None,
+            )],
+            ..Default::default()
+        };
+        let response = build_query_route_response(
+            &v2::QueryRouteRequest {
+                topic: Some(v2::Resource {
+                    resource_namespace: String::new(),
+                    name: "TopicA".to_owned(),
+                }),
+                endpoints: Some(v2::Endpoints::default()),
+            },
+            &QueryRoutePlan {
+                route,
+                topic_message_type: ProxyTopicMessageType::Normal,
+            },
+        );
+
+        assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
+        assert_eq!(response.message_queues.len(), 1);
+    }
+}

--- a/rocketmq-proxy/src/grpc/mod.rs
+++ b/rocketmq-proxy/src/grpc/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod adapter;
+pub mod server;
+pub mod service;
+
+pub use service::ProxyGrpcService;

--- a/rocketmq-proxy/src/grpc/server.rs
+++ b/rocketmq-proxy/src/grpc/server.rs
@@ -1,0 +1,44 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use tonic::transport::Server;
+
+use crate::config::ProxyConfig;
+use crate::error::ProxyError;
+use crate::error::ProxyResult;
+use crate::grpc::service::ProxyGrpcService;
+use crate::processor::MessagingProcessor;
+use crate::proto::v2::messaging_service_server::MessagingServiceServer;
+
+pub async fn serve<P, F>(config: Arc<ProxyConfig>, service: ProxyGrpcService<P>, shutdown: F) -> ProxyResult<()>
+where
+    P: MessagingProcessor + 'static,
+    F: Future<Output = ()> + Send + 'static,
+{
+    let addr = config.grpc.socket_addr()?;
+    let service = MessagingServiceServer::new(service)
+        .max_decoding_message_size(config.grpc.max_decoding_message_size)
+        .max_encoding_message_size(config.grpc.max_encoding_message_size);
+
+    Server::builder()
+        .add_service(service)
+        .serve_with_shutdown(addr, shutdown)
+        .await
+        .map_err(|error| ProxyError::Transport {
+            message: format!("proxy gRPC server failed: {error}"),
+        })
+}

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -1,0 +1,549 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures::stream;
+use futures::Stream;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
+use tonic::Request;
+use tonic::Response;
+use tonic::Status;
+
+use crate::config::ProxyConfig;
+use crate::context::ProxyContext;
+use crate::error::ProxyError;
+use crate::error::ProxyResult;
+use crate::grpc::adapter;
+use crate::processor::MessagingProcessor;
+use crate::proto::v2;
+use crate::session::ClientSessionRegistry;
+use crate::status::ProxyStatusMapper;
+
+type ResponseStream<T> = Pin<Box<dyn Stream<Item = Result<T, Status>> + Send + 'static>>;
+
+#[derive(Clone)]
+struct ExecutionGuards {
+    route: Arc<Semaphore>,
+    producer: Arc<Semaphore>,
+    consumer: Arc<Semaphore>,
+    client_manager: Arc<Semaphore>,
+}
+
+impl ExecutionGuards {
+    fn from_config(config: &ProxyConfig) -> Self {
+        Self {
+            route: Arc::new(Semaphore::new(config.runtime.route_permits)),
+            producer: Arc::new(Semaphore::new(config.runtime.producer_permits)),
+            consumer: Arc::new(Semaphore::new(config.runtime.consumer_permits)),
+            client_manager: Arc::new(Semaphore::new(config.runtime.client_manager_permits)),
+        }
+    }
+
+    fn try_route(&self) -> ProxyResult<OwnedSemaphorePermit> {
+        self.route
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| ProxyError::too_many_requests("route"))
+    }
+
+    fn try_consumer(&self) -> ProxyResult<OwnedSemaphorePermit> {
+        self.consumer
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| ProxyError::too_many_requests("consumer"))
+    }
+
+    fn try_producer(&self) -> ProxyResult<OwnedSemaphorePermit> {
+        self.producer
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| ProxyError::too_many_requests("producer"))
+    }
+
+    fn try_client_manager(&self) -> ProxyResult<OwnedSemaphorePermit> {
+        self.client_manager
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| ProxyError::too_many_requests("client-manager"))
+    }
+}
+
+#[derive(Clone)]
+pub struct ProxyGrpcService<P> {
+    config: Arc<ProxyConfig>,
+    processor: Arc<P>,
+    sessions: ClientSessionRegistry,
+    guards: ExecutionGuards,
+}
+
+impl<P> ProxyGrpcService<P> {
+    pub fn new(config: Arc<ProxyConfig>, processor: Arc<P>, sessions: ClientSessionRegistry) -> Self {
+        Self {
+            guards: ExecutionGuards::from_config(config.as_ref()),
+            config,
+            processor,
+            sessions,
+        }
+    }
+
+    fn context<T>(&self, rpc_name: &'static str, request: &Request<T>) -> ProxyContext {
+        ProxyContext::from_grpc_request(rpc_name, request)
+    }
+
+    fn status_stream<T>(&self, item: T) -> ResponseStream<T>
+    where
+        T: Send + 'static,
+    {
+        Box::pin(stream::iter(vec![Ok(item)]))
+    }
+}
+
+impl<P> ProxyGrpcService<P>
+where
+    P: MessagingProcessor + 'static,
+{
+    fn not_implemented_status(&self, feature: &'static str) -> v2::Status {
+        ProxyStatusMapper::from_error(&ProxyError::not_implemented(feature))
+    }
+
+    fn validate_client_context<'a>(&self, context: &'a ProxyContext) -> ProxyResult<&'a str> {
+        context.require_client_id()
+    }
+
+    fn validate_heartbeat_request(&self, context: &ProxyContext, client_type: i32) -> ProxyResult<()> {
+        self.validate_client_context(context)?;
+
+        match v2::ClientType::try_from(client_type) {
+            Ok(v2::ClientType::Producer)
+            | Ok(v2::ClientType::PushConsumer)
+            | Ok(v2::ClientType::SimpleConsumer)
+            | Ok(v2::ClientType::PullConsumer)
+            | Ok(v2::ClientType::LitePushConsumer)
+            | Ok(v2::ClientType::LiteSimpleConsumer) => Ok(()),
+            _ => Err(ProxyError::UnrecognizedClientType(client_type)),
+        }
+    }
+
+    fn receive_status(status: v2::Status) -> v2::ReceiveMessageResponse {
+        v2::ReceiveMessageResponse {
+            content: Some(v2::receive_message_response::Content::Status(status)),
+        }
+    }
+
+    fn pull_status(status: v2::Status) -> v2::PullMessageResponse {
+        v2::PullMessageResponse {
+            content: Some(v2::pull_message_response::Content::Status(status)),
+        }
+    }
+
+    fn telemetry_status(status: v2::Status) -> v2::TelemetryCommand {
+        v2::TelemetryCommand {
+            status: Some(status),
+            command: None,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl<P> v2::messaging_service_server::MessagingService for ProxyGrpcService<P>
+where
+    P: MessagingProcessor + 'static,
+{
+    type ReceiveMessageStream = ResponseStream<v2::ReceiveMessageResponse>;
+    type PullMessageStream = ResponseStream<v2::PullMessageResponse>;
+    type TelemetryStream = ResponseStream<v2::TelemetryCommand>;
+
+    async fn query_route(
+        &self,
+        request: Request<v2::QueryRouteRequest>,
+    ) -> Result<Response<v2::QueryRouteResponse>, Status> {
+        let context = self.context("QueryRoute", &request);
+        let request = request.into_inner();
+
+        let response = match self
+            .validate_client_context(&context)
+            .and_then(|_| adapter::build_query_route_request(self.config.as_ref(), &request))
+        {
+            Ok(input) => match self.guards.try_route() {
+                Ok(_permit) => match self.processor.query_route(&context, input).await {
+                    Ok(plan) => adapter::build_query_route_response(&request, &plan),
+                    Err(error) => adapter::error_query_route_response(ProxyStatusMapper::from_error(&error)),
+                },
+                Err(error) => adapter::error_query_route_response(ProxyStatusMapper::from_error(&error)),
+            },
+            Err(error) => adapter::error_query_route_response(ProxyStatusMapper::from_error(&error)),
+        };
+
+        Ok(Response::new(response))
+    }
+
+    async fn heartbeat(
+        &self,
+        request: Request<v2::HeartbeatRequest>,
+    ) -> Result<Response<v2::HeartbeatResponse>, Status> {
+        let context = self.context("Heartbeat", &request);
+        let request = request.into_inner();
+
+        let status = match self.guards.try_client_manager() {
+            Ok(_permit) => match self.validate_heartbeat_request(&context, request.client_type) {
+                Ok(()) => {
+                    self.sessions.upsert_from_context(&context);
+                    ProxyStatusMapper::ok()
+                }
+                Err(error) => ProxyStatusMapper::from_error(&error),
+            },
+            Err(error) => ProxyStatusMapper::from_error(&error),
+        };
+
+        Ok(Response::new(v2::HeartbeatResponse { status: Some(status) }))
+    }
+
+    async fn send_message(
+        &self,
+        _request: Request<v2::SendMessageRequest>,
+    ) -> Result<Response<v2::SendMessageResponse>, Status> {
+        let status = match self.guards.try_producer() {
+            Ok(_permit) => self.not_implemented_status("SendMessage"),
+            Err(error) => ProxyStatusMapper::from_error(&error),
+        };
+        Ok(Response::new(v2::SendMessageResponse {
+            status: Some(status),
+            entries: Vec::new(),
+        }))
+    }
+
+    async fn query_assignment(
+        &self,
+        request: Request<v2::QueryAssignmentRequest>,
+    ) -> Result<Response<v2::QueryAssignmentResponse>, Status> {
+        let context = self.context("QueryAssignment", &request);
+        let request = request.into_inner();
+
+        let response = match self
+            .validate_client_context(&context)
+            .and_then(|_| adapter::build_query_assignment_request(self.config.as_ref(), &request))
+        {
+            Ok(input) => match self.guards.try_route() {
+                Ok(_permit) => match self.processor.query_assignment(&context, input).await {
+                    Ok(plan) => adapter::build_query_assignment_response(&request, &plan),
+                    Err(error) => adapter::error_query_assignment_response(ProxyStatusMapper::from_error(&error)),
+                },
+                Err(error) => adapter::error_query_assignment_response(ProxyStatusMapper::from_error(&error)),
+            },
+            Err(error) => adapter::error_query_assignment_response(ProxyStatusMapper::from_error(&error)),
+        };
+
+        Ok(Response::new(response))
+    }
+
+    async fn receive_message(
+        &self,
+        request: Request<v2::ReceiveMessageRequest>,
+    ) -> Result<Response<Self::ReceiveMessageStream>, Status> {
+        let context = self.context("ReceiveMessage", &request);
+        let status = match self
+            .validate_client_context(&context)
+            .and_then(|_| self.guards.try_consumer().map(|_| ()))
+        {
+            Ok(()) => self.not_implemented_status("ReceiveMessage"),
+            Err(error) => ProxyStatusMapper::from_error(&error),
+        };
+
+        Ok(Response::new(self.status_stream(Self::receive_status(status))))
+    }
+
+    async fn ack_message(
+        &self,
+        _request: Request<v2::AckMessageRequest>,
+    ) -> Result<Response<v2::AckMessageResponse>, Status> {
+        Ok(Response::new(v2::AckMessageResponse {
+            status: Some(self.not_implemented_status("AckMessage")),
+            entries: Vec::new(),
+        }))
+    }
+
+    async fn forward_message_to_dead_letter_queue(
+        &self,
+        _request: Request<v2::ForwardMessageToDeadLetterQueueRequest>,
+    ) -> Result<Response<v2::ForwardMessageToDeadLetterQueueResponse>, Status> {
+        Ok(Response::new(v2::ForwardMessageToDeadLetterQueueResponse {
+            status: Some(self.not_implemented_status("ForwardMessageToDeadLetterQueue")),
+        }))
+    }
+
+    async fn pull_message(
+        &self,
+        request: Request<v2::PullMessageRequest>,
+    ) -> Result<Response<Self::PullMessageStream>, Status> {
+        let context = self.context("PullMessage", &request);
+        let status = match self
+            .validate_client_context(&context)
+            .and_then(|_| self.guards.try_consumer().map(|_| ()))
+        {
+            Ok(()) => self.not_implemented_status("PullMessage"),
+            Err(error) => ProxyStatusMapper::from_error(&error),
+        };
+        Ok(Response::new(self.status_stream(Self::pull_status(status))))
+    }
+
+    async fn update_offset(
+        &self,
+        _request: Request<v2::UpdateOffsetRequest>,
+    ) -> Result<Response<v2::UpdateOffsetResponse>, Status> {
+        Ok(Response::new(v2::UpdateOffsetResponse {
+            status: Some(self.not_implemented_status("UpdateOffset")),
+        }))
+    }
+
+    async fn get_offset(
+        &self,
+        _request: Request<v2::GetOffsetRequest>,
+    ) -> Result<Response<v2::GetOffsetResponse>, Status> {
+        Ok(Response::new(v2::GetOffsetResponse {
+            status: Some(self.not_implemented_status("GetOffset")),
+            offset: 0,
+        }))
+    }
+
+    async fn query_offset(
+        &self,
+        _request: Request<v2::QueryOffsetRequest>,
+    ) -> Result<Response<v2::QueryOffsetResponse>, Status> {
+        Ok(Response::new(v2::QueryOffsetResponse {
+            status: Some(self.not_implemented_status("QueryOffset")),
+            offset: 0,
+        }))
+    }
+
+    async fn end_transaction(
+        &self,
+        _request: Request<v2::EndTransactionRequest>,
+    ) -> Result<Response<v2::EndTransactionResponse>, Status> {
+        Ok(Response::new(v2::EndTransactionResponse {
+            status: Some(self.not_implemented_status("EndTransaction")),
+        }))
+    }
+
+    async fn telemetry(
+        &self,
+        request: Request<tonic::Streaming<v2::TelemetryCommand>>,
+    ) -> Result<Response<Self::TelemetryStream>, Status> {
+        let context = self.context("Telemetry", &request);
+        let status = match self
+            .validate_client_context(&context)
+            .and_then(|_| self.guards.try_client_manager().map(|_| ()))
+        {
+            Ok(()) => {
+                self.sessions.upsert_from_context(&context);
+                self.not_implemented_status("Telemetry")
+            }
+            Err(error) => ProxyStatusMapper::from_error(&error),
+        };
+
+        Ok(Response::new(self.status_stream(Self::telemetry_status(status))))
+    }
+
+    async fn notify_client_termination(
+        &self,
+        request: Request<v2::NotifyClientTerminationRequest>,
+    ) -> Result<Response<v2::NotifyClientTerminationResponse>, Status> {
+        let context = self.context("NotifyClientTermination", &request);
+        let status = match self
+            .guards
+            .try_client_manager()
+            .and_then(|_| self.validate_client_context(&context))
+        {
+            Ok(client_id) => {
+                self.sessions.remove(client_id);
+                ProxyStatusMapper::ok()
+            }
+            Err(error) => ProxyStatusMapper::from_error(&error),
+        };
+
+        Ok(Response::new(v2::NotifyClientTerminationResponse {
+            status: Some(status),
+        }))
+    }
+
+    async fn change_invisible_duration(
+        &self,
+        _request: Request<v2::ChangeInvisibleDurationRequest>,
+    ) -> Result<Response<v2::ChangeInvisibleDurationResponse>, Status> {
+        Ok(Response::new(v2::ChangeInvisibleDurationResponse {
+            status: Some(self.not_implemented_status("ChangeInvisibleDuration")),
+            receipt_handle: String::new(),
+        }))
+    }
+
+    async fn recall_message(
+        &self,
+        _request: Request<v2::RecallMessageRequest>,
+    ) -> Result<Response<v2::RecallMessageResponse>, Status> {
+        Ok(Response::new(v2::RecallMessageResponse {
+            status: Some(self.not_implemented_status("RecallMessage")),
+            message_id: String::new(),
+        }))
+    }
+
+    async fn sync_lite_subscription(
+        &self,
+        _request: Request<v2::SyncLiteSubscriptionRequest>,
+    ) -> Result<Response<v2::SyncLiteSubscriptionResponse>, Status> {
+        Ok(Response::new(v2::SyncLiteSubscriptionResponse {
+            status: Some(self.not_implemented_status("SyncLiteSubscription")),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
+    use rocketmq_remoting::protocol::route::route_data_view::QueueData;
+    use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+    use tonic::metadata::MetadataValue;
+    use tonic::Request;
+
+    use super::ProxyGrpcService;
+    use crate::config::ProxyConfig;
+    use crate::processor::DefaultMessagingProcessor;
+    use crate::proto::v2;
+    use crate::proto::v2::messaging_service_server::MessagingService;
+    use crate::service::ClusterServiceManager;
+    use crate::service::ProxyTopicMessageType;
+    use crate::service::ResourceIdentity;
+    use crate::service::StaticMetadataService;
+    use crate::service::StaticRouteService;
+    use crate::service::SubscriptionGroupMetadata;
+    use crate::session::ClientSessionRegistry;
+
+    fn test_service(
+        route_service: StaticRouteService,
+        metadata_service: StaticMetadataService,
+    ) -> ProxyGrpcService<DefaultMessagingProcessor> {
+        let manager = ClusterServiceManager::new(Arc::new(route_service), Arc::new(metadata_service));
+        let processor = Arc::new(DefaultMessagingProcessor::new(Arc::new(manager)));
+        ProxyGrpcService::new(
+            Arc::new(ProxyConfig::default()),
+            processor,
+            ClientSessionRegistry::default(),
+        )
+    }
+
+    fn sample_route() -> TopicRouteData {
+        let mut broker_addrs = HashMap::new();
+        broker_addrs.insert(0_u64, CheetahString::from("127.0.0.1:10911"));
+
+        TopicRouteData {
+            queue_datas: vec![QueueData::new(CheetahString::from("broker-a"), 1, 1, 6, 0)],
+            broker_datas: vec![BrokerData::new(
+                CheetahString::from("cluster-a"),
+                CheetahString::from("broker-a"),
+                broker_addrs,
+                None,
+            )],
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn query_route_returns_route_entries() {
+        let route_service = StaticRouteService::default();
+        route_service.insert(ResourceIdentity::new("", "TopicA"), sample_route());
+
+        let metadata_service = StaticMetadataService::default();
+        metadata_service.set_topic_message_type(ResourceIdentity::new("", "TopicA"), ProxyTopicMessageType::Normal);
+
+        let service = test_service(route_service, metadata_service);
+        let mut request = Request::new(v2::QueryRouteRequest {
+            topic: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "TopicA".to_owned(),
+            }),
+            endpoints: Some(v2::Endpoints {
+                scheme: v2::AddressScheme::IPv4 as i32,
+                addresses: vec![v2::Address {
+                    host: "127.0.0.1".to_owned(),
+                    port: 8081,
+                }],
+            }),
+        });
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+
+        let response = service.query_route(request).await.unwrap().into_inner();
+        assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
+        assert_eq!(response.message_queues.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn query_assignment_uses_fifo_group_semantics() {
+        let route_service = StaticRouteService::default();
+        route_service.insert(ResourceIdentity::new("", "TopicA"), sample_route());
+
+        let metadata_service = StaticMetadataService::default();
+        metadata_service.set_subscription_group(
+            ResourceIdentity::new("", "GroupA"),
+            SubscriptionGroupMetadata {
+                consume_message_orderly: true,
+                lite_bind_topic: None,
+            },
+        );
+
+        let service = test_service(route_service, metadata_service);
+        let mut request = Request::new(v2::QueryAssignmentRequest {
+            topic: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "TopicA".to_owned(),
+            }),
+            group: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "GroupA".to_owned(),
+            }),
+            endpoints: Some(v2::Endpoints {
+                scheme: v2::AddressScheme::IPv4 as i32,
+                addresses: vec![v2::Address {
+                    host: "127.0.0.1".to_owned(),
+                    port: 8081,
+                }],
+            }),
+        });
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+
+        let response = service.query_assignment(request).await.unwrap().into_inner();
+        assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
+        assert_eq!(response.assignments[0].message_queue.as_ref().unwrap().id, 0);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_requires_client_id_header() {
+        let service = test_service(StaticRouteService::default(), StaticMetadataService::default());
+        let request = Request::new(v2::HeartbeatRequest {
+            group: None,
+            client_type: v2::ClientType::Producer as i32,
+        });
+
+        let response = service.heartbeat(request).await.unwrap().into_inner();
+        assert_eq!(response.status.unwrap().code, v2::Code::ClientIdRequired as i32);
+    }
+}

--- a/rocketmq-proxy/src/lib.rs
+++ b/rocketmq-proxy/src/lib.rs
@@ -1,14 +1,65 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#![warn(rust_2018_idioms)]
+#![warn(clippy::all)]
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+//! RocketMQ Proxy runtime for the Rust implementation.
+//!
+//! This crate now provides the Phase 1 gRPC foundation and the first
+//! route/assignment/heartbeat slice of the Java proxy architecture.
+
+pub mod bootstrap;
+pub mod config;
+pub mod context;
+pub mod error;
+pub mod grpc;
+pub mod processor;
+pub mod proto;
+pub mod service;
+pub mod session;
+pub mod status;
+
+pub use bootstrap::ProxyRuntime;
+pub use bootstrap::ProxyRuntimeBuilder;
+pub use config::GrpcConfig;
+pub use config::ProxyConfig;
+pub use config::ProxyMode;
+pub use config::RuntimeConfig;
+pub use config::SessionConfig;
+pub use error::ProxyError;
+pub use error::ProxyResult;
+pub use processor::DefaultMessagingProcessor;
+pub use processor::MessagingProcessor;
+pub use processor::QueryAssignmentPlan;
+pub use processor::QueryAssignmentRequest;
+pub use processor::QueryRoutePlan;
+pub use processor::QueryRouteRequest;
+pub use service::ClusterServiceManager;
+pub use service::DefaultMetadataService;
+pub use service::LocalServiceManager;
+pub use service::MetadataService;
+pub use service::ProxyTopicMessageType;
+pub use service::ResourceIdentity;
+pub use service::RouteService;
+pub use service::ServiceManager;
+pub use service::StaticMetadataService;
+pub use service::StaticRouteService;
+pub use service::SubscriptionGroupMetadata;
+pub use service::UnsupportedRouteService;
+pub use session::ClientSession;
+pub use session::ClientSessionRegistry;
+
+/// Default gRPC port used by the proxy runtime.
+pub const DEFAULT_PROXY_GRPC_PORT: u16 = 8081;

--- a/rocketmq-proxy/src/processor.rs
+++ b/rocketmq-proxy/src/processor.rs
@@ -1,0 +1,114 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+
+use crate::context::ProxyContext;
+use crate::context::ResolvedEndpoint;
+use crate::error::ProxyResult;
+use crate::service::ProxyTopicMessageType;
+use crate::service::ResourceIdentity;
+use crate::service::ServiceManager;
+use crate::service::SubscriptionGroupMetadata;
+
+#[derive(Debug, Clone)]
+pub struct QueryRouteRequest {
+    pub topic: ResourceIdentity,
+    pub endpoints: Vec<ResolvedEndpoint>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryRoutePlan {
+    pub route: TopicRouteData,
+    pub topic_message_type: ProxyTopicMessageType,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryAssignmentRequest {
+    pub topic: ResourceIdentity,
+    pub group: ResourceIdentity,
+    pub endpoints: Vec<ResolvedEndpoint>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryAssignmentPlan {
+    pub route: TopicRouteData,
+    pub subscription_group: Option<SubscriptionGroupMetadata>,
+}
+
+#[async_trait]
+pub trait MessagingProcessor: Send + Sync {
+    async fn query_route(&self, context: &ProxyContext, request: QueryRouteRequest) -> ProxyResult<QueryRoutePlan>;
+
+    async fn query_assignment(
+        &self,
+        context: &ProxyContext,
+        request: QueryAssignmentRequest,
+    ) -> ProxyResult<QueryAssignmentPlan>;
+}
+
+#[derive(Clone)]
+pub struct DefaultMessagingProcessor {
+    service_manager: Arc<dyn ServiceManager>,
+}
+
+impl DefaultMessagingProcessor {
+    pub fn new(service_manager: Arc<dyn ServiceManager>) -> Self {
+        Self { service_manager }
+    }
+
+    pub fn service_manager(&self) -> &Arc<dyn ServiceManager> {
+        &self.service_manager
+    }
+}
+
+#[async_trait]
+impl MessagingProcessor for DefaultMessagingProcessor {
+    async fn query_route(&self, context: &ProxyContext, request: QueryRouteRequest) -> ProxyResult<QueryRoutePlan> {
+        let route_service = self.service_manager.route_service();
+        let metadata_service = self.service_manager.metadata_service();
+
+        let route = route_service
+            .query_route(context, &request.topic, &request.endpoints)
+            .await?;
+        let topic_message_type = metadata_service.topic_message_type(context, &request.topic).await?;
+
+        Ok(QueryRoutePlan {
+            route,
+            topic_message_type,
+        })
+    }
+
+    async fn query_assignment(
+        &self,
+        context: &ProxyContext,
+        request: QueryAssignmentRequest,
+    ) -> ProxyResult<QueryAssignmentPlan> {
+        let route_service = self.service_manager.route_service();
+        let metadata_service = self.service_manager.metadata_service();
+
+        let route = route_service
+            .query_route(context, &request.topic, &request.endpoints)
+            .await?;
+        let subscription_group = metadata_service.subscription_group(context, &request.group).await?;
+
+        Ok(QueryAssignmentPlan {
+            route,
+            subscription_group,
+        })
+    }
+}

--- a/rocketmq-proxy/src/proto.rs
+++ b/rocketmq-proxy/src/proto.rs
@@ -1,0 +1,21 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[allow(clippy::large_enum_variant)]
+#[allow(clippy::doc_lazy_continuation)]
+pub mod v2 {
+    tonic::include_proto!("rocketmq_rust_proxy.v2");
+}
+
+pub use v2::*;

--- a/rocketmq-proxy/src/service.rs
+++ b/rocketmq-proxy/src/service.rs
@@ -1,0 +1,288 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use rocketmq_error::RocketMQError;
+use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+
+use crate::config::ProxyMode;
+use crate::context::ProxyContext;
+use crate::context::ResolvedEndpoint;
+use crate::error::ProxyError;
+use crate::error::ProxyResult;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ResourceIdentity {
+    namespace: String,
+    name: String,
+}
+
+impl ResourceIdentity {
+    pub fn new(namespace: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            namespace: namespace.into(),
+            name: name.into(),
+        }
+    }
+
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl fmt::Display for ResourceIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.namespace.is_empty() {
+            write!(f, "{}", self.name)
+        } else {
+            write!(f, "{}%{}", self.namespace, self.name)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProxyTopicMessageType {
+    Unspecified,
+    #[default]
+    Normal,
+    Fifo,
+    Delay,
+    Transaction,
+    Mixed,
+    Lite,
+    Priority,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SubscriptionGroupMetadata {
+    pub consume_message_orderly: bool,
+    pub lite_bind_topic: Option<String>,
+}
+
+#[async_trait]
+pub trait RouteService: Send + Sync {
+    async fn query_route(
+        &self,
+        context: &ProxyContext,
+        topic: &ResourceIdentity,
+        endpoints: &[ResolvedEndpoint],
+    ) -> ProxyResult<TopicRouteData>;
+}
+
+#[async_trait]
+pub trait MetadataService: Send + Sync {
+    async fn topic_message_type(
+        &self,
+        context: &ProxyContext,
+        topic: &ResourceIdentity,
+    ) -> ProxyResult<ProxyTopicMessageType>;
+
+    async fn subscription_group(
+        &self,
+        context: &ProxyContext,
+        group: &ResourceIdentity,
+    ) -> ProxyResult<Option<SubscriptionGroupMetadata>>;
+}
+
+pub trait ServiceManager: Send + Sync {
+    fn mode(&self) -> ProxyMode;
+
+    fn route_service(&self) -> Arc<dyn RouteService>;
+
+    fn metadata_service(&self) -> Arc<dyn MetadataService>;
+}
+
+#[derive(Debug, Default)]
+pub struct UnsupportedRouteService;
+
+#[async_trait]
+impl RouteService for UnsupportedRouteService {
+    async fn query_route(
+        &self,
+        _context: &ProxyContext,
+        _topic: &ResourceIdentity,
+        _endpoints: &[ResolvedEndpoint],
+    ) -> ProxyResult<TopicRouteData> {
+        Err(ProxyError::not_implemented("route service"))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DefaultMetadataService;
+
+#[async_trait]
+impl MetadataService for DefaultMetadataService {
+    async fn topic_message_type(
+        &self,
+        _context: &ProxyContext,
+        _topic: &ResourceIdentity,
+    ) -> ProxyResult<ProxyTopicMessageType> {
+        Ok(ProxyTopicMessageType::Normal)
+    }
+
+    async fn subscription_group(
+        &self,
+        _context: &ProxyContext,
+        _group: &ResourceIdentity,
+    ) -> ProxyResult<Option<SubscriptionGroupMetadata>> {
+        Ok(None)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct StaticRouteService {
+    routes: Arc<DashMap<ResourceIdentity, TopicRouteData>>,
+}
+
+impl StaticRouteService {
+    pub fn insert(&self, topic: ResourceIdentity, route: TopicRouteData) {
+        self.routes.insert(topic, route);
+    }
+}
+
+#[async_trait]
+impl RouteService for StaticRouteService {
+    async fn query_route(
+        &self,
+        _context: &ProxyContext,
+        topic: &ResourceIdentity,
+        _endpoints: &[ResolvedEndpoint],
+    ) -> ProxyResult<TopicRouteData> {
+        self.routes
+            .get(topic)
+            .map(|entry| entry.clone())
+            .ok_or_else(|| RocketMQError::route_not_found(topic.name()).into())
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct StaticMetadataService {
+    topic_message_types: Arc<DashMap<ResourceIdentity, ProxyTopicMessageType>>,
+    subscription_groups: Arc<DashMap<ResourceIdentity, SubscriptionGroupMetadata>>,
+}
+
+impl StaticMetadataService {
+    pub fn set_topic_message_type(&self, topic: ResourceIdentity, message_type: ProxyTopicMessageType) {
+        self.topic_message_types.insert(topic, message_type);
+    }
+
+    pub fn set_subscription_group(&self, group: ResourceIdentity, metadata: SubscriptionGroupMetadata) {
+        self.subscription_groups.insert(group, metadata);
+    }
+}
+
+#[async_trait]
+impl MetadataService for StaticMetadataService {
+    async fn topic_message_type(
+        &self,
+        _context: &ProxyContext,
+        topic: &ResourceIdentity,
+    ) -> ProxyResult<ProxyTopicMessageType> {
+        Ok(self
+            .topic_message_types
+            .get(topic)
+            .map(|entry| *entry)
+            .unwrap_or(ProxyTopicMessageType::Normal))
+    }
+
+    async fn subscription_group(
+        &self,
+        _context: &ProxyContext,
+        group: &ResourceIdentity,
+    ) -> ProxyResult<Option<SubscriptionGroupMetadata>> {
+        Ok(self.subscription_groups.get(group).map(|entry| entry.clone()))
+    }
+}
+
+pub struct ClusterServiceManager {
+    route_service: Arc<dyn RouteService>,
+    metadata_service: Arc<dyn MetadataService>,
+}
+
+impl ClusterServiceManager {
+    pub fn new(route_service: Arc<dyn RouteService>, metadata_service: Arc<dyn MetadataService>) -> Self {
+        Self {
+            route_service,
+            metadata_service,
+        }
+    }
+}
+
+impl Default for ClusterServiceManager {
+    fn default() -> Self {
+        Self::new(
+            Arc::new(StaticRouteService::default()),
+            Arc::new(StaticMetadataService::default()),
+        )
+    }
+}
+
+impl ServiceManager for ClusterServiceManager {
+    fn mode(&self) -> ProxyMode {
+        ProxyMode::Cluster
+    }
+
+    fn route_service(&self) -> Arc<dyn RouteService> {
+        Arc::clone(&self.route_service)
+    }
+
+    fn metadata_service(&self) -> Arc<dyn MetadataService> {
+        Arc::clone(&self.metadata_service)
+    }
+}
+
+pub struct LocalServiceManager {
+    route_service: Arc<dyn RouteService>,
+    metadata_service: Arc<dyn MetadataService>,
+}
+
+impl LocalServiceManager {
+    pub fn new(route_service: Arc<dyn RouteService>, metadata_service: Arc<dyn MetadataService>) -> Self {
+        Self {
+            route_service,
+            metadata_service,
+        }
+    }
+}
+
+impl Default for LocalServiceManager {
+    fn default() -> Self {
+        Self::new(
+            Arc::new(StaticRouteService::default()),
+            Arc::new(StaticMetadataService::default()),
+        )
+    }
+}
+
+impl ServiceManager for LocalServiceManager {
+    fn mode(&self) -> ProxyMode {
+        ProxyMode::Local
+    }
+
+    fn route_service(&self) -> Arc<dyn RouteService> {
+        Arc::clone(&self.route_service)
+    }
+
+    fn metadata_service(&self) -> Arc<dyn MetadataService> {
+        Arc::clone(&self.metadata_service)
+    }
+}

--- a/rocketmq-proxy/src/session.rs
+++ b/rocketmq-proxy/src/session.rs
@@ -1,0 +1,67 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use dashmap::DashMap;
+
+use crate::context::ProxyContext;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientSession {
+    pub client_id: String,
+    pub remote_addr: Option<String>,
+    pub namespace: Option<String>,
+    pub last_seen: SystemTime,
+}
+
+#[derive(Clone, Default)]
+pub struct ClientSessionRegistry {
+    sessions: Arc<DashMap<String, ClientSession>>,
+}
+
+impl ClientSessionRegistry {
+    pub fn upsert_from_context(&self, context: &ProxyContext) {
+        let Some(client_id) = context.client_id() else {
+            return;
+        };
+
+        self.sessions.insert(
+            client_id.to_owned(),
+            ClientSession {
+                client_id: client_id.to_owned(),
+                remote_addr: context.remote_addr().map(str::to_owned),
+                namespace: context.namespace().map(str::to_owned),
+                last_seen: SystemTime::now(),
+            },
+        );
+    }
+
+    pub fn remove(&self, client_id: &str) -> Option<ClientSession> {
+        self.sessions.remove(client_id).map(|(_, session)| session)
+    }
+
+    pub fn get(&self, client_id: &str) -> Option<ClientSession> {
+        self.sessions.get(client_id).map(|entry| entry.clone())
+    }
+
+    pub fn len(&self) -> usize {
+        self.sessions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+}

--- a/rocketmq-proxy/src/status.rs
+++ b/rocketmq-proxy/src/status.rs
@@ -1,0 +1,137 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::RocketMQError;
+use tonic::Code as TonicCode;
+use tonic::Status as TonicStatus;
+
+use crate::error::ProxyError;
+use crate::proto::v2;
+
+pub struct ProxyStatusMapper;
+
+impl ProxyStatusMapper {
+    pub fn ok() -> v2::Status {
+        Self::from_code(v2::Code::Ok, "OK")
+    }
+
+    pub fn from_code(code: v2::Code, message: impl Into<String>) -> v2::Status {
+        v2::Status {
+            code: code as i32,
+            message: message.into(),
+        }
+    }
+
+    pub fn from_error(error: &ProxyError) -> v2::Status {
+        let code = match error {
+            ProxyError::ClientIdRequired => v2::Code::ClientIdRequired,
+            ProxyError::UnrecognizedClientType(_) => v2::Code::UnrecognizedClientType,
+            ProxyError::NotImplemented { .. } => v2::Code::NotImplemented,
+            ProxyError::TooManyRequests { .. } => v2::Code::TooManyRequests,
+            ProxyError::InvalidMetadata { .. } => v2::Code::BadRequest,
+            ProxyError::Transport { .. } => v2::Code::InternalError,
+            ProxyError::RocketMQ(inner) => Self::from_rocketmq_error(inner),
+        };
+        Self::from_code(code, error.to_string())
+    }
+
+    pub fn to_tonic_status(error: &ProxyError) -> TonicStatus {
+        let payload = Self::from_error(error);
+        let tonic_code = match v2::Code::try_from(payload.code).unwrap_or(v2::Code::InternalError) {
+            v2::Code::BadRequest
+            | v2::Code::IllegalAccessPoint
+            | v2::Code::IllegalTopic
+            | v2::Code::IllegalConsumerGroup
+            | v2::Code::IllegalMessageTag
+            | v2::Code::IllegalMessageKey
+            | v2::Code::IllegalMessageGroup
+            | v2::Code::IllegalMessagePropertyKey
+            | v2::Code::InvalidTransactionId
+            | v2::Code::IllegalMessageId
+            | v2::Code::IllegalFilterExpression
+            | v2::Code::IllegalInvisibleTime
+            | v2::Code::IllegalDeliveryTime
+            | v2::Code::InvalidReceiptHandle
+            | v2::Code::MessagePropertyConflictWithType
+            | v2::Code::UnrecognizedClientType
+            | v2::Code::ClientIdRequired
+            | v2::Code::IllegalPollingTime
+            | v2::Code::IllegalOffset
+            | v2::Code::IllegalLiteTopic => TonicCode::InvalidArgument,
+            v2::Code::Unauthorized => TonicCode::Unauthenticated,
+            v2::Code::Forbidden => TonicCode::PermissionDenied,
+            v2::Code::NotFound
+            | v2::Code::MessageNotFound
+            | v2::Code::TopicNotFound
+            | v2::Code::ConsumerGroupNotFound
+            | v2::Code::OffsetNotFound => TonicCode::NotFound,
+            v2::Code::RequestTimeout | v2::Code::ProxyTimeout => TonicCode::DeadlineExceeded,
+            v2::Code::TooManyRequests | v2::Code::LiteTopicQuotaExceeded | v2::Code::LiteSubscriptionQuotaExceeded => {
+                TonicCode::ResourceExhausted
+            }
+            v2::Code::NotImplemented
+            | v2::Code::Unsupported
+            | v2::Code::VersionUnsupported
+            | v2::Code::VerifyFifoMessageUnsupported => TonicCode::Unimplemented,
+            _ => TonicCode::Internal,
+        };
+
+        TonicStatus::new(tonic_code, payload.message)
+    }
+
+    fn from_rocketmq_error(error: &RocketMQError) -> v2::Code {
+        match error {
+            RocketMQError::TopicNotExist { .. } | RocketMQError::RouteNotFound { .. } => v2::Code::TopicNotFound,
+            RocketMQError::SubscriptionGroupNotExist { .. } => v2::Code::ConsumerGroupNotFound,
+            RocketMQError::Authentication(_) => v2::Code::Unauthorized,
+            RocketMQError::BrokerPermissionDenied { .. } | RocketMQError::TopicSendingForbidden { .. } => {
+                v2::Code::Forbidden
+            }
+            RocketMQError::MessageTooLarge { .. } => v2::Code::MessageBodyTooLarge,
+            RocketMQError::IllegalArgument(_)
+            | RocketMQError::InvalidProperty(_)
+            | RocketMQError::RequestBodyInvalid { .. }
+            | RocketMQError::RequestHeaderError(_)
+            | RocketMQError::ResponseProcessFailed { .. }
+            | RocketMQError::MissingRequiredMessageProperty { .. } => v2::Code::BadRequest,
+            RocketMQError::BrokerNotFound { .. }
+            | RocketMQError::QueueNotExist { .. }
+            | RocketMQError::ClusterNotFound { .. } => v2::Code::NotFound,
+            RocketMQError::Timeout { .. } => v2::Code::ProxyTimeout,
+            RocketMQError::Network(_) => v2::Code::RequestTimeout,
+            _ => v2::Code::InternalError,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_error::RocketMQError;
+
+    use super::ProxyStatusMapper;
+    use crate::error::ProxyError;
+    use crate::proto::v2;
+
+    #[test]
+    fn client_id_required_maps_to_expected_code() {
+        let status = ProxyStatusMapper::from_error(&ProxyError::ClientIdRequired);
+        assert_eq!(status.code, v2::Code::ClientIdRequired as i32);
+    }
+
+    #[test]
+    fn route_not_found_maps_to_topic_not_found() {
+        let status = ProxyStatusMapper::from_error(&ProxyError::RocketMQ(RocketMQError::route_not_found("TestTopic")));
+        assert_eq!(status.code, v2::Code::TopicNotFound as i32);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6799

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced a gRPC proxy service enabling clients to interact with RocketMQ through gRPC protocol.
- Supports core messaging operations including route discovery, message publishing and consumption, message acknowledgments, offset management, and transactional operations.
- Includes client session lifecycle management for persistent client-server connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->