### PR TITLE
[ISSUE #6842]♻️Refactor ProxyContext and enhance gRPC timeout handling with error validation

### DIFF
--- a/rocketmq-proxy/src/context.rs
+++ b/rocketmq-proxy/src/context.rs
@@ -56,9 +56,11 @@ pub struct ProxyContext {
 }
 
 impl ProxyContext {
-    pub fn from_grpc_request<T>(rpc_name: &'static str, request: &Request<T>) -> Self {
+    pub fn from_grpc_request<T>(rpc_name: &'static str, request: &Request<T>) -> ProxyResult<Self> {
         let metadata = request.metadata();
-        Self {
+        let deadline = parse_grpc_timeout_metadata(metadata)?;
+
+        Ok(Self {
             request_id: Uuid::new_v4().to_string(),
             rpc_name,
             remote_addr: request.remote_addr().map(|addr| addr.to_string()),
@@ -68,13 +70,10 @@ impl ProxyContext {
             client_version: metadata_string(metadata, "x-mq-client-version"),
             namespace: metadata_string(metadata, "x-mq-namespace"),
             connection_id: metadata_string(metadata, "x-mq-channel-id"),
-            deadline: metadata
-                .get("grpc-timeout")
-                .and_then(|value| value.to_str().ok())
-                .and_then(parse_grpc_timeout),
+            deadline,
             received_at: Instant::now(),
             authenticated_principal: None,
-        }
+        })
     }
 
     pub(crate) fn set_authenticated_principal(&mut self, principal: AuthenticatedPrincipal) {
@@ -141,6 +140,22 @@ fn metadata_string(metadata: &MetadataMap, key: &'static str) -> Option<String> 
         .map(str::to_owned)
 }
 
+fn parse_grpc_timeout_metadata(metadata: &MetadataMap) -> ProxyResult<Option<Duration>> {
+    let Some(raw) = metadata.get("grpc-timeout") else {
+        return Ok(None);
+    };
+    let raw = raw
+        .to_str()
+        .map_err(|_| ProxyError::invalid_metadata("grpc-timeout must be valid ASCII"))?;
+    parse_grpc_timeout(raw)
+        .ok_or_else(|| {
+            ProxyError::invalid_metadata(format!(
+                "grpc-timeout '{raw}' must use the gRPC timeout format <digits><H|M|S|m|u|n>",
+            ))
+        })
+        .map(Some)
+}
+
 pub(crate) fn parse_grpc_timeout(raw: &str) -> Option<Duration> {
     if raw.len() < 2 {
         return None;
@@ -168,6 +183,7 @@ mod tests {
 
     use super::parse_grpc_timeout;
     use super::ProxyContext;
+    use crate::error::ProxyError;
     use crate::grpc::middleware::GrpcTransportContext;
 
     #[test]
@@ -194,8 +210,20 @@ mod tests {
             .metadata_mut()
             .insert("x-mq-client-id", "client-a".parse().expect("client id metadata"));
 
-        let context = ProxyContext::from_grpc_request("QueryRoute", &request);
+        let context = ProxyContext::from_grpc_request("QueryRoute", &request).expect("context should be constructed");
         assert_eq!(context.local_addr(), Some("127.0.0.1:8080"));
         assert_eq!(context.client_id(), Some("client-a"));
+    }
+
+    #[test]
+    fn proxy_context_rejects_invalid_grpc_timeout_metadata() {
+        let mut request = Request::new(());
+        request
+            .metadata_mut()
+            .insert("grpc-timeout", "bad-timeout".parse().expect("timeout metadata"));
+
+        let error = ProxyContext::from_grpc_request("QueryRoute", &request).expect_err("context should reject timeout");
+        assert!(matches!(error, ProxyError::InvalidMetadata { .. }));
+        assert!(error.to_string().contains("grpc-timeout"));
     }
 }

--- a/rocketmq-proxy/src/grpc/adapter.rs
+++ b/rocketmq-proxy/src/grpc/adapter.rs
@@ -1704,7 +1704,8 @@ mod tests {
 
     #[test]
     fn build_send_message_request_maps_fifo_properties() {
-        let context = ProxyContext::from_grpc_request("SendMessage", &tonic::Request::new(()));
+        let context = ProxyContext::from_grpc_request("SendMessage", &tonic::Request::new(()))
+            .expect("context should be constructed");
         let request = v2::SendMessageRequest {
             messages: vec![v2::Message {
                 topic: Some(v2::Resource {
@@ -1744,7 +1745,8 @@ mod tests {
 
     #[test]
     fn build_send_message_request_rejects_missing_message_id() {
-        let context = ProxyContext::from_grpc_request("SendMessage", &tonic::Request::new(()));
+        let context = ProxyContext::from_grpc_request("SendMessage", &tonic::Request::new(()))
+            .expect("context should be constructed");
         let request = v2::SendMessageRequest {
             messages: vec![v2::Message {
                 topic: Some(v2::Resource {

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -143,8 +143,8 @@ impl<P> ProxyGrpcService<P> {
         self
     }
 
-    fn context<T>(&self, rpc_name: &'static str, request: &Request<T>) -> ProxyContext {
-        ProxyContext::from_grpc_request(rpc_name, request)
+    fn context<T>(&self, rpc_name: &'static str, request: &Request<T>) -> Result<ProxyContext, Status> {
+        ProxyContext::from_grpc_request(rpc_name, request).map_err(|error| ProxyStatusMapper::to_tonic_status(&error))
     }
 
     fn status_stream<T>(&self, item: T) -> ResponseStream<T>
@@ -159,6 +159,67 @@ impl<P> ProxyGrpcService<P> {
         T: Send + 'static,
     {
         Box::pin(stream::iter(items.into_iter().map(Ok)))
+    }
+
+    fn unary_error_response<T>(
+        &self,
+        error: ProxyError,
+        payload_builder: impl FnOnce(v2::Status) -> T,
+    ) -> Result<Response<T>, Status> {
+        if ProxyStatusMapper::should_use_tonic_status(&error) {
+            Err(ProxyStatusMapper::to_tonic_status(&error))
+        } else {
+            Ok(Response::new(payload_builder(ProxyStatusMapper::from_error(&error))))
+        }
+    }
+
+    fn stream_error_response<T>(
+        &self,
+        error: ProxyError,
+        payload_builder: impl FnOnce(v2::Status) -> ResponseStream<T>,
+    ) -> Result<Response<ResponseStream<T>>, Status> {
+        if ProxyStatusMapper::should_use_tonic_status(&error) {
+            Err(ProxyStatusMapper::to_tonic_status(&error))
+        } else {
+            Ok(Response::new(payload_builder(ProxyStatusMapper::from_error(&error))))
+        }
+    }
+
+    async fn enter_unary<TRequest: 'static, TResponse>(
+        &self,
+        rpc_name: &'static str,
+        request: Request<TRequest>,
+        payload_builder: impl FnOnce(v2::Status) -> TResponse,
+    ) -> Result<(ProxyContext, Option<AuthenticatedPrincipal>, TRequest), Result<Response<TResponse>, Status>> {
+        self.reap_session_state_if_due();
+        let mut context = match self.context(rpc_name, &request) {
+            Ok(context) => context,
+            Err(status) => return Err(Err(status)),
+        };
+        let principal = match self.authenticate_request(&mut context, &request).await {
+            Ok(principal) => principal,
+            Err(error) => return Err(self.unary_error_response(error, payload_builder)),
+        };
+        Ok((context, principal, request.into_inner()))
+    }
+
+    async fn enter_stream<TRequest: 'static, TItem>(
+        &self,
+        rpc_name: &'static str,
+        request: Request<TRequest>,
+        payload_builder: impl FnOnce(v2::Status) -> ResponseStream<TItem>,
+    ) -> Result<(ProxyContext, Option<AuthenticatedPrincipal>, TRequest), Result<Response<ResponseStream<TItem>>, Status>>
+    {
+        self.reap_session_state_if_due();
+        let mut context = match self.context(rpc_name, &request) {
+            Ok(context) => context,
+            Err(status) => return Err(Err(status)),
+        };
+        let principal = match self.authenticate_request(&mut context, &request).await {
+            Ok(principal) => principal,
+            Err(error) => return Err(self.stream_error_response(error, payload_builder)),
+        };
+        Ok((context, principal, request.into_inner()))
     }
 
     async fn authenticate_request<T: 'static>(
@@ -838,17 +899,13 @@ where
         &self,
         request: Request<v2::QueryRouteRequest>,
     ) -> Result<Response<v2::QueryRouteResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("QueryRoute", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(adapter::error_query_route_response(
-                    ProxyStatusMapper::from_error(&error),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("QueryRoute", request, adapter::error_query_route_response)
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
 
         let response = match self
             .validate_client_context(&context)
@@ -877,17 +934,15 @@ where
         &self,
         request: Request<v2::HeartbeatRequest>,
     ) -> Result<Response<v2::HeartbeatResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("Heartbeat", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(v2::HeartbeatResponse {
-                    status: Some(ProxyStatusMapper::from_error(&error)),
-                }));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("Heartbeat", request, |status| v2::HeartbeatResponse {
+                status: Some(status),
+            })
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
 
         let status = match self.guards.try_client_manager() {
             Ok(_permit) => match self.validate_heartbeat_request(&context, request.client_type) {
@@ -914,17 +969,13 @@ where
         &self,
         request: Request<v2::SendMessageRequest>,
     ) -> Result<Response<v2::SendMessageResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("SendMessage", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(adapter::error_send_message_response(
-                    ProxyStatusMapper::from_error(&error),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("SendMessage", request, adapter::error_send_message_response)
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
 
         let response = match self
             .validate_client_context(&context)
@@ -956,17 +1007,13 @@ where
         &self,
         request: Request<v2::QueryAssignmentRequest>,
     ) -> Result<Response<v2::QueryAssignmentResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("QueryAssignment", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(adapter::error_query_assignment_response(
-                    ProxyStatusMapper::from_error(&error),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("QueryAssignment", request, adapter::error_query_assignment_response)
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
 
         let response = match self
             .validate_client_context(&context)
@@ -995,17 +1042,15 @@ where
         &self,
         request: Request<v2::ReceiveMessageRequest>,
     ) -> Result<Response<Self::ReceiveMessageStream>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("ReceiveMessage", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(self.items_stream(
-                    adapter::error_receive_message_responses(ProxyStatusMapper::from_error(&error)),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_stream("ReceiveMessage", request, |status| {
+                self.items_stream(adapter::error_receive_message_responses(status))
+            })
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
         let responses = match self
             .validate_client_context(&context)
             .and_then(|_| adapter::build_receive_message_request(&request))
@@ -1042,17 +1087,13 @@ where
         &self,
         request: Request<v2::AckMessageRequest>,
     ) -> Result<Response<v2::AckMessageResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("AckMessage", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(adapter::error_ack_message_response(
-                    ProxyStatusMapper::from_error(&error),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("AckMessage", request, adapter::error_ack_message_response)
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
 
         let response = match self
             .validate_client_context(&context)
@@ -1084,17 +1125,17 @@ where
         &self,
         request: Request<v2::ForwardMessageToDeadLetterQueueRequest>,
     ) -> Result<Response<v2::ForwardMessageToDeadLetterQueueResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("ForwardMessageToDeadLetterQueue", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(
-                    adapter::error_forward_message_to_dead_letter_queue_response(ProxyStatusMapper::from_error(&error)),
-                ));
-            }
+        let (context, principal, request) = match self
+            .enter_unary(
+                "ForwardMessageToDeadLetterQueue",
+                request,
+                adapter::error_forward_message_to_dead_letter_queue_response,
+            )
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
 
         let response = match self
             .validate_client_context(&context)
@@ -1139,17 +1180,15 @@ where
         &self,
         request: Request<v2::PullMessageRequest>,
     ) -> Result<Response<Self::PullMessageStream>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("PullMessage", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(self.items_stream(adapter::error_pull_message_responses(
-                    ProxyStatusMapper::from_error(&error),
-                ))));
-            }
+        let (context, principal, request) = match self
+            .enter_stream("PullMessage", request, |status| {
+                self.items_stream(adapter::error_pull_message_responses(status))
+            })
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
         let responses = match adapter::build_pull_message_request(&request) {
             Ok(input) => match self
                 .validate_client_context(&context)
@@ -1179,17 +1218,13 @@ where
         &self,
         request: Request<v2::UpdateOffsetRequest>,
     ) -> Result<Response<v2::UpdateOffsetResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("UpdateOffset", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(adapter::error_update_offset_response(
-                    ProxyStatusMapper::from_error(&error),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("UpdateOffset", request, adapter::error_update_offset_response)
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
         let response = match adapter::build_update_offset_request(&request) {
             Ok(input) => match self
                 .validate_client_context(&context)
@@ -1216,17 +1251,13 @@ where
         &self,
         request: Request<v2::GetOffsetRequest>,
     ) -> Result<Response<v2::GetOffsetResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("GetOffset", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(adapter::error_get_offset_response(
-                    ProxyStatusMapper::from_error(&error),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("GetOffset", request, adapter::error_get_offset_response)
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
         let response = match adapter::build_get_offset_request(&request) {
             Ok(input) => match self
                 .validate_client_context(&context)
@@ -1253,17 +1284,13 @@ where
         &self,
         request: Request<v2::QueryOffsetRequest>,
     ) -> Result<Response<v2::QueryOffsetResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("QueryOffset", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(adapter::error_query_offset_response(
-                    ProxyStatusMapper::from_error(&error),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("QueryOffset", request, adapter::error_query_offset_response)
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
         let response = match adapter::build_query_offset_request(&request) {
             Ok(input) => match self
                 .validate_client_context(&context)
@@ -1290,17 +1317,13 @@ where
         &self,
         request: Request<v2::EndTransactionRequest>,
     ) -> Result<Response<v2::EndTransactionResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("EndTransaction", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(adapter::error_end_transaction_response(
-                    ProxyStatusMapper::from_error(&error),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("EndTransaction", request, adapter::error_end_transaction_response)
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
 
         let response = match self
             .validate_client_context(&context)
@@ -1335,17 +1358,16 @@ where
         &self,
         request: Request<tonic::Streaming<v2::TelemetryCommand>>,
     ) -> Result<Response<Self::TelemetryStream>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("Telemetry", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(
-                    self.status_stream(Self::telemetry_status(ProxyStatusMapper::from_error(&error))),
-                ));
-            }
+        let (context, principal, inbound) = match self
+            .enter_stream("Telemetry", request, |status| {
+                self.status_stream(Self::telemetry_status(status))
+            })
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let mut inbound = request.into_inner();
+        let mut inbound = inbound;
         let permit = match self
             .validate_client_context(&context)
             .and_then(|_| self.guards.try_client_manager())
@@ -1412,17 +1434,15 @@ where
         &self,
         request: Request<v2::NotifyClientTerminationRequest>,
     ) -> Result<Response<v2::NotifyClientTerminationResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("NotifyClientTermination", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(v2::NotifyClientTerminationResponse {
-                    status: Some(ProxyStatusMapper::from_error(&error)),
-                }));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("NotifyClientTermination", request, |status| {
+                v2::NotifyClientTerminationResponse { status: Some(status) }
+            })
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
         let status = match self
             .guards
             .try_client_manager()
@@ -1454,17 +1474,17 @@ where
         &self,
         request: Request<v2::ChangeInvisibleDurationRequest>,
     ) -> Result<Response<v2::ChangeInvisibleDurationResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("ChangeInvisibleDuration", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(adapter::error_change_invisible_duration_response(
-                    ProxyStatusMapper::from_error(&error),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_unary(
+                "ChangeInvisibleDuration",
+                request,
+                adapter::error_change_invisible_duration_response,
+            )
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
 
         let response = match self
             .validate_client_context(&context)
@@ -1504,17 +1524,13 @@ where
         &self,
         request: Request<v2::RecallMessageRequest>,
     ) -> Result<Response<v2::RecallMessageResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("RecallMessage", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(adapter::error_recall_message_response(
-                    ProxyStatusMapper::from_error(&error),
-                )));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("RecallMessage", request, adapter::error_recall_message_response)
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
 
         let response = match self
             .validate_client_context(&context)
@@ -1543,17 +1559,15 @@ where
         &self,
         request: Request<v2::SyncLiteSubscriptionRequest>,
     ) -> Result<Response<v2::SyncLiteSubscriptionResponse>, Status> {
-        self.reap_session_state_if_due();
-        let mut context = self.context("SyncLiteSubscription", &request);
-        let principal = match self.authenticate_request(&mut context, &request).await {
-            Ok(principal) => principal,
-            Err(error) => {
-                return Ok(Response::new(v2::SyncLiteSubscriptionResponse {
-                    status: Some(ProxyStatusMapper::from_error(&error)),
-                }));
-            }
+        let (context, principal, request) = match self
+            .enter_unary("SyncLiteSubscription", request, |status| {
+                v2::SyncLiteSubscriptionResponse { status: Some(status) }
+            })
+            .await
+        {
+            Ok(state) => state,
+            Err(response) => return response,
         };
-        let request = request.into_inner();
 
         let status = match self.validate_client_context(&context).and_then(|client_id| {
             let _permit = self.guards.try_client_manager()?;
@@ -2136,6 +2150,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn query_route_rejects_invalid_grpc_timeout_as_transport_status() {
+        let route_service = StaticRouteService::default();
+        route_service.insert(ResourceIdentity::new("", "TopicA"), sample_route());
+        let service = test_service(route_service, StaticMetadataService::default());
+
+        let mut request = Request::new(v2::QueryRouteRequest {
+            topic: Some(v2::Resource {
+                resource_namespace: String::new(),
+                name: "TopicA".to_owned(),
+            }),
+            endpoints: Some(v2::Endpoints {
+                scheme: v2::AddressScheme::IPv4 as i32,
+                addresses: vec![v2::Address {
+                    host: "127.0.0.1".to_owned(),
+                    port: 8080,
+                }],
+            }),
+        });
+        request
+            .metadata_mut()
+            .insert("grpc-timeout", MetadataValue::from_static("bad-timeout"));
+
+        let status = service
+            .query_route(request)
+            .await
+            .expect_err("invalid timeout metadata should fail ingress");
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("grpc-timeout"));
+    }
+
+    #[tokio::test]
     async fn query_route_accepts_valid_grpc_authentication_headers() {
         let route_service = StaticRouteService::default();
         route_service.insert(ResourceIdentity::new("", "TopicA"), sample_route());
@@ -2208,7 +2253,9 @@ mod tests {
 
         let mut auth_request = Request::new(());
         apply_auth_headers(&mut auth_request, "client-a", "alice", "secret");
-        let mut context = service.context("Telemetry", &auth_request);
+        let mut context = service
+            .context("Telemetry", &auth_request)
+            .expect("context should be constructed");
         let principal = service
             .authenticate_request(&mut context, &auth_request)
             .await
@@ -2948,7 +2995,9 @@ mod tests {
         request
             .metadata_mut()
             .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
-        let context = service.context("ReceiveMessage", &request);
+        let context = service
+            .context("ReceiveMessage", &request)
+            .expect("context should be constructed");
 
         let merged = service.merged_telemetry_settings(&v2::Settings {
             client_type: Some(v2::ClientType::PushConsumer as i32),
@@ -3298,7 +3347,9 @@ mod tests {
         context_request
             .metadata_mut()
             .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
-        let context = service.context("Telemetry", &context_request);
+        let context = service
+            .context("Telemetry", &context_request)
+            .expect("context should be constructed");
         let _ = service.sessions.update_settings_from_telemetry(
             &context,
             &service.merged_telemetry_settings(&v2::Settings {
@@ -3363,7 +3414,9 @@ mod tests {
         context_request
             .metadata_mut()
             .insert("x-mq-client-id", MetadataValue::from_static("client-a"));
-        let context = service.context("Telemetry", &context_request);
+        let context = service
+            .context("Telemetry", &context_request)
+            .expect("context should be constructed");
         let _ = service.sessions.update_settings_from_telemetry(
             &context,
             &service.merged_telemetry_settings(&v2::Settings {

--- a/rocketmq-proxy/src/session.rs
+++ b/rocketmq-proxy/src/session.rs
@@ -926,7 +926,7 @@ mod tests {
             "x-mq-channel-id",
             tonic::metadata::MetadataValue::from_static("channel-a"),
         );
-        ProxyContext::from_grpc_request("Test", &request)
+        ProxyContext::from_grpc_request("Test", &request).expect("context should be constructed")
     }
 
     fn tracked_handle(client_id: &str, message_id: &str, receipt_handle: &str) -> ReceiptHandleRegistration {

--- a/rocketmq-proxy/src/status.rs
+++ b/rocketmq-proxy/src/status.rs
@@ -61,6 +61,10 @@ impl From<ProxyPayloadStatus> for v2::Status {
 pub struct ProxyStatusMapper;
 
 impl ProxyStatusMapper {
+    pub fn should_use_tonic_status(error: &ProxyError) -> bool {
+        matches!(error, ProxyError::InvalidMetadata { .. } | ProxyError::Transport { .. })
+    }
+
     pub fn ok_payload() -> ProxyPayloadStatus {
         Self::from_payload_code(v2::Code::Ok, "OK")
     }
@@ -122,6 +126,16 @@ impl ProxyStatusMapper {
     }
 
     pub fn to_tonic_status(error: &ProxyError) -> TonicStatus {
+        match error {
+            ProxyError::InvalidMetadata { message } => {
+                return TonicStatus::new(TonicCode::InvalidArgument, message.clone());
+            }
+            ProxyError::Transport { message } => {
+                return TonicStatus::new(TonicCode::Unavailable, message.clone());
+            }
+            _ => {}
+        }
+
         let payload = Self::from_error(error);
         let tonic_code = match v2::Code::try_from(payload.code).unwrap_or(v2::Code::InternalError) {
             v2::Code::BadRequest
@@ -216,5 +230,27 @@ mod tests {
     fn route_not_found_maps_to_topic_not_found() {
         let status = ProxyStatusMapper::from_error(&ProxyError::RocketMQ(RocketMQError::route_not_found("TestTopic")));
         assert_eq!(status.code, v2::Code::TopicNotFound as i32);
+    }
+
+    #[test]
+    fn invalid_metadata_prefers_tonic_status() {
+        let error = ProxyError::invalid_metadata("grpc-timeout must be valid");
+        assert!(ProxyStatusMapper::should_use_tonic_status(&error));
+        assert_eq!(
+            ProxyStatusMapper::to_tonic_status(&error).code(),
+            tonic::Code::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn transport_error_maps_to_unavailable_tonic_status() {
+        let error = ProxyError::Transport {
+            message: "cluster worker unavailable".to_owned(),
+        };
+        assert!(ProxyStatusMapper::should_use_tonic_status(&error));
+        assert_eq!(
+            ProxyStatusMapper::to_tonic_status(&error).code(),
+            tonic::Code::Unavailable
+        );
     }
 }

--- a/rocketmq-proxy/tests/grpc_ingress.rs
+++ b/rocketmq-proxy/tests/grpc_ingress.rs
@@ -1,0 +1,285 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rocketmq_proxy::context::ProxyContext;
+use rocketmq_proxy::context::ResolvedEndpoint;
+use rocketmq_proxy::proto::v2;
+use rocketmq_proxy::proto::v2::messaging_service_client::MessagingServiceClient;
+use rocketmq_proxy::ClusterServiceManager;
+use rocketmq_proxy::DefaultAssignmentService;
+use rocketmq_proxy::DefaultConsumerService;
+use rocketmq_proxy::DefaultMessageService;
+use rocketmq_proxy::DefaultTransactionService;
+use rocketmq_proxy::GrpcConfig;
+use rocketmq_proxy::MetadataService;
+use rocketmq_proxy::ProxyConfig;
+use rocketmq_proxy::ProxyResult;
+use rocketmq_proxy::ProxyRuntime;
+use rocketmq_proxy::ProxyTopicMessageType;
+use rocketmq_proxy::ResourceIdentity;
+use rocketmq_proxy::RouteService;
+use rocketmq_proxy::StaticMetadataService;
+use rocketmq_proxy::StaticRouteService;
+use rocketmq_proxy::SubscriptionGroupMetadata;
+use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use tokio::sync::oneshot;
+use tonic::metadata::MetadataValue;
+use tonic::Request;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ObservedRouteContext {
+    local_addr: Option<String>,
+    remote_addr: Option<String>,
+}
+
+#[derive(Default)]
+struct RecordingRouteService {
+    observed: Mutex<Vec<ObservedRouteContext>>,
+}
+
+impl RecordingRouteService {
+    fn observed(&self) -> Vec<ObservedRouteContext> {
+        self.observed.lock().expect("route service mutex poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl RouteService for RecordingRouteService {
+    async fn query_route(
+        &self,
+        context: &ProxyContext,
+        _topic: &ResourceIdentity,
+        _endpoints: &[ResolvedEndpoint],
+    ) -> ProxyResult<TopicRouteData> {
+        self.observed
+            .lock()
+            .expect("route service mutex poisoned")
+            .push(ObservedRouteContext {
+                local_addr: context.local_addr().map(str::to_owned),
+                remote_addr: context.remote_addr().map(str::to_owned),
+            });
+        Ok(TopicRouteData::default())
+    }
+}
+
+#[derive(Default)]
+struct NormalMetadataService;
+
+#[async_trait]
+impl MetadataService for NormalMetadataService {
+    async fn topic_message_type(
+        &self,
+        _context: &ProxyContext,
+        _topic: &ResourceIdentity,
+    ) -> ProxyResult<ProxyTopicMessageType> {
+        Ok(ProxyTopicMessageType::Normal)
+    }
+
+    async fn subscription_group(
+        &self,
+        _context: &ProxyContext,
+        _topic: &ResourceIdentity,
+        _group: &ResourceIdentity,
+    ) -> ProxyResult<Option<SubscriptionGroupMetadata>> {
+        Ok(None)
+    }
+}
+
+#[tokio::test]
+async fn query_route_integration_injects_transport_context() {
+    let route_service = Arc::new(RecordingRouteService::default());
+    let (listen_addr, shutdown_tx, server_task) = spawn_runtime(Arc::new(ClusterServiceManager::with_services(
+        route_service.clone(),
+        Arc::new(NormalMetadataService),
+        Arc::new(DefaultAssignmentService),
+        Arc::new(DefaultMessageService),
+        Arc::new(DefaultConsumerService),
+        Arc::new(DefaultTransactionService),
+    )))
+    .await;
+    let mut client = connect_with_retry(listen_addr).await;
+
+    let response = client
+        .query_route(route_request("TopicA"))
+        .await
+        .expect("query route should succeed")
+        .into_inner();
+    assert_eq!(
+        response.status.as_ref().map(|status| status.code),
+        Some(v2::Code::Ok as i32)
+    );
+
+    let _ = shutdown_tx.send(());
+    let serve_result = server_task.await.expect("server task should join");
+    assert!(
+        serve_result.is_ok(),
+        "server should shut down cleanly: {serve_result:?}"
+    );
+
+    let observed = route_service.observed();
+    let expected_local_addr = listen_addr.to_string();
+    assert_eq!(observed.len(), 1);
+    assert_eq!(observed[0].local_addr.as_deref(), Some(expected_local_addr.as_str()));
+    assert!(
+        observed[0]
+            .remote_addr
+            .as_deref()
+            .is_some_and(|remote| remote.starts_with("127.0.0.1:")),
+        "expected remote address to be recorded, got {:?}",
+        observed[0].remote_addr
+    );
+}
+
+#[tokio::test]
+async fn query_route_integration_rejects_invalid_grpc_timeout_before_business_logic() {
+    let route_service = Arc::new(RecordingRouteService::default());
+    let (listen_addr, shutdown_tx, server_task) = spawn_runtime(Arc::new(ClusterServiceManager::with_services(
+        route_service.clone(),
+        Arc::new(NormalMetadataService),
+        Arc::new(DefaultAssignmentService),
+        Arc::new(DefaultMessageService),
+        Arc::new(DefaultConsumerService),
+        Arc::new(DefaultTransactionService),
+    )))
+    .await;
+    let mut client = connect_with_retry(listen_addr).await;
+
+    let mut request = route_request("TopicA");
+    request
+        .metadata_mut()
+        .insert("grpc-timeout", MetadataValue::from_static("bad-timeout"));
+    let error = client
+        .query_route(request)
+        .await
+        .expect_err("invalid timeout metadata should fail ingress");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(error.message().contains("grpc-timeout"));
+
+    let _ = shutdown_tx.send(());
+    let serve_result = server_task.await.expect("server task should join");
+    assert!(
+        serve_result.is_ok(),
+        "server should shut down cleanly: {serve_result:?}"
+    );
+
+    assert!(
+        route_service.observed().is_empty(),
+        "business route service should not run when ingress metadata is invalid",
+    );
+}
+
+#[tokio::test]
+async fn query_route_integration_keeps_topic_not_found_as_payload_status() {
+    let (listen_addr, shutdown_tx, server_task) = spawn_runtime(Arc::new(ClusterServiceManager::with_services(
+        Arc::new(StaticRouteService::default()),
+        Arc::new(StaticMetadataService::default()),
+        Arc::new(DefaultAssignmentService),
+        Arc::new(DefaultMessageService),
+        Arc::new(DefaultConsumerService),
+        Arc::new(DefaultTransactionService),
+    )))
+    .await;
+    let mut client = connect_with_retry(listen_addr).await;
+
+    let response = client
+        .query_route(route_request("MissingTopic"))
+        .await
+        .expect("business route failures should stay in payload")
+        .into_inner();
+    assert_eq!(
+        response.status.as_ref().map(|status| status.code),
+        Some(v2::Code::TopicNotFound as i32)
+    );
+
+    let _ = shutdown_tx.send(());
+    let serve_result = server_task.await.expect("server task should join");
+    assert!(
+        serve_result.is_ok(),
+        "server should shut down cleanly: {serve_result:?}"
+    );
+}
+
+async fn spawn_runtime(
+    service_manager: Arc<dyn rocketmq_proxy::ServiceManager>,
+) -> (
+    SocketAddr,
+    oneshot::Sender<()>,
+    tokio::task::JoinHandle<rocketmq_proxy::ProxyResult<()>>,
+) {
+    let port_probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local port probe");
+    let listen_addr = port_probe.local_addr().expect("discover local addr");
+    drop(port_probe);
+
+    let runtime = ProxyRuntime::builder(ProxyConfig {
+        grpc: GrpcConfig {
+            listen_addr: listen_addr.to_string(),
+            ..GrpcConfig::default()
+        },
+        ..ProxyConfig::default()
+    })
+    .with_service_manager(service_manager)
+    .build();
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        runtime
+            .serve_with_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+
+    (listen_addr, shutdown_tx, server_task)
+}
+
+async fn connect_with_retry(addr: SocketAddr) -> MessagingServiceClient<tonic::transport::Channel> {
+    let endpoint = format!("http://{addr}");
+    let mut last_error = None;
+    for _ in 0..20 {
+        match MessagingServiceClient::connect(endpoint.clone()).await {
+            Ok(client) => return client,
+            Err(error) => {
+                last_error = Some(error);
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        }
+    }
+    panic!("gRPC client failed to connect to {endpoint}: {last_error:?}");
+}
+
+fn route_request(topic: &str) -> Request<v2::QueryRouteRequest> {
+    let mut request = Request::new(v2::QueryRouteRequest {
+        topic: Some(v2::Resource {
+            resource_namespace: String::new(),
+            name: topic.to_owned(),
+        }),
+        endpoints: Some(v2::Endpoints {
+            scheme: v2::AddressScheme::IPv4 as i32,
+            addresses: vec![v2::Address {
+                host: "127.0.0.1".to_owned(),
+                port: 8081,
+            }],
+        }),
+    });
+    request
+        .metadata_mut()
+        .insert("x-mq-client-id", MetadataValue::from_static("integration-client"));
+    request
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6842

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid `grpc-timeout` metadata in requests is now properly rejected with a clear error message instead of being silently ignored.
  * Improved robustness of request validation for malformed gRPC metadata.

* **Tests**
  * Added integration tests for gRPC ingress handling to verify metadata validation and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->