### PR TITLE
[ISSUE #6832]🚀Implement recall message functionality with request and response handling

### DIFF
--- a/rocketmq-proxy/src/cluster.rs
+++ b/rocketmq-proxy/src/cluster.rs
@@ -70,6 +70,8 @@ use crate::processor::ChangeInvisibleDurationPlan;
 use crate::processor::ChangeInvisibleDurationRequest;
 use crate::processor::EndTransactionPlan;
 use crate::processor::EndTransactionRequest;
+use crate::processor::RecallMessagePlan;
+use crate::processor::RecallMessageRequest;
 use crate::processor::ReceiveMessagePlan;
 use crate::processor::ReceiveMessageRequest;
 use crate::processor::ReceivedMessage;
@@ -109,6 +111,12 @@ pub trait ClusterClient: Send + Sync {
         context: &ProxyContext,
         request: &SendMessageRequest,
     ) -> ProxyResult<Vec<SendMessageResultEntry>>;
+
+    async fn recall_message(
+        &self,
+        context: &ProxyContext,
+        request: &RecallMessageRequest,
+    ) -> ProxyResult<RecallMessagePlan>;
 
     async fn receive_message(
         &self,
@@ -197,6 +205,20 @@ impl ClusterClient for RocketmqClusterClient {
             .await
     }
 
+    async fn recall_message(
+        &self,
+        context: &ProxyContext,
+        request: &RecallMessageRequest,
+    ) -> ProxyResult<RecallMessagePlan> {
+        self.executor
+            .recall_message(
+                request.clone(),
+                context.client_id().map(ToOwned::to_owned),
+                context.request_id().to_owned(),
+            )
+            .await
+    }
+
     async fn receive_message(
         &self,
         context: &ProxyContext,
@@ -269,6 +291,12 @@ enum ClusterCommand {
         client_id: Option<String>,
         request_id: String,
         reply: oneshot::Sender<ProxyResult<Vec<SendMessageResultEntry>>>,
+    },
+    RecallMessage {
+        request: RecallMessageRequest,
+        client_id: Option<String>,
+        request_id: String,
+        reply: oneshot::Sender<ProxyResult<RecallMessagePlan>>,
     },
     ReceiveMessage {
         request: ReceiveMessageRequest,
@@ -353,6 +381,21 @@ impl ClusterTaskExecutor {
         request_id: String,
     ) -> ProxyResult<Vec<SendMessageResultEntry>> {
         self.execute(|reply| ClusterCommand::SendMessage {
+            request,
+            client_id,
+            request_id,
+            reply,
+        })
+        .await
+    }
+
+    async fn recall_message(
+        &self,
+        request: RecallMessageRequest,
+        client_id: Option<String>,
+        request_id: String,
+    ) -> ProxyResult<RecallMessagePlan> {
+        self.execute(|reply| ClusterCommand::RecallMessage {
             request,
             client_id,
             request_id,
@@ -476,6 +519,14 @@ async fn handle_cluster_command(config: &ClusterConfig, state: &mut ClusterWorke
             reply,
         } => {
             let _ = reply.send(send_message_inner(config, state, request, client_id, request_id).await);
+        }
+        ClusterCommand::RecallMessage {
+            request,
+            client_id,
+            request_id,
+            reply,
+        } => {
+            let _ = reply.send(recall_message_inner(config, state, request, client_id, request_id).await);
         }
         ClusterCommand::ReceiveMessage {
             request,
@@ -631,6 +682,34 @@ async fn send_message_inner(
         results.push(send_message_entry(producer, entry, timeout).await);
     }
     Ok(results)
+}
+
+async fn recall_message_inner(
+    config: &ClusterConfig,
+    state: &mut ClusterWorkerState,
+    request: RecallMessageRequest,
+    client_id: Option<String>,
+    request_id: String,
+) -> ProxyResult<RecallMessagePlan> {
+    let producer_group = build_proxy_producer_group(config, client_id.as_deref(), request_id.as_str());
+    let topic = CheetahString::from(request.topic.to_string());
+    let producer = acquire_send_producer(
+        config,
+        state,
+        producer_group.as_str(),
+        vec![topic.clone()],
+        config.send_message_timeout_ms.max(1),
+    )
+    .await?;
+    let message_id = producer
+        .recall_message(topic, CheetahString::from(request.recall_handle))
+        .await
+        .map_err(ProxyError::from)?;
+
+    Ok(RecallMessagePlan {
+        status: ProxyStatusMapper::ok_payload(),
+        message_id,
+    })
 }
 
 async fn acquire_send_producer<'a>(

--- a/rocketmq-proxy/src/grpc/adapter.rs
+++ b/rocketmq-proxy/src/grpc/adapter.rs
@@ -49,6 +49,8 @@ use crate::processor::QueryAssignmentPlan;
 use crate::processor::QueryAssignmentRequest;
 use crate::processor::QueryRoutePlan;
 use crate::processor::QueryRouteRequest;
+use crate::processor::RecallMessagePlan;
+use crate::processor::RecallMessageRequest;
 use crate::processor::ReceiveMessagePlan;
 use crate::processor::ReceiveMessageRequest;
 use crate::processor::ReceiveTarget;
@@ -103,6 +105,13 @@ pub fn build_send_message_request(
     Ok(SendMessageRequest {
         messages,
         timeout: context.deadline(),
+    })
+}
+
+pub fn build_recall_message_request(request: &v2::RecallMessageRequest) -> ProxyResult<RecallMessageRequest> {
+    Ok(RecallMessageRequest {
+        topic: resource_identity(request.topic.as_ref(), "topic")?,
+        recall_handle: validate_non_empty_string("recallHandle", request.recall_handle.as_str())?,
     })
 }
 
@@ -411,6 +420,13 @@ pub fn build_end_transaction_response(plan: &EndTransactionPlan) -> v2::EndTrans
     }
 }
 
+pub fn build_recall_message_response(plan: &RecallMessagePlan) -> v2::RecallMessageResponse {
+    v2::RecallMessageResponse {
+        status: Some(plan.status.clone().into()),
+        message_id: plan.message_id.clone(),
+    }
+}
+
 fn build_query_assignment_response_from_server(
     request: &v2::QueryAssignmentRequest,
     plan: &QueryAssignmentPlan,
@@ -470,6 +486,13 @@ pub fn error_change_invisible_duration_response(status: v2::Status) -> v2::Chang
 
 pub fn error_end_transaction_response(status: v2::Status) -> v2::EndTransactionResponse {
     v2::EndTransactionResponse { status: Some(status) }
+}
+
+pub fn error_recall_message_response(status: v2::Status) -> v2::RecallMessageResponse {
+    v2::RecallMessageResponse {
+        status: Some(status),
+        message_id: String::new(),
+    }
 }
 
 fn resource_identity(resource: Option<&v2::Resource>, field: &'static str) -> ProxyResult<ResourceIdentity> {

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -163,6 +163,7 @@ impl<P> ProxyGrpcService<P> {
                 _ = &mut shutdown => break,
                 _ = interval.tick() => {
                     self.reap_session_state();
+                    self.dispatch_due_prepared_transaction_recoveries();
                     self.schedule_next_reap();
                 }
             }
@@ -211,6 +212,52 @@ impl<P> ProxyGrpcService<P> {
         {
             self.reap_session_state();
         }
+    }
+
+    fn dispatch_due_prepared_transaction_recoveries(&self) {
+        self.dispatch_due_prepared_transaction_recoveries_for_client(None);
+    }
+
+    fn dispatch_due_prepared_transaction_recoveries_for_client(&self, client_id: Option<&str>) {
+        let now = SystemTime::now();
+        let due_transactions = self.sessions.prepared_transactions_due_for_recovery(now);
+        for tracked in due_transactions {
+            if client_id.is_some_and(|expected| tracked.client_id != expected) {
+                continue;
+            }
+
+            if self.queue_recover_orphaned_transaction_command(
+                tracked.client_id.as_str(),
+                tracked.message.clone(),
+                tracked.transaction_id.clone(),
+            ) {
+                let _ = self.sessions.prepared_transaction(
+                    tracked.client_id.as_str(),
+                    tracked.transaction_id.as_str(),
+                    tracked.message_id.as_str(),
+                );
+            }
+        }
+    }
+
+    fn queue_recover_orphaned_transaction_command(
+        &self,
+        client_id: &str,
+        message: v2::Message,
+        transaction_id: impl Into<String>,
+    ) -> bool {
+        self.sessions.send_telemetry_command(
+            client_id,
+            v2::TelemetryCommand {
+                status: Some(ProxyStatusMapper::ok()),
+                command: Some(v2::telemetry_command::Command::RecoverOrphanedTransactionCommand(
+                    v2::RecoverOrphanedTransactionCommand {
+                        message: Some(message),
+                        transaction_id: transaction_id.into(),
+                    },
+                )),
+            },
+        )
     }
 }
 
@@ -487,6 +534,7 @@ where
     fn track_prepared_transactions(
         &self,
         context: &ProxyContext,
+        grpc_request: &v2::SendMessageRequest,
         request: &crate::processor::SendMessageRequest,
         plan: &crate::processor::SendMessagePlan,
     ) {
@@ -496,7 +544,12 @@ where
         let producer_group =
             crate::cluster::build_proxy_producer_group(&self.config.cluster, Some(client_id), context.request_id());
 
-        for (message, result) in request.messages.iter().zip(plan.entries.iter()) {
+        for ((grpc_message, message), result) in grpc_request
+            .messages
+            .iter()
+            .zip(request.messages.iter())
+            .zip(plan.entries.iter())
+        {
             if !is_transaction_message(&message.message) {
                 continue;
             }
@@ -527,6 +580,12 @@ where
                     producer_group: producer_group.clone(),
                     transaction_state_table_offset: send_result.queue_offset,
                     commit_log_message_id,
+                    message: grpc_message.clone(),
+                    orphaned_transaction_recovery_duration: grpc_message
+                        .system_properties
+                        .as_ref()
+                        .and_then(|system| system.orphaned_transaction_recovery_duration.as_ref())
+                        .and_then(proto_duration),
                 });
         }
     }
@@ -788,7 +847,7 @@ where
             Ok(input) => match self.guards.try_producer() {
                 Ok(_permit) => match self.processor.send_message(&context, input.clone()).await {
                     Ok(plan) => {
-                        self.track_prepared_transactions(&context, &input, &plan);
+                        self.track_prepared_transactions(&context, &request, &input, &plan);
                         adapter::build_send_message_response(&plan, &input)
                     }
                     Err(error) => adapter::error_send_message_response(ProxyStatusMapper::from_error(&error)),
@@ -997,6 +1056,7 @@ where
         };
         let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel();
         self.sessions.bind_telemetry_link(client_id.clone(), outbound_tx);
+        self.dispatch_due_prepared_transaction_recoveries_for_client(Some(client_id.as_str()));
         let service = self.clone();
         let (sender, receiver) = mpsc::channel(16);
         tokio::spawn(async move {
@@ -1091,12 +1151,27 @@ where
 
     async fn recall_message(
         &self,
-        _request: Request<v2::RecallMessageRequest>,
+        request: Request<v2::RecallMessageRequest>,
     ) -> Result<Response<v2::RecallMessageResponse>, Status> {
-        Ok(Response::new(v2::RecallMessageResponse {
-            status: Some(self.not_implemented_status("RecallMessage")),
-            message_id: String::new(),
-        }))
+        self.reap_session_state_if_due();
+        let context = self.context("RecallMessage", &request);
+        let request = request.into_inner();
+
+        let response = match self
+            .validate_client_context(&context)
+            .and_then(|_| adapter::build_recall_message_request(&request))
+        {
+            Ok(input) => match self.guards.try_producer() {
+                Ok(_permit) => match self.processor.recall_message(&context, input).await {
+                    Ok(plan) => adapter::build_recall_message_response(&plan),
+                    Err(error) => adapter::error_recall_message_response(ProxyStatusMapper::from_error(&error)),
+                },
+                Err(error) => adapter::error_recall_message_response(ProxyStatusMapper::from_error(&error)),
+            },
+            Err(error) => adapter::error_recall_message_response(ProxyStatusMapper::from_error(&error)),
+        };
+
+        Ok(Response::new(response))
     }
 
     async fn sync_lite_subscription(
@@ -1178,6 +1253,7 @@ mod tests {
     use crate::session::ClientSessionRegistry;
     use crate::status::ProxyPayloadStatus;
     use crate::status::ProxyStatusMapper;
+    use crate::PreparedTransactionRegistration;
 
     struct PartialMessageService;
 
@@ -1223,6 +1299,17 @@ mod tests {
                     }
                 })
                 .collect())
+        }
+
+        async fn recall_message(
+            &self,
+            _context: &crate::context::ProxyContext,
+            request: &crate::processor::RecallMessageRequest,
+        ) -> crate::error::ProxyResult<crate::processor::RecallMessagePlan> {
+            Ok(crate::processor::RecallMessagePlan {
+                status: ProxyStatusMapper::ok_payload(),
+                message_id: request.recall_handle.clone(),
+            })
         }
     }
 
@@ -1495,6 +1582,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recall_message_returns_recalled_message_id() {
+        let service = test_service_with_message_service(
+            StaticRouteService::default(),
+            StaticMetadataService::default(),
+            Arc::new(StaticMessageService::with_send_status(SendStatus::SendOk)),
+        );
+        let mut request = Request::new(v2::RecallMessageRequest {
+            topic: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "TopicA".to_owned(),
+            }),
+            recall_handle: "recall-handle-1".to_owned(),
+        });
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+
+        let response = service.recall_message(request).await.unwrap().into_inner();
+        assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
+        assert_eq!(response.message_id, "recall-handle-1");
+    }
+
+    #[tokio::test]
     async fn send_message_tracks_prepared_transactions_for_transactional_entries() {
         let service = test_service_with_message_service(
             StaticRouteService::default(),
@@ -1533,6 +1643,64 @@ mod tests {
         assert_eq!(tracked.producer_group, "PROXY_SEND-client-a");
         assert_eq!(tracked.transaction_state_table_offset, 0);
         assert_eq!(tracked.commit_log_message_id, "offset-msg-1");
+        assert_eq!(
+            tracked
+                .message
+                .system_properties
+                .as_ref()
+                .map(|properties| properties.message_id.as_str()),
+            Some("msg-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn due_prepared_transaction_dispatches_recovery_command() {
+        let service = test_service(StaticRouteService::default(), StaticMetadataService::default());
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        service.sessions.bind_telemetry_link("client-a", sender);
+        service
+            .sessions
+            .track_prepared_transaction(PreparedTransactionRegistration {
+                client_id: "client-a".to_owned(),
+                topic: ResourceIdentity::new("", "TopicA"),
+                message_id: "msg-1".to_owned(),
+                transaction_id: "tx-1".to_owned(),
+                producer_group: "PROXY_SEND-client-a".to_owned(),
+                transaction_state_table_offset: 7,
+                commit_log_message_id: "offset-msg-1".to_owned(),
+                message: v2::Message {
+                    topic: Some(v2::Resource {
+                        resource_namespace: String::new(),
+                        name: "TopicA".to_owned(),
+                    }),
+                    user_properties: HashMap::new(),
+                    system_properties: Some(v2::SystemProperties {
+                        message_id: "msg-1".to_owned(),
+                        orphaned_transaction_recovery_duration: Some(prost_types::Duration { seconds: 0, nanos: 0 }),
+                        ..Default::default()
+                    }),
+                    body: Bytes::from_static(b"hello").to_vec(),
+                },
+                orphaned_transaction_recovery_duration: Some(std::time::Duration::ZERO),
+            });
+
+        service.dispatch_due_prepared_transaction_recoveries();
+
+        let command = receiver.recv().await.expect("recovery command should be queued");
+        match command.command {
+            Some(v2::telemetry_command::Command::RecoverOrphanedTransactionCommand(command)) => {
+                assert_eq!(command.transaction_id, "tx-1");
+                let message = command.message.expect("recovery command should carry message");
+                assert_eq!(
+                    message
+                        .system_properties
+                        .as_ref()
+                        .map(|properties| properties.message_id.as_str()),
+                    Some("msg-1")
+                );
+            }
+            other => panic!("unexpected telemetry command: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/rocketmq-proxy/src/lib.rs
+++ b/rocketmq-proxy/src/lib.rs
@@ -58,6 +58,8 @@ pub use processor::QueryAssignmentPlan;
 pub use processor::QueryAssignmentRequest;
 pub use processor::QueryRoutePlan;
 pub use processor::QueryRouteRequest;
+pub use processor::RecallMessagePlan;
+pub use processor::RecallMessageRequest;
 pub use processor::ReceiveMessagePlan;
 pub use processor::ReceiveMessageRequest;
 pub use processor::ReceiveTarget;

--- a/rocketmq-proxy/src/processor.rs
+++ b/rocketmq-proxy/src/processor.rs
@@ -83,6 +83,18 @@ pub struct SendMessageResultEntry {
 }
 
 #[derive(Debug, Clone)]
+pub struct RecallMessageRequest {
+    pub topic: ResourceIdentity,
+    pub recall_handle: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecallMessagePlan {
+    pub status: ProxyPayloadStatus,
+    pub message_id: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct ConsumerFilterExpression {
     pub expression_type: String,
     pub expression: String,
@@ -207,6 +219,12 @@ pub trait MessagingProcessor: Send + Sync {
 
     async fn send_message(&self, context: &ProxyContext, request: SendMessageRequest) -> ProxyResult<SendMessagePlan>;
 
+    async fn recall_message(
+        &self,
+        context: &ProxyContext,
+        request: RecallMessageRequest,
+    ) -> ProxyResult<RecallMessagePlan>;
+
     async fn receive_message(
         &self,
         context: &ProxyContext,
@@ -291,6 +309,15 @@ impl MessagingProcessor for DefaultMessagingProcessor {
         let entries = message_service.send_message(context, &request).await?;
 
         Ok(SendMessagePlan { entries })
+    }
+
+    async fn recall_message(
+        &self,
+        context: &ProxyContext,
+        request: RecallMessageRequest,
+    ) -> ProxyResult<RecallMessagePlan> {
+        let message_service = self.service_manager.message_service();
+        message_service.recall_message(context, &request).await
     }
 
     async fn receive_message(

--- a/rocketmq-proxy/src/service.rs
+++ b/rocketmq-proxy/src/service.rs
@@ -39,6 +39,8 @@ use crate::processor::ChangeInvisibleDurationPlan;
 use crate::processor::ChangeInvisibleDurationRequest;
 use crate::processor::EndTransactionPlan;
 use crate::processor::EndTransactionRequest;
+use crate::processor::RecallMessagePlan;
+use crate::processor::RecallMessageRequest;
 use crate::processor::ReceiveMessagePlan;
 use crate::processor::ReceiveMessageRequest;
 use crate::processor::SendMessageRequest;
@@ -141,6 +143,12 @@ pub trait MessageService: Send + Sync {
         context: &ProxyContext,
         request: &SendMessageRequest,
     ) -> ProxyResult<Vec<SendMessageResultEntry>>;
+
+    async fn recall_message(
+        &self,
+        context: &ProxyContext,
+        request: &RecallMessageRequest,
+    ) -> ProxyResult<RecallMessagePlan>;
 }
 
 #[async_trait]
@@ -256,6 +264,14 @@ impl MessageService for DefaultMessageService {
         _request: &SendMessageRequest,
     ) -> ProxyResult<Vec<SendMessageResultEntry>> {
         Err(ProxyError::not_implemented("message service"))
+    }
+
+    async fn recall_message(
+        &self,
+        _context: &ProxyContext,
+        _request: &RecallMessageRequest,
+    ) -> ProxyResult<RecallMessagePlan> {
+        Err(ProxyError::not_implemented("message recall service"))
     }
 }
 
@@ -417,6 +433,17 @@ impl MessageService for StaticMessageService {
             })
             .collect())
     }
+
+    async fn recall_message(
+        &self,
+        _context: &ProxyContext,
+        request: &RecallMessageRequest,
+    ) -> ProxyResult<RecallMessagePlan> {
+        Ok(RecallMessagePlan {
+            status: ProxyStatusMapper::ok_payload(),
+            message_id: request.recall_handle.clone(),
+        })
+    }
 }
 
 pub struct ClusterRouteService {
@@ -514,6 +541,14 @@ impl MessageService for ClusterMessageService {
         request: &SendMessageRequest,
     ) -> ProxyResult<Vec<SendMessageResultEntry>> {
         self.client.send_message(context, request).await
+    }
+
+    async fn recall_message(
+        &self,
+        context: &ProxyContext,
+        request: &RecallMessageRequest,
+    ) -> ProxyResult<RecallMessagePlan> {
+        self.client.recall_message(context, request).await
     }
 }
 

--- a/rocketmq-proxy/src/session.rs
+++ b/rocketmq-proxy/src/session.rs
@@ -142,9 +142,11 @@ pub struct PreparedTransactionRegistration {
     pub producer_group: String,
     pub transaction_state_table_offset: u64,
     pub commit_log_message_id: String,
+    pub message: v2::Message,
+    pub orphaned_transaction_recovery_duration: Option<Duration>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PreparedTransactionHandle {
     pub client_id: String,
     pub topic: ResourceIdentity,
@@ -153,6 +155,8 @@ pub struct PreparedTransactionHandle {
     pub producer_group: String,
     pub transaction_state_table_offset: u64,
     pub commit_log_message_id: String,
+    pub message: v2::Message,
+    pub orphaned_transaction_recovery_duration: Option<Duration>,
     pub last_touched: SystemTime,
 }
 
@@ -411,6 +415,8 @@ impl ClientSessionRegistry {
             producer_group: registration.producer_group,
             transaction_state_table_offset: registration.transaction_state_table_offset,
             commit_log_message_id: registration.commit_log_message_id,
+            message: registration.message,
+            orphaned_transaction_recovery_duration: registration.orphaned_transaction_recovery_duration,
             last_touched: SystemTime::now(),
         };
         self.prepared_transactions.insert(
@@ -509,6 +515,17 @@ impl ClientSessionRegistry {
         self.prepared_transactions
             .remove(&matching_key)
             .map(|(_, tracked)| tracked)
+    }
+
+    pub fn prepared_transactions_due_for_recovery(&self, now: SystemTime) -> Vec<PreparedTransactionHandle> {
+        self.prepared_transactions
+            .iter()
+            .filter_map(|entry| {
+                let tracked = entry.value();
+                let recovery_duration = tracked.orphaned_transaction_recovery_duration?;
+                is_expired(tracked.last_touched, now, recovery_duration).then(|| tracked.clone())
+            })
+            .collect()
     }
 
     pub fn track_receipt_handle(&self, registration: ReceiptHandleRegistration) -> TrackedReceiptHandle {
@@ -936,6 +953,19 @@ mod tests {
             producer_group: format!("PROXY_SEND-{client_id}"),
             transaction_state_table_offset: 7,
             commit_log_message_id: format!("offset-{message_id}"),
+            message: v2::Message {
+                topic: Some(v2::Resource {
+                    resource_namespace: String::new(),
+                    name: "TopicA".to_owned(),
+                }),
+                user_properties: Default::default(),
+                system_properties: Some(v2::SystemProperties {
+                    message_id: message_id.to_owned(),
+                    ..Default::default()
+                }),
+                body: b"hello".to_vec(),
+            },
+            orphaned_transaction_recovery_duration: None,
         }
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6832

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added message recall functionality, allowing users to withdraw previously sent messages.

* **Improvements**
  * Implemented automatic recovery of orphaned transactions during message operations to enhance service reliability and ensure data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->