### PR TITLE
[ISSUE #6924]✨Add timer metrics and checkpoint retrieval to BrokerConfigRequestHandler

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -295,6 +295,11 @@ impl BrokerRuntime {
         self.inner.message_store_config()
     }
 
+    #[cfg(test)]
+    pub(crate) fn inner_for_test(&mut self) -> &mut ArcMut<BrokerRuntimeInner<LocalFileMessageStore>> {
+        &mut self.inner
+    }
+
     pub(crate) fn topic_config(&self, topic: &CheetahString) -> Option<ArcMut<TopicConfig>> {
         self.inner.topic_config_manager().select_topic_config(topic)
     }

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -106,6 +106,8 @@ use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_remoting::runtime::RPCHook;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::timer::timer_checkpoint::TimerCheckpointSnapshot;
+use rocketmq_store::timer::timer_metrics::TimerMetricsSerializeWrapper;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
@@ -983,6 +985,48 @@ impl BrokerOuterAPI {
         } else {
             Err(RocketMQError::BrokerOperationFailed {
                 operation: "get_message_request_mode",
+                code: response.code(),
+                message: response.remark().map_or("".to_string(), |s| s.to_string()),
+                broker_addr: Some(addr.to_string()),
+            })
+        }
+    }
+
+    pub async fn get_timer_metrics(
+        &self,
+        addr: &CheetahString,
+    ) -> rocketmq_error::RocketMQResult<Option<TimerMetricsSerializeWrapper>> {
+        let request = RemotingCommand::create_remoting_command(RequestCode::GetTimerMetrics);
+        let mut response = self.remoting_client.invoke_request(Some(addr), request, 3000).await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.take_body() {
+                return Ok(Some(serde_json::from_slice(body.as_ref())?));
+            }
+            Ok(None)
+        } else {
+            Err(RocketMQError::BrokerOperationFailed {
+                operation: "get_timer_metrics",
+                code: response.code(),
+                message: response.remark().map_or("".to_string(), |s| s.to_string()),
+                broker_addr: Some(addr.to_string()),
+            })
+        }
+    }
+
+    pub async fn get_timer_check_point(
+        &self,
+        addr: &CheetahString,
+    ) -> rocketmq_error::RocketMQResult<Option<TimerCheckpointSnapshot>> {
+        let request = RemotingCommand::create_remoting_command(RequestCode::GetTimerCheckPoint);
+        let mut response = self.remoting_client.invoke_request(Some(addr), request, 3000).await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.take_body() {
+                return Ok(Some(TimerCheckpointSnapshot::decode(body.as_ref())?));
+            }
+            Ok(None)
+        } else {
+            Err(RocketMQError::BrokerOperationFailed {
+                operation: "get_timer_check_point",
                 code: response.code(),
                 message: response.remark().map_or("".to_string(), |s| s.to_string()),
                 broker_addr: Some(addr.to_string()),

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -216,8 +216,16 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .get_all_topic_config(channel, ctx, request_code, request)
                     .await
             }
-            RequestCode::GetTimerCheckPoint => Ok(get_unknown_cmd_response(request_code)),
-            RequestCode::GetTimerMetrics => Ok(get_unknown_cmd_response(request_code)),
+            RequestCode::GetTimerCheckPoint => {
+                self.broker_config_request_handler
+                    .get_timer_check_point(channel, ctx, request_code, request)
+                    .await
+            }
+            RequestCode::GetTimerMetrics => {
+                self.broker_config_request_handler
+                    .get_timer_metrics(channel, ctx, request_code, request)
+                    .await
+            }
             RequestCode::UpdateBrokerConfig => {
                 self.broker_config_request_handler
                     .update_broker_config(channel, ctx, request_code, request)

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -18,6 +18,7 @@ use cheetah_string::CheetahString;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::kv_table::KVTable;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
@@ -94,6 +95,58 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         let key_value_table = KVTable { table: runtime_info };
         response.set_body_mut_ref(serde_json::to_string(&key_value_table).unwrap());
         Ok(Some(response))
+    }
+
+    pub async fn get_timer_metrics(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        _request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        Ok(Some(self.build_timer_metrics_response()))
+    }
+
+    pub async fn get_timer_check_point(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        _request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        Ok(Some(self.build_timer_checkpoint_response()))
+    }
+
+    fn build_timer_metrics_response(&self) -> RemotingCommand {
+        let mut response =
+            RemotingCommand::create_response_command_with_code_remark(ResponseCode::SystemError, "Unknown");
+        let Some(timer_message_store) = self.broker_runtime_inner.timer_message_store() else {
+            response.set_remark_mut(CheetahString::from_static_str("The timer message store is null"));
+            return response;
+        };
+
+        response.set_body_mut_ref(timer_message_store.timer_metrics_payload());
+        response.set_code_mut(ResponseCode::Success);
+        response.set_remark_option_mut(None::<CheetahString>);
+        response
+    }
+
+    fn build_timer_checkpoint_response(&self) -> RemotingCommand {
+        let mut response =
+            RemotingCommand::create_response_command_with_code_remark(ResponseCode::SystemError, "Unknown");
+        let Some(timer_message_store) = self.broker_runtime_inner.timer_message_store() else {
+            response.set_remark_mut(CheetahString::from_static_str("The timer message store is null"));
+            return response;
+        };
+        let Some(checkpoint_body) = timer_message_store.timer_checkpoint_payload() else {
+            response.set_remark_mut(CheetahString::from_static_str("The checkpoint is null"));
+            return response;
+        };
+
+        response.set_body_mut_ref(checkpoint_body);
+        response.set_code_mut(ResponseCode::Success);
+        response.set_remark_option_mut(None::<CheetahString>);
+        response
     }
 
     fn prepare_runtime_info(&self) -> HashMap<CheetahString, CheetahString> {
@@ -282,5 +335,73 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
     }
     fn is_special_service_running(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::fs;
+    use std::sync::Arc;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::TimeUtils::current_millis;
+    use rocketmq_remoting::code::response_code::ResponseCode;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+    use rocketmq_store::timer::timer_checkpoint::TimerCheckpointSnapshot;
+    use rocketmq_store::timer::timer_message_store::TimerMessageStore;
+    use rocketmq_store::timer::timer_metrics::TimerMetricsSerializeWrapper;
+
+    use crate::broker_runtime::BrokerRuntime;
+
+    use super::BrokerConfigRequestHandler;
+
+    #[tokio::test]
+    async fn build_timer_metrics_response_returns_encoded_timer_metrics() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+
+        let timer_message_store = TimerMessageStore::new_empty();
+        timer_message_store
+            .timer_metrics
+            .add_timing_count(&CheetahString::from_static_str("TimerTopicA"), 2);
+        runtime.inner_for_test().set_timer_message_store(timer_message_store);
+
+        let handler = BrokerConfigRequestHandler::new(runtime.inner_for_test().clone());
+        let response = handler.build_timer_metrics_response();
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let body = response.body().expect("timer metrics response body should exist");
+        let wrapper: TimerMetricsSerializeWrapper = serde_json::from_slice(body.as_ref()).unwrap();
+        assert_eq!(wrapper.timing_count_snapshot().get("TimerTopicA"), Some(&2));
+    }
+
+    #[tokio::test]
+    async fn build_timer_checkpoint_response_returns_encoded_checkpoint_snapshot() {
+        let temp_dir = env::temp_dir().join(format!("rmq-rust-timer-checkpoint-{}", current_millis()));
+        let _ = fs::remove_dir_all(&temp_dir);
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig {
+            timer_wheel_enable: true,
+            store_path_root_dir: temp_dir.to_string_lossy().to_string().into(),
+            ..MessageStoreConfig::default()
+        });
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config.clone());
+
+        let timer_message_store = TimerMessageStore::new_with_config(None, message_store_config);
+        assert!(timer_message_store.load());
+        runtime.inner_for_test().set_timer_message_store(timer_message_store);
+
+        let handler = BrokerConfigRequestHandler::new(runtime.inner_for_test().clone());
+        let response = handler.build_timer_checkpoint_response();
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let body = response.body().expect("timer checkpoint response body should exist");
+        let snapshot = TimerCheckpointSnapshot::decode(body.as_ref()).unwrap();
+        assert!(snapshot.last_read_time_ms() > 0);
+        assert_eq!(snapshot.master_timer_queue_offset(), 0);
+        let _ = fs::remove_dir_all(&temp_dir);
     }
 }

--- a/rocketmq-broker/src/slave/slave_synchronize.rs
+++ b/rocketmq-broker/src/slave/slave_synchronize.rs
@@ -89,7 +89,46 @@ where
     }
 
     pub async fn sync_timer_check_point(&self) {
-        error!("SlaveSynchronize::sync_timer_check_point is not implemented yet");
+        let (flag, master_addr) = self.check_master_addr();
+        if !flag {
+            return;
+        }
+
+        if let Some(master_addr) = master_addr {
+            let Some(timer_message_store) = self.broker_runtime_inner.timer_message_store() else {
+                return;
+            };
+            if timer_message_store.is_should_running_dequeue() {
+                return;
+            }
+
+            match self
+                .broker_runtime_inner
+                .broker_outer_api()
+                .get_timer_check_point(&master_addr)
+                .await
+            {
+                Ok(Some(checkpoint_snapshot)) => {
+                    match timer_message_store.sync_checkpoint_from_master(&checkpoint_snapshot) {
+                        Ok(true) => {
+                            info!("Update slave timer checkpoint from master, {}", master_addr);
+                        }
+                        Ok(false) => {
+                            warn!("Local timer checkpoint is not initialized, {}", master_addr);
+                        }
+                        Err(e) => {
+                            error!("Persist synced timer checkpoint error, {}: {:?}", master_addr, e);
+                        }
+                    }
+                }
+                Ok(None) => {
+                    warn!("GetTimerCheckPoint return null, {}", master_addr);
+                }
+                Err(e) => {
+                    error!("SyncTimerCheckPoint Exception, {}: {:?}", master_addr, e);
+                }
+            }
+        }
     }
 
     async fn sync_topic_config(&self) {
@@ -326,6 +365,36 @@ where
     }
 
     async fn sync_timer_metrics(&self) {
-        error!("SlaveSynchronize::sync_timer_metrics is not implemented yet");
+        let (flag, master_addr) = self.check_master_addr();
+        if !flag {
+            return;
+        }
+
+        if let Some(master_addr) = master_addr {
+            let Some(timer_message_store) = self.broker_runtime_inner.timer_message_store() else {
+                return;
+            };
+
+            match self
+                .broker_runtime_inner
+                .broker_outer_api()
+                .get_timer_metrics(&master_addr)
+                .await
+            {
+                Ok(Some(metrics_wrapper)) => {
+                    if timer_message_store.timer_metrics.data_version() != *metrics_wrapper.data_version() {
+                        timer_message_store.timer_metrics.apply_wrapper(metrics_wrapper);
+                        timer_message_store.timer_metrics.persist();
+                    }
+                    info!("Update slave timer metrics from master, {}", master_addr);
+                }
+                Ok(None) => {
+                    warn!("GetTimerMetrics return null, {}", master_addr);
+                }
+                Err(e) => {
+                    error!("SyncTimerMetrics Exception, {}: {:?}", master_addr, e);
+                }
+            }
+        }
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -877,13 +877,14 @@ dependencies = [
 
 [[package]]
 name = "cron"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
 dependencies = [
  "chrono",
  "once_cell",
- "winnow 0.6.26",
+ "phf 0.11.3",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -6725,15 +6726,6 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
 dependencies = [
  "memchr",
 ]

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -308,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -537,13 +537,14 @@ dependencies = [
 
 [[package]]
 name = "cron"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
 dependencies = [
  "chrono",
  "once_cell",
- "winnow 0.6.26",
+ "phf 0.11.3",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1824,11 +1825,53 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3772,18 +3815,12 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/rocketmq-store/src/timer/timer_checkpoint.rs
+++ b/rocketmq-store/src/timer/timer_checkpoint.rs
@@ -28,6 +28,15 @@ use rocketmq_remoting::protocol::DataVersion;
 
 const TIMER_CHECKPOINT_SIZE: usize = 56;
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct TimerCheckpointSnapshot {
+    last_read_time_ms: i64,
+    last_timer_log_flush_pos: i64,
+    last_timer_queue_offset: i64,
+    master_timer_queue_offset: i64,
+    data_version: DataVersion,
+}
+
 pub struct TimerCheckpoint {
     path: PathBuf,
     last_read_time_ms: AtomicI64,
@@ -129,6 +138,21 @@ impl TimerCheckpoint {
         self.data_version.lock().next_version_with(state_version);
     }
 
+    pub fn snapshot(&self) -> TimerCheckpointSnapshot {
+        TimerCheckpointSnapshot {
+            last_read_time_ms: self.last_read_time_ms(),
+            last_timer_log_flush_pos: self.last_timer_log_flush_pos(),
+            last_timer_queue_offset: self.last_timer_queue_offset(),
+            master_timer_queue_offset: self.master_timer_queue_offset(),
+            data_version: self.data_version(),
+        }
+    }
+
+    pub fn sync_from_master_snapshot(&self, snapshot: &TimerCheckpointSnapshot) {
+        self.set_master_timer_queue_offset(snapshot.master_timer_queue_offset());
+        *self.data_version.lock() = snapshot.data_version().clone();
+    }
+
     fn load_from_disk(&mut self) -> std::io::Result<()> {
         if !self.path.exists() {
             return Ok(());
@@ -173,6 +197,82 @@ fn read_i64(buffer: &[u8]) -> i64 {
     i64::from_be_bytes(buffer.try_into().expect("timer checkpoint field size must be 8 bytes"))
 }
 
+impl TimerCheckpointSnapshot {
+    pub fn new(
+        last_read_time_ms: i64,
+        last_timer_log_flush_pos: i64,
+        last_timer_queue_offset: i64,
+        master_timer_queue_offset: i64,
+        data_version: DataVersion,
+    ) -> Self {
+        Self {
+            last_read_time_ms,
+            last_timer_log_flush_pos,
+            last_timer_queue_offset,
+            master_timer_queue_offset,
+            data_version,
+        }
+    }
+
+    pub fn last_read_time_ms(&self) -> i64 {
+        self.last_read_time_ms
+    }
+
+    pub fn last_timer_log_flush_pos(&self) -> i64 {
+        self.last_timer_log_flush_pos
+    }
+
+    pub fn last_timer_queue_offset(&self) -> i64 {
+        self.last_timer_queue_offset
+    }
+
+    pub fn master_timer_queue_offset(&self) -> i64 {
+        self.master_timer_queue_offset
+    }
+
+    pub fn data_version(&self) -> &DataVersion {
+        &self.data_version
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buffer = [0u8; TIMER_CHECKPOINT_SIZE];
+        buffer[0..8].copy_from_slice(&self.last_read_time_ms.to_be_bytes());
+        buffer[8..16].copy_from_slice(&self.last_timer_log_flush_pos.to_be_bytes());
+        buffer[16..24].copy_from_slice(&self.last_timer_queue_offset.to_be_bytes());
+        buffer[24..32].copy_from_slice(&self.master_timer_queue_offset.to_be_bytes());
+        buffer[32..40].copy_from_slice(&self.data_version.state_version().to_be_bytes());
+        buffer[40..48].copy_from_slice(&self.data_version.timestamp().to_be_bytes());
+        buffer[48..56].copy_from_slice(&self.data_version.counter().to_be_bytes());
+        buffer.to_vec()
+    }
+
+    pub fn decode(buffer: &[u8]) -> std::io::Result<Self> {
+        if buffer.len() < TIMER_CHECKPOINT_SIZE {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                format!(
+                    "timer checkpoint snapshot requires {} bytes, got {}",
+                    TIMER_CHECKPOINT_SIZE,
+                    buffer.len()
+                ),
+            ));
+        }
+
+        let mut data_version = DataVersion::new();
+        data_version.set_state_version(read_i64(&buffer[32..40]));
+        data_version.set_timestamp(read_i64(&buffer[40..48]));
+        data_version.set_counter(read_i64(&buffer[48..56]));
+
+        Ok(Self {
+            last_read_time_ms: read_i64(&buffer[0..8]),
+            last_timer_log_flush_pos: read_i64(&buffer[8..16]),
+            last_timer_queue_offset: read_i64(&buffer[16..24]),
+            master_timer_queue_offset: read_i64(&buffer[24..32]),
+            data_version,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
@@ -198,5 +298,27 @@ mod tests {
         assert_eq!(reloaded.last_timer_queue_offset(), 3_000);
         assert_eq!(reloaded.master_timer_queue_offset(), 4_000);
         assert_eq!(reloaded.data_version().state_version(), 99);
+    }
+
+    #[test]
+    fn snapshot_encode_decode_round_trips_timer_checkpoint_state() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("config").join("timercheck");
+
+        let checkpoint = TimerCheckpoint::new(&path).unwrap();
+        checkpoint.set_last_read_time_ms(11);
+        checkpoint.set_last_timer_log_flush_pos(22);
+        checkpoint.set_last_timer_queue_offset(33);
+        checkpoint.set_master_timer_queue_offset(44);
+        checkpoint.update_data_version(55);
+
+        let snapshot = checkpoint.snapshot();
+        let decoded = TimerCheckpointSnapshot::decode(snapshot.encode().as_slice()).unwrap();
+
+        assert_eq!(decoded.last_read_time_ms(), 11);
+        assert_eq!(decoded.last_timer_log_flush_pos(), 22);
+        assert_eq!(decoded.last_timer_queue_offset(), 33);
+        assert_eq!(decoded.master_timer_queue_offset(), 44);
+        assert_eq!(decoded.data_version().state_version(), 55);
     }
 }

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -52,8 +52,10 @@ use crate::store_path_config_helper::get_timer_metrics_path;
 use crate::store_path_config_helper::get_timer_wheel_path;
 use crate::timer::slot::Slot;
 use crate::timer::timer_checkpoint::TimerCheckpoint;
+use crate::timer::timer_checkpoint::TimerCheckpointSnapshot;
 use crate::timer::timer_log::TimerLog;
 use crate::timer::timer_metrics::TimerMetrics;
+use crate::timer::timer_metrics::TimerMetricsSerializeWrapper;
 use crate::timer::timer_wheel::TimerWheel;
 
 pub const TIMER_TOPIC: &str = concat!("rmq_sys_", "wheel_timer");
@@ -399,6 +401,39 @@ impl TimerMessageStore {
 
     pub fn get_dequeue_tps(&self) -> f32 {
         self.dequeue_tps_counter.get_tps()
+    }
+
+    pub fn is_should_running_dequeue(&self) -> bool {
+        self.should_running_dequeue.load(Ordering::Relaxed)
+    }
+
+    pub fn timer_metrics_wrapper(&self) -> TimerMetricsSerializeWrapper {
+        self.timer_metrics.to_wrapper()
+    }
+
+    pub fn timer_metrics_payload(&self) -> Vec<u8> {
+        self.timer_metrics.encode().into_bytes()
+    }
+
+    pub fn timer_checkpoint_payload(&self) -> Option<Vec<u8>> {
+        self.timer_checkpoint
+            .lock()
+            .as_ref()
+            .map(|timer_checkpoint| timer_checkpoint.snapshot().encode())
+    }
+
+    pub fn sync_checkpoint_from_master(&self, snapshot: &TimerCheckpointSnapshot) -> std::io::Result<bool> {
+        let checkpoint_guard = self.timer_checkpoint.lock();
+        let Some(timer_checkpoint) = checkpoint_guard.as_ref() else {
+            return Ok(false);
+        };
+        timer_checkpoint.sync_from_master_snapshot(snapshot);
+        let caught_up = self.curr_queue_offset.load(Ordering::Relaxed) >= snapshot.master_timer_queue_offset();
+        if caught_up {
+            timer_checkpoint.set_last_read_time_ms(snapshot.last_read_time_ms());
+        }
+        timer_checkpoint.flush()?;
+        Ok(true)
     }
 
     pub fn new(default_message_store: Option<ArcMut<LocalFileMessageStore>>) -> Self {
@@ -1382,6 +1417,7 @@ mod tests {
     use rocketmq_common::common::message::MessageConst;
     use rocketmq_common::common::message::MessageTrait;
     use rocketmq_common::MessageDecoder::message_properties_to_string;
+    use rocketmq_remoting::protocol::DataVersion;
     use tempfile::tempdir;
 
     use super::*;
@@ -1644,6 +1680,67 @@ mod tests {
         );
         assert_eq!(reloaded_store.get_timer_wheel_slot(valid_time_ms).unwrap().num, 2);
         assert!(reloaded_store.get_timer_wheel_slot(invalid_time_ms).is_none());
+    }
+
+    #[test]
+    fn sync_checkpoint_from_master_keeps_local_read_cursor_until_caught_up() {
+        let temp_dir = tempdir().unwrap();
+        let root_dir = temp_dir.path().to_string_lossy().to_string();
+        let config = config_with_root(root_dir.as_str());
+        let timer_message_store = TimerMessageStore::new_with_config(None, config);
+        assert!(timer_message_store.load());
+        let local_read_time = timer_message_store.curr_read_time_ms.load(Ordering::Relaxed);
+
+        let mut data_version = DataVersion::new();
+        data_version.next_version_with(88);
+        let snapshot = TimerCheckpointSnapshot::new(12_000, 34, 56, 78, data_version.clone());
+
+        assert!(timer_message_store.sync_checkpoint_from_master(&snapshot).unwrap());
+        assert_eq!(timer_message_store.curr_read_time_ms.load(Ordering::Relaxed), local_read_time);
+
+        let checkpoint_guard = timer_message_store.timer_checkpoint.lock();
+        let checkpoint = checkpoint_guard.as_ref().expect("checkpoint should exist");
+        assert_eq!(checkpoint.last_read_time_ms(), local_read_time);
+        assert_eq!(checkpoint.master_timer_queue_offset(), 78);
+        assert_eq!(checkpoint.data_version(), data_version);
+
+        drop(checkpoint_guard);
+        let reloaded_checkpoint = TimerCheckpoint::new(get_timer_check_path(root_dir.as_str())).unwrap();
+        assert_eq!(reloaded_checkpoint.last_read_time_ms(), local_read_time);
+        assert_eq!(reloaded_checkpoint.master_timer_queue_offset(), 78);
+        assert_eq!(reloaded_checkpoint.data_version(), data_version);
+    }
+
+    #[tokio::test]
+    async fn sync_checkpoint_from_master_does_not_rebucket_pending_timer_messages() {
+        let temp_dir = tempdir().unwrap();
+        let root_dir = temp_dir.path().to_string_lossy().to_string();
+        let (store, timer_message_store, real_topic) = build_store_with_timer(root_dir.as_str());
+
+        assert!(store.mut_from_ref().load().await);
+        let local_read_time = timer_message_store.curr_read_time_ms.load(Ordering::Relaxed);
+        let deliver_time_ms = (local_read_time as u64).saturating_add(60_000);
+        let master_read_time_ms = local_read_time + 120_000;
+
+        let mut data_version = DataVersion::new();
+        data_version.next_version_with(99);
+        let snapshot = TimerCheckpointSnapshot::new(master_read_time_ms, 0, 0, 10, data_version);
+
+        assert!(timer_message_store.sync_checkpoint_from_master(&snapshot).unwrap());
+        assert!(store
+            .mut_from_ref()
+            .put_message(build_timer_message(&real_topic, deliver_time_ms))
+            .await
+            .is_ok());
+        store.mut_from_ref().reput_once().await;
+
+        let indexed = timer_message_store.process_once().await;
+        let expected_slot_time = timer_message_store.ceil_time_ms(deliver_time_ms as i64);
+
+        assert_eq!(indexed, 1);
+        assert_eq!(timer_message_store.curr_read_time_ms.load(Ordering::Relaxed), local_read_time);
+        assert_eq!(timer_message_store.get_timer_wheel_slot(expected_slot_time).unwrap().num, 1);
+        assert!(timer_message_store.get_timer_wheel_slot(master_read_time_ms).is_none());
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -1696,7 +1696,10 @@ mod tests {
         let snapshot = TimerCheckpointSnapshot::new(12_000, 34, 56, 78, data_version.clone());
 
         assert!(timer_message_store.sync_checkpoint_from_master(&snapshot).unwrap());
-        assert_eq!(timer_message_store.curr_read_time_ms.load(Ordering::Relaxed), local_read_time);
+        assert_eq!(
+            timer_message_store.curr_read_time_ms.load(Ordering::Relaxed),
+            local_read_time
+        );
 
         let checkpoint_guard = timer_message_store.timer_checkpoint.lock();
         let checkpoint = checkpoint_guard.as_ref().expect("checkpoint should exist");
@@ -1738,8 +1741,17 @@ mod tests {
         let expected_slot_time = timer_message_store.ceil_time_ms(deliver_time_ms as i64);
 
         assert_eq!(indexed, 1);
-        assert_eq!(timer_message_store.curr_read_time_ms.load(Ordering::Relaxed), local_read_time);
-        assert_eq!(timer_message_store.get_timer_wheel_slot(expected_slot_time).unwrap().num, 1);
+        assert_eq!(
+            timer_message_store.curr_read_time_ms.load(Ordering::Relaxed),
+            local_read_time
+        );
+        assert_eq!(
+            timer_message_store
+                .get_timer_wheel_slot(expected_slot_time)
+                .unwrap()
+                .num,
+            1
+        );
         assert!(timer_message_store.get_timer_wheel_slot(master_read_time_ms).is_none());
     }
 

--- a/rocketmq-store/src/timer/timer_metrics.rs
+++ b/rocketmq-store/src/timer/timer_metrics.rs
@@ -38,7 +38,7 @@ struct Metric {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct TimerMetricsSerializeWrapper {
+pub struct TimerMetricsSerializeWrapper {
     timing_count: HashMap<String, Metric>,
     #[serde(default)]
     timing_distribution: HashMap<i32, Metric>,
@@ -135,6 +135,26 @@ impl TimerMetrics {
         *self.config_path.get_mut() = config_path;
     }
 
+    pub fn data_version(&self) -> DataVersion {
+        self.data_version.lock().clone()
+    }
+
+    pub fn to_wrapper(&self) -> TimerMetricsSerializeWrapper {
+        TimerMetricsSerializeWrapper {
+            timing_count: self.timing_count.read().clone(),
+            timing_distribution: self.timing_distribution.read().clone(),
+            timer_dist: self.timer_dist.read().clone(),
+            data_version: self.data_version(),
+        }
+    }
+
+    pub fn apply_wrapper(&self, wrapper: TimerMetricsSerializeWrapper) {
+        *self.timing_count.write() = wrapper.timing_count;
+        *self.timing_distribution.write() = wrapper.timing_distribution;
+        *self.timer_dist.write() = wrapper.timer_dist;
+        *self.data_version.lock() = wrapper.data_version;
+    }
+
     pub fn get_timing_count(&self, key: &CheetahString) -> i64 {
         self.timing_count
             .read()
@@ -210,5 +230,29 @@ impl TimerMetrics {
     pub fn set_timer_dist_list(&self, timer_dist: Vec<i32>) {
         *self.timer_dist.write() = timer_dist;
         self.data_version.lock().next_version();
+    }
+}
+
+impl TimerMetricsSerializeWrapper {
+    pub fn data_version(&self) -> &DataVersion {
+        &self.data_version
+    }
+
+    pub fn timing_count_snapshot(&self) -> HashMap<String, i64> {
+        self.timing_count
+            .iter()
+            .filter_map(|(topic, metric)| (metric.count > 0).then_some((topic.clone(), metric.count)))
+            .collect()
+    }
+
+    pub fn timing_distribution_snapshot(&self) -> HashMap<i32, i64> {
+        self.timing_distribution
+            .iter()
+            .filter_map(|(period, metric)| (metric.count > 0).then_some((*period, metric.count)))
+            .collect()
+    }
+
+    pub fn timer_dist(&self) -> &[i32] {
+        &self.timer_dist
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6924

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timer metrics and checkpoint synchronization capabilities between broker and slave instances.
  * Implemented new APIs to retrieve timer metrics and checkpoint state from broker.
  * Enhanced timer synchronization logic with real master-slave state synchronization.
  * Added timer checkpoint snapshot structure for serialization and state management.

* **Tests**
  * Added test-only accessors for broker runtime internals.
  * Added unit tests validating timer metrics and checkpoint snapshot encoding/decoding.
  * Added tests verifying checkpoint synchronization behavior and cursor management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->