### PR TITLE
[ISSUE #6892]🚀Implement batch resend functionality for DLQ messages with UI integration and error handling

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-common/src/message.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-common/src/message.rs
@@ -83,6 +83,12 @@ pub struct DlqResendMessageRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct DlqBatchResendMessageRequest {
+    pub messages: Vec<DlqResendMessageRequest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageDirectConsumeRequest {
     pub topic: String,
     pub consumer_group: String,
@@ -195,6 +201,22 @@ mod tests {
 
         let json = serde_json::to_string(&request).expect("serialize dlq resend request");
 
+        assert!(json.contains("\"consumerGroup\""));
+        assert!(json.contains("\"messageId\""));
+    }
+
+    #[test]
+    fn dlq_batch_resend_message_request_uses_java_dashboard_field_names() {
+        let request = super::DlqBatchResendMessageRequest {
+            messages: vec![super::DlqResendMessageRequest {
+                consumer_group: "group-a".to_string(),
+                message_id: "msg-1".to_string(),
+            }],
+        };
+
+        let json = serde_json::to_string(&request).expect("serialize dlq batch resend request");
+
+        assert!(json.contains("\"messages\""));
         assert!(json.contains("\"consumerGroup\""));
         assert!(json.contains("\"messageId\""));
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -116,6 +116,7 @@ pub fn run() {
             message::commands::view_message_detail,
             message::commands::view_dlq_message_detail,
             message::commands::resend_dlq_message,
+            message::commands::batch_resend_dlq_message,
             message::commands::consume_message_directly,
             message::commands::query_message_trace_by_id,
             message::commands::view_message_trace_detail,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 use crate::message::service::MessageManager;
+use crate::message::types::MessageBatchResendResponse;
 use crate::message::types::MessageDetailView;
 use crate::message::types::MessagePageResponse;
 use crate::message::types::MessageResendResult;
 use crate::message::types::MessageSummaryListResponse;
 use crate::message::types::MessageTraceDetailView;
+use rocketmq_dashboard_common::DlqBatchResendMessageRequest;
 use rocketmq_dashboard_common::DlqMessagePageQueryRequest;
 use rocketmq_dashboard_common::DlqResendMessageRequest;
 use rocketmq_dashboard_common::DlqViewMessageRequest;
@@ -102,6 +104,17 @@ pub async fn resend_dlq_message(
 ) -> Result<MessageResendResult, String> {
     message_manager
         .resend_dlq_message(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn batch_resend_dlq_message(
+    request: DlqBatchResendMessageRequest,
+    message_manager: State<'_, MessageManager>,
+) -> Result<MessageBatchResendResponse, String> {
+    message_manager
+        .batch_resend_dlq_message(request)
         .await
         .map_err(|error| error.to_string())
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
@@ -20,6 +20,7 @@ use crate::message::page_cache::NormalizedMessagePageQuery;
 use crate::message::page_cache::QueueScanState;
 use crate::message::page_cache::build_page_selection;
 use crate::message::page_cache::normalize_message_page_query;
+use crate::message::types::MessageBatchResendResponse;
 use crate::message::types::MessageDetailView;
 use crate::message::types::MessageError;
 use crate::message::types::MessagePageResponse;
@@ -45,6 +46,7 @@ use rocketmq_common::common::mix_all;
 #[allow(deprecated)]
 use rocketmq_common::common::tools::message_track::MessageTrack;
 use rocketmq_common::common::topic::TopicValidator;
+use rocketmq_dashboard_common::DlqBatchResendMessageRequest;
 use rocketmq_dashboard_common::DlqMessagePageQueryRequest;
 use rocketmq_dashboard_common::DlqResendMessageRequest;
 use rocketmq_dashboard_common::DlqViewMessageRequest;
@@ -261,6 +263,34 @@ impl MessageManager {
                 Err(error) => return Err(error),
             }
         }
+    }
+
+    pub(crate) async fn batch_resend_dlq_message(
+        &self,
+        request: DlqBatchResendMessageRequest,
+    ) -> MessageResult<MessageBatchResendResponse> {
+        let requests = normalize_batch_resend_requests(request.messages)?;
+        let mut items = Vec::with_capacity(requests.len());
+
+        for request in requests {
+            let consumer_group = request.consumer_group.trim().to_string();
+            let message_id = request.message_id.trim().to_string();
+            let result = match self.resend_dlq_message(request).await {
+                Ok(result) => result,
+                Err(error) => build_failed_message_resend_result(consumer_group, message_id, error),
+            };
+            items.push(result);
+        }
+
+        let success_count = items.iter().filter(|item| item.success).count();
+        let total = items.len();
+
+        Ok(MessageBatchResendResponse {
+            items,
+            total,
+            success_count,
+            failure_count: total.saturating_sub(success_count),
+        })
     }
 
     pub(crate) async fn consume_message_directly(
@@ -1138,6 +1168,26 @@ fn normalize_required_field(field_name: &str, value: String) -> MessageResult<St
     Ok(normalized)
 }
 
+fn normalize_batch_resend_requests(
+    requests: Vec<DlqResendMessageRequest>,
+) -> MessageResult<Vec<DlqResendMessageRequest>> {
+    if requests.is_empty() {
+        return Err(MessageError::Validation(
+            "At least one DLQ message must be selected for batch resend.".to_string(),
+        ));
+    }
+
+    requests
+        .into_iter()
+        .map(|request| {
+            Ok(DlqResendMessageRequest {
+                consumer_group: normalize_required_field("consumerGroup", request.consumer_group)?,
+                message_id: normalize_required_field("messageId", request.message_id)?,
+            })
+        })
+        .collect()
+}
+
 fn normalize_trace_topic(value: String) -> String {
     let normalized = value.trim();
     if normalized.is_empty() {
@@ -1354,6 +1404,22 @@ fn build_message_resend_result(
         msg_id,
         consume_result: consume_result_text,
         remark,
+    }
+}
+
+fn build_failed_message_resend_result(
+    consumer_group: String,
+    msg_id: String,
+    error: MessageError,
+) -> MessageResendResult {
+    MessageResendResult {
+        success: false,
+        message: format!("Direct consume failed for `{msg_id}` in consumer group `{consumer_group}`."),
+        consumer_group,
+        topic: String::new(),
+        msg_id,
+        consume_result: None,
+        remark: Some(error.to_string()),
     }
 }
 
@@ -1879,6 +1945,48 @@ mod tests {
         assert_eq!(result.consume_result.as_deref(), Some("CR_LATER"));
         assert_eq!(result.remark.as_deref(), Some("retry later"));
         assert!(result.message.contains("CR_LATER"));
+    }
+
+    #[test]
+    fn normalize_batch_resend_requests_rejects_empty_input() {
+        let error = normalize_batch_resend_requests(Vec::new()).expect_err("empty batch resend should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("At least one DLQ message must be selected for batch resend")
+        );
+    }
+
+    #[test]
+    fn normalize_batch_resend_requests_trims_fields() {
+        let requests = normalize_batch_resend_requests(vec![DlqResendMessageRequest {
+            consumer_group: " group-a ".to_string(),
+            message_id: " msg-1 ".to_string(),
+        }])
+        .expect("batch resend requests should normalize");
+
+        assert_eq!(
+            requests,
+            vec![DlqResendMessageRequest {
+                consumer_group: "group-a".to_string(),
+                message_id: "msg-1".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn build_failed_message_resend_result_preserves_error_context() {
+        let result = build_failed_message_resend_result(
+            "group-a".to_string(),
+            "msg-1".to_string(),
+            MessageError::Validation("missing origin id".to_string()),
+        );
+
+        assert!(!result.success);
+        assert_eq!(result.consumer_group, "group-a");
+        assert_eq!(result.msg_id, "msg-1");
+        assert_eq!(result.remark.as_deref(), Some("Validation error: missing origin id"));
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
@@ -91,6 +91,15 @@ pub(crate) struct MessageResendResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct MessageBatchResendResponse {
+    pub(crate) items: Vec<MessageResendResult>,
+    pub(crate) total: usize,
+    pub(crate) success_count: usize,
+    pub(crate) failure_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
 pub(crate) struct MessageTrackView {
     pub(crate) consumer_group: String,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
@@ -33,6 +33,8 @@ const defaultPagination = {
   totalElements: 0,
 };
 
+const EMPTY_SELECTED_IDS = new Set<string>();
+
 const pad = (value: number) => value.toString().padStart(2, '0');
 
 const formatDateTimeInput = (date: Date) =>
@@ -61,6 +63,8 @@ export const DLQMessageView = () => {
   const [hasSearched, setHasSearched] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
   const [resendingMessageId, setResendingMessageId] = useState<string | null>(null);
+  const [isBatchResending, setIsBatchResending] = useState(false);
+  const [selectedMessageIds, setSelectedMessageIds] = useState<Set<string>>(EMPTY_SELECTED_IDS);
   const [taskId, setTaskId] = useState('');
   const [pagination, setPagination] = useState(defaultPagination);
   const {
@@ -88,6 +92,7 @@ export const DLQMessageView = () => {
     setSelectedMessage(null);
     setSearchError('');
     setHasSearched(false);
+    setSelectedMessageIds(EMPTY_SELECTED_IDS);
     setTaskId('');
     setPagination(defaultPagination);
   }, [activeTab]);
@@ -115,6 +120,7 @@ export const DLQMessageView = () => {
     setSelectedMessage(null);
     setSearchError('');
     setHasSearched(false);
+    setSelectedMessageIds(EMPTY_SELECTED_IDS);
     setTaskId('');
     setPagination(defaultPagination);
   };
@@ -151,6 +157,7 @@ export const DLQMessageView = () => {
       });
 
       setMessages(response.page.content);
+      setSelectedMessageIds(EMPTY_SELECTED_IDS);
       setTaskId(response.taskId);
       setPagination({
         currentPage: response.page.number + 1,
@@ -179,6 +186,7 @@ export const DLQMessageView = () => {
     setIsSearching(true);
     setSearchError('');
     setHasSearched(true);
+    setSelectedMessageIds(EMPTY_SELECTED_IDS);
     setTaskId('');
     setPagination(defaultPagination);
 
@@ -242,6 +250,98 @@ export const DLQMessageView = () => {
     }
   };
 
+  const isMessageSelected = (message: DlqMessageSummary) => selectedMessageIds.has(message.queryMsgId);
+
+  const allVisibleSelected =
+    messages.length > 0 && messages.every((message) => selectedMessageIds.has(message.queryMsgId));
+
+  const toggleMessageSelection = (message: DlqMessageSummary) => {
+    setSelectedMessageIds((current) => {
+      const next = new Set(current);
+      if (next.has(message.queryMsgId)) {
+        next.delete(message.queryMsgId);
+      } else {
+        next.add(message.queryMsgId);
+      }
+      return next;
+    });
+  };
+
+  const toggleSelectAllVisible = () => {
+    setSelectedMessageIds((current) => {
+      if (messages.length === 0) {
+        return current;
+      }
+
+      const next = new Set(current);
+      if (messages.every((message) => next.has(message.queryMsgId))) {
+        messages.forEach((message) => next.delete(message.queryMsgId));
+      } else {
+        messages.forEach((message) => next.add(message.queryMsgId));
+      }
+      return next;
+    });
+  };
+
+  const handleBatchResend = async () => {
+    const normalizedConsumerGroup = consumerGroup.trim();
+    if (!normalizedConsumerGroup) {
+      setSearchError('Consumer group is required.');
+      return;
+    }
+
+    const selectedMessages = messages.filter((message) => selectedMessageIds.has(message.queryMsgId));
+    if (selectedMessages.length === 0) {
+      setSearchError('Select at least one DLQ message to resend.');
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Request direct consume for ${selectedMessages.length} DLQ message(s) in consumer group ${normalizedConsumerGroup}?`,
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setIsBatchResending(true);
+    setSearchError('');
+
+    try {
+      const response = await DlqService.batchResendDlqMessage({
+        messages: selectedMessages.map((message) => ({
+          consumerGroup: normalizedConsumerGroup,
+          messageId: message.queryMsgId,
+        })),
+      });
+
+      if (response.failureCount === 0) {
+        toast.success(`Batch resend completed for ${response.successCount} DLQ message(s).`);
+      } else if (response.successCount === 0) {
+        const failureMessage =
+          response.items.find((item) => !item.success)?.remark ??
+          `Batch resend failed for ${response.failureCount} DLQ message(s).`;
+        toast.error(failureMessage);
+        setSearchError(failureMessage);
+      } else {
+        const firstFailure = response.items.find((item) => !item.success)?.remark;
+        toast.warning(
+          `Batch resend completed with ${response.successCount} success and ${response.failureCount} failure(s).`,
+        );
+        if (firstFailure) {
+          setSearchError(firstFailure);
+        }
+      }
+
+      await queryDlqPage(pagination.currentPage || 1);
+    } catch (error) {
+      const messageText = error instanceof Error ? error.message : 'Failed to batch resend DLQ messages.';
+      toast.error(messageText);
+      setSearchError(messageText);
+    } finally {
+      setIsBatchResending(false);
+    }
+  };
+
   const renderEmptyCopy = () => {
     if (activeTab === 'Consumer') {
       return 'Enter a consumer group and time range to search DLQ messages.';
@@ -277,7 +377,7 @@ export const DLQMessageView = () => {
 
       <div className="flex items-start gap-3 rounded-2xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900/40 dark:bg-blue-900/20 dark:text-blue-200">
         <Info className="mt-0.5 h-4 w-4 shrink-0" />
-        <div>Phase 6 enables real single-message DLQ resend. Batch resend and export remain disabled.</div>
+          <div>Single-message and batch DLQ resend are available. Export is not available yet.</div>
       </div>
 
       <div className="sticky top-0 z-20 flex flex-col justify-between gap-4 rounded-2xl border border-gray-100 bg-white/90 p-4 shadow-sm backdrop-blur-xl transition-colors dark:border-gray-800 dark:bg-gray-900/90 xl:flex-row xl:items-center">
@@ -371,11 +471,12 @@ export const DLQMessageView = () => {
           {activeTab === 'Consumer' ? (
             <>
               <button
-                disabled
-                className="flex items-center rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-400 shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-500"
+                onClick={() => void handleBatchResend()}
+                disabled={isBatchResending || selectedMessageIds.size === 0}
+                className="flex items-center rounded-xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-medium text-amber-700 shadow-sm transition-all hover:border-amber-300 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:border-amber-800 dark:hover:bg-amber-900/30"
               >
                 <Send className="mr-2 h-4 w-4" />
-                Batch Resend
+                {isBatchResending ? 'Batch Resending...' : `Batch Resend${selectedMessageIds.size > 0 ? ` (${selectedMessageIds.size})` : ''}`}
               </button>
               <button
                 disabled
@@ -405,10 +506,28 @@ export const DLQMessageView = () => {
 
       <div>
         {messages.length > 0 ? (
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 2xl:grid-cols-3">
+          <>
+            {activeTab === 'Consumer' ? (
+              <div className="mb-4 flex items-center justify-between rounded-2xl border border-gray-100 bg-white px-4 py-3 text-sm text-gray-600 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300">
+                <label className="flex items-center gap-3">
+                  <input
+                    type="checkbox"
+                    checked={allVisibleSelected}
+                    onChange={toggleSelectAllVisible}
+                    className="h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-800"
+                  />
+                  <span>Select all messages on this page</span>
+                </label>
+                <span className="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">
+                  {selectedMessageIds.size} selected
+                </span>
+              </div>
+            ) : null}
+
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 2xl:grid-cols-3">
             {messages.map((message, index) => (
               <motion.div
-              key={`${message.topic}-${message.queryMsgId}`}
+                key={`${message.topic}-${message.queryMsgId}`}
                 initial={{ opacity: 0, y: 16 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: index * 0.04 }}
@@ -419,9 +538,19 @@ export const DLQMessageView = () => {
                     <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">
                       Message ID
                     </span>
-                    <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-500 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
-                      DLQ
-                    </span>
+                    <div className="flex items-center gap-3">
+                      {activeTab === 'Consumer' ? (
+                        <input
+                          type="checkbox"
+                          checked={isMessageSelected(message)}
+                          onChange={() => toggleMessageSelection(message)}
+                          className="h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-800"
+                        />
+                      ) : null}
+                      <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-500 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+                        DLQ
+                      </span>
+                    </div>
                   </div>
                   <p className="break-all font-mono text-sm font-bold text-gray-900 dark:text-white">{message.msgId}</p>
                 </div>
@@ -473,11 +602,11 @@ export const DLQMessageView = () => {
                   <div className="grid grid-cols-2 gap-3">
                     <button
                       onClick={() => void handleResend(message)}
-                  disabled={resendingMessageId === message.queryMsgId}
+                      disabled={resendingMessageId === message.queryMsgId || isBatchResending}
                       className="flex items-center justify-center rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 shadow-sm transition-all hover:border-amber-300 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:border-amber-800 dark:hover:bg-amber-900/30"
                     >
                       <Send className="mr-1.5 h-4 w-4" />
-                  {resendingMessageId === message.queryMsgId ? 'Resending...' : 'Resend'}
+                      {resendingMessageId === message.queryMsgId ? 'Resending...' : 'Resend'}
                     </button>
                     <button
                       onClick={() => setSelectedMessage(message)}
@@ -490,7 +619,8 @@ export const DLQMessageView = () => {
                 </div>
               </motion.div>
             ))}
-          </div>
+            </div>
+          </>
         ) : hasSearched ? (
           <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-gray-200 bg-white py-20 text-center text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400">
             <div className="mb-4 rounded-full bg-gray-50 p-4 dark:bg-gray-800">

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageDetailModal.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageDetailModal.tsx
@@ -325,10 +325,6 @@ export const MessageDetailModal = ({ isOpen, onClose, message }: MessageDetailMo
                       <div className="flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 px-4 py-4 text-sm text-blue-800 dark:border-blue-900/40 dark:bg-blue-900/20 dark:text-blue-200">
                         <Info className="mt-0.5 h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" />
                         <div>No consumer track records matched the current message.</div>
-                        <div className="hidden">
-                          `messageTrackList` 依赖的底层 `message_track_detail` 能力在 `rocketmq-rust` 里尚未实现。
-                          当前 Phase 2 先保证详情主数据真实，Track 与 Resend 留到后续 phase。
-                        </div>
                       </div>
                     )}
                   </div>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageTraceView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/MessageTraceView.tsx
@@ -483,7 +483,7 @@ export const MessageTraceView = () => {
           </div>
           <div>
             <h2 className="text-lg font-bold text-gray-900 dark:text-white">Message Trace</h2>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Query lifecycle events without reintroducing the old mock page.</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Query lifecycle events from the selected trace topic.</p>
           </div>
         </div>
 

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/types/dlq.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/types/dlq.types.ts
@@ -23,6 +23,10 @@ export interface DlqResendMessageRequest {
     messageId: string;
 }
 
+export interface DlqBatchResendMessageRequest {
+    messages: DlqResendMessageRequest[];
+}
+
 export interface DlqResendMessageResult {
     success: boolean;
     message: string;
@@ -31,6 +35,13 @@ export interface DlqResendMessageResult {
     msgId: string;
     consumeResult?: string | null;
     remark?: string | null;
+}
+
+export interface DlqBatchResendMessageResponse {
+    items: DlqResendMessageResult[];
+    total: number;
+    successCount: number;
+    failureCount: number;
 }
 
 export type DlqMessageSummary = MessageSummary;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/dlq.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/dlq.service.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import type {
+    DlqBatchResendMessageRequest,
+    DlqBatchResendMessageResponse,
     DlqMessageDetail,
     DlqMessageDetailRequest,
     DlqMessagePageQueryRequest,
@@ -21,5 +23,11 @@ export class DlqService {
 
     static async resendDlqMessage(request: DlqResendMessageRequest): Promise<DlqResendMessageResult> {
         return invoke<DlqResendMessageResult>('resend_dlq_message', { request });
+    }
+
+    static async batchResendDlqMessage(
+        request: DlqBatchResendMessageRequest,
+    ): Promise<DlqBatchResendMessageResponse> {
+        return invoke<DlqBatchResendMessageResponse>('batch_resend_dlq_message', { request });
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6892

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch resend capability for Dead Letter Queue messages, allowing users to select multiple messages and resend them together with aggregated success/failure reporting.
  * Enhanced Consumer tab with message selection checkboxes and "select all" functionality for streamlined multi-message operations.

* **Documentation**
  * Updated Message Trace header description for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->