### PR TITLE
[ISSUE #6909]✨Enhance TimerMessageStore recovery process with log truncation and state revision

### DIFF
--- a/rocketmq-store/src/timer/timer_log.rs
+++ b/rocketmq-store/src/timer/timer_log.rs
@@ -86,6 +86,21 @@ impl TimerLog {
         Ok(self.len()? == 0)
     }
 
+    pub fn truncate(&self, length: u64) -> std::io::Result<()> {
+        let _guard = self.io_lock.lock();
+        ensure_dir_ok(self.dir_path.to_string_lossy().as_ref());
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(self.active_file_path())?;
+        file.set_len(length)?;
+        file.sync_data()?;
+        self.next_offset.store(length, Ordering::Release);
+        Ok(())
+    }
+
     pub fn flush(&self) -> std::io::Result<()> {
         let _guard = self.io_lock.lock();
         if !self.active_file_path().exists() {
@@ -139,5 +154,21 @@ mod tests {
         assert_eq!(offset, 0);
         assert_eq!(reloaded.read_at(0, 9).unwrap(), b"timer-log");
         assert_eq!(reloaded.len().unwrap(), 9);
+    }
+
+    #[test]
+    fn truncate_discards_unflushed_tail() {
+        let temp_dir = tempdir().unwrap();
+        let timer_log = TimerLog::new(temp_dir.path().join("timerlog"), 1024);
+        assert!(timer_log.load().unwrap());
+
+        timer_log.append(b"first").unwrap();
+        timer_log.append(b"tail").unwrap();
+        timer_log.truncate(5).unwrap();
+
+        let reloaded = TimerLog::new(temp_dir.path().join("timerlog"), 1024);
+        assert!(reloaded.load().unwrap());
+        assert_eq!(reloaded.len().unwrap(), 5);
+        assert_eq!(reloaded.read_at(0, 5).unwrap(), b"first");
     }
 }

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -124,6 +124,12 @@ struct TimerLogEntry {
     record: TimerLogRecord,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct RecoveredTimerState {
+    read_time_ms: i64,
+    queue_offset: i64,
+}
+
 pub struct TimerMessageStore {
     pub curr_read_time_ms: AtomicI64,
     pub curr_queue_offset: AtomicI64,
@@ -171,10 +177,18 @@ impl TimerMessageStore {
             return false;
         }
 
+        let recovered_state = match self.recover_and_revise(&timer_checkpoint, &timer_log, &timer_wheel) {
+            Ok(recovered_state) => recovered_state,
+            Err(err) => {
+                error!("recover timer state failed: {err}");
+                return false;
+            }
+        };
+
         self.curr_read_time_ms
-            .store(timer_checkpoint.last_read_time_ms(), Ordering::Relaxed);
+            .store(recovered_state.read_time_ms, Ordering::Relaxed);
         self.curr_queue_offset
-            .store(timer_checkpoint.last_timer_queue_offset(), Ordering::Relaxed);
+            .store(recovered_state.queue_offset, Ordering::Relaxed);
         *self.timer_checkpoint.lock() = Some(timer_checkpoint);
         *self.timer_log.lock() = Some(timer_log);
         *self.timer_wheel.lock() = Some(timer_wheel);
@@ -398,6 +412,126 @@ impl TimerMessageStore {
             .lock()
             .as_ref()
             .and_then(|timer_wheel| timer_wheel.get_slot(time_ms))
+    }
+
+    fn recover_and_revise(
+        &self,
+        timer_checkpoint: &TimerCheckpoint,
+        timer_log: &TimerLog,
+        timer_wheel: &TimerWheel,
+    ) -> std::io::Result<RecoveredTimerState> {
+        let recovered_log_len = self.recover_timer_log_len(timer_checkpoint, timer_log)?;
+        let recovered_read_time_ms = self.recover_read_time_ms(timer_checkpoint.last_read_time_ms());
+        let recovered_queue_offset = self.recover_queue_offset(timer_checkpoint.last_timer_queue_offset());
+        self.repair_timer_wheel(timer_wheel, recovered_log_len)?;
+        self.persist_recovered_state(
+            timer_checkpoint,
+            timer_log,
+            timer_wheel,
+            recovered_read_time_ms,
+            recovered_queue_offset,
+            recovered_log_len,
+        )?;
+        Ok(RecoveredTimerState {
+            read_time_ms: recovered_read_time_ms,
+            queue_offset: recovered_queue_offset,
+        })
+    }
+
+    fn recover_timer_log_len(&self, timer_checkpoint: &TimerCheckpoint, timer_log: &TimerLog) -> std::io::Result<i64> {
+        let current_len = timer_log.len()? as i64;
+        let checkpoint_len = timer_checkpoint.last_timer_log_flush_pos().clamp(0, current_len);
+        let recovered_len = checkpoint_len - checkpoint_len.rem_euclid(TimerLogRecord::SIZE as i64);
+        let aligned_current_len = current_len - current_len.rem_euclid(TimerLogRecord::SIZE as i64);
+        let target_len = recovered_len.min(aligned_current_len);
+        if target_len != current_len {
+            warn!(
+                "revise timer log from {} to {} based on checkpoint flush position {}",
+                current_len, target_len, checkpoint_len
+            );
+            timer_log.truncate(target_len as u64)?;
+        }
+        Ok(target_len)
+    }
+
+    fn recover_read_time_ms(&self, checkpoint_read_time_ms: i64) -> i64 {
+        let now_floor = self.floor_time_ms(current_millis() as i64);
+        let ttl_floor = now_floor.saturating_sub(self.timer_wheel_window_ms());
+        let base = if checkpoint_read_time_ms <= 0 {
+            now_floor
+        } else {
+            self.floor_time_ms(checkpoint_read_time_ms)
+        };
+        base.max(ttl_floor)
+    }
+
+    fn recover_queue_offset(&self, checkpoint_queue_offset: i64) -> i64 {
+        let Some(message_store) = self.default_message_store.as_ref() else {
+            return checkpoint_queue_offset.max(0);
+        };
+        let consume_queue = message_store.find_consume_queue(&CheetahString::from_static_str(TIMER_TOPIC), 0);
+        let Some(consume_queue) = consume_queue else {
+            return checkpoint_queue_offset.max(0);
+        };
+        let min_offset = consume_queue.get_min_offset_in_queue();
+        let max_offset = consume_queue.get_max_offset_in_queue();
+        if checkpoint_queue_offset < min_offset {
+            warn!(
+                "revise timer queue offset from {} to consume queue min {}",
+                checkpoint_queue_offset, min_offset
+            );
+            min_offset
+        } else if checkpoint_queue_offset > max_offset {
+            warn!(
+                "revise timer queue offset from {} to consume queue max {}",
+                checkpoint_queue_offset, max_offset
+            );
+            max_offset
+        } else {
+            checkpoint_queue_offset
+        }
+    }
+
+    fn repair_timer_wheel(&self, timer_wheel: &TimerWheel, recovered_log_len: i64) -> std::io::Result<()> {
+        timer_wheel.revise_slots(|slot| {
+            if slot.num <= 0 {
+                return Slot::new_with_num_magic(0, 0, 0, 0, 0);
+            }
+            let invalid = slot.first_pos < 0
+                || slot.last_pos < 0
+                || slot.first_pos >= recovered_log_len
+                || slot.last_pos >= recovered_log_len
+                || slot.first_pos > slot.last_pos
+                || slot.first_pos.rem_euclid(TimerLogRecord::SIZE as i64) != 0
+                || slot.last_pos.rem_euclid(TimerLogRecord::SIZE as i64) != 0;
+            if invalid {
+                warn!(
+                    "clear invalid timer wheel slot time={} first={} last={} num={} against log len {}",
+                    slot.time_ms, slot.first_pos, slot.last_pos, slot.num, recovered_log_len
+                );
+                Slot::new_with_num_magic(0, 0, 0, 0, 0)
+            } else {
+                slot
+            }
+        })
+    }
+
+    fn persist_recovered_state(
+        &self,
+        timer_checkpoint: &TimerCheckpoint,
+        timer_log: &TimerLog,
+        timer_wheel: &TimerWheel,
+        recovered_read_time_ms: i64,
+        recovered_queue_offset: i64,
+        recovered_log_len: i64,
+    ) -> std::io::Result<()> {
+        timer_checkpoint.set_last_read_time_ms(recovered_read_time_ms);
+        timer_checkpoint.set_last_timer_queue_offset(recovered_queue_offset);
+        timer_checkpoint.set_master_timer_queue_offset(recovered_queue_offset);
+        timer_checkpoint.set_last_timer_log_flush_pos(recovered_log_len);
+        timer_log.flush()?;
+        timer_wheel.flush()?;
+        timer_checkpoint.flush()
     }
 
     pub async fn process_once(&self) -> usize {
@@ -699,6 +833,10 @@ impl TimerMessageStore {
     fn precision_ms(&self) -> i64 {
         self.message_store_config.timer_precision_ms.max(1) as i64
     }
+
+    fn timer_wheel_window_ms(&self) -> i64 {
+        self.precision_ms() * (TIMER_WHEEL_TTL_DAY as i64 * DAY_SECS as i64)
+    }
 }
 
 fn parse_deliver_time_ms(message: &MessageExt) -> Option<i64> {
@@ -809,14 +947,17 @@ mod tests {
         assert!(Path::new(get_timer_log_path(root_dir.as_str()).as_str()).exists());
         assert!(Path::new(get_timer_wheel_path(root_dir.as_str()).as_str()).exists());
 
-        timer_message_store.curr_read_time_ms.store(12_345, Ordering::Relaxed);
+        let read_time_ms = timer_message_store.floor_time_ms(current_millis() as i64);
+        timer_message_store
+            .curr_read_time_ms
+            .store(read_time_ms, Ordering::Relaxed);
         timer_message_store.curr_queue_offset.store(9, Ordering::Relaxed);
         timer_message_store.sync_last_read_time_ms();
         timer_message_store.shutdown();
 
         let reloaded_store = TimerMessageStore::new_with_config(None, config);
         assert!(reloaded_store.load());
-        assert_eq!(reloaded_store.curr_read_time_ms.load(Ordering::Relaxed), 12_345);
+        assert_eq!(reloaded_store.curr_read_time_ms.load(Ordering::Relaxed), read_time_ms);
         assert_eq!(reloaded_store.curr_queue_offset.load(Ordering::Relaxed), 9);
     }
 
@@ -830,22 +971,97 @@ mod tests {
         let timer_message_store = TimerMessageStore::new_with_config(None, config.clone());
         assert!(timer_message_store.load());
 
-        let log_offset = timer_message_store.append_timer_log(b"phase2").unwrap();
+        let record = TimerLogRecord {
+            deliver_time_ms,
+            commit_log_offset: 11,
+            size: 12,
+            queue_offset: 13,
+            prev_pos: EMPTY_TIMER_LOG_POS,
+            magic: MAGIC_DEFAULT,
+        };
+        let log_offset = timer_message_store.append_timer_log(&record.encode()).unwrap();
         timer_message_store
-            .put_timer_wheel_slot(
-                deliver_time_ms,
-                log_offset as i64,
-                (log_offset + 5) as i64,
-                1,
-                MAGIC_DEFAULT,
-            )
+            .put_timer_wheel_slot(deliver_time_ms, log_offset as i64, log_offset as i64, 1, MAGIC_DEFAULT)
             .unwrap();
         timer_message_store.shutdown();
 
         let reloaded_store = TimerMessageStore::new_with_config(None, config);
         assert!(reloaded_store.load());
-        assert_eq!(reloaded_store.read_timer_log(log_offset, 6).unwrap(), b"phase2");
+        assert_eq!(
+            reloaded_store.read_timer_log(log_offset, TimerLogRecord::SIZE).unwrap(),
+            record.encode()
+        );
         assert_eq!(reloaded_store.get_timer_wheel_slot(deliver_time_ms).unwrap().num, 1);
+    }
+
+    #[test]
+    fn load_truncates_timer_log_tail_and_clears_invalid_wheel_slot() {
+        let temp_dir = tempdir().unwrap();
+        let root_dir = temp_dir.path().to_string_lossy().to_string();
+        let config = config_with_root(root_dir.as_str());
+        let valid_time_ms = 10_000;
+        let invalid_time_ms = 20_000;
+
+        let timer_message_store = TimerMessageStore::new_with_config(None, config.clone());
+        assert!(timer_message_store.load());
+        let first_record = TimerLogRecord {
+            deliver_time_ms: valid_time_ms,
+            commit_log_offset: 1,
+            size: 2,
+            queue_offset: 3,
+            prev_pos: EMPTY_TIMER_LOG_POS,
+            magic: MAGIC_DEFAULT,
+        };
+        let second_record = TimerLogRecord {
+            deliver_time_ms: valid_time_ms,
+            commit_log_offset: 4,
+            size: 5,
+            queue_offset: 6,
+            prev_pos: 0,
+            magic: MAGIC_DEFAULT,
+        };
+        let first_offset = timer_message_store.append_timer_log(&first_record.encode()).unwrap();
+        let second_offset = timer_message_store.append_timer_log(&second_record.encode()).unwrap();
+        timer_message_store
+            .put_timer_wheel_slot(
+                valid_time_ms,
+                first_offset as i64,
+                second_offset as i64,
+                2,
+                MAGIC_DEFAULT,
+            )
+            .unwrap();
+        timer_message_store.sync_last_read_time_ms();
+        timer_message_store.shutdown();
+
+        let timer_log = TimerLog::new(get_timer_log_path(root_dir.as_str()), config.mapped_file_size_timer_log);
+        assert!(timer_log.load().unwrap());
+        let tail_offset = timer_log.append(&first_record.encode()).unwrap();
+        let timer_wheel = TimerWheel::new(
+            get_timer_wheel_path(root_dir.as_str()),
+            TIMER_WHEEL_TTL_DAY as usize * DAY_SECS as usize,
+            config.timer_precision_ms,
+        );
+        timer_wheel.load().unwrap();
+        timer_wheel
+            .put_slot(
+                invalid_time_ms,
+                tail_offset as i64,
+                tail_offset as i64,
+                1,
+                MAGIC_DEFAULT,
+            )
+            .unwrap();
+        timer_wheel.flush().unwrap();
+
+        let reloaded_store = TimerMessageStore::new_with_config(None, config);
+        assert!(reloaded_store.load());
+        assert_eq!(
+            reloaded_store.timer_log.lock().as_ref().unwrap().len().unwrap(),
+            (TimerLogRecord::SIZE * 2) as u64
+        );
+        assert_eq!(reloaded_store.get_timer_wheel_slot(valid_time_ms).unwrap().num, 2);
+        assert!(reloaded_store.get_timer_wheel_slot(invalid_time_ms).is_none());
     }
 
     #[tokio::test]
@@ -903,5 +1119,70 @@ mod tests {
         assert!(delivered
             .property(&CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_OUT_MS))
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn restart_recovers_indexed_due_timer_message_from_persisted_wheel() {
+        let temp_dir = tempdir().unwrap();
+        let root_dir = temp_dir.path().to_string_lossy().to_string();
+        let (store, timer_message_store, real_topic) = build_store_with_timer(root_dir.as_str());
+
+        assert!(store.mut_from_ref().load().await);
+        let deliver_ms = current_millis().saturating_sub(2_000);
+        let put_result = store
+            .mut_from_ref()
+            .put_message(build_timer_message(&real_topic, deliver_ms))
+            .await;
+        assert!(put_result.is_ok());
+        store.mut_from_ref().reput_once().await;
+
+        assert_eq!(timer_message_store.process_once().await, 1);
+        assert_eq!(store.get_max_offset_in_queue(&real_topic, 0), 0);
+        store.mut_from_ref().shutdown().await;
+
+        let (reloaded_store, reloaded_timer_message_store, reloaded_topic) = build_store_with_timer(root_dir.as_str());
+        assert_eq!(reloaded_topic, real_topic);
+        assert!(reloaded_store.mut_from_ref().load().await);
+        reloaded_timer_message_store.set_should_running_dequeue(true);
+
+        let delivered = reloaded_timer_message_store.process_once().await;
+        reloaded_store.mut_from_ref().reput_once().await;
+
+        assert_eq!(delivered, 1);
+        assert_eq!(
+            reloaded_timer_message_store.curr_queue_offset.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(reloaded_store.get_max_offset_in_queue(&real_topic, 0), 1);
+    }
+
+    #[tokio::test]
+    async fn load_revises_checkpoint_queue_offset_to_timer_queue_max() {
+        let temp_dir = tempdir().unwrap();
+        let root_dir = temp_dir.path().to_string_lossy().to_string();
+        let (store, timer_message_store, real_topic) = build_store_with_timer(root_dir.as_str());
+
+        assert!(store.mut_from_ref().load().await);
+        let deliver_ms = current_millis() + 60_000;
+        let put_result = store
+            .mut_from_ref()
+            .put_message(build_timer_message(&real_topic, deliver_ms))
+            .await;
+        assert!(put_result.is_ok());
+        store.mut_from_ref().reput_once().await;
+        assert_eq!(timer_message_store.process_once().await, 1);
+        store.mut_from_ref().shutdown().await;
+
+        let checkpoint = TimerCheckpoint::new(get_timer_check_path(root_dir.as_str())).unwrap();
+        checkpoint.set_last_timer_queue_offset(99);
+        checkpoint.set_master_timer_queue_offset(99);
+        checkpoint.flush().unwrap();
+
+        let (reloaded_store, reloaded_timer_message_store, _) = build_store_with_timer(root_dir.as_str());
+        assert!(reloaded_store.mut_from_ref().load().await);
+        assert_eq!(
+            reloaded_timer_message_store.curr_queue_offset.load(Ordering::Relaxed),
+            1
+        );
     }
 }

--- a/rocketmq-store/src/timer/timer_wheel.rs
+++ b/rocketmq-store/src/timer/timer_wheel.rs
@@ -150,6 +150,21 @@ impl TimerWheel {
         self.get_slot(time_ms).map(|slot| slot.num as i64).unwrap_or_default()
     }
 
+    pub fn revise_slots<F>(&self, mut revise: F) -> std::io::Result<()>
+    where
+        F: FnMut(Slot) -> Slot,
+    {
+        let mut slots = self.slots.lock();
+        if slots.is_empty() {
+            return Err(std::io::Error::other("timer wheel is not loaded"));
+        }
+
+        for slot in slots.iter_mut() {
+            *slot = revise(*slot);
+        }
+        Ok(())
+    }
+
     pub fn get_all_num(&self, time_start_ms: i64) -> i64 {
         let slots = self.slots.lock();
         if slots.is_empty() {
@@ -221,5 +236,19 @@ mod tests {
         assert_eq!(slot.last_pos, 20);
         assert_eq!(slot.num, 1);
         assert_eq!(slot.magic, 2);
+    }
+
+    #[test]
+    fn revise_slots_can_clear_invalid_slot() {
+        let temp_dir = tempdir().unwrap();
+        let timer_wheel = TimerWheel::new(temp_dir.path().join("timerwheel"), 16, 1_000);
+        timer_wheel.load().unwrap();
+        timer_wheel.put_slot(5_000, 10, 20, 1, 2).unwrap();
+
+        timer_wheel
+            .revise_slots(|slot| if slot.time_ms == 5_000 { empty_slot() } else { slot })
+            .unwrap();
+
+        assert!(timer_wheel.get_slot(5_000).is_none());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6909

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timer log truncation functionality for cleanup operations.
  * Introduced enhanced timer state recovery during system restarts.

* **Bug Fixes**
  * Automatic detection and repair of invalid timer wheel slots during recovery.
  * Improved checkpoint validation and restoration of persisted timer state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->