### PR TITLE
[ISSUE #6959]✨Enhance OpenRaft controller with leadership watch loop, notify cache management, and persistent storage integration

### DIFF
--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 
 use super::raft_controller::RaftController;
 use crate::controller::broker_heartbeat_manager::BrokerHeartbeatManager;
@@ -30,6 +32,8 @@ use crate::metrics::ControllerMetricsManager;
 use crate::processor::controller_request_processor::ControllerRequestProcessor;
 use crate::processor::ProcessorManager;
 use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use parking_lot::RwLock;
 use rocketmq_common::common::controller::ControllerConfig;
 use rocketmq_common::common::server::config::ServerConfig;
 use rocketmq_common::TimeUtils::current_millis;
@@ -52,9 +56,25 @@ use rocketmq_remoting::request_processor::default_request_processor::DefaultRemo
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::WeakArcMut;
+use tokio::task::JoinHandle;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct NotifyCacheKey {
+    cluster_name: String,
+    broker_name: String,
+    broker_id: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NotifyCacheState {
+    master_broker_id: u64,
+    master_epoch: i32,
+    sync_state_set_epoch: i32,
+    master_address: Option<String>,
+}
 
 struct BrokerInactiveListener {
     controller_manager: WeakArcMut<ControllerManager>,
@@ -208,6 +228,8 @@ pub struct ControllerManager {
     initialized: Arc<AtomicBool>,
 
     broker_housekeeping_service: Option<Arc<BrokerHousekeepingService>>,
+    leadership_watch_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+    notify_cache: Arc<RwLock<HashMap<NotifyCacheKey, NotifyCacheState>>>,
 }
 
 impl ControllerManager {
@@ -298,6 +320,8 @@ impl ControllerManager {
             running: Arc::new(AtomicBool::new(false)),
             initialized: Arc::new(AtomicBool::new(false)),
             broker_housekeeping_service: None,
+            leadership_watch_task: Arc::new(Mutex::new(None)),
+            notify_cache: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 
@@ -527,6 +551,8 @@ impl ControllerManager {
             info!("Remoting client started");
         }
 
+        self.start_leadership_watch_loop();
+
         // Metrics are already running if enabled
         #[cfg(feature = "metrics")]
         info!("Metrics manager is already running (singleton)");
@@ -563,6 +589,13 @@ impl ControllerManager {
         }
 
         info!("Shutting down controller manager...");
+
+        if let Some(handle) = self.leadership_watch_task.lock().take() {
+            handle.abort();
+        }
+        if let Err(error) = self.apply_leadership_state(false).await {
+            warn!("Failed to stop leader-only scheduling during shutdown: {}", error);
+        }
 
         // Shutdown processor first to stop accepting requests
         // Errors are logged but don't stop the shutdown process
@@ -718,6 +751,10 @@ impl ControllerManager {
         &self.raft_controller
     }
 
+    fn scheduling_enabled(&self) -> bool {
+        self.raft_controller.scheduling_enabled()
+    }
+
     pub fn set_raft_runtime_tick_enabled(&self, enabled: bool) -> Result<()> {
         self.raft_controller.set_runtime_tick_enabled(enabled)
     }
@@ -728,6 +765,82 @@ impl ControllerManager {
 
     pub fn set_raft_runtime_elect_enabled(&self, enabled: bool) -> Result<()> {
         self.raft_controller.set_runtime_elect_enabled(enabled)
+    }
+
+    fn start_leadership_watch_loop(self: &ArcMut<Self>) {
+        if self.leadership_watch_task.lock().is_some() {
+            return;
+        }
+
+        let weak_manager = ArcMut::downgrade(self);
+        let interval = Duration::from_millis(self.config.heartbeat_interval_ms.max(100));
+        let handle = tokio::spawn(async move {
+            let mut was_leader = false;
+            let mut ticker = tokio::time::interval(interval);
+
+            loop {
+                ticker.tick().await;
+
+                let Some(manager) = weak_manager.upgrade() else {
+                    break;
+                };
+
+                if !manager.is_running() {
+                    break;
+                }
+
+                let is_leader = manager.is_leader();
+                if is_leader == was_leader {
+                    continue;
+                }
+
+                if let Err(error) = manager.apply_leadership_state(is_leader).await {
+                    warn!("Failed to apply leadership state transition: {}", error);
+                } else {
+                    was_leader = is_leader;
+                }
+            }
+        });
+
+        *self.leadership_watch_task.lock() = Some(handle);
+    }
+
+    async fn apply_leadership_state(&self, is_leader: bool) -> Result<()> {
+        if is_leader {
+            self.raft_controller.start_scheduling().await.map_err(|error| {
+                ControllerError::Internal(format!("Failed to start controller scheduling: {}", error))
+            })?;
+            info!("Leader-only scheduling enabled on controller {}", self.config.node_id);
+        } else {
+            self.raft_controller.stop_scheduling().await.map_err(|error| {
+                ControllerError::Internal(format!("Failed to stop controller scheduling: {}", error))
+            })?;
+            self.notify_cache.write().clear();
+            info!(
+                "Leader-only scheduling disabled and notify cache cleared on controller {}",
+                self.config.node_id
+            );
+        }
+        Ok(())
+    }
+
+    fn should_notify_broker_role_change(&self, cache_key: NotifyCacheKey, cache_state: NotifyCacheState) -> bool {
+        let mut notify_cache = self.notify_cache.write();
+        match notify_cache.get(&cache_key) {
+            Some(previous)
+                if previous.master_epoch > cache_state.master_epoch
+                    || (previous.master_epoch == cache_state.master_epoch
+                        && previous.sync_state_set_epoch >= cache_state.sync_state_set_epoch
+                        && previous.master_broker_id == cache_state.master_broker_id
+                        && previous.master_address == cache_state.master_address) =>
+            {
+                false
+            }
+            _ => {
+                notify_cache.insert(cache_key, cache_state);
+                true
+            }
+        }
     }
 
     async fn notify_broker_role_changed(&self, response: RemotingCommand) -> Result<()> {
@@ -764,6 +877,8 @@ impl ControllerManager {
         };
 
         let sync_state_set_epoch = response_header.sync_state_set_epoch.unwrap_or_default();
+        let master_epoch = response_header.master_epoch.unwrap_or_default();
+        let master_address = response_header.master_address.clone().map(|value| value.to_string());
         let sync_state_set = SyncStateSet::with_values(response_body.sync_state_set, sync_state_set_epoch)
             .encode()
             .map_err(|error| {
@@ -788,6 +903,21 @@ impl ControllerManager {
                 sync_state_set_epoch: response_header.sync_state_set_epoch,
                 master_broker_id: Some(master_broker_id),
             };
+            if !self.should_notify_broker_role_change(
+                NotifyCacheKey {
+                    cluster_name: member_group.cluster.to_string(),
+                    broker_name: member_group.broker_name.to_string(),
+                    broker_id,
+                },
+                NotifyCacheState {
+                    master_broker_id,
+                    master_epoch,
+                    sync_state_set_epoch,
+                    master_address: master_address.clone(),
+                },
+            ) {
+                continue;
+            }
             let request = RemotingCommand::create_request_command(RequestCode::NotifyBrokerRoleChanged, request_header)
                 .set_body(sync_state_set.clone());
 
@@ -820,6 +950,8 @@ impl Drop for ControllerManager {
             let processor = self.processor.clone();
             let mut heartbeat_manager = self.heartbeat_manager.clone();
             let metadata = self.metadata.clone();
+            let leadership_watch_task = self.leadership_watch_task.clone();
+            let notify_cache = self.notify_cache.clone();
 
             // Clone remoting_client for emergency shutdown
             let mut remoting_client = self.remoting_client.clone();
@@ -839,6 +971,10 @@ impl Drop for ControllerManager {
                 // Shutdown remoting client
 
                 remoting_client.shutdown();
+                if let Some(handle) = leadership_watch_task.lock().take() {
+                    handle.abort();
+                }
+                notify_cache.write().clear();
 
                 // Note: raft shutdown handled by Drop impl of RaftController
 
@@ -850,9 +986,11 @@ impl Drop for ControllerManager {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::net::SocketAddr;
 
     use super::*;
+    use crate::typ::Node;
 
     #[tokio::test]
     async fn test_manager_lifecycle() {
@@ -928,6 +1066,89 @@ mod tests {
         assert!(!manager.is_running());
 
         // Prevent dropping runtime in async context
+        std::mem::forget(manager);
+    }
+
+    #[tokio::test]
+    async fn test_notify_cache_skips_duplicate_and_stale_role_changes() {
+        let config = ControllerConfig::default().with_node_info(1, "127.0.0.1:9882".parse::<SocketAddr>().unwrap());
+        let manager = ControllerManager::new(config).await.expect("Failed to create manager");
+
+        let key = NotifyCacheKey {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "broker-a".to_string(),
+            broker_id: 1,
+        };
+        let first_state = NotifyCacheState {
+            master_broker_id: 1,
+            master_epoch: 2,
+            sync_state_set_epoch: 3,
+            master_address: Some("127.0.0.1:10911".to_string()),
+        };
+
+        assert!(manager.should_notify_broker_role_change(key.clone(), first_state.clone()));
+        assert!(!manager.should_notify_broker_role_change(key.clone(), first_state.clone()));
+        assert!(!manager.should_notify_broker_role_change(
+            key.clone(),
+            NotifyCacheState {
+                sync_state_set_epoch: 2,
+                ..first_state.clone()
+            }
+        ));
+        assert!(manager.should_notify_broker_role_change(
+            key.clone(),
+            NotifyCacheState {
+                master_epoch: 3,
+                ..first_state.clone()
+            }
+        ));
+
+        manager.apply_leadership_state(false).await.expect("stop scheduling");
+        assert!(manager.notify_cache.read().is_empty());
+
+        std::mem::forget(manager);
+    }
+
+    #[tokio::test]
+    async fn test_leadership_watch_enables_scheduling_for_openraft_leader() {
+        let port = 9883;
+        let config = ControllerConfig::default()
+            .with_node_info(1, format!("127.0.0.1:{port}").parse::<SocketAddr>().unwrap())
+            .with_heartbeat_interval_ms(100)
+            .with_election_timeout_ms(300);
+
+        let manager = ArcMut::new(ControllerManager::new(config).await.expect("Failed to create manager"));
+        manager.clone().initialize().await.expect("initialize manager");
+        manager.clone().start().await.expect("start manager");
+
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            1,
+            Node {
+                node_id: 1,
+                rpc_addr: format!("127.0.0.1:{port}"),
+            },
+        );
+        manager
+            .controller()
+            .initialize_cluster(nodes)
+            .await
+            .expect("initialize single-node cluster");
+
+        for _ in 0..30 {
+            if manager.is_leader() && manager.scheduling_enabled() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        assert!(manager.is_leader(), "controller manager should become leader");
+        assert!(
+            manager.scheduling_enabled(),
+            "leadership watcher should enable leader-only scheduling"
+        );
+
+        manager.shutdown().await.expect("shutdown manager");
         std::mem::forget(manager);
     }
 }

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -290,6 +290,10 @@ impl OpenRaftController {
             .ok_or_else(|| ControllerError::NotInitialized("OpenRaft node is not started".to_string()))?;
         Ok(node.has_committed_log())
     }
+
+    pub fn scheduling_enabled(&self) -> bool {
+        self.scheduling.load(Ordering::Acquire)
+    }
 }
 
 impl Controller for OpenRaftController {

--- a/rocketmq-controller/src/controller/raft_controller.rs
+++ b/rocketmq-controller/src/controller/raft_controller.rs
@@ -135,6 +135,13 @@ impl RaftController {
             )),
         }
     }
+
+    pub fn scheduling_enabled(&self) -> bool {
+        match self {
+            Self::OpenRaft(controller) => controller.scheduling_enabled(),
+            Self::RaftRs(_) => false,
+        }
+    }
 }
 
 impl Controller for RaftController {

--- a/rocketmq-controller/src/openraft/log_store.rs
+++ b/rocketmq-controller/src/openraft/log_store.rs
@@ -28,18 +28,51 @@ use openraft::storage::RaftLogStorage;
 use openraft::LogState;
 use openraft::OptionalSend;
 use openraft::RaftLogReader;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use tokio::sync::RwLock;
 
+use crate::storage::SharedStorageBackend;
 use crate::typ::LogEntry;
 use crate::typ::LogId;
 use crate::typ::TypeConfig;
 use crate::typ::Vote;
 
+const LOG_PREFIX: &str = "openraft/log/";
+const LAST_PURGED_KEY: &str = "openraft/meta/last_purged";
+const COMMITTED_KEY: &str = "openraft/meta/committed";
+const VOTE_KEY: &str = "openraft/meta/vote";
+
+fn storage_error(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::other(error.to_string())
+}
+
+async fn load_json<T: DeserializeOwned>(
+    backend: &SharedStorageBackend,
+    key: &str,
+) -> Result<Option<T>, std::io::Error> {
+    let Some(bytes) = backend.get(key).await.map_err(storage_error)? else {
+        return Ok(None);
+    };
+
+    serde_json::from_slice(&bytes).map(Some).map_err(storage_error)
+}
+
+async fn persist_json<T: Serialize>(
+    backend: &SharedStorageBackend,
+    key: &str,
+    value: &T,
+) -> Result<(), std::io::Error> {
+    let bytes = serde_json::to_vec(value).map_err(storage_error)?;
+    backend.put(key, &bytes).await.map_err(storage_error)?;
+    Ok(())
+}
+
 /// In-memory log store for Raft
 ///
 /// This implementation stores all log entries in memory using DashMap.
 /// For production use, consider implementing persistent storage.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct LogStore {
     /// Log entries indexed by log index
     logs: Arc<DashMap<u64, LogEntry>>,
@@ -49,6 +82,7 @@ pub struct LogStore {
     committed: Arc<RwLock<Option<LogId>>>,
     /// Current vote information
     vote: Arc<RwLock<Option<Vote>>>,
+    backend: Option<SharedStorageBackend>,
 }
 
 impl Default for LogStore {
@@ -65,7 +99,46 @@ impl LogStore {
             last_purged_log_id: Arc::new(RwLock::new(None)),
             committed: Arc::new(RwLock::new(None)),
             vote: Arc::new(RwLock::new(None)),
+            backend: None,
         }
+    }
+
+    pub async fn open(backend: SharedStorageBackend) -> Result<Self, std::io::Error> {
+        let store = Self {
+            logs: Arc::new(DashMap::new()),
+            last_purged_log_id: Arc::new(RwLock::new(load_json(&backend, LAST_PURGED_KEY).await?)),
+            committed: Arc::new(RwLock::new(load_json(&backend, COMMITTED_KEY).await?)),
+            vote: Arc::new(RwLock::new(load_json(&backend, VOTE_KEY).await?)),
+            backend: Some(backend.clone()),
+        };
+
+        let mut log_keys = backend.list_keys(LOG_PREFIX).await.map_err(storage_error)?;
+        log_keys.sort_by_key(|key| {
+            key.rsplit('/')
+                .next()
+                .and_then(|index| index.parse::<u64>().ok())
+                .unwrap_or_default()
+        });
+
+        for key in log_keys {
+            let Some(entry) = load_json::<LogEntry>(&backend, &key).await? else {
+                continue;
+            };
+            store.logs.insert(entry.log_id.index, entry);
+        }
+
+        Ok(store)
+    }
+
+    fn log_key(index: u64) -> String {
+        format!("{LOG_PREFIX}{index:020}")
+    }
+
+    async fn sync_backend(&self) -> Result<(), std::io::Error> {
+        if let Some(backend) = &self.backend {
+            backend.sync().await.map_err(storage_error)?;
+        }
+        Ok(())
     }
 
     /// Get the last log ID
@@ -102,6 +175,22 @@ impl LogStore {
         }
         entries
     }
+
+    async fn persist_vote(&self, vote: &Vote) -> Result<(), std::io::Error> {
+        if let Some(backend) = &self.backend {
+            persist_json(backend, VOTE_KEY, vote).await?;
+            self.sync_backend().await?;
+        }
+        Ok(())
+    }
+
+    async fn persist_last_purged(&self, log_id: &LogId) -> Result<(), std::io::Error> {
+        if let Some(backend) = &self.backend {
+            persist_json(backend, LAST_PURGED_KEY, log_id).await?;
+            self.sync_backend().await?;
+        }
+        Ok(())
+    }
 }
 
 impl RaftLogReader<TypeConfig> for LogStore {
@@ -136,6 +225,7 @@ impl RaftLogStorage<TypeConfig> for LogStore {
 
     async fn save_vote(&mut self, vote: &Vote) -> Result<(), std::io::Error> {
         *self.vote.write().await = Some(*vote);
+        self.persist_vote(vote).await?;
         Ok(())
     }
 
@@ -148,9 +238,21 @@ impl RaftLogStorage<TypeConfig> for LogStore {
         I: IntoIterator<Item = LogEntry> + OptionalSend,
         I::IntoIter: OptionalSend,
     {
+        let mut persisted_entries = Vec::new();
         for entry in entries {
             let log_id = entry.log_id;
+            if self.backend.is_some() {
+                let bytes = serde_json::to_vec(&entry).map_err(storage_error)?;
+                persisted_entries.push((Self::log_key(log_id.index), bytes));
+            }
             self.logs.insert(log_id.index, entry);
+        }
+
+        if let Some(backend) = &self.backend {
+            if !persisted_entries.is_empty() {
+                backend.batch_put(persisted_entries).await.map_err(storage_error)?;
+            }
+            self.sync_backend().await?;
         }
         callback.io_completed(Ok(()));
         Ok(())
@@ -171,14 +273,26 @@ impl RaftLogStorage<TypeConfig> for LogStore {
                 })
                 .collect();
 
+            if let Some(backend) = &self.backend {
+                backend
+                    .batch_delete(keys_to_remove.iter().map(|key| Self::log_key(*key)).collect())
+                    .await
+                    .map_err(storage_error)?;
+            }
+
             for key in keys_to_remove {
                 self.logs.remove(&key);
             }
         } else {
             // If log_id is None, remove all logs
+            if let Some(backend) = &self.backend {
+                let keys_to_remove: Vec<String> = self.logs.iter().map(|entry| Self::log_key(*entry.key())).collect();
+                backend.batch_delete(keys_to_remove).await.map_err(storage_error)?;
+            }
             self.logs.clear();
         }
 
+        self.sync_backend().await?;
         Ok(())
     }
 
@@ -196,11 +310,19 @@ impl RaftLogStorage<TypeConfig> for LogStore {
             })
             .collect();
 
+        if let Some(backend) = &self.backend {
+            backend
+                .batch_delete(keys_to_remove.iter().map(|key| Self::log_key(*key)).collect())
+                .await
+                .map_err(storage_error)?;
+        }
+
         for key in keys_to_remove {
             self.logs.remove(&key);
         }
 
         *self.last_purged_log_id.write().await = Some(log_id);
+        self.persist_last_purged(&log_id).await?;
         Ok(())
     }
 }

--- a/rocketmq-controller/src/openraft/node.rs
+++ b/rocketmq-controller/src/openraft/node.rs
@@ -56,7 +56,7 @@ impl RaftNodeManager {
         let node_id = config.node_id;
 
         // Create storage
-        let store = Arc::new(Store::new(config.clone()));
+        let store = Arc::new(Store::open(config.clone()).await?);
 
         // Create network factory
         let network = NetworkFactory::new();

--- a/rocketmq-controller/src/openraft/state_machine.rs
+++ b/rocketmq-controller/src/openraft/state_machine.rs
@@ -24,8 +24,11 @@ use openraft::storage::Snapshot;
 use openraft::EntryPayload;
 use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
+use openraft::SnapshotMeta;
 use openraft::StoredMembership;
 use rocketmq_rust::ArcMut;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use tokio::sync::RwLock;
 
 use crate::config::ControllerConfig;
@@ -33,6 +36,7 @@ use crate::elect::elect_policy::ElectPolicy;
 use crate::event::controller_result::ControllerResult;
 use crate::helper::broker_valid_predicate::BrokerValidPredicate;
 use crate::manager::replicas_info_manager::ReplicasInfoManager;
+use crate::storage::SharedStorageBackend;
 use crate::typ::BrokerLiveInfoSnapshot;
 use crate::typ::ControllerRequest;
 use crate::typ::ControllerResponse;
@@ -124,6 +128,37 @@ fn compare_live_info(left: &BrokerLiveInfoSnapshot, right: &BrokerLiveInfoSnapsh
     }
 }
 
+const SNAPSHOT_META_KEY: &str = "openraft/state_machine/current_snapshot_meta";
+const SNAPSHOT_DATA_KEY: &str = "openraft/state_machine/current_snapshot_data";
+const REPLICAS_INFO_MANAGER_STATE_KEY: &str = "openraft/state_machine/replicas_info_manager";
+const LAST_APPLIED_KEY: &str = "openraft/state_machine/last_applied";
+const LAST_MEMBERSHIP_KEY: &str = "openraft/state_machine/last_membership";
+
+fn storage_error(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::other(error.to_string())
+}
+
+async fn load_json<T: DeserializeOwned>(
+    backend: &SharedStorageBackend,
+    key: &str,
+) -> Result<Option<T>, std::io::Error> {
+    let Some(bytes) = backend.get(key).await.map_err(storage_error)? else {
+        return Ok(None);
+    };
+
+    serde_json::from_slice(&bytes).map(Some).map_err(storage_error)
+}
+
+async fn persist_json<T: Serialize>(
+    backend: &SharedStorageBackend,
+    key: &str,
+    value: &T,
+) -> Result<(), std::io::Error> {
+    let bytes = serde_json::to_vec(value).map_err(storage_error)?;
+    backend.put(key, &bytes).await.map_err(storage_error)?;
+    Ok(())
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SnapshotData {
     pub replicas_info_manager_state: Vec<u8>,
@@ -131,11 +166,26 @@ pub struct SnapshotData {
     pub last_membership: Option<StoredMembership<TypeConfig>>,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct PersistedSnapshotMeta {
+    last_log_id: Option<LogId>,
+    last_membership: StoredMembership<TypeConfig>,
+    snapshot_id: String,
+}
+
+#[derive(Clone)]
+struct CurrentSnapshot {
+    meta: SnapshotMeta<TypeConfig>,
+    data: Vec<u8>,
+}
+
 #[derive(Clone)]
 pub struct StateMachine {
     replicas_info_manager: Arc<ReplicasInfoManager>,
     last_applied: Arc<RwLock<Option<LogId>>>,
     last_membership: Arc<RwLock<StoredMembership<TypeConfig>>>,
+    current_snapshot: Arc<RwLock<Option<CurrentSnapshot>>>,
+    backend: Option<SharedStorageBackend>,
 }
 
 impl StateMachine {
@@ -144,7 +194,48 @@ impl StateMachine {
             replicas_info_manager: Arc::new(ReplicasInfoManager::new(config)),
             last_applied: Arc::new(RwLock::new(None)),
             last_membership: Arc::new(RwLock::new(StoredMembership::default())),
+            current_snapshot: Arc::new(RwLock::new(None)),
+            backend: None,
         }
+    }
+
+    pub async fn open(config: ArcMut<ControllerConfig>, backend: SharedStorageBackend) -> Result<Self, std::io::Error> {
+        let state_machine = Self {
+            replicas_info_manager: Arc::new(ReplicasInfoManager::new(config)),
+            last_applied: Arc::new(RwLock::new(load_json(&backend, LAST_APPLIED_KEY).await?)),
+            last_membership: Arc::new(RwLock::new(
+                load_json(&backend, LAST_MEMBERSHIP_KEY).await?.unwrap_or_default(),
+            )),
+            current_snapshot: Arc::new(RwLock::new(None)),
+            backend: Some(backend.clone()),
+        };
+
+        if let Some(state) = backend
+            .get(REPLICAS_INFO_MANAGER_STATE_KEY)
+            .await
+            .map_err(storage_error)?
+        {
+            state_machine
+                .replicas_info_manager
+                .deserialize_from(&state)
+                .map_err(storage_error)?;
+        }
+
+        if let (Some(meta), Some(data)) = (
+            load_json::<PersistedSnapshotMeta>(&backend, SNAPSHOT_META_KEY).await?,
+            backend.get(SNAPSHOT_DATA_KEY).await.map_err(storage_error)?,
+        ) {
+            *state_machine.current_snapshot.write().await = Some(CurrentSnapshot {
+                meta: SnapshotMeta {
+                    last_log_id: meta.last_log_id,
+                    last_membership: meta.last_membership,
+                    snapshot_id: meta.snapshot_id,
+                },
+                data,
+            });
+        }
+
+        Ok(state_machine)
     }
 
     pub fn replicas_info_manager(&self) -> Arc<ReplicasInfoManager> {
@@ -301,6 +392,53 @@ impl StateMachine {
             .map_err(|error| std::io::Error::other(error.to_string()))?;
         *self.last_applied.write().await = data.last_applied;
         *self.last_membership.write().await = data.last_membership.unwrap_or_default();
+        self.persist_state().await?;
+        Ok(())
+    }
+
+    async fn persist_state(&self) -> Result<(), std::io::Error> {
+        let Some(backend) = &self.backend else {
+            return Ok(());
+        };
+
+        let replicas_info_manager_state = self.replicas_info_manager.serialize().map_err(storage_error)?;
+        let last_applied = *self.last_applied.read().await;
+        let last_membership = self.last_membership.read().await.clone();
+
+        backend
+            .batch_put(vec![
+                (REPLICAS_INFO_MANAGER_STATE_KEY.to_string(), replicas_info_manager_state),
+                (
+                    LAST_APPLIED_KEY.to_string(),
+                    serde_json::to_vec(&last_applied).map_err(storage_error)?,
+                ),
+                (
+                    LAST_MEMBERSHIP_KEY.to_string(),
+                    serde_json::to_vec(&last_membership).map_err(storage_error)?,
+                ),
+            ])
+            .await
+            .map_err(storage_error)?;
+        backend.sync().await.map_err(storage_error)?;
+        Ok(())
+    }
+
+    async fn persist_snapshot(&self, snapshot: &CurrentSnapshot) -> Result<(), std::io::Error> {
+        let Some(backend) = &self.backend else {
+            return Ok(());
+        };
+
+        let persisted_meta = PersistedSnapshotMeta {
+            last_log_id: snapshot.meta.last_log_id,
+            last_membership: snapshot.meta.last_membership.clone(),
+            snapshot_id: snapshot.meta.snapshot_id.clone(),
+        };
+        persist_json(backend, SNAPSHOT_META_KEY, &persisted_meta).await?;
+        backend
+            .put(SNAPSHOT_DATA_KEY, &snapshot.data)
+            .await
+            .map_err(storage_error)?;
+        backend.sync().await.map_err(storage_error)?;
         Ok(())
     }
 }
@@ -312,13 +450,19 @@ impl RaftSnapshotBuilder<TypeConfig> for StateMachine {
         let last_membership = data.last_membership.clone().unwrap_or_default();
         let snapshot_data = serde_json::to_vec(&data)
             .map_err(|error| std::io::Error::other(format!("Failed to serialize snapshot: {}", error)))?;
-
-        Ok(Snapshot {
+        let current_snapshot = CurrentSnapshot {
             meta: openraft::SnapshotMeta {
                 last_log_id: last_applied,
                 last_membership,
                 snapshot_id: format!("snapshot-{}", last_applied.map_or(0, |log_id| log_id.index)),
             },
+            data: snapshot_data.clone(),
+        };
+        *self.current_snapshot.write().await = Some(current_snapshot.clone());
+        self.persist_snapshot(&current_snapshot).await?;
+
+        Ok(Snapshot {
+            meta: current_snapshot.meta,
             snapshot: std::io::Cursor::new(snapshot_data),
         })
     }
@@ -343,6 +487,7 @@ impl RaftStateMachine<TypeConfig> for StateMachine {
         use futures::StreamExt;
 
         futures::pin_mut!(entries);
+        let mut responses = Vec::new();
 
         while let Some(entry_result) = entries.next().await {
             let (entry, responder) = entry_result?;
@@ -359,6 +504,12 @@ impl RaftStateMachine<TypeConfig> for StateMachine {
                 }
             };
 
+            responses.push((responder, response));
+        }
+
+        self.persist_state().await?;
+
+        for (responder, response) in responses {
             if let Some(tx) = responder {
                 tx.send(response);
             }
@@ -388,12 +539,21 @@ impl RaftStateMachine<TypeConfig> for StateMachine {
         })?;
 
         self.install_snapshot_data(snapshot_data).await?;
+        let current_snapshot = CurrentSnapshot {
+            meta: meta.clone(),
+            data: snapshot.into_inner(),
+        };
+        *self.current_snapshot.write().await = Some(current_snapshot.clone());
+        self.persist_snapshot(&current_snapshot).await?;
         tracing::info!("Installed snapshot at {:?}", meta.last_log_id);
         Ok(())
     }
 
     async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, std::io::Error> {
-        Ok(None)
+        Ok(self.current_snapshot.read().await.clone().map(|snapshot| Snapshot {
+            meta: snapshot.meta,
+            snapshot: std::io::Cursor::new(snapshot.data),
+        }))
     }
 }
 

--- a/rocketmq-controller/src/openraft/storage.rs
+++ b/rocketmq-controller/src/openraft/storage.rs
@@ -17,9 +17,15 @@
 //! This module provides the storage implementation for OpenRaft,
 //! including log storage and state machine.
 
+use std::path::PathBuf;
+
 use rocketmq_rust::ArcMut;
 
 use crate::config::ControllerConfig;
+use crate::config::StorageBackendType;
+use crate::error::Result;
+use crate::storage::create_storage;
+use crate::storage::StorageConfig;
 
 use super::log_store::LogStore;
 use super::state_machine::StateMachine;
@@ -42,4 +48,63 @@ impl Store {
             state_machine: StateMachine::new(config),
         }
     }
+
+    pub async fn open(config: ArcMut<ControllerConfig>) -> Result<Self> {
+        let backend = create_storage(storage_config(config.as_ref())?).await?;
+        let log_store = LogStore::open(backend.clone()).await?;
+        let state_machine = StateMachine::open(config, backend).await?;
+
+        Ok(Self {
+            log_store,
+            state_machine,
+        })
+    }
+}
+
+fn storage_config(config: &ControllerConfig) -> Result<StorageConfig> {
+    match config.storage_backend {
+        StorageBackendType::Memory => Ok(StorageConfig::Memory),
+        StorageBackendType::File => {
+            #[cfg(feature = "storage-file")]
+            {
+                Ok(StorageConfig::File {
+                    path: resolved_storage_path(config),
+                })
+            }
+            #[cfg(not(feature = "storage-file"))]
+            {
+                Err(crate::error::ControllerError::StorageError(
+                    "The file storage backend is not enabled for rocketmq-controller".to_string(),
+                ))
+            }
+        }
+        StorageBackendType::RocksDB => {
+            #[cfg(feature = "storage-rocksdb")]
+            {
+                Ok(StorageConfig::RocksDB {
+                    path: resolved_storage_path(config),
+                })
+            }
+            #[cfg(not(feature = "storage-rocksdb"))]
+            {
+                Err(crate::error::ControllerError::StorageError(
+                    "The rocksdb storage backend is not enabled for rocketmq-controller".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+fn resolved_storage_path(config: &ControllerConfig) -> PathBuf {
+    if !config.storage_path.is_empty() {
+        return PathBuf::from(&config.storage_path);
+    }
+
+    if !config.controller_store_path.is_empty() {
+        return PathBuf::from(&config.controller_store_path);
+    }
+
+    PathBuf::from(&config.rocketmq_home)
+        .join("controller")
+        .join(format!("node-{}", config.node_id))
 }

--- a/rocketmq-controller/src/storage/mod.rs
+++ b/rocketmq-controller/src/storage/mod.rs
@@ -24,6 +24,7 @@ pub mod rocksdb_backend;
 pub mod file_backend;
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
@@ -89,6 +90,8 @@ pub trait StorageBackend: Send + Sync {
     async fn stats(&self) -> Result<StorageStats>;
 }
 
+pub type SharedStorageBackend = Arc<dyn StorageBackend>;
+
 /// Storage statistics
 #[derive(Debug, Clone, Default)]
 pub struct StorageStats {
@@ -145,18 +148,18 @@ pub trait StorageBackendExt: StorageBackend {
 impl<T: StorageBackend + ?Sized> StorageBackendExt for T {}
 
 /// Create a storage backend based on configuration
-pub async fn create_storage(config: StorageConfig) -> Result<Box<dyn StorageBackend>> {
+pub async fn create_storage(config: StorageConfig) -> Result<SharedStorageBackend> {
     match config {
         #[cfg(feature = "storage-rocksdb")]
         StorageConfig::RocksDB { path } => {
             let backend = rocksdb_backend::RocksDBBackend::new(path).await?;
-            Ok(Box::new(backend))
+            Ok(Arc::new(backend))
         }
 
         #[cfg(feature = "storage-file")]
         StorageConfig::File { path } => {
             let backend = file_backend::FileBackend::new(path).await?;
-            Ok(Box::new(backend))
+            Ok(Arc::new(backend))
         }
 
         StorageConfig::Memory => {
@@ -237,7 +240,7 @@ pub async fn create_storage(config: StorageConfig) -> Result<Box<dyn StorageBack
                 }
             }
 
-            Ok(Box::new(MemoryBackend {
+            Ok(Arc::new(MemoryBackend {
                 data: Arc::new(RwLock::new(HashMap::new())),
             }))
         }

--- a/rocketmq-controller/tests/multi_node_cluster_test.rs
+++ b/rocketmq-controller/tests/multi_node_cluster_test.rs
@@ -181,6 +181,54 @@ async fn wait_for_learner_readiness(nodes: &[(u64, Arc<RaftNodeManager>)], learn
     panic!("Learner node {learner_id} failed to become ready under leader {leader_id}");
 }
 
+async fn wait_for_failover_leader(
+    nodes: &[(u64, Arc<RaftNodeManager>)],
+    excluded_node_id: u64,
+) -> (u64, Arc<RaftNodeManager>) {
+    for attempt in 1..=80 {
+        let metrics = snapshot_metrics(nodes);
+        let leaders = metrics
+            .iter()
+            .filter(|(node_id, _)| *node_id != excluded_node_id)
+            .filter_map(|(node_id, metrics)| {
+                (metrics.state == ServerState::Leader && metrics.current_leader == Some(*node_id)).then_some(*node_id)
+            })
+            .collect::<Vec<_>>();
+
+        if leaders.len() == 1 {
+            let leader_id = leaders[0];
+            let all_survivors_follow = metrics
+                .iter()
+                .filter(|(node_id, _)| *node_id != excluded_node_id)
+                .all(|(_, metrics)| metrics.current_leader == Some(leader_id));
+
+            if all_survivors_follow {
+                let leader_node = nodes
+                    .iter()
+                    .find(|(node_id, _)| *node_id == leader_id)
+                    .map(|(_, node)| node.clone())
+                    .expect("leader node should be present");
+                return (leader_id, leader_node);
+            }
+        }
+
+        if attempt % 10 == 0 {
+            println!(
+                "Waiting for failover leader excluding node {}, current snapshot: {:?}",
+                excluded_node_id,
+                metrics
+                    .iter()
+                    .map(|(node_id, metrics)| (*node_id, metrics.state, metrics.current_leader))
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    panic!("Cluster failed to elect a failover leader after excluding node {excluded_node_id}");
+}
+
 /// Bootstrap a stable multi-voter cluster by delaying follower startup until the
 /// initial leader has a committed write in its current term.
 async fn bootstrap_cluster(node_count: u64, base_port: u16) -> Vec<(u64, Arc<RaftNodeManager>)> {
@@ -542,4 +590,89 @@ async fn test_cluster_metrics() {
     }
 
     println!("All nodes have valid metrics");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_three_node_cluster_re_elects_after_leader_shutdown() {
+    const BASE_PORT: u16 = 55000;
+
+    let nodes = bootstrap_cluster(3, BASE_PORT).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let mut old_leader = None;
+    for (node_id, node) in &nodes {
+        if node.is_leader().await.unwrap_or(false) {
+            old_leader = Some((*node_id, node.clone()));
+            break;
+        }
+    }
+    let (old_leader_id, old_leader_node) = old_leader.expect("cluster should elect an initial leader");
+
+    let pre_failover_write = old_leader_node
+        .client_write(ControllerRequest::ApplyBrokerId {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "broker-before-failover".to_string(),
+            broker_address: "127.0.0.1:10921".to_string(),
+            applied_broker_id: 1,
+            register_check_code: "broker-before-failover-check-code".to_string(),
+        })
+        .await
+        .expect("pre-failover write should succeed");
+    assert_eq!(
+        pre_failover_write.data.response_code,
+        rocketmq_remoting::code::response_code::ResponseCode::Success as i32,
+        "pre-failover controller write should succeed"
+    );
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    old_leader_node.shutdown().await.expect("shutdown old leader");
+
+    let (new_leader_id, new_leader_node) = wait_for_failover_leader(&nodes, old_leader_id).await;
+    assert_ne!(
+        new_leader_id, old_leader_id,
+        "cluster should elect a different leader after shutdown"
+    );
+
+    let post_failover_write = new_leader_node
+        .client_write(ControllerRequest::ApplyBrokerId {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "broker-after-failover".to_string(),
+            broker_address: "127.0.0.1:10922".to_string(),
+            applied_broker_id: 1,
+            register_check_code: "broker-after-failover-check-code".to_string(),
+        })
+        .await
+        .expect("post-failover write should succeed");
+    assert_eq!(
+        post_failover_write.data.response_code,
+        rocketmq_remoting::code::response_code::ResponseCode::Success as i32,
+        "post-failover controller write should succeed"
+    );
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    for (node_id, node) in nodes.iter().filter(|(node_id, _)| *node_id != old_leader_id) {
+        let metrics = node.raft().metrics().borrow_watched().clone();
+        assert_eq!(
+            metrics.current_leader,
+            Some(new_leader_id),
+            "surviving node {} should follow the new leader",
+            node_id
+        );
+
+        let replicas_info_manager = node.store().state_machine.replicas_info_manager();
+        let next_before = replicas_info_manager
+            .get_next_broker_id("test-cluster", "broker-before-failover")
+            .response()
+            .and_then(|header| header.next_broker_id)
+            .expect("pre-failover broker id should remain visible");
+        let next_after = replicas_info_manager
+            .get_next_broker_id("test-cluster", "broker-after-failover")
+            .response()
+            .and_then(|header| header.next_broker_id)
+            .expect("post-failover broker id should replicate");
+
+        assert_eq!(next_before, 2, "node {} should retain pre-failover state", node_id);
+        assert_eq!(next_after, 2, "node {} should apply post-failover state", node_id);
+    }
 }

--- a/rocketmq-controller/tests/openraft_integration_test.rs
+++ b/rocketmq-controller/tests/openraft_integration_test.rs
@@ -16,13 +16,17 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashSet;
+use std::path::Path;
 
 use rocketmq_controller::config::ControllerConfig;
+use rocketmq_controller::config::StorageBackendType;
 use rocketmq_controller::openraft::RaftNodeManager;
 use rocketmq_controller::openraft::StateMachine;
 use rocketmq_controller::openraft::Store;
 use rocketmq_controller::typ::ControllerRequest;
+use rocketmq_controller::typ::ControllerResponseHeader;
 use rocketmq_controller::typ::Node;
+use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_rust::ArcMut;
 
 fn test_config(port: u16) -> ArcMut<ControllerConfig> {
@@ -31,6 +35,17 @@ fn test_config(port: u16) -> ArcMut<ControllerConfig> {
             .with_node_info(1, format!("127.0.0.1:{port}").parse().expect("valid socket addr"))
             .with_election_timeout_ms(1000)
             .with_heartbeat_interval_ms(300),
+    )
+}
+
+fn persistent_test_config(port: u16, storage_path: &Path) -> ArcMut<ControllerConfig> {
+    ArcMut::new(
+        ControllerConfig::default()
+            .with_node_info(1, format!("127.0.0.1:{port}").parse().expect("valid socket addr"))
+            .with_election_timeout_ms(1000)
+            .with_heartbeat_interval_ms(300)
+            .with_storage_backend(StorageBackendType::File)
+            .with_storage_path(storage_path.to_string_lossy().into_owned()),
     )
 }
 
@@ -165,4 +180,155 @@ async fn test_client_write_updates_replicas_info_manager() {
         .and_then(|header| header.next_broker_id)
         .expect("next broker id");
     assert_eq!(next_broker_id, 2);
+}
+
+#[tokio::test]
+async fn test_single_node_restart_recovers_state_from_file_storage() {
+    let temp_root = tempfile::tempdir().expect("create temp dir for persistent openraft controller storage");
+    let storage_path = temp_root.path().join("controller-openraft-restart");
+    let config = persistent_test_config(59876, &storage_path);
+
+    let node = RaftNodeManager::new(config.clone()).await.unwrap();
+
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        1,
+        Node {
+            node_id: 1,
+            rpc_addr: "127.0.0.1:59876".to_string(),
+        },
+    );
+
+    node.initialize_cluster(nodes).await.unwrap();
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let apply_master = node
+        .client_write(ControllerRequest::ApplyBrokerId {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "restart-broker".to_string(),
+            broker_address: "127.0.0.1:10911".to_string(),
+            applied_broker_id: 1,
+            register_check_code: "master-check-code".to_string(),
+        })
+        .await
+        .expect("apply master broker id before restart");
+    assert_eq!(apply_master.data.response_code, ResponseCode::Success as i32);
+
+    let apply_replica = node
+        .client_write(ControllerRequest::ApplyBrokerId {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "restart-broker".to_string(),
+            broker_address: "127.0.0.1:10912".to_string(),
+            applied_broker_id: 2,
+            register_check_code: "replica-check-code".to_string(),
+        })
+        .await
+        .expect("apply replica broker id before restart");
+    assert_eq!(apply_replica.data.response_code, ResponseCode::Success as i32);
+
+    let alive_broker_ids = HashSet::from([1_u64, 2_u64]);
+    let register_master = node
+        .client_write(ControllerRequest::RegisterBroker {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "restart-broker".to_string(),
+            broker_address: "127.0.0.1:10911".to_string(),
+            broker_id: 1,
+            alive_broker_ids: alive_broker_ids.clone(),
+        })
+        .await
+        .expect("register master broker before restart");
+    assert_eq!(register_master.data.response_code, ResponseCode::Success as i32);
+
+    let register_replica = node
+        .client_write(ControllerRequest::RegisterBroker {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "restart-broker".to_string(),
+            broker_address: "127.0.0.1:10912".to_string(),
+            broker_id: 2,
+            alive_broker_ids: alive_broker_ids.clone(),
+        })
+        .await
+        .expect("register replica broker before restart");
+    assert_eq!(register_replica.data.response_code, ResponseCode::Success as i32);
+
+    let elect_response = node
+        .client_write(ControllerRequest::ElectMaster {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "restart-broker".to_string(),
+            broker_id: Some(1),
+            designate_elect: false,
+            alive_broker_ids: alive_broker_ids.clone(),
+            live_broker_infos: Default::default(),
+        })
+        .await
+        .expect("elect master before restart");
+    assert_eq!(elect_response.data.response_code, ResponseCode::Success as i32);
+
+    let elect_header = match elect_response.data.header {
+        Some(ControllerResponseHeader::ElectMaster(header)) => header,
+        _ => panic!("elect master should return elect-master response header"),
+    };
+
+    let alter_response = node
+        .client_write(ControllerRequest::AlterSyncStateSet {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "restart-broker".to_string(),
+            master_broker_id: 1,
+            master_epoch: elect_header.master_epoch.expect("master epoch before restart"),
+            new_sync_state_set: HashSet::from([1_u64, 2_u64]),
+            sync_state_set_epoch: elect_header
+                .sync_state_set_epoch
+                .expect("sync state set epoch before restart"),
+            alive_broker_ids,
+        })
+        .await
+        .expect("alter sync state set before restart");
+    assert_eq!(alter_response.data.response_code, ResponseCode::Success as i32);
+
+    node.shutdown().await.expect("shutdown node before restart");
+
+    let restarted_node = RaftNodeManager::new(config).await.unwrap();
+    let replicas_info_manager = restarted_node.store().state_machine.replicas_info_manager();
+
+    assert_eq!(
+        replicas_info_manager.cluster_name("restart-broker").as_deref(),
+        Some("test-cluster")
+    );
+    assert_eq!(
+        replicas_info_manager.broker_ids("restart-broker"),
+        HashSet::from([1_u64, 2_u64])
+    );
+
+    let replica_info = replicas_info_manager.get_replica_info("restart-broker");
+    assert!(
+        replica_info.is_success(),
+        "replica info should be recovered after restart"
+    );
+    let replica_header = replica_info.response().expect("replica info response");
+    assert_eq!(replica_header.master_broker_id, Some(1));
+    assert_eq!(replica_header.master_address.as_deref(), Some("127.0.0.1:10911"));
+    assert_eq!(replica_header.master_epoch, Some(1));
+
+    for _ in 0..20 {
+        if restarted_node.is_leader().await.unwrap_or(false) {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    }
+    assert!(
+        restarted_node.is_leader().await.unwrap_or(false),
+        "restarted single node should recover leadership without reinitializing cluster"
+    );
+
+    let post_restart_write = restarted_node
+        .client_write(ControllerRequest::ApplyBrokerId {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "restart-broker-after".to_string(),
+            broker_address: "127.0.0.1:10913".to_string(),
+            applied_broker_id: 1,
+            register_check_code: "post-restart-check-code".to_string(),
+        })
+        .await
+        .expect("post-restart write should succeed");
+    assert_eq!(post_restart_write.data.response_code, ResponseCode::Success as i32);
 }

--- a/rocketmq-controller/tests/snapshot_test.rs
+++ b/rocketmq-controller/tests/snapshot_test.rs
@@ -15,14 +15,19 @@
 //! Snapshot functionality tests for the OpenRaft controller state machine.
 
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::collections::HashSet;
 
+use openraft::storage::RaftStateMachine;
 use openraft::RaftSnapshotBuilder;
 use rocketmq_controller::config::ControllerConfig;
 use rocketmq_controller::openraft::RaftNodeManager;
 use rocketmq_controller::openraft::StateMachine;
 use rocketmq_controller::typ::ControllerRequest;
+use rocketmq_controller::typ::ControllerResponseHeader;
 use rocketmq_controller::typ::Node;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::protocol::body::sync_state_set_body::SyncStateSet;
 use rocketmq_rust::ArcMut;
 
 fn test_config(port: u16) -> ArcMut<ControllerConfig> {
@@ -96,8 +101,6 @@ async fn test_state_machine_snapshot() {
 
 #[tokio::test]
 async fn test_snapshot_install() {
-    use openraft::storage::RaftStateMachine;
-
     let mut source = StateMachine::new(test_config(59876));
     let replicas_info_manager = source.replicas_info_manager();
     let apply_result =
@@ -119,4 +122,140 @@ async fn test_snapshot_install() {
         .and_then(|header| header.next_broker_id)
         .expect("next broker id");
     assert_eq!(next_broker_id, 2);
+}
+
+#[tokio::test]
+async fn test_snapshot_install_preserves_master_and_sync_state_set() {
+    let node = RaftNodeManager::new(test_config(61876)).await.unwrap();
+
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        1,
+        Node {
+            node_id: 1,
+            rpc_addr: "127.0.0.1:61876".to_string(),
+        },
+    );
+
+    node.initialize_cluster(nodes).await.unwrap();
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let apply_master = node
+        .client_write(ControllerRequest::ApplyBrokerId {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "broker-sync".to_string(),
+            broker_address: "127.0.0.1:10911".to_string(),
+            applied_broker_id: 1,
+            register_check_code: "master-check-code".to_string(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(apply_master.data.response_code, ResponseCode::Success as i32);
+
+    let apply_replica = node
+        .client_write(ControllerRequest::ApplyBrokerId {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "broker-sync".to_string(),
+            broker_address: "127.0.0.1:10912".to_string(),
+            applied_broker_id: 2,
+            register_check_code: "replica-check-code".to_string(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(apply_replica.data.response_code, ResponseCode::Success as i32);
+
+    let alive_broker_ids = HashSet::from([1_u64, 2_u64]);
+    let register_master = node
+        .client_write(ControllerRequest::RegisterBroker {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "broker-sync".to_string(),
+            broker_address: "127.0.0.1:10911".to_string(),
+            broker_id: 1,
+            alive_broker_ids: alive_broker_ids.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(register_master.data.response_code, ResponseCode::Success as i32);
+
+    let register_replica = node
+        .client_write(ControllerRequest::RegisterBroker {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "broker-sync".to_string(),
+            broker_address: "127.0.0.1:10912".to_string(),
+            broker_id: 2,
+            alive_broker_ids: alive_broker_ids.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(register_replica.data.response_code, ResponseCode::Success as i32);
+
+    let elect_response = node
+        .client_write(ControllerRequest::ElectMaster {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "broker-sync".to_string(),
+            broker_id: Some(1),
+            designate_elect: false,
+            alive_broker_ids: alive_broker_ids.clone(),
+            live_broker_infos: HashMap::new(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(elect_response.data.response_code, ResponseCode::Success as i32);
+
+    let elect_header = match elect_response.data.header {
+        Some(ControllerResponseHeader::ElectMaster(header)) => header,
+        _ => panic!("elect master should return elect-master response header"),
+    };
+    assert_eq!(elect_header.master_broker_id, Some(1));
+    assert_eq!(elect_header.master_epoch, Some(1));
+    assert_eq!(elect_header.sync_state_set_epoch, Some(1));
+
+    let alter_response = node
+        .client_write(ControllerRequest::AlterSyncStateSet {
+            cluster_name: "test-cluster".to_string(),
+            broker_name: "broker-sync".to_string(),
+            master_broker_id: 1,
+            master_epoch: elect_header.master_epoch.expect("master epoch"),
+            new_sync_state_set: HashSet::from([1_u64, 2_u64]),
+            sync_state_set_epoch: elect_header.sync_state_set_epoch.expect("sync state set epoch"),
+            alive_broker_ids,
+        })
+        .await
+        .unwrap();
+    assert_eq!(alter_response.data.response_code, ResponseCode::Success as i32);
+
+    let mut source = node.store().state_machine.clone();
+    let snapshot = source.build_snapshot().await.unwrap();
+
+    let mut target = StateMachine::new(test_config(62876));
+    target
+        .install_snapshot(&snapshot.meta, snapshot.snapshot)
+        .await
+        .unwrap();
+
+    let replica_info = target.replicas_info_manager().get_replica_info("broker-sync");
+    assert!(
+        replica_info.is_success(),
+        "replica info should be restored from snapshot"
+    );
+    let replica_header = replica_info.response().expect("replica info header");
+    assert_eq!(replica_header.master_broker_id, Some(1));
+    assert_eq!(replica_header.master_address.as_deref(), Some("127.0.0.1:10911"));
+    assert_eq!(replica_header.master_epoch, Some(1));
+
+    let sync_state_set: SyncStateSet =
+        serde_json::from_slice(replica_info.body().expect("replica sync state body")).expect("decode sync state set");
+    assert_eq!(sync_state_set.get_sync_state_set_epoch(), 2);
+    assert_eq!(
+        sync_state_set.get_sync_state_set().cloned().unwrap_or_default(),
+        HashSet::from([1_i64, 2_i64])
+    );
+    assert_eq!(
+        target.replicas_info_manager().cluster_name("broker-sync").as_deref(),
+        Some("test-cluster")
+    );
+    assert_eq!(
+        target.replicas_info_manager().broker_ids("broker-sync"),
+        HashSet::from([1_u64, 2_u64])
+    );
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6959

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic leadership-driven scheduling control for improved cluster behavior during leader transitions
  * Added persistent state recovery, allowing the controller to restore cluster state after restarts
  * Enabled intelligent broker notification deduplication to eliminate duplicate change notifications
  * Enhanced snapshot handling with persistence and restoration support

* **Tests**
  * Added integration tests for multi-node failover scenarios, persistent storage recovery, and snapshot installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->