### PR TITLE
[ISSUE #6981]✨Add unit tests for NameServerBootstrap and enhance route info manager methods

### DIFF
--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -778,3 +778,105 @@ impl NameServerRuntimeInner {
             .expect("BrokerHousekeepingService not initialized")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::mix_all::MASTER_ID;
+    use rocketmq_remoting::local::LocalRequestHarness;
+    use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
+
+    use super::*;
+
+    fn build_bootstrap_with_default_v2() -> NameServerBootstrap {
+        let bootstrap = Builder::new().build();
+        assert!(matches!(
+            bootstrap.name_server_runtime.inner.route_info_manager(),
+            RouteInfoManagerWrapper::V2(_)
+        ));
+        bootstrap
+    }
+
+    async fn register_test_broker(
+        bootstrap: &NameServerBootstrap,
+        cluster_name: &CheetahString,
+        broker_name: &CheetahString,
+        broker_addr: &CheetahString,
+        zone_name: &CheetahString,
+        enable_acting_master: bool,
+    ) {
+        let harness = LocalRequestHarness::new().await.unwrap();
+        let result = bootstrap
+            .name_server_runtime
+            .inner
+            .route_info_manager()
+            .register_broker(
+                cluster_name.clone(),
+                broker_addr.clone(),
+                broker_name.clone(),
+                MASTER_ID,
+                CheetahString::from_static_str("10.0.0.1:10912"),
+                Some(zone_name.clone()),
+                Some(30_000),
+                Some(enable_acting_master),
+                TopicConfigAndMappingSerializeWrapper::default(),
+                vec![],
+                harness.channel(),
+            );
+
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn default_v2_system_topic_list_includes_cluster_and_broker_names() {
+        let bootstrap = build_bootstrap_with_default_v2();
+        let cluster_name = CheetahString::from_static_str("cluster-a");
+        let broker_name = CheetahString::from_static_str("broker-a");
+        let broker_addr = CheetahString::from_static_str("10.0.0.1:10911");
+        let zone_name = CheetahString::from_static_str("zone-a");
+
+        register_test_broker(&bootstrap, &cluster_name, &broker_name, &broker_addr, &zone_name, true).await;
+
+        let topic_list = bootstrap
+            .name_server_runtime
+            .inner
+            .route_info_manager()
+            .get_system_topic_list();
+
+        assert!(topic_list.topic_list.contains(&cluster_name));
+        assert!(topic_list.topic_list.contains(&broker_name));
+        assert_eq!(topic_list.broker_addr.as_ref(), Some(&broker_addr));
+    }
+
+    #[tokio::test]
+    async fn default_v2_cluster_info_preserves_zone_and_acting_master_metadata() {
+        let bootstrap = build_bootstrap_with_default_v2();
+        let cluster_name = CheetahString::from_static_str("cluster-a");
+        let broker_name = CheetahString::from_static_str("broker-a");
+        let broker_addr = CheetahString::from_static_str("10.0.0.1:10911");
+        let zone_name = CheetahString::from_static_str("zone-a");
+
+        register_test_broker(&bootstrap, &cluster_name, &broker_name, &broker_addr, &zone_name, true).await;
+
+        let cluster_info = bootstrap
+            .name_server_runtime
+            .inner
+            .route_info_manager()
+            .get_all_cluster_info();
+        let broker_data = cluster_info
+            .broker_addr_table
+            .as_ref()
+            .and_then(|brokers| brokers.get(&broker_name))
+            .expect("registered broker must exist in cluster info");
+        let broker_names = cluster_info
+            .cluster_addr_table
+            .as_ref()
+            .and_then(|clusters| clusters.get(&cluster_name))
+            .expect("registered cluster must exist in cluster info");
+
+        assert!(broker_names.contains(&broker_name));
+        assert_eq!(broker_data.zone_name(), Some(&zone_name));
+        assert!(broker_data.enable_acting_master());
+        assert_eq!(broker_data.broker_addrs().get(&MASTER_ID), Some(&broker_addr));
+    }
+}

--- a/rocketmq-namesrv/src/route/route_info_manager_v2.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_v2.rs
@@ -1751,12 +1751,9 @@ impl RouteInfoManagerV2 {
 
     /// Get all cluster info
     ///
-    /// Rust requires creating copies due to ownership rules and DashMap usage.
+    /// Rust requires creating snapshot copies due to ownership rules and DashMap usage.
     pub fn get_all_cluster_info(&self) -> RouteResult<ClusterInfo> {
-        use std::collections::HashMap;
         use std::collections::HashSet;
-
-        use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
 
         // Get all cluster data first for capacity pre-allocation
         let cluster_data = self.cluster_addr_table.get_all_cluster_brokers();
@@ -1765,7 +1762,7 @@ impl RouteInfoManagerV2 {
         // Pre-allocate with known capacity for better performance
         let mut cluster_addr_table: HashMap<CheetahString, HashSet<CheetahString>> =
             HashMap::with_capacity(cluster_data.len());
-        let mut broker_addr_table: HashMap<CheetahString, BrokerData> = HashMap::with_capacity(broker_data_list.len());
+        let mut broker_addr_table = HashMap::with_capacity(broker_data_list.len());
 
         // Populate cluster_addr_table
         for (cluster_name, broker_names) in cluster_data {
@@ -1774,17 +1771,7 @@ impl RouteInfoManagerV2 {
 
         // Populate broker_addr_table
         for (broker_name, broker_data) in broker_data_list {
-            let data = BrokerData::new(
-                CheetahString::from_slice(broker_data.cluster()),
-                broker_name.clone(),
-                broker_data
-                    .broker_addrs()
-                    .iter()
-                    .map(|(id, addr)| (*id, addr.clone()))
-                    .collect(),
-                None,
-            );
-            broker_addr_table.insert(broker_name, data);
+            broker_addr_table.insert(broker_name, broker_data.as_ref().clone());
         }
 
         Ok(ClusterInfo {
@@ -1865,20 +1852,30 @@ impl RouteInfoManagerV2 {
     }
 
     /// Get system topic list (v1 compatibility)
+    ///
+    /// Java NameServer exposes cluster names and broker names here rather than
+    /// filtering the topic table by built-in system topics.
     pub fn get_system_topic_list(&self) -> RouteResult<TopicList> {
-        use rocketmq_common::common::topic::TopicValidator;
+        let cluster_data = self.cluster_addr_table.get_all_cluster_brokers();
+        let broker_data_list = self.broker_addr_table.get_all_brokers();
+        let mut topic_list = Vec::new();
+        let mut broker_addr = None;
 
-        let system_topic_set = TopicValidator::get_system_topic_set();
-        let topics: Vec<CheetahString> = self
-            .topic_queue_table
-            .get_all_topics()
-            .into_iter()
-            .filter(|topic| system_topic_set.iter().any(|s| s == topic.as_str()))
-            .collect();
+        for (cluster_name, broker_names) in cluster_data {
+            topic_list.push(cluster_name);
+            topic_list.extend(broker_names);
+        }
+
+        for (_broker_name, broker_data) in broker_data_list {
+            if let Some(addr) = broker_data.broker_addrs().values().next() {
+                broker_addr = Some(addr.clone());
+                break;
+            }
+        }
 
         Ok(TopicList {
-            topic_list: topics,
-            broker_addr: None,
+            topic_list,
+            broker_addr,
         })
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6981

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive tests for NameServer broker registration and cluster metadata handling, verifying proper broker registration, cluster information retrieval, and broker address mapping.

* **Improvements**
  * Streamlined system topic list and cluster information retrieval by optimizing data construction and retrieval mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->