### PR TITLE
[ISSUE #6866]🚀Add message detail viewing functionality with base64 support and enhance message service

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -4118,6 +4118,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argon2",
+ "base64 0.22.1",
  "cheetah-string",
  "chrono",
  "json5",

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ tauri-build = { version = "2.5.4", features = [] }
 
 [dependencies]
 serde_json       = "1.0"
+base64           = "0.22"
 json5            = "0.4"
 serde            = { version = "1.0", features = ["derive"] }
 log              = "0.4"

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -111,6 +111,7 @@ pub fn run() {
             consumer::commands::delete_consumer_group,
             message::commands::query_message_by_topic_key,
             message::commands::query_message_by_id,
+            message::commands::view_message_detail,
             producer::commands::get_producer_topic_options,
             producer::commands::query_producer_connections,
             topic::commands::get_topic_list,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use crate::message::service::MessageManager;
+use crate::message::types::MessageDetailView;
 use crate::message::types::MessageSummaryListResponse;
 use rocketmq_dashboard_common::MessageIdQueryRequest;
 use rocketmq_dashboard_common::MessageKeyQueryRequest;
+use rocketmq_dashboard_common::ViewMessageRequest;
 use tauri::State;
 
 #[tauri::command]
@@ -36,6 +38,17 @@ pub async fn query_message_by_id(
 ) -> Result<MessageSummaryListResponse, String> {
     message_manager
         .query_message_by_id(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn view_message_detail(
+    request: ViewMessageRequest,
+    message_manager: State<'_, MessageManager>,
+) -> Result<MessageDetailView, String> {
+    message_manager
+        .view_message_detail(request)
         .await
         .map_err(|error| error.to_string())
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
@@ -14,15 +14,20 @@
 
 use crate::message::admin::ManagedMessageAdmin;
 use crate::message::types::MessageError;
+use crate::message::types::MessageDetailView;
 use crate::message::types::MessageResult;
 use crate::message::types::MessageSummaryListResponse;
 use crate::message::types::MessageSummaryView;
 use crate::nameserver::NameServerRuntimeState;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine as _;
 use cheetah_string::CheetahString;
 use rocketmq_admin_core::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_dashboard_common::ViewMessageRequest;
 use rocketmq_dashboard_common::MessageIdQueryRequest;
 use rocketmq_dashboard_common::MessageKeyQueryRequest;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -110,6 +115,38 @@ impl MessageManager {
         }
     }
 
+    pub(crate) async fn view_message_detail(&self, request: ViewMessageRequest) -> MessageResult<MessageDetailView> {
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("message admin session should be initialized before use");
+                self.view_message_detail_with_admin(&mut session.admin, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "view_message_detail failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `view_message_detail` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
     async fn ensure_admin_session(&self, session_slot: &mut Option<ManagedMessageAdmin>) -> MessageResult<()> {
         let generation = self.runtime.generation();
         let needs_reconnect = session_slot
@@ -190,8 +227,36 @@ impl MessageManager {
         admin: &mut DefaultMQAdminExt,
         request: MessageIdQueryRequest,
     ) -> MessageResult<MessageSummaryListResponse> {
-        let topic = normalize_required_field("topic", request.topic)?;
-        let message_id = normalize_required_field("messageId", request.message_id)?;
+        let message = self
+            .find_message_by_id_with_admin(admin, request.topic, request.message_id)
+            .await?;
+
+        Ok(MessageSummaryListResponse {
+            items: vec![map_message_summary(message)],
+            total: 1,
+        })
+    }
+
+    async fn view_message_detail_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: ViewMessageRequest,
+    ) -> MessageResult<MessageDetailView> {
+        let message = self
+            .find_message_by_id_with_admin(admin, request.topic, request.message_id)
+            .await?;
+
+        Ok(map_message_detail(message))
+    }
+
+    async fn find_message_by_id_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        topic: String,
+        message_id: String,
+    ) -> MessageResult<MessageExt> {
+        let topic = normalize_required_field("topic", topic)?;
+        let message_id = normalize_required_field("messageId", message_id)?;
 
         let result = admin
             .query_message_by_unique_key(
@@ -206,12 +271,7 @@ impl MessageManager {
             .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
 
         let messages = result.message_list().to_vec();
-        let message = first_message_or_validation_error(messages)?;
-
-        Ok(MessageSummaryListResponse {
-            items: vec![map_message_summary(message)],
-            total: 1,
-        })
+        first_message_or_validation_error(messages)
     }
 }
 
@@ -262,6 +322,48 @@ fn map_message_summary(message: MessageExt) -> MessageSummaryView {
     }
 }
 
+fn map_message_detail(message: MessageExt) -> MessageDetailView {
+    let properties = message
+        .properties()
+        .iter()
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect::<BTreeMap<_, _>>();
+    let body = message.body().map(|body| body.to_vec()).unwrap_or_default();
+    let (body_text, body_base64) = decode_body_fields(&body);
+
+    MessageDetailView {
+        topic: message.topic().to_string(),
+        msg_id: message.msg_id().to_string(),
+        born_host: Some(message.born_host().to_string()),
+        store_host: Some(message.store_host().to_string()),
+        born_timestamp: Some(message.born_timestamp()),
+        store_timestamp: Some(message.store_timestamp()),
+        queue_id: Some(message.queue_id()),
+        queue_offset: Some(message.queue_offset()),
+        store_size: Some(message.store_size()),
+        reconsume_times: Some(message.reconsume_times()),
+        body_crc: Some(message.body_crc()),
+        sys_flag: Some(message.sys_flag()),
+        flag: Some(message.flag()),
+        prepared_transaction_offset: Some(message.prepared_transaction_offset()),
+        properties,
+        body_text,
+        body_base64,
+        message_track_list: None,
+    }
+}
+
+fn decode_body_fields(body: &[u8]) -> (Option<String>, Option<String>) {
+    if body.is_empty() {
+        return (Some(String::new()), None);
+    }
+
+    match String::from_utf8(body.to_vec()) {
+        Ok(text) => (Some(text), None),
+        Err(_) => (None, Some(BASE64_STANDARD.encode(body))),
+    }
+}
+
 fn first_message_or_validation_error(mut messages: Vec<MessageExt>) -> MessageResult<MessageExt> {
     messages.sort_by(|left, right| {
         right
@@ -309,5 +411,68 @@ mod tests {
         let error = first_message_or_validation_error(Vec::new()).expect_err("empty results should fail");
 
         assert!(error.to_string().contains("No message matched the current query"));
+    }
+
+    #[test]
+    fn map_message_detail_maps_hosts_properties_and_utf8_body() {
+        let message = MessageBuilder::new()
+            .topic("TopicTest")
+            .body_slice(br#"{"ok":true}"#)
+            .tags("TagA")
+            .keys(vec!["KeyA".to_string()])
+            .trace_switch(true)
+            .raw_property("order_source", "mobile")
+            .expect("custom property should be accepted")
+            .build_unchecked();
+
+        let mut message_ext = MessageExt::default();
+        message_ext.set_message_inner(message);
+        message_ext.set_msg_id(CheetahString::from("msg-2"));
+        message_ext.set_store_timestamp(1_700_000_000_123);
+        message_ext.set_born_timestamp(1_700_000_000_000);
+        message_ext.set_queue_id(3);
+        message_ext.set_queue_offset(288);
+        message_ext.set_store_size(264);
+        message_ext.set_reconsume_times(0);
+        message_ext.set_body_crc(613_185_359);
+        message_ext.set_sys_flag(7);
+        message_ext.set_store_host("172.20.48.1:10911".parse().expect("store host"));
+        message_ext.set_born_host("172.20.48.1:61266".parse().expect("born host"));
+
+        let detail = map_message_detail(message_ext);
+
+        assert_eq!(detail.topic, "TopicTest");
+        assert_eq!(detail.msg_id, "msg-2");
+        assert_eq!(detail.store_host.as_deref(), Some("172.20.48.1:10911"));
+        assert_eq!(detail.born_host.as_deref(), Some("172.20.48.1:61266"));
+        assert_eq!(detail.queue_id, Some(3));
+        assert_eq!(detail.queue_offset, Some(288));
+        assert_eq!(detail.store_size, Some(264));
+        assert_eq!(detail.body_text.as_deref(), Some(r#"{"ok":true}"#));
+        assert_eq!(detail.body_base64, None);
+        assert_eq!(detail.properties.get("TAGS").map(String::as_str), Some("TagA"));
+        assert_eq!(detail.properties.get("KEYS").map(String::as_str), Some("KeyA"));
+        assert_eq!(
+            detail.properties.get("order_source").map(String::as_str),
+            Some("mobile")
+        );
+        assert_eq!(detail.message_track_list, None);
+    }
+
+    #[test]
+    fn map_message_detail_falls_back_to_base64_for_binary_body() {
+        let message = MessageBuilder::new()
+            .topic("TopicTest")
+            .body(vec![0xff, 0x00, 0x41])
+            .build_unchecked();
+
+        let mut message_ext = MessageExt::default();
+        message_ext.set_message_inner(message);
+        message_ext.set_msg_id(CheetahString::from("msg-bin"));
+
+        let detail = map_message_detail(message_ext);
+
+        assert_eq!(detail.body_text, None);
+        assert_eq!(detail.body_base64.as_deref(), Some("/wBB"));
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageDetailModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageDetailModal.tsx
@@ -1,56 +1,104 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { X, FileText, Activity, Users, CheckCircle2, RotateCcw, Copy, Database, Server, Clock, HardDrive, Flag, RefreshCw, Hash, Tag, Globe, Key, Layers, Code, User, AlertCircle } from 'lucide-react';
+import {
+  X,
+  FileText,
+  Activity,
+  Users,
+  Copy,
+  Database,
+  Server,
+  Clock,
+  HardDrive,
+  Flag,
+  RefreshCw,
+  Hash,
+  Tag,
+  Globe,
+  Key,
+  Layers,
+  AlertCircle,
+  Info,
+} from 'lucide-react';
 import { toast } from 'sonner@2.0.3';
+import { MessageService } from '../services/message.service';
+import type { MessageDetail, MessageSummary } from '../features/message/types/message.types';
 
 interface MessageDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
-  message: any;
+  message: MessageSummary | null;
 }
 
 export const MessageDetailModal = ({ isOpen, onClose, message }: MessageDetailModalProps) => {
   if (!isOpen) return null;
+  const [detail, setDetail] = useState<MessageDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
 
-  // Mock data if message is missing some fields, based on screenshot
-  const data = {
-    topic: message?.topic || 'TopicTest',
-    messageId: message?.msgId || '240E03B350D263C087AA69AB77E798719CBC18B4AAC28A91AB100000',
-    storeHost: message?.storeHost || '172.20.48.1:10911',
-    bornHost: message?.bornHost || '172.20.48.1:61266',
-    storeTime: message?.storeTime || '2026-01-27 21:46:42',
-    bornTime: message?.bornTime || '2026-01-27 21:46:42',
-    queueId: message?.queueId || '3',
-    queueOffset: message?.queueOffset || '288',
-    storeSize: message?.storeSize || '264 bytes',
-    reconsume: message?.reconsume || '0',
-    bodyCRC: message?.bodyCRC || '613185359',
-    sysFlag: message?.sysFlag || '0',
-    flag: message?.flag || '0',
-    transOffset: message?.transOffset || '0',
-    // Properties
-    msgRegion: 'DefaultRegion',
-    uniqKey: message?.msgId || '240E03B350D263C087AA69AB77E798719CBC18B4AAC28A91AB100000',
-    cluster: 'DefaultCluster',
-    tags: message?.tag || 'TagA',
-    wait: 'true',
-    traceOn: 'true',
-    // User Props
-    orderSource: 'mobile_app',
-    traceId: 't_88992211',
-    userLevel: 'vip_gold',
-    clientVersion: 'v5.0.1',
-    // Body
-    body: message?.body || 'Hello RocketMQ Key: Key_0',
-    // Tracking
-    consumerGroup: 'please_rename_unique_group_name_4',
-    status: 'CONSUMED'
-  };
+  useEffect(() => {
+    if (!isOpen || !message) {
+      setDetail(null);
+      setError('');
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError('');
+    setDetail(null);
+
+    void MessageService.viewMessageDetail({
+      topic: message.topic,
+      messageId: message.msgId,
+    })
+      .then((result) => {
+        if (!cancelled) {
+          setDetail(result);
+        }
+      })
+      .catch((loadError) => {
+        if (!cancelled) {
+          setError(loadError instanceof Error ? loadError.message : 'Failed to load message detail');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, message]);
 
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
     toast.success("Copied to clipboard");
   };
+
+  const formatTimestamp = (value?: number | null) => {
+    if (!value) {
+      return '-';
+    }
+    return new Date(value).toLocaleString();
+  };
+
+  const systemPropertyEntries = useMemo(() => {
+    if (!detail) {
+      return [];
+    }
+    return Object.entries(detail.properties).filter(([key]) => key === key.toUpperCase());
+  }, [detail]);
+
+  const userPropertyEntries = useMemo(() => {
+    if (!detail) {
+      return [];
+    }
+    return Object.entries(detail.properties).filter(([key]) => key !== key.toUpperCase());
+  }, [detail]);
 
   const InfoItem = ({ icon: Icon, label, value, mono = false, copyable = false }: any) => (
     <div className="flex items-start p-3 hover:bg-gray-50 dark:hover:bg-gray-800/50 rounded-lg transition-colors group">
@@ -115,125 +163,131 @@ export const MessageDetailModal = ({ isOpen, onClose, message }: MessageDetailMo
 
           {/* Body Content */}
           <div className="flex-1 overflow-y-auto bg-gray-50/50 dark:bg-gray-950/50 p-6 space-y-6">
-            
-            {/* Message Info Section */}
-            <div className="space-y-3">
-              <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider px-1">Message Info</h3>
-              <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-2 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-0">
-                <InfoItem icon={Database} label="Topic" value={data.topic} mono />
-                <InfoItem icon={Globe} label="BornHost" value={data.bornHost} mono />
-                
-                <InfoItem icon={Hash} label="Message ID" value={data.messageId} mono copyable />
-                <InfoItem icon={Clock} label="BornTime" value={data.bornTime} mono />
-                
-                <InfoItem icon={Server} label="StoreHost" value={data.storeHost} mono />
-                <InfoItem icon={Clock} label="StoreTime" value={data.storeTime} mono />
-                
-                <InfoItem icon={Layers} label="Queue ID" value={data.queueId} mono />
-                <InfoItem icon={RefreshCw} label="Reconsume" value={data.reconsume} mono />
-                
-                <InfoItem icon={HardDrive} label="StoreSize" value={data.storeSize} mono />
-                <InfoItem icon={Flag} label="SysFlag" value={data.sysFlag} mono />
-                
-                <InfoItem icon={Key} label="BodyCRC" value={data.bodyCRC} mono />
-                <InfoItem icon={RefreshCw} label="Trans Offset" value={data.transOffset} mono />
-                
-                <InfoItem icon={Tag} label="Flag" value={data.flag} mono />
-                <InfoItem icon={Layers} label="Queue Offset" value={data.queueOffset} mono />
+            {isLoading ? (
+              <div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 bg-white px-6 py-20 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900">
+                <RefreshCw className="mb-4 h-8 w-8 animate-spin text-blue-500" />
+                <p className="text-sm font-medium text-gray-700 dark:text-gray-200">Loading message detail...</p>
               </div>
-            </div>
+            ) : error ? (
+              <div className="flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-4 text-sm text-red-800 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-200">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <div>{error}</div>
+              </div>
+            ) : detail ? (
+              <>
+                <div className="space-y-3">
+                  <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider px-1">Message Info</h3>
+                  <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-2 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-0">
+                    <InfoItem icon={Database} label="Topic" value={detail.topic} mono />
+                    <InfoItem icon={Globe} label="BornHost" value={detail.bornHost || '-'} mono />
 
-            {/* Properties Section */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-               {/* System Properties */}
-               <div className="space-y-3">
-                  <div className="flex items-center justify-between px-1">
-                    <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
-                       <Activity className="w-3.5 h-3.5" /> System Properties
-                    </h3>
-                    <span className="bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-[10px] font-bold px-1.5 py-0.5 rounded">6</span>
-                  </div>
-                  <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-4 space-y-1">
-                    <PropertyItem label="MSG_REGION" value={data.msgRegion} />
-                    <PropertyItem label="UNIQ_KEY" value={data.uniqKey} />
-                    <PropertyItem label="CLUSTER" value={data.cluster} />
-                    <PropertyItem label="TAGS" value={data.tags} />
-                    <PropertyItem label="WAIT" value={data.wait} />
-                    <PropertyItem label="TRACE_ON" value={data.traceOn} />
-                  </div>
-               </div>
+                    <InfoItem icon={Hash} label="Message ID" value={detail.msgId} mono copyable />
+                    <InfoItem icon={Clock} label="BornTime" value={formatTimestamp(detail.bornTimestamp)} mono />
 
-               {/* User Properties */}
-               <div className="space-y-3">
-                  <div className="flex items-center justify-between px-1">
-                    <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
-                       <Users className="w-3.5 h-3.5" /> User Properties
-                    </h3>
-                    <span className="bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-[10px] font-bold px-1.5 py-0.5 rounded">4</span>
-                  </div>
-                  <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-4 space-y-1">
-                    <PropertyItem label="order_source" value={data.orderSource} />
-                    <PropertyItem label="trace_id" value={data.traceId} />
-                    <PropertyItem label="user_level" value={data.userLevel} />
-                    <PropertyItem label="client_version" value={data.clientVersion} />
-                  </div>
-               </div>
-            </div>
+                    <InfoItem icon={Server} label="StoreHost" value={detail.storeHost || '-'} mono />
+                    <InfoItem icon={Clock} label="StoreTime" value={formatTimestamp(detail.storeTimestamp)} mono />
 
-            {/* Message Body */}
-            <div className="space-y-3">
-               <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider px-1">Message Body</h3>
-               <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-4 font-mono text-sm text-gray-800 dark:text-gray-200 overflow-x-auto">
-                 {data.body}
-               </div>
-            </div>
+                    <InfoItem icon={Layers} label="Queue ID" value={String(detail.queueId ?? '-')} mono />
+                    <InfoItem icon={RefreshCw} label="Reconsume" value={String(detail.reconsumeTimes ?? '-')} mono />
 
-            {/* Message Tracking */}
-            <div className="space-y-3">
-               <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider px-1">Message Tracking</h3>
-               <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden">
-                  <div className="divide-y divide-gray-100 dark:divide-gray-800">
-                    <div className="p-4 flex flex-col md:flex-row md:items-center justify-between gap-4">
-                       <div className="flex items-center gap-3">
-                          <Users className="w-4 h-4 text-gray-400" />
-                          <span className="text-sm font-medium text-gray-500 dark:text-gray-400">Consumer Group</span>
-                       </div>
-                       <div className="font-mono text-sm font-semibold text-gray-900 dark:text-white">
-                          {data.consumerGroup}
-                       </div>
+                    <InfoItem icon={HardDrive} label="StoreSize" value={detail.storeSize ? `${detail.storeSize} bytes` : '-'} mono />
+                    <InfoItem icon={Flag} label="SysFlag" value={String(detail.sysFlag ?? '-')} mono />
+
+                    <InfoItem icon={Key} label="BodyCRC" value={String(detail.bodyCrc ?? '-')} mono />
+                    <InfoItem icon={RefreshCw} label="Trans Offset" value={String(detail.preparedTransactionOffset ?? '-')} mono />
+
+                    <InfoItem icon={Tag} label="Flag" value={String(detail.flag ?? '-')} mono />
+                    <InfoItem icon={Layers} label="Queue Offset" value={String(detail.queueOffset ?? '-')} mono />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between px-1">
+                      <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                        <Activity className="w-3.5 h-3.5" /> System Properties
+                      </h3>
+                      <span className="bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-[10px] font-bold px-1.5 py-0.5 rounded">
+                        {systemPropertyEntries.length}
+                      </span>
                     </div>
-                    
-                    <div className="p-4 flex flex-col md:flex-row md:items-center justify-between gap-4">
-                       <div className="flex items-center gap-3">
-                          <Activity className="w-4 h-4 text-gray-400" />
-                          <span className="text-sm font-medium text-gray-500 dark:text-gray-400">Status</span>
-                       </div>
-                       <div>
-                          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 text-xs font-bold uppercase border border-green-100 dark:border-green-900/30">
-                             <CheckCircle2 className="w-3.5 h-3.5" />
-                             {data.status}
-                          </span>
-                       </div>
-                    </div>
-
-                    <div className="p-4 flex flex-col md:flex-row md:items-center justify-between gap-4">
-                       <div className="flex items-center gap-3">
-                          <RotateCcw className="w-4 h-4 text-gray-400" />
-                          <span className="text-sm font-medium text-gray-500 dark:text-gray-400">Operation</span>
-                       </div>
-                       <div>
-                          <button 
-                            onClick={() => toast.success("Message resend requested")}
-                            className="flex items-center px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors shadow-sm"
-                          >
-                             <RotateCcw className="w-3.5 h-3.5 mr-1.5" />
-                             Resend Message
-                          </button>
-                       </div>
+                    <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-4 space-y-1">
+                      {systemPropertyEntries.length > 0 ? systemPropertyEntries.map(([key, value]) => (
+                        <PropertyItem key={key} label={key} value={value} />
+                      )) : (
+                        <div className="text-sm text-gray-500 dark:text-gray-400">No system properties</div>
+                      )}
                     </div>
                   </div>
-               </div>
-            </div>
+
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between px-1">
+                      <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                        <Users className="w-3.5 h-3.5" /> User Properties
+                      </h3>
+                      <span className="bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-[10px] font-bold px-1.5 py-0.5 rounded">
+                        {userPropertyEntries.length}
+                      </span>
+                    </div>
+                    <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-4 space-y-1">
+                      {userPropertyEntries.length > 0 ? userPropertyEntries.map(([key, value]) => (
+                        <PropertyItem key={key} label={key} value={value} />
+                      )) : (
+                        <div className="text-sm text-gray-500 dark:text-gray-400">No user properties</div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider px-1">Message Body</h3>
+                  <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-4 space-y-3">
+                    {detail.bodyText !== null && detail.bodyText !== undefined ? (
+                      <div className="font-mono text-sm text-gray-800 dark:text-gray-200 overflow-x-auto whitespace-pre-wrap break-all">
+                        {detail.bodyText}
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200">
+                          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                          <span>消息体不是有效 UTF-8，当前以 base64 形式展示。</span>
+                        </div>
+                        <div className="font-mono text-xs text-gray-800 dark:text-gray-200 overflow-x-auto break-all">
+                          {detail.bodyBase64 || '-'}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider px-1">Message Tracking</h3>
+                  <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm p-4">
+                    {detail.messageTrackList && detail.messageTrackList.length > 0 ? (
+                      <div className="space-y-2">
+                        {detail.messageTrackList.map((track) => (
+                          <div key={`${track.consumerGroup}-${track.trackType}`} className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-2 text-sm dark:border-gray-800 dark:bg-gray-800/40">
+                            <div className="font-medium text-gray-900 dark:text-white">{track.consumerGroup}</div>
+                            <div className="mt-1 text-gray-600 dark:text-gray-300">{track.trackType}</div>
+                            {track.exceptionDesc && (
+                              <div className="mt-1 font-mono text-xs text-red-600 dark:text-red-300 break-all">{track.exceptionDesc}</div>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="flex items-start gap-3 rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-4 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800/40 dark:text-gray-300">
+                        <Info className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+                        <div>
+                          `messageTrackList` 依赖的底层 `message_track_detail` 能力在 `rocketmq-rust` 里尚未实现。
+                          当前 Phase 2 先保证详情主数据真实，Track 与 Resend 留到后续 phase。
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </>
+            ) : null}
 
           </div>
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageView.tsx
@@ -15,6 +15,7 @@ import {
 import { toast } from 'sonner@2.0.3';
 import { Input } from './ui/input';
 import { MessageService } from '../services/message.service';
+import { MessageDetailModal } from './MessageDetailModal';
 import { useTopicCatalog } from '../features/topic/hooks/useTopicCatalog';
 import type { MessageSummary } from '../features/message/types/message.types';
 
@@ -26,6 +27,7 @@ export const MessageView = () => {
   const [startDate, setStartDate] = useState('2026-01-27 00:00:00');
   const [endDate, setEndDate] = useState('2026-01-28 00:00:00');
   const [messages, setMessages] = useState<MessageSummary[]>([]);
+  const [selectedMessage, setSelectedMessage] = useState<MessageSummary | null>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [searchError, setSearchError] = useState('');
   const [hasSearched, setHasSearched] = useState(false);
@@ -235,6 +237,12 @@ export const MessageView = () => {
 
   return (
     <div className="max-w-[1600px] mx-auto space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500 pb-12">
+        <MessageDetailModal
+          isOpen={!!selectedMessage}
+          onClose={() => setSelectedMessage(null)}
+          message={selectedMessage}
+        />
+
         {/* Header Tabs */}
         <div className="flex justify-center mb-8">
            <div className="bg-gray-100 dark:bg-gray-800 p-1 rounded-xl inline-flex shadow-inner">
@@ -404,11 +412,11 @@ export const MessageView = () => {
                     {/* Action Footer - Previous Style (Full Width Black Button) */}
                     <div className="p-4 bg-gray-50/50 dark:bg-gray-800/50 border-t border-gray-100 dark:border-gray-800">
                         <button 
-                            disabled
-                            className="w-full flex items-center justify-center space-x-2 px-4 py-2.5 rounded-xl bg-gray-300 text-white text-xs font-bold transition-colors shadow-sm cursor-not-allowed dark:bg-gray-700 dark:text-gray-300"
+                            onClick={() => setSelectedMessage(msg)}
+                            className="w-full flex items-center justify-center space-x-2 px-4 py-2.5 rounded-xl bg-gray-900 dark:bg-blue-600 text-white dark:text-white text-xs font-bold hover:bg-gray-800 dark:hover:bg-blue-500 transition-colors shadow-sm active:scale-[0.98]"
                         >
                             <FileText className="w-3.5 h-3.5" />
-                            <span>Detail In Phase 2</span>
+                            <span>View Details</span>
                         </button>
                     </div>
                 </motion.div>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message/types/message.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message/types/message.types.ts
@@ -20,3 +20,35 @@ export interface MessageIdQueryRequest {
     topic: string;
     messageId: string;
 }
+
+export interface ViewMessageRequest {
+    topic: string;
+    messageId: string;
+}
+
+export interface MessageTrack {
+    consumerGroup: string;
+    trackType: string;
+    exceptionDesc?: string | null;
+}
+
+export interface MessageDetail {
+    topic: string;
+    msgId: string;
+    bornHost?: string | null;
+    storeHost?: string | null;
+    bornTimestamp?: number | null;
+    storeTimestamp?: number | null;
+    queueId?: number | null;
+    queueOffset?: number | null;
+    storeSize?: number | null;
+    reconsumeTimes?: number | null;
+    bodyCrc?: number | null;
+    sysFlag?: number | null;
+    flag?: number | null;
+    preparedTransactionOffset?: number | null;
+    properties: Record<string, string>;
+    bodyText?: string | null;
+    bodyBase64?: string | null;
+    messageTrackList?: MessageTrack[] | null;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/message.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/message.service.ts
@@ -1,8 +1,10 @@
 import { invoke } from '@tauri-apps/api/core';
 import type {
+    MessageDetail,
     MessageIdQueryRequest,
     MessageKeyQueryRequest,
     MessageSummaryListResponse,
+    ViewMessageRequest,
 } from '../features/message/types/message.types';
 
 export class MessageService {
@@ -12,5 +14,9 @@ export class MessageService {
 
     static async queryMessageById(request: MessageIdQueryRequest): Promise<MessageSummaryListResponse> {
         return invoke<MessageSummaryListResponse>('query_message_by_id', { request });
+    }
+
+    static async viewMessageDetail(request: ViewMessageRequest): Promise<MessageDetail> {
+        return invoke<MessageDetail>('view_message_detail', { request });
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6866

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled message detail viewing with comprehensive information including properties, metadata (timestamps, hosts, queue details), and message body content.
  * Message body automatically renders as UTF-8 text or base64 encoding based on content type.

* **Tests**
  * Added unit tests for message detail mapping and body content decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->