### PR TITLE
[ISSUE #6806]✨Enhance send message functionality with support for multiple results and improved error handling

### DIFF
--- a/rocketmq-proxy/src/cluster.rs
+++ b/rocketmq-proxy/src/cluster.rs
@@ -24,6 +24,7 @@ use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
 use rocketmq_client_rust::producer::mq_producer::MQProducer;
 use rocketmq_client_rust::producer::send_result::SendResult;
 use rocketmq_common::common::attribute::topic_message_type::TopicMessageType;
+use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_queue_assignment::MessageQueueAssignment;
 use rocketmq_common::common::mix_all::MASTER_ID;
 use rocketmq_error::RocketMQError;
@@ -36,10 +37,13 @@ use crate::config::ClusterConfig;
 use crate::context::ProxyContext;
 use crate::error::ProxyError;
 use crate::error::ProxyResult;
+use crate::processor::SendMessageEntry;
 use crate::processor::SendMessageRequest;
+use crate::processor::SendMessageResultEntry;
 use crate::service::ProxyTopicMessageType;
 use crate::service::ResourceIdentity;
 use crate::service::SubscriptionGroupMetadata;
+use crate::status::ProxyStatusMapper;
 
 #[async_trait]
 pub trait ClusterClient: Send + Sync {
@@ -60,7 +64,11 @@ pub trait ClusterClient: Send + Sync {
         group: &ResourceIdentity,
     ) -> ProxyResult<Option<SubscriptionGroupMetadata>>;
 
-    async fn send_message(&self, context: &ProxyContext, request: &SendMessageRequest) -> ProxyResult<Vec<SendResult>>;
+    async fn send_message(
+        &self,
+        context: &ProxyContext,
+        request: &SendMessageRequest,
+    ) -> ProxyResult<Vec<SendMessageResultEntry>>;
 }
 
 pub struct RocketmqClusterClient {
@@ -195,7 +203,11 @@ impl ClusterClient for RocketmqClusterClient {
         .await
     }
 
-    async fn send_message(&self, context: &ProxyContext, request: &SendMessageRequest) -> ProxyResult<Vec<SendResult>> {
+    async fn send_message(
+        &self,
+        context: &ProxyContext,
+        request: &SendMessageRequest,
+    ) -> ProxyResult<Vec<SendMessageResultEntry>> {
         let config = self.config.clone();
         let request = request.clone();
         let request_id = context.request_id().to_owned();
@@ -203,18 +215,19 @@ impl ClusterClient for RocketmqClusterClient {
         run_cluster_task(move || async move {
             let timeout = effective_send_timeout_ms(&config, request.timeout);
             let mut producer = build_send_producer(&config, &request, request_id.as_str(), timeout);
-            producer.start().await?;
+            if let Err(error) = producer.start().await {
+                let error = ProxyError::from(error);
+                return Ok(request
+                    .messages
+                    .iter()
+                    .map(|_| failure_send_result_entry(&error))
+                    .collect());
+            }
 
             let send_result = async {
                 let mut results = Vec::with_capacity(request.messages.len());
                 for entry in request.messages {
-                    let result = producer
-                        .send_with_timeout(entry.message, timeout)
-                        .await?
-                        .ok_or_else(|| ProxyError::Transport {
-                            message: format!("send result was empty for topic '{}'", entry.topic),
-                        })?;
-                    results.push(result);
+                    results.push(send_message_entry(&mut producer, entry, timeout).await);
                 }
                 Ok(results)
             }
@@ -291,6 +304,81 @@ fn build_send_producer(
         .topics(topics)
         .send_msg_timeout(timeout_ms as u32)
         .build()
+}
+
+async fn send_message_entry(
+    producer: &mut DefaultMQProducer,
+    entry: SendMessageEntry,
+    timeout: u64,
+) -> SendMessageResultEntry {
+    match send_message_entry_inner(producer, entry, timeout).await {
+        Ok(send_result) => SendMessageResultEntry {
+            status: ProxyStatusMapper::from_send_result_payload(&send_result),
+            send_result: Some(send_result),
+        },
+        Err(error) => failure_send_result_entry(&error),
+    }
+}
+
+async fn send_message_entry_inner(
+    producer: &mut DefaultMQProducer,
+    entry: SendMessageEntry,
+    timeout: u64,
+) -> ProxyResult<SendResult> {
+    let queue = resolve_target_queue(producer, &entry).await?;
+    let result = if let Some(queue) = queue {
+        producer
+            .send_to_queue_with_timeout(entry.message, queue, timeout)
+            .await?
+    } else {
+        producer.send_with_timeout(entry.message, timeout).await?
+    };
+
+    result.ok_or_else(|| ProxyError::Transport {
+        message: format!("send result was empty for topic '{}'", entry.topic),
+    })
+}
+
+async fn resolve_target_queue(
+    producer: &mut DefaultMQProducer,
+    entry: &SendMessageEntry,
+) -> ProxyResult<Option<MessageQueue>> {
+    let Some(queue_id) = entry.queue_id else {
+        return Ok(None);
+    };
+
+    let queues = producer
+        .fetch_publish_message_queues(entry.topic.to_string().as_str())
+        .await?;
+    let max_queue_id = queues.iter().map(MessageQueue::queue_id).max().unwrap_or(-1);
+
+    queues
+        .into_iter()
+        .find(|queue| queue.queue_id() == queue_id)
+        .map(Some)
+        .ok_or_else(|| {
+            if max_queue_id >= 0 {
+                RocketMQError::QueueIdOutOfRange {
+                    topic: entry.topic.to_string(),
+                    queue_id,
+                    max: max_queue_id,
+                }
+                .into()
+            } else {
+                RocketMQError::QueueNotExist {
+                    topic: entry.topic.to_string(),
+                    queue_id,
+                }
+                .into()
+            }
+        })
+}
+
+fn failure_send_result_entry(error: &ProxyError) -> SendMessageResultEntry {
+    SendMessageResultEntry {
+        status: ProxyStatusMapper::from_error_payload(error),
+        send_result: None,
+    }
 }
 
 fn build_send_producer_group(config: &ClusterConfig, request_id: &str) -> String {

--- a/rocketmq-proxy/src/grpc/adapter.rs
+++ b/rocketmq-proxy/src/grpc/adapter.rs
@@ -18,8 +18,6 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 
 use cheetah_string::CheetahString;
-use rocketmq_client_rust::producer::send_result::SendResult;
-use rocketmq_client_rust::producer::send_status::SendStatus;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::message::message_queue_assignment::MessageQueueAssignment;
 use rocketmq_common::common::message::message_single::Message;
@@ -42,9 +40,11 @@ use crate::processor::QueryRouteRequest;
 use crate::processor::SendMessageEntry;
 use crate::processor::SendMessagePlan;
 use crate::processor::SendMessageRequest;
+use crate::processor::SendMessageResultEntry;
 use crate::proto::v2;
 use crate::service::ProxyTopicMessageType;
 use crate::service::ResourceIdentity;
+use crate::status::ProxyPayloadStatus;
 use crate::status::ProxyStatusMapper;
 
 pub fn build_query_route_request(
@@ -74,10 +74,6 @@ pub fn build_send_message_request(
 ) -> ProxyResult<SendMessageRequest> {
     if request.messages.is_empty() {
         return Err(rocketmq_error::RocketMQError::illegal_argument("messages must not be empty").into());
-    }
-
-    if request.messages.len() != 1 {
-        return Err(ProxyError::not_implemented("SendMessage(batch)"));
     }
 
     let messages = request
@@ -206,13 +202,8 @@ pub fn build_send_message_response(plan: &SendMessagePlan, request: &SendMessage
         .map(|(result, message)| build_send_result_entry(result, message))
         .collect();
 
-    let status = entries
-        .first()
-        .and_then(|entry| entry.status.clone())
-        .unwrap_or_else(ProxyStatusMapper::ok);
-
     v2::SendMessageResponse {
-        status: Some(status),
+        status: Some(summarize_send_response_status(&plan.entries).into()),
         entries,
     }
 }
@@ -358,6 +349,7 @@ fn build_send_message_entry(message: &v2::Message) -> ProxyResult<SendMessageEnt
         topic,
         client_message_id,
         message: rocketmq_message,
+        queue_id: explicit_queue_id(system.queue_id),
     })
 }
 
@@ -535,32 +527,41 @@ fn timestamp_to_epoch_millis(timestamp: &prost_types::Timestamp) -> ProxyResult<
         .ok_or_else(|| ProxyError::illegal_delivery_time("delivery timestamp overflowed milliseconds"))
 }
 
-fn build_send_result_entry(result: &SendResult, request: &SendMessageEntry) -> v2::SendResultEntry {
+fn explicit_queue_id(queue_id: i32) -> Option<i32> {
+    (queue_id > 0).then_some(queue_id)
+}
+
+fn build_send_result_entry(result: &SendMessageResultEntry, request: &SendMessageEntry) -> v2::SendResultEntry {
     v2::SendResultEntry {
-        status: Some(map_send_result_status(result)),
+        status: Some(result.status.clone().into()),
         message_id: result
-            .msg_id
+            .send_result
             .as_ref()
-            .map(ToString::to_string)
+            .and_then(|send_result| send_result.msg_id.as_ref().map(ToString::to_string))
             .unwrap_or_else(|| request.client_message_id.clone()),
-        transaction_id: result.transaction_id.clone().unwrap_or_default(),
-        offset: result.queue_offset as i64,
+        transaction_id: result
+            .send_result
+            .as_ref()
+            .and_then(|send_result| send_result.transaction_id.clone())
+            .unwrap_or_default(),
+        offset: result
+            .send_result
+            .as_ref()
+            .map(|send_result| send_result.queue_offset as i64)
+            .unwrap_or_default(),
         recall_handle: String::new(),
     }
 }
 
-fn map_send_result_status(result: &SendResult) -> v2::Status {
-    match result.send_status {
-        SendStatus::SendOk => ProxyStatusMapper::ok(),
-        SendStatus::FlushDiskTimeout => {
-            ProxyStatusMapper::from_code(v2::Code::MasterPersistenceTimeout, "broker flush disk timed out")
-        }
-        SendStatus::FlushSlaveTimeout => {
-            ProxyStatusMapper::from_code(v2::Code::SlavePersistenceTimeout, "broker slave flush timed out")
-        }
-        SendStatus::SlaveNotAvailable => {
-            ProxyStatusMapper::from_code(v2::Code::HaNotAvailable, "slave broker not available")
-        }
+fn summarize_send_response_status(entries: &[SendMessageResultEntry]) -> ProxyPayloadStatus {
+    match entries {
+        [] => ProxyStatusMapper::ok_payload(),
+        [entry] => entry.status.clone(),
+        _ if entries.iter().all(|entry| entry.status.is_ok()) => ProxyStatusMapper::ok_payload(),
+        _ => ProxyStatusMapper::from_payload_code(
+            v2::Code::MultipleResults,
+            "send message entries contain mixed success or failure results",
+        ),
     }
 }
 
@@ -796,6 +797,7 @@ mod tests {
     use crate::processor::QueryAssignmentPlan;
     use crate::processor::QueryRoutePlan;
     use crate::processor::SendMessagePlan;
+    use crate::processor::SendMessageResultEntry;
     use crate::proto::v2;
     use crate::service::ProxyTopicMessageType;
     use crate::service::ResourceIdentity;
@@ -965,13 +967,22 @@ mod tests {
     fn send_message_response_maps_send_status() {
         let response = build_send_message_response(
             &SendMessagePlan {
-                entries: vec![SendResult::new(
-                    SendStatus::FlushDiskTimeout,
-                    Some(CheetahString::from("server-msg-id")),
-                    None,
-                    None,
-                    12,
-                )],
+                entries: vec![SendMessageResultEntry {
+                    status: ProxyStatusMapper::from_send_result_payload(&SendResult::new(
+                        SendStatus::FlushDiskTimeout,
+                        Some(CheetahString::from("server-msg-id")),
+                        None,
+                        None,
+                        12,
+                    )),
+                    send_result: Some(SendResult::new(
+                        SendStatus::FlushDiskTimeout,
+                        Some(CheetahString::from("server-msg-id")),
+                        None,
+                        None,
+                        12,
+                    )),
+                }],
             },
             &crate::processor::SendMessageRequest {
                 messages: vec![crate::processor::SendMessageEntry {
@@ -981,6 +992,7 @@ mod tests {
                         .topic("TopicA")
                         .body(Bytes::from_static(b"hello"))
                         .build_unchecked(),
+                    queue_id: None,
                 }],
                 timeout: None,
             },

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -424,8 +424,10 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use async_trait::async_trait;
     use bytes::Bytes;
     use cheetah_string::CheetahString;
+    use rocketmq_client_rust::producer::send_result::SendResult;
     use rocketmq_client_rust::producer::send_status::SendStatus;
     use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
     use rocketmq_remoting::protocol::route::route_data_view::QueueData;
@@ -436,9 +438,12 @@ mod tests {
     use super::ProxyGrpcService;
     use crate::config::ProxyConfig;
     use crate::processor::DefaultMessagingProcessor;
+    use crate::processor::SendMessageRequest;
+    use crate::processor::SendMessageResultEntry;
     use crate::proto::v2;
     use crate::proto::v2::messaging_service_server::MessagingService;
     use crate::service::ClusterServiceManager;
+    use crate::service::MessageService;
     use crate::service::ProxyTopicMessageType;
     use crate::service::ResourceIdentity;
     use crate::service::StaticMessageService;
@@ -446,6 +451,48 @@ mod tests {
     use crate::service::StaticRouteService;
     use crate::service::SubscriptionGroupMetadata;
     use crate::session::ClientSessionRegistry;
+    use crate::status::ProxyPayloadStatus;
+    use crate::status::ProxyStatusMapper;
+
+    struct PartialMessageService;
+
+    #[async_trait]
+    impl MessageService for PartialMessageService {
+        async fn send_message(
+            &self,
+            _context: &crate::context::ProxyContext,
+            request: &SendMessageRequest,
+        ) -> crate::error::ProxyResult<Vec<SendMessageResultEntry>> {
+            Ok(request
+                .messages
+                .iter()
+                .enumerate()
+                .map(|(index, message)| {
+                    if index == 0 {
+                        let send_result = SendResult::new(
+                            SendStatus::SendOk,
+                            Some(CheetahString::from(message.client_message_id.as_str())),
+                            None,
+                            None,
+                            0,
+                        );
+                        SendMessageResultEntry {
+                            status: ProxyStatusMapper::from_send_result_payload(&send_result),
+                            send_result: Some(send_result),
+                        }
+                    } else {
+                        SendMessageResultEntry {
+                            status: ProxyPayloadStatus::new(
+                                v2::Code::TopicNotFound as i32,
+                                "Topic 'TopicA' does not exist",
+                            ),
+                            send_result: None,
+                        }
+                    }
+                })
+                .collect())
+        }
+    }
 
     fn test_service(
         route_service: StaticRouteService,
@@ -610,7 +657,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_message_rejects_batch_until_partial_results_are_implemented() {
+    async fn send_message_accepts_batch_requests() {
         let service = test_service_with_message_service(
             StaticRouteService::default(),
             StaticMetadataService::default(),
@@ -651,7 +698,60 @@ mod tests {
             .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
 
         let response = service.send_message(request).await.unwrap().into_inner();
-        assert_eq!(response.status.unwrap().code, v2::Code::NotImplemented as i32);
-        assert!(response.entries.is_empty());
+        assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
+        assert_eq!(response.entries.len(), 2);
+        assert_eq!(response.entries[0].message_id, "msg-1");
+        assert_eq!(response.entries[1].message_id, "msg-2");
+    }
+
+    #[tokio::test]
+    async fn send_message_uses_multiple_results_for_partial_failures() {
+        let service = test_service_with_message_service(
+            StaticRouteService::default(),
+            StaticMetadataService::default(),
+            Arc::new(PartialMessageService),
+        );
+        let mut request = Request::new(v2::SendMessageRequest {
+            messages: vec![
+                v2::Message {
+                    topic: Some(v2::Resource {
+                        resource_namespace: String::new(),
+                        name: "TopicA".to_owned(),
+                    }),
+                    user_properties: HashMap::new(),
+                    system_properties: Some(v2::SystemProperties {
+                        message_id: "msg-1".to_owned(),
+                        body_encoding: v2::Encoding::Identity as i32,
+                        ..Default::default()
+                    }),
+                    body: Bytes::from_static(b"hello").to_vec(),
+                },
+                v2::Message {
+                    topic: Some(v2::Resource {
+                        resource_namespace: String::new(),
+                        name: "TopicA".to_owned(),
+                    }),
+                    user_properties: HashMap::new(),
+                    system_properties: Some(v2::SystemProperties {
+                        message_id: "msg-2".to_owned(),
+                        body_encoding: v2::Encoding::Identity as i32,
+                        ..Default::default()
+                    }),
+                    body: Bytes::from_static(b"world").to_vec(),
+                },
+            ],
+        });
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+
+        let response = service.send_message(request).await.unwrap().into_inner();
+        assert_eq!(response.status.unwrap().code, v2::Code::MultipleResults as i32);
+        assert_eq!(response.entries.len(), 2);
+        assert_eq!(response.entries[0].status.as_ref().unwrap().code, v2::Code::Ok as i32);
+        assert_eq!(
+            response.entries[1].status.as_ref().unwrap().code,
+            v2::Code::TopicNotFound as i32
+        );
     }
 }

--- a/rocketmq-proxy/src/lib.rs
+++ b/rocketmq-proxy/src/lib.rs
@@ -53,6 +53,7 @@ pub use processor::QueryRouteRequest;
 pub use processor::SendMessageEntry;
 pub use processor::SendMessagePlan;
 pub use processor::SendMessageRequest;
+pub use processor::SendMessageResultEntry;
 pub use service::AssignmentService;
 pub use service::ClusterServiceManager;
 pub use service::DefaultAssignmentService;
@@ -73,6 +74,7 @@ pub use service::SubscriptionGroupMetadata;
 pub use service::UnsupportedRouteService;
 pub use session::ClientSession;
 pub use session::ClientSessionRegistry;
+pub use status::ProxyPayloadStatus;
 
 /// Default gRPC port used by the proxy runtime.
 pub const DEFAULT_PROXY_GRPC_PORT: u16 = 8081;

--- a/rocketmq-proxy/src/processor.rs
+++ b/rocketmq-proxy/src/processor.rs
@@ -28,6 +28,7 @@ use crate::service::ProxyTopicMessageType;
 use crate::service::ResourceIdentity;
 use crate::service::ServiceManager;
 use crate::service::SubscriptionGroupMetadata;
+use crate::status::ProxyPayloadStatus;
 
 #[derive(Debug, Clone)]
 pub struct QueryRouteRequest {
@@ -66,11 +67,18 @@ pub struct SendMessageEntry {
     pub topic: ResourceIdentity,
     pub client_message_id: String,
     pub message: Message,
+    pub queue_id: Option<i32>,
 }
 
 #[derive(Debug, Clone)]
 pub struct SendMessagePlan {
-    pub entries: Vec<SendResult>,
+    pub entries: Vec<SendMessageResultEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SendMessageResultEntry {
+    pub status: ProxyPayloadStatus,
+    pub send_result: Option<SendResult>,
 }
 
 #[async_trait]

--- a/rocketmq-proxy/src/service.rs
+++ b/rocketmq-proxy/src/service.rs
@@ -32,6 +32,8 @@ use crate::context::ResolvedEndpoint;
 use crate::error::ProxyError;
 use crate::error::ProxyResult;
 use crate::processor::SendMessageRequest;
+use crate::processor::SendMessageResultEntry;
+use crate::status::ProxyStatusMapper;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ResourceIdentity {
@@ -124,7 +126,11 @@ pub trait AssignmentService: Send + Sync {
 
 #[async_trait]
 pub trait MessageService: Send + Sync {
-    async fn send_message(&self, context: &ProxyContext, request: &SendMessageRequest) -> ProxyResult<Vec<SendResult>>;
+    async fn send_message(
+        &self,
+        context: &ProxyContext,
+        request: &SendMessageRequest,
+    ) -> ProxyResult<Vec<SendMessageResultEntry>>;
 }
 
 pub trait ServiceManager: Send + Sync {
@@ -204,7 +210,7 @@ impl MessageService for DefaultMessageService {
         &self,
         _context: &ProxyContext,
         _request: &SendMessageRequest,
-    ) -> ProxyResult<Vec<SendResult>> {
+    ) -> ProxyResult<Vec<SendMessageResultEntry>> {
         Err(ProxyError::not_implemented("message service"))
     }
 }
@@ -292,19 +298,23 @@ impl MessageService for StaticMessageService {
         &self,
         _context: &ProxyContext,
         request: &SendMessageRequest,
-    ) -> ProxyResult<Vec<SendResult>> {
+    ) -> ProxyResult<Vec<SendMessageResultEntry>> {
         Ok(request
             .messages
             .iter()
             .enumerate()
             .map(|(index, message)| {
-                SendResult::new(
+                let send_result = SendResult::new(
                     self.send_status,
                     Some(CheetahString::from(message.client_message_id.as_str())),
                     None,
                     None,
                     index as u64,
-                )
+                );
+                SendMessageResultEntry {
+                    status: ProxyStatusMapper::from_send_result_payload(&send_result),
+                    send_result: Some(send_result),
+                }
             })
             .collect())
     }
@@ -399,7 +409,11 @@ impl ClusterMessageService {
 
 #[async_trait]
 impl MessageService for ClusterMessageService {
-    async fn send_message(&self, context: &ProxyContext, request: &SendMessageRequest) -> ProxyResult<Vec<SendResult>> {
+    async fn send_message(
+        &self,
+        context: &ProxyContext,
+        request: &SendMessageRequest,
+    ) -> ProxyResult<Vec<SendMessageResultEntry>> {
         self.client.send_message(context, request).await
     }
 }

--- a/rocketmq-proxy/src/status.rs
+++ b/rocketmq-proxy/src/status.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_client_rust::producer::send_result::SendResult;
+use rocketmq_client_rust::producer::send_status::SendStatus;
 use rocketmq_error::RocketMQError;
 use tonic::Code as TonicCode;
 use tonic::Status as TonicStatus;
@@ -19,21 +21,77 @@ use tonic::Status as TonicStatus;
 use crate::error::ProxyError;
 use crate::proto::v2;
 
-pub struct ProxyStatusMapper;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxyPayloadStatus {
+    code: i32,
+    message: String,
+}
 
-impl ProxyStatusMapper {
-    pub fn ok() -> v2::Status {
-        Self::from_code(v2::Code::Ok, "OK")
-    }
-
-    pub fn from_code(code: v2::Code, message: impl Into<String>) -> v2::Status {
-        v2::Status {
-            code: code as i32,
+impl ProxyPayloadStatus {
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
             message: message.into(),
         }
     }
 
-    pub fn from_error(error: &ProxyError) -> v2::Status {
+    pub fn code(&self) -> i32 {
+        self.code
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn is_ok(&self) -> bool {
+        self.code == v2::Code::Ok as i32
+    }
+}
+
+impl From<ProxyPayloadStatus> for v2::Status {
+    fn from(value: ProxyPayloadStatus) -> Self {
+        Self {
+            code: value.code,
+            message: value.message,
+        }
+    }
+}
+
+pub struct ProxyStatusMapper;
+
+impl ProxyStatusMapper {
+    pub fn ok_payload() -> ProxyPayloadStatus {
+        Self::from_payload_code(v2::Code::Ok, "OK")
+    }
+
+    pub fn ok() -> v2::Status {
+        Self::ok_payload().into()
+    }
+
+    pub fn from_payload_code(code: v2::Code, message: impl Into<String>) -> ProxyPayloadStatus {
+        ProxyPayloadStatus::new(code as i32, message)
+    }
+
+    pub fn from_code(code: v2::Code, message: impl Into<String>) -> v2::Status {
+        Self::from_payload_code(code, message).into()
+    }
+
+    pub fn from_send_result_payload(result: &SendResult) -> ProxyPayloadStatus {
+        match result.send_status {
+            SendStatus::SendOk => Self::ok_payload(),
+            SendStatus::FlushDiskTimeout => {
+                Self::from_payload_code(v2::Code::MasterPersistenceTimeout, "broker flush disk timed out")
+            }
+            SendStatus::FlushSlaveTimeout => {
+                Self::from_payload_code(v2::Code::SlavePersistenceTimeout, "broker slave flush timed out")
+            }
+            SendStatus::SlaveNotAvailable => {
+                Self::from_payload_code(v2::Code::HaNotAvailable, "slave broker not available")
+            }
+        }
+    }
+
+    pub fn from_error_payload(error: &ProxyError) -> ProxyPayloadStatus {
         let code = match error {
             ProxyError::ClientIdRequired => v2::Code::ClientIdRequired,
             ProxyError::UnrecognizedClientType(_) => v2::Code::UnrecognizedClientType,
@@ -47,7 +105,11 @@ impl ProxyStatusMapper {
             ProxyError::MessagePropertyConflictWithType { .. } => v2::Code::MessagePropertyConflictWithType,
             ProxyError::RocketMQ(inner) => Self::from_rocketmq_error(inner),
         };
-        Self::from_code(code, error.to_string())
+        Self::from_payload_code(code, error.to_string())
+    }
+
+    pub fn from_error(error: &ProxyError) -> v2::Status {
+        Self::from_error_payload(error).into()
     }
 
     pub fn to_tonic_status(error: &ProxyError) -> TonicStatus {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6806

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled batch message sending support, allowing multiple messages to be sent together in a single request.
  * Implemented per-message status tracking with individual error codes and detailed error reporting for each message.
  * Enhanced failure handling so that partial send failures no longer fail the entire batch operation.
  * Added support for queue-targeted messaging, enabling clients to send messages directly to specific message queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->