### PR TITLE
[ISSUE #6809]🚀Add recall handle support to send message response and related structures

### DIFF
--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -1564,7 +1564,7 @@ pub fn process_send_response(
             Some(uniq_msg_id),
             Some(response_header.msg_id().to_string()),
             Some(message_queue),
-            response_header.queue_id() as u64,
+            response_header.queue_offset() as u64,
         );
 
         send_result.set_transaction_id(
@@ -1572,6 +1572,9 @@ pub fn process_send_response(
                 .transaction_id()
                 .map_or("".to_string(), |s| s.to_string()),
         );
+        if let Some(recall_handle) = response_header.recall_handle() {
+            send_result.set_recall_handle(recall_handle.to_string());
+        }
         if let Some(region_id) = response
             .get_ext_fields()
             .unwrap()
@@ -1585,7 +1588,7 @@ pub fn process_send_response(
         if let Some(trace_on) = response
             .get_ext_fields()
             .unwrap()
-            .get(&CheetahString::from_static_str(MessageConst::PROPERTY_MSG_REGION))
+            .get(&CheetahString::from_static_str(MessageConst::PROPERTY_TRACE_SWITCH))
         {
             send_result.set_trace_on(trace_on == "true");
         } else {

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -32,6 +32,7 @@ use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mix_all::RETRY_GROUP_TOPIC_PREFIX;
 use rocketmq_common::common::mq_version::RocketMqVersion;
+use rocketmq_common::common::producer::HandleV1;
 use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::common::FAQUrl;
@@ -397,6 +398,7 @@ where
                 request,
                 topic.as_str(),
                 transaction_id,
+                None,
                 &mut send_message_context,
                 ctx,
                 queue_id,
@@ -549,6 +551,7 @@ where
         let start = Instant::now();
         let topic = message_ext.topic().clone();
         let transaction_id = MessageClientIDSetter::get_uniq_id(&message_ext.message_ext_inner.message);
+        let recall_handle = self.build_recall_handle(&message_ext);
         let put_message_result = if send_transaction_prepare_message {
             self.inner
                 .transactional_message_service
@@ -568,6 +571,7 @@ where
                 request,
                 topic.as_str(),
                 transaction_id,
+                recall_handle,
                 &mut send_message_context,
                 ctx,
                 queue_id,
@@ -732,6 +736,7 @@ where
         put_message_result: &PutMessageResult,
         queue_id: i32,
         transaction_id: Option<CheetahString>,
+        recall_handle: Option<CheetahString>,
     ) {
         // SAFETY: When send_ok is true, append_message_result must exist
         let result = put_message_result
@@ -746,6 +751,7 @@ where
         response_header.set_queue_id(queue_id);
         response_header.set_queue_offset(result.logics_offset);
         response_header.set_transaction_id(transaction_id);
+        response_header.set_recall_handle(recall_handle);
     }
 
     /// Update send message context for hooks
@@ -828,6 +834,7 @@ where
         request: &RemotingCommand,
         topic: &str,
         transaction_id: Option<CheetahString>,
+        recall_handle: Option<CheetahString>,
         send_message_context: &mut SendMessageContext,
         ctx: &mut ConnectionHandlerContext,
         queue_id_int: i32,
@@ -857,6 +864,7 @@ where
                     &put_message_result,
                     queue_id_int,
                     transaction_id.clone(),
+                    recall_handle.clone(),
                 );
 
                 let rewrite_result = rewrite_response_for_static_topic(response_header, mapping_context);
@@ -899,6 +907,37 @@ where
             }
             (None, false)
         }
+    }
+
+    fn build_recall_handle(&self, message: &MessageExtBrokerInner) -> Option<CheetahString> {
+        let timestamp_str = message
+            .message_ext_inner
+            .message
+            .property(&CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_OUT_MS))?;
+        let real_topic = message
+            .message_ext_inner
+            .message
+            .property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))?;
+        if real_topic.starts_with(RETRY_GROUP_TOPIC_PREFIX) {
+            return None;
+        }
+
+        let uniq_id = MessageClientIDSetter::get_uniq_id(&message.message_ext_inner.message)?;
+        let timestamp = timestamp_str.parse::<i64>().ok()?.checked_add(1)?;
+        let broker_name = self
+            .inner
+            .broker_runtime_inner
+            .broker_config()
+            .broker_identity
+            .broker_name
+            .clone();
+
+        Some(CheetahString::from_string(HandleV1::build_handle(
+            real_topic,
+            broker_name,
+            timestamp.to_string(),
+            uniq_id,
+        )))
     }
 
     pub async fn pre_send(

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -1703,6 +1703,7 @@ impl MQClientAPIImpl {
                             message_queue: Some(message_queue),
                             queue_offset: response_header.queue_offset() as u64,
                             transaction_id: response_header.transaction_id().map(|s| s.to_string()),
+                            recall_handle: response_header.recall_handle().map(|s| s.to_string()),
                             region_id: Some(region_id),
                             trace_on,
                             ..Default::default()
@@ -1802,6 +1803,7 @@ impl MQClientAPIImpl {
             message_queue: Some(message_queue),
             queue_offset: response_header.queue_offset() as u64,
             transaction_id: response_header.transaction_id().map(|s| s.to_string()),
+            recall_handle: response_header.recall_handle().map(|s| s.to_string()),
             region_id: Some(region_id),
             trace_on,
             ..Default::default()

--- a/rocketmq-client/src/producer/send_result.rs
+++ b/rocketmq-client/src/producer/send_result.rs
@@ -27,6 +27,7 @@ pub struct SendResult {
     pub queue_offset: u64,
     pub transaction_id: Option<String>,
     pub offset_msg_id: Option<String>,
+    pub recall_handle: Option<String>,
     pub region_id: Option<String>,
     pub trace_on: bool,
     pub raw_resp_body: Option<Vec<u8>>,
@@ -41,6 +42,7 @@ impl Default for SendResult {
             queue_offset: 0,
             transaction_id: None,
             offset_msg_id: None,
+            recall_handle: None,
             region_id: None,
             trace_on: true,
             raw_resp_body: None,
@@ -63,6 +65,7 @@ impl SendResult {
             queue_offset,
             transaction_id: None,
             offset_msg_id,
+            recall_handle: None,
             region_id: None,
             trace_on: true,
             raw_resp_body: None,
@@ -85,6 +88,7 @@ impl SendResult {
             queue_offset,
             transaction_id,
             offset_msg_id,
+            recall_handle: None,
             region_id,
             trace_on: true,
             raw_resp_body: None,
@@ -137,6 +141,16 @@ impl SendResult {
     }
 
     #[inline]
+    pub fn set_recall_handle(&mut self, recall_handle: String) {
+        self.recall_handle = Some(recall_handle);
+    }
+
+    #[inline]
+    pub fn recall_handle(&self) -> Option<&str> {
+        self.recall_handle.as_deref()
+    }
+
+    #[inline]
     pub fn set_raw_resp_body(&mut self, body: Vec<u8>) {
         self.raw_resp_body = Some(body);
     }
@@ -171,6 +185,7 @@ mod tests {
         assert_eq!(result.queue_offset, 0);
         assert!(result.transaction_id.is_none());
         assert!(result.offset_msg_id.is_none());
+        assert!(result.recall_handle.is_none());
         assert!(result.region_id.is_none());
         assert!(result.is_trace_on());
         assert!(result.get_raw_resp_body().is_none());
@@ -198,6 +213,7 @@ mod tests {
         assert_eq!(result.queue_offset, queue_offset);
         assert!(result.transaction_id.is_none());
         assert_eq!(result.offset_msg_id, offset_msg_id);
+        assert!(result.recall_handle.is_none());
         assert!(result.region_id.is_none());
         assert!(result.is_trace_on());
         assert!(result.get_raw_resp_body().is_none());
@@ -229,6 +245,7 @@ mod tests {
         assert_eq!(result.queue_offset, queue_offset);
         assert_eq!(result.transaction_id, transaction_id);
         assert_eq!(result.offset_msg_id, offset_msg_id);
+        assert!(result.recall_handle.is_none());
         assert_eq!(result.region_id, region_id);
         assert!(result.is_trace_on());
         assert!(result.get_raw_resp_body().is_none());
@@ -263,6 +280,9 @@ mod tests {
         result.set_offset_msg_id("offset_msg_id".to_string());
         assert_eq!(result.offset_msg_id, Some("offset_msg_id".to_string()));
 
+        result.set_recall_handle("recall_handle".to_string());
+        assert_eq!(result.recall_handle(), Some("recall_handle"));
+
         let body = vec![1, 2, 3];
         result.set_raw_resp_body(body.clone());
         assert_eq!(result.get_raw_resp_body(), Some(body.as_slice()));
@@ -293,6 +313,7 @@ mod tests {
         assert_eq!(deserialized.queue_offset, result.queue_offset);
         assert_eq!(deserialized.transaction_id, result.transaction_id);
         assert_eq!(deserialized.offset_msg_id, result.offset_msg_id);
+        assert_eq!(deserialized.recall_handle, result.recall_handle);
         assert_eq!(deserialized.region_id, result.region_id);
         assert_eq!(deserialized.is_trace_on(), result.is_trace_on());
         assert_eq!(deserialized.get_raw_resp_body(), result.get_raw_resp_body());

--- a/rocketmq-proxy/src/grpc/adapter.rs
+++ b/rocketmq-proxy/src/grpc/adapter.rs
@@ -549,7 +549,11 @@ fn build_send_result_entry(result: &SendMessageResultEntry, request: &SendMessag
             .as_ref()
             .map(|send_result| send_result.queue_offset as i64)
             .unwrap_or_default(),
-        recall_handle: String::new(),
+        recall_handle: result
+            .send_result
+            .as_ref()
+            .and_then(|send_result| send_result.recall_handle().map(ToOwned::to_owned))
+            .unwrap_or_default(),
     }
 }
 
@@ -557,7 +561,12 @@ fn summarize_send_response_status(entries: &[SendMessageResultEntry]) -> ProxyPa
     match entries {
         [] => ProxyStatusMapper::ok_payload(),
         [entry] => entry.status.clone(),
-        _ if entries.iter().all(|entry| entry.status.is_ok()) => ProxyStatusMapper::ok_payload(),
+        _ if entries
+            .iter()
+            .all(|entry| entry.status.code() == entries[0].status.code()) =>
+        {
+            entries[0].status.clone()
+        }
         _ => ProxyStatusMapper::from_payload_code(
             v2::Code::MultipleResults,
             "send message entries contain mixed success or failure results",
@@ -965,23 +974,19 @@ mod tests {
 
     #[test]
     fn send_message_response_maps_send_status() {
+        let mut send_result = SendResult::new(
+            SendStatus::FlushDiskTimeout,
+            Some(CheetahString::from("server-msg-id")),
+            None,
+            None,
+            12,
+        );
+        send_result.set_recall_handle("recall-handle".to_string());
         let response = build_send_message_response(
             &SendMessagePlan {
                 entries: vec![SendMessageResultEntry {
-                    status: ProxyStatusMapper::from_send_result_payload(&SendResult::new(
-                        SendStatus::FlushDiskTimeout,
-                        Some(CheetahString::from("server-msg-id")),
-                        None,
-                        None,
-                        12,
-                    )),
-                    send_result: Some(SendResult::new(
-                        SendStatus::FlushDiskTimeout,
-                        Some(CheetahString::from("server-msg-id")),
-                        None,
-                        None,
-                        12,
-                    )),
+                    status: ProxyStatusMapper::from_send_result_payload(&send_result),
+                    send_result: Some(send_result),
                 }],
             },
             &crate::processor::SendMessageRequest {
@@ -1000,9 +1005,53 @@ mod tests {
 
         assert_eq!(response.status.unwrap().code, v2::Code::MasterPersistenceTimeout as i32);
         assert_eq!(response.entries[0].message_id, "server-msg-id");
+        assert_eq!(response.entries[0].recall_handle, "recall-handle");
         assert_eq!(
             response.entries[0].status.as_ref().unwrap().code,
             v2::Code::MasterPersistenceTimeout as i32
         );
+    }
+
+    #[test]
+    fn send_message_response_uses_shared_failure_code_when_all_entries_fail_same_way() {
+        let response = build_send_message_response(
+            &SendMessagePlan {
+                entries: vec![
+                    SendMessageResultEntry {
+                        status: ProxyStatusMapper::from_payload_code(v2::Code::TopicNotFound, "topic a missing"),
+                        send_result: None,
+                    },
+                    SendMessageResultEntry {
+                        status: ProxyStatusMapper::from_payload_code(v2::Code::TopicNotFound, "topic b missing"),
+                        send_result: None,
+                    },
+                ],
+            },
+            &crate::processor::SendMessageRequest {
+                messages: vec![
+                    crate::processor::SendMessageEntry {
+                        topic: ResourceIdentity::new("", "TopicA"),
+                        client_message_id: "client-msg-id-1".to_owned(),
+                        message: Message::builder()
+                            .topic("TopicA")
+                            .body(Bytes::from_static(b"hello"))
+                            .build_unchecked(),
+                        queue_id: None,
+                    },
+                    crate::processor::SendMessageEntry {
+                        topic: ResourceIdentity::new("", "TopicA"),
+                        client_message_id: "client-msg-id-2".to_owned(),
+                        message: Message::builder()
+                            .topic("TopicA")
+                            .body(Bytes::from_static(b"world"))
+                            .build_unchecked(),
+                        queue_id: None,
+                    },
+                ],
+                timeout: None,
+            },
+        );
+
+        assert_eq!(response.status.unwrap().code, v2::Code::TopicNotFound as i32);
     }
 }

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_response_header.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_response_header.rs
@@ -29,6 +29,8 @@ pub struct SendMessageResponseHeader {
     queue_offset: i64,
     transaction_id: Option<CheetahString>,
     batch_uniq_id: Option<CheetahString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    recall_handle: Option<CheetahString>,
 }
 
 impl SendMessageResponseHeader {
@@ -38,6 +40,7 @@ impl SendMessageResponseHeader {
         queue_offset: i64,
         transaction_id: Option<CheetahString>,
         batch_uniq_id: Option<CheetahString>,
+        recall_handle: Option<CheetahString>,
     ) -> Self {
         SendMessageResponseHeader {
             msg_id,
@@ -45,6 +48,7 @@ impl SendMessageResponseHeader {
             queue_offset,
             transaction_id,
             batch_uniq_id,
+            recall_handle,
         }
     }
 
@@ -68,6 +72,10 @@ impl SendMessageResponseHeader {
         self.batch_uniq_id.as_deref()
     }
 
+    pub fn recall_handle(&self) -> Option<&str> {
+        self.recall_handle.as_deref()
+    }
+
     pub fn set_msg_id(&mut self, msg_id: impl Into<CheetahString>) {
         self.msg_id = msg_id.into();
     }
@@ -87,6 +95,10 @@ impl SendMessageResponseHeader {
     pub fn set_batch_uniq_id(&mut self, batch_uniq_id: Option<CheetahString>) {
         self.batch_uniq_id = batch_uniq_id;
     }
+
+    pub fn set_recall_handle(&mut self, recall_handle: Option<CheetahString>) {
+        self.recall_handle = recall_handle;
+    }
 }
 
 impl FastCodesHeader for SendMessageResponseHeader {
@@ -99,6 +111,9 @@ impl FastCodesHeader for SendMessageResponseHeader {
         }
         if let Some(ref batch_uniq_id) = self.batch_uniq_id {
             Self::write_if_not_null(out, "batchUniqId", batch_uniq_id.as_str());
+        }
+        if let Some(ref recall_handle) = self.recall_handle {
+            Self::write_if_not_null(out, "recallHandle", recall_handle.as_str());
         }
     }
 
@@ -122,6 +137,10 @@ impl FastCodesHeader for SendMessageResponseHeader {
         if let Some(str) = fields.get(&CheetahString::from_slice("batchUniqId")) {
             self.batch_uniq_id = Some(str.clone());
         }
+
+        if let Some(str) = fields.get(&CheetahString::from_slice("recallHandle")) {
+            self.recall_handle = Some(str.clone());
+        }
     }
 }
 
@@ -137,6 +156,7 @@ mod tests {
             100,
             Some(CheetahString::from("tx456")),
             Some(CheetahString::from("batch789")),
+            Some(CheetahString::from("recall-handle")),
         );
 
         assert_eq!(header.msg_id(), "msg123");
@@ -144,6 +164,7 @@ mod tests {
         assert_eq!(header.queue_offset(), 100);
         assert_eq!(header.transaction_id(), Some("tx456"));
         assert_eq!(header.batch_uniq_id(), Some("batch789"));
+        assert_eq!(header.recall_handle(), Some("recall-handle"));
 
         let header = SendMessageResponseHeader::default();
 
@@ -152,6 +173,7 @@ mod tests {
         assert_eq!(header.queue_offset(), 0);
         assert_eq!(header.transaction_id(), None);
         assert_eq!(header.batch_uniq_id(), None);
+        assert_eq!(header.recall_handle(), None);
     }
 
     #[test]
@@ -162,12 +184,14 @@ mod tests {
         header.set_queue_offset(200);
         header.set_transaction_id(Some(CheetahString::from("newTxId")));
         header.set_batch_uniq_id(Some(CheetahString::from("newBatchId")));
+        header.set_recall_handle(Some(CheetahString::from("recall-123")));
 
         assert_eq!(header.msg_id(), "newMsgId");
         assert_eq!(header.queue_id(), 2);
         assert_eq!(header.queue_offset(), 200);
         assert_eq!(header.transaction_id(), Some("newTxId"));
         assert_eq!(header.batch_uniq_id(), Some("newBatchId"));
+        assert_eq!(header.recall_handle(), Some("recall-123"));
     }
 
     #[test]
@@ -178,12 +202,13 @@ mod tests {
             100,
             Some(CheetahString::from("tx456")),
             Some(CheetahString::from("batch789")),
+            Some(CheetahString::from("recall-handle")),
         );
 
         let json = serde_json::to_string(&header).unwrap();
         assert_eq!(
             json,
-            r#"{"msgId":"msg123","queueId":1,"queueOffset":100,"transactionId":"tx456","batchUniqId":"batch789"}"#
+            r#"{"msgId":"msg123","queueId":1,"queueOffset":100,"transactionId":"tx456","batchUniqId":"batch789","recallHandle":"recall-handle"}"#
         );
 
         let header: SendMessageResponseHeader = serde_json::from_str(&json).unwrap();
@@ -192,6 +217,7 @@ mod tests {
         assert_eq!(header.queue_offset(), 100);
         assert_eq!(header.transaction_id(), Some("tx456"));
         assert_eq!(header.batch_uniq_id(), Some("batch789"));
+        assert_eq!(header.recall_handle(), Some("recall-handle"));
     }
 
     #[test]
@@ -202,6 +228,7 @@ mod tests {
             100,
             Some(CheetahString::from("tx456")),
             Some(CheetahString::from("batch789")),
+            Some(CheetahString::from("recall-handle")),
         );
 
         let mut out = bytes::BytesMut::new();
@@ -214,6 +241,10 @@ mod tests {
         fields.insert(CheetahString::from("queueOffset"), CheetahString::from("100"));
         fields.insert(CheetahString::from("transactionId"), CheetahString::from("tx456"));
         fields.insert(CheetahString::from("batchUniqId"), CheetahString::from("batch789"));
+        fields.insert(
+            CheetahString::from("recallHandle"),
+            CheetahString::from("recall-handle"),
+        );
 
         let mut header = SendMessageResponseHeader::default();
         header.decode_fast(&fields);
@@ -223,5 +254,6 @@ mod tests {
         assert_eq!(header.queue_offset(), 100);
         assert_eq!(header.transaction_id(), Some("tx456"));
         assert_eq!(header.batch_uniq_id(), Some("batch789"));
+        assert_eq!(header.recall_handle(), Some("recall-handle"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6809

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages now include recall handles that enable enhanced tracking and management capabilities
  * Recall handles are automatically generated and returned with send operation responses
  * Clients can access recall handles to support message retrieval and lifecycle management features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->