### PR TITLE
[ISSUE #6851]🚀Implement remoting support with configuration and request processing enhancements

### DIFF
--- a/rocketmq-proxy/src/bootstrap.rs
+++ b/rocketmq-proxy/src/bootstrap.rs
@@ -16,6 +16,8 @@ use std::future;
 use std::future::Future;
 use std::sync::Arc;
 
+use futures::FutureExt;
+
 use crate::auth::ProxyAuthRuntime;
 use crate::config::ProxyConfig;
 use crate::config::ProxyMode;
@@ -26,6 +28,7 @@ use crate::observability::ProxyHookChain;
 use crate::observability::ProxyMetrics;
 use crate::processor::DefaultMessagingProcessor;
 use crate::processor::MessagingProcessor;
+use crate::remoting;
 use crate::service::ClusterServiceManager;
 use crate::service::LocalServiceManager;
 use crate::service::ServiceManager;
@@ -87,6 +90,7 @@ impl ProxyRuntimeBuilder {
 
 pub struct ProxyRuntime<P = DefaultMessagingProcessor> {
     config: Arc<ProxyConfig>,
+    processor: Arc<P>,
     grpc_service: ProxyGrpcService<P>,
     local_mode_supported: bool,
     auth_runtime: Option<ProxyAuthRuntime>,
@@ -140,6 +144,7 @@ where
             .with_metrics(metrics);
         Self {
             config,
+            processor: Arc::clone(grpc_service.processor()),
             grpc_service,
             local_mode_supported,
             auth_runtime,
@@ -160,6 +165,7 @@ where
     {
         let ProxyRuntime {
             config,
+            processor,
             grpc_service,
             local_mode_supported,
             auth_runtime,
@@ -173,7 +179,26 @@ where
             Some(auth_runtime) => Some(auth_runtime),
             None => ProxyAuthRuntime::from_proxy_config(&config.auth).await?,
         };
-        server::serve(config, grpc_service.with_auth_runtime(auth_runtime), shutdown).await
+        let grpc_service = grpc_service.with_auth_runtime(auth_runtime);
+        if !config.remoting.enabled {
+            return server::serve(config, grpc_service, shutdown).await;
+        }
+
+        let shared_shutdown = shutdown.boxed().shared();
+        let grpc_shutdown = {
+            let shared_shutdown = shared_shutdown.clone();
+            async move {
+                shared_shutdown.await;
+            }
+        };
+        let remoting_shutdown = async move {
+            shared_shutdown.await;
+        };
+        let grpc_future = server::serve(config.clone(), grpc_service, grpc_shutdown);
+        let remoting_future = remoting::serve(config, processor, remoting_shutdown);
+        let (grpc_result, remoting_result) = tokio::join!(grpc_future, remoting_future);
+        grpc_result?;
+        remoting_result
     }
 }
 

--- a/rocketmq-proxy/src/config.rs
+++ b/rocketmq-proxy/src/config.rs
@@ -24,6 +24,7 @@ use serde::Serialize;
 
 use crate::error::ProxyResult;
 use crate::DEFAULT_PROXY_GRPC_PORT;
+use crate::DEFAULT_PROXY_REMOTING_PORT;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -60,6 +61,38 @@ impl GrpcConfig {
         self.listen_addr.parse().map_err(|error| {
             RocketMQError::illegal_argument(format!(
                 "invalid proxy gRPC listen address '{}': {error}",
+                self.listen_addr
+            ))
+            .into()
+        })
+    }
+
+    pub fn listen_port(&self) -> ProxyResult<u16> {
+        Ok(self.socket_addr()?.port())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct RemotingConfig {
+    pub enabled: bool,
+    pub listen_addr: String,
+}
+
+impl Default for RemotingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            listen_addr: format!("0.0.0.0:{DEFAULT_PROXY_REMOTING_PORT}"),
+        }
+    }
+}
+
+impl RemotingConfig {
+    pub fn socket_addr(&self) -> ProxyResult<SocketAddr> {
+        self.listen_addr.parse().map_err(|error| {
+            RocketMQError::illegal_argument(format!(
+                "invalid proxy remoting listen address '{}': {error}",
                 self.listen_addr
             ))
             .into()
@@ -267,6 +300,7 @@ impl ProxyAuthConfig {
 pub struct ProxyConfig {
     pub mode: ProxyMode,
     pub grpc: GrpcConfig,
+    pub remoting: RemotingConfig,
     pub cluster: ClusterConfig,
     pub local: LocalConfig,
     pub runtime: RuntimeConfig,

--- a/rocketmq-proxy/src/context.rs
+++ b/rocketmq-proxy/src/context.rs
@@ -23,6 +23,8 @@ use crate::auth::AuthenticatedPrincipal;
 use crate::error::ProxyError;
 use crate::error::ProxyResult;
 use crate::grpc::middleware;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ResolvedAddressScheme {
@@ -78,6 +80,23 @@ impl ProxyContext {
 
     pub(crate) fn set_authenticated_principal(&mut self, principal: AuthenticatedPrincipal) {
         self.authenticated_principal = Some(principal);
+    }
+
+    pub fn from_remoting_request(rpc_name: &'static str, channel: &Channel, request: &RemotingCommand) -> Self {
+        Self {
+            request_id: request.opaque().to_string(),
+            rpc_name,
+            remote_addr: Some(channel.remote_address().to_string()),
+            local_addr: Some(channel.local_address().to_string()),
+            client_id: remoting_ext_field(request, "clientID"),
+            language: Some(format!("{:?}", request.language())),
+            client_version: Some(request.version().to_string()),
+            namespace: remoting_ext_field(request, "namespace"),
+            connection_id: Some(channel.channel_id().to_owned()),
+            deadline: None,
+            received_at: Instant::now(),
+            authenticated_principal: None,
+        }
     }
 
     pub fn for_internal_client(rpc_name: &'static str, client_id: impl Into<String>) -> Self {
@@ -155,6 +174,15 @@ fn metadata_string(metadata: &MetadataMap, key: &'static str) -> Option<String> 
         .get(key)
         .and_then(|value| value.to_str().ok())
         .map(str::to_owned)
+}
+
+fn remoting_ext_field(request: &RemotingCommand, key: &str) -> Option<String> {
+    request.ext_fields().and_then(|fields| {
+        fields
+            .iter()
+            .find(|(field_key, _)| field_key.as_str() == key)
+            .map(|(_, value)| value.to_string())
+    })
 }
 
 fn parse_grpc_timeout_metadata(metadata: &MetadataMap) -> ProxyResult<Option<Duration>> {

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -180,6 +180,12 @@ impl<P> Clone for ProxyGrpcService<P> {
 }
 
 impl<P> ProxyGrpcService<P> {
+    pub(crate) fn processor(&self) -> &Arc<P> {
+        &self.processor
+    }
+}
+
+impl<P> ProxyGrpcService<P> {
     pub fn new(config: Arc<ProxyConfig>, processor: Arc<P>, sessions: ClientSessionRegistry) -> Self {
         let interval_ms = Self::housekeeping_interval_from_config(config.as_ref())
             .as_millis()

--- a/rocketmq-proxy/src/lib.rs
+++ b/rocketmq-proxy/src/lib.rs
@@ -47,6 +47,7 @@ pub use config::LocalConfig;
 pub use config::ProxyAuthConfig;
 pub use config::ProxyConfig;
 pub use config::ProxyMode;
+pub use config::RemotingConfig;
 pub use config::RuntimeConfig;
 pub use config::SessionConfig;
 pub use error::ProxyError;
@@ -134,3 +135,6 @@ pub use status::ProxyPayloadStatus;
 
 /// Default gRPC port used by the proxy runtime.
 pub const DEFAULT_PROXY_GRPC_PORT: u16 = 8081;
+
+/// Default remoting port used by the proxy runtime.
+pub const DEFAULT_PROXY_REMOTING_PORT: u16 = 8080;

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use std::future::Future;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -26,6 +27,7 @@ use rocketmq_common::common::message::MessageTrait;
 use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::prelude::RemotingDeserializable;
 use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_remoting::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
@@ -49,9 +51,16 @@ use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateCo
 use rocketmq_remoting::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetResponseHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingSerializable;
+use rocketmq_remoting::remoting_server::rocketmq_tokio_server;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_remoting::runtime::processor::RejectRequestResponse;
+use rocketmq_remoting::runtime::processor::RequestProcessor;
+use tokio::net::TcpListener;
 
+use crate::config::ProxyConfig;
 use crate::context::ProxyContext;
 use crate::error::ProxyError;
+use crate::error::ProxyResult;
 use crate::processor::ConsumerFilterExpression;
 use crate::processor::GetOffsetRequest;
 use crate::processor::MessageQueueTarget;
@@ -65,6 +74,69 @@ use crate::processor::SendMessageEntry;
 use crate::processor::SendMessageRequest;
 use crate::service::ResourceIdentity;
 use crate::status::ProxyPayloadStatus;
+
+pub struct ProxyRemotingRequestProcessor<P> {
+    dispatcher: Arc<ProxyRemotingDispatcher<P>>,
+}
+
+impl<P> Clone for ProxyRemotingRequestProcessor<P> {
+    fn clone(&self) -> Self {
+        Self {
+            dispatcher: Arc::clone(&self.dispatcher),
+        }
+    }
+}
+
+impl<P> ProxyRemotingRequestProcessor<P>
+where
+    P: MessagingProcessor + 'static,
+{
+    pub fn new(processor: Arc<P>) -> Self {
+        Self {
+            dispatcher: Arc::new(ProxyRemotingDispatcher::new(processor)),
+        }
+    }
+}
+
+impl<P> RequestProcessor for ProxyRemotingRequestProcessor<P>
+where
+    P: MessagingProcessor + 'static,
+{
+    async fn process_request(
+        &mut self,
+        channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let context = ProxyContext::from_remoting_request(remoting_rpc_name(request.code()), &channel, request);
+        Ok(Some(self.dispatcher.dispatch(&context, request).await))
+    }
+
+    fn reject_request(&self, _code: i32) -> RejectRequestResponse {
+        (false, None)
+    }
+}
+
+pub async fn serve<P, F>(config: Arc<ProxyConfig>, processor: Arc<P>, shutdown: F) -> ProxyResult<()>
+where
+    P: MessagingProcessor + 'static,
+    F: Future<Output = ()> + Send + 'static,
+{
+    let addr = config.remoting.socket_addr()?;
+    let listener = TcpListener::bind(addr).await.map_err(|error| ProxyError::Transport {
+        message: format!("proxy remoting server failed to bind {addr}: {error}"),
+    })?;
+    rocketmq_tokio_server::run(
+        listener,
+        shutdown,
+        ProxyRemotingRequestProcessor::new(processor),
+        None,
+        Vec::new(),
+        None,
+    )
+    .await;
+    Ok(())
+}
 
 pub struct ProxyRemotingDispatcher<P> {
     processor: Arc<P>,
@@ -421,6 +493,22 @@ where
             (!plan.status.is_ok()).then(|| plan.status.message().to_owned()),
             None,
         )
+    }
+}
+
+fn remoting_rpc_name(code: i32) -> &'static str {
+    match RequestCode::from(code) {
+        RequestCode::GetRouteinfoByTopic => "RemotingGetRouteinfoByTopic",
+        RequestCode::QueryAssignment => "RemotingQueryAssignment",
+        RequestCode::SendMessage => "RemotingSendMessage",
+        RequestCode::SendMessageV2 => "RemotingSendMessageV2",
+        RequestCode::PullMessage => "RemotingPullMessage",
+        RequestCode::UpdateConsumerOffset => "RemotingUpdateConsumerOffset",
+        RequestCode::QueryConsumerOffset => "RemotingQueryConsumerOffset",
+        RequestCode::GetMaxOffset => "RemotingGetMaxOffset",
+        RequestCode::GetMinOffset => "RemotingGetMinOffset",
+        RequestCode::SearchOffsetByTimestamp => "RemotingSearchOffsetByTimestamp",
+        _ => "RemotingRequest",
     }
 }
 

--- a/rocketmq-proxy/tests/remoting_ingress.rs
+++ b/rocketmq-proxy/tests/remoting_ingress.rs
@@ -1,0 +1,212 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rocketmq_proxy::context::ProxyContext;
+use rocketmq_proxy::context::ResolvedEndpoint;
+use rocketmq_proxy::ClusterServiceManager;
+use rocketmq_proxy::DefaultAssignmentService;
+use rocketmq_proxy::DefaultConsumerService;
+use rocketmq_proxy::DefaultMessageService;
+use rocketmq_proxy::DefaultTransactionService;
+use rocketmq_proxy::GrpcConfig;
+use rocketmq_proxy::MetadataService;
+use rocketmq_proxy::ProxyConfig;
+use rocketmq_proxy::ProxyResult;
+use rocketmq_proxy::ProxyRuntime;
+use rocketmq_proxy::ProxyTopicMessageType;
+use rocketmq_proxy::RemotingConfig;
+use rocketmq_proxy::ResourceIdentity;
+use rocketmq_proxy::RouteService;
+use rocketmq_proxy::SubscriptionGroupMetadata;
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::connection::Connection;
+use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ObservedRouteContext {
+    local_addr: Option<String>,
+    remote_addr: Option<String>,
+}
+
+#[derive(Default)]
+struct RecordingRouteService {
+    observed: Mutex<Vec<ObservedRouteContext>>,
+}
+
+impl RecordingRouteService {
+    fn observed(&self) -> Vec<ObservedRouteContext> {
+        self.observed.lock().expect("route service mutex poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl RouteService for RecordingRouteService {
+    async fn query_route(
+        &self,
+        context: &ProxyContext,
+        _topic: &ResourceIdentity,
+        _endpoints: &[ResolvedEndpoint],
+    ) -> ProxyResult<TopicRouteData> {
+        self.observed
+            .lock()
+            .expect("route service mutex poisoned")
+            .push(ObservedRouteContext {
+                local_addr: context.local_addr().map(str::to_owned),
+                remote_addr: context.remote_addr().map(str::to_owned),
+            });
+        Ok(TopicRouteData::default())
+    }
+}
+
+#[derive(Default)]
+struct StaticMetadataService;
+
+#[async_trait]
+impl MetadataService for StaticMetadataService {
+    async fn topic_message_type(
+        &self,
+        _context: &ProxyContext,
+        _topic: &ResourceIdentity,
+    ) -> ProxyResult<ProxyTopicMessageType> {
+        Ok(ProxyTopicMessageType::Normal)
+    }
+
+    async fn subscription_group(
+        &self,
+        _context: &ProxyContext,
+        _topic: &ResourceIdentity,
+        _group: &ResourceIdentity,
+    ) -> ProxyResult<Option<SubscriptionGroupMetadata>> {
+        Ok(None)
+    }
+}
+
+#[tokio::test]
+async fn query_route_over_remoting_integration_injects_transport_context() {
+    let route_service = Arc::new(RecordingRouteService::default());
+    let service_manager = Arc::new(ClusterServiceManager::with_services(
+        route_service.clone(),
+        Arc::new(StaticMetadataService),
+        Arc::new(DefaultAssignmentService),
+        Arc::new(DefaultMessageService),
+        Arc::new(DefaultConsumerService),
+        Arc::new(DefaultTransactionService),
+    ));
+
+    let grpc_addr = free_local_addr();
+    let remoting_addr = free_local_addr();
+    let runtime = ProxyRuntime::builder(ProxyConfig {
+        grpc: GrpcConfig {
+            listen_addr: grpc_addr.to_string(),
+            ..GrpcConfig::default()
+        },
+        remoting: RemotingConfig {
+            enabled: true,
+            listen_addr: remoting_addr.to_string(),
+        },
+        ..ProxyConfig::default()
+    })
+    .with_service_manager(service_manager)
+    .build();
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        runtime
+            .serve_with_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+
+    let mut connection = connect_remoting_with_retry(remoting_addr).await;
+    let request = RemotingCommand::create_request_command(
+        RequestCode::GetRouteinfoByTopic,
+        GetRouteInfoRequestHeader::new("TopicA", None),
+    );
+    let opaque = request.opaque();
+    connection
+        .send_command(request)
+        .await
+        .expect("remoting request should be sent");
+
+    let response = timeout(Duration::from_secs(3), async {
+        loop {
+            match connection.receive_command().await {
+                Some(Ok(response)) => break response,
+                Some(Err(error)) => panic!("failed to decode remoting response: {error}"),
+                None => continue,
+            }
+        }
+    })
+    .await
+    .expect("remoting response should arrive before timeout");
+
+    assert_eq!(response.code(), ResponseCode::Success as i32);
+    assert_eq!(response.opaque(), opaque);
+
+    let _ = shutdown_tx.send(());
+    let serve_result = server_task.await.expect("server task should join");
+    assert!(
+        serve_result.is_ok(),
+        "server should shut down cleanly: {serve_result:?}"
+    );
+
+    let observed = route_service.observed();
+    assert_eq!(observed.len(), 1);
+    assert_eq!(
+        observed[0].local_addr.as_deref(),
+        Some(remoting_addr.to_string().as_str())
+    );
+    assert!(
+        observed[0]
+            .remote_addr
+            .as_deref()
+            .is_some_and(|remote| remote.starts_with("127.0.0.1:")),
+        "expected remote address to be recorded, got {:?}",
+        observed[0].remote_addr
+    );
+}
+
+async fn connect_remoting_with_retry(addr: SocketAddr) -> Connection {
+    let mut last_error = None;
+    for _ in 0..20 {
+        match tokio::net::TcpStream::connect(addr).await {
+            Ok(stream) => return Connection::new(stream),
+            Err(error) => {
+                last_error = Some(error);
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        }
+    }
+
+    panic!("remoting client failed to connect to {addr}: {last_error:?}");
+}
+
+fn free_local_addr() -> SocketAddr {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local port probe");
+    let addr = listener.local_addr().expect("discover local addr");
+    drop(listener);
+    addr
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6851

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Proxy now supports RocketMQ remoting protocol in addition to gRPC, enabling clients to use either transport layer
  * Added remoting configuration options to enable/disable the protocol and customize listen address and port (default port: 8080)
  * Both gRPC and remoting protocols can operate concurrently

* **Tests**
  * Added integration tests validating remoting protocol request handling and context routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->