### PR TITLE
[ISSUE #6882]✨Enhance message querying by delegating to inner implementation and improve message ID handling in detail views

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
@@ -869,7 +869,10 @@ impl MessageManager {
         let message_tracks = admin
             .message_track_detail(message.clone())
             .await
-            .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
+            .unwrap_or_else(|error| {
+                log::warn!("Failed to load message track detail: {}", error);
+                Vec::new()
+            });
 
         Ok(map_message_detail(message, message_tracks))
     }
@@ -911,20 +914,14 @@ impl MessageManager {
         let topic = normalize_required_field("topic", topic)?;
         let message_id = normalize_required_field("messageId", message_id)?;
 
-        let result = admin
-            .query_message_by_unique_key(
-                None,
+        admin
+            .query_message(
+                CheetahString::default(),
                 CheetahString::from(topic),
                 CheetahString::from(message_id),
-                32,
-                0,
-                i64::MAX,
             )
             .await
-            .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
-
-        let messages = result.message_list().to_vec();
-        first_message_or_validation_error(messages)
+            .map_err(|error| MessageError::RocketMQ(error.to_string()))
     }
 
     async fn query_message_trace_by_id_with_admin(
@@ -1089,19 +1086,10 @@ fn extract_keys(message: &MessageExt) -> Option<String> {
         .filter(|keys| !keys.is_empty())
 }
 
-fn extract_msg_id(message: &MessageExt) -> String {
-    message
-        .property(&CheetahString::from_static_str(
-            MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
-        ))
-        .map(|id| id.to_string())
-        .unwrap_or_else(|| message.msg_id().to_string())
-}
-
 fn map_message_summary(message: MessageExt) -> MessageSummaryView {
     MessageSummaryView {
         topic: message.topic().to_string(),
-        msg_id: extract_msg_id(&message),
+        msg_id: message.msg_id().to_string(),
         tags: message.get_tags().map(|value| value.to_string()),
         keys: extract_keys(&message),
         store_timestamp: message.store_timestamp(),
@@ -1274,7 +1262,7 @@ fn build_trace_summary(message_id: &str, mut seeds: Vec<TraceSeed>) -> MessageRe
         ));
     }
 
-    seeds.sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+    seeds.sort_by_key(|left| left.timestamp);
     let selected = seeds
         .iter()
         .find(|seed| seed.trace_type == "Pub")
@@ -1349,11 +1337,11 @@ fn build_trace_detail(
     let mut consumer_groups = grouped_consumers
         .into_iter()
         .map(|(consumer_group, mut nodes)| {
-            nodes.sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+            nodes.sort_by_key(|left| left.timestamp);
             MessageTraceConsumerGroupView { consumer_group, nodes }
         })
         .collect::<Vec<_>>();
-    consumer_groups.sort_by(|left, right| left.consumer_group.cmp(&right.consumer_group));
+    consumer_groups.sort_by_key(|left| left.consumer_group.clone());
 
     let min_timestamp = timeline.iter().map(|node| node.timestamp).min();
     let max_timestamp = timeline.iter().map(|node| node.timestamp).max();
@@ -1428,7 +1416,7 @@ fn map_message_detail(message: MessageExt, message_tracks: Vec<MessageTrack>) ->
 
     MessageDetailView {
         topic: message.topic().to_string(),
-        msg_id: extract_msg_id(&message),
+        msg_id: message.msg_id().to_string(),
         born_host: Some(message.born_host().to_string()),
         store_host: Some(message.store_host().to_string()),
         born_timestamp: Some(message.born_timestamp()),
@@ -1457,20 +1445,6 @@ fn decode_body_fields(body: &[u8]) -> (Option<String>, Option<String>) {
         Ok(text) => (Some(text), None),
         Err(_) => (None, Some(BASE64_STANDARD.encode(body))),
     }
-}
-
-fn first_message_or_validation_error(mut messages: Vec<MessageExt>) -> MessageResult<MessageExt> {
-    messages.sort_by(|left, right| {
-        right
-            .store_timestamp()
-            .cmp(&left.store_timestamp())
-            .then_with(|| left.msg_id().cmp(right.msg_id()))
-    });
-
-    messages
-        .into_iter()
-        .next()
-        .ok_or_else(|| MessageError::Validation("No message matched the current query.".to_string()))
 }
 
 #[cfg(test)]
@@ -1507,10 +1481,23 @@ mod tests {
     }
 
     #[test]
-    fn first_message_or_validation_error_requires_a_match() {
-        let error = first_message_or_validation_error(Vec::new()).expect_err("empty results should fail");
+    fn map_message_summary_uses_offset_msg_id_instead_of_uniq_key_property() {
+        let message = MessageBuilder::new()
+            .topic("TopicTest")
+            .body_slice(b"payload")
+            .build_unchecked();
 
-        assert!(error.to_string().contains("No message matched the current query"));
+        let mut message_ext = MessageExt::default();
+        message_ext.set_message_inner(message);
+        message_ext.set_msg_id(CheetahString::from("offset-msg-id"));
+        message_ext.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX),
+            CheetahString::from("uniq-msg-id"),
+        );
+
+        let summary = map_message_summary(message_ext);
+
+        assert_eq!(summary.msg_id, "offset-msg-id");
     }
 
     #[test]
@@ -1637,6 +1624,26 @@ mod tests {
             Some("mobile")
         );
         assert_eq!(detail.message_track_list, Some(Vec::new()));
+    }
+
+    #[test]
+    fn map_message_detail_uses_offset_msg_id_instead_of_uniq_key_property() {
+        let message = MessageBuilder::new()
+            .topic("TopicTest")
+            .body_slice(b"payload")
+            .build_unchecked();
+
+        let mut message_ext = MessageExt::default();
+        message_ext.set_message_inner(message);
+        message_ext.set_msg_id(CheetahString::from("offset-msg-id"));
+        message_ext.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX),
+            CheetahString::from("uniq-msg-id"),
+        );
+
+        let detail = map_message_detail(message_ext, Vec::new());
+
+        assert_eq!(detail.msg_id, "offset-msg-id");
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1352,11 +1352,13 @@ impl MQAdminExt for DefaultMQAdminExt {
 
     async fn query_message(
         &self,
-        _cluster_name: CheetahString,
-        _topic: CheetahString,
-        _msg_id: CheetahString,
+        cluster_name: CheetahString,
+        topic: CheetahString,
+        msg_id: CheetahString,
     ) -> rocketmq_error::RocketMQResult<MessageExt> {
-        unimplemented!("query_message not implemented yet")
+        self.default_mqadmin_ext_impl
+            .query_message(cluster_name, topic, msg_id)
+            .await
     }
 
     async fn get_broker_ha_status(&self, broker_addr: CheetahString) -> rocketmq_error::RocketMQResult<HARuntimeInfo> {
@@ -1520,6 +1522,10 @@ impl MQAdminExt for DefaultMQAdminExt {
 
 #[cfg(test)]
 mod tests {
+    use cheetah_string::CheetahString;
+    use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+    use rocketmq_error::RocketMQError;
+
     use super::DefaultMQAdminExt;
     use std::time::Duration;
 
@@ -1537,5 +1543,21 @@ mod tests {
         let grouped_timed_admin =
             DefaultMQAdminExt::with_admin_ext_group_and_timeout("dashboard-test", Duration::from_secs(3));
         assert!(grouped_timed_admin.default_mqadmin_ext_impl.has_inner());
+    }
+
+    #[tokio::test]
+    async fn query_message_delegates_to_inner_impl() {
+        let admin = DefaultMQAdminExt::new();
+
+        let error = admin
+            .query_message(
+                CheetahString::default(),
+                CheetahString::from("TopicTest"),
+                CheetahString::from("msg-id"),
+            )
+            .await
+            .expect_err("unstarted admin should return an error instead of panicking");
+
+        assert!(matches!(error, RocketMQError::ClientNotStarted));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6882

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for message detail retrieval—the system now logs warnings and continues operation instead of failing.

* **Refactor**
  * Optimized message ID query logic for more reliable retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->