### PR TITLE
[ISSUE #6900]🚀Implement probe functionality for name server with request handling and response management

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1565,6 +1565,15 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
             .unwrap_or_default())
     }
 
+    async fn probe_name_server(&self, name_server: CheetahString) -> rocketmq_error::RocketMQResult<()> {
+        self.client_instance
+            .as_ref()
+            .ok_or(rocketmq_error::RocketMQError::ClientNotStarted)?
+            .get_mq_client_api_impl()
+            .probe_name_server(&name_server, self.timeout_millis)
+            .await
+    }
+
     async fn resume_check_half_message(
         &self,
         topic: CheetahString,

--- a/rocketmq-client/src/admin/mq_admin_ext_async.rs
+++ b/rocketmq-client/src/admin/mq_admin_ext_async.rs
@@ -459,6 +459,8 @@ pub trait MQAdminExt: Send {
         name_servers: Vec<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<HashMap<CheetahString, HashMap<CheetahString, CheetahString>>>;
 
+    async fn probe_name_server(&self, name_server: CheetahString) -> rocketmq_error::RocketMQResult<()>;
+
     async fn query_consume_queue(
         &self,
         broker_addr: CheetahString,

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -132,6 +132,7 @@ use rocketmq_remoting::protocol::header::lock_batch_mq_request_header::LockBatch
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+use rocketmq_remoting::protocol::header::namesrv::config_header::GetNamesrvConfigRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::DeleteKVConfigRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::GetKVConfigRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::GetKVConfigResponseHeader;
@@ -3324,6 +3325,25 @@ impl MQClientAPIImpl {
             }
         }
         Ok(Some(config_map))
+    }
+
+    pub async fn probe_name_server(&self, name_server: &CheetahString, timeout_millis: Duration) -> RocketMQResult<()> {
+        let request = RemotingCommand::create_request_command(
+            RequestCode::GetNamesrvConfig,
+            GetNamesrvConfigRequestHeader::for_probe(),
+        );
+        let response = self
+            .remoting_client
+            .invoke_request(Some(name_server), request, timeout_millis.as_millis() as u64)
+            .await?;
+
+        match ResponseCode::from(response.code()) {
+            ResponseCode::Success => Ok(()),
+            _ => Err(mq_client_err!(
+                response.code(),
+                response.remark().map_or("".to_string(), |s| s.to_string())
+            )),
+        }
     }
 
     pub async fn get_controller_metadata(

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/nameserver/service.rs
@@ -54,7 +54,9 @@ impl NameServerProbe for DefaultNameServerProbe {
                 Duration::from_millis(NAMESERVER_PROBE_TIMEOUT_MILLIS),
             );
             admin.client_config_mut().set_namesrv_addr(CheetahString::from(address));
-            admin.client_config_mut().set_vip_channel_enabled(snapshot.use_vip_channel);
+            admin
+                .client_config_mut()
+                .set_vip_channel_enabled(snapshot.use_vip_channel);
             admin.client_config_mut().set_use_tls(snapshot.use_tls);
 
             let started = match admin.start().await {
@@ -70,7 +72,7 @@ impl NameServerProbe for DefaultNameServerProbe {
             }
 
             let probe_result = admin
-                .get_name_server_config(vec![CheetahString::from(address)])
+                .probe_name_server(CheetahString::from(address))
                 .await
                 .map(|_| true)
                 .unwrap_or_else(|error| {
@@ -179,14 +181,14 @@ mod tests {
     use crate::nameserver::db::SqliteNameServerStore;
     use crate::nameserver::runtime::NameServerRuntimeState;
     use crate::nameserver::types::NameServerHomePageView;
-    use rocketmq_dashboard_common::NameServerConfigStore;
     use rocketmq_dashboard_common::NameServerConfigSnapshot;
+    use rocketmq_dashboard_common::NameServerConfigStore;
     use std::collections::HashMap;
     use std::env;
-    use std::future::Future;
     use std::fs;
-    use std::pin::Pin;
+    use std::future::Future;
     use std::path::PathBuf;
+    use std::pin::Pin;
     use std::sync::Arc;
     use std::sync::Mutex;
     use tokio::runtime::Builder;
@@ -339,10 +341,7 @@ mod tests {
                 .iter()
                 .map(|server| (server.address.as_str(), server.is_current, server.is_alive))
                 .collect::<Vec<_>>(),
-            vec![
-                ("127.0.0.1:9876", true, true),
-                ("127.0.0.2:9876", false, false),
-            ]
+            vec![("127.0.0.1:9876", true, true), ("127.0.0.2:9876", false, false),]
         );
     }
 

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -30,6 +30,7 @@ use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper:
 use rocketmq_remoting::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::broker_request::GetBrokerMemberGroupRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::broker_request::UnRegisterBrokerRequestHeader;
+use rocketmq_remoting::protocol::header::namesrv::config_header::GetNamesrvConfigRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::DeleteKVConfigRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::GetKVConfigRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::kv_config_header::GetKVConfigResponseHeader;
@@ -581,16 +582,14 @@ impl DefaultRequestProcessor {
         )
     }
 
-    fn get_config(&mut self, _request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
+    fn get_config(&mut self, request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
+        if is_probe_only_namesrv_config_request(request) {
+            return Ok(create_namesrv_config_success_response(None));
+        }
+
         let config = self.name_server_runtime_inner.name_server_config();
         let result = match config.get_all_configs_format_string() {
-            Ok(content) => {
-                let response = RemotingCommand::create_response_command_with_code_remark(
-                    RemotingSysResponseCode::Success,
-                    CheetahString::empty(),
-                );
-                response.set_body(content.into_bytes())
-            }
+            Ok(content) => create_namesrv_config_success_response(Some(content.into_bytes())),
             Err(e) => RemotingCommand::create_response_command_with_code_remark(
                 ResponseCode::SystemError,
                 format!("UnsupportedEncodingException {e}"),
@@ -684,8 +683,36 @@ fn validate_blacklist_config_exist(
     false
 }
 
+fn is_probe_only_namesrv_config_request(request: &RemotingCommand) -> bool {
+    let Some(_) = request.ext_fields() else {
+        return false;
+    };
+
+    request
+        .decode_command_custom_header_fast::<GetNamesrvConfigRequestHeader>()
+        .map(|header| header.probe_only.unwrap_or(false))
+        .unwrap_or_else(|error| {
+            warn!("Failed to decode GetNamesrvConfigRequestHeader: {:?}", error);
+            false
+        })
+}
+
+fn create_namesrv_config_success_response(body: Option<Vec<u8>>) -> RemotingCommand {
+    let response = RemotingCommand::create_response_command_with_code_remark(
+        RemotingSysResponseCode::Success,
+        CheetahString::empty(),
+    );
+
+    match body {
+        Some(body) => response.set_body(body),
+        None => response,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use rocketmq_remoting::code::request_code::RequestCode;
+    use rocketmq_remoting::protocol::header::namesrv::config_header::GetNamesrvConfigRequestHeader;
     use rocketmq_remoting::protocol::header::namesrv::register_broker_header::RegisterBrokerRequestHeader;
 
     use super::*;
@@ -813,5 +840,33 @@ mod tests {
         };
         let result = check_sum_crc32(&request, &request_header);
         assert!(result);
+    }
+
+    #[test]
+    fn get_namesrv_config_defaults_to_full_response_without_probe_header() {
+        let request = RemotingCommand::create_remoting_command(RequestCode::GetNamesrvConfig);
+        assert!(!is_probe_only_namesrv_config_request(&request));
+
+        let response = create_namesrv_config_success_response(Some(b"name=value".to_vec()));
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert_eq!(
+            response.body().map(|body| body.as_ref().to_vec()),
+            Some(b"name=value".to_vec())
+        );
+    }
+
+    #[test]
+    fn get_namesrv_config_probe_only_request_skips_body() {
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::GetNamesrvConfig,
+            GetNamesrvConfigRequestHeader::for_probe(),
+        );
+        request.make_custom_header_to_net();
+
+        assert!(is_probe_only_namesrv_config_request(&request));
+
+        let response = create_namesrv_config_success_response(None);
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert!(response.body().is_none());
     }
 }

--- a/rocketmq-remoting/src/protocol/header/namesrv.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv.rs
@@ -14,6 +14,7 @@
 
 pub mod broker_request;
 pub mod brokerid_change_request_header;
+pub mod config_header;
 pub mod kv_config_header;
 pub mod perm_broker_header;
 pub mod query_data_version_header;

--- a/rocketmq-remoting/src/protocol/header/namesrv/config_header.rs
+++ b/rocketmq-remoting/src/protocol/header/namesrv/config_header.rs
@@ -1,0 +1,70 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct GetNamesrvConfigRequestHeader {
+    pub probe_only: Option<bool>,
+}
+
+impl GetNamesrvConfigRequestHeader {
+    pub fn for_probe() -> Self {
+        Self { probe_only: Some(true) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::GetNamesrvConfigRequestHeader;
+    use crate::code::request_code::RequestCode;
+    use crate::protocol::remoting_command::RemotingCommand;
+
+    #[test]
+    fn for_probe_sets_probe_only_flag() {
+        let header = GetNamesrvConfigRequestHeader::for_probe();
+        assert_eq!(header.probe_only, Some(true));
+    }
+
+    #[test]
+    fn request_command_encodes_probe_only_header() {
+        let mut command = RemotingCommand::create_request_command(
+            RequestCode::GetNamesrvConfig,
+            GetNamesrvConfigRequestHeader::for_probe(),
+        );
+        command.make_custom_header_to_net();
+
+        let ext_fields = command.ext_fields().expect("header fields should exist");
+        assert_eq!(ext_fields.get("probeOnly").map(CheetahString::as_str), Some("true"));
+    }
+
+    #[test]
+    fn request_command_decodes_probe_only_header() {
+        let mut command = RemotingCommand::create_request_command(
+            RequestCode::GetNamesrvConfig,
+            GetNamesrvConfigRequestHeader::for_probe(),
+        );
+        command.make_custom_header_to_net();
+
+        let decoded = command
+            .decode_command_custom_header_fast::<GetNamesrvConfigRequestHeader>()
+            .expect("header should decode");
+        assert_eq!(decoded.probe_only, Some(true));
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -775,6 +775,10 @@ impl MQAdminExt for DefaultMQAdminExt {
         self.default_mqadmin_ext_impl.get_name_server_config(name_servers).await
     }
 
+    async fn probe_name_server(&self, name_server: CheetahString) -> rocketmq_error::RocketMQResult<()> {
+        self.default_mqadmin_ext_impl.probe_name_server(name_server).await
+    }
+
     async fn resume_check_half_message(
         &self,
         topic: CheetahString,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6900

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a name server probe functionality enabling administrators to efficiently verify name server connectivity, availability, and health status. This lightweight operation uses minimal network bandwidth compared to standard configuration retrieval, allowing for real-time monitoring and diagnostics. The feature is integrated into admin tools for convenient access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->