### PR TITLE
[ISSUE #6969]✨Enhance AutoSwitchHAClient with broker ID tracking and controller target synchronization

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -39,7 +39,6 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::compute_next_morning_time_millis;
 use rocketmq_remoting::base::channel_event_listener::ChannelEventListener;
 use rocketmq_remoting::code::request_code::RequestCode;
-use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigSerializeWrapper;
@@ -83,6 +82,7 @@ use crate::controller::replicas_manager::BrokerReplicaRole;
 use crate::controller::replicas_manager::ControllerBrokerIdAction;
 use crate::controller::replicas_manager::ControllerRegisterFollowup;
 use crate::controller::replicas_manager::ControllerReplicaInfoFollowup;
+use crate::controller::replicas_manager::ControllerReplicaSyncFollowup;
 use crate::controller::replicas_manager::ReplicasManager;
 use crate::failover::escape_bridge::EscapeBridge;
 use crate::filter::commit_log_dispatcher_calc_bit_map::CommitLogDispatcherCalcBitMap;
@@ -2439,10 +2439,7 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
             }
         }
 
-        if let Err(error) = this
-            .send_heartbeat_to_controller_leader(&controller_leader, controller_broker_id as i64)
-            .await
-        {
+        if let Err(error) = this.send_heartbeat_to_controller_leader(&controller_leader).await {
             warn!("Send bootstrap heartbeat to controller failed: {}", error);
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -2684,7 +2681,16 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
             Ok((leader, response_header, sync_state_set_body)) => {
                 let sync_state_set_epoch = sync_state_set_body.get_sync_state_set_epoch();
                 let sync_state_set = sync_state_set_body.get_sync_state_set().cloned().unwrap_or_default();
-                if response_header.master_broker_id.is_some() && response_header.master_epoch.is_some() {
+                let sync_followup = this
+                    .replicas_manager()
+                    .map(|replicas_manager| {
+                        replicas_manager.replica_sync_followup(
+                            response_header.master_broker_id.and_then(|id| u64::try_from(id).ok()),
+                            response_header.master_epoch,
+                        )
+                    })
+                    .unwrap_or(ControllerReplicaSyncFollowup::Bootstrap);
+                if sync_followup == ControllerReplicaSyncFollowup::ApplyRoleChange {
                     if let Err(error) = BrokerRuntimeInner::apply_controller_role_change(
                         this,
                         Some(leader),
@@ -2703,7 +2709,13 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
                 }
             }
             Err(rocketmq_error::RocketMQError::BrokerOperationFailed { code, .. })
-                if code == ResponseCode::ControllerBrokerMetadataNotExist.to_i32() =>
+                if this
+                    .replicas_manager()
+                    .map(|replicas_manager| {
+                        replicas_manager.replica_sync_error_followup(Some(code))
+                            == ControllerReplicaSyncFollowup::Bootstrap
+                    })
+                    .unwrap_or(true) =>
             {
                 BrokerRuntimeInner::bootstrap_controller_mode(this).await;
             }
@@ -3162,7 +3174,8 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
         let Some(replicas_manager) = self.replicas_manager() else {
             return;
         };
-        let controller_targets = replicas_manager.heartbeat_targets();
+        let heartbeat_state = replicas_manager.controller_heartbeat_state();
+        let controller_targets = heartbeat_state.controller_targets;
         if controller_targets.is_empty() {
             warn!(
                 "Skip controller heartbeat because no controller address is configured, broker={}",
@@ -3174,8 +3187,8 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
         let cluster_name = self.broker_config.broker_identity.broker_cluster_name.clone();
         let broker_addr = self.get_broker_addr().clone();
         let broker_name = self.broker_config.broker_identity.broker_name.clone();
-        let broker_id = replicas_manager.broker_controller_id() as i64;
-        let epoch = (replicas_manager.master_epoch() > 0).then_some(replicas_manager.master_epoch());
+        let broker_id = heartbeat_state.broker_id;
+        let epoch = heartbeat_state.epoch;
         let max_offset = self
             .message_store
             .as_ref()
@@ -3207,18 +3220,15 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     async fn send_heartbeat_to_controller_leader(
         &self,
         controller_leader: &CheetahString,
-        broker_id: i64,
     ) -> rocketmq_error::RocketMQResult<()> {
-        let epoch = (self
+        let heartbeat_state = self
             .replicas_manager()
-            .map(|replicas_manager| replicas_manager.master_epoch())
-            .unwrap_or_default()
-            > 0)
-        .then(|| {
-            self.replicas_manager()
-                .map(|replicas_manager| replicas_manager.master_epoch())
-                .unwrap_or_default()
-        });
+            .map(|replicas_manager| replicas_manager.controller_heartbeat_state())
+            .ok_or_else(|| {
+                rocketmq_error::RocketMQError::illegal_argument(
+                    "replicas manager missing while sending controller leader heartbeat",
+                )
+            })?;
         let max_offset = self
             .message_store
             .as_ref()
@@ -3234,9 +3244,9 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
                 self.broker_config.broker_identity.broker_cluster_name.clone(),
                 self.get_broker_addr().clone(),
                 self.broker_config.broker_identity.broker_name.clone(),
-                broker_id,
+                heartbeat_state.broker_id,
                 self.broker_config.send_heartbeat_timeout_millis,
-                epoch,
+                heartbeat_state.epoch,
                 max_offset,
                 confirm_offset,
                 Some(self.broker_config.controller_heartbeat_timeout_mills),
@@ -3816,7 +3826,7 @@ mod tests {
 
         runtime
             .inner
-            .send_heartbeat_to_controller_leader(&controller_leader, controller_broker_id as i64)
+            .send_heartbeat_to_controller_leader(&controller_leader)
             .await
             .expect("send bootstrap heartbeat to controller");
         sleep(Duration::from_millis(300)).await;

--- a/rocketmq-broker/src/controller/replicas_manager.rs
+++ b/rocketmq-broker/src/controller/replicas_manager.rs
@@ -80,6 +80,19 @@ pub enum ControllerReplicaInfoFollowup {
     ElectMaster,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControllerReplicaSyncFollowup {
+    ApplyRoleChange,
+    Bootstrap,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControllerHeartbeatState {
+    pub controller_targets: Vec<CheetahString>,
+    pub broker_id: i64,
+    pub epoch: Option<i32>,
+}
+
 impl RoleChangeOutcome {
     pub fn target_broker_role(&self) -> Option<BrokerRole> {
         match self.role {
@@ -249,6 +262,14 @@ impl ReplicasManager {
         &self.sync_state_set
     }
 
+    pub fn controller_heartbeat_state(&self) -> ControllerHeartbeatState {
+        ControllerHeartbeatState {
+            controller_targets: self.heartbeat_targets(),
+            broker_id: self.broker_controller_id as i64,
+            epoch: (self.master_epoch > 0).then_some(self.master_epoch),
+        }
+    }
+
     pub fn needs_broker_id_application(&self) -> bool {
         self.metadata.is_none()
     }
@@ -373,6 +394,29 @@ impl ReplicasManager {
             ControllerReplicaInfoFollowup::ApplyRoleChange
         } else {
             ControllerReplicaInfoFollowup::ElectMaster
+        }
+    }
+
+    pub fn replica_sync_followup(
+        &self,
+        master_broker_id: Option<u64>,
+        master_epoch: Option<i32>,
+    ) -> ControllerReplicaSyncFollowup {
+        if master_broker_id.is_some() && master_epoch.is_some() {
+            ControllerReplicaSyncFollowup::ApplyRoleChange
+        } else {
+            ControllerReplicaSyncFollowup::Bootstrap
+        }
+    }
+
+    pub fn replica_sync_error_followup(&self, response_code: Option<i32>) -> ControllerReplicaSyncFollowup {
+        if matches!(
+            response_code,
+            Some(code) if code == rocketmq_remoting::code::response_code::ResponseCode::ControllerBrokerMetadataNotExist.to_i32()
+        ) {
+            ControllerReplicaSyncFollowup::Bootstrap
+        } else {
+            ControllerReplicaSyncFollowup::ApplyRoleChange
         }
     }
 
@@ -814,6 +858,40 @@ mod tests {
     }
 
     #[test]
+    fn controller_heartbeat_state_is_derived_by_replicas_manager() {
+        let config = broker_config_with_controller_addr("127.0.0.1:9878;127.0.0.2:9878", 2);
+        let message_store_config = message_store_config_with_identity_path("heartbeat-state");
+        let mut manager = ReplicasManager::new(&config, &message_store_config, "127.0.0.1:10911".into());
+
+        let initial_state = manager.controller_heartbeat_state();
+        assert_eq!(initial_state.broker_id, 2);
+        assert_eq!(initial_state.epoch, None);
+        assert_eq!(
+            initial_state.controller_targets,
+            vec![
+                CheetahString::from("127.0.0.1:9878"),
+                CheetahString::from("127.0.0.2:9878"),
+            ]
+        );
+
+        manager.set_controller_leader_address("127.0.0.2:9878".into());
+        manager
+            .change_broker_role(None, Some(2), None, Some(5), Some(6), Some(&HashSet::from([2_i64])))
+            .expect("promote to master");
+
+        let next_state = manager.controller_heartbeat_state();
+        assert_eq!(next_state.broker_id, 2);
+        assert_eq!(next_state.epoch, Some(5));
+        assert_eq!(
+            next_state.controller_targets,
+            vec![
+                CheetahString::from("127.0.0.2:9878"),
+                CheetahString::from("127.0.0.1:9878"),
+            ]
+        );
+    }
+
+    #[test]
     fn prepare_controller_broker_id_action_reuses_pending_and_existing_metadata() {
         let config = broker_config_with_controller_addr("127.0.0.1:9878", 7);
         let message_store_config = message_store_config_with_identity_path("broker-id-action");
@@ -874,6 +952,34 @@ mod tests {
         assert_eq!(
             manager.replica_info_followup(Some(9), Some(4)),
             ControllerReplicaInfoFollowup::ApplyRoleChange
+        );
+    }
+
+    #[test]
+    fn controller_periodic_sync_followups_are_derived_by_replicas_manager() {
+        let config = broker_config_with_controller_addr("127.0.0.1:9878", 7);
+        let message_store_config = message_store_config_with_identity_path("sync-followup");
+        let manager = ReplicasManager::new(&config, &message_store_config, "127.0.0.1:10911".into());
+
+        assert_eq!(
+            manager.replica_sync_followup(Some(7), Some(3)),
+            ControllerReplicaSyncFollowup::ApplyRoleChange
+        );
+        assert_eq!(
+            manager.replica_sync_followup(None, None),
+            ControllerReplicaSyncFollowup::Bootstrap
+        );
+        assert_eq!(
+            manager.replica_sync_error_followup(Some(
+                rocketmq_remoting::code::response_code::ResponseCode::ControllerBrokerMetadataNotExist.to_i32()
+            )),
+            ControllerReplicaSyncFollowup::Bootstrap
+        );
+        assert_eq!(
+            manager.replica_sync_error_followup(Some(
+                rocketmq_remoting::code::response_code::ResponseCode::SystemError.to_i32()
+            )),
+            ControllerReplicaSyncFollowup::ApplyRoleChange
         );
     }
 }

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_client.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_client.rs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
 use rocketmq_rust::ArcMut;
+use tokio::sync::Mutex;
 
 use crate::ha::default_ha_client::DefaultHAClient;
 use crate::ha::default_ha_client::HAClientError;
@@ -22,6 +27,9 @@ use crate::message_store::local_file_message_store::LocalFileMessageStore;
 
 pub struct AutoSwitchHAClient {
     delegate: ArcMut<DefaultHAClient>,
+    reported_broker_id: Arc<AtomicI64>,
+    master_address: Arc<Mutex<Option<String>>>,
+    ha_master_address: Arc<Mutex<Option<String>>>,
 }
 
 impl AutoSwitchHAClient {
@@ -30,11 +38,40 @@ impl AutoSwitchHAClient {
         client.set_reported_broker_id(broker_id);
         Ok(Self {
             delegate: ArcMut::new(client),
+            reported_broker_id: Arc::new(AtomicI64::new(broker_id.unwrap_or(-1))),
+            master_address: Arc::new(Mutex::new(None)),
+            ha_master_address: Arc::new(Mutex::new(None)),
         })
     }
 
     pub fn set_reported_broker_id(&self, broker_id: Option<i64>) {
+        self.reported_broker_id.store(broker_id.unwrap_or(-1), Ordering::SeqCst);
         self.delegate.set_reported_broker_id(broker_id);
+    }
+
+    pub fn reported_broker_id(&self) -> Option<i64> {
+        match self.reported_broker_id.load(Ordering::SeqCst) {
+            id if id >= 0 => Some(id),
+            _ => None,
+        }
+    }
+
+    pub async fn sync_controller_master_target(&self, new_address: &str) {
+        {
+            let mut master_address = self.master_address.lock().await;
+            *master_address = (!new_address.is_empty()).then_some(new_address.to_string());
+        }
+        {
+            let mut ha_master_address = self.ha_master_address.lock().await;
+            *ha_master_address = (!new_address.is_empty()).then_some(new_address.to_string());
+        }
+        self.delegate.update_master_address(new_address).await;
+        self.delegate.update_ha_master_address(new_address).await;
+    }
+
+    pub async fn clear_controller_master_target(&self) {
+        self.delegate.close_master().await;
+        self.sync_controller_master_target("").await;
     }
 }
 
@@ -52,19 +89,35 @@ impl HAClient for AutoSwitchHAClient {
     }
 
     async fn update_master_address(&self, new_address: &str) {
+        {
+            let mut master_address = self.master_address.lock().await;
+            *master_address = (!new_address.is_empty()).then_some(new_address.to_string());
+        }
         self.delegate.update_master_address(new_address).await;
     }
 
     async fn update_ha_master_address(&self, new_address: &str) {
+        {
+            let mut ha_master_address = self.ha_master_address.lock().await;
+            *ha_master_address = (!new_address.is_empty()).then_some(new_address.to_string());
+        }
         self.delegate.update_ha_master_address(new_address).await;
     }
 
     fn get_master_address(&self) -> String {
-        HAClient::get_master_address(&*self.delegate)
+        self.master_address
+            .try_lock()
+            .ok()
+            .and_then(|guard| guard.clone())
+            .unwrap_or_else(|| HAClient::get_master_address(&*self.delegate))
     }
 
     fn get_ha_master_address(&self) -> String {
-        HAClient::get_ha_master_address(&*self.delegate)
+        self.ha_master_address
+            .try_lock()
+            .ok()
+            .and_then(|guard| guard.clone())
+            .unwrap_or_else(|| HAClient::get_ha_master_address(&*self.delegate))
     }
 
     fn get_last_read_timestamp(&self) -> i64 {
@@ -89,5 +142,81 @@ impl HAClient for AutoSwitchHAClient {
 
     fn get_transferred_byte_in_second(&self) -> i64 {
         HAClient::get_transferred_byte_in_second(&*self.delegate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use cheetah_string::CheetahString;
+    use dashmap::DashMap;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_common::TimeUtils::current_millis;
+
+    use super::*;
+    use crate::config::message_store_config::MessageStoreConfig;
+
+    fn new_test_message_store(root: &Path) -> ArcMut<LocalFileMessageStore> {
+        std::fs::create_dir_all(root).expect("create temp root dir");
+
+        let broker_config = BrokerConfig {
+            enable_controller_mode: true,
+            ..BrokerConfig::default()
+        };
+
+        let message_store_config = MessageStoreConfig {
+            enable_controller_mode: true,
+            store_path_root_dir: root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        };
+
+        let topic_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>> = Arc::new(DashMap::new());
+        let mut store = ArcMut::new(LocalFileMessageStore::new(
+            Arc::new(message_store_config),
+            Arc::new(broker_config),
+            topic_table,
+            None,
+            false,
+        ));
+        let store_clone = store.clone();
+        store.set_message_store_arc(store_clone);
+        store
+    }
+
+    #[tokio::test]
+    async fn auto_switch_client_tracks_reported_broker_id_and_controller_target() {
+        let temp_root =
+            std::env::temp_dir().join(format!("rocketmq-rust-auto-switch-client-target-{}", current_millis()));
+        let store = new_test_message_store(&temp_root);
+        let client = AutoSwitchHAClient::new(store, Some(9)).expect("create auto switch client");
+
+        assert_eq!(client.reported_broker_id(), Some(9));
+
+        client.sync_controller_master_target("127.0.0.1:10912").await;
+
+        assert_eq!(client.get_master_address(), "127.0.0.1:10912");
+        assert_eq!(client.get_ha_master_address(), "127.0.0.1:10912");
+
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn auto_switch_client_clear_controller_target_resets_addresses_but_keeps_broker_identity() {
+        let temp_root =
+            std::env::temp_dir().join(format!("rocketmq-rust-auto-switch-client-clear-{}", current_millis()));
+        let store = new_test_message_store(&temp_root);
+        let client = AutoSwitchHAClient::new(store, Some(11)).expect("create auto switch client");
+
+        client.sync_controller_master_target("127.0.0.1:10912").await;
+        client.clear_controller_master_target().await;
+
+        assert_eq!(client.reported_broker_id(), Some(11));
+        assert_eq!(client.get_master_address(), "");
+        assert_eq!(client.get_ha_master_address(), "");
+
+        let _ = std::fs::remove_dir_all(temp_root);
     }
 }

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -83,16 +83,13 @@ impl AutoSwitchHAService {
     async fn clear_master_target(&self) {
         self.delegate.set_ha_client_reported_broker_id(None);
         if let Some(client) = self.delegate.get_ha_client() {
-            client.close_master().await;
-            client.update_master_address("").await;
-            client.update_ha_master_address("").await;
+            client.clear_controller_master_target().await;
         }
     }
 
     async fn update_master_target(&self, new_master_addr: &str) {
         if let Some(client) = self.delegate.get_ha_client() {
-            client.update_master_address(new_master_addr).await;
-            client.update_ha_master_address(new_master_addr).await;
+            client.sync_controller_master_target(new_master_addr).await;
             client.wakeup().await;
         }
     }

--- a/rocketmq-store/src/ha/general_ha_client.rs
+++ b/rocketmq-store/src/ha/general_ha_client.rs
@@ -40,6 +40,31 @@ impl GeneralHAClient {
             GeneralHAClient::AutoSwitchHaClient(client) => client.set_reported_broker_id(broker_id),
         }
     }
+
+    pub async fn sync_controller_master_target(&self, new_address: &str) {
+        match self {
+            GeneralHAClient::DefaultHaClient(client) => {
+                client.update_master_address(new_address).await;
+                client.update_ha_master_address(new_address).await;
+            }
+            GeneralHAClient::AutoSwitchHaClient(client) => {
+                client.sync_controller_master_target(new_address).await;
+            }
+        }
+    }
+
+    pub async fn clear_controller_master_target(&self) {
+        match self {
+            GeneralHAClient::DefaultHaClient(client) => {
+                client.close_master().await;
+                client.update_master_address("").await;
+                client.update_ha_master_address("").await;
+            }
+            GeneralHAClient::AutoSwitchHaClient(client) => {
+                client.clear_controller_master_target().await;
+            }
+        }
+    }
 }
 
 impl HAClient for GeneralHAClient {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6969

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored broker-to-controller heartbeat mechanism for improved reliability and simplified state management.
  * Streamlined high-availability client master address synchronization logic.
  * Enhanced controller replica synchronization decision-making to better handle topology changes and failover scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->