### PR TITLE
[ISSUE #6410]🚀Implement QueryMsgByUniqueKey Command for Unique Key-Based Lookup

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -384,6 +384,41 @@ impl DefaultMQAdminExtImpl {
         _key_type: CheetahString,
         _last_key: Option<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<crate::base::query_result::QueryResult> {
+        self.query_message_by_key_internal(cluster_name, topic, key, max_num, begin_timestamp, end_timestamp, false)
+            .await
+    }
+
+    pub async fn query_message_by_unique_key(
+        &self,
+        cluster_name: Option<CheetahString>,
+        topic: CheetahString,
+        unique_key: CheetahString,
+        max_num: i32,
+        begin_timestamp: i64,
+        end_timestamp: i64,
+    ) -> rocketmq_error::RocketMQResult<crate::base::query_result::QueryResult> {
+        self.query_message_by_key_internal(
+            cluster_name,
+            topic,
+            unique_key,
+            max_num,
+            begin_timestamp,
+            end_timestamp,
+            true,
+        )
+        .await
+    }
+
+    async fn query_message_by_key_internal(
+        &self,
+        cluster_name: Option<CheetahString>,
+        topic: CheetahString,
+        key: CheetahString,
+        max_num: i32,
+        begin_timestamp: i64,
+        end_timestamp: i64,
+        unique_key_flag: bool,
+    ) -> rocketmq_error::RocketMQResult<crate::base::query_result::QueryResult> {
         let route_topic = cluster_name.unwrap_or_else(|| topic.clone());
         let topic_route_data = self
             .examine_topic_route_info(route_topic.clone())
@@ -414,7 +449,9 @@ impl DefaultMQAdminExtImpl {
                     topic_request_header: None,
                 };
 
-            match MQClientAPIImpl::query_message(&api_impl, &broker_addr, request_header, timeout).await {
+            match MQClientAPIImpl::query_message(&api_impl, &broker_addr, request_header, unique_key_flag, timeout)
+                .await
+            {
                 Ok(Some((response_header, body))) => {
                     if let Some(mut body_bytes) = body {
                         let msgs = message_decoder::decodes_batch(&mut body_bytes, true, true);

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -2284,9 +2284,14 @@ impl MQClientAPIImpl {
         this: &ArcMut<Self>,
         addr: &CheetahString,
         request_header: QueryMessageRequestHeader,
+        unique_key_flag: bool,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<Option<(QueryMessageResponseHeader, Option<bytes::Bytes>)>> {
-        let request = RemotingCommand::create_request_command(RequestCode::QueryMessage, request_header);
+        let mut request = RemotingCommand::create_request_command(RequestCode::QueryMessage, request_header);
+        if unique_key_flag {
+            request.ensure_ext_fields_initialized();
+            request.add_ext_field(mix_all::UNIQUE_MSG_QUERY_FLAG, "true");
+        }
         let response = this
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)

--- a/rocketmq-remoting/src/protocol/body/consumer_running_info.rs
+++ b/rocketmq-remoting/src/protocol/body/consumer_running_info.rs
@@ -123,6 +123,10 @@ impl Display for ConsumerRunningInfo {
 }
 
 impl ConsumerRunningInfo {
+    pub fn is_push_type(&self) -> bool {
+        matches!(self.consume_type, ConsumeType::ConsumePassively)
+    }
+
     pub async fn analyze_subscription(
         cri_table: BTreeMap<String /* clientId */, ConsumerRunningInfo>,
     ) -> RocketMQResult<()> {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -251,6 +251,20 @@ impl DefaultMQAdminExt {
             )
             .await
     }
+
+    pub async fn query_message_by_unique_key(
+        &self,
+        cluster_name: Option<CheetahString>,
+        topic: CheetahString,
+        unique_key: CheetahString,
+        max_num: i32,
+        begin_timestamp: i64,
+        end_timestamp: i64,
+    ) -> rocketmq_error::RocketMQResult<rocketmq_client_rust::base::query_result::QueryResult> {
+        self.default_mqadmin_ext_impl
+            .query_message_by_unique_key(cluster_name, topic, unique_key, max_num, begin_timestamp, end_timestamp)
+            .await
+    }
 }
 
 impl Default for DefaultMQAdminExt {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands.rs
@@ -490,6 +490,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Message",
+                command: "queryMsgByUniqueKey",
+                remark: "Query Message by Unique key.",
+            },
+            Command {
+                category: "Message",
                 command: "queryMsgTraceById",
                 remark: "Query message trace by message ID.",
             },

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message.rs
@@ -20,6 +20,7 @@ pub mod print_msg_by_queue_sub_command;
 pub mod query_msg_by_id_sub_command;
 pub mod query_msg_by_key_sub_command;
 pub mod query_msg_by_offset_sub_command;
+pub mod query_msg_by_unique_key_sub_command;
 pub mod query_msg_trace_by_id_sub_command;
 pub mod send_message_sub_command;
 
@@ -37,6 +38,7 @@ use crate::commands::message::print_msg_by_queue_sub_command::PrintMsgByQueueSub
 use crate::commands::message::query_msg_by_id_sub_command::QueryMsgByIdSubCommand;
 use crate::commands::message::query_msg_by_key_sub_command::QueryMsgByKeySubCommand;
 use crate::commands::message::query_msg_by_offset_sub_command::QueryMsgByOffsetSubCommand;
+use crate::commands::message::query_msg_by_unique_key_sub_command::QueryMsgByUniqueKeySubCommand;
 use crate::commands::message::query_msg_trace_by_id_sub_command::QueryMsgTraceByIdSubCommand;
 use crate::commands::message::send_message_sub_command::SendMessageSubCommand;
 use crate::commands::CommandExecute;
@@ -99,6 +101,13 @@ pub enum MessageCommands {
     QueryMsgByOffset(QueryMsgByOffsetSubCommand),
 
     #[command(
+        name = "queryMsgByUniqueKey",
+        about = "Query Message by Unique key.",
+        long_about = None,
+    )]
+    QueryMsgByUniqueKey(QueryMsgByUniqueKeySubCommand),
+
+    #[command(
         name = "queryMsgTraceById",
         about = "Query message trace by message ID.",
         long_about = None,
@@ -124,6 +133,7 @@ impl CommandExecute for MessageCommands {
             MessageCommands::QueryMsgById(value) => value.execute(rpc_hook).await,
             MessageCommands::QueryMsgByKey(value) => value.execute(rpc_hook).await,
             MessageCommands::QueryMsgByOffset(value) => value.execute(rpc_hook).await,
+            MessageCommands::QueryMsgByUniqueKey(value) => value.execute(rpc_hook).await,
             MessageCommands::QueryMsgTraceById(value) => value.execute(rpc_hook).await,
             MessageCommands::SendMessage(value) => value.execute(rpc_hook).await,
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message/query_msg_by_unique_key_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/commands/message/query_msg_by_unique_key_sub_command.rs
@@ -1,0 +1,248 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use clap::Parser;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_common::utils::util_all::time_millis_to_human_string2;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use crate::commands::CommandExecute;
+
+const QUERY_MAX_NUM: i32 = 32;
+const DEFAULT_QUERY_WINDOW_MS: i64 = 36 * 60 * 60 * 1000;
+
+#[derive(Debug, Clone, Parser)]
+pub struct QueryMsgByUniqueKeySubCommand {
+    #[arg(short = 'i', long = "msgId", required = true, help = "Message Id")]
+    msg_id: String,
+
+    #[arg(short = 'g', long = "consumerGroup", required = false, help = "consumer group name")]
+    consumer_group: Option<String>,
+
+    #[arg(short = 'd', long = "clientId", required = false, help = "The consumer's client id")]
+    client_id: Option<String>,
+
+    #[arg(short = 't', long = "topic", required = true, help = "The topic of msg")]
+    topic: String,
+
+    #[arg(short = 'a', long = "showAll", required = false, default_value_t = false, action = clap::ArgAction::SetTrue, help = "Print all message, the limit is 32")]
+    show_all: bool,
+
+    #[arg(
+        short = 'c',
+        long = "cluster",
+        required = false,
+        help = "Cluster name or lmq parent topic, lmq is used to find the route."
+    )]
+    cluster: Option<String>,
+
+    #[arg(short = 's', long = "startTime", required = false, help = "startTime")]
+    start_time: Option<String>,
+
+    #[arg(short = 'e', long = "endTime", required = false, help = "endTime")]
+    end_time: Option<String>,
+}
+
+impl QueryMsgByUniqueKeySubCommand {
+    async fn query_by_id(
+        admin: &DefaultMQAdminExt,
+        cluster_name: Option<CheetahString>,
+        topic: &str,
+        msg_id: &str,
+        show_all: bool,
+        start_time: Option<&str>,
+        end_time: Option<&str>,
+    ) -> RocketMQResult<()> {
+        let query_result = if let (Some(start_time), Some(end_time)) = (start_time, end_time) {
+            let start_time_long = start_time
+                .trim()
+                .parse::<i64>()
+                .map_err(|e| RocketMQError::IllegalArgument(format!("Invalid startTime '{}': {}", start_time, e)))?;
+            let end_time_long = end_time
+                .trim()
+                .parse::<i64>()
+                .map_err(|e| RocketMQError::IllegalArgument(format!("Invalid endTime '{}': {}", end_time, e)))?;
+
+            admin
+                .query_message_by_unique_key(
+                    cluster_name,
+                    CheetahString::from(topic),
+                    CheetahString::from(msg_id),
+                    QUERY_MAX_NUM,
+                    start_time_long,
+                    end_time_long,
+                )
+                .await?
+        } else {
+            let now = current_millis() as i64;
+            admin
+                .query_message_by_unique_key(
+                    cluster_name,
+                    CheetahString::from(topic),
+                    CheetahString::from(msg_id),
+                    QUERY_MAX_NUM,
+                    now - DEFAULT_QUERY_WINDOW_MS,
+                    now + DEFAULT_QUERY_WINDOW_MS,
+                )
+                .await?
+        };
+
+        let mut list: Vec<&MessageExt> = query_result.message_list().iter().collect();
+        if list.is_empty() {
+            return Ok(());
+        }
+
+        list.sort_by_key(|msg| msg.store_timestamp());
+        let upper = if show_all { list.len() } else { 1 };
+        for (index, msg) in list.iter().take(upper).enumerate() {
+            Self::show_message(msg, index)?;
+        }
+
+        Ok(())
+    }
+
+    fn show_message(msg: &MessageExt, index: usize) -> RocketMQResult<()> {
+        let body_tmp_file_path = Self::create_body_file(msg, index)?;
+        println!("{:<20} {}", "Topic:", msg.topic());
+        println!("{:<20} [{}]", "Tags:", msg.get_tags().unwrap_or_default());
+        if let Some(keys) = msg.message_inner().keys() {
+            println!("{:<20} [{}]", "Keys:", keys.join(" "));
+        } else {
+            println!("{:<20} []", "Keys:");
+        }
+        println!("{:<20} {}", "Queue ID:", msg.queue_id());
+        println!("{:<20} {}", "Queue Offset:", msg.queue_offset());
+        println!("{:<20} {}", "CommitLog Offset:", msg.commit_log_offset());
+        println!("{:<20} {}", "Reconsume Times:", msg.reconsume_times());
+        println!(
+            "{:<20} {}",
+            "Born Timestamp:",
+            time_millis_to_human_string2(msg.born_timestamp())
+        );
+        println!(
+            "{:<20} {}",
+            "Store Timestamp:",
+            time_millis_to_human_string2(msg.store_timestamp())
+        );
+        println!("{:<20} {}", "Born Host:", msg.born_host());
+        println!("{:<20} {}", "Store Host:", msg.store_host());
+        println!("{:<20} {}", "System Flag:", msg.sys_flag());
+        println!("{:<20} {:?}", "Properties:", msg.properties());
+        println!("{:<20} {}", "Message Body Path:", body_tmp_file_path.display());
+
+        println!();
+        println!("WARN: messageTrackDetail is not implemented yet in rocketmq-rust");
+        println!();
+
+        Ok(())
+    }
+
+    fn create_body_file(msg: &MessageExt, index: usize) -> RocketMQResult<PathBuf> {
+        let mut body_tmp_file_path = PathBuf::from("/tmp/rocketmq/msgbodys");
+        fs::create_dir_all(&body_tmp_file_path)
+            .map_err(|e| RocketMQError::Internal(format!("Failed to create body temp directory: {}", e)))?;
+
+        let mut filename = msg.msg_id().to_string();
+        if index > 0 {
+            filename.push_str(&format!("_{}", index));
+        }
+        body_tmp_file_path.push(filename);
+
+        let body = msg.body().map(|b| b.to_vec()).unwrap_or_default();
+        fs::write(&body_tmp_file_path, &body)
+            .map_err(|e| RocketMQError::Internal(format!("Failed to write body file: {}", e)))?;
+
+        Ok(body_tmp_file_path)
+    }
+}
+
+impl CommandExecute for QueryMsgByUniqueKeySubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
+            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
+        } else {
+            DefaultMQAdminExt::new()
+        };
+        default_mqadmin_ext
+            .client_config_mut()
+            .set_instance_name(current_millis().to_string().into());
+
+        let operation_result = async {
+            MQAdminExt::start(&mut default_mqadmin_ext)
+                .await
+                .map_err(|e| RocketMQError::Internal(format!("Failed to start MQAdminExt: {}", e)))?;
+
+            let msg_id = self.msg_id.trim();
+            let topic = self.topic.trim();
+            let cluster_name = self.cluster.as_deref().map(|s| CheetahString::from(s.trim()));
+            let start_time = self.start_time.as_deref().map(str::trim);
+            let end_time = self.end_time.as_deref().map(str::trim);
+
+            if let (Some(consumer_group), Some(client_id)) = (&self.consumer_group, &self.client_id) {
+                let consumer_group = CheetahString::from(consumer_group.trim());
+                let client_id = CheetahString::from(client_id.trim());
+
+                let consumer_running_info = default_mqadmin_ext
+                    .get_consumer_running_info(consumer_group.clone(), client_id.clone(), false, Some(false))
+                    .await;
+
+                match consumer_running_info {
+                    Ok(info) if info.is_push_type() => {
+                        println!(
+                            "consumeMessageDirectly path is not implemented in rocketmq-rust yet, skip direct push \
+                             for client {}",
+                            client_id
+                        );
+                    }
+                    Ok(_) => {
+                        println!(
+                            "get consumer info failed or this {} client is not push consumer, not support direct push",
+                            client_id
+                        );
+                    }
+                    Err(_) => {
+                        println!("get consumer runtime info for {} client failed", client_id);
+                    }
+                }
+            } else {
+                Self::query_by_id(
+                    &default_mqadmin_ext,
+                    cluster_name,
+                    topic,
+                    msg_id,
+                    self.show_all,
+                    start_time,
+                    end_time,
+                )
+                .await?;
+            }
+
+            Ok(())
+        }
+        .await;
+
+        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
+        operation_result
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6410 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin API to query messages by unique key identifier.
  * Introduced a new CLI command `queryMsgByUniqueKey` to search for messages by ID with optional cluster, topic, and time range filtering.
  * Results display message metadata and save message bodies to local files for inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->