### PR TITLE
[ISSUE #6829]✨Enhance cluster command handling with state management and telemetry command support

### DIFF
--- a/rocketmq-proxy/src/cluster.rs
+++ b/rocketmq-proxy/src/cluster.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeSet;
+use std::collections::HashMap;
 use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
@@ -292,6 +294,11 @@ enum ClusterCommand {
     },
 }
 
+#[derive(Default)]
+struct ClusterWorkerState {
+    send_producers: HashMap<String, DefaultMQProducer>,
+}
+
 impl ClusterTaskExecutor {
     fn new(config: ClusterConfig) -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
@@ -433,13 +440,17 @@ fn run_cluster_worker(config: ClusterConfig, mut receiver: mpsc::UnboundedReceiv
         .build()
         .expect("failed to build proxy cluster worker runtime");
     runtime.block_on(async move {
+        let mut state = ClusterWorkerState::default();
         while let Some(command) = receiver.recv().await {
-            handle_cluster_command(&config, command).await;
+            handle_cluster_command(&config, &mut state, command).await;
+        }
+        for producer in state.send_producers.values_mut() {
+            producer.shutdown().await;
         }
     });
 }
 
-async fn handle_cluster_command(config: &ClusterConfig, command: ClusterCommand) {
+async fn handle_cluster_command(config: &ClusterConfig, state: &mut ClusterWorkerState, command: ClusterCommand) {
     match command {
         ClusterCommand::QueryRoute { topic, reply } => {
             let _ = reply.send(query_route_inner(config, topic).await);
@@ -464,7 +475,7 @@ async fn handle_cluster_command(config: &ClusterConfig, command: ClusterCommand)
             request_id,
             reply,
         } => {
-            let _ = reply.send(send_message_inner(config, request, client_id, request_id).await);
+            let _ = reply.send(send_message_inner(config, state, request, client_id, request_id).await);
         }
         ClusterCommand::ReceiveMessage {
             request,
@@ -597,27 +608,80 @@ async fn query_subscription_group_inner(
 
 async fn send_message_inner(
     config: &ClusterConfig,
+    state: &mut ClusterWorkerState,
     request: SendMessageRequest,
     client_id: Option<String>,
     request_id: String,
 ) -> ProxyResult<Vec<SendMessageResultEntry>> {
     let timeout = effective_send_timeout_ms(config, request.timeout);
-    let mut producer = build_send_producer(config, &request, client_id.as_deref(), request_id.as_str(), timeout);
-    if let Err(error) = producer.start().await {
-        let error = ProxyError::from(error);
-        return Ok(request
-            .messages
-            .iter()
-            .map(|_| failure_send_result_entry(&error))
-            .collect());
-    }
-
+    let producer_group = build_proxy_producer_group(config, client_id.as_deref(), request_id.as_str());
+    let topics = collect_send_topics(&request);
+    let producer = match acquire_send_producer(config, state, producer_group.as_str(), topics, timeout).await {
+        Ok(producer) => producer,
+        Err(error) => {
+            return Ok(request
+                .messages
+                .iter()
+                .map(|_| failure_send_result_entry(&error))
+                .collect());
+        }
+    };
     let mut results = Vec::with_capacity(request.messages.len());
     for entry in request.messages {
-        results.push(send_message_entry(&mut producer, entry, timeout).await);
+        results.push(send_message_entry(producer, entry, timeout).await);
     }
-    producer.shutdown().await;
     Ok(results)
+}
+
+async fn acquire_send_producer<'a>(
+    config: &ClusterConfig,
+    state: &'a mut ClusterWorkerState,
+    producer_group: &str,
+    topics: Vec<CheetahString>,
+    timeout_ms: u64,
+) -> Result<&'a mut DefaultMQProducer, ProxyError> {
+    if !state.send_producers.contains_key(producer_group) {
+        let mut producer = build_send_producer(config, producer_group, timeout_ms);
+        producer.set_topics(topics.clone());
+        if let Err(error) = producer.start().await {
+            return Err(ProxyError::from(error));
+        }
+        state.send_producers.insert(producer_group.to_owned(), producer);
+    }
+
+    let producer = state
+        .send_producers
+        .get_mut(producer_group)
+        .expect("send producer should exist after initialization");
+    refresh_send_producer(producer, topics, timeout_ms);
+    Ok(producer)
+}
+
+fn refresh_send_producer(producer: &mut DefaultMQProducer, topics: Vec<CheetahString>, timeout_ms: u64) {
+    producer.set_topics(merge_topics(producer.topics().clone(), topics));
+    producer.set_send_msg_timeout(timeout_ms.clamp(1, u64::from(u32::MAX)) as u32);
+}
+
+fn merge_topics(existing: Vec<CheetahString>, incoming: Vec<CheetahString>) -> Vec<CheetahString> {
+    existing
+        .into_iter()
+        .chain(incoming)
+        .map(|topic| topic.to_string())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(CheetahString::from)
+        .collect()
+}
+
+fn collect_send_topics(request: &SendMessageRequest) -> Vec<CheetahString> {
+    request
+        .messages
+        .iter()
+        .map(|message| message.topic.to_string())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(CheetahString::from)
+        .collect()
 }
 
 async fn receive_message_inner(
@@ -1175,34 +1239,21 @@ async fn resolve_subscription_broker_name(
     }
 }
 
-fn build_send_producer(
-    config: &ClusterConfig,
-    request: &SendMessageRequest,
-    client_id: Option<&str>,
-    request_id: &str,
-    timeout_ms: u64,
-) -> DefaultMQProducer {
+fn build_send_producer(config: &ClusterConfig, producer_group: &str, timeout_ms: u64) -> DefaultMQProducer {
     let mut client_config = RocketmqClientConfig::default();
     client_config.set_instance_name(CheetahString::from(format!(
         "{}-{}",
         config.instance_name,
-        sanitize_group_component(request_id)
+        sanitize_group_component(producer_group)
     )));
     client_config.set_mq_client_api_timeout(config.mq_client_api_timeout_ms);
     if let Some(namesrv_addr) = config.namesrv_addr.as_ref() {
         client_config.set_namesrv_addr(CheetahString::from(namesrv_addr.as_str()));
     }
 
-    let topics = request
-        .messages
-        .iter()
-        .map(|message| CheetahString::from(message.topic.to_string()))
-        .collect();
-
     DefaultMQProducer::builder()
         .client_config(client_config)
-        .producer_group(build_proxy_producer_group(config, client_id, request_id))
-        .topics(topics)
+        .producer_group(producer_group)
         .send_msg_timeout(timeout_ms as u32)
         .build()
 }

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -13,8 +13,12 @@
 // limitations under the License.
 
 use std::pin::Pin;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use futures::stream;
 use futures::Stream;
@@ -99,6 +103,7 @@ pub struct ProxyGrpcService<P> {
     processor: Arc<P>,
     sessions: ClientSessionRegistry,
     guards: ExecutionGuards,
+    next_reap_at_ms: Arc<AtomicU64>,
 }
 
 impl<P> Clone for ProxyGrpcService<P> {
@@ -108,17 +113,22 @@ impl<P> Clone for ProxyGrpcService<P> {
             processor: Arc::clone(&self.processor),
             sessions: self.sessions.clone(),
             guards: self.guards.clone(),
+            next_reap_at_ms: Arc::clone(&self.next_reap_at_ms),
         }
     }
 }
 
 impl<P> ProxyGrpcService<P> {
     pub fn new(config: Arc<ProxyConfig>, processor: Arc<P>, sessions: ClientSessionRegistry) -> Self {
+        let interval_ms = Self::housekeeping_interval_from_config(config.as_ref())
+            .as_millis()
+            .clamp(1, u128::from(u64::MAX)) as u64;
         Self {
             guards: ExecutionGuards::from_config(config.as_ref()),
             config,
             processor,
             sessions,
+            next_reap_at_ms: Arc::new(AtomicU64::new(current_epoch_millis().saturating_add(interval_ms))),
         }
     }
 
@@ -153,19 +163,19 @@ impl<P> ProxyGrpcService<P> {
                 _ = &mut shutdown => break,
                 _ = interval.tick() => {
                     self.reap_session_state();
+                    self.schedule_next_reap();
                 }
             }
         }
     }
 
     fn housekeeping_interval(&self) -> Duration {
-        let min_ttl = self
-            .config
-            .session
-            .client_ttl()
-            .min(self.config.session.receipt_handle_ttl());
-        let half_ttl_ms = min_ttl.as_millis().saturating_div(2).clamp(1_000, 30_000) as u64;
-        Duration::from_millis(half_ttl_ms)
+        Self::housekeeping_interval_from_config(self.config.as_ref())
+    }
+
+    fn housekeeping_interval_from_config(config: &ProxyConfig) -> Duration {
+        let min_ttl = config.session.client_ttl().min(config.session.receipt_handle_ttl());
+        Duration::from_millis(min_ttl.as_millis().saturating_div(2).clamp(1_000, 30_000) as u64)
     }
 
     fn reap_session_state(&self) {
@@ -173,6 +183,34 @@ impl<P> ProxyGrpcService<P> {
             self.config.session.client_ttl(),
             self.config.session.receipt_handle_ttl(),
         );
+    }
+
+    fn schedule_next_reap(&self) {
+        let next = current_epoch_millis()
+            .saturating_add(self.housekeeping_interval().as_millis().clamp(1, u128::from(u64::MAX)) as u64);
+        self.next_reap_at_ms.store(next, Ordering::Relaxed);
+    }
+
+    fn reap_session_state_if_due(&self) {
+        let now = current_epoch_millis();
+        let next = self.next_reap_at_ms.load(Ordering::Relaxed);
+        if now < next {
+            return;
+        }
+
+        let interval_ms = self.housekeeping_interval().as_millis().clamp(1, u128::from(u64::MAX)) as u64;
+        if self
+            .next_reap_at_ms
+            .compare_exchange(
+                next,
+                now.saturating_add(interval_ms),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+        {
+            self.reap_session_state();
+        }
     }
 }
 
@@ -213,6 +251,83 @@ where
             status: Some(status),
             command: None,
         }
+    }
+
+    pub fn send_reconnect_endpoints_command(&self, client_id: &str, nonce: impl Into<String>) -> bool {
+        self.send_server_telemetry_command(
+            client_id,
+            v2::TelemetryCommand {
+                status: Some(ProxyStatusMapper::ok()),
+                command: Some(v2::telemetry_command::Command::ReconnectEndpointsCommand(
+                    v2::ReconnectEndpointsCommand { nonce: nonce.into() },
+                )),
+            },
+        )
+    }
+
+    pub fn send_print_thread_stack_trace_command(&self, client_id: &str, nonce: impl Into<String>) -> bool {
+        self.send_server_telemetry_command(
+            client_id,
+            v2::TelemetryCommand {
+                status: Some(ProxyStatusMapper::ok()),
+                command: Some(v2::telemetry_command::Command::PrintThreadStackTraceCommand(
+                    v2::PrintThreadStackTraceCommand { nonce: nonce.into() },
+                )),
+            },
+        )
+    }
+
+    pub fn send_verify_message_command(&self, client_id: &str, nonce: impl Into<String>, message: v2::Message) -> bool {
+        self.send_server_telemetry_command(
+            client_id,
+            v2::TelemetryCommand {
+                status: Some(ProxyStatusMapper::ok()),
+                command: Some(v2::telemetry_command::Command::VerifyMessageCommand(
+                    v2::VerifyMessageCommand {
+                        nonce: nonce.into(),
+                        message: Some(message),
+                    },
+                )),
+            },
+        )
+    }
+
+    pub fn send_recover_orphaned_transaction_command(
+        &self,
+        client_id: &str,
+        message: v2::Message,
+        transaction_id: impl Into<String>,
+    ) -> bool {
+        self.send_server_telemetry_command(
+            client_id,
+            v2::TelemetryCommand {
+                status: Some(ProxyStatusMapper::ok()),
+                command: Some(v2::telemetry_command::Command::RecoverOrphanedTransactionCommand(
+                    v2::RecoverOrphanedTransactionCommand {
+                        message: Some(message),
+                        transaction_id: transaction_id.into(),
+                    },
+                )),
+            },
+        )
+    }
+
+    pub fn send_notify_unsubscribe_lite_command(&self, client_id: &str, lite_topic: impl Into<String>) -> bool {
+        self.send_server_telemetry_command(
+            client_id,
+            v2::TelemetryCommand {
+                status: Some(ProxyStatusMapper::ok()),
+                command: Some(v2::telemetry_command::Command::NotifyUnsubscribeLiteCommand(
+                    v2::NotifyUnsubscribeLiteCommand {
+                        lite_topic: lite_topic.into(),
+                    },
+                )),
+            },
+        )
+    }
+
+    fn send_server_telemetry_command(&self, client_id: &str, command: v2::TelemetryCommand) -> bool {
+        self.sessions.send_telemetry_command(client_id, command)
     }
 
     fn merged_telemetry_settings(&self, settings: &v2::Settings) -> v2::Settings {
@@ -586,6 +701,13 @@ fn is_lite_client(client_type: Option<i32>) -> bool {
     )
 }
 
+fn current_epoch_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().clamp(0, u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
 fn is_transaction_message(message: &rocketmq_common::common::message::message_single::Message) -> bool {
     message
         .property(&cheetah_string::CheetahString::from_static_str(
@@ -607,7 +729,7 @@ where
         &self,
         request: Request<v2::QueryRouteRequest>,
     ) -> Result<Response<v2::QueryRouteResponse>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("QueryRoute", &request);
         let request = request.into_inner();
 
@@ -632,7 +754,7 @@ where
         &self,
         request: Request<v2::HeartbeatRequest>,
     ) -> Result<Response<v2::HeartbeatResponse>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("Heartbeat", &request);
         let request = request.into_inner();
 
@@ -655,7 +777,7 @@ where
         &self,
         request: Request<v2::SendMessageRequest>,
     ) -> Result<Response<v2::SendMessageResponse>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("SendMessage", &request);
         let request = request.into_inner();
 
@@ -683,7 +805,7 @@ where
         &self,
         request: Request<v2::QueryAssignmentRequest>,
     ) -> Result<Response<v2::QueryAssignmentResponse>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("QueryAssignment", &request);
         let request = request.into_inner();
 
@@ -708,7 +830,7 @@ where
         &self,
         request: Request<v2::ReceiveMessageRequest>,
     ) -> Result<Response<Self::ReceiveMessageStream>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("ReceiveMessage", &request);
         let request = request.into_inner();
         let responses = match self
@@ -739,7 +861,7 @@ where
         &self,
         request: Request<v2::AckMessageRequest>,
     ) -> Result<Response<v2::AckMessageResponse>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("AckMessage", &request);
         let request = request.into_inner();
 
@@ -776,7 +898,7 @@ where
         &self,
         request: Request<v2::PullMessageRequest>,
     ) -> Result<Response<Self::PullMessageStream>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("PullMessage", &request);
         let status = match self
             .validate_client_context(&context)
@@ -821,7 +943,7 @@ where
         &self,
         request: Request<v2::EndTransactionRequest>,
     ) -> Result<Response<v2::EndTransactionResponse>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("EndTransaction", &request);
         let request = request.into_inner();
 
@@ -852,7 +974,7 @@ where
         &self,
         request: Request<tonic::Streaming<v2::TelemetryCommand>>,
     ) -> Result<Response<Self::TelemetryStream>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("Telemetry", &request);
         let mut inbound = request.into_inner();
         let permit = match self
@@ -868,25 +990,47 @@ where
         };
 
         self.sessions.upsert_from_context(&context);
+        let Some(client_id) = context.client_id().map(ToOwned::to_owned) else {
+            return Ok(Response::new(self.status_stream(Self::telemetry_status(
+                ProxyStatusMapper::from_error(&ProxyError::ClientIdRequired),
+            ))));
+        };
+        let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel();
+        self.sessions.bind_telemetry_link(client_id.clone(), outbound_tx);
         let service = self.clone();
         let (sender, receiver) = mpsc::channel(16);
         tokio::spawn(async move {
             let _permit = permit;
             loop {
-                match inbound.next().await {
-                    Some(Ok(command)) => {
-                        let response = service.handle_telemetry_command(&context, command).await;
-                        if sender.send(Ok(response)).await.is_err() {
-                            break;
+                tokio::select! {
+                    outbound = outbound_rx.recv() => {
+                        match outbound {
+                            Some(command) => {
+                                if sender.send(Ok(command)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            None => break,
                         }
                     }
-                    Some(Err(error)) => {
-                        let _ = sender.send(Err(error)).await;
-                        break;
+                    inbound_item = inbound.next() => {
+                        match inbound_item {
+                            Some(Ok(command)) => {
+                                let response = service.handle_telemetry_command(&context, command).await;
+                                if sender.send(Ok(response)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Some(Err(error)) => {
+                                let _ = sender.send(Err(error)).await;
+                                break;
+                            }
+                            None => break,
+                        }
                     }
-                    None => break,
                 }
             }
+            service.sessions.unbind_telemetry_link(client_id.as_str());
         });
 
         Ok(Response::new(Box::pin(ReceiverStream::new(receiver))))
@@ -896,7 +1040,7 @@ where
         &self,
         request: Request<v2::NotifyClientTerminationRequest>,
     ) -> Result<Response<v2::NotifyClientTerminationResponse>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("NotifyClientTermination", &request);
         let status = match self
             .guards
@@ -919,7 +1063,7 @@ where
         &self,
         request: Request<v2::ChangeInvisibleDurationRequest>,
     ) -> Result<Response<v2::ChangeInvisibleDurationResponse>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("ChangeInvisibleDuration", &request);
         let request = request.into_inner();
 
@@ -959,7 +1103,7 @@ where
         &self,
         request: Request<v2::SyncLiteSubscriptionRequest>,
     ) -> Result<Response<v2::SyncLiteSubscriptionResponse>, Status> {
-        self.reap_session_state();
+        self.reap_session_state_if_due();
         let context = self.context("SyncLiteSubscription", &request);
         let request = request.into_inner();
 
@@ -998,6 +1142,7 @@ mod tests {
     use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
     use rocketmq_remoting::protocol::route::route_data_view::QueueData;
     use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+    use tokio::sync::mpsc;
     use tonic::metadata::MetadataValue;
     use tonic::Request;
 
@@ -1684,6 +1829,23 @@ mod tests {
         };
         assert_eq!(subscription.lite_subscription_quota, Some(1200));
         assert_eq!(subscription.max_lite_topic_size, Some(64));
+    }
+
+    #[tokio::test]
+    async fn server_side_telemetry_command_is_queued_for_bound_client() {
+        let service = test_service(StaticRouteService::default(), StaticMetadataService::default());
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        service.sessions.bind_telemetry_link("client-a", sender);
+
+        assert!(service.send_reconnect_endpoints_command("client-a", "nonce-a"));
+
+        let command = receiver.recv().await.expect("telemetry command should be queued");
+        match command.command {
+            Some(v2::telemetry_command::Command::ReconnectEndpointsCommand(command)) => {
+                assert_eq!(command.nonce, "nonce-a");
+            }
+            other => panic!("unexpected telemetry command: {other:?}"),
+        }
     }
 
     #[test]

--- a/rocketmq-proxy/src/session.rs
+++ b/rocketmq-proxy/src/session.rs
@@ -20,6 +20,7 @@ use std::time::SystemTime;
 use dashmap::DashMap;
 use rocketmq_common::get_parent_and_lite_topic;
 use rocketmq_common::to_lmq_name;
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::context::ProxyContext;
@@ -155,6 +156,11 @@ pub struct PreparedTransactionHandle {
     pub last_touched: SystemTime,
 }
 
+#[derive(Clone)]
+pub struct TelemetryLink {
+    pub sender: mpsc::UnboundedSender<v2::TelemetryCommand>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ReapSummary {
     pub removed_sessions: usize,
@@ -236,6 +242,7 @@ pub struct ClientSessionRegistry {
     receipt_handles: Arc<DashMap<ReceiptHandleKey, TrackedReceiptHandle>>,
     lite_subscriptions: Arc<DashMap<LiteSubscriptionKey, LiteSubscriptionSnapshot>>,
     prepared_transactions: Arc<DashMap<PreparedTransactionKey, PreparedTransactionHandle>>,
+    telemetry_links: Arc<DashMap<String, TelemetryLink>>,
 }
 
 impl ClientSessionRegistry {
@@ -411,6 +418,36 @@ impl ClientSessionRegistry {
             tracked.clone(),
         );
         tracked
+    }
+
+    pub fn bind_telemetry_link(
+        &self,
+        client_id: impl Into<String>,
+        sender: mpsc::UnboundedSender<v2::TelemetryCommand>,
+    ) {
+        self.telemetry_links.insert(client_id.into(), TelemetryLink { sender });
+    }
+
+    pub fn send_telemetry_command(&self, client_id: &str, command: v2::TelemetryCommand) -> bool {
+        let Some(link) = self.telemetry_links.get(client_id) else {
+            return false;
+        };
+
+        if link.sender.send(command).is_ok() {
+            true
+        } else {
+            drop(link);
+            self.telemetry_links.remove(client_id);
+            false
+        }
+    }
+
+    pub fn unbind_telemetry_link(&self, client_id: &str) -> bool {
+        self.telemetry_links.remove(client_id).is_some()
+    }
+
+    pub fn has_telemetry_link(&self, client_id: &str) -> bool {
+        self.telemetry_links.contains_key(client_id)
     }
 
     pub fn prepared_transaction(
@@ -595,6 +632,7 @@ impl ClientSessionRegistry {
         for key in prepared_transaction_keys {
             let _ = self.prepared_transactions.remove(&key);
         }
+        self.telemetry_links.remove(client_id);
         session
     }
 
@@ -618,11 +656,16 @@ impl ClientSessionRegistry {
         self.prepared_transactions.len()
     }
 
+    pub fn telemetry_link_count(&self) -> usize {
+        self.telemetry_links.len()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.sessions.is_empty()
             && self.receipt_handles.is_empty()
             && self.lite_subscriptions.is_empty()
             && self.prepared_transactions.is_empty()
+            && self.telemetry_links.is_empty()
     }
 
     pub fn reap_expired(&self, client_ttl: Duration, receipt_handle_ttl: Duration) -> ReapSummary {
@@ -842,6 +885,7 @@ mod tests {
     use std::time::Duration;
     use std::time::SystemTime;
 
+    use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
 
     use super::ClientSession;
@@ -1071,6 +1115,37 @@ mod tests {
         assert_eq!(registry.prepared_transaction_count(), 0);
     }
 
+    #[tokio::test]
+    async fn telemetry_link_can_send_and_unbind_commands() {
+        let registry = ClientSessionRegistry::default();
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        registry.bind_telemetry_link("client-a", sender);
+
+        assert!(registry.send_telemetry_command(
+            "client-a",
+            v2::TelemetryCommand {
+                status: None,
+                command: Some(v2::telemetry_command::Command::ReconnectEndpointsCommand(
+                    v2::ReconnectEndpointsCommand {
+                        nonce: "nonce-a".to_owned(),
+                    },
+                )),
+            },
+        ));
+        assert!(registry.has_telemetry_link("client-a"));
+
+        let command = receiver.recv().await.expect("telemetry command should be delivered");
+        match command.command.expect("command should be present") {
+            v2::telemetry_command::Command::ReconnectEndpointsCommand(command) => {
+                assert_eq!(command.nonce, "nonce-a");
+            }
+            other => panic!("unexpected telemetry command: {other:?}"),
+        }
+
+        assert!(registry.unbind_telemetry_link("client-a"));
+        assert!(!registry.has_telemetry_link("client-a"));
+    }
+
     #[test]
     fn remove_client_clears_receipt_handles() {
         let registry = ClientSessionRegistry::default();
@@ -1078,6 +1153,8 @@ mod tests {
         registry.upsert_from_context(&context);
         let tracked = registry.track_receipt_handle(tracked_handle("client-a", "msg-1", "handle-1"));
         registry.track_prepared_transaction(prepared_transaction("client-a", "msg-2", "tx-2"));
+        let (sender, _receiver) = mpsc::unbounded_channel();
+        registry.bind_telemetry_link("client-a", sender);
         let _ = registry.sync_lite_subscription(
             "client-a",
             lite_sync_request(v2::LiteSubscriptionAction::CompleteAdd, &["lite-a"]),
@@ -1091,6 +1168,7 @@ mod tests {
         assert_eq!(registry.tracked_handle_count(), 0);
         assert_eq!(registry.lite_subscription_count(), 0);
         assert_eq!(registry.prepared_transaction_count(), 0);
+        assert_eq!(registry.telemetry_link_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6829

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added telemetry command infrastructure enabling enhanced server-client communication capabilities.

* **Refactor**
  * Optimized producer instance reuse and lifecycle management to improve resource efficiency.
  * Improved session housekeeping with conditional scheduling instead of unconditional reaping.
  * Enhanced producer acquisition and topic management logic.

* **Tests**
  * Added unit tests validating telemetry command delivery and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->