### PR TITLE
[ISSUE #6890]✨Add queryMsgId to message types and update related components for improved message handling

### DIFF
--- a/rocketmq-common/src/common/message/broker_message.rs
+++ b/rocketmq-common/src/common/message/broker_message.rs
@@ -308,7 +308,7 @@ impl MessageTrait for BrokerMessage {
     }
 
     fn transaction_id(&self) -> Option<&CheetahString> {
-        self.envelope.message().transaction_id()
+        MessageTrait::transaction_id(self.envelope.message())
     }
 
     fn set_transaction_id(&mut self, transaction_id: CheetahString) {

--- a/rocketmq-common/src/common/message/message_batch.rs
+++ b/rocketmq-common/src/common/message/message_batch.rs
@@ -231,7 +231,7 @@ impl MessageTrait for MessageBatch {
 
     #[inline]
     fn transaction_id(&self) -> Option<&CheetahString> {
-        self.final_message.transaction_id()
+        MessageTrait::transaction_id(&self.final_message)
     }
 
     #[inline]

--- a/rocketmq-common/src/common/message/message_envelope.rs
+++ b/rocketmq-common/src/common/message/message_envelope.rs
@@ -24,6 +24,7 @@ use crate::common::message::message_client_id_setter::MessageClientIDSetter;
 use crate::common::message::message_single::Message;
 use crate::common::message::routing_context::RoutingContext;
 use crate::common::message::storage_metadata::StorageMetadata;
+use crate::common::message::MessageTrait;
 
 /// Complete message envelope (stored message)
 ///
@@ -386,7 +387,7 @@ impl crate::common::message::MessageTrait for MessageEnvelope {
     }
 
     fn transaction_id(&self) -> Option<&CheetahString> {
-        self.message.transaction_id()
+        MessageTrait::transaction_id(&self.message)
     }
 
     fn set_transaction_id(&mut self, transaction_id: CheetahString) {

--- a/rocketmq-common/src/common/message/message_ext.rs
+++ b/rocketmq-common/src/common/message/message_ext.rs
@@ -342,7 +342,7 @@ impl MessageTrait for MessageExt {
 
     #[inline]
     fn transaction_id(&self) -> Option<&CheetahString> {
-        self.message.transaction_id()
+        MessageTrait::transaction_id(&self.message)
     }
 
     fn set_transaction_id(&mut self, transaction_id: CheetahString) {
@@ -440,5 +440,23 @@ impl From<crate::common::message::message_envelope::MessageEnvelope> for Message
             reconsume_times: envelope.reconsume_times(),
             prepared_transaction_offset: envelope.prepared_transaction_offset(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+    use crate::common::message::MessageTrait;
+
+    #[test]
+    fn message_ext_message_trait_transaction_id_returns_cheetah_string_ref() {
+        let mut message_ext = MessageExt::default();
+        message_ext.set_transaction_id(CheetahString::from_static_str("tx-123"));
+
+        let transaction_id = <MessageExt as MessageTrait>::transaction_id(&message_ext);
+
+        assert_eq!(transaction_id, Some(&CheetahString::from_static_str("tx-123")));
     }
 }

--- a/rocketmq-common/src/common/message/message_single.rs
+++ b/rocketmq-common/src/common/message/message_single.rs
@@ -341,6 +341,11 @@ impl Message {
     }
 
     #[inline]
+    pub fn get_transaction_id(&self) -> Option<&CheetahString> {
+        self.transaction_id.as_ref()
+    }
+
+    #[inline]
     pub fn get_tags(&self) -> Option<CheetahString> {
         self.properties.as_map().get(MessageConst::PROPERTY_TAGS).cloned()
     }
@@ -769,6 +774,16 @@ mod tests {
         assert_eq!(msg.topic().as_str(), "test_topic");
         assert!(!msg.is_wait_store_msg_ok());
         assert_eq!(msg.body().unwrap(), body);
+    }
+
+    #[test]
+    fn test_get_transaction_id_returns_cheetah_string_ref() {
+        let mut msg = Message::new("test_topic", b"test_body");
+        msg.set_transaction_id(CheetahString::from_static_str("tx-123"));
+
+        let transaction_id = msg.get_transaction_id();
+
+        assert_eq!(transaction_id, Some(&CheetahString::from_static_str("tx-123")));
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
@@ -1188,6 +1188,7 @@ fn map_message_summary(message: MessageExt) -> MessageSummaryView {
     MessageSummaryView {
         topic: message.topic().to_string(),
         msg_id: resolve_message_summary_id(&message),
+        query_msg_id: message.msg_id().to_string(),
         tags: message.get_tags().map(|value| value.to_string()),
         keys: extract_keys(&message),
         store_timestamp: message.store_timestamp(),
@@ -1389,6 +1390,7 @@ fn build_trace_summary(message_id: &str, mut seeds: Vec<TraceSeed>) -> MessageRe
     Ok(MessageSummaryView {
         topic: selected.topic.clone().unwrap_or_default(),
         msg_id: message_id.to_string(),
+        query_msg_id: message_id.to_string(),
         tags: selected.tags.clone(),
         keys: selected.keys.clone(),
         store_timestamp: selected.timestamp,
@@ -1606,6 +1608,7 @@ mod tests {
 
         assert_eq!(summary.topic, "TopicTest");
         assert_eq!(summary.msg_id, "msg-1");
+        assert_eq!(summary.query_msg_id, "msg-1");
         assert_eq!(summary.tags.as_deref(), Some("TagA"));
         assert_eq!(summary.keys.as_deref(), Some("KeyA KeyB"));
         assert_eq!(summary.store_timestamp, 1_700_000_000_123);
@@ -1629,6 +1632,7 @@ mod tests {
         let summary = map_message_summary(message_ext);
 
         assert_eq!(summary.msg_id, "uniq-msg-id");
+        assert_eq!(summary.query_msg_id, "offset-msg-id");
     }
 
     #[test]
@@ -1649,6 +1653,7 @@ mod tests {
         let summary = map_message_summary(message_ext);
 
         assert_eq!(summary.msg_id, "offset-msg-id");
+        assert_eq!(summary.query_msg_id, "offset-msg-id");
     }
 
     #[test]
@@ -1931,6 +1936,7 @@ mod tests {
         .expect("trace summary should build");
 
         assert_eq!(summary.msg_id, "msg-1");
+        assert_eq!(summary.query_msg_id, "msg-1");
         assert_eq!(summary.topic, "TopicTest");
         assert_eq!(summary.tags.as_deref(), Some("TagA"));
         assert_eq!(summary.keys.as_deref(), Some("KeyA"));

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
@@ -43,6 +43,7 @@ impl std::error::Error for MessageError {}
 pub(crate) struct MessageSummaryView {
     pub(crate) topic: String,
     pub(crate) msg_id: String,
+    pub(crate) query_msg_id: String,
     pub(crate) tags: Option<String>,
     pub(crate) keys: Option<String>,
     pub(crate) store_timestamp: i64,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
@@ -42,7 +42,8 @@ const formatDateTimeInput = (date: Date) =>
 
 const toSummary = (detail: Awaited<ReturnType<typeof DlqService.viewDlqMessageDetail>>): DlqMessageSummary => ({
   topic: detail.topic,
-  msgId: detail.msgId,
+  msgId: detail.properties.UNIQ_KEY?.trim() || detail.msgId,
+  queryMsgId: detail.msgId,
   tags: detail.properties.TAGS ?? null,
   keys: detail.properties.KEYS ?? null,
   storeTimestamp: detail.storeTimestamp ?? 0,
@@ -218,13 +219,13 @@ export const DLQMessageView = () => {
       return;
     }
 
-    setResendingMessageId(message.msgId);
+    setResendingMessageId(message.queryMsgId);
     setSearchError('');
 
     try {
       const result = await DlqService.resendDlqMessage({
         consumerGroup: normalizedConsumerGroup,
-        messageId: message.msgId,
+        messageId: message.queryMsgId,
       });
 
       if (result.success) {
@@ -407,7 +408,7 @@ export const DLQMessageView = () => {
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 2xl:grid-cols-3">
             {messages.map((message, index) => (
               <motion.div
-                key={`${message.topic}-${message.msgId}`}
+              key={`${message.topic}-${message.queryMsgId}`}
                 initial={{ opacity: 0, y: 16 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: index * 0.04 }}
@@ -472,11 +473,11 @@ export const DLQMessageView = () => {
                   <div className="grid grid-cols-2 gap-3">
                     <button
                       onClick={() => void handleResend(message)}
-                      disabled={resendingMessageId === message.msgId}
+                  disabled={resendingMessageId === message.queryMsgId}
                       className="flex items-center justify-center rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 shadow-sm transition-all hover:border-amber-300 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:border-amber-800 dark:hover:bg-amber-900/30"
                     >
                       <Send className="mr-1.5 h-4 w-4" />
-                      {resendingMessageId === message.msgId ? 'Resending...' : 'Resend'}
+                  {resendingMessageId === message.queryMsgId ? 'Resending...' : 'Resend'}
                     </button>
                     <button
                       onClick={() => setSelectedMessage(message)}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageDetailModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageDetailModal.tsx
@@ -52,7 +52,7 @@ export const MessageDetailModal = ({ isOpen, onClose, message }: MessageDetailMo
 
     void MessageService.viewMessageDetail({
       topic: message.topic,
-      messageId: message.msgId,
+      messageId: message.queryMsgId,
     })
       .then((result) => {
         if (!cancelled) {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageView.tsx
@@ -176,6 +176,7 @@ export const MessageView = () => {
       setSelectedMessage({
         topic: topic.trim(),
         msgId: msgId.trim(),
+        queryMsgId: msgId.trim(),
         tags: null,
         keys: null,
         storeTimestamp: 0,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message/types/message.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/message/types/message.types.ts
@@ -1,6 +1,7 @@
 export interface MessageSummary {
     topic: string;
     msgId: string;
+    queryMsgId: string;
     tags?: string | null;
     keys?: string | null;
     storeTimestamp: number;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6890

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `queryMsgId` field to message summaries to track the original query message identifier separately from the resolved message ID.
  * Added a new accessor method for retrieving transaction IDs with proper type handling.

* **Bug Fixes**
  * Updated message detail lookup and DLQ message operations to use the correct message identifier field for accurate message retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->