### PR TITLE
[ISSUE #6887]🚀Add direct message consumption functionality with request handling and UI integration

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-common/src/message.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-common/src/message.rs
@@ -81,6 +81,16 @@ pub struct DlqResendMessageRequest {
     pub message_id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageDirectConsumeRequest {
+    pub topic: String,
+    pub consumer_group: String,
+    pub message_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -187,5 +197,22 @@ mod tests {
 
         assert!(json.contains("\"consumerGroup\""));
         assert!(json.contains("\"messageId\""));
+    }
+
+    #[test]
+    fn message_direct_consume_request_uses_java_dashboard_field_names() {
+        let request = super::MessageDirectConsumeRequest {
+            topic: "TopicTest".to_string(),
+            consumer_group: "group-a".to_string(),
+            message_id: "msg-1".to_string(),
+            client_id: Some("client-a".to_string()),
+        };
+
+        let json = serde_json::to_string(&request).expect("serialize direct consume request");
+
+        assert!(json.contains("\"topic\""));
+        assert!(json.contains("\"consumerGroup\""));
+        assert!(json.contains("\"messageId\""));
+        assert!(json.contains("\"clientId\""));
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -116,6 +116,7 @@ pub fn run() {
             message::commands::view_message_detail,
             message::commands::view_dlq_message_detail,
             message::commands::resend_dlq_message,
+            message::commands::consume_message_directly,
             message::commands::query_message_trace_by_id,
             message::commands::view_message_trace_detail,
             producer::commands::get_producer_topic_options,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
@@ -21,6 +21,7 @@ use crate::message::types::MessageTraceDetailView;
 use rocketmq_dashboard_common::DlqMessagePageQueryRequest;
 use rocketmq_dashboard_common::DlqResendMessageRequest;
 use rocketmq_dashboard_common::DlqViewMessageRequest;
+use rocketmq_dashboard_common::MessageDirectConsumeRequest;
 use rocketmq_dashboard_common::MessageIdQueryRequest;
 use rocketmq_dashboard_common::MessageKeyQueryRequest;
 use rocketmq_dashboard_common::MessagePageQueryRequest;
@@ -101,6 +102,17 @@ pub async fn resend_dlq_message(
 ) -> Result<MessageResendResult, String> {
     message_manager
         .resend_dlq_message(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn consume_message_directly(
+    request: MessageDirectConsumeRequest,
+    message_manager: State<'_, MessageManager>,
+) -> Result<MessageResendResult, String> {
+    message_manager
+        .consume_message_directly(request)
         .await
         .map_err(|error| error.to_string())
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
@@ -48,6 +48,7 @@ use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_dashboard_common::DlqMessagePageQueryRequest;
 use rocketmq_dashboard_common::DlqResendMessageRequest;
 use rocketmq_dashboard_common::DlqViewMessageRequest;
+use rocketmq_dashboard_common::MessageDirectConsumeRequest;
 use rocketmq_dashboard_common::MessageIdQueryRequest;
 use rocketmq_dashboard_common::MessageKeyQueryRequest;
 use rocketmq_dashboard_common::MessagePageQueryRequest;
@@ -256,6 +257,42 @@ impl MessageManager {
                 Ok(response) => return Ok(response),
                 Err(error) if should_reset && attempt < 2 => {
                     log::warn!("Retrying `resend_dlq_message` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    pub(crate) async fn consume_message_directly(
+        &self,
+        request: MessageDirectConsumeRequest,
+    ) -> MessageResult<MessageResendResult> {
+        let request = normalize_direct_consume_request(request)?;
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("message admin session should be initialized before use");
+                self.consume_message_directly_with_admin(&mut session.admin, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "consume_message_directly failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `consume_message_directly` after reconnect: {}", error);
                 }
                 Err(error) => return Err(error),
             }
@@ -887,20 +924,38 @@ impl MessageManager {
         let message_id = normalize_required_field("messageId", request.message_id)?;
         let dlq_message = self.find_message_by_id_with_admin(admin, dlq_topic, message_id).await?;
         let resend_target = build_dlq_resend_target(&dlq_message)?;
+        self.consume_message_directly_with_admin(
+            admin,
+            NormalizedDirectConsumeRequest {
+                topic: resend_target.topic,
+                consumer_group,
+                message_id: resend_target.msg_id,
+                client_id: None,
+            },
+        )
+        .await
+    }
+
+    async fn consume_message_directly_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: NormalizedDirectConsumeRequest,
+    ) -> MessageResult<MessageResendResult> {
+        let client_id = request.client_id.clone().unwrap_or_default();
         let consume_result = admin
             .consume_message_directly(
-                CheetahString::from(consumer_group.clone()),
-                CheetahString::default(),
-                CheetahString::from(resend_target.topic.clone()),
-                CheetahString::from(resend_target.msg_id.clone()),
+                CheetahString::from(request.consumer_group.clone()),
+                CheetahString::from(client_id),
+                CheetahString::from(request.topic.clone()),
+                CheetahString::from(request.message_id.clone()),
             )
             .await
             .map_err(|error| MessageError::RocketMQ(error.to_string()))?;
 
         Ok(build_message_resend_result(
-            consumer_group,
-            resend_target.topic,
-            resend_target.msg_id,
+            request.consumer_group,
+            request.topic,
+            request.message_id,
             consume_result,
         ))
     }
@@ -913,6 +968,39 @@ impl MessageManager {
     ) -> MessageResult<MessageExt> {
         let topic = normalize_required_field("topic", topic)?;
         let message_id = normalize_required_field("messageId", message_id)?;
+
+        match admin
+            .query_message_by_unique_key(
+                None,
+                CheetahString::from(topic.clone()),
+                CheetahString::from(message_id.clone()),
+                32,
+                0,
+                i64::MAX,
+            )
+            .await
+        {
+            Ok(result) if !result.message_list().is_empty() => {
+                return first_message_or_validation_error(result.message_list().to_vec());
+            }
+            Ok(_) => {
+                log::warn!(
+                    "query_message_by_unique_key returned no match for topic `{}` and messageId `{}`, falling back to \
+                     direct query_message",
+                    topic,
+                    message_id
+                );
+            }
+            Err(error) => {
+                log::warn!(
+                    "query_message_by_unique_key failed for topic `{}` and messageId `{}`: {}. Falling back to direct \
+                     query_message",
+                    topic,
+                    message_id,
+                    error
+                );
+            }
+        }
 
         admin
             .query_message(
@@ -1086,10 +1174,20 @@ fn extract_keys(message: &MessageExt) -> Option<String> {
         .filter(|keys| !keys.is_empty())
 }
 
+fn resolve_message_summary_id(message: &MessageExt) -> String {
+    message
+        .property(&CheetahString::from_static_str(
+            MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+        ))
+        .map(|value| value.to_string())
+        .and_then(|value| non_empty(&value))
+        .unwrap_or_else(|| message.msg_id().to_string())
+}
+
 fn map_message_summary(message: MessageExt) -> MessageSummaryView {
     MessageSummaryView {
         topic: message.topic().to_string(),
-        msg_id: message.msg_id().to_string(),
+        msg_id: resolve_message_summary_id(&message),
         tags: message.get_tags().map(|value| value.to_string()),
         keys: extract_keys(&message),
         store_timestamp: message.store_timestamp(),
@@ -1130,6 +1228,14 @@ struct DlqResendTarget {
     msg_id: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedDirectConsumeRequest {
+    topic: String,
+    consumer_group: String,
+    message_id: String,
+    client_id: Option<String>,
+}
+
 fn build_dlq_resend_target(message: &MessageExt) -> MessageResult<DlqResendTarget> {
     let retry_topic = message
         .property(&CheetahString::from_static_str(MessageConst::PROPERTY_RETRY_TOPIC))
@@ -1160,6 +1266,17 @@ fn build_dlq_resend_target(message: &MessageExt) -> MessageResult<DlqResendTarge
     Ok(DlqResendTarget {
         topic: retry_topic,
         msg_id: origin_message_id,
+    })
+}
+
+fn normalize_direct_consume_request(
+    request: MessageDirectConsumeRequest,
+) -> MessageResult<NormalizedDirectConsumeRequest> {
+    Ok(NormalizedDirectConsumeRequest {
+        topic: normalize_required_field("topic", request.topic)?,
+        consumer_group: normalize_required_field("consumerGroup", request.consumer_group)?,
+        message_id: normalize_required_field("messageId", request.message_id)?,
+        client_id: request.client_id.as_deref().and_then(non_empty),
     })
 }
 
@@ -1447,6 +1564,20 @@ fn decode_body_fields(body: &[u8]) -> (Option<String>, Option<String>) {
     }
 }
 
+fn first_message_or_validation_error(mut messages: Vec<MessageExt>) -> MessageResult<MessageExt> {
+    messages.sort_by(|left, right| {
+        right
+            .store_timestamp()
+            .cmp(&left.store_timestamp())
+            .then_with(|| left.msg_id().cmp(right.msg_id()))
+    });
+
+    messages
+        .into_iter()
+        .next()
+        .ok_or_else(|| MessageError::Validation("No message matched the current query.".to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1481,7 +1612,7 @@ mod tests {
     }
 
     #[test]
-    fn map_message_summary_uses_offset_msg_id_instead_of_uniq_key_property() {
+    fn map_message_summary_prefers_uniq_key_property_over_offset_msg_id() {
         let message = MessageBuilder::new()
             .topic("TopicTest")
             .body_slice(b"payload")
@@ -1497,7 +1628,54 @@ mod tests {
 
         let summary = map_message_summary(message_ext);
 
+        assert_eq!(summary.msg_id, "uniq-msg-id");
+    }
+
+    #[test]
+    fn map_message_summary_falls_back_to_offset_msg_id_when_uniq_key_is_blank() {
+        let message = MessageBuilder::new()
+            .topic("TopicTest")
+            .body_slice(b"payload")
+            .build_unchecked();
+
+        let mut message_ext = MessageExt::default();
+        message_ext.set_message_inner(message);
+        message_ext.set_msg_id(CheetahString::from("offset-msg-id"));
+        message_ext.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX),
+            CheetahString::from("   "),
+        );
+
+        let summary = map_message_summary(message_ext);
+
         assert_eq!(summary.msg_id, "offset-msg-id");
+    }
+
+    #[test]
+    fn first_message_or_validation_error_prefers_latest_store_timestamp() {
+        let first = MessageBuilder::new()
+            .topic("TopicTest")
+            .body_slice(b"one")
+            .build_unchecked();
+        let second = MessageBuilder::new()
+            .topic("TopicTest")
+            .body_slice(b"two")
+            .build_unchecked();
+
+        let mut first_ext = MessageExt::default();
+        first_ext.set_message_inner(first);
+        first_ext.set_msg_id(CheetahString::from("msg-1"));
+        first_ext.set_store_timestamp(100);
+
+        let mut second_ext = MessageExt::default();
+        second_ext.set_message_inner(second);
+        second_ext.set_msg_id(CheetahString::from("msg-2"));
+        second_ext.set_store_timestamp(200);
+
+        let selected =
+            first_message_or_validation_error(vec![first_ext, second_ext]).expect("latest message should be selected");
+
+        assert_eq!(selected.msg_id(), "msg-2");
     }
 
     #[test]
@@ -1696,6 +1874,23 @@ mod tests {
         assert_eq!(result.consume_result.as_deref(), Some("CR_LATER"));
         assert_eq!(result.remark.as_deref(), Some("retry later"));
         assert!(result.message.contains("CR_LATER"));
+    }
+
+    #[test]
+    fn normalize_direct_consume_request_trims_and_drops_blank_client_id() {
+        let request = rocketmq_dashboard_common::MessageDirectConsumeRequest {
+            topic: " TopicTest ".to_string(),
+            consumer_group: " group-a ".to_string(),
+            message_id: " msg-1 ".to_string(),
+            client_id: Some("   ".to_string()),
+        };
+
+        let normalized = normalize_direct_consume_request(request).expect("request should normalize");
+
+        assert_eq!(normalized.topic, "TopicTest");
+        assert_eq!(normalized.consumer_group, "group-a");
+        assert_eq!(normalized.message_id, "msg-1");
+        assert_eq!(normalized.client_id, None);
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageDetailModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageDetailModal.tsx
@@ -34,12 +34,14 @@ export const MessageDetailModal = ({ isOpen, onClose, message }: MessageDetailMo
   const [detail, setDetail] = useState<MessageDetail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+  const [consumingGroup, setConsumingGroup] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isOpen || !message) {
       setDetail(null);
       setError('');
       setIsLoading(false);
+      setConsumingGroup(null);
       return;
     }
 
@@ -76,6 +78,41 @@ export const MessageDetailModal = ({ isOpen, onClose, message }: MessageDetailMo
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
     toast.success("Copied to clipboard");
+  };
+
+  const handleDirectConsume = async (consumerGroup: string) => {
+    if (!detail) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Request direct consume for message ${detail.msgId} in consumer group ${consumerGroup}?`,
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setConsumingGroup(consumerGroup);
+
+    try {
+      const result = await MessageService.consumeMessageDirectly({
+        topic: detail.topic,
+        consumerGroup,
+        messageId: detail.msgId,
+      });
+
+      if (result.success) {
+        toast.success(result.message);
+      } else {
+        toast.error(result.message);
+      }
+    } catch (consumeError) {
+      const messageText =
+        consumeError instanceof Error ? consumeError.message : 'Failed to request direct consume.';
+      toast.error(messageText);
+    } finally {
+      setConsumingGroup(null);
+    }
   };
 
   const formatTimestamp = (value?: number | null) => {
@@ -270,6 +307,14 @@ export const MessageDetailModal = ({ isOpen, onClose, message }: MessageDetailMo
                           <div key={`${track.consumerGroup}-${track.trackType}`} className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-2 text-sm dark:border-gray-800 dark:bg-gray-800/40">
                             <div className="font-medium text-gray-900 dark:text-white">{track.consumerGroup}</div>
                             <div className="mt-1 text-gray-600 dark:text-gray-300">{track.trackType}</div>
+                            <button
+                              onClick={() => void handleDirectConsume(track.consumerGroup)}
+                              disabled={consumingGroup === track.consumerGroup}
+                              className="mt-3 inline-flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-700 shadow-sm transition-all hover:border-amber-300 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:border-amber-800 dark:hover:bg-amber-900/30"
+                            >
+                              <RefreshCw className={`h-3.5 w-3.5 ${consumingGroup === track.consumerGroup ? 'animate-spin' : ''}`} />
+                              {consumingGroup === track.consumerGroup ? 'Requesting...' : 'Resend'}
+                            </button>
                             {track.exceptionDesc && (
                               <div className="mt-1 font-mono text-xs text-red-600 dark:text-red-300 break-all">{track.exceptionDesc}</div>
                             )}
@@ -277,8 +322,8 @@ export const MessageDetailModal = ({ isOpen, onClose, message }: MessageDetailMo
                         ))}
                       </div>
                     ) : (
-                      <div className="flex items-start gap-3 rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-4 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800/40 dark:text-gray-300">
-                        <Info className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+                      <div className="flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 px-4 py-4 text-sm text-blue-800 dark:border-blue-900/40 dark:bg-blue-900/20 dark:text-blue-200">
+                        <Info className="mt-0.5 h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" />
                         <div>No consumer track records matched the current message.</div>
                         <div className="hidden">
                           `messageTrackList` 依赖的底层 `message_track_detail` 能力在 `rocketmq-rust` 里尚未实现。

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageView.tsx
@@ -22,7 +22,7 @@ import { MessageService } from '../services/message.service';
 
 type MessageTab = 'Topic' | 'Message Key' | 'Message ID';
 
-const DEFAULT_PAGE_SIZE = 10;
+const DEFAULT_PAGE_SIZE = 12;
 
 const defaultPagination = {
   currentPage: 1,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message/types/message.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message/types/message.types.ts
@@ -52,6 +52,13 @@ export interface ViewMessageRequest {
     messageId: string;
 }
 
+export interface MessageDirectConsumeRequest {
+    topic: string;
+    consumerGroup: string;
+    messageId: string;
+    clientId?: string | null;
+}
+
 export interface MessageTrack {
     consumerGroup: string;
     trackType: string;
@@ -77,4 +84,14 @@ export interface MessageDetail {
     bodyText?: string | null;
     bodyBase64?: string | null;
     messageTrackList?: MessageTrack[] | null;
+}
+
+export interface MessageDirectConsumeResult {
+    success: boolean;
+    message: string;
+    consumerGroup: string;
+    topic: string;
+    msgId: string;
+    consumeResult?: string | null;
+    remark?: string | null;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/message.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/message.service.ts
@@ -1,6 +1,8 @@
 import { invoke } from '@tauri-apps/api/core';
 import type {
     MessageDetail,
+    MessageDirectConsumeRequest,
+    MessageDirectConsumeResult,
     MessageIdQueryRequest,
     MessageKeyQueryRequest,
     MessagePageQueryRequest,
@@ -24,5 +26,11 @@ export class MessageService {
 
     static async viewMessageDetail(request: ViewMessageRequest): Promise<MessageDetail> {
         return invoke<MessageDetail>('view_message_detail', { request });
+    }
+
+    static async consumeMessageDirectly(
+        request: MessageDirectConsumeRequest,
+    ): Promise<MessageDirectConsumeResult> {
+        return invoke<MessageDirectConsumeResult>('consume_message_directly', { request });
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6887

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added direct message consumption with "Resend" button in message tracking, enabling users to resend messages to specific consumer groups with optional client ID specification
  * Enhanced message lookup to prioritize unique client message identifiers

* **Style**
  * Increased message list pagination size from 10 to 12 items per page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->