### PR TITLE
[ISSUE #6849]🚀Enhance PullMessagePlan with min and max offset support, implement local consumer service for message handling

### DIFF
--- a/rocketmq-proxy/src/cluster.rs
+++ b/rocketmq-proxy/src/cluster.rs
@@ -1822,10 +1822,14 @@ fn build_receive_plan(pop_result: PopResult) -> ReceiveMessagePlan {
 
 fn build_pull_plan(pull_result: rocketmq_client_rust::consumer::pull_result::PullResult) -> PullMessagePlan {
     let next_offset = pull_result.next_begin_offset() as i64;
+    let min_offset = pull_result.min_offset() as i64;
+    let max_offset = pull_result.max_offset() as i64;
     match pull_result.pull_status() {
         PullStatus::Found => PullMessagePlan {
             status: ProxyStatusMapper::ok_payload(),
             next_offset,
+            min_offset,
+            max_offset,
             messages: pull_result
                 .msg_found_list()
                 .cloned()
@@ -1837,11 +1841,15 @@ fn build_pull_plan(pull_result: rocketmq_client_rust::consumer::pull_result::Pul
         PullStatus::NoNewMsg | PullStatus::NoMatchedMsg => PullMessagePlan {
             status: ProxyStatusMapper::from_payload_code(v2::Code::MessageNotFound, "no message available"),
             next_offset,
+            min_offset,
+            max_offset,
             messages: Vec::new(),
         },
         PullStatus::OffsetIllegal => PullMessagePlan {
             status: ProxyStatusMapper::from_payload_code(v2::Code::IllegalOffset, "pull offset is illegal"),
             next_offset,
+            min_offset,
+            max_offset,
             messages: Vec::new(),
         },
     }

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -2105,6 +2105,8 @@ mod tests {
             Ok(PullMessagePlan {
                 status: ProxyStatusMapper::ok_payload(),
                 next_offset: request.offset + 1,
+                min_offset: 0,
+                max_offset: request.offset + 1024,
                 messages: vec![message],
             })
         }

--- a/rocketmq-proxy/src/local.rs
+++ b/rocketmq-proxy/src/local.rs
@@ -12,8 +12,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use cheetah_string::CheetahString;
@@ -21,13 +23,18 @@ use rocketmq_broker::ProxyBrokerFacade;
 use rocketmq_client_rust::producer::send_result::SendResult;
 use rocketmq_client_rust::producer::send_status::SendStatus;
 use rocketmq_common::common::attribute::topic_message_type::TopicMessageType;
+use rocketmq_common::common::boundary_type::BoundaryType;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_common::common::filter::expression_type::ExpressionType;
+use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_queue_assignment::MessageQueueAssignment;
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::common::mix_all;
 use rocketmq_common::common::sys_flag::message_sys_flag::MessageSysFlag;
+use rocketmq_common::common::sys_flag::pull_sys_flag::PullSysFlag;
 use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::MessageDecoder;
 use rocketmq_common::TimeUtils::current_millis;
@@ -37,11 +44,30 @@ use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::prelude::RemotingDeserializable;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
+use rocketmq_remoting::protocol::header::ack_message_request_header::AckMessageRequestHeader;
+use rocketmq_remoting::protocol::header::change_invisible_time_request_header::ChangeInvisibleTimeRequestHeader;
+use rocketmq_remoting::protocol::header::change_invisible_time_response_header::ChangeInvisibleTimeResponseHeader;
+use rocketmq_remoting::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
 use rocketmq_remoting::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
+use rocketmq_remoting::protocol::header::extra_info_util::ExtraInfoUtil;
+use rocketmq_remoting::protocol::header::get_max_offset_request_header::GetMaxOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
+use rocketmq_remoting::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::get_min_offset_response_header::GetMinOffsetResponseHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+use rocketmq_remoting::protocol::header::namesrv::topic_operation_header::TopicRequestHeader as OperationTopicRequestHeader;
+use rocketmq_remoting::protocol::header::pop_message_request_header::PopMessageRequestHeader;
+use rocketmq_remoting::protocol::header::pop_message_response_header::PopMessageResponseHeader;
+use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_remoting::protocol::header::pull_message_response_header::PullMessageResponseHeader;
+use rocketmq_remoting::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::query_consumer_offset_response_header::QueryConsumerOffsetResponseHeader;
 use rocketmq_remoting::protocol::header::recall_message_request_header::RecallMessageRequestHeader;
 use rocketmq_remoting::protocol::header::recall_message_response_header::RecallMessageResponseHeader;
+use rocketmq_remoting::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
+use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
 use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
@@ -58,17 +84,35 @@ use crate::context::ProxyContext;
 use crate::context::ResolvedEndpoint;
 use crate::error::ProxyError;
 use crate::error::ProxyResult;
+use crate::processor::AckMessageRequest;
+use crate::processor::AckMessageResultEntry;
+use crate::processor::ChangeInvisibleDurationPlan;
+use crate::processor::ChangeInvisibleDurationRequest;
 use crate::processor::EndTransactionPlan;
 use crate::processor::EndTransactionRequest;
+use crate::processor::ForwardMessageToDeadLetterQueuePlan;
+use crate::processor::ForwardMessageToDeadLetterQueueRequest;
+use crate::processor::GetOffsetPlan;
+use crate::processor::GetOffsetRequest;
+use crate::processor::PullMessagePlan;
+use crate::processor::PullMessageRequest;
+use crate::processor::QueryOffsetPlan;
+use crate::processor::QueryOffsetPolicy;
+use crate::processor::QueryOffsetRequest;
 use crate::processor::RecallMessagePlan;
 use crate::processor::RecallMessageRequest;
+use crate::processor::ReceiveMessagePlan;
+use crate::processor::ReceiveMessageRequest;
+use crate::processor::ReceivedMessage;
 use crate::processor::SendMessageEntry;
 use crate::processor::SendMessageRequest;
 use crate::processor::SendMessageResultEntry;
 use crate::processor::TransactionResolution;
 use crate::processor::TransactionSource;
+use crate::processor::UpdateOffsetPlan;
+use crate::processor::UpdateOffsetRequest;
 use crate::service::AssignmentService;
-use crate::service::DefaultConsumerService;
+use crate::service::ConsumerService;
 use crate::service::LocalServiceManager;
 use crate::service::MessageService;
 use crate::service::MetadataService;
@@ -82,6 +126,7 @@ use crate::status::ProxyStatusMapper;
 #[derive(Clone)]
 pub struct LocalBrokerFacadeClient {
     sender: mpsc::UnboundedSender<LocalBrokerCommand>,
+    broker_name: String,
 }
 
 enum LocalBrokerCommand {
@@ -131,6 +176,7 @@ enum LocalBrokerCommand {
 impl LocalBrokerFacadeClient {
     pub fn new(config: LocalConfig) -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
+        let broker_name = config.broker_name.clone();
         let thread_name = format!(
             "rocketmq-proxy-local-{}",
             sanitize_thread_component(&config.broker_name)
@@ -139,7 +185,11 @@ impl LocalBrokerFacadeClient {
             .name(thread_name)
             .spawn(move || run_local_broker_worker(config, receiver))
             .expect("failed to spawn proxy local broker worker");
-        Self { sender }
+        Self { sender, broker_name }
+    }
+
+    pub fn broker_name(&self) -> &str {
+        self.broker_name.as_str()
     }
 
     pub async fn query_route(&self, topic: ResourceIdentity) -> ProxyResult<TopicRouteData> {
@@ -403,6 +453,80 @@ impl TransactionService for LocalTransactionService {
     }
 }
 
+#[derive(Clone)]
+pub struct LocalConsumerService {
+    client: LocalBrokerFacadeClient,
+}
+
+impl LocalConsumerService {
+    pub fn new(client: LocalBrokerFacadeClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl ConsumerService for LocalConsumerService {
+    async fn receive_message(
+        &self,
+        _context: &ProxyContext,
+        request: &ReceiveMessageRequest,
+    ) -> ProxyResult<ReceiveMessagePlan> {
+        receive_message_via_broker(&self.client, request).await
+    }
+
+    async fn pull_message(
+        &self,
+        _context: &ProxyContext,
+        request: &PullMessageRequest,
+    ) -> ProxyResult<PullMessagePlan> {
+        pull_message_via_broker(&self.client, request).await
+    }
+
+    async fn ack_message(
+        &self,
+        _context: &ProxyContext,
+        request: &AckMessageRequest,
+    ) -> ProxyResult<Vec<AckMessageResultEntry>> {
+        ack_message_via_broker(&self.client, request).await
+    }
+
+    async fn forward_message_to_dead_letter_queue(
+        &self,
+        _context: &ProxyContext,
+        request: &ForwardMessageToDeadLetterQueueRequest,
+    ) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
+        forward_message_to_dead_letter_queue_via_broker(&self.client, request).await
+    }
+
+    async fn change_invisible_duration(
+        &self,
+        _context: &ProxyContext,
+        request: &ChangeInvisibleDurationRequest,
+    ) -> ProxyResult<ChangeInvisibleDurationPlan> {
+        change_invisible_duration_via_broker(&self.client, request).await
+    }
+
+    async fn update_offset(
+        &self,
+        _context: &ProxyContext,
+        request: &UpdateOffsetRequest,
+    ) -> ProxyResult<UpdateOffsetPlan> {
+        update_offset_via_broker(&self.client, request).await
+    }
+
+    async fn get_offset(&self, _context: &ProxyContext, request: &GetOffsetRequest) -> ProxyResult<GetOffsetPlan> {
+        get_offset_via_broker(&self.client, request).await
+    }
+
+    async fn query_offset(
+        &self,
+        _context: &ProxyContext,
+        request: &QueryOffsetRequest,
+    ) -> ProxyResult<QueryOffsetPlan> {
+        query_offset_via_broker(&self.client, request).await
+    }
+}
+
 pub fn local_service_manager_from_config(config: LocalConfig, strategy_name: impl Into<String>) -> LocalServiceManager {
     let client = LocalBrokerFacadeClient::new(config);
     LocalServiceManager::with_services(
@@ -410,7 +534,7 @@ pub fn local_service_manager_from_config(config: LocalConfig, strategy_name: imp
         std::sync::Arc::new(LocalMetadataService::new(client.clone())),
         std::sync::Arc::new(LocalAssignmentService::new(client.clone(), strategy_name)),
         std::sync::Arc::new(LocalMessageService::new(client.clone())),
-        std::sync::Arc::new(DefaultConsumerService),
+        std::sync::Arc::new(LocalConsumerService::new(client.clone())),
         std::sync::Arc::new(LocalTransactionService::new(client)),
     )
 }
@@ -708,6 +832,337 @@ async fn end_transaction(
     })
 }
 
+async fn receive_message_via_broker(
+    client: &LocalBrokerFacadeClient,
+    request: &ReceiveMessageRequest,
+) -> ProxyResult<ReceiveMessagePlan> {
+    let header = build_pop_request_header(client.broker_name(), request);
+    let response = client
+        .process_remoting(RemotingCommand::create_request_command(RequestCode::PopMessage, header))
+        .await?;
+    process_pop_response(
+        response,
+        client.broker_name(),
+        request.target.topic.to_string().as_str(),
+        request.target.fifo,
+    )
+}
+
+async fn pull_message_via_broker(
+    client: &LocalBrokerFacadeClient,
+    request: &PullMessageRequest,
+) -> ProxyResult<PullMessagePlan> {
+    let header = build_pull_request_header(client.broker_name(), request);
+    let response = client
+        .process_remoting(RemotingCommand::create_request_command(
+            RequestCode::PullMessage,
+            header,
+        ))
+        .await?;
+    process_pull_response(response)
+}
+
+async fn ack_message_via_broker(
+    client: &LocalBrokerFacadeClient,
+    request: &AckMessageRequest,
+) -> ProxyResult<Vec<AckMessageResultEntry>> {
+    let mut results = Vec::with_capacity(request.entries.len());
+    for entry in &request.entries {
+        let status = match ack_message_entry_via_broker(client, request, entry).await {
+            Ok(status) => status,
+            Err(error) => ProxyStatusMapper::from_error_payload(&error),
+        };
+        results.push(AckMessageResultEntry {
+            message_id: entry.message_id.clone(),
+            receipt_handle: entry.receipt_handle.clone(),
+            status,
+        });
+    }
+    Ok(results)
+}
+
+async fn ack_message_entry_via_broker(
+    client: &LocalBrokerFacadeClient,
+    request: &AckMessageRequest,
+    entry: &crate::processor::AckMessageEntry,
+) -> ProxyResult<crate::status::ProxyPayloadStatus> {
+    let topic_name = entry.lite_topic.clone().unwrap_or_else(|| request.topic.to_string());
+    let group_name = request.group.to_string();
+    let parsed = parse_receipt_handle(entry.receipt_handle.as_str(), topic_name.as_str(), group_name.as_str())?;
+    let header = AckMessageRequestHeader {
+        consumer_group: CheetahString::from(group_name),
+        topic: parsed.topic.clone(),
+        queue_id: parsed.queue_id,
+        extra_info: parsed.raw.clone(),
+        offset: parsed.queue_offset,
+        topic_request_header: Some(TopicRequestHeader {
+            rpc_request_header: Some(RpcRequestHeader {
+                broker_name: Some(parsed.broker_name.clone()),
+                ..Default::default()
+            }),
+            lo: None,
+        }),
+    };
+    let response = client
+        .process_remoting(RemotingCommand::create_request_command(RequestCode::AckMessage, header))
+        .await?;
+
+    Ok(if ResponseCode::from(response.code()) == ResponseCode::Success {
+        ProxyStatusMapper::ok_payload()
+    } else {
+        ProxyStatusMapper::from_payload_code(
+            crate::proto::v2::Code::InvalidReceiptHandle,
+            "receipt handle has expired or message no longer exists",
+        )
+    })
+}
+
+async fn forward_message_to_dead_letter_queue_via_broker(
+    client: &LocalBrokerFacadeClient,
+    request: &ForwardMessageToDeadLetterQueueRequest,
+) -> ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
+    let topic_name = request.lite_topic.clone().unwrap_or_else(|| request.topic.to_string());
+    let parsed = parse_receipt_handle(
+        request.receipt_handle.as_str(),
+        topic_name.as_str(),
+        request.group.to_string().as_str(),
+    )?;
+    let broker_message_id = decode_broker_message_id(request.message_id.as_str())?;
+    let header = ConsumerSendMsgBackRequestHeader {
+        offset: broker_message_id.offset,
+        group: CheetahString::from(request.group.to_string()),
+        delay_level: -1,
+        origin_msg_id: Some(CheetahString::from(request.message_id.as_str())),
+        origin_topic: Some(parsed.topic),
+        unit_mode: false,
+        max_reconsume_times: Some(request.max_delivery_attempts),
+        rpc_request_header: Some(RpcRequestHeader {
+            broker_name: Some(parsed.broker_name),
+            ..Default::default()
+        }),
+    };
+    let response = client
+        .process_remoting(RemotingCommand::create_request_command(
+            RequestCode::ConsumerSendMsgBack,
+            header,
+        ))
+        .await?;
+    if ResponseCode::from(response.code()) != ResponseCode::Success {
+        return Err(broker_operation_error("forwardMessageToDeadLetterQueue", &response).into());
+    }
+
+    Ok(ForwardMessageToDeadLetterQueuePlan {
+        status: ProxyStatusMapper::ok_payload(),
+    })
+}
+
+async fn change_invisible_duration_via_broker(
+    client: &LocalBrokerFacadeClient,
+    request: &ChangeInvisibleDurationRequest,
+) -> ProxyResult<ChangeInvisibleDurationPlan> {
+    let topic_name = request.lite_topic.clone().unwrap_or_else(|| request.topic.to_string());
+    let parsed = parse_receipt_handle(
+        request.receipt_handle.as_str(),
+        topic_name.as_str(),
+        request.group.to_string().as_str(),
+    )?;
+    let header = ChangeInvisibleTimeRequestHeader {
+        consumer_group: CheetahString::from(request.group.to_string()),
+        topic: parsed.topic.clone(),
+        queue_id: parsed.queue_id,
+        extra_info: parsed.raw.clone(),
+        offset: parsed.queue_offset,
+        invisible_time: request.invisible_duration.as_millis().clamp(1, i64::MAX as u128) as i64,
+        topic_request_header: Some(TopicRequestHeader {
+            rpc_request_header: Some(RpcRequestHeader {
+                broker_name: Some(parsed.broker_name.clone()),
+                ..Default::default()
+            }),
+            lo: None,
+        }),
+    };
+    let response = client
+        .process_remoting(RemotingCommand::create_request_command(
+            RequestCode::ChangeMessageInvisibleTime,
+            header,
+        ))
+        .await?;
+    if ResponseCode::from(response.code()) != ResponseCode::Success {
+        return Ok(ChangeInvisibleDurationPlan {
+            status: ProxyStatusMapper::from_payload_code(
+                crate::proto::v2::Code::InvalidReceiptHandle,
+                "receipt handle has expired or message no longer exists",
+            ),
+            receipt_handle: String::new(),
+        });
+    }
+
+    let response_header = response
+        .decode_command_custom_header::<ChangeInvisibleTimeResponseHeader>()
+        .map_err(|error| ProxyError::Transport {
+            message: format!("failed to decode local changeInvisibleDuration response header: {error}"),
+        })?;
+    Ok(ChangeInvisibleDurationPlan {
+        status: ProxyStatusMapper::ok_payload(),
+        receipt_handle: format!(
+            "{}{}{}",
+            ExtraInfoUtil::build_extra_info(
+                parsed.queue_offset,
+                response_header.pop_time as i64,
+                response_header.invisible_time,
+                response_header.revive_qid as i32,
+                parsed.topic.as_str(),
+                &parsed.broker_name,
+                parsed.queue_id,
+            ),
+            MessageConst::KEY_SEPARATOR,
+            parsed.queue_offset
+        ),
+    })
+}
+
+async fn update_offset_via_broker(
+    client: &LocalBrokerFacadeClient,
+    request: &UpdateOffsetRequest,
+) -> ProxyResult<UpdateOffsetPlan> {
+    let header = build_update_offset_request_header(client.broker_name(), request);
+    let response = client
+        .process_remoting(RemotingCommand::create_request_command(
+            RequestCode::UpdateConsumerOffset,
+            header,
+        ))
+        .await?;
+    if ResponseCode::from(response.code()) != ResponseCode::Success {
+        return Err(broker_operation_error("updateOffset", &response).into());
+    }
+
+    Ok(UpdateOffsetPlan {
+        status: ProxyStatusMapper::ok_payload(),
+    })
+}
+
+async fn get_offset_via_broker(
+    client: &LocalBrokerFacadeClient,
+    request: &GetOffsetRequest,
+) -> ProxyResult<GetOffsetPlan> {
+    let header = build_query_consumer_offset_request_header(client.broker_name(), request);
+    let response = client
+        .process_remoting(RemotingCommand::create_request_command(
+            RequestCode::QueryConsumerOffset,
+            header,
+        ))
+        .await?;
+    if ResponseCode::from(response.code()) != ResponseCode::Success {
+        return Err(broker_operation_error("getOffset", &response).into());
+    }
+
+    let response_header = response
+        .decode_command_custom_header::<QueryConsumerOffsetResponseHeader>()
+        .map_err(|error| ProxyError::Transport {
+            message: format!("failed to decode local getOffset response header: {error}"),
+        })?;
+    Ok(GetOffsetPlan {
+        status: ProxyStatusMapper::ok_payload(),
+        offset: response_header.offset.unwrap_or_default(),
+    })
+}
+
+async fn query_offset_via_broker(
+    client: &LocalBrokerFacadeClient,
+    request: &QueryOffsetRequest,
+) -> ProxyResult<QueryOffsetPlan> {
+    let broker_name = CheetahString::from(client.broker_name());
+    let (request_code, command) = match request.policy {
+        QueryOffsetPolicy::Beginning => {
+            let header = GetMinOffsetRequestHeader {
+                topic: CheetahString::from(request.target.topic.to_string()),
+                queue_id: request.target.queue_id,
+                topic_request_header: Some(TopicRequestHeader {
+                    rpc_request_header: Some(RpcRequestHeader {
+                        broker_name: Some(broker_name.clone()),
+                        ..Default::default()
+                    }),
+                    lo: None,
+                }),
+            };
+            (
+                RequestCode::GetMinOffset,
+                RemotingCommand::create_request_command(RequestCode::GetMinOffset, header),
+            )
+        }
+        QueryOffsetPolicy::End => {
+            let header = GetMaxOffsetRequestHeader {
+                topic: CheetahString::from(request.target.topic.to_string()),
+                queue_id: request.target.queue_id,
+                committed: false,
+                topic_request_header: Some(TopicRequestHeader {
+                    rpc_request_header: Some(RpcRequestHeader {
+                        broker_name: Some(broker_name.clone()),
+                        ..Default::default()
+                    }),
+                    lo: None,
+                }),
+            };
+            (
+                RequestCode::GetMaxOffset,
+                RemotingCommand::create_request_command(RequestCode::GetMaxOffset, header),
+            )
+        }
+        QueryOffsetPolicy::Timestamp => {
+            let header = SearchOffsetRequestHeader {
+                topic: CheetahString::from(request.target.topic.to_string()),
+                queue_id: request.target.queue_id,
+                timestamp: request
+                    .timestamp_ms
+                    .ok_or_else(|| ProxyError::illegal_offset("timestamp policy requires timestamp to be present"))?,
+                boundary_type: BoundaryType::Lower,
+                topic_request_header: Some(TopicRequestHeader {
+                    rpc_request_header: Some(RpcRequestHeader {
+                        broker_name: Some(broker_name),
+                        ..Default::default()
+                    }),
+                    lo: None,
+                }),
+            };
+            (
+                RequestCode::SearchOffsetByTimestamp,
+                RemotingCommand::create_request_command(RequestCode::SearchOffsetByTimestamp, header),
+            )
+        }
+    };
+    let response = client.process_remoting(command).await?;
+    if ResponseCode::from(response.code()) != ResponseCode::Success {
+        return Err(broker_operation_error("queryOffset", &response).into());
+    }
+
+    let offset = match request_code {
+        RequestCode::GetMinOffset => response
+            .decode_command_custom_header::<GetMinOffsetResponseHeader>()
+            .map(|header| header.offset)
+            .map_err(|error| ProxyError::Transport {
+                message: format!("failed to decode local min offset response header: {error}"),
+            })?,
+        RequestCode::GetMaxOffset => response
+            .decode_command_custom_header::<GetMaxOffsetResponseHeader>()
+            .map(|header| header.offset)
+            .map_err(|error| ProxyError::Transport {
+                message: format!("failed to decode local max offset response header: {error}"),
+            })?,
+        RequestCode::SearchOffsetByTimestamp => response
+            .decode_command_custom_header::<SearchOffsetResponseHeader>()
+            .map(|header| header.offset)
+            .map_err(|error| ProxyError::Transport {
+                message: format!("failed to decode local search offset response header: {error}"),
+            })?,
+        _ => unreachable!("query offset uses only min/max/search request codes"),
+    };
+
+    Ok(QueryOffsetPlan {
+        status: ProxyStatusMapper::ok_payload(),
+        offset,
+    })
+}
+
 fn build_send_message_request(
     broker_name: &CheetahString,
     producer_group: &str,
@@ -748,6 +1203,99 @@ fn build_send_message_request(
     Ok(command)
 }
 
+fn build_pop_request_header(broker_name: &str, request: &ReceiveMessageRequest) -> PopMessageRequestHeader {
+    PopMessageRequestHeader {
+        consumer_group: CheetahString::from(request.group.to_string()),
+        topic: CheetahString::from(request.target.topic.to_string()),
+        queue_id: request.target.queue_id,
+        max_msg_nums: request.batch_size,
+        invisible_time: request.invisible_duration.as_millis().clamp(1, u128::from(u64::MAX)) as u64,
+        poll_time: request.long_polling_timeout.as_millis().clamp(0, u128::from(u64::MAX)) as u64,
+        born_time: current_millis(),
+        init_mode: 0,
+        exp_type: Some(CheetahString::from(request.filter_expression.expression_type.as_str())),
+        exp: Some(CheetahString::from(request.filter_expression.expression.as_str())),
+        order: Some(request.target.fifo),
+        attempt_id: request.attempt_id.as_deref().map(CheetahString::from),
+        topic_request_header: Some(OperationTopicRequestHeader {
+            lo: None,
+            rpc: Some(RpcRequestHeader {
+                broker_name: Some(CheetahString::from(broker_name)),
+                ..Default::default()
+            }),
+        }),
+    }
+}
+
+fn build_pull_request_header(broker_name: &str, request: &PullMessageRequest) -> PullMessageRequestHeader {
+    PullMessageRequestHeader {
+        consumer_group: CheetahString::from(request.group.to_string()),
+        topic: CheetahString::from(request.target.topic.to_string()),
+        queue_id: request.target.queue_id,
+        queue_offset: request.offset,
+        max_msg_nums: request.batch_size.min(i32::MAX as u32) as i32,
+        sys_flag: PullSysFlag::build_sys_flag(
+            false,
+            !request.long_polling_timeout.is_zero(),
+            true,
+            request.filter_expression.expression_type != ExpressionType::TAG,
+        ) as i32,
+        commit_offset: 0,
+        suspend_timeout_millis: request.long_polling_timeout.as_millis().clamp(0, u128::from(u64::MAX)) as u64,
+        sub_version: 0,
+        subscription: Some(CheetahString::from(request.filter_expression.expression.as_str())),
+        expression_type: Some(CheetahString::from(request.filter_expression.expression_type.as_str())),
+        max_msg_bytes: None,
+        request_source: None,
+        proxy_forward_client_id: None,
+        topic_request: Some(OperationTopicRequestHeader {
+            lo: None,
+            rpc: Some(RpcRequestHeader {
+                broker_name: Some(CheetahString::from(broker_name)),
+                ..Default::default()
+            }),
+        }),
+    }
+}
+
+fn build_update_offset_request_header(
+    broker_name: &str,
+    request: &UpdateOffsetRequest,
+) -> UpdateConsumerOffsetRequestHeader {
+    UpdateConsumerOffsetRequestHeader {
+        consumer_group: CheetahString::from(request.group.to_string()),
+        topic: CheetahString::from(request.target.topic.to_string()),
+        queue_id: request.target.queue_id,
+        commit_offset: request.offset,
+        topic_request_header: Some(OperationTopicRequestHeader {
+            lo: None,
+            rpc: Some(RpcRequestHeader {
+                broker_name: Some(CheetahString::from(broker_name)),
+                ..Default::default()
+            }),
+        }),
+    }
+}
+
+fn build_query_consumer_offset_request_header(
+    broker_name: &str,
+    request: &GetOffsetRequest,
+) -> QueryConsumerOffsetRequestHeader {
+    QueryConsumerOffsetRequestHeader {
+        consumer_group: CheetahString::from(request.group.to_string()),
+        topic: CheetahString::from(request.target.topic.to_string()),
+        queue_id: request.target.queue_id,
+        set_zero_if_not_found: Some(false),
+        topic_request_header: Some(OperationTopicRequestHeader {
+            lo: None,
+            rpc: Some(RpcRequestHeader {
+                broker_name: Some(CheetahString::from(broker_name)),
+                ..Default::default()
+            }),
+        }),
+    }
+}
+
 fn build_send_result(
     topic: ResourceIdentity,
     broker_name: &CheetahString,
@@ -785,6 +1333,343 @@ fn build_send_result(
         result.set_recall_handle(recall_handle.to_owned());
     }
     Ok(result)
+}
+
+fn process_pop_response(
+    mut response: RemotingCommand,
+    broker_name: &str,
+    topic: &str,
+    is_order: bool,
+) -> ProxyResult<ReceiveMessagePlan> {
+    match ResponseCode::from(response.code()) {
+        ResponseCode::Success => {
+            let response_header = response
+                .decode_command_custom_header::<PopMessageResponseHeader>()
+                .map_err(|error| ProxyError::Transport {
+                    message: format!("failed to decode local pop response header: {error}"),
+                })?;
+            let delivery_timestamp_ms = (response_header.pop_time > 0).then_some(response_header.pop_time as i64);
+            let mut messages = response
+                .get_body_mut()
+                .map(|body| MessageDecoder::decodes_batch(body, true, true))
+                .unwrap_or_default();
+            attach_pop_receipt_handles(
+                &mut messages,
+                topic,
+                &CheetahString::from(broker_name),
+                &response_header,
+                is_order,
+            )?;
+            let invisible_duration = Duration::from_millis(response_header.invisible_time.max(1));
+            let status = if messages.is_empty() {
+                ProxyStatusMapper::from_payload_code(crate::proto::v2::Code::MessageNotFound, "no message available")
+            } else {
+                ProxyStatusMapper::ok_payload()
+            };
+            Ok(ReceiveMessagePlan {
+                status,
+                delivery_timestamp_ms,
+                messages: messages
+                    .into_iter()
+                    .map(|message| ReceivedMessage {
+                        message,
+                        invisible_duration,
+                    })
+                    .collect(),
+            })
+        }
+        ResponseCode::PollingFull => Ok(ReceiveMessagePlan {
+            status: ProxyStatusMapper::from_payload_code(
+                crate::proto::v2::Code::TooManyRequests,
+                "broker polling queue is full",
+            ),
+            delivery_timestamp_ms: None,
+            messages: Vec::new(),
+        }),
+        ResponseCode::PollingTimeout | ResponseCode::PullNotFound => Ok(ReceiveMessagePlan {
+            status: ProxyStatusMapper::from_payload_code(
+                crate::proto::v2::Code::MessageNotFound,
+                "no message available",
+            ),
+            delivery_timestamp_ms: None,
+            messages: Vec::new(),
+        }),
+        _ => Err(broker_operation_error("receiveMessage", &response).into()),
+    }
+}
+
+fn process_pull_response(mut response: RemotingCommand) -> ProxyResult<PullMessagePlan> {
+    let response_header = response
+        .decode_command_custom_header::<PullMessageResponseHeader>()
+        .map_err(|error| ProxyError::Transport {
+            message: format!("failed to decode local pull response header: {error}"),
+        })?;
+    let next_offset = response_header.next_begin_offset;
+    let min_offset = response_header.min_offset;
+    let max_offset = response_header.max_offset;
+    match ResponseCode::from(response.code()) {
+        ResponseCode::Success => Ok(PullMessagePlan {
+            status: ProxyStatusMapper::ok_payload(),
+            next_offset,
+            min_offset,
+            max_offset,
+            messages: response
+                .get_body_mut()
+                .map(|body| MessageDecoder::decodes_batch(body, true, true))
+                .unwrap_or_default(),
+        }),
+        ResponseCode::PullNotFound | ResponseCode::PullRetryImmediately => Ok(PullMessagePlan {
+            status: ProxyStatusMapper::from_payload_code(
+                crate::proto::v2::Code::MessageNotFound,
+                "no message available",
+            ),
+            next_offset,
+            min_offset,
+            max_offset,
+            messages: Vec::new(),
+        }),
+        ResponseCode::PullOffsetMoved => Ok(PullMessagePlan {
+            status: ProxyStatusMapper::from_payload_code(
+                crate::proto::v2::Code::IllegalOffset,
+                "pull offset is illegal",
+            ),
+            next_offset,
+            min_offset,
+            max_offset,
+            messages: Vec::new(),
+        }),
+        _ => Err(broker_operation_error("pullMessage", &response).into()),
+    }
+}
+
+fn attach_pop_receipt_handles(
+    messages: &mut Vec<MessageExt>,
+    topic: &str,
+    broker_name: &CheetahString,
+    response_header: &PopMessageResponseHeader,
+    is_order: bool,
+) -> ProxyResult<()> {
+    let start_offset_info = ExtraInfoUtil::parse_start_offset_info(
+        response_header
+            .start_offset_info
+            .as_ref()
+            .unwrap_or(&CheetahString::from_slice("")),
+    )?;
+    let order_count_info = ExtraInfoUtil::parse_order_count_info(
+        response_header
+            .order_count_info
+            .as_ref()
+            .unwrap_or(&CheetahString::from_slice("")),
+    )?;
+    let sort_map = build_queue_offset_sorted_map(topic, messages.as_slice())?;
+    let mut cached_extra = HashMap::with_capacity(5);
+    for message in messages {
+        if start_offset_info.is_empty() {
+            let key = CheetahString::from_string(format!("{}{}", message.topic(), message.queue_id() as i64));
+            if !cached_extra.contains_key(&key) {
+                let extra_info = ExtraInfoUtil::build_extra_info(
+                    message.queue_offset(),
+                    response_header.pop_time as i64,
+                    response_header.invisible_time as i64,
+                    response_header.revive_qid as i32,
+                    message.topic(),
+                    broker_name,
+                    message.queue_id(),
+                );
+                cached_extra.insert(key.clone(), CheetahString::from_string(extra_info));
+            }
+            message.put_property(
+                CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK),
+                CheetahString::from_string(format!(
+                    "{}{}{}",
+                    cached_extra.get(&key).cloned().unwrap_or_default(),
+                    MessageConst::KEY_SEPARATOR,
+                    message.queue_offset()
+                )),
+            );
+        } else if message
+            .property(&CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK))
+            .is_none()
+        {
+            let dispatch = message
+                .property(&CheetahString::from_static_str(
+                    MessageConst::PROPERTY_INNER_MULTI_DISPATCH,
+                ))
+                .unwrap_or_default();
+            let (queue_offset_key, queue_id_key) = if mix_all::is_lmq(Some(topic)) && !dispatch.is_empty() {
+                let queues: Vec<&str> = dispatch.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+                let data = message
+                    .property(&CheetahString::from_static_str(
+                        MessageConst::PROPERTY_INNER_MULTI_QUEUE_OFFSET,
+                    ))
+                    .unwrap_or_default();
+                let queue_offsets: Vec<&str> = data.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+                let offset = queue_offsets[queues.iter().position(|&queue| queue == topic).unwrap()]
+                    .parse::<i64>()
+                    .unwrap_or_default();
+                let queue_id_key = ExtraInfoUtil::get_start_offset_info_map_key(topic, mix_all::LMQ_QUEUE_ID as i64);
+                let queue_offset_key =
+                    ExtraInfoUtil::get_queue_offset_map_key(topic, mix_all::LMQ_QUEUE_ID as i64, offset);
+                let index = sort_map
+                    .get(&queue_id_key)
+                    .and_then(|offsets| offsets.iter().position(|queue_offset| *queue_offset == offset as u64))
+                    .unwrap_or_default();
+                let msg_queue_offset = sort_map
+                    .get(&queue_offset_key)
+                    .and_then(|offsets| offsets.get(index))
+                    .copied()
+                    .unwrap_or_default();
+                let extra_info = ExtraInfoUtil::build_extra_info(
+                    message.queue_offset(),
+                    response_header.pop_time as i64,
+                    response_header.invisible_time as i64,
+                    response_header.revive_qid as i32,
+                    message.topic(),
+                    broker_name,
+                    msg_queue_offset as i32,
+                );
+                message.put_property(
+                    CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK),
+                    CheetahString::from_string(extra_info),
+                );
+                (queue_offset_key, queue_id_key)
+            } else {
+                let queue_id_key =
+                    ExtraInfoUtil::get_start_offset_info_map_key(message.topic(), message.queue_id() as i64);
+                let queue_offset_key = ExtraInfoUtil::get_queue_offset_map_key(
+                    message.topic(),
+                    message.queue_id() as i64,
+                    message.queue_offset(),
+                );
+                let index = sort_map
+                    .get(&queue_id_key)
+                    .and_then(|offsets| {
+                        offsets
+                            .iter()
+                            .position(|queue_offset| *queue_offset == message.queue_offset() as u64)
+                    })
+                    .unwrap_or_default();
+                let msg_queue_offset = sort_map
+                    .get(&queue_offset_key)
+                    .and_then(|offsets| offsets.get(index))
+                    .copied()
+                    .unwrap_or_default();
+                let extra_info = ExtraInfoUtil::build_extra_info(
+                    message.queue_offset(),
+                    response_header.pop_time as i64,
+                    response_header.invisible_time as i64,
+                    response_header.revive_qid as i32,
+                    message.topic(),
+                    broker_name,
+                    msg_queue_offset as i32,
+                );
+                message.put_property(
+                    CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK),
+                    CheetahString::from_string(extra_info),
+                );
+                (queue_offset_key, queue_id_key)
+            };
+            if is_order && !order_count_info.is_empty() {
+                let count = order_count_info
+                    .get(&queue_offset_key)
+                    .or_else(|| order_count_info.get(&queue_id_key));
+                if let Some(count) = count {
+                    message.set_reconsume_times(*count);
+                }
+            }
+        }
+        message.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_FIRST_POP_TIME),
+            CheetahString::from(response_header.pop_time.to_string()),
+        );
+        message.broker_name = broker_name.clone();
+        message.set_topic(CheetahString::from(topic));
+    }
+    Ok(())
+}
+
+fn build_queue_offset_sorted_map(topic: &str, messages: &[MessageExt]) -> ProxyResult<HashMap<String, Vec<u64>>> {
+    let mut sort_map = HashMap::with_capacity(16);
+    for message in messages {
+        let dispatch = message
+            .property(&CheetahString::from_static_str(
+                MessageConst::PROPERTY_INNER_MULTI_DISPATCH,
+            ))
+            .unwrap_or_default();
+        if mix_all::is_lmq(Some(topic)) && message.reconsume_times() == 0 && !dispatch.is_empty() {
+            let queues: Vec<&str> = dispatch.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+            let data = message
+                .property(&CheetahString::from_static_str(
+                    MessageConst::PROPERTY_INNER_MULTI_QUEUE_OFFSET,
+                ))
+                .unwrap_or_default();
+            let queue_offsets: Vec<&str> = data.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+            let key = ExtraInfoUtil::get_start_offset_info_map_key(topic, mix_all::LMQ_QUEUE_ID as i64);
+            sort_map.entry(key).or_insert_with(|| Vec::with_capacity(4)).push(
+                queue_offsets[queues.iter().position(|&queue| queue == topic).unwrap()]
+                    .parse()
+                    .unwrap_or_default(),
+            );
+            continue;
+        }
+        let key = ExtraInfoUtil::get_start_offset_info_map_key_with_pop_ck(
+            message.topic(),
+            message
+                .property(&CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK))
+                .as_ref()
+                .map(|value| value.as_str()),
+            message.queue_id() as i64,
+        )
+        .map_err(|error| ProxyError::Transport {
+            message: format!("failed to build local pop queue offset key: {error}"),
+        })?;
+        sort_map
+            .entry(key)
+            .or_insert_with(|| Vec::with_capacity(4))
+            .push(message.queue_offset() as u64);
+    }
+    Ok(sort_map)
+}
+
+#[derive(Debug, Clone)]
+struct ParsedReceiptHandle {
+    raw: CheetahString,
+    broker_name: CheetahString,
+    topic: CheetahString,
+    queue_id: i32,
+    queue_offset: i64,
+}
+
+fn parse_receipt_handle(receipt_handle: &str, topic: &str, consumer_group: &str) -> ProxyResult<ParsedReceiptHandle> {
+    let trimmed = receipt_handle.trim();
+    if trimmed.is_empty() {
+        return Err(ProxyError::invalid_receipt_handle("receipt handle must not be empty"));
+    }
+
+    let parts = ExtraInfoUtil::split(trimmed);
+    let broker_name = ExtraInfoUtil::get_broker_name(parts.as_slice())
+        .map(CheetahString::from_string)
+        .map_err(|error| ProxyError::invalid_receipt_handle(error.to_string()))?;
+    let queue_id = ExtraInfoUtil::get_queue_id(parts.as_slice())
+        .map_err(|error| ProxyError::invalid_receipt_handle(error.to_string()))?;
+    let queue_offset = ExtraInfoUtil::get_queue_offset(parts.as_slice())
+        .map_err(|error| ProxyError::invalid_receipt_handle(error.to_string()))?;
+    let real_topic = ExtraInfoUtil::get_real_topic(parts.as_slice(), topic, consumer_group)
+        .map(CheetahString::from_string)
+        .map_err(|error| ProxyError::invalid_receipt_handle(error.to_string()))?;
+
+    Ok(ParsedReceiptHandle {
+        raw: CheetahString::from(trimmed),
+        broker_name,
+        topic: real_topic,
+        queue_id,
+        queue_offset,
+    })
+}
+
+fn decode_broker_message_id(message_id: &str) -> ProxyResult<rocketmq_common::common::message::message_id::MessageId> {
+    MessageDecoder::decode_message_id(&CheetahString::from(message_id))
+        .map_err(|error| ProxyError::illegal_message_id(format!("failed to decode broker message id: {error}")))
 }
 
 fn attach_transaction_producer_group(message: &mut Message, producer_group: &str) {

--- a/rocketmq-proxy/src/processor.rs
+++ b/rocketmq-proxy/src/processor.rs
@@ -156,6 +156,8 @@ pub struct PullMessageRequest {
 pub struct PullMessagePlan {
     pub status: ProxyPayloadStatus,
     pub next_offset: i64,
+    pub min_offset: i64,
+    pub max_offset: i64,
     pub messages: Vec<MessageExt>,
 }
 

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -14,22 +14,57 @@
 
 use std::sync::Arc;
 
+use bytes::Bytes;
+use bytes::BytesMut;
+use cheetah_string::CheetahString;
+use rocketmq_common::common::filter::expression_type::ExpressionType;
+use rocketmq_common::common::message::message_decoder;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_common::common::message::MessageConst;
+use rocketmq_common::common::message::MessageTrait;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::prelude::RemotingDeserializable;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
+use rocketmq_remoting::protocol::command_custom_header::CommandCustomHeader;
 use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+use rocketmq_remoting::protocol::header::get_max_offset_request_header::GetMaxOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
+use rocketmq_remoting::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::get_min_offset_response_header::GetMinOffsetResponseHeader;
+use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::parse_request_header;
+use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
+use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+use rocketmq_remoting::protocol::header::message_operation_header::TopicRequestHeaderTrait;
+use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_remoting::protocol::header::pull_message_response_header::PullMessageResponseHeader;
+use rocketmq_remoting::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::query_consumer_offset_response_header::QueryConsumerOffsetResponseHeader;
+use rocketmq_remoting::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
+use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
+use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetResponseHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingSerializable;
 
 use crate::context::ProxyContext;
 use crate::error::ProxyError;
+use crate::processor::ConsumerFilterExpression;
+use crate::processor::GetOffsetRequest;
+use crate::processor::MessageQueueTarget;
 use crate::processor::MessagingProcessor;
+use crate::processor::PullMessageRequest;
 use crate::processor::QueryAssignmentRequest;
+use crate::processor::QueryOffsetPolicy;
+use crate::processor::QueryOffsetRequest;
 use crate::processor::QueryRouteRequest;
+use crate::processor::SendMessageEntry;
+use crate::processor::SendMessageRequest;
 use crate::service::ResourceIdentity;
+use crate::status::ProxyPayloadStatus;
 
 pub struct ProxyRemotingDispatcher<P> {
     processor: Arc<P>,
@@ -47,14 +82,24 @@ where
         match RequestCode::from(request.code()) {
             RequestCode::GetRouteinfoByTopic => self.dispatch_query_route(context, request).await,
             RequestCode::QueryAssignment => self.dispatch_query_assignment(context, request).await,
-            _ => RemotingCommand::create_response_command_with_code_remark(
-                ResponseCode::RequestCodeNotSupported,
+            RequestCode::SendMessage | RequestCode::SendMessageV2 => self.dispatch_send_message(context, request).await,
+            RequestCode::SendBatchMessage => unsupported_response(
+                request.opaque(),
+                "proxy remoting ingress does not support SendBatchMessage yet",
+            ),
+            RequestCode::PullMessage => self.dispatch_pull_message(context, request).await,
+            RequestCode::UpdateConsumerOffset => self.dispatch_update_consumer_offset(context, request).await,
+            RequestCode::QueryConsumerOffset => self.dispatch_query_consumer_offset(context, request).await,
+            RequestCode::GetMaxOffset => self.dispatch_get_max_offset(context, request).await,
+            RequestCode::GetMinOffset => self.dispatch_get_min_offset(context, request).await,
+            RequestCode::SearchOffsetByTimestamp => self.dispatch_search_offset(context, request).await,
+            _ => unsupported_response(
+                request.opaque(),
                 format!(
                     "proxy remoting ingress does not support request code {}",
                     request.code()
                 ),
-            )
-            .set_opaque(request.opaque()),
+            ),
         }
     }
 
@@ -131,6 +176,516 @@ where
             .set_body(encoded)
             .set_opaque(request.opaque())
     }
+
+    async fn dispatch_send_message(&self, context: &ProxyContext, request: &RemotingCommand) -> RemotingCommand {
+        let request_code = RequestCode::from(request.code());
+        let header = match parse_request_header(request, request_code) {
+            Ok(header) => header,
+            Err(error) => return decode_error_response(request.opaque(), "decode sendMessage header", error),
+        };
+        if header.is_batch() {
+            return unsupported_response(
+                request.opaque(),
+                "proxy remoting ingress does not support batch send yet",
+            );
+        }
+
+        let send_request = match build_send_message_request(request, &header) {
+            Ok(send_request) => send_request,
+            Err(error) => return proxy_error_response(request.opaque(), error),
+        };
+        let fallback_queue_id = send_request
+            .messages
+            .first()
+            .and_then(|entry| entry.queue_id)
+            .unwrap_or_default();
+        let plan = match self.processor.send_message(context, send_request).await {
+            Ok(plan) => plan,
+            Err(error) => return proxy_error_response(request.opaque(), error),
+        };
+        let Some(entry) = plan.entries.into_iter().next() else {
+            return transport_error_response(
+                request.opaque(),
+                "build sendMessage response",
+                "processor returned no send results",
+            );
+        };
+        if let Some(send_result) = entry.send_result.as_ref() {
+            let response_header = build_send_message_response_header(send_result, fallback_queue_id);
+            return response_with_header(
+                request.opaque(),
+                send_result_to_response_code(send_result),
+                response_header,
+                None,
+                None,
+            );
+        }
+
+        response_with_code(
+            request.opaque(),
+            send_payload_status_to_response_code(&entry.status),
+            entry.status.message().to_owned(),
+        )
+    }
+
+    async fn dispatch_pull_message(&self, context: &ProxyContext, request: &RemotingCommand) -> RemotingCommand {
+        let header = match request.decode_command_custom_header::<PullMessageRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => return decode_error_response(request.opaque(), "decode pullMessage header", error),
+        };
+        let pull_request = build_pull_message_request(&header);
+        let plan = match self.processor.pull_message(context, pull_request).await {
+            Ok(plan) => plan,
+            Err(error) => return proxy_error_response(request.opaque(), error),
+        };
+
+        let body = if plan.messages.is_empty() {
+            None
+        } else {
+            match encode_message_ext_batch(plan.messages.as_slice()) {
+                Ok(body) => Some(body),
+                Err(error) => return proxy_error_response(request.opaque(), error),
+            }
+        };
+        let response_header = PullMessageResponseHeader {
+            suggest_which_broker_id: 0,
+            next_begin_offset: plan.next_offset,
+            min_offset: plan.min_offset,
+            max_offset: plan.max_offset,
+            offset_delta: None,
+            topic_sys_flag: None,
+            group_sys_flag: None,
+            forbidden_type: None,
+        };
+        response_with_header(
+            request.opaque(),
+            pull_payload_status_to_response_code(&plan.status),
+            response_header,
+            (!plan.status.is_ok()).then(|| plan.status.message().to_owned()),
+            body,
+        )
+    }
+
+    async fn dispatch_update_consumer_offset(
+        &self,
+        context: &ProxyContext,
+        request: &RemotingCommand,
+    ) -> RemotingCommand {
+        let header = match request.decode_command_custom_header::<UpdateConsumerOffsetRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => {
+                return decode_error_response(request.opaque(), "decode updateConsumerOffset header", error);
+            }
+        };
+        let plan = match self
+            .processor
+            .update_offset(context, build_update_offset_request(&header))
+            .await
+        {
+            Ok(plan) => plan,
+            Err(error) => return proxy_error_response(request.opaque(), error),
+        };
+        response_with_header(
+            request.opaque(),
+            offset_payload_status_to_response_code(&plan.status, ResponseCode::QueryNotFound),
+            UpdateConsumerOffsetResponseHeader::default(),
+            (!plan.status.is_ok()).then(|| plan.status.message().to_owned()),
+            None,
+        )
+    }
+
+    async fn dispatch_query_consumer_offset(
+        &self,
+        context: &ProxyContext,
+        request: &RemotingCommand,
+    ) -> RemotingCommand {
+        let header = match request.decode_command_custom_header::<QueryConsumerOffsetRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => {
+                return decode_error_response(request.opaque(), "decode queryConsumerOffset header", error);
+            }
+        };
+        let plan = match self
+            .processor
+            .get_offset(context, build_get_offset_request(&header))
+            .await
+        {
+            Ok(plan) => plan,
+            Err(error) => return proxy_error_response(request.opaque(), error),
+        };
+        response_with_header(
+            request.opaque(),
+            offset_payload_status_to_response_code(&plan.status, ResponseCode::QueryNotFound),
+            QueryConsumerOffsetResponseHeader {
+                offset: plan.status.is_ok().then_some(plan.offset),
+            },
+            (!plan.status.is_ok()).then(|| plan.status.message().to_owned()),
+            None,
+        )
+    }
+
+    async fn dispatch_get_max_offset(&self, context: &ProxyContext, request: &RemotingCommand) -> RemotingCommand {
+        let header = match request.decode_command_custom_header::<GetMaxOffsetRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => return decode_error_response(request.opaque(), "decode getMaxOffset header", error),
+        };
+        let plan = match self
+            .processor
+            .query_offset(
+                context,
+                build_query_offset_request(
+                    topic_identity(&header),
+                    header.queue_id,
+                    header.broker_name().map(ToString::to_string),
+                    crate::processor::QueryOffsetPolicy::End,
+                    None,
+                ),
+            )
+            .await
+        {
+            Ok(plan) => plan,
+            Err(error) => return proxy_error_response(request.opaque(), error),
+        };
+        response_with_header(
+            request.opaque(),
+            offset_payload_status_to_response_code(&plan.status, ResponseCode::QueryNotFound),
+            GetMaxOffsetResponseHeader {
+                offset: if plan.status.is_ok() { plan.offset } else { 0 },
+            },
+            (!plan.status.is_ok()).then(|| plan.status.message().to_owned()),
+            None,
+        )
+    }
+
+    async fn dispatch_get_min_offset(&self, context: &ProxyContext, request: &RemotingCommand) -> RemotingCommand {
+        let header = match request.decode_command_custom_header::<GetMinOffsetRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => return decode_error_response(request.opaque(), "decode getMinOffset header", error),
+        };
+        let plan = match self
+            .processor
+            .query_offset(
+                context,
+                build_query_offset_request(
+                    topic_identity(&header),
+                    header.queue_id,
+                    header.broker_name().map(ToString::to_string),
+                    crate::processor::QueryOffsetPolicy::Beginning,
+                    None,
+                ),
+            )
+            .await
+        {
+            Ok(plan) => plan,
+            Err(error) => return proxy_error_response(request.opaque(), error),
+        };
+        response_with_header(
+            request.opaque(),
+            offset_payload_status_to_response_code(&plan.status, ResponseCode::QueryNotFound),
+            GetMinOffsetResponseHeader {
+                offset: if plan.status.is_ok() { plan.offset } else { 0 },
+            },
+            (!plan.status.is_ok()).then(|| plan.status.message().to_owned()),
+            None,
+        )
+    }
+
+    async fn dispatch_search_offset(&self, context: &ProxyContext, request: &RemotingCommand) -> RemotingCommand {
+        let header = match request.decode_command_custom_header::<SearchOffsetRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => return decode_error_response(request.opaque(), "decode searchOffset header", error),
+        };
+        let plan = match self
+            .processor
+            .query_offset(
+                context,
+                build_query_offset_request(
+                    topic_identity(&header),
+                    header.queue_id,
+                    header.broker_name().map(ToString::to_string),
+                    crate::processor::QueryOffsetPolicy::Timestamp,
+                    Some(header.timestamp),
+                ),
+            )
+            .await
+        {
+            Ok(plan) => plan,
+            Err(error) => return proxy_error_response(request.opaque(), error),
+        };
+        response_with_header(
+            request.opaque(),
+            offset_payload_status_to_response_code(&plan.status, ResponseCode::QueryNotFound),
+            SearchOffsetResponseHeader {
+                offset: if plan.status.is_ok() { plan.offset } else { 0 },
+            },
+            (!plan.status.is_ok()).then(|| plan.status.message().to_owned()),
+            None,
+        )
+    }
+}
+
+fn build_send_message_request(
+    request: &RemotingCommand,
+    header: &SendMessageRequestHeader,
+) -> crate::error::ProxyResult<SendMessageRequest> {
+    let topic = topic_identity(header);
+    let body = request.body().cloned().ok_or_else(|| {
+        RocketMQError::request_body_invalid(
+            "sendMessage",
+            format!("sendMessage request body is missing for topic '{}'", header.topic),
+        )
+    })?;
+    let mut message = Message::builder()
+        .topic(topic.to_string())
+        .body(body)
+        .flag_bits(header.flag)
+        .build_unchecked();
+    let properties = message_decoder::string_to_message_properties(header.properties.as_ref());
+    message.set_properties(properties.clone());
+    attach_transaction_producer_group(&mut message, header.producer_group.as_str());
+
+    let client_message_id = properties
+        .get(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+        ))
+        .map(ToString::to_string)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| format!("remoting-{}", request.opaque()));
+
+    Ok(SendMessageRequest {
+        messages: vec![SendMessageEntry {
+            topic,
+            client_message_id,
+            message,
+            queue_id: (header.queue_id >= 0).then_some(header.queue_id),
+        }],
+        timeout: None,
+    })
+}
+
+fn build_pull_message_request(header: &PullMessageRequestHeader) -> PullMessageRequest {
+    let namespace = header.namespace().unwrap_or_default().to_owned();
+    PullMessageRequest {
+        group: ResourceIdentity::new(namespace.clone(), header.consumer_group.to_string()),
+        target: MessageQueueTarget {
+            topic: ResourceIdentity::new(namespace, header.topic.to_string()),
+            queue_id: header.queue_id,
+            broker_name: header.broker_name().map(ToString::to_string),
+            broker_addr: None,
+        },
+        offset: header.queue_offset,
+        batch_size: header.max_msg_nums.max(1) as u32,
+        filter_expression: ConsumerFilterExpression {
+            expression_type: header
+                .expression_type
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| ExpressionType::TAG.to_owned()),
+            expression: header
+                .subscription
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "*".to_owned()),
+        },
+        long_polling_timeout: std::time::Duration::from_millis(header.suspend_timeout_millis),
+    }
+}
+
+fn build_update_offset_request(header: &UpdateConsumerOffsetRequestHeader) -> crate::processor::UpdateOffsetRequest {
+    let namespace = header.namespace().unwrap_or_default().to_owned();
+    crate::processor::UpdateOffsetRequest {
+        group: ResourceIdentity::new(namespace.clone(), header.consumer_group.to_string()),
+        target: MessageQueueTarget {
+            topic: ResourceIdentity::new(namespace, header.topic.to_string()),
+            queue_id: header.queue_id,
+            broker_name: header.broker_name().map(ToString::to_string),
+            broker_addr: None,
+        },
+        offset: header.commit_offset,
+    }
+}
+
+fn build_get_offset_request(header: &QueryConsumerOffsetRequestHeader) -> GetOffsetRequest {
+    let namespace = header.namespace().unwrap_or_default().to_owned();
+    GetOffsetRequest {
+        group: ResourceIdentity::new(namespace.clone(), header.consumer_group.to_string()),
+        target: MessageQueueTarget {
+            topic: ResourceIdentity::new(namespace, header.topic.to_string()),
+            queue_id: header.queue_id,
+            broker_name: header.broker_name().map(ToString::to_string),
+            broker_addr: None,
+        },
+    }
+}
+
+fn build_query_offset_request(
+    topic: ResourceIdentity,
+    queue_id: i32,
+    broker_name: Option<String>,
+    policy: QueryOffsetPolicy,
+    timestamp_ms: Option<i64>,
+) -> QueryOffsetRequest {
+    QueryOffsetRequest {
+        target: MessageQueueTarget {
+            topic,
+            queue_id,
+            broker_name,
+            broker_addr: None,
+        },
+        policy,
+        timestamp_ms,
+    }
+}
+
+fn topic_identity<T: TopicRequestHeaderTrait>(header: &T) -> ResourceIdentity {
+    ResourceIdentity::new(header.namespace().unwrap_or_default(), header.topic().to_string())
+}
+
+fn build_send_message_response_header(
+    send_result: &rocketmq_client_rust::producer::send_result::SendResult,
+    fallback_queue_id: i32,
+) -> SendMessageResponseHeader {
+    let queue_id = send_result
+        .message_queue
+        .as_ref()
+        .map(|queue| queue.queue_id())
+        .unwrap_or(fallback_queue_id);
+    SendMessageResponseHeader::new(
+        send_result.msg_id.clone().unwrap_or_default(),
+        queue_id,
+        send_result.queue_offset as i64,
+        send_result.transaction_id.as_deref().map(CheetahString::from),
+        None,
+        send_result.recall_handle().map(CheetahString::from),
+    )
+}
+
+fn encode_message_ext_batch(messages: &[MessageExt]) -> crate::error::ProxyResult<Bytes> {
+    let mut encoded = BytesMut::new();
+    for message in messages {
+        let body = message_decoder::encode(message, false)?;
+        encoded.extend_from_slice(body.as_ref());
+    }
+    Ok(encoded.freeze())
+}
+
+fn attach_transaction_producer_group(message: &mut Message, producer_group: &str) {
+    if !is_transaction_prepared(message) {
+        return;
+    }
+
+    message.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_PRODUCER_GROUP),
+        CheetahString::from(producer_group),
+    );
+}
+
+fn is_transaction_prepared(message: &Message) -> bool {
+    message
+        .property_ref(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_TRANSACTION_PREPARED,
+        ))
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(false)
+}
+
+fn send_result_to_response_code(send_result: &rocketmq_client_rust::producer::send_result::SendResult) -> ResponseCode {
+    match send_result.send_status {
+        rocketmq_client_rust::producer::send_status::SendStatus::SendOk => ResponseCode::Success,
+        rocketmq_client_rust::producer::send_status::SendStatus::FlushDiskTimeout => ResponseCode::FlushDiskTimeout,
+        rocketmq_client_rust::producer::send_status::SendStatus::FlushSlaveTimeout => ResponseCode::FlushSlaveTimeout,
+        rocketmq_client_rust::producer::send_status::SendStatus::SlaveNotAvailable => ResponseCode::SlaveNotAvailable,
+    }
+}
+
+fn send_payload_status_to_response_code(status: &ProxyPayloadStatus) -> ResponseCode {
+    match payload_code(status) {
+        crate::proto::v2::Code::Ok => ResponseCode::Success,
+        crate::proto::v2::Code::MasterPersistenceTimeout => ResponseCode::FlushDiskTimeout,
+        crate::proto::v2::Code::SlavePersistenceTimeout => ResponseCode::FlushSlaveTimeout,
+        crate::proto::v2::Code::HaNotAvailable => ResponseCode::SlaveNotAvailable,
+        crate::proto::v2::Code::TopicNotFound => ResponseCode::TopicNotExist,
+        crate::proto::v2::Code::ConsumerGroupNotFound => ResponseCode::SubscriptionGroupNotExist,
+        crate::proto::v2::Code::Forbidden | crate::proto::v2::Code::Unauthorized => ResponseCode::NoPermission,
+        crate::proto::v2::Code::TooManyRequests => ResponseCode::SystemBusy,
+        crate::proto::v2::Code::BadRequest
+        | crate::proto::v2::Code::IllegalMessageId
+        | crate::proto::v2::Code::IllegalMessageKey
+        | crate::proto::v2::Code::IllegalMessageTag
+        | crate::proto::v2::Code::IllegalMessageGroup
+        | crate::proto::v2::Code::IllegalDeliveryTime
+        | crate::proto::v2::Code::MessageBodyTooLarge
+        | crate::proto::v2::Code::MessagePropertyConflictWithType => ResponseCode::MessageIllegal,
+        crate::proto::v2::Code::NotImplemented
+        | crate::proto::v2::Code::Unsupported
+        | crate::proto::v2::Code::VersionUnsupported => ResponseCode::RequestCodeNotSupported,
+        _ => ResponseCode::SystemError,
+    }
+}
+
+fn pull_payload_status_to_response_code(status: &ProxyPayloadStatus) -> ResponseCode {
+    match payload_code(status) {
+        crate::proto::v2::Code::Ok => ResponseCode::Success,
+        crate::proto::v2::Code::MessageNotFound => ResponseCode::PullNotFound,
+        crate::proto::v2::Code::IllegalOffset => ResponseCode::PullOffsetMoved,
+        crate::proto::v2::Code::TopicNotFound => ResponseCode::TopicNotExist,
+        crate::proto::v2::Code::ConsumerGroupNotFound => ResponseCode::SubscriptionGroupNotExist,
+        crate::proto::v2::Code::Forbidden | crate::proto::v2::Code::Unauthorized => ResponseCode::NoPermission,
+        crate::proto::v2::Code::TooManyRequests => ResponseCode::SystemBusy,
+        crate::proto::v2::Code::BadRequest | crate::proto::v2::Code::IllegalFilterExpression => {
+            ResponseCode::InvalidParameter
+        }
+        _ => ResponseCode::SystemError,
+    }
+}
+
+fn offset_payload_status_to_response_code(status: &ProxyPayloadStatus, not_found: ResponseCode) -> ResponseCode {
+    match payload_code(status) {
+        crate::proto::v2::Code::Ok => ResponseCode::Success,
+        crate::proto::v2::Code::OffsetNotFound | crate::proto::v2::Code::MessageNotFound => not_found,
+        crate::proto::v2::Code::TopicNotFound => ResponseCode::TopicNotExist,
+        crate::proto::v2::Code::ConsumerGroupNotFound => ResponseCode::SubscriptionGroupNotExist,
+        crate::proto::v2::Code::Forbidden | crate::proto::v2::Code::Unauthorized => ResponseCode::NoPermission,
+        crate::proto::v2::Code::TooManyRequests => ResponseCode::SystemBusy,
+        crate::proto::v2::Code::BadRequest | crate::proto::v2::Code::IllegalOffset => ResponseCode::InvalidParameter,
+        crate::proto::v2::Code::NotImplemented
+        | crate::proto::v2::Code::Unsupported
+        | crate::proto::v2::Code::VersionUnsupported => ResponseCode::RequestCodeNotSupported,
+        _ => ResponseCode::SystemError,
+    }
+}
+
+fn payload_code(status: &ProxyPayloadStatus) -> crate::proto::v2::Code {
+    crate::proto::v2::Code::try_from(status.code()).unwrap_or(crate::proto::v2::Code::InternalError)
+}
+
+fn response_with_header<H>(
+    opaque: i32,
+    code: ResponseCode,
+    header: H,
+    remark: Option<String>,
+    body: Option<Bytes>,
+) -> RemotingCommand
+where
+    H: CommandCustomHeader + Send + Sync + 'static,
+{
+    let mut response = RemotingCommand::create_response_command_with_header(header).set_code(code);
+    if let Some(remark) = remark {
+        response = response.set_remark(remark);
+    }
+    if let Some(body) = body {
+        response = response.set_body(body);
+    }
+    response.make_custom_header_to_net();
+    response.set_opaque(opaque)
+}
+
+fn response_with_code(opaque: i32, code: ResponseCode, remark: impl Into<String>) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code_remark(code, remark.into()).set_opaque(opaque)
+}
+
+fn unsupported_response(opaque: i32, remark: impl Into<String>) -> RemotingCommand {
+    response_with_code(opaque, ResponseCode::RequestCodeNotSupported, remark)
 }
 
 fn decode_error_response(opaque: i32, operation: &'static str, error: RocketMQError) -> RemotingCommand {
@@ -159,6 +714,13 @@ fn proxy_error_response(opaque: i32, error: ProxyError) -> RemotingCommand {
         ProxyError::RocketMQ(RocketMQError::BrokerPermissionDenied { .. })
         | ProxyError::RocketMQ(RocketMQError::TopicSendingForbidden { .. }) => ResponseCode::NoPermission,
         ProxyError::TooManyRequests { .. } => ResponseCode::SystemBusy,
+        ProxyError::IllegalOffset { .. } => ResponseCode::PullOffsetMoved,
+        ProxyError::IllegalFilterExpression { .. } => ResponseCode::SubscriptionParseFailed,
+        ProxyError::NotImplemented { .. } => ResponseCode::RequestCodeNotSupported,
+        ProxyError::IllegalMessageId { .. }
+        | ProxyError::IllegalMessageGroup { .. }
+        | ProxyError::IllegalDeliveryTime { .. }
+        | ProxyError::MessagePropertyConflictWithType { .. } => ResponseCode::MessageIllegal,
         _ => ResponseCode::SystemError,
     };
     RemotingCommand::create_response_command_with_code_remark(code, error.to_string()).set_opaque(opaque)
@@ -169,9 +731,19 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use async_trait::async_trait;
+    use bytes::Bytes;
     use cheetah_string::CheetahString;
+    use rocketmq_client_rust::producer::send_result::SendResult;
+    use rocketmq_client_rust::producer::send_status::SendStatus;
+    use rocketmq_common::common::boundary_type::BoundaryType;
     use rocketmq_common::common::message::message_enum::MessageRequestMode;
+    use rocketmq_common::common::message::message_ext::MessageExt;
+    use rocketmq_common::common::message::message_queue::MessageQueue;
     use rocketmq_common::common::message::message_queue_assignment::MessageQueueAssignment;
+    use rocketmq_common::common::message::MessageConst;
+    use rocketmq_common::common::message::MessageTrait;
+    use rocketmq_common::MessageDecoder;
     use rocketmq_remoting::code::request_code::RequestCode;
     use rocketmq_remoting::code::response_code::ResponseCode;
     use rocketmq_remoting::prelude::RemotingDeserializable;
@@ -179,6 +751,17 @@ mod tests {
     use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
     use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
     use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+    use rocketmq_remoting::protocol::header::get_max_offset_request_header::GetMaxOffsetRequestHeader;
+    use rocketmq_remoting::protocol::header::get_max_offset_response_header::GetMaxOffsetResponseHeader;
+    use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
+    use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+    use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+    use rocketmq_remoting::protocol::header::pull_message_response_header::PullMessageResponseHeader;
+    use rocketmq_remoting::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
+    use rocketmq_remoting::protocol::header::query_consumer_offset_response_header::QueryConsumerOffsetResponseHeader;
+    use rocketmq_remoting::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
+    use rocketmq_remoting::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
+    use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
     use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
     use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
     use rocketmq_remoting::protocol::route::route_data_view::QueueData;
@@ -186,18 +769,55 @@ mod tests {
 
     use super::ProxyRemotingDispatcher;
     use crate::context::ProxyContext;
+    use crate::processor::AckMessageRequest;
+    use crate::processor::AckMessageResultEntry;
+    use crate::processor::ChangeInvisibleDurationPlan;
+    use crate::processor::ChangeInvisibleDurationRequest;
     use crate::processor::DefaultMessagingProcessor;
+    use crate::processor::ForwardMessageToDeadLetterQueuePlan;
+    use crate::processor::ForwardMessageToDeadLetterQueueRequest;
+    use crate::processor::GetOffsetPlan;
+    use crate::processor::GetOffsetRequest;
+    use crate::processor::PullMessagePlan;
+    use crate::processor::PullMessageRequest;
+    use crate::processor::QueryOffsetPlan;
+    use crate::processor::QueryOffsetPolicy;
+    use crate::processor::QueryOffsetRequest;
+    use crate::processor::RecallMessagePlan;
+    use crate::processor::RecallMessageRequest;
+    use crate::processor::ReceiveMessagePlan;
+    use crate::processor::ReceiveMessageRequest;
+    use crate::processor::SendMessageRequest;
+    use crate::processor::SendMessageResultEntry;
+    use crate::processor::UpdateOffsetPlan;
+    use crate::processor::UpdateOffsetRequest;
+    use crate::service::AssignmentService;
+    use crate::service::ConsumerService;
     use crate::service::DefaultAssignmentService;
-    use crate::service::DefaultConsumerService;
     use crate::service::DefaultTransactionService;
     use crate::service::LocalServiceManager;
+    use crate::service::MessageService;
     use crate::service::ResourceIdentity;
-    use crate::service::StaticMessageService;
     use crate::service::StaticMetadataService;
     use crate::service::StaticRouteService;
+    use crate::status::ProxyStatusMapper;
 
     fn test_context() -> ProxyContext {
         ProxyContext::for_internal_client("Remoting", "remoting-client")
+    }
+
+    fn test_dispatcher() -> ProxyRemotingDispatcher<DefaultMessagingProcessor> {
+        let processor = Arc::new(DefaultMessagingProcessor::new(Arc::new(
+            LocalServiceManager::with_services(
+                Arc::new(StaticRouteService::default()),
+                Arc::new(StaticMetadataService::default()),
+                Arc::new(DefaultAssignmentService),
+                Arc::new(TestMessageService),
+                Arc::new(TestConsumerService),
+                Arc::new(DefaultTransactionService),
+            ),
+        )));
+        ProxyRemotingDispatcher::new(processor)
     }
 
     #[tokio::test]
@@ -221,8 +841,8 @@ mod tests {
                 Arc::new(route_service),
                 Arc::new(StaticMetadataService::default()),
                 Arc::new(DefaultAssignmentService),
-                Arc::new(StaticMessageService::default()),
-                Arc::new(DefaultConsumerService),
+                Arc::new(TestMessageService),
+                Arc::new(TestConsumerService),
                 Arc::new(DefaultTransactionService),
             ),
         )));
@@ -252,8 +872,8 @@ mod tests {
                 Arc::new(route_service),
                 Arc::new(StaticMetadataService::default()),
                 assignment_service,
-                Arc::new(StaticMessageService::default()),
-                Arc::new(DefaultConsumerService),
+                Arc::new(TestMessageService),
+                Arc::new(TestConsumerService),
                 Arc::new(DefaultTransactionService),
             ),
         )));
@@ -282,11 +902,166 @@ mod tests {
         assert_eq!(decoded.message_queue_assignments.len(), 1);
     }
 
-    #[derive(Default)]
+    #[tokio::test]
+    async fn dispatch_send_message_returns_send_response_header() {
+        let dispatcher = test_dispatcher();
+        let properties = MessageDecoder::message_properties_to_string(&HashMap::from([(
+            CheetahString::from_static_str(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX),
+            CheetahString::from("client-msg-id"),
+        )]));
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::SendMessage,
+            SendMessageRequestHeader {
+                producer_group: CheetahString::from("ProducerA"),
+                topic: CheetahString::from("TopicA"),
+                default_topic: CheetahString::from("TBW102"),
+                default_topic_queue_nums: 4,
+                queue_id: 1,
+                sys_flag: 0,
+                born_timestamp: 1,
+                flag: 0,
+                properties: Some(properties),
+                reconsume_times: None,
+                unit_mode: Some(false),
+                batch: Some(false),
+                max_reconsume_times: None,
+                topic_request_header: None,
+            },
+        )
+        .set_body(Bytes::from_static(b"hello"));
+        request.make_custom_header_to_net();
+
+        let response = dispatcher.dispatch(&test_context(), &request).await;
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let header = response
+            .decode_command_custom_header::<SendMessageResponseHeader>()
+            .expect("sendMessage response header should decode");
+        assert_eq!(header.msg_id(), "client-msg-id");
+        assert_eq!(header.queue_id(), 1);
+    }
+
+    #[tokio::test]
+    async fn dispatch_pull_message_returns_header_and_body() {
+        let dispatcher = test_dispatcher();
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::PullMessage,
+            PullMessageRequestHeader {
+                consumer_group: CheetahString::from("GroupA"),
+                topic: CheetahString::from("TopicA"),
+                queue_id: 2,
+                queue_offset: 7,
+                max_msg_nums: 16,
+                sys_flag: 0,
+                commit_offset: 0,
+                suspend_timeout_millis: 500,
+                sub_version: 0,
+                subscription: Some(CheetahString::from("*")),
+                expression_type: Some(CheetahString::from("TAG")),
+                max_msg_bytes: None,
+                request_source: None,
+                proxy_forward_client_id: None,
+                topic_request: None,
+            },
+        );
+        request.make_custom_header_to_net();
+
+        let response = dispatcher.dispatch(&test_context(), &request).await;
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let header = response
+            .decode_command_custom_header::<PullMessageResponseHeader>()
+            .expect("pullMessage response header should decode");
+        assert_eq!(header.next_begin_offset, 8);
+        assert_eq!(header.min_offset, 0);
+        assert_eq!(header.max_offset, 1024);
+
+        let messages = MessageDecoder::decodes_batch(
+            &mut response.body().cloned().expect("pull response body should exist"),
+            true,
+            true,
+        );
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].topic().as_str(), "TopicA");
+        assert_eq!(messages[0].queue_offset(), 7);
+        assert_eq!(messages[0].body().as_deref(), Some(&b"hello"[..]));
+    }
+
+    #[tokio::test]
+    async fn dispatch_update_and_query_consumer_offset_return_expected_headers() {
+        let dispatcher = test_dispatcher();
+
+        let mut update_request = RemotingCommand::create_request_command(
+            RequestCode::UpdateConsumerOffset,
+            UpdateConsumerOffsetRequestHeader {
+                consumer_group: CheetahString::from("GroupA"),
+                topic: CheetahString::from("TopicA"),
+                queue_id: 0,
+                commit_offset: 88,
+                topic_request_header: None,
+            },
+        );
+        update_request.make_custom_header_to_net();
+        let update_response = dispatcher.dispatch(&test_context(), &update_request).await;
+        assert_eq!(ResponseCode::from(update_response.code()), ResponseCode::Success);
+
+        let mut query_request = RemotingCommand::create_request_command(
+            RequestCode::QueryConsumerOffset,
+            QueryConsumerOffsetRequestHeader::new("GroupA", "TopicA", 0),
+        );
+        query_request.make_custom_header_to_net();
+        let query_response = dispatcher.dispatch(&test_context(), &query_request).await;
+        assert_eq!(ResponseCode::from(query_response.code()), ResponseCode::Success);
+        let query_header = query_response
+            .decode_command_custom_header::<QueryConsumerOffsetResponseHeader>()
+            .expect("queryConsumerOffset response header should decode");
+        assert_eq!(query_header.offset, Some(123));
+    }
+
+    #[tokio::test]
+    async fn dispatch_max_and_search_offset_return_expected_headers() {
+        let dispatcher = test_dispatcher();
+
+        let mut max_request = RemotingCommand::create_request_command(
+            RequestCode::GetMaxOffset,
+            GetMaxOffsetRequestHeader {
+                topic: CheetahString::from("TopicA"),
+                queue_id: 1,
+                committed: true,
+                topic_request_header: None,
+            },
+        );
+        max_request.make_custom_header_to_net();
+        let max_response = dispatcher.dispatch(&test_context(), &max_request).await;
+        assert_eq!(ResponseCode::from(max_response.code()), ResponseCode::Success);
+        let max_header = max_response
+            .decode_command_custom_header::<GetMaxOffsetResponseHeader>()
+            .expect("getMaxOffset response header should decode");
+        assert_eq!(max_header.offset, 2048);
+
+        let mut search_request = RemotingCommand::create_request_command(
+            RequestCode::SearchOffsetByTimestamp,
+            SearchOffsetRequestHeader {
+                topic: CheetahString::from("TopicA"),
+                queue_id: 1,
+                timestamp: 99,
+                boundary_type: BoundaryType::Lower,
+                topic_request_header: None,
+            },
+        );
+        search_request.make_custom_header_to_net();
+        let search_response = dispatcher.dispatch(&test_context(), &search_request).await;
+        assert_eq!(ResponseCode::from(search_response.code()), ResponseCode::Success);
+        let search_header = search_response
+            .decode_command_custom_header::<SearchOffsetResponseHeader>()
+            .expect("searchOffset response header should decode");
+        assert_eq!(search_header.offset, 99);
+    }
+
     struct TestAssignmentService;
 
-    #[async_trait::async_trait]
-    impl crate::service::AssignmentService for TestAssignmentService {
+    #[async_trait]
+    impl AssignmentService for TestAssignmentService {
         async fn query_assignment(
             &self,
             _context: &ProxyContext,
@@ -295,16 +1070,149 @@ mod tests {
             _endpoints: &[crate::context::ResolvedEndpoint],
         ) -> crate::error::ProxyResult<Option<Vec<MessageQueueAssignment>>> {
             Ok(Some(vec![MessageQueueAssignment {
-                message_queue: Some(
-                    rocketmq_common::common::message::message_queue::MessageQueue::from_parts(
-                        "TopicA",
-                        CheetahString::from("broker-a"),
-                        0,
-                    ),
-                ),
+                message_queue: Some(MessageQueue::from_parts("TopicA", CheetahString::from("broker-a"), 0)),
                 mode: MessageRequestMode::Pull,
                 attachments: None,
             }]))
+        }
+    }
+
+    struct TestMessageService;
+
+    #[async_trait]
+    impl MessageService for TestMessageService {
+        async fn send_message(
+            &self,
+            _context: &ProxyContext,
+            request: &SendMessageRequest,
+        ) -> crate::error::ProxyResult<Vec<SendMessageResultEntry>> {
+            Ok(request
+                .messages
+                .iter()
+                .map(|entry| {
+                    let queue_id = entry.queue_id.unwrap_or_default();
+                    let send_result = SendResult::new(
+                        SendStatus::SendOk,
+                        Some(CheetahString::from(entry.client_message_id.as_str())),
+                        None,
+                        Some(MessageQueue::from_parts(
+                            entry.topic.to_string(),
+                            CheetahString::from("broker-a"),
+                            queue_id,
+                        )),
+                        7,
+                    );
+                    SendMessageResultEntry {
+                        status: ProxyStatusMapper::ok_payload(),
+                        send_result: Some(send_result),
+                    }
+                })
+                .collect())
+        }
+
+        async fn recall_message(
+            &self,
+            _context: &ProxyContext,
+            request: &RecallMessageRequest,
+        ) -> crate::error::ProxyResult<RecallMessagePlan> {
+            Ok(RecallMessagePlan {
+                status: ProxyStatusMapper::ok_payload(),
+                message_id: request.recall_handle.clone(),
+            })
+        }
+    }
+
+    struct TestConsumerService;
+
+    #[async_trait]
+    impl ConsumerService for TestConsumerService {
+        async fn receive_message(
+            &self,
+            _context: &ProxyContext,
+            _request: &ReceiveMessageRequest,
+        ) -> crate::error::ProxyResult<ReceiveMessagePlan> {
+            Err(crate::error::ProxyError::not_implemented("test receive"))
+        }
+
+        async fn pull_message(
+            &self,
+            _context: &ProxyContext,
+            request: &PullMessageRequest,
+        ) -> crate::error::ProxyResult<PullMessagePlan> {
+            let mut message = MessageExt::default();
+            message.set_topic(CheetahString::from(request.target.topic.to_string()));
+            message.set_body(Bytes::from_static(b"hello"));
+            message.set_msg_id(CheetahString::from("pull-msg-id"));
+            message.set_queue_id(request.target.queue_id);
+            message.set_queue_offset(request.offset);
+            Ok(PullMessagePlan {
+                status: ProxyStatusMapper::ok_payload(),
+                next_offset: request.offset + 1,
+                min_offset: 0,
+                max_offset: 1024,
+                messages: vec![message],
+            })
+        }
+
+        async fn ack_message(
+            &self,
+            _context: &ProxyContext,
+            _request: &AckMessageRequest,
+        ) -> crate::error::ProxyResult<Vec<AckMessageResultEntry>> {
+            Err(crate::error::ProxyError::not_implemented("test ack"))
+        }
+
+        async fn forward_message_to_dead_letter_queue(
+            &self,
+            _context: &ProxyContext,
+            _request: &ForwardMessageToDeadLetterQueueRequest,
+        ) -> crate::error::ProxyResult<ForwardMessageToDeadLetterQueuePlan> {
+            Err(crate::error::ProxyError::not_implemented("test dlq"))
+        }
+
+        async fn change_invisible_duration(
+            &self,
+            _context: &ProxyContext,
+            _request: &ChangeInvisibleDurationRequest,
+        ) -> crate::error::ProxyResult<ChangeInvisibleDurationPlan> {
+            Err(crate::error::ProxyError::not_implemented("test change invisible"))
+        }
+
+        async fn update_offset(
+            &self,
+            _context: &ProxyContext,
+            _request: &UpdateOffsetRequest,
+        ) -> crate::error::ProxyResult<UpdateOffsetPlan> {
+            Ok(UpdateOffsetPlan {
+                status: ProxyStatusMapper::ok_payload(),
+            })
+        }
+
+        async fn get_offset(
+            &self,
+            _context: &ProxyContext,
+            _request: &GetOffsetRequest,
+        ) -> crate::error::ProxyResult<GetOffsetPlan> {
+            Ok(GetOffsetPlan {
+                status: ProxyStatusMapper::ok_payload(),
+                offset: 123,
+            })
+        }
+
+        async fn query_offset(
+            &self,
+            _context: &ProxyContext,
+            request: &QueryOffsetRequest,
+        ) -> crate::error::ProxyResult<QueryOffsetPlan> {
+            let offset = match request.policy {
+                QueryOffsetPolicy::Beginning => 0,
+                QueryOffsetPolicy::End => 2048,
+                QueryOffsetPolicy::Timestamp => request.timestamp_ms.unwrap_or_default(),
+            };
+            Ok(QueryOffsetPlan {
+                status: ProxyStatusMapper::ok_payload(),
+                offset,
+            })
         }
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6849

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedded consumer support with message consumption, acknowledgment, offset management, and dead-letter queue routing capabilities.
  * Pull message operations now include minimum and maximum offset bounds for better request tracking.
  * Expanded request handling for send, pull, and consumer offset operations.

* **Refactor**
  * Enhanced internal message request/response processing and conversion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->