### PR TITLE
[ISSUE #6815]✨Enhance session management with receipt handle tracking and telemetry settings integration

### DIFF
--- a/rocketmq-proxy/src/config.rs
+++ b/rocketmq-proxy/src/config.rs
@@ -14,6 +14,7 @@
 
 use std::net::SocketAddr;
 use std::path::Path;
+use std::time::Duration;
 
 use rocketmq_error::RocketMQError;
 use serde::Deserialize;
@@ -118,6 +119,8 @@ pub struct SessionConfig {
     pub client_ttl_ms: u64,
     pub receipt_handle_ttl_ms: u64,
     pub auto_renew_enabled: bool,
+    pub min_long_polling_timeout_ms: u64,
+    pub max_long_polling_timeout_ms: u64,
 }
 
 impl Default for SessionConfig {
@@ -126,7 +129,27 @@ impl Default for SessionConfig {
             client_ttl_ms: 60_000,
             receipt_handle_ttl_ms: 5 * 60_000,
             auto_renew_enabled: true,
+            min_long_polling_timeout_ms: 5_000,
+            max_long_polling_timeout_ms: 20_000,
         }
+    }
+}
+
+impl SessionConfig {
+    pub fn client_ttl(&self) -> Duration {
+        Duration::from_millis(self.client_ttl_ms.max(1))
+    }
+
+    pub fn receipt_handle_ttl(&self) -> Duration {
+        Duration::from_millis(self.receipt_handle_ttl_ms.max(1))
+    }
+
+    pub fn min_long_polling_timeout(&self) -> Duration {
+        Duration::from_millis(self.min_long_polling_timeout_ms)
+    }
+
+    pub fn max_long_polling_timeout(&self) -> Duration {
+        Duration::from_millis(self.max_long_polling_timeout_ms.max(self.min_long_polling_timeout_ms))
     }
 }
 

--- a/rocketmq-proxy/src/grpc/server.rs
+++ b/rocketmq-proxy/src/grpc/server.rs
@@ -15,6 +15,7 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use tokio::sync::watch;
 use tonic::transport::Server;
 
 use crate::config::ProxyConfig;
@@ -30,15 +31,38 @@ where
     F: Future<Output = ()> + Send + 'static,
 {
     let addr = config.grpc.socket_addr()?;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let shutdown_signal = shutdown_tx.clone();
+    let housekeeping_service = service.clone();
+    tokio::spawn(async move {
+        let mut shutdown_rx = shutdown_rx;
+        housekeeping_service
+            .run_housekeeping_until(async move {
+                loop {
+                    if *shutdown_rx.borrow() {
+                        break;
+                    }
+                    if shutdown_rx.changed().await.is_err() {
+                        break;
+                    }
+                }
+            })
+            .await;
+    });
     let service = MessagingServiceServer::new(service)
         .max_decoding_message_size(config.grpc.max_decoding_message_size)
         .max_encoding_message_size(config.grpc.max_encoding_message_size);
 
-    Server::builder()
+    let result = Server::builder()
         .add_service(service)
-        .serve_with_shutdown(addr, shutdown)
-        .await
-        .map_err(|error| ProxyError::Transport {
-            message: format!("proxy gRPC server failed: {error}"),
+        .serve_with_shutdown(addr, async move {
+            shutdown.await;
+            let _ = shutdown_signal.send(true);
         })
+        .await;
+    let _ = shutdown_tx.send(true);
+
+    result.map_err(|error| ProxyError::Transport {
+        message: format!("proxy gRPC server failed: {error}"),
+    })
 }

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -14,11 +14,18 @@
 
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::stream;
 use futures::Stream;
+use futures::StreamExt;
+use rocketmq_common::common::message::MessageConst;
+use rocketmq_common::common::message::MessageTrait;
+use tokio::sync::mpsc;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
+use tokio::time::MissedTickBehavior;
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::Request;
 use tonic::Response;
 use tonic::Status;
@@ -30,7 +37,11 @@ use crate::error::ProxyResult;
 use crate::grpc::adapter;
 use crate::processor::MessagingProcessor;
 use crate::proto::v2;
+use crate::service::ResourceIdentity;
 use crate::session::ClientSessionRegistry;
+use crate::session::ClientSettingsSnapshot;
+use crate::session::ReceiptHandleRegistration;
+use crate::session::TrackedReceiptHandle;
 use crate::status::ProxyStatusMapper;
 
 type ResponseStream<T> = Pin<Box<dyn Stream<Item = Result<T, Status>> + Send + 'static>>;
@@ -82,12 +93,22 @@ impl ExecutionGuards {
     }
 }
 
-#[derive(Clone)]
 pub struct ProxyGrpcService<P> {
     config: Arc<ProxyConfig>,
     processor: Arc<P>,
     sessions: ClientSessionRegistry,
     guards: ExecutionGuards,
+}
+
+impl<P> Clone for ProxyGrpcService<P> {
+    fn clone(&self) -> Self {
+        Self {
+            config: Arc::clone(&self.config),
+            processor: Arc::clone(&self.processor),
+            sessions: self.sessions.clone(),
+            guards: self.guards.clone(),
+        }
+    }
 }
 
 impl<P> ProxyGrpcService<P> {
@@ -116,6 +137,41 @@ impl<P> ProxyGrpcService<P> {
         T: Send + 'static,
     {
         Box::pin(stream::iter(items.into_iter().map(Ok)))
+    }
+
+    pub async fn run_housekeeping_until<F>(&self, shutdown: F)
+    where
+        F: std::future::Future<Output = ()> + Send,
+    {
+        let mut interval = tokio::time::interval(self.housekeeping_interval());
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        tokio::pin!(shutdown);
+
+        loop {
+            tokio::select! {
+                _ = &mut shutdown => break,
+                _ = interval.tick() => {
+                    self.reap_session_state();
+                }
+            }
+        }
+    }
+
+    fn housekeeping_interval(&self) -> Duration {
+        let min_ttl = self
+            .config
+            .session
+            .client_ttl()
+            .min(self.config.session.receipt_handle_ttl());
+        let half_ttl_ms = min_ttl.as_millis().saturating_div(2).clamp(1_000, 30_000) as u64;
+        Duration::from_millis(half_ttl_ms)
+    }
+
+    fn reap_session_state(&self) {
+        let _ = self.sessions.reap_expired(
+            self.config.session.client_ttl(),
+            self.config.session.receipt_handle_ttl(),
+        );
     }
 }
 
@@ -157,6 +213,277 @@ where
             command: None,
         }
     }
+
+    fn merged_telemetry_settings(&self, settings: &v2::Settings) -> v2::Settings {
+        let mut merged = settings.clone();
+        if let Some(v2::settings::PubSub::Subscription(subscription)) = merged.pub_sub.as_mut() {
+            if subscription.receive_batch_size.is_some_and(|value| value <= 0) {
+                subscription.receive_batch_size = Some(1);
+            }
+
+            let timeout = subscription
+                .long_polling_timeout
+                .as_ref()
+                .and_then(proto_duration)
+                .unwrap_or_else(|| self.config.session.min_long_polling_timeout());
+            subscription.long_polling_timeout = Some(duration_to_proto_duration(clamp_duration(
+                timeout,
+                self.config.session.min_long_polling_timeout(),
+                self.config.session.max_long_polling_timeout(),
+            )));
+        }
+        merged
+    }
+
+    fn effective_receive_request(
+        &self,
+        context: &ProxyContext,
+        mut request: crate::processor::ReceiveMessageRequest,
+    ) -> ProxyResult<crate::processor::ReceiveMessageRequest> {
+        if let Some(client_id) = context.client_id() {
+            if let Some(settings) = self.sessions.settings_for_client(client_id) {
+                self.apply_receive_settings(&mut request, &settings);
+            }
+        }
+
+        if let Some(deadline) = context.deadline() {
+            request.long_polling_timeout = request.long_polling_timeout.min(deadline);
+        }
+
+        Ok(request)
+    }
+
+    fn apply_receive_settings(
+        &self,
+        request: &mut crate::processor::ReceiveMessageRequest,
+        settings: &ClientSettingsSnapshot,
+    ) {
+        let Some(subscription) = settings.subscription.as_ref() else {
+            return;
+        };
+
+        if let Some(receive_batch_size) = subscription.receive_batch_size {
+            request.batch_size = request.batch_size.min(receive_batch_size.max(1));
+        }
+
+        if let Some(long_polling_timeout) = subscription.long_polling_timeout {
+            request.long_polling_timeout = clamp_duration(
+                long_polling_timeout,
+                self.config.session.min_long_polling_timeout(),
+                self.config.session.max_long_polling_timeout(),
+            );
+        }
+
+        request.target.fifo |= subscription.fifo;
+    }
+
+    fn track_received_receipt_handles(
+        &self,
+        context: &ProxyContext,
+        request: &crate::processor::ReceiveMessageRequest,
+        plan: &crate::processor::ReceiveMessagePlan,
+    ) {
+        if !(self.config.session.auto_renew_enabled && request.auto_renew) {
+            return;
+        }
+        let Some(client_id) = context.client_id() else {
+            return;
+        };
+
+        for message in &plan.messages {
+            let Some(receipt_handle) = message
+                .message
+                .property(&cheetah_string::CheetahString::from_static_str(
+                    MessageConst::PROPERTY_POP_CK,
+                ))
+                .map(|value| value.to_string())
+            else {
+                continue;
+            };
+
+            let tracked = self.sessions.track_receipt_handle(ReceiptHandleRegistration {
+                client_id: client_id.to_owned(),
+                group: request.group.clone(),
+                topic: ResourceIdentity::new(
+                    request.target.topic.namespace().to_owned(),
+                    message.message.topic().to_string(),
+                ),
+                message_id: message.message.msg_id().to_string(),
+                receipt_handle,
+                invisible_duration: message.invisible_duration,
+            });
+            self.spawn_auto_renew_task(context.clone(), tracked);
+        }
+    }
+
+    fn reconcile_ack_result(
+        &self,
+        context: &ProxyContext,
+        request: &crate::processor::AckMessageRequest,
+        plan: &crate::processor::AckMessagePlan,
+    ) {
+        let Some(client_id) = context.client_id() else {
+            return;
+        };
+
+        for entry in &plan.entries {
+            if entry.status.is_ok() {
+                let _ = self.sessions.remove_receipt_handle_matching(
+                    client_id,
+                    &request.group,
+                    &request.topic,
+                    entry.message_id.as_str(),
+                    entry.receipt_handle.as_str(),
+                );
+            }
+        }
+    }
+
+    fn reconcile_change_invisible_result(
+        &self,
+        context: &ProxyContext,
+        request: &crate::processor::ChangeInvisibleDurationRequest,
+        plan: &crate::processor::ChangeInvisibleDurationPlan,
+    ) {
+        let Some(client_id) = context.client_id() else {
+            return;
+        };
+        if !plan.status.is_ok() {
+            return;
+        }
+
+        let _ = self.sessions.update_receipt_handle_matching(
+            client_id,
+            &request.group,
+            &request.topic,
+            request.message_id.as_str(),
+            request.receipt_handle.as_str(),
+            plan.receipt_handle.as_str(),
+            request.invisible_duration,
+        );
+    }
+
+    fn spawn_auto_renew_task(&self, context: ProxyContext, tracked: TrackedReceiptHandle) {
+        let processor = Arc::clone(&self.processor);
+        let sessions = self.sessions.clone();
+        tokio::spawn(async move {
+            let client_id = tracked.client_id.clone();
+            let group = tracked.group.clone();
+            let topic = tracked.topic.clone();
+            let message_id = tracked.message_id.clone();
+
+            loop {
+                let Some(current) =
+                    sessions.tracked_receipt_handle(client_id.as_str(), &group, &topic, message_id.as_str())
+                else {
+                    break;
+                };
+                let delay = auto_renew_interval(current.invisible_duration);
+                let cancellation = current.cancellation.clone();
+
+                tokio::select! {
+                    _ = cancellation.cancelled() => break,
+                    _ = tokio::time::sleep(delay) => {}
+                }
+
+                let Some(current) =
+                    sessions.tracked_receipt_handle(client_id.as_str(), &group, &topic, message_id.as_str())
+                else {
+                    break;
+                };
+
+                let renew_request = crate::processor::ChangeInvisibleDurationRequest {
+                    group: group.clone(),
+                    topic: topic.clone(),
+                    receipt_handle: current.receipt_handle.clone(),
+                    invisible_duration: current.invisible_duration,
+                    message_id: message_id.clone(),
+                    lite_topic: None,
+                    suspend: None,
+                };
+
+                match processor
+                    .change_invisible_duration(&context, renew_request.clone())
+                    .await
+                {
+                    Ok(plan) if plan.status.is_ok() => {
+                        let next_receipt_handle = if plan.receipt_handle.is_empty() {
+                            renew_request.receipt_handle
+                        } else {
+                            plan.receipt_handle
+                        };
+                        let _ = sessions.update_receipt_handle(
+                            client_id.as_str(),
+                            &group,
+                            &topic,
+                            message_id.as_str(),
+                            next_receipt_handle.as_str(),
+                            renew_request.invisible_duration,
+                        );
+                    }
+                    Ok(plan) if plan.status.code() == v2::Code::InvalidReceiptHandle as i32 => {
+                        let _ = sessions.remove_receipt_handle(client_id.as_str(), &group, &topic, message_id.as_str());
+                        break;
+                    }
+                    Ok(_) | Err(_) => {}
+                }
+            }
+        });
+    }
+
+    async fn handle_telemetry_command(
+        &self,
+        context: &ProxyContext,
+        command: v2::TelemetryCommand,
+    ) -> v2::TelemetryCommand {
+        self.sessions.upsert_from_context(context);
+
+        match command.command {
+            Some(v2::telemetry_command::Command::Settings(settings)) => {
+                let merged = self.merged_telemetry_settings(&settings);
+                let _ = self.sessions.update_settings_from_telemetry(context, &merged);
+                v2::TelemetryCommand {
+                    status: Some(ProxyStatusMapper::ok()),
+                    command: Some(v2::telemetry_command::Command::Settings(merged)),
+                }
+            }
+            Some(v2::telemetry_command::Command::ThreadStackTrace(_))
+            | Some(v2::telemetry_command::Command::VerifyMessageResult(_)) => {
+                Self::telemetry_status(ProxyStatusMapper::ok())
+            }
+            Some(_) => Self::telemetry_status(ProxyStatusMapper::from_code(
+                v2::Code::BadRequest,
+                "client sent an unsupported telemetry command",
+            )),
+            None => Self::telemetry_status(ProxyStatusMapper::ok()),
+        }
+    }
+}
+
+fn clamp_duration(duration: Duration, minimum: Duration, maximum: Duration) -> Duration {
+    duration.max(minimum).min(maximum)
+}
+
+fn auto_renew_interval(invisible_duration: Duration) -> Duration {
+    let half_millis = invisible_duration.as_millis().saturating_div(2).clamp(1_000, 15_000) as u64;
+    Duration::from_millis(half_millis)
+}
+
+fn proto_duration(duration: &prost_types::Duration) -> Option<Duration> {
+    if duration.seconds < 0 || duration.nanos < 0 || duration.nanos >= 1_000_000_000 {
+        return None;
+    }
+
+    let seconds = u64::try_from(duration.seconds).ok()?;
+    let nanos = u32::try_from(duration.nanos).ok()?;
+    Some(Duration::new(seconds, nanos))
+}
+
+fn duration_to_proto_duration(duration: Duration) -> prost_types::Duration {
+    prost_types::Duration {
+        seconds: duration.as_secs() as i64,
+        nanos: duration.subsec_nanos() as i32,
+    }
 }
 
 #[tonic::async_trait]
@@ -172,6 +499,7 @@ where
         &self,
         request: Request<v2::QueryRouteRequest>,
     ) -> Result<Response<v2::QueryRouteResponse>, Status> {
+        self.reap_session_state();
         let context = self.context("QueryRoute", &request);
         let request = request.into_inner();
 
@@ -196,13 +524,15 @@ where
         &self,
         request: Request<v2::HeartbeatRequest>,
     ) -> Result<Response<v2::HeartbeatResponse>, Status> {
+        self.reap_session_state();
         let context = self.context("Heartbeat", &request);
         let request = request.into_inner();
 
         let status = match self.guards.try_client_manager() {
             Ok(_permit) => match self.validate_heartbeat_request(&context, request.client_type) {
                 Ok(()) => {
-                    self.sessions.upsert_from_context(&context);
+                    self.sessions
+                        .upsert_from_context_with_client_type(&context, Some(request.client_type));
                     ProxyStatusMapper::ok()
                 }
                 Err(error) => ProxyStatusMapper::from_error(&error),
@@ -217,6 +547,7 @@ where
         &self,
         request: Request<v2::SendMessageRequest>,
     ) -> Result<Response<v2::SendMessageResponse>, Status> {
+        self.reap_session_state();
         let context = self.context("SendMessage", &request);
         let request = request.into_inner();
 
@@ -241,6 +572,7 @@ where
         &self,
         request: Request<v2::QueryAssignmentRequest>,
     ) -> Result<Response<v2::QueryAssignmentResponse>, Status> {
+        self.reap_session_state();
         let context = self.context("QueryAssignment", &request);
         let request = request.into_inner();
 
@@ -265,17 +597,22 @@ where
         &self,
         request: Request<v2::ReceiveMessageRequest>,
     ) -> Result<Response<Self::ReceiveMessageStream>, Status> {
+        self.reap_session_state();
         let context = self.context("ReceiveMessage", &request);
         let request = request.into_inner();
         let responses = match self
             .validate_client_context(&context)
             .and_then(|_| adapter::build_receive_message_request(&request))
+            .and_then(|input| self.effective_receive_request(&context, input))
         {
             Ok(input) => match self.guards.try_consumer() {
                 Ok(_permit) => {
                     self.sessions.upsert_from_context(&context);
-                    match self.processor.receive_message(&context, input).await {
-                        Ok(plan) => adapter::build_receive_message_responses(&plan),
+                    match self.processor.receive_message(&context, input.clone()).await {
+                        Ok(plan) => {
+                            self.track_received_receipt_handles(&context, &input, &plan);
+                            adapter::build_receive_message_responses(&plan)
+                        }
                         Err(error) => adapter::error_receive_message_responses(ProxyStatusMapper::from_error(&error)),
                     }
                 }
@@ -291,6 +628,7 @@ where
         &self,
         request: Request<v2::AckMessageRequest>,
     ) -> Result<Response<v2::AckMessageResponse>, Status> {
+        self.reap_session_state();
         let context = self.context("AckMessage", &request);
         let request = request.into_inner();
 
@@ -299,8 +637,11 @@ where
             .and_then(|_| adapter::build_ack_message_request(&request))
         {
             Ok(input) => match self.guards.try_consumer() {
-                Ok(_permit) => match self.processor.ack_message(&context, input).await {
-                    Ok(plan) => adapter::build_ack_message_response(&plan),
+                Ok(_permit) => match self.processor.ack_message(&context, input.clone()).await {
+                    Ok(plan) => {
+                        self.reconcile_ack_result(&context, &input, &plan);
+                        adapter::build_ack_message_response(&plan)
+                    }
                     Err(error) => adapter::error_ack_message_response(ProxyStatusMapper::from_error(&error)),
                 },
                 Err(error) => adapter::error_ack_message_response(ProxyStatusMapper::from_error(&error)),
@@ -324,6 +665,7 @@ where
         &self,
         request: Request<v2::PullMessageRequest>,
     ) -> Result<Response<Self::PullMessageStream>, Status> {
+        self.reap_session_state();
         let context = self.context("PullMessage", &request);
         let status = match self
             .validate_client_context(&context)
@@ -377,25 +719,51 @@ where
         &self,
         request: Request<tonic::Streaming<v2::TelemetryCommand>>,
     ) -> Result<Response<Self::TelemetryStream>, Status> {
+        self.reap_session_state();
         let context = self.context("Telemetry", &request);
-        let status = match self
+        let mut inbound = request.into_inner();
+        let permit = match self
             .validate_client_context(&context)
-            .and_then(|_| self.guards.try_client_manager().map(|_| ()))
+            .and_then(|_| self.guards.try_client_manager())
         {
-            Ok(()) => {
-                self.sessions.upsert_from_context(&context);
-                self.not_implemented_status("Telemetry")
+            Ok(permit) => permit,
+            Err(error) => {
+                return Ok(Response::new(
+                    self.status_stream(Self::telemetry_status(ProxyStatusMapper::from_error(&error))),
+                ));
             }
-            Err(error) => ProxyStatusMapper::from_error(&error),
         };
 
-        Ok(Response::new(self.status_stream(Self::telemetry_status(status))))
+        self.sessions.upsert_from_context(&context);
+        let service = self.clone();
+        let (sender, receiver) = mpsc::channel(16);
+        tokio::spawn(async move {
+            let _permit = permit;
+            loop {
+                match inbound.next().await {
+                    Some(Ok(command)) => {
+                        let response = service.handle_telemetry_command(&context, command).await;
+                        if sender.send(Ok(response)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Err(error)) => {
+                        let _ = sender.send(Err(error)).await;
+                        break;
+                    }
+                    None => break,
+                }
+            }
+        });
+
+        Ok(Response::new(Box::pin(ReceiverStream::new(receiver))))
     }
 
     async fn notify_client_termination(
         &self,
         request: Request<v2::NotifyClientTerminationRequest>,
     ) -> Result<Response<v2::NotifyClientTerminationResponse>, Status> {
+        self.reap_session_state();
         let context = self.context("NotifyClientTermination", &request);
         let status = match self
             .guards
@@ -403,7 +771,7 @@ where
             .and_then(|_| self.validate_client_context(&context))
         {
             Ok(client_id) => {
-                self.sessions.remove(client_id);
+                self.sessions.remove_client(client_id);
                 ProxyStatusMapper::ok()
             }
             Err(error) => ProxyStatusMapper::from_error(&error),
@@ -418,6 +786,7 @@ where
         &self,
         request: Request<v2::ChangeInvisibleDurationRequest>,
     ) -> Result<Response<v2::ChangeInvisibleDurationResponse>, Status> {
+        self.reap_session_state();
         let context = self.context("ChangeInvisibleDuration", &request);
         let request = request.into_inner();
 
@@ -426,8 +795,11 @@ where
             .and_then(|_| adapter::build_change_invisible_duration_request(&request))
         {
             Ok(input) => match self.guards.try_consumer() {
-                Ok(_permit) => match self.processor.change_invisible_duration(&context, input).await {
-                    Ok(plan) => adapter::build_change_invisible_duration_response(&plan),
+                Ok(_permit) => match self.processor.change_invisible_duration(&context, input.clone()).await {
+                    Ok(plan) => {
+                        self.reconcile_change_invisible_result(&context, &input, &plan);
+                        adapter::build_change_invisible_duration_response(&plan)
+                    }
                     Err(error) => {
                         adapter::error_change_invisible_duration_response(ProxyStatusMapper::from_error(&error))
                     }
@@ -482,6 +854,7 @@ mod tests {
 
     use super::ProxyGrpcService;
     use crate::config::ProxyConfig;
+    use crate::grpc::adapter;
     use crate::processor::AckMessageRequest;
     use crate::processor::AckMessageResultEntry;
     use crate::processor::ChangeInvisibleDurationPlan;
@@ -1011,5 +1384,291 @@ mod tests {
         let response = service.change_invisible_duration(request).await.unwrap().into_inner();
         assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
         assert_eq!(response.receipt_handle, "handle-1-renewed");
+    }
+
+    #[test]
+    fn telemetry_settings_are_merged_with_proxy_bounds() {
+        let service = test_service(StaticRouteService::default(), StaticMetadataService::default());
+        let merged = service.merged_telemetry_settings(&v2::Settings {
+            client_type: Some(v2::ClientType::PushConsumer as i32),
+            access_point: None,
+            backoff_policy: None,
+            request_timeout: None,
+            pub_sub: Some(v2::settings::PubSub::Subscription(v2::Subscription {
+                group: Some(v2::Resource {
+                    resource_namespace: String::new(),
+                    name: "GroupA".to_owned(),
+                }),
+                subscriptions: Vec::new(),
+                fifo: Some(true),
+                receive_batch_size: Some(64),
+                long_polling_timeout: Some(prost_types::Duration { seconds: 1, nanos: 0 }),
+                lite_subscription_quota: None,
+                max_lite_topic_size: None,
+            })),
+            user_agent: None,
+            metric: None,
+        });
+
+        let subscription = match merged.pub_sub.unwrap() {
+            v2::settings::PubSub::Subscription(subscription) => subscription,
+            _ => panic!("expected subscription settings"),
+        };
+        assert_eq!(subscription.receive_batch_size, Some(64));
+        assert_eq!(
+            subscription.long_polling_timeout,
+            Some(prost_types::Duration { seconds: 5, nanos: 0 })
+        );
+    }
+
+    #[test]
+    fn effective_receive_request_uses_telemetry_settings() {
+        let service = test_service(StaticRouteService::default(), StaticMetadataService::default());
+        let mut request = Request::new(());
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+        let context = service.context("ReceiveMessage", &request);
+
+        let merged = service.merged_telemetry_settings(&v2::Settings {
+            client_type: Some(v2::ClientType::PushConsumer as i32),
+            access_point: None,
+            backoff_policy: None,
+            request_timeout: None,
+            pub_sub: Some(v2::settings::PubSub::Subscription(v2::Subscription {
+                group: Some(v2::Resource {
+                    resource_namespace: String::new(),
+                    name: "GroupA".to_owned(),
+                }),
+                subscriptions: Vec::new(),
+                fifo: Some(true),
+                receive_batch_size: Some(32),
+                long_polling_timeout: Some(prost_types::Duration { seconds: 1, nanos: 0 }),
+                lite_subscription_quota: None,
+                max_lite_topic_size: None,
+            })),
+            user_agent: None,
+            metric: None,
+        });
+        let _ = service.sessions.update_settings_from_telemetry(&context, &merged);
+
+        let request = service
+            .effective_receive_request(
+                &context,
+                adapter::build_receive_message_request(&v2::ReceiveMessageRequest {
+                    group: Some(v2::Resource {
+                        resource_namespace: String::new(),
+                        name: "GroupA".to_owned(),
+                    }),
+                    message_queue: Some(v2::MessageQueue {
+                        topic: Some(v2::Resource {
+                            resource_namespace: String::new(),
+                            name: "TopicA".to_owned(),
+                        }),
+                        id: 3,
+                        permission: v2::Permission::ReadWrite as i32,
+                        broker: None,
+                        accept_message_types: vec![v2::MessageType::Normal as i32],
+                    }),
+                    filter_expression: None,
+                    batch_size: 64,
+                    invisible_duration: Some(prost_types::Duration { seconds: 30, nanos: 0 }),
+                    auto_renew: false,
+                    long_polling_timeout: Some(prost_types::Duration { seconds: 30, nanos: 0 }),
+                    attempt_id: None,
+                })
+                .unwrap(),
+            )
+            .unwrap();
+
+        assert_eq!(request.batch_size, 32);
+        assert_eq!(request.long_polling_timeout, std::time::Duration::from_secs(5));
+        assert!(request.target.fifo);
+    }
+
+    #[tokio::test]
+    async fn receive_message_with_auto_renew_tracks_receipt_handles() {
+        let service = test_service_with_services(
+            StaticRouteService::default(),
+            StaticMetadataService::default(),
+            Arc::new(StaticMessageService::with_send_status(SendStatus::SendOk)),
+            Arc::new(TestConsumerService),
+        );
+        let mut request = Request::new(v2::ReceiveMessageRequest {
+            group: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "GroupA".to_owned(),
+            }),
+            message_queue: Some(v2::MessageQueue {
+                topic: Some(v2::Resource {
+                    resource_namespace: String::new(),
+                    name: "TopicA".to_owned(),
+                }),
+                id: 3,
+                permission: v2::Permission::ReadWrite as i32,
+                broker: None,
+                accept_message_types: vec![v2::MessageType::Normal as i32],
+            }),
+            filter_expression: None,
+            batch_size: 1,
+            invisible_duration: Some(prost_types::Duration { seconds: 30, nanos: 0 }),
+            auto_renew: true,
+            long_polling_timeout: Some(prost_types::Duration { seconds: 1, nanos: 0 }),
+            attempt_id: None,
+        });
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+
+        let mut stream = service.receive_message(request).await.unwrap().into_inner();
+        let _ = stream.next().await;
+        let _ = stream.next().await;
+        let _ = stream.next().await;
+
+        let tracked = service
+            .sessions
+            .tracked_receipt_handle(
+                "client-a",
+                &ResourceIdentity::new("", "GroupA"),
+                &ResourceIdentity::new("", "TopicA"),
+                "server-msg-id",
+            )
+            .expect("receipt handle should be tracked");
+        assert_eq!(tracked.receipt_handle, "receipt-handle");
+        tracked.cancellation.cancel();
+    }
+
+    #[tokio::test]
+    async fn ack_message_success_clears_tracked_receipt_handle() {
+        let service = test_service_with_services(
+            StaticRouteService::default(),
+            StaticMetadataService::default(),
+            Arc::new(StaticMessageService::with_send_status(SendStatus::SendOk)),
+            Arc::new(TestConsumerService),
+        );
+        service
+            .sessions
+            .track_receipt_handle(crate::session::ReceiptHandleRegistration {
+                client_id: "client-a".to_owned(),
+                group: ResourceIdentity::new("", "GroupA"),
+                topic: ResourceIdentity::new("", "TopicA"),
+                message_id: "msg-1".to_owned(),
+                receipt_handle: "handle-1".to_owned(),
+                invisible_duration: std::time::Duration::from_secs(30),
+            });
+
+        let mut request = Request::new(v2::AckMessageRequest {
+            group: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "GroupA".to_owned(),
+            }),
+            topic: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "TopicA".to_owned(),
+            }),
+            entries: vec![v2::AckMessageEntry {
+                message_id: "msg-1".to_owned(),
+                receipt_handle: "handle-1".to_owned(),
+                lite_topic: None,
+            }],
+        });
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+
+        let response = service.ack_message(request).await.unwrap().into_inner();
+        assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
+        assert_eq!(service.sessions.tracked_handle_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn change_invisible_duration_updates_tracked_receipt_handle() {
+        let service = test_service_with_services(
+            StaticRouteService::default(),
+            StaticMetadataService::default(),
+            Arc::new(StaticMessageService::with_send_status(SendStatus::SendOk)),
+            Arc::new(TestConsumerService),
+        );
+        service
+            .sessions
+            .track_receipt_handle(crate::session::ReceiptHandleRegistration {
+                client_id: "client-a".to_owned(),
+                group: ResourceIdentity::new("", "GroupA"),
+                topic: ResourceIdentity::new("", "TopicA"),
+                message_id: "msg-1".to_owned(),
+                receipt_handle: "handle-1".to_owned(),
+                invisible_duration: std::time::Duration::from_secs(30),
+            });
+
+        let mut request = Request::new(v2::ChangeInvisibleDurationRequest {
+            group: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "GroupA".to_owned(),
+            }),
+            topic: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "TopicA".to_owned(),
+            }),
+            receipt_handle: "handle-1".to_owned(),
+            invisible_duration: Some(prost_types::Duration { seconds: 45, nanos: 0 }),
+            message_id: "msg-1".to_owned(),
+            lite_topic: None,
+            suspend: None,
+        });
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+
+        let response = service.change_invisible_duration(request).await.unwrap().into_inner();
+        assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
+        let tracked = service
+            .sessions
+            .tracked_receipt_handle(
+                "client-a",
+                &ResourceIdentity::new("", "GroupA"),
+                &ResourceIdentity::new("", "TopicA"),
+                "msg-1",
+            )
+            .expect("receipt handle should remain tracked");
+        assert_eq!(tracked.receipt_handle, "handle-1-renewed");
+        assert_eq!(tracked.invisible_duration, std::time::Duration::from_secs(45));
+    }
+
+    #[tokio::test]
+    async fn notify_client_termination_clears_session_and_receipt_handles() {
+        let service = test_service_with_services(
+            StaticRouteService::default(),
+            StaticMetadataService::default(),
+            Arc::new(StaticMessageService::with_send_status(SendStatus::SendOk)),
+            Arc::new(TestConsumerService),
+        );
+        let mut heartbeat = Request::new(v2::HeartbeatRequest {
+            group: None,
+            client_type: v2::ClientType::SimpleConsumer as i32,
+        });
+        heartbeat
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+        let _ = service.heartbeat(heartbeat).await.unwrap();
+        service
+            .sessions
+            .track_receipt_handle(crate::session::ReceiptHandleRegistration {
+                client_id: "client-a".to_owned(),
+                group: ResourceIdentity::new("", "GroupA"),
+                topic: ResourceIdentity::new("", "TopicA"),
+                message_id: "msg-1".to_owned(),
+                receipt_handle: "handle-1".to_owned(),
+                invisible_duration: std::time::Duration::from_secs(30),
+            });
+
+        let mut request = Request::new(v2::NotifyClientTerminationRequest { group: None });
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+
+        let response = service.notify_client_termination(request).await.unwrap().into_inner();
+        assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
+        assert!(service.sessions.get("client-a").is_none());
+        assert_eq!(service.sessions.tracked_handle_count(), 0);
     }
 }

--- a/rocketmq-proxy/src/lib.rs
+++ b/rocketmq-proxy/src/lib.rs
@@ -86,6 +86,11 @@ pub use service::SubscriptionGroupMetadata;
 pub use service::UnsupportedRouteService;
 pub use session::ClientSession;
 pub use session::ClientSessionRegistry;
+pub use session::ClientSettingsSnapshot;
+pub use session::ReapSummary;
+pub use session::ReceiptHandleRegistration;
+pub use session::SubscriptionSettingsSnapshot;
+pub use session::TrackedReceiptHandle;
 pub use status::ProxyPayloadStatus;
 
 /// Default gRPC port used by the proxy runtime.

--- a/rocketmq-proxy/src/session.rs
+++ b/rocketmq-proxy/src/session.rs
@@ -13,30 +13,159 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::SystemTime;
 
 use dashmap::DashMap;
+use tokio_util::sync::CancellationToken;
 
 use crate::context::ProxyContext;
+use crate::proto::v2;
+use crate::service::ResourceIdentity;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubscriptionSettingsSnapshot {
+    pub group: Option<ResourceIdentity>,
+    pub fifo: bool,
+    pub receive_batch_size: Option<u32>,
+    pub long_polling_timeout: Option<Duration>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientSettingsSnapshot {
+    pub client_type: Option<i32>,
+    pub request_timeout: Option<Duration>,
+    pub subscription: Option<SubscriptionSettingsSnapshot>,
+}
+
+impl ClientSettingsSnapshot {
+    pub fn from_proto(settings: &v2::Settings) -> Self {
+        let subscription = match settings.pub_sub.as_ref() {
+            Some(v2::settings::PubSub::Subscription(subscription)) => Some(SubscriptionSettingsSnapshot {
+                group: subscription.group.as_ref().map(resource_identity),
+                fifo: subscription.fifo.unwrap_or(false),
+                receive_batch_size: subscription
+                    .receive_batch_size
+                    .and_then(|value| u32::try_from(value).ok())
+                    .filter(|value| *value > 0),
+                long_polling_timeout: subscription.long_polling_timeout.as_ref().and_then(proto_duration),
+            }),
+            _ => None,
+        };
+
+        Self {
+            client_type: settings.client_type,
+            request_timeout: settings.request_timeout.as_ref().and_then(proto_duration),
+            subscription,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClientSession {
     pub client_id: String,
     pub remote_addr: Option<String>,
     pub namespace: Option<String>,
+    pub language: Option<String>,
+    pub client_version: Option<String>,
+    pub connection_id: Option<String>,
+    pub client_type: Option<i32>,
+    pub settings: Option<ClientSettingsSnapshot>,
     pub last_seen: SystemTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReceiptHandleRegistration {
+    pub client_id: String,
+    pub group: ResourceIdentity,
+    pub topic: ResourceIdentity,
+    pub message_id: String,
+    pub receipt_handle: String,
+    pub invisible_duration: Duration,
+}
+
+#[derive(Debug, Clone)]
+pub struct TrackedReceiptHandle {
+    pub client_id: String,
+    pub group: ResourceIdentity,
+    pub topic: ResourceIdentity,
+    pub message_id: String,
+    pub receipt_handle: String,
+    pub invisible_duration: Duration,
+    pub last_touched: SystemTime,
+    pub cancellation: CancellationToken,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ReapSummary {
+    pub removed_sessions: usize,
+    pub removed_receipt_handles: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ReceiptHandleKey {
+    client_id: String,
+    group: ResourceIdentity,
+    topic: ResourceIdentity,
+    message_id: String,
+}
+
+impl ReceiptHandleKey {
+    fn new(
+        client_id: impl Into<String>,
+        group: ResourceIdentity,
+        topic: ResourceIdentity,
+        message_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            client_id: client_id.into(),
+            group,
+            topic,
+            message_id: message_id.into(),
+        }
+    }
+}
+
+impl From<&TrackedReceiptHandle> for ReceiptHandleKey {
+    fn from(value: &TrackedReceiptHandle) -> Self {
+        Self::new(
+            value.client_id.clone(),
+            value.group.clone(),
+            value.topic.clone(),
+            value.message_id.clone(),
+        )
+    }
 }
 
 #[derive(Clone, Default)]
 pub struct ClientSessionRegistry {
     sessions: Arc<DashMap<String, ClientSession>>,
+    receipt_handles: Arc<DashMap<ReceiptHandleKey, TrackedReceiptHandle>>,
 }
 
 impl ClientSessionRegistry {
     pub fn upsert_from_context(&self, context: &ProxyContext) {
+        self.upsert_from_context_with_client_type(context, None);
+    }
+
+    pub fn upsert_from_context_with_client_type(&self, context: &ProxyContext, client_type: Option<i32>) {
         let Some(client_id) = context.client_id() else {
             return;
         };
+
+        let now = SystemTime::now();
+        if let Some(mut session) = self.sessions.get_mut(client_id) {
+            session.remote_addr = context.remote_addr().map(str::to_owned);
+            session.namespace = context.namespace().map(str::to_owned);
+            session.language = context.language().map(str::to_owned);
+            session.client_version = context.client_version().map(str::to_owned);
+            session.connection_id = context.connection_id().map(str::to_owned);
+            if let Some(client_type) = client_type {
+                session.client_type = Some(client_type);
+            }
+            session.last_seen = now;
+            return;
+        }
 
         self.sessions.insert(
             client_id.to_owned(),
@@ -44,13 +173,142 @@ impl ClientSessionRegistry {
                 client_id: client_id.to_owned(),
                 remote_addr: context.remote_addr().map(str::to_owned),
                 namespace: context.namespace().map(str::to_owned),
-                last_seen: SystemTime::now(),
+                language: context.language().map(str::to_owned),
+                client_version: context.client_version().map(str::to_owned),
+                connection_id: context.connection_id().map(str::to_owned),
+                client_type,
+                settings: None,
+                last_seen: now,
             },
         );
     }
 
+    pub fn update_settings_from_telemetry(
+        &self,
+        context: &ProxyContext,
+        settings: &v2::Settings,
+    ) -> Option<ClientSettingsSnapshot> {
+        let client_id = context.client_id()?;
+        let snapshot = ClientSettingsSnapshot::from_proto(settings);
+        self.upsert_from_context_with_client_type(context, snapshot.client_type);
+
+        if let Some(mut session) = self.sessions.get_mut(client_id) {
+            session.client_type = snapshot.client_type.or(session.client_type);
+            session.settings = Some(snapshot.clone());
+            session.last_seen = SystemTime::now();
+        }
+
+        Some(snapshot)
+    }
+
+    pub fn settings_for_client(&self, client_id: &str) -> Option<ClientSettingsSnapshot> {
+        self.sessions.get(client_id).and_then(|entry| entry.settings.clone())
+    }
+
+    pub fn track_receipt_handle(&self, registration: ReceiptHandleRegistration) -> TrackedReceiptHandle {
+        let tracked = TrackedReceiptHandle {
+            client_id: registration.client_id,
+            group: registration.group,
+            topic: registration.topic,
+            message_id: registration.message_id,
+            receipt_handle: registration.receipt_handle,
+            invisible_duration: registration.invisible_duration,
+            last_touched: SystemTime::now(),
+            cancellation: CancellationToken::new(),
+        };
+        let key = ReceiptHandleKey::from(&tracked);
+        if let Some((_, previous)) = self.receipt_handles.remove(&key) {
+            previous.cancellation.cancel();
+        }
+        self.receipt_handles.insert(key, tracked.clone());
+        tracked
+    }
+
+    pub fn tracked_receipt_handle(
+        &self,
+        client_id: &str,
+        group: &ResourceIdentity,
+        topic: &ResourceIdentity,
+        message_id: &str,
+    ) -> Option<TrackedReceiptHandle> {
+        let key = ReceiptHandleKey::new(client_id, group.clone(), topic.clone(), message_id);
+        self.receipt_handles.get(&key).map(|entry| entry.clone())
+    }
+
+    pub fn update_receipt_handle(
+        &self,
+        client_id: &str,
+        group: &ResourceIdentity,
+        topic: &ResourceIdentity,
+        message_id: &str,
+        new_receipt_handle: &str,
+        invisible_duration: Duration,
+    ) -> Option<TrackedReceiptHandle> {
+        let key = self.resolve_receipt_handle_key(client_id, group, topic, message_id, None)?;
+        let mut tracked = self.receipt_handles.get_mut(&key)?;
+        tracked.receipt_handle = new_receipt_handle.to_owned();
+        tracked.invisible_duration = invisible_duration;
+        tracked.last_touched = SystemTime::now();
+        Some(tracked.clone())
+    }
+
+    pub fn update_receipt_handle_matching(
+        &self,
+        client_id: &str,
+        group: &ResourceIdentity,
+        topic: &ResourceIdentity,
+        message_id: &str,
+        current_receipt_handle: &str,
+        new_receipt_handle: &str,
+        invisible_duration: Duration,
+    ) -> Option<TrackedReceiptHandle> {
+        let key = self.resolve_receipt_handle_key(client_id, group, topic, message_id, Some(current_receipt_handle))?;
+        let mut tracked = self.receipt_handles.get_mut(&key)?;
+        tracked.receipt_handle = new_receipt_handle.to_owned();
+        tracked.invisible_duration = invisible_duration;
+        tracked.last_touched = SystemTime::now();
+        Some(tracked.clone())
+    }
+
+    pub fn remove_receipt_handle(
+        &self,
+        client_id: &str,
+        group: &ResourceIdentity,
+        topic: &ResourceIdentity,
+        message_id: &str,
+    ) -> Option<TrackedReceiptHandle> {
+        let key = self.resolve_receipt_handle_key(client_id, group, topic, message_id, None)?;
+        self.remove_receipt_handle_by_key(&key)
+    }
+
+    pub fn remove_receipt_handle_matching(
+        &self,
+        client_id: &str,
+        group: &ResourceIdentity,
+        topic: &ResourceIdentity,
+        message_id: &str,
+        receipt_handle: &str,
+    ) -> Option<TrackedReceiptHandle> {
+        let key = self.resolve_receipt_handle_key(client_id, group, topic, message_id, Some(receipt_handle))?;
+        self.remove_receipt_handle_by_key(&key)
+    }
+
     pub fn remove(&self, client_id: &str) -> Option<ClientSession> {
-        self.sessions.remove(client_id).map(|(_, session)| session)
+        self.remove_client(client_id)
+    }
+
+    pub fn remove_client(&self, client_id: &str) -> Option<ClientSession> {
+        let session = self.sessions.remove(client_id).map(|(_, session)| session);
+        let keys = self
+            .receipt_handles
+            .iter()
+            .filter(|entry| entry.key().client_id == client_id)
+            .map(|entry| entry.key().clone())
+            .collect::<Vec<_>>();
+        for key in keys {
+            let _ = self.remove_receipt_handle_by_key(&key);
+        }
+        session
     }
 
     pub fn get(&self, client_id: &str) -> Option<ClientSession> {
@@ -61,7 +319,273 @@ impl ClientSessionRegistry {
         self.sessions.len()
     }
 
+    pub fn tracked_handle_count(&self) -> usize {
+        self.receipt_handles.len()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.sessions.is_empty()
+    }
+
+    pub fn reap_expired(&self, client_ttl: Duration, receipt_handle_ttl: Duration) -> ReapSummary {
+        let now = SystemTime::now();
+        let mut summary = ReapSummary::default();
+
+        let expired_sessions = self
+            .sessions
+            .iter()
+            .filter(|entry| is_expired(entry.last_seen, now, client_ttl))
+            .map(|entry| entry.key().clone())
+            .collect::<Vec<_>>();
+        for client_id in expired_sessions {
+            if self.remove_client(&client_id).is_some() {
+                summary.removed_sessions += 1;
+            }
+        }
+
+        let expired_receipt_handles = self
+            .receipt_handles
+            .iter()
+            .filter(|entry| is_expired(entry.last_touched, now, receipt_handle_ttl))
+            .map(|entry| entry.key().clone())
+            .collect::<Vec<_>>();
+        for key in expired_receipt_handles {
+            if self.remove_receipt_handle_by_key(&key).is_some() {
+                summary.removed_receipt_handles += 1;
+            }
+        }
+
+        summary
+    }
+
+    fn resolve_receipt_handle_key(
+        &self,
+        client_id: &str,
+        group: &ResourceIdentity,
+        topic: &ResourceIdentity,
+        message_id: &str,
+        receipt_handle: Option<&str>,
+    ) -> Option<ReceiptHandleKey> {
+        let trimmed_message_id = message_id.trim();
+        if !trimmed_message_id.is_empty() {
+            let key = ReceiptHandleKey::new(
+                client_id.to_owned(),
+                group.clone(),
+                topic.clone(),
+                trimmed_message_id.to_owned(),
+            );
+            if self.receipt_handles.contains_key(&key) {
+                return Some(key);
+            }
+        }
+
+        let receipt_handle = receipt_handle?;
+        self.receipt_handles
+            .iter()
+            .find(|entry| {
+                entry.key().client_id == client_id
+                    && entry.key().group == *group
+                    && entry.key().topic == *topic
+                    && entry.value().receipt_handle == receipt_handle
+            })
+            .map(|entry| entry.key().clone())
+    }
+
+    fn remove_receipt_handle_by_key(&self, key: &ReceiptHandleKey) -> Option<TrackedReceiptHandle> {
+        self.receipt_handles.remove(key).map(|(_, tracked)| {
+            tracked.cancellation.cancel();
+            tracked
+        })
+    }
+}
+
+fn resource_identity(resource: &v2::Resource) -> ResourceIdentity {
+    ResourceIdentity::new(resource.resource_namespace.clone(), resource.name.clone())
+}
+
+fn proto_duration(duration: &prost_types::Duration) -> Option<Duration> {
+    if duration.seconds < 0 || duration.nanos < 0 || duration.nanos >= 1_000_000_000 {
+        return None;
+    }
+
+    let seconds = u64::try_from(duration.seconds).ok()?;
+    let nanos = u32::try_from(duration.nanos).ok()?;
+    Some(Duration::new(seconds, nanos))
+}
+
+fn is_expired(instant: SystemTime, now: SystemTime, ttl: Duration) -> bool {
+    match now.duration_since(instant) {
+        Ok(elapsed) => elapsed >= ttl,
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use std::time::SystemTime;
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::ClientSession;
+    use super::ClientSessionRegistry;
+    use super::ReceiptHandleRegistration;
+    use super::TrackedReceiptHandle;
+    use crate::context::ProxyContext;
+    use crate::proto::v2;
+    use crate::service::ResourceIdentity;
+
+    fn context(client_id: &'static str) -> ProxyContext {
+        let mut request = tonic::Request::new(());
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", tonic::metadata::MetadataValue::from_static(client_id));
+        request.metadata_mut().insert(
+            "x-mq-channel-id",
+            tonic::metadata::MetadataValue::from_static("channel-a"),
+        );
+        ProxyContext::from_grpc_request("Test", &request)
+    }
+
+    fn tracked_handle(client_id: &str, message_id: &str, receipt_handle: &str) -> ReceiptHandleRegistration {
+        ReceiptHandleRegistration {
+            client_id: client_id.to_owned(),
+            group: ResourceIdentity::new("", "GroupA"),
+            topic: ResourceIdentity::new("", "TopicA"),
+            message_id: message_id.to_owned(),
+            receipt_handle: receipt_handle.to_owned(),
+            invisible_duration: Duration::from_secs(30),
+        }
+    }
+
+    #[test]
+    fn telemetry_settings_are_snapshotted() {
+        let registry = ClientSessionRegistry::default();
+        let context = context("client-a");
+        let settings = v2::Settings {
+            client_type: Some(v2::ClientType::PushConsumer as i32),
+            request_timeout: Some(prost_types::Duration { seconds: 3, nanos: 0 }),
+            pub_sub: Some(v2::settings::PubSub::Subscription(v2::Subscription {
+                group: Some(v2::Resource {
+                    resource_namespace: String::new(),
+                    name: "GroupA".to_owned(),
+                }),
+                subscriptions: Vec::new(),
+                fifo: Some(true),
+                receive_batch_size: Some(32),
+                long_polling_timeout: Some(prost_types::Duration { seconds: 15, nanos: 0 }),
+                lite_subscription_quota: None,
+                max_lite_topic_size: None,
+            })),
+            user_agent: None,
+            access_point: None,
+            backoff_policy: None,
+            metric: None,
+        };
+
+        let snapshot = registry
+            .update_settings_from_telemetry(&context, &settings)
+            .expect("settings should be stored");
+
+        assert_eq!(snapshot.client_type, Some(v2::ClientType::PushConsumer as i32));
+        assert_eq!(snapshot.request_timeout, Some(Duration::from_secs(3)));
+        assert_eq!(
+            snapshot
+                .subscription
+                .as_ref()
+                .and_then(|subscription| subscription.receive_batch_size),
+            Some(32)
+        );
+        assert!(registry.get("client-a").and_then(|session| session.settings).is_some());
+    }
+
+    #[test]
+    fn tracked_receipt_handle_can_be_updated_and_removed() {
+        let registry = ClientSessionRegistry::default();
+        registry.track_receipt_handle(tracked_handle("client-a", "msg-1", "handle-1"));
+
+        let updated = registry
+            .update_receipt_handle_matching(
+                "client-a",
+                &ResourceIdentity::new("", "GroupA"),
+                &ResourceIdentity::new("", "TopicA"),
+                "msg-1",
+                "handle-1",
+                "handle-2",
+                Duration::from_secs(45),
+            )
+            .expect("receipt handle should be updated");
+        assert_eq!(updated.receipt_handle, "handle-2");
+        assert_eq!(updated.invisible_duration, Duration::from_secs(45));
+
+        let removed = registry
+            .remove_receipt_handle_matching(
+                "client-a",
+                &ResourceIdentity::new("", "GroupA"),
+                &ResourceIdentity::new("", "TopicA"),
+                "msg-1",
+                "handle-2",
+            )
+            .expect("receipt handle should be removed");
+        assert_eq!(removed.receipt_handle, "handle-2");
+        assert_eq!(registry.tracked_handle_count(), 0);
+    }
+
+    #[test]
+    fn remove_client_clears_receipt_handles() {
+        let registry = ClientSessionRegistry::default();
+        let context = context("client-a");
+        registry.upsert_from_context(&context);
+        let tracked = registry.track_receipt_handle(tracked_handle("client-a", "msg-1", "handle-1"));
+
+        registry.remove_client("client-a");
+
+        assert!(tracked.cancellation.is_cancelled());
+        assert!(registry.get("client-a").is_none());
+        assert_eq!(registry.tracked_handle_count(), 0);
+    }
+
+    #[test]
+    fn reap_expired_removes_stale_sessions_and_receipt_handles() {
+        let registry = ClientSessionRegistry::default();
+        registry.sessions.insert(
+            "client-a".to_owned(),
+            ClientSession {
+                client_id: "client-a".to_owned(),
+                remote_addr: None,
+                namespace: None,
+                language: None,
+                client_version: None,
+                connection_id: None,
+                client_type: None,
+                settings: None,
+                last_seen: SystemTime::UNIX_EPOCH,
+            },
+        );
+        registry.receipt_handles.insert(
+            super::ReceiptHandleKey::new(
+                "client-b",
+                ResourceIdentity::new("", "GroupA"),
+                ResourceIdentity::new("", "TopicA"),
+                "msg-1",
+            ),
+            TrackedReceiptHandle {
+                client_id: "client-b".to_owned(),
+                group: ResourceIdentity::new("", "GroupA"),
+                topic: ResourceIdentity::new("", "TopicA"),
+                message_id: "msg-1".to_owned(),
+                receipt_handle: "handle-1".to_owned(),
+                invisible_duration: Duration::from_secs(30),
+                last_touched: SystemTime::UNIX_EPOCH,
+                cancellation: CancellationToken::new(),
+            },
+        );
+
+        let summary = registry.reap_expired(Duration::from_secs(1), Duration::from_secs(1));
+
+        assert_eq!(summary.removed_sessions, 1);
+        assert_eq!(summary.removed_receipt_handles, 1);
+        assert!(registry.is_empty());
+        assert_eq!(registry.tracked_handle_count(), 0);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6815

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic message receipt renewal for long-polling consumers.
  * Enhanced telemetry integration for improved subscription settings management.

* **Configuration**
  * Extended session timeout configuration with new minimum and maximum long-polling timeout options.

* **Improvements**
  * Improved session lifecycle management with automatic cleanup of expired sessions and stale receipt handles.
  * Enhanced receipt handle tracking and reconciliation for better message durability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->