### PR TITLE
[ISSUE #6945]🚀Implement AutoSwitchHAConnection with slave broker ID management and integrate into GeneralHAConnection

### DIFF
--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_connection.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_connection.rs
@@ -12,59 +12,87 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering;
+
 use rocketmq_rust::WeakArcMut;
 use tokio::net::TcpStream;
 
+use crate::ha::default_ha_connection::DefaultHAConnection;
 use crate::ha::general_ha_connection::GeneralHAConnection;
 use crate::ha::ha_connection::HAConnection;
 use crate::ha::ha_connection::HAConnectionId;
 use crate::ha::ha_connection_state::HAConnectionState;
 use crate::ha::HAConnectionError;
 
-pub struct AutoSwitchHAConnection;
+pub struct AutoSwitchHAConnection {
+    delegate: DefaultHAConnection,
+    slave_broker_id: AtomicI64,
+}
+
+impl AutoSwitchHAConnection {
+    pub fn new(delegate: DefaultHAConnection) -> Self {
+        Self {
+            delegate,
+            slave_broker_id: AtomicI64::new(-1),
+        }
+    }
+
+    pub fn set_slave_broker_id(&self, slave_broker_id: Option<i64>) {
+        self.slave_broker_id
+            .store(slave_broker_id.unwrap_or(-1), Ordering::SeqCst);
+    }
+
+    pub fn slave_broker_id(&self) -> Option<i64> {
+        match self.slave_broker_id.load(Ordering::SeqCst) {
+            id if id >= 0 => Some(id),
+            _ => None,
+        }
+    }
+}
 
 impl HAConnection for AutoSwitchHAConnection {
     async fn start(&mut self, conn: WeakArcMut<GeneralHAConnection>) -> Result<(), HAConnectionError> {
-        todo!()
+        self.delegate.start(conn).await
     }
 
     async fn shutdown(&mut self) {
-        todo!()
+        self.delegate.shutdown().await;
     }
 
     fn close(&self) {
-        todo!()
+        self.delegate.close();
     }
 
     fn get_socket(&self) -> &TcpStream {
-        todo!()
+        self.delegate.get_socket()
     }
 
     async fn get_current_state(&self) -> HAConnectionState {
-        todo!()
+        self.delegate.get_current_state().await
     }
 
     fn get_client_address(&self) -> &str {
-        todo!()
+        self.delegate.get_client_address()
     }
 
     fn get_transferred_byte_in_second(&self) -> i64 {
-        todo!()
+        self.delegate.get_transferred_byte_in_second()
     }
 
     fn get_transfer_from_where(&self) -> i64 {
-        todo!()
+        self.delegate.get_transfer_from_where()
     }
 
     fn get_slave_ack_offset(&self) -> i64 {
-        todo!()
+        self.delegate.get_slave_ack_offset()
     }
 
     fn get_ha_connection_id(&self) -> &HAConnectionId {
-        todo!()
+        self.delegate.get_ha_connection_id()
     }
 
     fn remote_address(&self) -> String {
-        todo!()
+        self.delegate.remote_address()
     }
 }

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -26,6 +26,7 @@ use rocketmq_remoting::protocol::body::ha_connection_runtime_info::HAConnectionR
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_rust::ArcMut;
 use tokio::net::TcpListener;
+use tokio::net::TcpStream;
 use tokio::select;
 use tokio::sync::Mutex;
 use tokio::sync::Notify;
@@ -35,6 +36,7 @@ use tracing::info;
 
 use crate::base::message_store::MessageStore;
 use crate::config::message_store_config::MessageStoreConfig;
+use crate::ha::auto_switch::auto_switch_ha_connection::AutoSwitchHAConnection;
 use crate::ha::default_ha_client::DefaultHAClient;
 use crate::ha::default_ha_connection::DefaultHAConnection;
 use crate::ha::general_ha_client::GeneralHAClient;
@@ -122,6 +124,7 @@ impl DefaultHAService {
     pub(crate) fn init(this: &mut ArcMut<Self>, general_ha_service: GeneralHAService) -> HAResult<()> {
         // Initialize the DefaultHAService with the provided message store.
         let config = this.default_message_store.get_message_store_config();
+        let is_auto_switch = general_ha_service.is_auto_switch_enabled();
 
         let group_transfer_service = GroupTransferService::new(general_ha_service.clone());
         this.group_transfer_service = Some(group_transfer_service);
@@ -138,7 +141,7 @@ impl DefaultHAService {
         this.accept_socket_service = Some(AcceptSocketService::new(
             this.default_message_store.get_message_store_config(),
             arc_mut,
-            false,
+            is_auto_switch,
         ));
         Ok(())
     }
@@ -374,6 +377,23 @@ impl AcceptSocketService {
         }
     }
 
+    async fn build_connection(
+        default_ha_service: ArcMut<DefaultHAService>,
+        message_store_config: Arc<MessageStoreConfig>,
+        stream: TcpStream,
+        addr: SocketAddr,
+        is_auto_switch: bool,
+    ) -> Result<ArcMut<GeneralHAConnection>, crate::ha::HAConnectionError> {
+        let default_connection =
+            DefaultHAConnection::new(default_ha_service, stream, message_store_config, addr).await?;
+        let general_connection = if is_auto_switch {
+            GeneralHAConnection::new_with_auto_switch_ha_connection(AutoSwitchHAConnection::new(default_connection))
+        } else {
+            GeneralHAConnection::new_with_default_ha_connection(default_connection)
+        };
+        Ok(ArcMut::new(general_connection))
+    }
+
     pub async fn start(&mut self) -> HAResult<()> {
         let listener = TcpListener::bind(self.socket_address_listen)
             .await
@@ -396,20 +416,28 @@ impl AcceptSocketService {
                         match accept_result {
                             Ok((stream, addr)) => {
                                 info!("HAService receive new connection, {}", addr);
-                               if is_auto_switch {
-                                    unimplemented!("Auto-switching is not implemented yet");
-                                }else{
-                                    let default_conn = DefaultHAConnection::new(default_ha_service.clone(), stream,message_store_config.clone(),addr).await.expect("Error creating HAConnection");
-                                    let mut general_conn = ArcMut::new(GeneralHAConnection::new_with_default_ha_connection(default_conn));
-                                    let  conn_weak= ArcMut::downgrade(&general_conn);
-                                    if  let Err(e) =  general_conn.start(conn_weak).await {
-                                        error!("Error starting HAService: {}", e);
-                                    }else {
-                                        info!("HAService accept new connection, {}", addr);
-                                        default_ha_service.add_connection(general_conn).await;
+                                match AcceptSocketService::build_connection(
+                                    default_ha_service.clone(),
+                                    message_store_config.clone(),
+                                    stream,
+                                    addr,
+                                    is_auto_switch,
+                                )
+                                .await
+                                {
+                                    Ok(mut general_conn) => {
+                                        let conn_weak = ArcMut::downgrade(&general_conn);
+                                        if let Err(e) = general_conn.start(conn_weak).await {
+                                            error!("Error starting HAService: {}", e);
+                                        } else {
+                                            info!("HAService accept new connection, {}", addr);
+                                            default_ha_service.add_connection(general_conn).await;
+                                        }
                                     }
-
-                                };
+                                    Err(e) => {
+                                        error!("Error creating HAConnection: {}", e);
+                                    }
+                                }
                             }
                             Err(e) => {
                                 error!("Failed to accept connection: {}", e);
@@ -427,5 +455,107 @@ impl AcceptSocketService {
     pub fn shutdown(&self) {
         info!("Shutting down AcceptSocketService");
         self.shutdown_notify.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use cheetah_string::CheetahString;
+    use dashmap::DashMap;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_common::TimeUtils::current_millis;
+
+    use super::*;
+    use crate::ha::auto_switch::auto_switch_ha_service::AutoSwitchHAService;
+
+    fn new_test_message_store(root: &Path, enable_controller_mode: bool) -> ArcMut<LocalFileMessageStore> {
+        std::fs::create_dir_all(root).expect("create temp root dir");
+
+        let broker_config = BrokerConfig {
+            enable_controller_mode,
+            ..BrokerConfig::default()
+        };
+
+        let message_store_config = MessageStoreConfig {
+            enable_controller_mode,
+            store_path_root_dir: root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        };
+
+        let topic_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>> = Arc::new(DashMap::new());
+        let mut store = ArcMut::new(LocalFileMessageStore::new(
+            Arc::new(message_store_config),
+            Arc::new(broker_config),
+            topic_table,
+            None,
+            false,
+        ));
+        let store_clone = store.clone();
+        store.set_message_store_arc(store_clone);
+        store
+    }
+
+    async fn new_server_stream() -> (TcpStream, SocketAddr, TcpStream) {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind loopback listener");
+        let listen_addr = listener.local_addr().expect("listener local addr");
+        let client = TcpStream::connect(listen_addr).await.expect("connect loopback client");
+        let (server_stream, remote_addr) = listener.accept().await.expect("accept loopback client");
+        (server_stream, remote_addr, client)
+    }
+
+    #[test]
+    fn init_uses_auto_switch_accept_socket_service_for_auto_switch_mode() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-default-ha-init-{}", current_millis()));
+        let store = new_test_message_store(&temp_root, true);
+        let mut service = ArcMut::new(DefaultHAService::new(store.clone()));
+        let auto_switch_service = ArcMut::new(AutoSwitchHAService::new(store));
+
+        DefaultHAService::init(
+            &mut service,
+            GeneralHAService::new_with_auto_switch_ha_service(auto_switch_service),
+        )
+        .expect("init default ha service");
+
+        assert!(
+            service
+                .accept_socket_service
+                .as_ref()
+                .expect("accept socket service")
+                .is_auto_switch
+        );
+
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn build_connection_wraps_auto_switch_connections_when_enabled() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-default-ha-build-{}", current_millis()));
+        let store = new_test_message_store(&temp_root, true);
+        let service = ArcMut::new(DefaultHAService::new(store));
+        let (server_stream, remote_addr, _client) = new_server_stream().await;
+
+        let mut connection = AcceptSocketService::build_connection(
+            service.clone(),
+            service.get_default_message_store().message_store_config(),
+            server_stream,
+            remote_addr,
+            true,
+        )
+        .await
+        .expect("build auto-switch connection");
+
+        assert!(connection.is_auto_switch());
+        assert_eq!(connection.slave_broker_id(), None);
+        connection.set_slave_broker_id(Some(9));
+        assert_eq!(connection.slave_broker_id(), Some(9));
+
+        connection.shutdown().await;
+
+        let _ = std::fs::remove_dir_all(temp_root);
     }
 }

--- a/rocketmq-store/src/ha/general_ha_connection.rs
+++ b/rocketmq-store/src/ha/general_ha_connection.rs
@@ -55,6 +55,22 @@ impl GeneralHAConnection {
     pub fn set_auto_switch_ha_connection(&mut self, connection: AutoSwitchHAConnection) {
         self.auto_switch_ha_connection = Some(ArcMut::new(connection));
     }
+
+    pub fn is_auto_switch(&self) -> bool {
+        self.auto_switch_ha_connection.is_some()
+    }
+
+    pub fn set_slave_broker_id(&self, slave_broker_id: Option<i64>) {
+        if let Some(connection) = &self.auto_switch_ha_connection {
+            connection.set_slave_broker_id(slave_broker_id);
+        }
+    }
+
+    pub fn slave_broker_id(&self) -> Option<i64> {
+        self.auto_switch_ha_connection
+            .as_ref()
+            .and_then(|connection| connection.slave_broker_id())
+    }
 }
 
 impl HAConnection for GeneralHAConnection {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6945

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-switching High Availability mode is now fully operational with proper connection handling.
  * Added support for dynamic slave broker identification in High Availability configurations.
  * Improved error handling with detailed logging for connection creation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->