### PR TITLE
[ISSUE #6953]🚀Enhance AutoSwitchHAClient and DefaultHAService with broker ID management and connection runtime reporting

### DIFF
--- a/rocketmq-broker/src/broker/broker_pre_online_service.rs
+++ b/rocketmq-broker/src/broker/broker_pre_online_service.rs
@@ -18,11 +18,15 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
+use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mix_all::MASTER_ID;
+use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
+use rocketmq_common::FileUtils::string_to_file;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::common::remoting_helper::RemotingHelper;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
+use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_rust::task::service_task::ServiceContext;
 use rocketmq_rust::task::service_task::ServiceTask;
 use rocketmq_rust::task::ServiceManager;
@@ -30,10 +34,13 @@ use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::ha::ha_connection_state_notification_request::HAConnectionStateNotificationRequest;
 use rocketmq_store::ha::ha_service::HAService;
+use rocketmq_store::store_path_config_helper;
 use tracing::error;
 use tracing::info;
+use tracing::warn;
 
 use crate::broker_runtime::BrokerRuntimeInner;
+use crate::schedule::delay_offset_serialize_wrapper::DelayOffsetSerializeWrapper;
 
 pub struct BrokerPreOnlineService<MS: MessageStore> {
     service_manager: ServiceManager<BrokerPreOnlineServiceInner<MS>>,
@@ -217,8 +224,139 @@ where
             self.wait_broker_index.fetch_add(1, Ordering::SeqCst);
         }
     }
-    async fn sync_metadata_reverse(&self, _broker_addr: CheetahString) -> bool {
-        unimplemented!("syncMetadataReverse unimplemented")
+    async fn sync_metadata_reverse(&self, broker_addr: CheetahString) -> bool {
+        let mut success = true;
+
+        match self
+            .broker_runtime_inner
+            .broker_outer_api()
+            .get_all_consumer_offset(&broker_addr)
+            .await
+        {
+            Ok(Some(offset_wrapper)) => {
+                let local_version = self
+                    .broker_runtime_inner
+                    .consumer_offset_manager()
+                    .data_version()
+                    .as_ref()
+                    .clone();
+                if should_sync_from_peer(&local_version, Some(offset_wrapper.data_version())) {
+                    let consumer_offset_manager = self.broker_runtime_inner.consumer_offset_manager();
+                    consumer_offset_manager
+                        .data_version()
+                        .assign_new_one(offset_wrapper.data_version());
+                    let offset_table = consumer_offset_manager.offset_table();
+                    let mut consumer_offset_table = offset_table.write();
+                    consumer_offset_table.extend(offset_wrapper.offset_table());
+                    drop(consumer_offset_table);
+                    consumer_offset_manager.persist();
+                    info!(
+                        "{}'s consumer offset data version is newer or equal, merged into local broker",
+                        broker_addr
+                    );
+                }
+            }
+            Ok(None) => {
+                warn!("GetAllConsumerOffset return null, {}", broker_addr);
+            }
+            Err(e) => {
+                error!("GetAllConsumerOffset reverse sync failed, {}: {:?}", broker_addr, e);
+                success = false;
+            }
+        }
+
+        match self
+            .broker_runtime_inner
+            .broker_outer_api()
+            .get_delay_offset(&broker_addr)
+            .await
+        {
+            Ok(Some(delay_offset)) => {
+                match SerdeJsonUtils::from_json_str::<DelayOffsetSerializeWrapper>(delay_offset.as_str()) {
+                    Ok(delay_offset_wrapper) => {
+                        let local_version = self.broker_runtime_inner.schedule_message_service().get_data_version();
+                        if should_sync_from_peer(&local_version, delay_offset_wrapper.data_version()) {
+                            let file_name = store_path_config_helper::get_delay_offset_store_path(
+                                self.broker_runtime_inner
+                                    .message_store_config()
+                                    .store_path_root_dir
+                                    .as_str(),
+                            );
+                            match string_to_file(delay_offset.as_str(), file_name.as_str()) {
+                                Ok(_) => {
+                                    if let Err(e) = self
+                                        .broker_runtime_inner
+                                        .schedule_message_service()
+                                        .load_when_sync_delay_offset()
+                                    {
+                                        error!("LoadWhenSyncDelayOffset reverse error, {}: {:?}", broker_addr, e);
+                                        success = false;
+                                    }
+                                }
+                                Err(e) => {
+                                    error!("Write reverse delay offset file error, {}: {:?}", broker_addr, e);
+                                    success = false;
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!("Decode reverse delay offset failed, {}: {:?}", broker_addr, e);
+                        success = false;
+                    }
+                }
+            }
+            Ok(None) => {
+                warn!("GetDelayOffset return null, {}", broker_addr);
+            }
+            Err(e) => {
+                error!("GetDelayOffset reverse sync failed, {}: {:?}", broker_addr, e);
+                success = false;
+            }
+        }
+
+        if let Some(timer_message_store) = self.broker_runtime_inner.timer_message_store() {
+            match self
+                .broker_runtime_inner
+                .broker_outer_api()
+                .get_timer_check_point(&broker_addr)
+                .await
+            {
+                Ok(Some(checkpoint_snapshot)) => {
+                    let local_snapshot = timer_message_store.timer_checkpoint_snapshot();
+                    if local_snapshot.as_ref().is_none_or(|snapshot| {
+                        should_sync_from_peer(snapshot.data_version(), Some(checkpoint_snapshot.data_version()))
+                    }) {
+                        match timer_message_store.sync_checkpoint_from_master(&checkpoint_snapshot) {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                warn!("Local timer checkpoint is not initialized, {}", broker_addr);
+                            }
+                            Err(e) => {
+                                error!("Persist reverse timer checkpoint error, {}: {:?}", broker_addr, e);
+                                success = false;
+                            }
+                        }
+                    }
+                }
+                Ok(None) => {
+                    warn!("GetTimerCheckPoint return null, {}", broker_addr);
+                }
+                Err(e) => {
+                    error!("GetTimerCheckPoint reverse sync failed, {}: {:?}", broker_addr, e);
+                    success = false;
+                }
+            }
+        }
+
+        for plugin in self.broker_runtime_inner.broker_attached_plugins() {
+            if let Err(e) = plugin.sync_metadata_reverse(&broker_addr) {
+                error!("Plugin reverse metadata sync failed, {}: {:?}", broker_addr, e);
+                success = false;
+            }
+        }
+
+        success
     }
 
     async fn wait_for_ha_handshake_complete(&self, broker_addr: CheetahString) -> bool {
@@ -288,26 +426,35 @@ where
             message_store.set_master_flushed_offset(broker_sync_info.master_flush_offset);
         }
 
-        match broker_sync_info.master_ha_address {
-            None => {
-                let min_broker_id = self.get_min_broker_id(&broker_member_group.broker_addrs);
-                BrokerRuntimeInner::<MS>::start_service(
-                    self.broker_runtime_inner.clone(),
-                    min_broker_id,
-                    broker_member_group.broker_addrs.get(&mix_all::MASTER_ID).cloned(),
-                )
-                .await;
-            }
-            Some(ref value) => {
-                message_store.update_ha_master_address(value).await;
-                message_store.update_master_address(&broker_sync_info.master_address.clone().unwrap());
-            }
-        }
-
-        let ha_handshake_result = self
-            .wait_for_ha_handshake_complete(broker_sync_info.master_ha_address.unwrap())
+        let Some(master_ha_address) = broker_sync_info.master_ha_address.clone() else {
+            let min_broker_id = self.get_min_broker_id(&broker_member_group.broker_addrs);
+            BrokerRuntimeInner::<MS>::start_service(
+                self.broker_runtime_inner.clone(),
+                min_broker_id,
+                broker_member_group.broker_addrs.get(&mix_all::MASTER_ID).cloned(),
+            )
             .await;
+            return true;
+        };
+        let Some(master_address) = broker_sync_info.master_address.as_ref() else {
+            error!(
+                "retrieve master ha info missing master address, {}",
+                broker_member_group.broker_name
+            );
+            return false;
+        };
+        message_store.update_ha_master_address(&master_ha_address).await;
+        message_store.update_master_address(master_address);
+
+        let ha_handshake_result = self.wait_for_ha_handshake_complete(master_ha_address).await;
         self.future_wait_action(ha_handshake_result, &broker_member_group).await
+    }
+}
+
+fn should_sync_from_peer(local_version: &DataVersion, remote_version: Option<&DataVersion>) -> bool {
+    match remote_version {
+        Some(remote_version) => local_version <= remote_version,
+        None => true,
     }
 }
 
@@ -321,5 +468,47 @@ where
 
     pub async fn shutdown(&mut self) {
         self.service_manager.shutdown().await.unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_remoting::protocol::DataVersion;
+
+    use super::should_sync_from_peer;
+
+    #[test]
+    fn should_sync_from_peer_accepts_newer_version() {
+        let mut local = DataVersion::new();
+        local.set_state_version(1);
+        local.set_timestamp(10);
+        local.set_counter(1);
+
+        let mut remote = DataVersion::new();
+        remote.set_state_version(2);
+        remote.set_timestamp(20);
+        remote.set_counter(2);
+
+        assert!(should_sync_from_peer(&local, Some(&remote)));
+    }
+
+    #[test]
+    fn should_sync_from_peer_rejects_older_version() {
+        let mut local = DataVersion::new();
+        local.set_state_version(2);
+        local.set_timestamp(20);
+        local.set_counter(2);
+
+        let mut remote = DataVersion::new();
+        remote.set_state_version(1);
+        remote.set_timestamp(10);
+        remote.set_counter(1);
+
+        assert!(!should_sync_from_peer(&local, Some(&remote)));
+    }
+
+    #[test]
+    fn should_sync_from_peer_accepts_missing_version() {
+        assert!(should_sync_from_peer(&DataVersion::new(), None));
     }
 }

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -1857,6 +1857,11 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
+    pub fn broker_attached_plugins(&self) -> &[Arc<dyn BrokerAttachedPlugin>] {
+        &self.broker_attached_plugins
+    }
+
+    #[inline]
     pub fn broker_outer_api(&self) -> &BrokerOuterAPI {
         &self.broker_outer_api
     }
@@ -2251,17 +2256,23 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
             .topic_config_manager()
             .build_serialize_wrapper_with_topic_queue_map(topic_config_table, topic_queue_mapping_info_map);
 
-        if self.broker_config.enable_split_registration
+        let should_register = self.broker_config.enable_split_registration
             || force_register
             || need_register(
-                self.broker_config.broker_identity.broker_cluster_name.clone().as_str(),
-                self.broker_config.broker_ip1.clone().as_str(),
-                self.broker_config.broker_identity.broker_name.clone().as_str(),
-                self.broker_config.broker_identity.broker_id,
-                self.broker_config.register_broker_timeout_mills,
-                self.broker_config.is_in_broker_container,
-            )
-        {
+                &self
+                    .broker_outer_api
+                    .need_register(
+                        self.broker_config.broker_identity.broker_cluster_name.clone(),
+                        self.get_broker_addr().clone(),
+                        self.broker_config.broker_identity.broker_name.clone(),
+                        self.broker_config.broker_identity.broker_id,
+                        &topic_config_wrapper,
+                        self.broker_config.register_broker_timeout_mills as u64,
+                        self.broker_config.is_in_broker_container,
+                    )
+                    .await,
+            );
+        if should_register {
             BrokerRuntimeInner::<MS>::do_register_broker_all(this, check_order_config, oneway, topic_config_wrapper)
                 .await;
         }
@@ -3046,15 +3057,8 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 }
 
-fn need_register(
-    _cluster_name: &str,
-    _broker_addr: &str,
-    _broker_name: &str,
-    _broker_id: u64,
-    _register_timeout_mills: i32,
-    _in_broker_container: bool,
-) -> bool {
-    unimplemented!()
+fn need_register(change_list: &[bool]) -> bool {
+    change_list.iter().copied().any(|changed| changed)
 }
 
 #[cfg(test)]
@@ -3179,5 +3183,15 @@ mod tests {
         assert_eq!(store.message_store_config_ref().broker_role, BrokerRole::Slave);
 
         let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[test]
+    fn need_register_returns_true_when_any_namesrv_requests_reregister() {
+        assert!(super::need_register(&[false, true, false]));
+    }
+
+    #[test]
+    fn need_register_returns_false_when_all_namesrvs_are_in_sync() {
+        assert!(!super::need_register(&[false, false, false]));
     }
 }

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -45,6 +45,7 @@ use rocketmq_remoting::clients::RemotingClient;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
+use rocketmq_remoting::protocol::body::broker_body::broker_member_group::GetBrokerMemberGroupResponseBody;
 use rocketmq_remoting::protocol::body::broker_body::register_broker_body::RegisterBrokerBody;
 use rocketmq_remoting::protocol::body::consumer_offset_serialize_wrapper::ConsumerOffsetSerializeWrapper;
 use rocketmq_remoting::protocol::body::elect_master_response_body::ElectMasterResponseBody;
@@ -79,6 +80,7 @@ use rocketmq_remoting::protocol::header::message_operation_header::send_message_
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
 use rocketmq_remoting::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
+use rocketmq_remoting::protocol::header::namesrv::broker_request::GetBrokerMemberGroupRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::broker_request::UnRegisterBrokerRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::query_data_version_header::QueryDataVersionRequestHeader;
 use rocketmq_remoting::protocol::header::namesrv::query_data_version_header::QueryDataVersionResponseHeader;
@@ -1036,11 +1038,64 @@ impl BrokerOuterAPI {
 
     pub async fn sync_broker_member_group(
         &self,
-        _cluster_name: &CheetahString,
-        _broker_name: &CheetahString,
-        _is_compatible_with_old_name_srv: bool,
+        cluster_name: &CheetahString,
+        broker_name: &CheetahString,
+        is_compatible_with_old_name_srv: bool,
     ) -> rocketmq_error::RocketMQResult<Option<BrokerMemberGroup>> {
-        unimplemented!()
+        if is_compatible_with_old_name_srv {
+            self.get_broker_member_group_compatible(cluster_name, broker_name).await
+        } else {
+            self.get_broker_member_group(cluster_name, broker_name).await
+        }
+    }
+
+    async fn get_broker_member_group(
+        &self,
+        cluster_name: &CheetahString,
+        broker_name: &CheetahString,
+    ) -> rocketmq_error::RocketMQResult<Option<BrokerMemberGroup>> {
+        let request_header = GetBrokerMemberGroupRequestHeader::new(cluster_name.clone(), broker_name.clone());
+        let request = RemotingCommand::create_request_command(RequestCode::GetBrokerMemberGroup, request_header);
+        let mut response = self.remoting_client.invoke_request(None, request, 3000).await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.take_body() {
+                let response_body = GetBrokerMemberGroupResponseBody::decode(body.as_ref())?;
+                return Ok(Some(
+                    response_body
+                        .broker_member_group
+                        .unwrap_or_else(|| empty_broker_member_group(cluster_name, broker_name)),
+                ));
+            }
+        }
+        Ok(Some(empty_broker_member_group(cluster_name, broker_name)))
+    }
+
+    async fn get_broker_member_group_compatible(
+        &self,
+        cluster_name: &CheetahString,
+        broker_name: &CheetahString,
+    ) -> rocketmq_error::RocketMQResult<Option<BrokerMemberGroup>> {
+        let request_header = GetRouteInfoRequestHeader {
+            topic: CheetahString::from_string(format!(
+                "{}{}",
+                TopicValidator::SYNC_BROKER_MEMBER_GROUP_PREFIX,
+                broker_name
+            )),
+            ..Default::default()
+        };
+        let request = RemotingCommand::create_request_command(RequestCode::GetRouteinfoByTopic, request_header);
+        let mut response = self.remoting_client.invoke_request(None, request, 3000).await?;
+        if ResponseCode::from(response.code()) == ResponseCode::Success {
+            if let Some(body) = response.take_body() {
+                let topic_route_data = TopicRouteData::decode(body.as_ref())?;
+                return Ok(Some(broker_member_group_from_route_data(
+                    cluster_name,
+                    broker_name,
+                    &topic_route_data,
+                )));
+            }
+        }
+        Ok(Some(empty_broker_member_group(cluster_name, broker_name)))
     }
 
     /// Get controller metadata information
@@ -1558,6 +1613,27 @@ fn build_send_message_request(msg: MessageExt, group: CheetahString) -> Remoting
     RemotingCommand::create_request_command(RequestCode::SendMessage, header)
 }
 
+fn empty_broker_member_group(cluster_name: &CheetahString, broker_name: &CheetahString) -> BrokerMemberGroup {
+    BrokerMemberGroup::new(cluster_name.clone(), broker_name.clone())
+}
+
+fn broker_member_group_from_route_data(
+    cluster_name: &CheetahString,
+    broker_name: &CheetahString,
+    topic_route_data: &TopicRouteData,
+) -> BrokerMemberGroup {
+    let mut broker_member_group = empty_broker_member_group(cluster_name, broker_name);
+    for broker_data in &topic_route_data.broker_datas {
+        if broker_data.broker_name() == broker_name && broker_data.cluster() == cluster_name.as_str() {
+            broker_member_group
+                .broker_addrs
+                .extend(broker_data.broker_addrs().clone());
+            break;
+        }
+    }
+    broker_member_group
+}
+
 fn build_send_message_request_header_v2(msg: MessageExt, group: CheetahString) -> SendMessageRequestHeaderV2 {
     let header = SendMessageRequestHeader {
         producer_group: group,
@@ -1649,6 +1725,10 @@ pub fn process_send_response(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
+
     use super::*;
 
     #[test]
@@ -1670,5 +1750,49 @@ mod tests {
         let domain = "localhost";
         let addresses = dns_lookup_address_by_domain(domain);
         assert!(addresses.is_empty());
+    }
+
+    #[test]
+    fn broker_member_group_from_route_data_extracts_matching_broker() {
+        let cluster_name = CheetahString::from("cluster-a");
+        let broker_name = CheetahString::from("broker-a");
+        let mut broker_addrs = HashMap::new();
+        broker_addrs.insert(0, CheetahString::from("127.0.0.1:10911"));
+        let topic_route_data = TopicRouteData {
+            broker_datas: vec![BrokerData::new(
+                cluster_name.clone(),
+                broker_name.clone(),
+                broker_addrs.clone(),
+                None,
+            )],
+            ..Default::default()
+        };
+
+        let broker_member_group = broker_member_group_from_route_data(&cluster_name, &broker_name, &topic_route_data);
+
+        assert_eq!(broker_member_group.cluster, cluster_name);
+        assert_eq!(broker_member_group.broker_name, broker_name);
+        assert_eq!(broker_member_group.broker_addrs, broker_addrs);
+    }
+
+    #[test]
+    fn broker_member_group_from_route_data_ignores_non_matching_brokers() {
+        let topic_route_data = TopicRouteData {
+            broker_datas: vec![BrokerData::new(
+                CheetahString::from("other-cluster"),
+                CheetahString::from("other-broker"),
+                HashMap::from([(1, CheetahString::from("127.0.0.1:10912"))]),
+                None,
+            )],
+            ..Default::default()
+        };
+
+        let broker_member_group = broker_member_group_from_route_data(
+            &CheetahString::from("cluster-a"),
+            &CheetahString::from("broker-a"),
+            &topic_route_data,
+        );
+
+        assert!(broker_member_group.broker_addrs.is_empty());
     }
 }

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_client.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_client.rs
@@ -12,61 +12,82 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_rust::ArcMut;
+
+use crate::ha::default_ha_client::DefaultHAClient;
+use crate::ha::default_ha_client::HAClientError;
 use crate::ha::ha_client::HAClient;
 use crate::ha::ha_connection_state::HAConnectionState;
+use crate::message_store::local_file_message_store::LocalFileMessageStore;
 
-pub struct AutoSwitchHAClient;
+pub struct AutoSwitchHAClient {
+    delegate: ArcMut<DefaultHAClient>,
+}
+
+impl AutoSwitchHAClient {
+    pub fn new(message_store: ArcMut<LocalFileMessageStore>, broker_id: Option<i64>) -> Result<Self, HAClientError> {
+        let client = DefaultHAClient::new(message_store)?;
+        client.set_reported_broker_id(broker_id);
+        Ok(Self {
+            delegate: ArcMut::new(client),
+        })
+    }
+
+    pub fn set_reported_broker_id(&self, broker_id: Option<i64>) {
+        self.delegate.set_reported_broker_id(broker_id);
+    }
+}
 
 impl HAClient for AutoSwitchHAClient {
     async fn start(&mut self) {
-        todo!()
+        self.delegate.start().await;
     }
 
     async fn shutdown(&self) {
-        todo!()
+        self.delegate.shutdown().await;
     }
 
     async fn wakeup(&self) {
-        todo!()
+        self.delegate.wakeup().await;
     }
 
     async fn update_master_address(&self, new_address: &str) {
-        todo!()
+        self.delegate.update_master_address(new_address).await;
     }
 
     async fn update_ha_master_address(&self, new_address: &str) {
-        todo!()
+        self.delegate.update_ha_master_address(new_address).await;
     }
 
     fn get_master_address(&self) -> String {
-        todo!()
+        HAClient::get_master_address(&*self.delegate)
     }
 
     fn get_ha_master_address(&self) -> String {
-        todo!()
+        HAClient::get_ha_master_address(&*self.delegate)
     }
 
     fn get_last_read_timestamp(&self) -> i64 {
-        todo!()
+        HAClient::get_last_read_timestamp(&*self.delegate)
     }
 
     fn get_last_write_timestamp(&self) -> i64 {
-        todo!()
+        HAClient::get_last_write_timestamp(&*self.delegate)
     }
 
     fn get_current_state(&self) -> HAConnectionState {
-        todo!()
+        HAClient::get_current_state(&*self.delegate)
     }
 
     fn change_current_state(&self, ha_connection_state: HAConnectionState) {
-        todo!()
+        self.delegate.change_current_state(ha_connection_state);
     }
 
     async fn close_master(&self) {
-        todo!()
+        self.delegate.close_master().await;
     }
 
     fn get_transferred_byte_in_second(&self) -> i64 {
-        todo!()
+        HAClient::get_transferred_byte_in_second(&*self.delegate)
     }
 }

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -22,11 +22,13 @@ use std::sync::Mutex;
 
 use rocketmq_common::common::broker::broker_role::BrokerRole;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_remoting::protocol::body::ha_connection_runtime_info::HAConnectionRuntimeInfo;
 use rocketmq_remoting::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_rust::ArcMut;
 use tokio::sync::Notify;
 
 use crate::base::message_store::MessageStore;
+use crate::ha::auto_switch::auto_switch_ha_client::AutoSwitchHAClient;
 use crate::ha::default_ha_service::DefaultHAService;
 use crate::ha::general_ha_client::GeneralHAClient;
 use crate::ha::general_ha_connection::GeneralHAConnection;
@@ -72,7 +74,9 @@ impl AutoSwitchHAService {
         let mut delegate = this.delegate.clone();
         DefaultHAService::init(&mut delegate, general_ha_service)?;
         delegate.set_auto_switch_service(ArcMut::downgrade(this));
-        delegate.ensure_ha_client()?;
+        let client = AutoSwitchHAClient::new(this.message_store.clone(), None)
+            .map_err(|error| crate::store_error::HAError::Service(error.to_string()))?;
+        delegate.set_general_ha_client(GeneralHAClient::new_with_auto_switch_ha_client(client));
         Ok(())
     }
 
@@ -453,6 +457,24 @@ impl HAService for AutoSwitchHAService {
         let mut runtime_info = self.delegate.get_runtime_info(master_put_where);
         runtime_info.master = self.is_master.load(Ordering::SeqCst);
         runtime_info.in_sync_slave_nums = (self.local_sync_state_set_size(master_put_where) as i32 - 1).max(0);
+        if runtime_info.master {
+            let current_sync_state_set = self.get_local_sync_state_set();
+            runtime_info.ha_connection_info = self
+                .delegate
+                .try_snapshot_connections(master_put_where)
+                .into_iter()
+                .map(|connection| HAConnectionRuntimeInfo {
+                    addr: connection.addr,
+                    slave_ack_offset: connection.slave_ack_offset.max(0) as u64,
+                    diff: connection.diff,
+                    in_sync: connection
+                        .slave_broker_id
+                        .is_some_and(|slave_broker_id| current_sync_state_set.contains(&slave_broker_id)),
+                    transferred_byte_in_second: connection.transferred_byte_in_second.max(0) as u64,
+                    transfer_from_where: connection.transfer_from_where.max(0) as u64,
+                })
+                .collect();
+        }
         runtime_info
     }
 

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -147,8 +147,13 @@ impl HAConnection for DefaultHAConnection {
             .socket_stream
             .take()
             .ok_or_else(|| HAConnectionError::InvalidState("Socket already taken".into()))?;
+        let std_stream = tcp_stream.into_std().map_err(HAConnectionError::Io)?;
+        let retained_std_stream = std_stream.try_clone().map_err(HAConnectionError::Io)?;
+        let retained_stream = TcpStream::from_std(retained_std_stream).map_err(HAConnectionError::Io)?;
+        let split_stream = TcpStream::from_std(std_stream).map_err(HAConnectionError::Io)?;
+        self.socket_stream = Some(retained_stream);
         // let framed = Framed::with_capacity(tcp_stream, BytesCodec::new(), CAPACITY);
-        let (reader, write) = tcp_stream.into_split();
+        let (reader, write) = split_stream.into_split();
 
         // Create shutdown channel
         // Create shutdown channel with bounded capacity
@@ -244,7 +249,9 @@ impl HAConnection for DefaultHAConnection {
     }
 
     fn get_socket(&self) -> &TcpStream {
-        todo!()
+        self.socket_stream
+            .as_ref()
+            .expect("socket stream should remain available after connection start")
     }
 
     async fn get_current_state(&self) -> HAConnectionState {

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -56,6 +56,16 @@ use crate::message_store::local_file_message_store::LocalFileMessageStore;
 use crate::store_error::HAError;
 use crate::store_error::HAResult;
 
+#[derive(Clone, Debug)]
+pub(crate) struct HAConnectionRuntimeSnapshot {
+    pub addr: String,
+    pub slave_ack_offset: i64,
+    pub diff: i64,
+    pub transferred_byte_in_second: i64,
+    pub transfer_from_where: i64,
+    pub slave_broker_id: Option<i64>,
+}
+
 pub struct DefaultHAService {
     connection_count: Arc<AtomicU32>,
     connections: Arc<Mutex<HashMap<HAConnectionId, ArcMut<GeneralHAConnection>>>>,
@@ -106,6 +116,10 @@ impl DefaultHAService {
         }
     }
 
+    pub(crate) fn set_general_ha_client(&mut self, ha_client: GeneralHAClient) {
+        self.ha_client = Some(ha_client);
+    }
+
     pub(crate) fn set_auto_switch_service(&mut self, auto_switch_service: WeakArcMut<AutoSwitchHAService>) {
         self.auto_switch_service = Some(auto_switch_service);
     }
@@ -150,7 +164,7 @@ impl DefaultHAService {
         let group_transfer_service = GroupTransferService::new(general_ha_service.clone());
         this.group_transfer_service = Some(group_transfer_service);
 
-        if config.broker_role == BrokerRole::Slave {
+        if config.broker_role == BrokerRole::Slave && !is_auto_switch {
             this.ensure_ha_client()?;
         }
 
@@ -194,6 +208,28 @@ impl DefaultHAService {
         for (_, mut connection) in connections.drain() {
             connection.shutdown().await;
         }
+    }
+
+    pub(crate) fn try_snapshot_connections(&self, master_put_where: i64) -> Vec<HAConnectionRuntimeSnapshot> {
+        self.connections
+            .try_lock()
+            .map(|connections| {
+                connections
+                    .values()
+                    .map(|connection| {
+                        let slave_ack_offset = connection.get_slave_ack_offset();
+                        HAConnectionRuntimeSnapshot {
+                            addr: connection.remote_address(),
+                            slave_ack_offset,
+                            diff: master_put_where.saturating_sub(slave_ack_offset),
+                            transferred_byte_in_second: connection.get_transferred_byte_in_second(),
+                            transfer_from_where: connection.get_transfer_from_where(),
+                            slave_broker_id: connection.slave_broker_id(),
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     pub(crate) fn handle_connection_added(&self, connection: &GeneralHAConnection) {
@@ -356,22 +392,18 @@ impl HAService for DefaultHAService {
             ha_client_runtime_info: HAClientRuntimeInfo::default(),
         };
 
-        if let Ok(connections) = self.connections.try_lock() {
-            runtime_info.ha_connection_info = connections
-                .values()
-                .map(|connection| {
-                    let slave_ack_offset = connection.get_slave_ack_offset();
-                    HAConnectionRuntimeInfo {
-                        addr: connection.remote_address(),
-                        slave_ack_offset: slave_ack_offset.max(0) as u64,
-                        diff: master_put_where.saturating_sub(slave_ack_offset),
-                        in_sync: slave_ack_offset >= master_put_where,
-                        transferred_byte_in_second: connection.get_transferred_byte_in_second().max(0) as u64,
-                        transfer_from_where: connection.get_transfer_from_where().max(0) as u64,
-                    }
-                })
-                .collect();
-        }
+        runtime_info.ha_connection_info = self
+            .try_snapshot_connections(master_put_where)
+            .into_iter()
+            .map(|connection| HAConnectionRuntimeInfo {
+                addr: connection.addr,
+                slave_ack_offset: connection.slave_ack_offset.max(0) as u64,
+                diff: connection.diff,
+                in_sync: connection.slave_ack_offset >= master_put_where,
+                transferred_byte_in_second: connection.transferred_byte_in_second.max(0) as u64,
+                transfer_from_where: connection.transfer_from_where.max(0) as u64,
+            })
+            .collect();
 
         if let Some(ha_client) = &self.ha_client {
             runtime_info.ha_client_runtime_info = HAClientRuntimeInfo {

--- a/rocketmq-store/src/ha/general_ha_client.rs
+++ b/rocketmq-store/src/ha/general_ha_client.rs
@@ -35,8 +35,9 @@ impl GeneralHAClient {
     }
 
     pub fn set_reported_broker_id(&self, broker_id: Option<i64>) {
-        if let GeneralHAClient::DefaultHaClient(client) = self {
-            client.set_reported_broker_id(broker_id);
+        match self {
+            GeneralHAClient::DefaultHaClient(client) => client.set_reported_broker_id(broker_id),
+            GeneralHAClient::AutoSwitchHaClient(client) => client.set_reported_broker_id(broker_id),
         }
     }
 }

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -79,6 +79,13 @@ impl GeneralHAService {
             service.sync_controller_sync_state_set(local_broker_id, sync_state_set);
         }
     }
+
+    pub fn sync_state_set(&self) -> Option<HashSet<i64>> {
+        match self {
+            GeneralHAService::DefaultHAService(_) => None,
+            GeneralHAService::AutoSwitchHAService(service) => Some(service.get_sync_state_set()),
+        }
+    }
 }
 
 impl HAService for GeneralHAService {

--- a/rocketmq-store/src/ha/group_transfer_service.rs
+++ b/rocketmq-store/src/ha/group_transfer_service.rs
@@ -41,6 +41,12 @@ pub struct GroupTransferService {
     service_manager: ServiceManager<GroupTransferServiceInner>,
 }
 
+#[derive(Clone, Copy)]
+struct AckedReplica {
+    slave_broker_id: Option<i64>,
+    slave_ack_offset: i64,
+}
+
 impl GroupTransferService {
     pub fn new(ha_service: GeneralHAService) -> Self {
         let inner = Arc::new(GroupTransferServiceInner::new(ha_service));
@@ -146,6 +152,24 @@ impl GroupTransferServiceInner {
                     continue;
                 }
                 if all_ack_in_sync_state_set && self.ha_service.is_auto_switch_enabled() {
+                    if let Some(sync_state_set) = self.ha_service.sync_state_set() {
+                        let acked_replicas = self
+                            .ha_service
+                            .get_connection_list()
+                            .await
+                            .into_iter()
+                            .map(|connection| AckedReplica {
+                                slave_broker_id: connection.slave_broker_id(),
+                                slave_ack_offset: connection.get_slave_ack_offset(),
+                            })
+                            .collect::<Vec<_>>();
+                        transfer_ok = has_required_sync_state_set_acks(
+                            &sync_state_set,
+                            &acked_replicas,
+                            request.get_next_offset(),
+                        );
+                        continue;
+                    }
                     transfer_ok =
                         self.ha_service.in_sync_replicas_nums(request.get_next_offset()) >= request.get_ack_nums();
                 } else {
@@ -193,5 +217,73 @@ impl ServiceTask for GroupTransferServiceInner {
 
     async fn on_wait_end(&self) {
         self.swap_requests().await;
+    }
+}
+
+fn has_required_sync_state_set_acks(
+    sync_state_set: &std::collections::HashSet<i64>,
+    acked_replicas: &[AckedReplica],
+    next_offset: i64,
+) -> bool {
+    if sync_state_set.len() <= 1 {
+        return true;
+    }
+
+    let mut ack_nums = 1;
+    for replica in acked_replicas {
+        if replica
+            .slave_broker_id
+            .is_some_and(|slave_broker_id| sync_state_set.contains(&slave_broker_id))
+            && replica.slave_ack_offset >= next_offset
+        {
+            ack_nums += 1;
+        }
+        if ack_nums >= sync_state_set.len() {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn sync_state_set_ack_requires_all_members() {
+        let sync_state_set = HashSet::from([7_i64, 9_i64, 10_i64]);
+        let acked_replicas = vec![
+            AckedReplica {
+                slave_broker_id: Some(9),
+                slave_ack_offset: 128,
+            },
+            AckedReplica {
+                slave_broker_id: Some(10),
+                slave_ack_offset: 64,
+            },
+        ];
+
+        assert!(!has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 96));
+        assert!(has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 64));
+    }
+
+    #[test]
+    fn sync_state_set_ack_ignores_non_members() {
+        let sync_state_set = HashSet::from([7_i64, 9_i64]);
+        let acked_replicas = vec![
+            AckedReplica {
+                slave_broker_id: Some(11),
+                slave_ack_offset: 256,
+            },
+            AckedReplica {
+                slave_broker_id: Some(9),
+                slave_ack_offset: 256,
+            },
+        ];
+
+        assert!(has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 128));
     }
 }

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -422,6 +422,13 @@ impl TimerMessageStore {
             .map(|timer_checkpoint| timer_checkpoint.snapshot().encode())
     }
 
+    pub fn timer_checkpoint_snapshot(&self) -> Option<TimerCheckpointSnapshot> {
+        self.timer_checkpoint
+            .lock()
+            .as_ref()
+            .map(|timer_checkpoint| timer_checkpoint.snapshot())
+    }
+
     pub fn sync_checkpoint_from_master(&self, snapshot: &TimerCheckpointSnapshot) -> std::io::Result<bool> {
         let checkpoint_guard = self.timer_checkpoint.lock();
         let Some(timer_checkpoint) = checkpoint_guard.as_ref() else {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6953

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented full reverse metadata synchronization for slave brokers, including consumer offsets, delay offsets, and timer checkpoints.
  * Enhanced high-availability client with active socket management and real-time connection monitoring.
  * Added sync state set tracking for improved replication acknowledgment verification.

* **Bug Fixes**
  * Fixed broker registration flow to properly use async broker identity checks.
  * Improved backward compatibility for name-server communication.

* **Refactor**
  * Streamlined broker online initialization with better control flow and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->