### PR TITLE
[ISSUE #6977]✨Refactor package publishing scripts to remove retry logic and simplify command execution

### DIFF
--- a/distribution/package_publish_workspace.bat
+++ b/distribution/package_publish_workspace.bat
@@ -9,8 +9,6 @@ set "VERBOSE=0"
 set "ALL_FEATURES=0"
 set "NO_DEFAULT_FEATURES=0"
 set "FEATURES="
-set "RETRY_COUNT=10"
-set "RETRY_DELAY=15"
 set "SUCCESS_COUNT=0"
 set "FAIL_COUNT=0"
 set "SKIP_COUNT=0"
@@ -90,16 +88,6 @@ if /i "%~1"=="--project" (
     shift
 )
 
-if /i "%~1"=="--retry-count" (
-    set "RETRY_COUNT=%~2"
-    shift
-)
-
-if /i "%~1"=="--retry-delay" (
-    set "RETRY_DELAY=%~2"
-    shift
-)
-
 if /i "%~1"=="--help" (
     echo Usage: package_publish_workspace.bat [OPTIONS]
     echo.
@@ -115,8 +103,6 @@ if /i "%~1"=="--help" (
     echo   --all-features
     echo   --no-default-features
     echo   --features "a,b,c"
-    echo   --retry-count N
-    echo   --retry-delay SECONDS
     echo   --help
     echo.
     echo Package aliases:
@@ -158,7 +144,6 @@ if %VERBOSE%==1                echo Mode: VERBOSE
 if %ALL_FEATURES%==1           echo Features: ALL FEATURES
 if %NO_DEFAULT_FEATURES%==1    echo Features: NO DEFAULT FEATURES
 if not "%FEATURES%"==""        echo Features: %FEATURES%
-echo Retries: %RETRY_COUNT% ^(delay: %RETRY_DELAY%s^)
 if not "%SPECIFIC_PROJECT%"=="" echo Target: %SPECIFIC_PROJECT%
 echo =====================================================
 echo.
@@ -259,10 +244,7 @@ exit /b 1
 
 :run_package
 set "P=%~1"
-set /a ATTEMPT=1
-
-:run_package_retry
-echo [!P!] Running cargo package... ^(attempt !ATTEMPT!/!RETRY_COUNT!^)
+echo [!P!] Running cargo package...
 
 set "CMD=cargo package"
 if %ALLOW_DIRTY%==1         set "CMD=!CMD! --allow-dirty"
@@ -272,27 +254,17 @@ if %NO_DEFAULT_FEATURES%==1 set "CMD=!CMD! --no-default-features"
 if not "%FEATURES%"==""     set "CMD=!CMD! --features ""%FEATURES%"""
 
 !CMD!
-if !errorlevel! equ 0 (
-    echo [!P!] Package OK
-    exit /b 0
-)
-
-if !ATTEMPT! geq !RETRY_COUNT! (
+if !errorlevel! neq 0 (
     echo [!P!] ERROR: cargo package failed
     exit /b 1
 )
 
-echo [!P!] WARNING: cargo package failed on attempt !ATTEMPT!/!RETRY_COUNT!. Retrying in !RETRY_DELAY!s...
-timeout /t !RETRY_DELAY! /nobreak >nul
-set /a ATTEMPT+=1
-goto run_package_retry
+echo [!P!] Package OK
+exit /b 0
 
 :run_publish
 set "P=%~1"
-set /a ATTEMPT=1
-
-:run_publish_retry
-echo [!P!] Publishing... ^(attempt !ATTEMPT!/!RETRY_COUNT!^)
+echo [!P!] Publishing...
 
 set "CMD=cargo publish"
 if %ALLOW_DIRTY%==1         set "CMD=!CMD! --allow-dirty"
@@ -302,17 +274,10 @@ if %NO_DEFAULT_FEATURES%==1 set "CMD=!CMD! --no-default-features"
 if not "%FEATURES%"==""     set "CMD=!CMD! --features ""%FEATURES%"""
 
 !CMD!
-if !errorlevel! equ 0 (
-    echo [!P!] Publish OK
-    exit /b 0
-)
-
-if !ATTEMPT! geq !RETRY_COUNT! (
+if !errorlevel! neq 0 (
     echo [!P!] ERROR: cargo publish failed
     exit /b 1
 )
 
-echo [!P!] WARNING: cargo publish failed on attempt !ATTEMPT!/!RETRY_COUNT!. Retrying in !RETRY_DELAY!s...
-timeout /t !RETRY_DELAY! /nobreak >nul
-set /a ATTEMPT+=1
-goto run_publish_retry
+echo [!P!] Publish OK
+exit /b 0

--- a/distribution/package_publish_workspace.sh
+++ b/distribution/package_publish_workspace.sh
@@ -21,8 +21,6 @@ VERBOSE=false
 ALL_FEATURES=false
 NO_DEFAULT_FEATURES=false
 FEATURES=""
-RETRY_COUNT=10
-RETRY_DELAY=15
 
 # Statistics
 SUCCESS_COUNT=0
@@ -113,30 +111,6 @@ matches_project_filter() {
     return 1
 }
 
-run_with_retry() {
-    local project_name="$1"
-    local step_name="$2"
-    shift 2
-
-    local attempt=1
-    local exit_code=0
-
-    while true; do
-        if "$@"; then
-            return 0
-        fi
-
-        exit_code=$?
-        if [ "$attempt" -ge "$RETRY_COUNT" ]; then
-            return "$exit_code"
-        fi
-
-        print_warning "[$project_name] $step_name failed (attempt $attempt/$RETRY_COUNT), retrying in ${RETRY_DELAY}s..."
-        sleep "$RETRY_DELAY"
-        attempt=$((attempt + 1))
-    done
-}
-
 show_usage() {
     cat << EOF
 ========================================
@@ -159,8 +133,6 @@ OPTIONS:
     --all-features         Activate all available features
     --no-default-features  Do not activate default features
     --features FEATURES    Space or comma separated list of features
-    --retry-count N        Retry failed cargo commands up to N times
-    --retry-delay SECONDS  Wait SECONDS between retries
     --help, -h             Show this help message
 
 EXAMPLES:
@@ -187,9 +159,6 @@ EXAMPLES:
 
     8. Skip packaging, only publish:
        ./$(basename "$0") --skip-package
-
-    9. Retry crates.io propagation during release:
-       ./$(basename "$0") --retry-count 20 --retry-delay 15
 
 PUBLISH ORDER:
     rocketmq-error -> rocketmq-macros -> rocketmq-runtime ->
@@ -250,14 +219,6 @@ while [[ $# -gt 0 ]]; do
             FEATURES="$2"
             shift 2
             ;;
-        --retry-count)
-            RETRY_COUNT="$2"
-            shift 2
-            ;;
-        --retry-delay)
-            RETRY_DELAY="$2"
-            shift 2
-            ;;
         --help|-h)
             show_usage
             ;;
@@ -300,7 +261,6 @@ fi
 if [ -n "$FEATURES" ]; then
     print_info "Features: $FEATURES"
 fi
-print_info "Retries: $RETRY_COUNT (delay: ${RETRY_DELAY}s)"
 if [ -n "$SPECIFIC_PROJECT" ]; then
     print_info "Target: $SPECIFIC_PROJECT"
 fi
@@ -351,7 +311,7 @@ for SPEC in "${PROJECT_SPECS[@]}"; do
             PACKAGE_ARGS+=("--features" "$FEATURES")
         fi
 
-        if run_with_retry "$PROJECT_NAME" "cargo package" cargo package "${PACKAGE_ARGS[@]}"; then
+        if cargo package "${PACKAGE_ARGS[@]}"; then
             print_success "[$PROJECT_NAME] Package created successfully"
         else
             print_error "[$PROJECT_NAME] cargo package failed"
@@ -380,7 +340,7 @@ for SPEC in "${PROJECT_SPECS[@]}"; do
             PUBLISH_ARGS+=("--features" "$FEATURES")
         fi
 
-        if run_with_retry "$PROJECT_NAME" "cargo publish" cargo publish "${PUBLISH_ARGS[@]}"; then
+        if cargo publish "${PUBLISH_ARGS[@]}"; then
             print_success "[$PROJECT_NAME] Published successfully"
             SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
         else


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6977

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `--retry-count` and `--retry-delay` command-line options from package publishing scripts. Commands now execute once and immediately fail on errors instead of retrying with configurable delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->