### PR TITLE
[ISSUE #6875]🚀Add DLQ message resending functionality with new request and result types

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -84,6 +84,7 @@ use rocketmq_remoting::protocol::body::subscription_group_wrapper::SubscriptionG
 use rocketmq_remoting::protocol::body::topic::topic_list::TopicList;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
 use rocketmq_remoting::protocol::body::user_info::UserInfo;
+use rocketmq_remoting::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
 use rocketmq_remoting::protocol::header::create_topic_request_header::CreateTopicRequestHeader;
 use rocketmq_remoting::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader;
 use rocketmq_remoting::protocol::header::elect_master_response_header::ElectMasterResponseHeader;
@@ -1400,18 +1401,46 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         topic: CheetahString,
         msg_id: CheetahString,
     ) -> rocketmq_error::RocketMQResult<ConsumeMessageDirectlyResult> {
-        todo!()
+        let consumer_connection = self
+            .examine_consumer_connection_info(consumer_group.clone(), None)
+            .await?;
+        let (resolved_client_id, client_addr) =
+            select_consumer_direct_connection(&consumer_group, &consumer_connection, Some(&client_id))?;
+        let message = MQAdminExt::query_message(self, CheetahString::default(), topic.clone(), msg_id.clone()).await?;
+        let request_header = ConsumeMessageDirectlyResultRequestHeader {
+            consumer_group,
+            client_id: Some(resolved_client_id),
+            msg_id: Some(msg_id),
+            broker_name: (!message.broker_name().is_empty()).then(|| message.broker_name.clone()),
+            topic: Some(topic),
+            topic_sys_flag: None,
+            group_sys_flag: None,
+            topic_request_header: None,
+        };
+
+        self.client_instance
+            .as_ref()
+            .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?
+            .get_mq_client_api_impl()
+            .consume_message_directly(
+                &client_addr,
+                request_header,
+                &message,
+                self.timeout_millis.as_millis() as u64,
+            )
+            .await
     }
 
     async fn consume_message_directly_ext(
         &self,
-        cluster_name: CheetahString,
+        _cluster_name: CheetahString,
         consumer_group: CheetahString,
         client_id: CheetahString,
         topic: CheetahString,
         msg_id: CheetahString,
     ) -> rocketmq_error::RocketMQResult<ConsumeMessageDirectlyResult> {
-        todo!()
+        self.consume_message_directly(consumer_group, client_id, topic, msg_id)
+            .await
     }
 
     async fn clone_group_offset(
@@ -2689,16 +2718,47 @@ fn merge_order_conf_entries(existing: &str, value: &str) -> String {
         .join(";")
 }
 
+fn select_consumer_direct_connection(
+    consumer_group: &CheetahString,
+    consumer_connection: &ConsumerConnection,
+    requested_client_id: Option<&CheetahString>,
+) -> rocketmq_error::RocketMQResult<(CheetahString, CheetahString)> {
+    let requested = requested_client_id.filter(|client_id| !client_id.is_empty());
+    let connection = consumer_connection
+        .get_connection_set()
+        .iter()
+        .find(|connection| {
+            requested
+                .map(|client_id| connection.get_client_id() == *client_id)
+                .unwrap_or_else(|| !connection.get_client_id().is_empty())
+        })
+        .ok_or_else(|| {
+            let message = requested
+                .map(|client_id| {
+                    format!(
+                        "Client `{}` was not found in consumer group `{}`",
+                        client_id, consumer_group
+                    )
+                })
+                .unwrap_or_else(|| format!("NO CONSUMER for consumer group `{}`", consumer_group));
+            rocketmq_error::RocketMQError::IllegalArgument(message)
+        })?;
+
+    Ok((connection.get_client_id(), connection.get_client_addr()))
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
     use cheetah_string::CheetahString;
     use rocketmq_remoting::protocol::body::connection::Connection;
+    use rocketmq_remoting::protocol::body::consumer_connection::ConsumerConnection;
     use rocketmq_remoting::protocol::body::producer_connection::ProducerConnection;
 
     use super::encode_topic_attributes;
     use super::merge_order_conf_entries;
+    use super::select_consumer_direct_connection;
 
     #[test]
     fn merge_order_conf_entries_replaces_existing_broker_value() {
@@ -2736,5 +2796,55 @@ mod tests {
         connection.connection_set_mut().insert(entry);
 
         assert_eq!(connection.connection_set().len(), 1);
+    }
+
+    #[test]
+    fn select_consumer_direct_connection_uses_requested_client_when_present() {
+        let consumer_group = CheetahString::from("group-a");
+        let requested_client_id = CheetahString::from("client-b");
+        let mut consumer_connection = ConsumerConnection::new();
+        let mut first = Connection::new();
+        first.set_client_id("client-a".into());
+        first.set_client_addr("127.0.0.1:1001".into());
+        let mut second = Connection::new();
+        second.set_client_id(requested_client_id.clone());
+        second.set_client_addr("127.0.0.1:1002".into());
+        consumer_connection.insert_connection(first);
+        consumer_connection.insert_connection(second);
+
+        let (client_id, client_addr) =
+            select_consumer_direct_connection(&consumer_group, &consumer_connection, Some(&requested_client_id))
+                .expect("requested client should be selected");
+
+        assert_eq!(client_id, requested_client_id);
+        assert_eq!(client_addr, CheetahString::from("127.0.0.1:1002"));
+    }
+
+    #[test]
+    fn select_consumer_direct_connection_returns_first_available_client_when_unspecified() {
+        let consumer_group = CheetahString::from("group-a");
+        let mut consumer_connection = ConsumerConnection::new();
+        let mut only = Connection::new();
+        only.set_client_id("client-a".into());
+        only.set_client_addr("127.0.0.1:1001".into());
+        consumer_connection.insert_connection(only);
+
+        let (client_id, client_addr) =
+            select_consumer_direct_connection(&consumer_group, &consumer_connection, Some(&CheetahString::default()))
+                .expect("single consumer should be selected");
+
+        assert_eq!(client_id, CheetahString::from("client-a"));
+        assert_eq!(client_addr, CheetahString::from("127.0.0.1:1001"));
+    }
+
+    #[test]
+    fn select_consumer_direct_connection_errors_when_group_is_offline() {
+        let consumer_group = CheetahString::from("group-a");
+        let consumer_connection = ConsumerConnection::new();
+
+        let error = select_consumer_direct_connection(&consumer_group, &consumer_connection, None)
+            .expect_err("offline group should not resolve a client");
+
+        assert!(error.to_string().contains("NO CONSUMER"));
     }
 }

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -1731,7 +1731,7 @@ impl MQClientInstance {
     ) -> Option<ConsumeMessageDirectlyResult> {
         let consumer_inner = self.consumer_table.get(consumer_group);
         if let Some(entry) = consumer_inner {
-            entry.value().consume_message_directly(message, broker_name).await;
+            return entry.value().consume_message_directly(message, broker_name).await;
         }
 
         None

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -45,6 +45,7 @@ use cheetah_string::CheetahString;
 
 use rocketmq_common::common::message::message_batch::MessageBatch;
 use rocketmq_common::common::message::message_client_id_setter::MessageClientIDSetter;
+use rocketmq_common::common::message::message_decoder;
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_common::common::message::message_enum::MessageType;
 use rocketmq_common::common::message::message_ext::MessageExt;
@@ -98,6 +99,7 @@ use rocketmq_remoting::protocol::header::change_invisible_time_request_header::C
 use rocketmq_remoting::protocol::header::change_invisible_time_response_header::ChangeInvisibleTimeResponseHeader;
 use rocketmq_remoting::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader;
 use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+use rocketmq_remoting::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
 use rocketmq_remoting::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
 use rocketmq_remoting::protocol::header::create_topic_request_header::CreateTopicRequestHeader;
 use rocketmq_remoting::protocol::header::create_user_request_header::CreateUserRequestHeader;
@@ -3647,6 +3649,41 @@ impl MQClientAPIImpl {
                 Err(mq_client_err!(
                     "get_consumer_running_info response body is empty".to_string()
                 ))
+            }
+            _ => Err(mq_client_err!(
+                response.code(),
+                response.remark().map_or_else(String::new, |remark| remark.to_string())
+            )),
+        }
+    }
+
+    pub(crate) async fn consume_message_directly(
+        &self,
+        client_addr: &CheetahString,
+        request_header: ConsumeMessageDirectlyResultRequestHeader,
+        message: &MessageExt,
+        timeout_millis: u64,
+    ) -> RocketMQResult<rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult>
+    {
+        let body = message_decoder::encode(message, false)?;
+        let request = RemotingCommand::create_request_command(RequestCode::ConsumeMessageDirectly, request_header)
+            .set_body(body.to_vec());
+        let mut response = self
+            .remoting_client
+            .invoke_request(Some(client_addr), request, timeout_millis)
+            .await?;
+
+        match ResponseCode::from(response.code()) {
+            ResponseCode::Success => {
+                if let Some(body) = response.take_body() {
+                    rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult::decode(
+                        body.as_ref(),
+                    )
+                } else {
+                    Err(mq_client_err!(
+                        "consume_message_directly response body is empty".to_string()
+                    ))
+                }
             }
             _ => Err(mq_client_err!(
                 response.code(),

--- a/rocketmq-dashboard/rocketmq-dashboard-common/src/message.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-common/src/message.rs
@@ -74,6 +74,13 @@ pub struct DlqViewMessageRequest {
     pub message_id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DlqResendMessageRequest {
+    pub consumer_group: String,
+    pub message_id: String,
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -164,6 +171,19 @@ mod tests {
         };
 
         let json = serde_json::to_string(&request).expect("serialize dlq detail request");
+
+        assert!(json.contains("\"consumerGroup\""));
+        assert!(json.contains("\"messageId\""));
+    }
+
+    #[test]
+    fn dlq_resend_message_request_uses_java_dashboard_field_names() {
+        let request = super::DlqResendMessageRequest {
+            consumer_group: "group-a".to_string(),
+            message_id: "msg-1".to_string(),
+        };
+
+        let json = serde_json::to_string(&request).expect("serialize dlq resend request");
 
         assert!(json.contains("\"consumerGroup\""));
         assert!(json.contains("\"messageId\""));

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -115,6 +115,7 @@ pub fn run() {
             message::commands::query_dlq_message_by_consumer_group,
             message::commands::view_message_detail,
             message::commands::view_dlq_message_detail,
+            message::commands::resend_dlq_message,
             message::commands::query_message_trace_by_id,
             message::commands::view_message_trace_detail,
             producer::commands::get_producer_topic_options,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
@@ -15,9 +15,11 @@
 use crate::message::service::MessageManager;
 use crate::message::types::MessageDetailView;
 use crate::message::types::MessagePageResponse;
-use crate::message::types::MessageTraceDetailView;
+use crate::message::types::MessageResendResult;
 use crate::message::types::MessageSummaryListResponse;
+use crate::message::types::MessageTraceDetailView;
 use rocketmq_dashboard_common::DlqMessagePageQueryRequest;
+use rocketmq_dashboard_common::DlqResendMessageRequest;
 use rocketmq_dashboard_common::DlqViewMessageRequest;
 use rocketmq_dashboard_common::MessageIdQueryRequest;
 use rocketmq_dashboard_common::MessageKeyQueryRequest;
@@ -88,6 +90,17 @@ pub async fn view_dlq_message_detail(
 ) -> Result<MessageDetailView, String> {
     message_manager
         .view_dlq_message_detail(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn resend_dlq_message(
+    request: DlqResendMessageRequest,
+    message_manager: State<'_, MessageManager>,
+) -> Result<MessageResendResult, String> {
+    message_manager
+        .resend_dlq_message(request)
         .await
         .map_err(|error| error.to_string())
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/page_cache.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/page_cache.rs
@@ -224,7 +224,10 @@ pub(crate) struct PageSelection {
     pub(crate) selected: usize,
 }
 
-pub(crate) fn build_page_selection(queue_states: &[QueueScanState], query: &NormalizedMessagePageQuery) -> PageSelection {
+pub(crate) fn build_page_selection(
+    queue_states: &[QueueScanState],
+    query: &NormalizedMessagePageQuery,
+) -> PageSelection {
     let mut queue_states = queue_states.to_vec();
     for queue_state in &mut queue_states {
         queue_state.reset_selection();
@@ -332,12 +335,12 @@ fn move_end_offset(queue_states: &mut [QueueScanState], page_size: usize, mut ne
 
 #[cfg(test)]
 mod tests {
-    use super::build_page_selection;
-    use super::normalize_message_page_query;
     use super::MessagePageCacheEntry;
     use super::MessagePageCacheKey;
     use super::NormalizedMessagePageQuery;
     use super::QueueScanState;
+    use super::build_page_selection;
+    use super::normalize_message_page_query;
     use rocketmq_common::common::message::message_queue::MessageQueue;
     use rocketmq_dashboard_common::MessagePageQueryRequest;
     use std::time::Duration;
@@ -374,11 +377,7 @@ mod tests {
             task_id: None,
         };
         let selection = build_page_selection(
-            &[
-                queue_state(0, 0, 5),
-                queue_state(1, 0, 5),
-                queue_state(2, 0, 5),
-            ],
+            &[queue_state(0, 0, 5), queue_state(1, 0, 5), queue_state(2, 0, 5)],
             &query,
         );
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
@@ -13,17 +13,18 @@
 // limitations under the License.
 
 use crate::message::admin::ManagedMessageAdmin;
-use crate::message::page_cache::build_page_selection;
-use crate::message::page_cache::normalize_message_page_query;
 use crate::message::page_cache::MessagePageCache;
 use crate::message::page_cache::MessagePageCacheEntry;
 use crate::message::page_cache::MessagePageCacheKey;
 use crate::message::page_cache::NormalizedMessagePageQuery;
 use crate::message::page_cache::QueueScanState;
-use crate::message::types::MessageError;
+use crate::message::page_cache::build_page_selection;
+use crate::message::page_cache::normalize_message_page_query;
 use crate::message::types::MessageDetailView;
+use crate::message::types::MessageError;
 use crate::message::types::MessagePageResponse;
 use crate::message::types::MessagePageView;
+use crate::message::types::MessageResendResult;
 use crate::message::types::MessageResult;
 use crate::message::types::MessageSummaryListResponse;
 use crate::message::types::MessageSummaryView;
@@ -31,23 +32,26 @@ use crate::message::types::MessageTraceConsumerGroupView;
 use crate::message::types::MessageTraceDetailView;
 use crate::message::types::MessageTraceNodeView;
 use crate::nameserver::NameServerRuntimeState;
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use cheetah_string::CheetahString;
 use rocketmq_admin_core::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use rocketmq_client_rust::TraceDataEncoder;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_client_rust::consumer::pull_status::PullStatus;
-use rocketmq_client_rust::TraceDataEncoder;
+use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_dashboard_common::DlqMessagePageQueryRequest;
+use rocketmq_dashboard_common::DlqResendMessageRequest;
 use rocketmq_dashboard_common::DlqViewMessageRequest;
 use rocketmq_dashboard_common::MessageIdQueryRequest;
 use rocketmq_dashboard_common::MessageKeyQueryRequest;
 use rocketmq_dashboard_common::MessagePageQueryRequest;
 use rocketmq_dashboard_common::MessageTraceQueryRequest;
 use rocketmq_dashboard_common::ViewMessageRequest;
+use rocketmq_remoting::protocol::body::cm_result::CMResult;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -219,6 +223,41 @@ impl MessageManager {
             message_id: request.message_id,
         })
         .await
+    }
+
+    pub(crate) async fn resend_dlq_message(
+        &self,
+        request: DlqResendMessageRequest,
+    ) -> MessageResult<MessageResendResult> {
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("message admin session should be initialized before use");
+                self.resend_dlq_message_with_admin(&mut session.admin, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "resend_dlq_message failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `resend_dlq_message` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     pub(crate) async fn query_message_trace_by_id(
@@ -454,9 +493,7 @@ impl MessageManager {
         }
 
         let selection = build_page_selection(&queue_states, query);
-        let items = self
-            .load_page_messages(admin, query, &selection.queue_states)
-            .await?;
+        let items = self.load_page_messages(admin, query, &selection.queue_states).await?;
         let task_id = self
             .page_cache
             .put(
@@ -494,16 +531,9 @@ impl MessageManager {
         entry: &MessagePageCacheEntry,
     ) -> MessageResult<MessagePageResponse> {
         let selection = build_page_selection(&entry.queue_states, query);
-        let items = self
-            .load_page_messages(admin, query, &selection.queue_states)
-            .await?;
+        let items = self.load_page_messages(admin, query, &selection.queue_states).await?;
 
-        Ok(build_message_page_response(
-            items,
-            entry.total,
-            query,
-            &entry.task_id,
-        ))
+        Ok(build_message_page_response(items, entry.total, query, &entry.task_id))
     }
 
     async fn build_topic_queue_states(
@@ -543,8 +573,7 @@ impl MessageManager {
                         PULL_TIMEOUT_MILLIS,
                     )
                     .await
-                    .map_err(|error| MessageError::RocketMQ(error.to_string()))?
-                    as i64;
+                    .map_err(|error| MessageError::RocketMQ(error.to_string()))? as i64;
                 let end = admin
                     .search_offset(
                         CheetahString::from(broker_addr.clone()),
@@ -554,8 +583,7 @@ impl MessageManager {
                         PULL_TIMEOUT_MILLIS,
                     )
                     .await
-                    .map_err(|error| MessageError::RocketMQ(error.to_string()))?
-                    as i64;
+                    .map_err(|error| MessageError::RocketMQ(error.to_string()))? as i64;
 
                 queue_states.push(QueueScanState::new(
                     idx,
@@ -730,8 +758,7 @@ impl MessageManager {
             let mut remaining = queue_state.selection_len();
 
             while remaining > 0 && pull_offset < queue_state.end_offset {
-                let batch_size = ((queue_state.end_offset - pull_offset).min(PULL_BATCH_SIZE as i64))
-                    .max(1) as i32;
+                let batch_size = ((queue_state.end_offset - pull_offset).min(PULL_BATCH_SIZE as i64)).max(1) as i32;
                 let result = admin
                     .pull_message_from_queue(
                         queue_state.broker_addr.as_str(),
@@ -758,8 +785,7 @@ impl MessageManager {
                                 break;
                             }
                             let message_ref: &MessageExt = message;
-                            if message_ref.store_timestamp() < query.begin
-                                || message_ref.store_timestamp() > query.end
+                            if message_ref.store_timestamp() < query.begin || message_ref.store_timestamp() > query.end
                             {
                                 continue;
                             }
@@ -805,12 +831,8 @@ impl MessageManager {
             .await
             .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
 
-        let mut items: Vec<MessageSummaryView> = result
-            .message_list()
-            .iter()
-            .cloned()
-            .map(map_message_summary)
-            .collect();
+        let mut items: Vec<MessageSummaryView> =
+            result.message_list().iter().cloned().map(map_message_summary).collect();
         sort_message_summaries_desc(&mut items);
 
         Ok(MessageSummaryListResponse {
@@ -844,6 +866,34 @@ impl MessageManager {
             .await?;
 
         Ok(map_message_detail(message))
+    }
+
+    async fn resend_dlq_message_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: DlqResendMessageRequest,
+    ) -> MessageResult<MessageResendResult> {
+        let consumer_group = normalize_required_field("consumerGroup", request.consumer_group)?;
+        let dlq_topic = build_dlq_topic(&consumer_group)?;
+        let message_id = normalize_required_field("messageId", request.message_id)?;
+        let dlq_message = self.find_message_by_id_with_admin(admin, dlq_topic, message_id).await?;
+        let resend_target = build_dlq_resend_target(&dlq_message)?;
+        let consume_result = admin
+            .consume_message_directly(
+                CheetahString::from(consumer_group.clone()),
+                CheetahString::default(),
+                CheetahString::from(resend_target.topic.clone()),
+                CheetahString::from(resend_target.msg_id.clone()),
+            )
+            .await
+            .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
+
+        Ok(build_message_resend_result(
+            consumer_group,
+            resend_target.topic,
+            resend_target.msg_id,
+            consume_result,
+        ))
     }
 
     async fn find_message_by_id_with_admin(
@@ -1071,25 +1121,56 @@ fn build_dlq_topic(consumer_group: &str) -> MessageResult<String> {
     Ok(format!("{}{}", mix_all::DLQ_GROUP_TOPIC_PREFIX, group))
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DlqResendTarget {
+    topic: String,
+    msg_id: String,
+}
+
+fn build_dlq_resend_target(message: &MessageExt) -> MessageResult<DlqResendTarget> {
+    let retry_topic = message
+        .property(&CheetahString::from_static_str(MessageConst::PROPERTY_RETRY_TOPIC))
+        .map(|value| value.to_string())
+        .and_then(|value| non_empty(&value))
+        .ok_or_else(|| {
+            MessageError::Validation("DLQ message is missing `RETRY_TOPIC`, so it cannot be resent safely.".to_string())
+        })?;
+    let origin_message_id = message
+        .property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_ORIGIN_MESSAGE_ID,
+        ))
+        .map(|value| value.to_string())
+        .or_else(|| {
+            message
+                .property(&CheetahString::from_static_str(
+                    MessageConst::PROPERTY_DLQ_ORIGIN_MESSAGE_ID,
+                ))
+                .map(|value| value.to_string())
+        })
+        .and_then(|value| non_empty(&value))
+        .ok_or_else(|| {
+            MessageError::Validation(
+                "DLQ message is missing `ORIGIN_MESSAGE_ID`, so it cannot be resent safely.".to_string(),
+            )
+        })?;
+
+    Ok(DlqResendTarget {
+        topic: retry_topic,
+        msg_id: origin_message_id,
+    })
+}
+
 async fn dlq_topic_exists_with_admin(admin: &mut DefaultMQAdminExt, topic: &str) -> MessageResult<bool> {
     let topic_list = admin
         .fetch_all_topic_list()
         .await
         .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
 
-    Ok(topic_list
-        .topic_list
-        .iter()
-        .any(|item| item.as_str() == topic))
+    Ok(topic_list.topic_list.iter().any(|item| item.as_str() == topic))
 }
 
 fn build_empty_message_page_response(query: &NormalizedMessagePageQuery) -> MessagePageResponse {
-    build_message_page_response(
-        Vec::new(),
-        0,
-        query,
-        query.task_id.as_deref().unwrap_or_default(),
-    )
+    build_message_page_response(Vec::new(), 0, query, query.task_id.as_deref().unwrap_or_default())
 }
 
 fn build_message_page_response(
@@ -1119,6 +1200,39 @@ fn build_message_page_response(
             empty: number_of_elements == 0,
         },
         task_id: task_id.to_string(),
+    }
+}
+
+fn build_message_resend_result(
+    consumer_group: String,
+    topic: String,
+    msg_id: String,
+    consume_result: rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult,
+) -> MessageResendResult {
+    let consume_result_text = consume_result.consume_result().map(|value| value.to_string());
+    let remark = consume_result.remark().map(|value| value.to_string());
+    let success = matches!(
+        consume_result.consume_result(),
+        Some(result) if *result == CMResult::CRSuccess
+    );
+    let mut message = if success {
+        format!("Direct consume succeeded for `{msg_id}` on `{topic}` in consumer group `{consumer_group}`.")
+    } else {
+        let status = consume_result_text.clone().unwrap_or_else(|| "UNKNOWN".to_string());
+        format!("Direct consume returned {status} for `{msg_id}` on `{topic}` in consumer group `{consumer_group}`.")
+    };
+    if let Some(remark_text) = remark.as_deref().and_then(non_empty) {
+        message.push_str(&format!(" Remark: {remark_text}."));
+    }
+
+    MessageResendResult {
+        success,
+        message,
+        consumer_group,
+        topic,
+        msg_id,
+        consume_result: consume_result_text,
+        remark,
     }
 }
 
@@ -1182,10 +1296,7 @@ fn build_trace_detail(
     let tags = seeds.iter().find_map(|seed| seed.tags.clone());
     let keys = seeds.iter().find_map(|seed| seed.keys.clone());
     let store_host = seeds.iter().find_map(|seed| non_empty(seed.store_host.as_str()));
-    let producer_seed = seeds
-        .iter()
-        .find(|seed| trace_role(seed) == "PRODUCER")
-        .cloned();
+    let producer_seed = seeds.iter().find(|seed| trace_role(seed) == "PRODUCER").cloned();
 
     let mut grouped_consumers: HashMap<String, Vec<MessageTraceNodeView>> = HashMap::new();
     let mut transaction_checks = Vec::new();
@@ -1334,6 +1445,7 @@ fn first_message_or_validation_error(mut messages: Vec<MessageExt>) -> MessageRe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rocketmq_common::common::message::MessageTrait;
     use rocketmq_common::common::message::message_builder::MessageBuilder;
 
     #[test]
@@ -1376,6 +1488,52 @@ mod tests {
             build_dlq_topic("%DLQ%group-a").expect("prefixed group should normalize"),
             format!("{}group-a", mix_all::DLQ_GROUP_TOPIC_PREFIX)
         );
+    }
+
+    #[test]
+    fn build_dlq_resend_target_uses_retry_topic_and_origin_message_id() {
+        let message = MessageBuilder::new()
+            .topic("%DLQ%group-a")
+            .body_slice(b"payload")
+            .build_unchecked();
+        let mut message_ext = MessageExt::default();
+        message_ext.set_message_inner(message);
+        message_ext.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_RETRY_TOPIC),
+            CheetahString::from("%RETRY%group-a"),
+        );
+        message_ext.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_ORIGIN_MESSAGE_ID),
+            CheetahString::from("origin-msg-1"),
+        );
+
+        let target = build_dlq_resend_target(&message_ext).expect("dlq resend target should map");
+
+        assert_eq!(
+            target,
+            DlqResendTarget {
+                topic: "%RETRY%group-a".to_string(),
+                msg_id: "origin-msg-1".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn build_dlq_resend_target_rejects_missing_origin_message_id() {
+        let message = MessageBuilder::new()
+            .topic("%DLQ%group-a")
+            .body_slice(b"payload")
+            .build_unchecked();
+        let mut message_ext = MessageExt::default();
+        message_ext.set_message_inner(message);
+        message_ext.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_RETRY_TOPIC),
+            CheetahString::from("%RETRY%group-a"),
+        );
+
+        let error = build_dlq_resend_target(&message_ext).expect_err("missing origin id should fail");
+
+        assert!(error.to_string().contains("ORIGIN_MESSAGE_ID"));
     }
 
     #[test]
@@ -1461,6 +1619,26 @@ mod tests {
 
         assert_eq!(detail.body_text, None);
         assert_eq!(detail.body_base64.as_deref(), Some("/wBB"));
+    }
+
+    #[test]
+    fn build_message_resend_result_marks_non_success_as_failure() {
+        let mut consume_result =
+            rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult::default();
+        consume_result.set_consume_result(CMResult::CRLater);
+        consume_result.set_remark(CheetahString::from("retry later"));
+
+        let result = build_message_resend_result(
+            "group-a".to_string(),
+            "%RETRY%group-a".to_string(),
+            "origin-msg-1".to_string(),
+            consume_result,
+        );
+
+        assert!(!result.success);
+        assert_eq!(result.consume_result.as_deref(), Some("CR_LATER"));
+        assert_eq!(result.remark.as_deref(), Some("retry later"));
+        assert!(result.message.contains("CR_LATER"));
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
@@ -78,6 +78,18 @@ pub(crate) struct MessagePageResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct MessageResendResult {
+    pub(crate) success: bool,
+    pub(crate) message: String,
+    pub(crate) consumer_group: String,
+    pub(crate) topic: String,
+    pub(crate) msg_id: String,
+    pub(crate) consume_result: Option<String>,
+    pub(crate) remark: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
 pub(crate) struct MessageTrackView {
     pub(crate) consumer_group: String,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { motion } from 'motion/react';
+import { toast } from 'sonner@2.0.3';
 import {
   AlertCircle,
   ArrowUpRight,
@@ -58,6 +59,7 @@ export const DLQMessageView = () => {
   const [searchError, setSearchError] = useState('');
   const [hasSearched, setHasSearched] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
+  const [resendingMessageId, setResendingMessageId] = useState<string | null>(null);
   const [taskId, setTaskId] = useState('');
   const [pagination, setPagination] = useState(defaultPagination);
   const {
@@ -202,6 +204,43 @@ export const DLQMessageView = () => {
     await queryDlqByMessageId();
   };
 
+  const handleResend = async (message: DlqMessageSummary) => {
+    const normalizedConsumerGroup = consumerGroup.trim();
+    if (!normalizedConsumerGroup) {
+      setSearchError('Consumer group is required.');
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Request direct consume for DLQ message ${message.msgId} in consumer group ${normalizedConsumerGroup}?`,
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setResendingMessageId(message.msgId);
+    setSearchError('');
+
+    try {
+      const result = await DlqService.resendDlqMessage({
+        consumerGroup: normalizedConsumerGroup,
+        messageId: message.msgId,
+      });
+
+      if (result.success) {
+        toast.success(result.message);
+      } else {
+        toast.error(result.message);
+      }
+    } catch (error) {
+      const messageText = error instanceof Error ? error.message : 'Failed to resend DLQ message.';
+      toast.error(messageText);
+      setSearchError(messageText);
+    } finally {
+      setResendingMessageId(null);
+    }
+  };
+
   const renderEmptyCopy = () => {
     if (activeTab === 'Consumer') {
       return 'Enter a consumer group and time range to search DLQ messages.';
@@ -237,7 +276,7 @@ export const DLQMessageView = () => {
 
       <div className="flex items-start gap-3 rounded-2xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900/40 dark:bg-blue-900/20 dark:text-blue-200">
         <Info className="mt-0.5 h-4 w-4 shrink-0" />
-        <div>Phase 5 only enables real DLQ query and detail. Resend and export remain disabled until Phase 6.</div>
+        <div>Phase 6 enables real single-message DLQ resend. Batch resend and export remain disabled.</div>
       </div>
 
       <div className="sticky top-0 z-20 flex flex-col justify-between gap-4 rounded-2xl border border-gray-100 bg-white/90 p-4 shadow-sm backdrop-blur-xl transition-colors dark:border-gray-800 dark:bg-gray-900/90 xl:flex-row xl:items-center">
@@ -430,13 +469,23 @@ export const DLQMessageView = () => {
                 </div>
 
                 <div className="border-t border-gray-100 bg-gray-50/30 px-5 py-3 dark:border-gray-800 dark:bg-gray-800/30">
-                  <button
-                    onClick={() => setSelectedMessage(message)}
-                    className="flex w-full items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all hover:border-blue-200 hover:bg-blue-50 hover:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-800 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
-                  >
-                    <FileText className="mr-1.5 h-4 w-4" />
-                    Detail
-                  </button>
+                  <div className="grid grid-cols-2 gap-3">
+                    <button
+                      onClick={() => void handleResend(message)}
+                      disabled={resendingMessageId === message.msgId}
+                      className="flex items-center justify-center rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 shadow-sm transition-all hover:border-amber-300 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:border-amber-800 dark:hover:bg-amber-900/30"
+                    >
+                      <Send className="mr-1.5 h-4 w-4" />
+                      {resendingMessageId === message.msgId ? 'Resending...' : 'Resend'}
+                    </button>
+                    <button
+                      onClick={() => setSelectedMessage(message)}
+                      className="flex items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all hover:border-blue-200 hover:bg-blue-50 hover:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-800 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
+                    >
+                      <FileText className="mr-1.5 h-4 w-4" />
+                      Detail
+                    </button>
+                  </div>
                 </div>
               </motion.div>
             ))}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/types/dlq.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/types/dlq.types.ts
@@ -18,6 +18,21 @@ export interface DlqMessageDetailRequest {
     messageId: string;
 }
 
+export interface DlqResendMessageRequest {
+    consumerGroup: string;
+    messageId: string;
+}
+
+export interface DlqResendMessageResult {
+    success: boolean;
+    message: string;
+    consumerGroup: string;
+    topic: string;
+    msgId: string;
+    consumeResult?: string | null;
+    remark?: string | null;
+}
+
 export type DlqMessageSummary = MessageSummary;
 export type DlqMessagePageResponse = MessagePageResponse;
 export type DlqMessageDetail = MessageDetail;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/dlq.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/dlq.service.ts
@@ -4,6 +4,8 @@ import type {
     DlqMessageDetailRequest,
     DlqMessagePageQueryRequest,
     DlqMessagePageResponse,
+    DlqResendMessageRequest,
+    DlqResendMessageResult,
 } from '../features/dlq/types/dlq.types';
 
 export class DlqService {
@@ -15,5 +17,9 @@ export class DlqService {
 
     static async viewDlqMessageDetail(request: DlqMessageDetailRequest): Promise<DlqMessageDetail> {
         return invoke<DlqMessageDetail>('view_dlq_message_detail', { request });
+    }
+
+    static async resendDlqMessage(request: DlqResendMessageRequest): Promise<DlqResendMessageResult> {
+        return invoke<DlqResendMessageResult>('resend_dlq_message', { request });
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -691,7 +691,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         topic: CheetahString,
         msg_id: CheetahString,
     ) -> rocketmq_error::RocketMQResult<ConsumeMessageDirectlyResult> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .consume_message_directly(consumer_group, client_id, topic, msg_id)
+            .await
     }
 
     async fn consume_message_directly_ext(
@@ -702,7 +704,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         topic: CheetahString,
         msg_id: CheetahString,
     ) -> rocketmq_error::RocketMQResult<ConsumeMessageDirectlyResult> {
-        todo!()
+        self.default_mqadmin_ext_impl
+            .consume_message_directly_ext(cluster_name, consumer_group, client_id, topic, msg_id)
+            .await
     }
 
     async fn clone_group_offset(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6875

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented direct message consumption capability to replay and diagnose specific messages during troubleshooting sessions
  * Added DLQ message resend functionality allowing users to resend dead letter queue messages with individual message actions and confirmation dialogs

* **Bug Fixes**
  * Fixed result return handling in the direct message consumption operation flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->