### PR TITLE
[ISSUE #6836]🚀Implement forward message to dead letter queue functionality with request and response handling

### DIFF
--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -850,6 +850,34 @@ impl MQClientInstance {
             .await
     }
 
+    pub async fn consumer_send_message_back(
+        &mut self,
+        broker_addr: &str,
+        broker_name: &str,
+        message: &MessageExt,
+        consumer_group: &str,
+        delay_level: i32,
+        timeout_millis: u64,
+        max_consume_retry_times: i32,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let api_impl = self
+            .mq_client_api_impl
+            .as_ref()
+            .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?;
+        api_impl
+            .clone()
+            .consumer_send_message_back(
+                broker_addr,
+                broker_name,
+                message,
+                consumer_group,
+                delay_level,
+                timeout_millis,
+                max_consume_retry_times,
+            )
+            .await
+    }
+
     pub async fn get_max_offset(
         &self,
         broker_addr: &str,

--- a/rocketmq-proxy/src/cluster.rs
+++ b/rocketmq-proxy/src/cluster.rs
@@ -34,6 +34,7 @@ use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
 use rocketmq_client_rust::producer::mq_producer::MQProducer;
 use rocketmq_client_rust::producer::send_result::SendResult;
 use rocketmq_common::common::attribute::topic_message_type::TopicMessageType;
+use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_id::MessageId;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_queue_assignment::MessageQueueAssignment;
@@ -75,6 +76,8 @@ use crate::processor::ChangeInvisibleDurationPlan;
 use crate::processor::ChangeInvisibleDurationRequest;
 use crate::processor::EndTransactionPlan;
 use crate::processor::EndTransactionRequest;
+use crate::processor::ForwardMessageToDeadLetterQueuePlan;
+use crate::processor::ForwardMessageToDeadLetterQueueRequest;
 use crate::processor::GetOffsetPlan;
 use crate::processor::GetOffsetRequest;
 use crate::processor::MessageQueueTarget;
@@ -146,6 +149,12 @@ pub trait ClusterClient: Send + Sync {
         context: &ProxyContext,
         request: &AckMessageRequest,
     ) -> ProxyResult<Vec<AckMessageResultEntry>>;
+
+    async fn forward_message_to_dead_letter_queue(
+        &self,
+        context: &ProxyContext,
+        request: &ForwardMessageToDeadLetterQueueRequest,
+    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan>;
 
     async fn change_invisible_duration(
         &self,
@@ -266,6 +275,16 @@ impl ClusterClient for RocketmqClusterClient {
         self.executor.ack_message(request.clone(), context.deadline()).await
     }
 
+    async fn forward_message_to_dead_letter_queue(
+        &self,
+        context: &ProxyContext,
+        request: &ForwardMessageToDeadLetterQueueRequest,
+    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
+        self.executor
+            .forward_message_to_dead_letter_queue(request.clone(), context.deadline())
+            .await
+    }
+
     async fn change_invisible_duration(
         &self,
         context: &ProxyContext,
@@ -359,6 +378,11 @@ enum ClusterCommand {
         request: AckMessageRequest,
         deadline: Option<Duration>,
         reply: oneshot::Sender<ProxyResult<Vec<AckMessageResultEntry>>>,
+    },
+    ForwardMessageToDeadLetterQueue {
+        request: ForwardMessageToDeadLetterQueueRequest,
+        deadline: Option<Duration>,
+        reply: oneshot::Sender<ProxyResult<ForwardMessageToDeadLetterQueuePlan>>,
     },
     ChangeInvisibleDuration {
         request: ChangeInvisibleDurationRequest,
@@ -503,6 +527,19 @@ impl ClusterTaskExecutor {
         deadline: Option<Duration>,
     ) -> ProxyResult<Vec<AckMessageResultEntry>> {
         self.execute(|reply| ClusterCommand::AckMessage {
+            request,
+            deadline,
+            reply,
+        })
+        .await
+    }
+
+    async fn forward_message_to_dead_letter_queue(
+        &self,
+        request: ForwardMessageToDeadLetterQueueRequest,
+        deadline: Option<Duration>,
+    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
+        self.execute(|reply| ClusterCommand::ForwardMessageToDeadLetterQueue {
             request,
             deadline,
             reply,
@@ -663,6 +700,13 @@ async fn handle_cluster_command(config: &ClusterConfig, state: &mut ClusterWorke
             reply,
         } => {
             let _ = reply.send(ack_message_inner(config, request, deadline).await);
+        }
+        ClusterCommand::ForwardMessageToDeadLetterQueue {
+            request,
+            deadline,
+            reply,
+        } => {
+            let _ = reply.send(forward_message_to_dead_letter_queue_inner(config, request, deadline).await);
         }
         ClusterCommand::ChangeInvisibleDuration {
             request,
@@ -959,6 +1003,46 @@ async fn ack_message_inner(
     }
 
     Ok(results)
+}
+
+async fn forward_message_to_dead_letter_queue_inner(
+    config: &ClusterConfig,
+    request: ForwardMessageToDeadLetterQueueRequest,
+    deadline: Option<Duration>,
+) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
+    let timeout_ms = effective_request_timeout_ms(config.mq_client_api_timeout_ms, deadline);
+    let mut client = initialize_client_instance(config.clone()).await?;
+    let topic_name = request.lite_topic.clone().unwrap_or_else(|| request.topic.to_string());
+    let group_name = request.group.to_string();
+    let parsed = parse_receipt_handle(
+        request.receipt_handle.as_str(),
+        topic_name.as_str(),
+        group_name.as_str(),
+    )?;
+    let actual_broker_name =
+        resolve_subscription_broker_name(&client, &parsed.topic, &parsed.broker_name, parsed.queue_id).await;
+    let broker_addr = find_subscribe_broker_addr(&mut client, &actual_broker_name, &parsed.topic)
+        .await
+        .ok_or_else(|| RocketMQError::BrokerNotFound {
+            name: actual_broker_name.to_string(),
+        })?;
+    let message = build_dead_letter_message(&request, &parsed, &actual_broker_name)?;
+
+    client
+        .consumer_send_message_back(
+            broker_addr.as_str(),
+            actual_broker_name.as_str(),
+            &message,
+            group_name.as_str(),
+            -1,
+            timeout_ms,
+            request.max_delivery_attempts,
+        )
+        .await?;
+
+    Ok(ForwardMessageToDeadLetterQueuePlan {
+        status: ProxyStatusMapper::ok_payload(),
+    })
 }
 
 async fn change_invisible_duration_request_inner(
@@ -1644,6 +1728,23 @@ fn ack_status_to_payload(ack_result: &AckResult) -> ProxyPayloadStatus {
     }
 }
 
+fn build_dead_letter_message(
+    request: &ForwardMessageToDeadLetterQueueRequest,
+    parsed: &ParsedReceiptHandle,
+    broker_name: &CheetahString,
+) -> ProxyResult<MessageExt> {
+    let broker_message_id = decode_broker_message_id(request.message_id.as_str())?;
+    let mut message = MessageExt::default();
+    message.set_topic(parsed.topic.clone());
+    message.set_msg_id(CheetahString::from(request.message_id.as_str()));
+    message.set_broker_name(broker_name.clone());
+    message.set_queue_id(parsed.queue_id);
+    message.set_queue_offset(parsed.queue_offset);
+    message.set_commit_log_offset(broker_message_id.offset);
+    message.set_reconsume_times(request.delivery_attempt.saturating_sub(1));
+    Ok(message)
+}
+
 fn parse_receipt_handle(receipt_handle: &str, topic: &str, consumer_group: &str) -> ProxyResult<ParsedReceiptHandle> {
     let trimmed = receipt_handle.trim();
     if trimmed.is_empty() {
@@ -1847,6 +1948,11 @@ fn decode_end_transaction_message_id(message_id: &str) -> ProxyResult<MessageId>
     MessageDecoder::decode_message_id(&CheetahString::from(message_id)).map_err(|error| {
         ProxyError::invalid_transaction_id(format!("failed to decode transactional message id: {error}"))
     })
+}
+
+fn decode_broker_message_id(message_id: &str) -> ProxyResult<MessageId> {
+    MessageDecoder::decode_message_id(&CheetahString::from(message_id))
+        .map_err(|error| ProxyError::illegal_message_id(format!("failed to decode broker message id: {error}")))
 }
 
 fn effective_send_timeout_ms(config: &ClusterConfig, deadline: Option<Duration>) -> u64 {

--- a/rocketmq-proxy/src/grpc/adapter.rs
+++ b/rocketmq-proxy/src/grpc/adapter.rs
@@ -45,6 +45,8 @@ use crate::processor::ChangeInvisibleDurationRequest;
 use crate::processor::ConsumerFilterExpression;
 use crate::processor::EndTransactionPlan;
 use crate::processor::EndTransactionRequest;
+use crate::processor::ForwardMessageToDeadLetterQueuePlan;
+use crate::processor::ForwardMessageToDeadLetterQueueRequest;
 use crate::processor::GetOffsetPlan;
 use crate::processor::GetOffsetRequest;
 use crate::processor::MessageQueueTarget;
@@ -223,6 +225,25 @@ pub fn build_ack_message_request(request: &v2::AckMessageRequest) -> ProxyResult
         group: resource_identity(request.group.as_ref(), "group")?,
         topic: resource_identity(request.topic.as_ref(), "topic")?,
         entries,
+    })
+}
+
+pub fn build_forward_message_to_dead_letter_queue_request(
+    request: &v2::ForwardMessageToDeadLetterQueueRequest,
+) -> ProxyResult<ForwardMessageToDeadLetterQueueRequest> {
+    Ok(ForwardMessageToDeadLetterQueueRequest {
+        group: resource_identity(request.group.as_ref(), "group")?,
+        topic: resource_identity(request.topic.as_ref(), "topic")?,
+        receipt_handle: validate_non_empty_string("receiptHandle", request.receipt_handle.as_str())?,
+        message_id: validate_non_empty_string("messageId", request.message_id.as_str())?,
+        delivery_attempt: request.delivery_attempt,
+        max_delivery_attempts: request.max_delivery_attempts,
+        lite_topic: request
+            .lite_topic
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned),
     })
 }
 
@@ -490,6 +511,14 @@ pub fn build_ack_message_response(plan: &AckMessagePlan) -> v2::AckMessageRespon
     }
 }
 
+pub fn build_forward_message_to_dead_letter_queue_response(
+    plan: &ForwardMessageToDeadLetterQueuePlan,
+) -> v2::ForwardMessageToDeadLetterQueueResponse {
+    v2::ForwardMessageToDeadLetterQueueResponse {
+        status: Some(plan.status.clone().into()),
+    }
+}
+
 pub fn build_change_invisible_duration_response(
     plan: &ChangeInvisibleDurationPlan,
 ) -> v2::ChangeInvisibleDurationResponse {
@@ -586,6 +615,12 @@ pub fn error_ack_message_response(status: v2::Status) -> v2::AckMessageResponse 
         status: Some(status),
         entries: Vec::new(),
     }
+}
+
+pub fn error_forward_message_to_dead_letter_queue_response(
+    status: v2::Status,
+) -> v2::ForwardMessageToDeadLetterQueueResponse {
+    v2::ForwardMessageToDeadLetterQueueResponse { status: Some(status) }
 }
 
 pub fn error_change_invisible_duration_response(status: v2::Status) -> v2::ChangeInvisibleDurationResponse {

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -265,10 +265,6 @@ impl<P> ProxyGrpcService<P>
 where
     P: MessagingProcessor + 'static,
 {
-    fn not_implemented_status(&self, feature: &'static str) -> v2::Status {
-        ProxyStatusMapper::from_error(&ProxyError::not_implemented(feature))
-    }
-
     fn validate_client_context<'a>(&self, context: &'a ProxyContext) -> ProxyResult<&'a str> {
         context.require_client_id()
     }
@@ -940,11 +936,37 @@ where
 
     async fn forward_message_to_dead_letter_queue(
         &self,
-        _request: Request<v2::ForwardMessageToDeadLetterQueueRequest>,
+        request: Request<v2::ForwardMessageToDeadLetterQueueRequest>,
     ) -> Result<Response<v2::ForwardMessageToDeadLetterQueueResponse>, Status> {
-        Ok(Response::new(v2::ForwardMessageToDeadLetterQueueResponse {
-            status: Some(self.not_implemented_status("ForwardMessageToDeadLetterQueue")),
-        }))
+        self.reap_session_state_if_due();
+        let context = self.context("ForwardMessageToDeadLetterQueue", &request);
+        let request = request.into_inner();
+
+        let response = match self
+            .validate_client_context(&context)
+            .and_then(|_| adapter::build_forward_message_to_dead_letter_queue_request(&request))
+        {
+            Ok(input) => match self.guards.try_consumer() {
+                Ok(_permit) => match self
+                    .processor
+                    .forward_message_to_dead_letter_queue(&context, input)
+                    .await
+                {
+                    Ok(plan) => adapter::build_forward_message_to_dead_letter_queue_response(&plan),
+                    Err(error) => adapter::error_forward_message_to_dead_letter_queue_response(
+                        ProxyStatusMapper::from_error(&error),
+                    ),
+                },
+                Err(error) => {
+                    adapter::error_forward_message_to_dead_letter_queue_response(ProxyStatusMapper::from_error(&error))
+                }
+            },
+            Err(error) => {
+                adapter::error_forward_message_to_dead_letter_queue_response(ProxyStatusMapper::from_error(&error))
+            }
+        };
+
+        Ok(Response::new(response))
     }
 
     async fn pull_message(
@@ -1275,6 +1297,8 @@ mod tests {
     use crate::processor::DefaultMessagingProcessor;
     use crate::processor::EndTransactionPlan;
     use crate::processor::EndTransactionRequest;
+    use crate::processor::ForwardMessageToDeadLetterQueuePlan;
+    use crate::processor::ForwardMessageToDeadLetterQueueRequest;
     use crate::processor::GetOffsetPlan;
     use crate::processor::GetOffsetRequest;
     use crate::processor::PullMessagePlan;
@@ -1312,6 +1336,7 @@ mod tests {
 
     #[derive(Default)]
     struct TestConsumerService {
+        dlq_requests: Mutex<Vec<ForwardMessageToDeadLetterQueueRequest>>,
         updated_offsets: Mutex<Vec<UpdateOffsetRequest>>,
     }
 
@@ -1431,6 +1456,20 @@ mod tests {
                     status: ProxyStatusMapper::ok_payload(),
                 })
                 .collect())
+        }
+
+        async fn forward_message_to_dead_letter_queue(
+            &self,
+            _context: &crate::context::ProxyContext,
+            request: &ForwardMessageToDeadLetterQueueRequest,
+        ) -> crate::error::ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
+            self.dlq_requests
+                .lock()
+                .expect("dlq requests mutex poisoned")
+                .push(request.clone());
+            Ok(ForwardMessageToDeadLetterQueuePlan {
+                status: ProxyStatusMapper::ok_payload(),
+            })
         }
 
         async fn change_invisible_duration(
@@ -2014,6 +2053,50 @@ mod tests {
         assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
         assert_eq!(response.entries.len(), 1);
         assert_eq!(response.entries[0].message_id, "msg-1");
+    }
+
+    #[tokio::test]
+    async fn forward_message_to_dead_letter_queue_records_request() {
+        let consumer_service = Arc::new(TestConsumerService::default());
+        let service = test_service_with_services(
+            StaticRouteService::default(),
+            StaticMetadataService::default(),
+            Arc::new(StaticMessageService::with_send_status(SendStatus::SendOk)),
+            consumer_service.clone(),
+        );
+        let mut request = Request::new(v2::ForwardMessageToDeadLetterQueueRequest {
+            group: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "GroupA".to_owned(),
+            }),
+            topic: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "TopicA".to_owned(),
+            }),
+            receipt_handle: "receipt-handle".to_owned(),
+            message_id: "msg-1".to_owned(),
+            delivery_attempt: 3,
+            max_delivery_attempts: 3,
+            lite_topic: Some("LiteTopicA".to_owned()),
+        });
+        request
+            .metadata_mut()
+            .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
+
+        let response = service
+            .forward_message_to_dead_letter_queue(request)
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.status.unwrap().code, v2::Code::Ok as i32);
+
+        let requests = consumer_service
+            .dlq_requests
+            .lock()
+            .expect("dlq requests mutex poisoned");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].message_id, "msg-1");
+        assert_eq!(requests[0].lite_topic.as_deref(), Some("LiteTopicA"));
     }
 
     #[tokio::test]

--- a/rocketmq-proxy/src/lib.rs
+++ b/rocketmq-proxy/src/lib.rs
@@ -53,6 +53,8 @@ pub use processor::ConsumerFilterExpression;
 pub use processor::DefaultMessagingProcessor;
 pub use processor::EndTransactionPlan;
 pub use processor::EndTransactionRequest;
+pub use processor::ForwardMessageToDeadLetterQueuePlan;
+pub use processor::ForwardMessageToDeadLetterQueueRequest;
 pub use processor::GetOffsetPlan;
 pub use processor::GetOffsetRequest;
 pub use processor::MessageQueueTarget;

--- a/rocketmq-proxy/src/processor.rs
+++ b/rocketmq-proxy/src/processor.rs
@@ -186,6 +186,22 @@ pub struct AckMessagePlan {
 }
 
 #[derive(Debug, Clone)]
+pub struct ForwardMessageToDeadLetterQueueRequest {
+    pub group: ResourceIdentity,
+    pub topic: ResourceIdentity,
+    pub receipt_handle: String,
+    pub message_id: String,
+    pub delivery_attempt: i32,
+    pub max_delivery_attempts: i32,
+    pub lite_topic: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ForwardMessageToDeadLetterQueuePlan {
+    pub status: ProxyPayloadStatus,
+}
+
+#[derive(Debug, Clone)]
 pub struct ChangeInvisibleDurationRequest {
     pub group: ResourceIdentity,
     pub topic: ResourceIdentity,
@@ -304,6 +320,12 @@ pub trait MessagingProcessor: Send + Sync {
 
     async fn ack_message(&self, context: &ProxyContext, request: AckMessageRequest) -> ProxyResult<AckMessagePlan>;
 
+    async fn forward_message_to_dead_letter_queue(
+        &self,
+        context: &ProxyContext,
+        request: ForwardMessageToDeadLetterQueueRequest,
+    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan>;
+
     async fn change_invisible_duration(
         &self,
         context: &ProxyContext,
@@ -419,6 +441,17 @@ impl MessagingProcessor for DefaultMessagingProcessor {
         let consumer_service = self.service_manager.consumer_service();
         let entries = consumer_service.ack_message(context, &request).await?;
         Ok(AckMessagePlan { entries })
+    }
+
+    async fn forward_message_to_dead_letter_queue(
+        &self,
+        context: &ProxyContext,
+        request: ForwardMessageToDeadLetterQueueRequest,
+    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
+        let consumer_service = self.service_manager.consumer_service();
+        consumer_service
+            .forward_message_to_dead_letter_queue(context, &request)
+            .await
     }
 
     async fn change_invisible_duration(

--- a/rocketmq-proxy/src/service.rs
+++ b/rocketmq-proxy/src/service.rs
@@ -39,6 +39,8 @@ use crate::processor::ChangeInvisibleDurationPlan;
 use crate::processor::ChangeInvisibleDurationRequest;
 use crate::processor::EndTransactionPlan;
 use crate::processor::EndTransactionRequest;
+use crate::processor::ForwardMessageToDeadLetterQueuePlan;
+use crate::processor::ForwardMessageToDeadLetterQueueRequest;
 use crate::processor::GetOffsetPlan;
 use crate::processor::GetOffsetRequest;
 use crate::processor::PullMessagePlan;
@@ -174,6 +176,12 @@ pub trait ConsumerService: Send + Sync {
         context: &ProxyContext,
         request: &AckMessageRequest,
     ) -> ProxyResult<Vec<AckMessageResultEntry>>;
+
+    async fn forward_message_to_dead_letter_queue(
+        &self,
+        context: &ProxyContext,
+        request: &ForwardMessageToDeadLetterQueueRequest,
+    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan>;
 
     async fn change_invisible_duration(
         &self,
@@ -321,6 +329,14 @@ impl ConsumerService for DefaultConsumerService {
         _context: &ProxyContext,
         _request: &AckMessageRequest,
     ) -> ProxyResult<Vec<AckMessageResultEntry>> {
+        Err(ProxyError::not_implemented("consumer service"))
+    }
+
+    async fn forward_message_to_dead_letter_queue(
+        &self,
+        _context: &ProxyContext,
+        _request: &ForwardMessageToDeadLetterQueueRequest,
+    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
         Err(ProxyError::not_implemented("consumer service"))
     }
 
@@ -630,6 +646,14 @@ impl ConsumerService for ClusterConsumerService {
         request: &AckMessageRequest,
     ) -> ProxyResult<Vec<AckMessageResultEntry>> {
         self.client.ack_message(context, request).await
+    }
+
+    async fn forward_message_to_dead_letter_queue(
+        &self,
+        context: &ProxyContext,
+        request: &ForwardMessageToDeadLetterQueueRequest,
+    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
+        self.client.forward_message_to_dead_letter_queue(context, request).await
     }
 
     async fn change_invisible_duration(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6836

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dead-letter queue forwarding capability that allows undeliverable consumer messages to be redirected to a dedicated dead-letter queue after exceeding maximum retry attempts, enabling better handling and analysis of problematic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->