### PR TITLE
[ISSUE #6896]🚀Implement batch export functionality for DLQ messages with UI integration and error handling

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-common/src/message.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-common/src/message.rs
@@ -89,6 +89,12 @@ pub struct DlqBatchResendMessageRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct DlqBatchExportMessageRequest {
+    pub messages: Vec<DlqViewMessageRequest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageDirectConsumeRequest {
     pub topic: String,
     pub consumer_group: String,
@@ -215,6 +221,22 @@ mod tests {
         };
 
         let json = serde_json::to_string(&request).expect("serialize dlq batch resend request");
+
+        assert!(json.contains("\"messages\""));
+        assert!(json.contains("\"consumerGroup\""));
+        assert!(json.contains("\"messageId\""));
+    }
+
+    #[test]
+    fn dlq_batch_export_message_request_uses_java_dashboard_field_names() {
+        let request = super::DlqBatchExportMessageRequest {
+            messages: vec![super::DlqViewMessageRequest {
+                consumer_group: "group-a".to_string(),
+                message_id: "msg-1".to_string(),
+            }],
+        };
+
+        let json = serde_json::to_string(&request).expect("serialize dlq batch export request");
 
         assert!(json.contains("\"messages\""));
         assert!(json.contains("\"consumerGroup\""));

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -118,6 +118,7 @@ pub fn run() {
             message::commands::resend_dlq_message,
             message::commands::batch_resend_dlq_message,
             message::commands::export_dlq_message,
+            message::commands::batch_export_dlq_message,
             message::commands::consume_message_directly,
             message::commands::query_message_trace_by_id,
             message::commands::view_message_trace_detail,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/commands.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::message::service::MessageManager;
+use crate::message::types::DlqBatchMessageExportView;
 use crate::message::types::DlqMessageExportView;
 use crate::message::types::MessageBatchResendResponse;
 use crate::message::types::MessageDetailView;
@@ -20,6 +21,7 @@ use crate::message::types::MessagePageResponse;
 use crate::message::types::MessageResendResult;
 use crate::message::types::MessageSummaryListResponse;
 use crate::message::types::MessageTraceDetailView;
+use rocketmq_dashboard_common::DlqBatchExportMessageRequest;
 use rocketmq_dashboard_common::DlqBatchResendMessageRequest;
 use rocketmq_dashboard_common::DlqMessagePageQueryRequest;
 use rocketmq_dashboard_common::DlqResendMessageRequest;
@@ -127,6 +129,17 @@ pub async fn export_dlq_message(
 ) -> Result<DlqMessageExportView, String> {
     message_manager
         .export_dlq_message(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn batch_export_dlq_message(
+    request: DlqBatchExportMessageRequest,
+    message_manager: State<'_, MessageManager>,
+) -> Result<DlqBatchMessageExportView, String> {
+    message_manager
+        .batch_export_dlq_message(request)
         .await
         .map_err(|error| error.to_string())
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/service.rs
@@ -20,6 +20,7 @@ use crate::message::page_cache::NormalizedMessagePageQuery;
 use crate::message::page_cache::QueueScanState;
 use crate::message::page_cache::build_page_selection;
 use crate::message::page_cache::normalize_message_page_query;
+use crate::message::types::DlqBatchMessageExportView;
 use crate::message::types::DlqMessageExportView;
 use crate::message::types::MessageBatchResendResponse;
 use crate::message::types::MessageDetailView;
@@ -49,6 +50,7 @@ use rocketmq_common::common::mix_all;
 #[allow(deprecated)]
 use rocketmq_common::common::tools::message_track::MessageTrack;
 use rocketmq_common::common::topic::TopicValidator;
+use rocketmq_dashboard_common::DlqBatchExportMessageRequest;
 use rocketmq_dashboard_common::DlqBatchResendMessageRequest;
 use rocketmq_dashboard_common::DlqMessagePageQueryRequest;
 use rocketmq_dashboard_common::DlqResendMessageRequest;
@@ -325,6 +327,41 @@ impl MessageManager {
                 Ok(response) => return Ok(response),
                 Err(error) if should_reset && attempt < 2 => {
                     log::warn!("Retrying `export_dlq_message` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    pub(crate) async fn batch_export_dlq_message(
+        &self,
+        request: DlqBatchExportMessageRequest,
+    ) -> MessageResult<DlqBatchMessageExportView> {
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let result = {
+                let session = session_guard
+                    .as_mut()
+                    .expect("message admin session should be initialized before use");
+                self.batch_export_dlq_message_with_admin(&mut session.admin, request.clone())
+                    .await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "batch_export_dlq_message failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `batch_export_dlq_message` after reconnect: {}", error);
                 }
                 Err(error) => return Err(error),
             }
@@ -1018,6 +1055,38 @@ impl MessageManager {
         Ok(build_dlq_export_view(topic, message))
     }
 
+    async fn batch_export_dlq_message_with_admin(
+        &self,
+        admin: &mut DefaultMQAdminExt,
+        request: DlqBatchExportMessageRequest,
+    ) -> MessageResult<DlqBatchMessageExportView> {
+        let requests = normalize_batch_export_requests(request.messages)?;
+        let mut rows = Vec::with_capacity(requests.len());
+        let mut success_count = 0usize;
+        let mut failure_count = 0usize;
+
+        for request in requests {
+            let consumer_group = request.consumer_group.clone();
+            let message_id = request.message_id.clone();
+            let topic = build_dlq_topic(&consumer_group)?;
+            match self
+                .find_message_by_id_with_admin(admin, topic.clone(), message_id.clone())
+                .await
+            {
+                Ok(message) => {
+                    rows.push(build_dlq_export_row(topic, message, String::new()));
+                    success_count += 1;
+                }
+                Err(error) => {
+                    rows.push(build_failed_dlq_export_row(topic, message_id, error));
+                    failure_count += 1;
+                }
+            }
+        }
+
+        Ok(build_batch_dlq_export_view(rows, success_count, failure_count))
+    }
+
     async fn consume_message_directly_with_admin(
         &self,
         admin: &mut DefaultMQAdminExt,
@@ -1233,6 +1302,24 @@ fn normalize_batch_resend_requests(
         .into_iter()
         .map(|request| {
             Ok(DlqResendMessageRequest {
+                consumer_group: normalize_required_field("consumerGroup", request.consumer_group)?,
+                message_id: normalize_required_field("messageId", request.message_id)?,
+            })
+        })
+        .collect()
+}
+
+fn normalize_batch_export_requests(requests: Vec<DlqViewMessageRequest>) -> MessageResult<Vec<DlqViewMessageRequest>> {
+    if requests.is_empty() {
+        return Err(MessageError::Validation(
+            "At least one DLQ message must be selected for batch export.".to_string(),
+        ));
+    }
+
+    requests
+        .into_iter()
+        .map(|request| {
+            Ok(DlqViewMessageRequest {
                 consumer_group: normalize_required_field("consumerGroup", request.consumer_group)?,
                 message_id: normalize_required_field("messageId", request.message_id)?,
             })
@@ -1476,19 +1563,38 @@ fn build_failed_message_resend_result(
 }
 
 fn build_dlq_export_view(request_topic: String, message: MessageExt) -> DlqMessageExportView {
-    let row = [
-        request_topic.clone(),
-        message.msg_id().to_string(),
-        message.born_host().to_string(),
-        format_export_timestamp(message.born_timestamp()),
-        format_export_timestamp(message.store_timestamp()),
-        message.reconsume_times().to_string(),
-        format_java_properties_string(&message),
-        decode_export_message_body(&message),
-        message.body_crc().to_string(),
-        String::new(),
-    ];
+    let msg_id = message.msg_id().to_string();
+    let row = build_dlq_export_row(request_topic.clone(), message, String::new());
 
+    DlqMessageExportView {
+        file_name: format!(
+            "dlq-{}-{}.csv",
+            sanitize_export_file_fragment(request_topic.trim_start_matches(mix_all::DLQ_GROUP_TOPIC_PREFIX)),
+            sanitize_export_file_fragment(&msg_id),
+        ),
+        mime_type: "text/csv;charset=utf-8".to_string(),
+        content: build_dlq_export_csv(vec![row]),
+    }
+}
+
+fn build_batch_dlq_export_view(
+    rows: Vec<[String; 10]>,
+    success_count: usize,
+    failure_count: usize,
+) -> DlqBatchMessageExportView {
+    let timestamp = Local::now().format("%Y%m%d%H%M%S");
+
+    DlqBatchMessageExportView {
+        file_name: format!("dlqs-{timestamp}.csv"),
+        mime_type: "text/csv;charset=utf-8".to_string(),
+        content: build_dlq_export_csv(rows),
+        total: success_count + failure_count,
+        success_count,
+        failure_count,
+    }
+}
+
+fn build_dlq_export_csv(rows: Vec<[String; 10]>) -> String {
     let header = [
         "topic",
         "msgId",
@@ -1502,19 +1608,43 @@ fn build_dlq_export_view(request_topic: String, message: MessageExt) -> DlqMessa
         "exception",
     ];
 
-    DlqMessageExportView {
-        file_name: format!(
-            "dlq-{}-{}.csv",
-            sanitize_export_file_fragment(request_topic.trim_start_matches(mix_all::DLQ_GROUP_TOPIC_PREFIX)),
-            sanitize_export_file_fragment(message.msg_id().as_str()),
-        ),
-        mime_type: "text/csv;charset=utf-8".to_string(),
-        content: format!(
-            "{}\n{}\n",
-            header.into_iter().map(csv_escape).collect::<Vec<_>>().join(","),
-            row.into_iter().map(csv_escape).collect::<Vec<_>>().join(",")
-        ),
-    }
+    let mut csv_rows = Vec::with_capacity(rows.len() + 1);
+    csv_rows.push(header.into_iter().map(csv_escape).collect::<Vec<_>>().join(","));
+    csv_rows.extend(
+        rows.into_iter()
+            .map(|row| row.into_iter().map(csv_escape).collect::<Vec<_>>().join(",")),
+    );
+    format!("{}\n", csv_rows.join("\n"))
+}
+
+fn build_dlq_export_row(request_topic: String, message: MessageExt, exception: String) -> [String; 10] {
+    [
+        request_topic,
+        message.msg_id().to_string(),
+        message.born_host().to_string(),
+        format_export_timestamp(message.born_timestamp()),
+        format_export_timestamp(message.store_timestamp()),
+        message.reconsume_times().to_string(),
+        format_java_properties_string(&message),
+        decode_export_message_body(&message),
+        message.body_crc().to_string(),
+        exception,
+    ]
+}
+
+fn build_failed_dlq_export_row(topic: String, message_id: String, error: MessageError) -> [String; 10] {
+    [
+        topic,
+        message_id,
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        error.to_string(),
+    ]
 }
 
 fn format_export_timestamp(value: i64) -> String {
@@ -2139,6 +2269,34 @@ mod tests {
     }
 
     #[test]
+    fn normalize_batch_export_requests_rejects_empty_input() {
+        let error = normalize_batch_export_requests(Vec::new()).expect_err("empty batch export should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("At least one DLQ message must be selected for batch export")
+        );
+    }
+
+    #[test]
+    fn normalize_batch_export_requests_trims_fields() {
+        let requests = normalize_batch_export_requests(vec![DlqViewMessageRequest {
+            consumer_group: " group-a ".to_string(),
+            message_id: " msg-1 ".to_string(),
+        }])
+        .expect("batch export requests should normalize");
+
+        assert_eq!(
+            requests,
+            vec![DlqViewMessageRequest {
+                consumer_group: "group-a".to_string(),
+                message_id: "msg-1".to_string(),
+            }]
+        );
+    }
+
+    #[test]
     fn build_dlq_export_view_maps_java_dashboard_columns() {
         let message = MessageBuilder::new()
             .topic("%DLQ%group-a")
@@ -2182,6 +2340,36 @@ mod tests {
         let export = build_dlq_export_view("%DLQ%group-a".to_string(), message_ext);
 
         assert!(export.content.contains("\"base64:/wBB\""));
+    }
+
+    #[test]
+    fn build_batch_dlq_export_view_includes_failure_rows() {
+        let rows = vec![
+            build_failed_dlq_export_row(
+                "%DLQ%group-a".to_string(),
+                "msg-1".to_string(),
+                MessageError::Validation("Failed to query message by Id: msg-1".to_string()),
+            ),
+            build_failed_dlq_export_row(
+                "%DLQ%group-a".to_string(),
+                "msg-2".to_string(),
+                MessageError::Validation("boom".to_string()),
+            ),
+        ];
+
+        let export = build_batch_dlq_export_view(rows, 0, 2);
+
+        assert_eq!(export.total, 2);
+        assert_eq!(export.success_count, 0);
+        assert_eq!(export.failure_count, 2);
+        assert!(export.file_name.starts_with("dlqs-"));
+        assert!(export.content.contains("\"exception\""));
+        assert!(
+            export
+                .content
+                .contains("\"Validation error: Failed to query message by Id: msg-1\"")
+        );
+        assert!(export.content.contains("\"msg-2\""));
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/message/types.rs
@@ -108,6 +108,17 @@ pub(crate) struct DlqMessageExportView {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct DlqBatchMessageExportView {
+    pub(crate) file_name: String,
+    pub(crate) mime_type: String,
+    pub(crate) content: String,
+    pub(crate) total: usize,
+    pub(crate) success_count: usize,
+    pub(crate) failure_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
 pub(crate) struct MessageTrackView {
     pub(crate) consumer_group: String,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/DLQMessageView.tsx
@@ -77,6 +77,7 @@ export const DLQMessageView = () => {
   const [resendingMessageId, setResendingMessageId] = useState<string | null>(null);
   const [exportingMessageId, setExportingMessageId] = useState<string | null>(null);
   const [isBatchResending, setIsBatchResending] = useState(false);
+  const [isBatchExporting, setIsBatchExporting] = useState(false);
   const [selectedMessageIds, setSelectedMessageIds] = useState<Set<string>>(EMPTY_SELECTED_IDS);
   const [taskId, setTaskId] = useState('');
   const [pagination, setPagination] = useState(defaultPagination);
@@ -381,6 +382,54 @@ export const DLQMessageView = () => {
     }
   };
 
+  const handleBatchExport = async () => {
+    const normalizedConsumerGroup = consumerGroup.trim();
+    if (!normalizedConsumerGroup) {
+      setSearchError('Consumer group is required.');
+      return;
+    }
+
+    const selectedMessages = messages.filter((message) => selectedMessageIds.has(message.queryMsgId));
+    if (selectedMessages.length === 0) {
+      setSearchError('Select at least one DLQ message to export.');
+      return;
+    }
+
+    setIsBatchExporting(true);
+    setSearchError('');
+
+    try {
+      const payload = await DlqService.batchExportDlqMessage({
+        messages: selectedMessages.map((message) => ({
+          consumerGroup: normalizedConsumerGroup,
+          messageId: message.queryMsgId,
+        })),
+      });
+
+      downloadExportPayload(payload.fileName, payload.mimeType, payload.content);
+
+      if (payload.failureCount === 0) {
+        toast.success(`Batch export completed for ${payload.successCount} DLQ message(s).`);
+      } else if (payload.successCount === 0) {
+        const failureMessage = `Batch export completed with ${payload.failureCount} failure row(s).`;
+        toast.warning(failureMessage);
+        setSearchError(failureMessage);
+      } else {
+        const partialMessage = `Batch export completed with ${payload.successCount} success and ${payload.failureCount} failure row(s).`;
+        toast.warning(partialMessage);
+        setSearchError(partialMessage);
+      }
+
+      setSelectedMessageIds(EMPTY_SELECTED_IDS);
+    } catch (error) {
+      const messageText = error instanceof Error ? error.message : 'Failed to batch export DLQ messages.';
+      toast.error(messageText);
+      setSearchError(messageText);
+    } finally {
+      setIsBatchExporting(false);
+    }
+  };
+
   const renderEmptyCopy = () => {
     if (activeTab === 'Consumer') {
       return 'Enter a consumer group and time range to search DLQ messages.';
@@ -416,7 +465,7 @@ export const DLQMessageView = () => {
 
       <div className="flex items-start gap-3 rounded-2xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900/40 dark:bg-blue-900/20 dark:text-blue-200">
         <Info className="mt-0.5 h-4 w-4 shrink-0" />
-          <div>Single-message export and resend are available. Batch resend is available. Batch export is not available yet.</div>
+          <div>Single-message export and resend are available. Batch resend and batch export are available.</div>
       </div>
 
       <div className="sticky top-0 z-20 flex flex-col justify-between gap-4 rounded-2xl border border-gray-100 bg-white/90 p-4 shadow-sm backdrop-blur-xl transition-colors dark:border-gray-800 dark:bg-gray-900/90 xl:flex-row xl:items-center">
@@ -511,18 +560,19 @@ export const DLQMessageView = () => {
             <>
               <button
                 onClick={() => void handleBatchResend()}
-                disabled={isBatchResending || selectedMessageIds.size === 0}
+                disabled={isBatchResending || isBatchExporting || selectedMessageIds.size === 0}
                 className="flex items-center rounded-xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-medium text-amber-700 shadow-sm transition-all hover:border-amber-300 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:border-amber-800 dark:hover:bg-amber-900/30"
               >
                 <Send className="mr-2 h-4 w-4" />
                 {isBatchResending ? 'Batch Resending...' : `Batch Resend${selectedMessageIds.size > 0 ? ` (${selectedMessageIds.size})` : ''}`}
               </button>
               <button
-                disabled
-                className="flex items-center rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-400 shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-500"
+                onClick={() => void handleBatchExport()}
+                disabled={isBatchExporting || isBatchResending || selectedMessageIds.size === 0}
+                className="flex items-center rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all hover:border-blue-200 hover:bg-blue-50 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-800 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
               >
                 <ArrowUpRight className="mr-2 h-4 w-4" />
-                Batch Export
+                {isBatchExporting ? 'Batch Exporting...' : `Batch Export${selectedMessageIds.size > 0 ? ` (${selectedMessageIds.size})` : ''}`}
               </button>
             </>
           ) : null}
@@ -644,7 +694,8 @@ export const DLQMessageView = () => {
                       disabled={
                         resendingMessageId === message.queryMsgId ||
                         exportingMessageId === message.queryMsgId ||
-                        isBatchResending
+                        isBatchResending ||
+                        isBatchExporting
                       }
                       className="flex items-center justify-center rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 shadow-sm transition-all hover:border-amber-300 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 dark:hover:border-amber-800 dark:hover:bg-amber-900/30"
                     >
@@ -656,7 +707,8 @@ export const DLQMessageView = () => {
                       disabled={
                         exportingMessageId === message.queryMsgId ||
                         resendingMessageId === message.queryMsgId ||
-                        isBatchResending
+                        isBatchResending ||
+                        isBatchExporting
                       }
                       className="flex items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all hover:border-blue-200 hover:bg-blue-50 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-800 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
                     >

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/types/dlq.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dlq/types/dlq.types.ts
@@ -32,6 +32,10 @@ export interface DlqBatchResendMessageRequest {
     messages: DlqResendMessageRequest[];
 }
 
+export interface DlqBatchExportMessageRequest {
+    messages: DlqMessageExportRequest[];
+}
+
 export interface DlqResendMessageResult {
     success: boolean;
     message: string;
@@ -53,6 +57,15 @@ export interface DlqMessageExportPayload {
     fileName: string;
     mimeType: string;
     content: string;
+}
+
+export interface DlqBatchMessageExportPayload {
+    fileName: string;
+    mimeType: string;
+    content: string;
+    total: number;
+    successCount: number;
+    failureCount: number;
 }
 
 export type DlqMessageSummary = MessageSummary;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/dlq.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/dlq.service.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import type {
+    DlqBatchExportMessageRequest,
+    DlqBatchMessageExportPayload,
     DlqBatchResendMessageRequest,
     DlqBatchResendMessageResponse,
     DlqMessageDetail,
@@ -35,5 +37,11 @@ export class DlqService {
 
     static async exportDlqMessage(request: DlqMessageExportRequest): Promise<DlqMessageExportPayload> {
         return invoke<DlqMessageExportPayload>('export_dlq_message', { request });
+    }
+
+    static async batchExportDlqMessage(
+        request: DlqBatchExportMessageRequest,
+    ): Promise<DlqBatchMessageExportPayload> {
+        return invoke<DlqBatchMessageExportPayload>('batch_export_dlq_message', { request });
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6896

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added batch export capability for Dead Letter Queue messages with detailed success and failure reporting.
  * Enabled "Batch Export" button in the DLQ interface to export multiple selected messages simultaneously.
  * Export now includes aggregate counts and per-item status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->