### PR TITLE
[ISSUE #6898]♻️Refactor NameServer home page functionality to support asynchronous data retrieval and enhance server status reporting

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver.rs
@@ -16,6 +16,7 @@ pub(crate) mod commands;
 pub(crate) mod db;
 pub(crate) mod runtime;
 pub(crate) mod service;
+pub(crate) mod types;
 
 pub(crate) use db::NameServerDb;
 pub(crate) use db::SqliteNameServerStore;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/commands.rs
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 use crate::nameserver::NameServerManager;
-use rocketmq_dashboard_common::NameServerHomePageInfo;
+use crate::nameserver::types::NameServerHomePageView;
 use rocketmq_dashboard_common::NameServerMutationResult;
 use tauri::State;
 
 #[tauri::command]
-pub fn get_name_server_home_page(
+pub async fn get_name_server_home_page(
     nameserver_manager: State<'_, NameServerManager>,
-) -> Result<NameServerHomePageInfo, String> {
-    nameserver_manager.home_page_info().map_err(|error| {
+) -> Result<NameServerHomePageView, String> {
+    nameserver_manager.home_page_info().await.map_err(|error| {
         log::error!("Failed to load NameServer home page: {}", error);
         error.to_string()
     })

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
@@ -15,30 +15,129 @@
 use crate::nameserver::db::NameServerDb;
 use crate::nameserver::db::SqliteNameServerStore;
 use crate::nameserver::runtime::NameServerRuntimeState;
+use crate::nameserver::types::NameServerHomePageView;
+use crate::nameserver::types::NameServerStatusItem;
 use anyhow::Result;
+use cheetah_string::CheetahString;
+use rocketmq_admin_core::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_dashboard_common::NameServerConfigSnapshot;
-use rocketmq_dashboard_common::NameServerHomePageInfo;
 use rocketmq_dashboard_common::NameServerMutationResult;
 use rocketmq_dashboard_common::NameServerService;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+const NAMESERVER_PROBE_TIMEOUT_MILLIS: u64 = 1_500;
+
+pub(crate) trait NameServerProbe: Send + Sync {
+    fn probe<'a>(
+        &'a self,
+        snapshot: &'a NameServerConfigSnapshot,
+        address: &'a str,
+    ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>>;
+}
+
+struct DefaultNameServerProbe;
+
+impl NameServerProbe for DefaultNameServerProbe {
+    fn probe<'a>(
+        &'a self,
+        snapshot: &'a NameServerConfigSnapshot,
+        address: &'a str,
+    ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+        Box::pin(async move {
+            let mut admin = DefaultMQAdminExt::with_admin_ext_group_and_timeout(
+                format!("dashboard-nameserver-probe-{}", Uuid::new_v4()),
+                Duration::from_millis(NAMESERVER_PROBE_TIMEOUT_MILLIS),
+            );
+            admin.client_config_mut().set_namesrv_addr(CheetahString::from(address));
+            admin.client_config_mut().set_vip_channel_enabled(snapshot.use_vip_channel);
+            admin.client_config_mut().set_use_tls(snapshot.use_tls);
+
+            let started = match admin.start().await {
+                Ok(_) => true,
+                Err(error) => {
+                    log::warn!("NameServer probe start failed for `{}`: {}", address, error);
+                    false
+                }
+            };
+
+            if !started {
+                return false;
+            }
+
+            let probe_result = admin
+                .get_name_server_config(vec![CheetahString::from(address)])
+                .await
+                .map(|_| true)
+                .unwrap_or_else(|error| {
+                    log::warn!("NameServer probe failed for `{}`: {}", address, error);
+                    false
+                });
+
+            admin.shutdown().await;
+            probe_result
+        })
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct NameServerManager {
     service: Arc<NameServerService<SqliteNameServerStore, NameServerRuntimeState>>,
     #[cfg_attr(not(test), allow(dead_code))]
     runtime: Arc<NameServerRuntimeState>,
+    probe: Arc<dyn NameServerProbe>,
 }
 
 impl NameServerManager {
     pub(crate) fn new(db: NameServerDb, runtime: Arc<NameServerRuntimeState>) -> Result<Self> {
+        Self::with_probe(db, runtime, Arc::new(DefaultNameServerProbe))
+    }
+
+    pub(crate) fn with_probe(
+        db: NameServerDb,
+        runtime: Arc<NameServerRuntimeState>,
+        probe: Arc<dyn NameServerProbe>,
+    ) -> Result<Self> {
         let store = Arc::new(SqliteNameServerStore::new(db));
         let service = Arc::new(NameServerService::new(store, runtime.clone()));
 
-        Ok(Self { service, runtime })
+        Ok(Self {
+            service,
+            runtime,
+            probe,
+        })
     }
 
-    pub(crate) fn home_page_info(&self) -> Result<NameServerHomePageInfo> {
-        self.service.home_page_info()
+    pub(crate) async fn home_page_info(&self) -> Result<NameServerHomePageView> {
+        let home_page = self.service.home_page_info()?;
+        let snapshot = NameServerConfigSnapshot {
+            current_namesrv: home_page.current_namesrv.clone(),
+            namesrv_addr_list: home_page.namesrv_addr_list.clone(),
+            use_vip_channel: home_page.use_vip_channel,
+            use_tls: home_page.use_tls,
+        };
+
+        let mut servers = Vec::with_capacity(home_page.namesrv_addr_list.len());
+        for address in &home_page.namesrv_addr_list {
+            let is_alive = self.probe.probe(&snapshot, address).await;
+            servers.push(NameServerStatusItem {
+                address: address.clone(),
+                is_current: home_page.current_namesrv.as_deref() == Some(address.as_str()),
+                is_alive,
+            });
+        }
+
+        Ok(NameServerHomePageView {
+            current_namesrv: home_page.current_namesrv,
+            namesrv_addr_list: home_page.namesrv_addr_list,
+            use_vip_channel: home_page.use_vip_channel,
+            use_tls: home_page.use_tls,
+            servers,
+        })
     }
 
     pub(crate) fn add_name_server(&self, address: &str) -> Result<NameServerMutationResult> {
@@ -75,14 +174,22 @@ impl NameServerManager {
 #[cfg(test)]
 mod tests {
     use super::NameServerManager;
+    use super::NameServerProbe;
     use crate::nameserver::db::NameServerDb;
     use crate::nameserver::db::SqliteNameServerStore;
     use crate::nameserver::runtime::NameServerRuntimeState;
+    use crate::nameserver::types::NameServerHomePageView;
     use rocketmq_dashboard_common::NameServerConfigStore;
+    use rocketmq_dashboard_common::NameServerConfigSnapshot;
+    use std::collections::HashMap;
     use std::env;
+    use std::future::Future;
     use std::fs;
+    use std::pin::Pin;
     use std::path::PathBuf;
     use std::sync::Arc;
+    use std::sync::Mutex;
+    use tokio::runtime::Builder;
     use uuid::Uuid;
 
     struct TestDir {
@@ -132,6 +239,68 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct ProbeSpy {
+        statuses: Mutex<HashMap<String, bool>>,
+    }
+
+    impl ProbeSpy {
+        fn with_statuses(statuses: &[(&str, bool)]) -> Self {
+            Self {
+                statuses: Mutex::new(
+                    statuses
+                        .iter()
+                        .map(|(address, is_alive)| (address.to_string(), *is_alive))
+                        .collect(),
+                ),
+            }
+        }
+    }
+
+    impl NameServerProbe for ProbeSpy {
+        fn probe<'a>(
+            &'a self,
+            _snapshot: &'a NameServerConfigSnapshot,
+            address: &'a str,
+        ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+            Box::pin(async move {
+                self.statuses
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .get(address)
+                    .copied()
+                    .unwrap_or(false)
+            })
+        }
+    }
+
+    fn setup_manager_with_probe(statuses: &[(&str, bool)]) -> TestContext {
+        let test_dir = TestDir::new();
+        let db = NameServerDb::from_path(test_dir.db_path());
+        db.init().expect("database initialization should succeed");
+        let store = SqliteNameServerStore::new(db.clone());
+        TestContext {
+            _test_dir: test_dir,
+            manager: NameServerManager::with_probe(
+                db,
+                Arc::new(NameServerRuntimeState::new(
+                    store.load_snapshot().expect("snapshot should load"),
+                )),
+                Arc::new(ProbeSpy::with_statuses(statuses)),
+            )
+            .expect("manager should initialize"),
+        }
+    }
+
+    fn load_home_page(manager: &NameServerManager) -> NameServerHomePageView {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime should build")
+            .block_on(manager.home_page_info())
+            .expect("home page should load")
+    }
+
     #[test]
     fn mutations_refresh_runtime_state_immediately() {
         let context = setup_manager();
@@ -153,5 +322,72 @@ mod tests {
         assert!(!runtime_snapshot.use_vip_channel);
         assert!(runtime_snapshot.use_tls);
         assert_eq!(manager.runtime_generation(), 4);
+    }
+
+    #[test]
+    fn home_page_info_reports_alive_status_per_server_and_preserves_order() {
+        let context = setup_manager_with_probe(&[("127.0.0.1:9876", true), ("127.0.0.2:9876", false)]);
+        let manager = &context.manager;
+
+        manager.add_name_server("127.0.0.2:9876").expect("add should succeed");
+
+        let home_page = load_home_page(manager);
+
+        assert_eq!(
+            home_page
+                .servers
+                .iter()
+                .map(|server| (server.address.as_str(), server.is_current, server.is_alive))
+                .collect::<Vec<_>>(),
+            vec![
+                ("127.0.0.1:9876", true, true),
+                ("127.0.0.2:9876", false, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn home_page_info_marks_current_server_offline_without_failing_the_page() {
+        let context = setup_manager_with_probe(&[("127.0.0.1:9876", false), ("127.0.0.2:9876", true)]);
+        let manager = &context.manager;
+
+        manager.add_name_server("127.0.0.2:9876").expect("add should succeed");
+
+        let home_page = load_home_page(manager);
+        let current_server = home_page
+            .servers
+            .iter()
+            .find(|server| server.is_current)
+            .expect("current server should exist");
+
+        assert_eq!(current_server.address, "127.0.0.1:9876");
+        assert!(!current_server.is_alive);
+        assert_eq!(home_page.servers.len(), 2);
+    }
+
+    #[test]
+    fn home_page_info_keeps_non_current_servers_when_current_is_offline() {
+        let context = setup_manager_with_probe(&[
+            ("127.0.0.1:9876", false),
+            ("127.0.0.2:9876", true),
+            ("127.0.0.3:9876", false),
+        ]);
+        let manager = &context.manager;
+
+        manager.add_name_server("127.0.0.2:9876").expect("add should succeed");
+        manager.add_name_server("127.0.0.3:9876").expect("add should succeed");
+
+        let home_page = load_home_page(manager);
+
+        assert_eq!(home_page.servers.len(), 3);
+        assert_eq!(
+            home_page
+                .servers
+                .iter()
+                .map(|server| server.address.as_str())
+                .collect::<Vec<_>>(),
+            vec!["127.0.0.1:9876", "127.0.0.2:9876", "127.0.0.3:9876"]
+        );
+        assert!(home_page.servers[1].is_alive);
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/types.rs
@@ -14,64 +14,23 @@
 
 use serde::Deserialize;
 use serde::Serialize;
-use std::fmt;
 
-pub(crate) type NameServerResult<T> = Result<T, NameServerError>;
-
-#[derive(Debug)]
-pub(crate) enum NameServerError {
-    Io(std::io::Error),
-    Database(rusqlite::Error),
-    AppPath(String),
-    Validation(String),
-}
-
-impl fmt::Display for NameServerError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Io(error) => write!(f, "I/O error: {error}"),
-            Self::Database(error) => write!(f, "Database error: {error}"),
-            Self::AppPath(message) => write!(f, "Application path error: {message}"),
-            Self::Validation(message) => write!(f, "Validation error: {message}"),
-        }
-    }
-}
-
-impl std::error::Error for NameServerError {}
-
-impl From<std::io::Error> for NameServerError {
-    fn from(error: std::io::Error) -> Self {
-        Self::Io(error)
-    }
-}
-
-impl From<rusqlite::Error> for NameServerError {
-    fn from(error: rusqlite::Error) -> Self {
-        Self::Database(error)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct NameServerRecord {
-    pub(crate) id: i64,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NameServerStatusItem {
     pub(crate) address: String,
-    pub(crate) is_active: bool,
+    pub(crate) is_current: bool,
+    pub(crate) is_alive: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct NameServerHomePageResponse {
-    pub(crate) success: bool,
-    pub(crate) message: String,
-    pub(crate) namesrv_addr_list: Vec<String>,
+pub(crate) struct NameServerHomePageView {
     pub(crate) current_namesrv: Option<String>,
+    pub(crate) namesrv_addr_list: Vec<String>,
+    #[serde(rename = "useVIPChannel")]
     pub(crate) use_vip_channel: bool,
+    #[serde(rename = "useTLS")]
     pub(crate) use_tls: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct NameServerMutationResponse {
-    pub(crate) success: bool,
-    pub(crate) message: String,
+    pub(crate) servers: Vec<NameServerStatusItem>,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/NameServerView.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/components/NameServerView.tsx
@@ -8,6 +8,70 @@ import { Button } from '../components/ui/LegacyButton';
 import { Input } from '../components/ui/LegacyInput';
 import { Toggle } from '../components/ui/LegacyToggle';
 
+const NAMESERVER_TABLE_GRID_STYLE: React.CSSProperties = {
+    gridTemplateColumns: 'minmax(0, 1fr) 176px 240px 176px',
+};
+const HEARTBEAT_WAVE_PATHS = [
+    'M4 20 C10 20, 12 9, 18 9 S26 28, 33 20 S42 8, 50 15 S58 28, 66 20 S76 10, 84 16 S94 20, 108 20',
+    'M4 20 C10 20, 12 13, 18 13 S26 24, 33 20 S42 12, 50 17 S58 24, 66 20 S76 13, 84 17 S94 20, 108 20',
+    'M4 20 C10 20, 12 7, 18 7 S26 31, 33 20 S42 6, 50 14 S58 31, 66 20 S76 8, 84 15 S94 20, 108 20',
+];
+const OFFLINE_WAVE_PATH = 'M4 20 L108 20';
+
+const NameServerHeartbeatWave = ({ isAlive }: { isAlive: boolean }) => (
+    <div
+        className={`relative flex h-12 w-36 items-center justify-center overflow-hidden rounded-full px-4 ${
+            isAlive
+                ? 'bg-emerald-50/90 ring-1 ring-emerald-100 dark:bg-emerald-950/30 dark:ring-emerald-900/40'
+                : 'bg-gray-100/90 ring-1 ring-gray-200 dark:bg-gray-800/70 dark:ring-gray-700/70'
+        }`}
+    >
+        <div
+            className={`absolute inset-x-4 h-px ${
+                isAlive ? 'bg-emerald-200/80 dark:bg-emerald-800/50' : 'bg-gray-300 dark:bg-gray-600'
+            }`}
+        />
+        <svg viewBox="0 0 112 40" className="relative z-10 h-9 w-full overflow-visible">
+            <motion.path
+                d={isAlive ? HEARTBEAT_WAVE_PATHS[0] : OFFLINE_WAVE_PATH}
+                fill="none"
+                stroke={isAlive ? 'rgba(16, 185, 129, 0.95)' : 'rgba(107, 114, 128, 0.9)'}
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                animate={
+                    isAlive
+                        ? {
+                              d: HEARTBEAT_WAVE_PATHS,
+                              opacity: [0.75, 1, 0.82, 1],
+                              pathLength: [0.92, 1, 0.95, 1],
+                          }
+                        : {
+                              opacity: [0.45, 0.7, 0.45],
+                          }
+                }
+                transition={{
+                    duration: isAlive ? 1.6 : 2.4,
+                    repeat: Infinity,
+                    ease: 'easeInOut',
+                }}
+            />
+            {isAlive ? (
+                <motion.circle
+                    cx="104"
+                    cy="20"
+                    r="2.6"
+                    fill="rgba(16, 185, 129, 1)"
+                    animate={{ opacity: [0.45, 1, 0.45], scale: [0.9, 1.15, 0.9] }}
+                    transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
+                />
+            ) : (
+                <circle cx="104" cy="20" r="2.2" fill="rgba(107, 114, 128, 0.8)" />
+            )}
+        </svg>
+    </div>
+);
+
 export const NameServerView = () => {
     const {
         data,
@@ -26,6 +90,11 @@ export const NameServerView = () => {
 
     const nameServers = data?.namesrvAddrList ?? [];
     const currentNameServer = data?.currentNamesrv ?? null;
+    const servers = data?.servers ?? nameServers.map((address) => ({
+        address,
+        isCurrent: address === currentNameServer,
+        isAlive: false,
+    }));
     const isBusy = pendingAction !== null;
 
     const handleAsyncAction = async (action: () => Promise<string | undefined>) => {
@@ -86,10 +155,14 @@ export const NameServerView = () => {
 
                     <div className="border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden bg-white dark:bg-gray-900 shadow-sm">
                         <div className="min-w-full">
-                            <div className="bg-gray-100 dark:bg-gray-800 border-b border-gray-100 dark:border-gray-800 px-6 py-3 flex items-center text-xs font-medium text-gray-900 dark:text-gray-200 uppercase tracking-wider">
-                                <div className="flex-1">Address</div>
-                                <div className="w-32 text-center">Status</div>
-                                <div className="w-32 text-right">Actions</div>
+                            <div
+                                className="grid items-center gap-x-10 bg-gray-100 dark:bg-gray-800 border-b border-gray-100 dark:border-gray-800 px-10 py-4 text-[11px] font-medium text-gray-900 dark:text-gray-200 uppercase tracking-[0.18em]"
+                                style={NAMESERVER_TABLE_GRID_STYLE}
+                            >
+                                <div className="min-w-0 whitespace-nowrap">Address</div>
+                                <div className="text-center whitespace-nowrap">Status</div>
+                                <div className="text-center whitespace-nowrap">Pulse</div>
+                                <div className="text-right whitespace-nowrap">Actions</div>
                             </div>
 
                             {isLoading && !data ? (
@@ -112,8 +185,8 @@ export const NameServerView = () => {
                                     }}
                                 >
                                     <AnimatePresence mode="popLayout">
-                                        {nameServers.map((address) => {
-                                            const isCurrent = address === currentNameServer;
+                                        {servers.map((server) => {
+                                            const { address, isCurrent, isAlive } = server;
                                             const isSwitching = pendingAction === `switch:${address}`;
                                             const isDeleting = pendingAction === `delete:${address}`;
 
@@ -128,9 +201,10 @@ export const NameServerView = () => {
                                                     exit={{ opacity: 0, height: 0, marginBottom: 0, transition: { duration: 0.2 } }}
                                                     whileHover={{ scale: 1.002 }}
                                                     transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-                                                    className={`flex items-center px-6 py-4 transition-colors relative group hover:bg-gray-50 dark:hover:bg-gray-800/50 ${
+                                                    className={`grid items-center gap-x-10 px-10 py-5 transition-colors relative group hover:bg-gray-50 dark:hover:bg-gray-800/50 ${
                                                         isCurrent ? 'bg-gray-100 dark:bg-gray-800' : 'bg-white dark:bg-gray-900'
                                                     }`}
+                                                    style={NAMESERVER_TABLE_GRID_STYLE}
                                                 >
                                                     {isCurrent && (
                                                         <motion.div
@@ -139,18 +213,18 @@ export const NameServerView = () => {
                                                         />
                                                     )}
 
-                                                    <div className="flex-1 font-mono text-sm text-gray-700 dark:text-gray-300 flex items-center">
+                                                    <div className="flex-1 min-w-0 font-mono text-sm text-gray-700 dark:text-gray-300 flex items-center">
                                                         <Server
-                                                            className={`w-4 h-4 mr-3 ${
+                                                            className={`w-4 h-4 mr-3 shrink-0 ${
                                                                 isCurrent ? 'text-blue-500' : 'text-gray-400 dark:text-gray-500'
                                                             }`}
                                                         />
-                                                        {address}
+                                                        <span className="truncate">{address}</span>
                                                     </div>
 
-                                                    <div className="w-32 flex justify-center">
+                                                    <div className="flex justify-center px-2">
                                                         {isCurrent ? (
-                                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400 border border-green-200 dark:border-green-800 shadow-sm">
+                                                            <span className="inline-flex items-center px-3.5 py-1 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400 border border-green-200 dark:border-green-800 shadow-sm">
                                                                 <motion.span
                                                                     animate={{ scale: [1, 1.2, 1], opacity: [1, 0.5, 1] }}
                                                                     transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
@@ -159,13 +233,17 @@ export const NameServerView = () => {
                                                                 Active
                                                             </span>
                                                         ) : (
-                                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700">
+                                                            <span className="inline-flex items-center px-3.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700">
                                                                 Standby
                                                             </span>
                                                         )}
                                                     </div>
 
-                                                    <div className="w-32 flex justify-end items-center space-x-2">
+                                                    <div className="flex justify-center px-2">
+                                                        <NameServerHeartbeatWave isAlive={isAlive} />
+                                                    </div>
+
+                                                    <div className="flex justify-end items-center space-x-3 px-2">
                                                         {!isCurrent && (
                                                             <motion.button
                                                                 whileHover={{ scale: 1.05 }}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/hooks/useNameServer.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/hooks/useNameServer.ts
@@ -3,7 +3,10 @@ import { NameServerService } from '../../../services/nameserver.service';
 import type {
     NameServerConfigSnapshot,
     NameServerHomePageInfo,
+    NameServerStatusItem,
 } from '../types/nameserver.types';
+
+const NAMESERVER_REFRESH_INTERVAL_MS = 5_000;
 
 const toErrorMessage = (error: unknown) => {
     if (error instanceof Error) {
@@ -15,6 +18,19 @@ const toErrorMessage = (error: unknown) => {
     }
 
     return 'NameServer operation failed';
+};
+
+const buildServerStatuses = (
+    snapshot: NameServerConfigSnapshot,
+    previousServers: NameServerStatusItem[] = [],
+): NameServerStatusItem[] => {
+    const previousAliveByAddress = new Map(previousServers.map((server) => [server.address, server.isAlive]));
+
+    return snapshot.namesrvAddrList.map((address) => ({
+        address,
+        isCurrent: snapshot.currentNamesrv === address,
+        isAlive: previousAliveByAddress.get(address) ?? false,
+    }));
 };
 
 export const useNameServer = () => {
@@ -40,26 +56,32 @@ export const useNameServer = () => {
     useEffect(() => {
         let isMounted = true;
 
-        loadHomePage()
-            .then((homePage) => {
-                if (isMounted) {
-                    setData(homePage);
-                }
-            })
-            .catch((error) => {
+        const loadInitialState = async () => {
+            try {
+                await loadHomePage();
+            } catch (error) {
                 console.error('Failed to load NameServer home page', error);
                 if (isMounted) {
                     setLoadError(toErrorMessage(error));
                 }
-            })
-            .finally(() => {
+            } finally {
                 if (isMounted) {
                     setIsLoading(false);
                 }
+            }
+        };
+
+        void loadInitialState();
+
+        const intervalId = window.setInterval(() => {
+            void loadHomePage().catch((error) => {
+                console.error('Failed to refresh NameServer home page', error);
             });
+        }, NAMESERVER_REFRESH_INTERVAL_MS);
 
         return () => {
             isMounted = false;
+            window.clearInterval(intervalId);
         };
     }, []);
 
@@ -116,12 +138,13 @@ export const useNameServer = () => {
     };
 
     const applySnapshot = (snapshot: NameServerConfigSnapshot) => {
-        setData({
+        setData((previous) => ({
             currentNamesrv: snapshot.currentNamesrv,
             namesrvAddrList: snapshot.namesrvAddrList,
             useVIPChannel: snapshot.useVIPChannel,
             useTLS: snapshot.useTLS,
-        });
+            servers: buildServerStatuses(snapshot, previous?.servers),
+        }));
     };
 
     const updateVipChannel = async (enabled: boolean) => {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/types/nameserver.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/nameserver/types/nameserver.types.ts
@@ -5,7 +5,15 @@ export interface NameServerConfigSnapshot {
     useTLS: boolean;
 }
 
-export interface NameServerHomePageInfo extends NameServerConfigSnapshot {}
+export interface NameServerStatusItem {
+    address: string;
+    isCurrent: boolean;
+    isAlive: boolean;
+}
+
+export interface NameServerHomePageInfo extends NameServerConfigSnapshot {
+    servers: NameServerStatusItem[];
+}
 
 export interface NameServerMutationResult {
     message: string;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6898

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nameserver health status monitoring with automatic periodic checks every 5 seconds to determine server availability.
  * Introduced visual heartbeat pulse indicators showing live/offline status for each nameserver in the UI.

* **Improvements**
  * Redesigned nameserver table layout with grid structure and added "Pulse" column for enhanced status visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->