### PR TITLE
[ISSUE #6985]✨Enhance broker management by adding channel lifecycle handling and improving unregister logic in route info manager

### DIFF
--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -804,14 +804,18 @@ impl NameServerRuntimeInner {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use cheetah_string::CheetahString;
     use rocketmq_common::common::config::TopicConfig;
     use rocketmq_common::common::constant::PermName;
     use rocketmq_common::common::mix_all::MASTER_ID;
     use rocketmq_common::common::namesrv::namesrv_config::NamesrvConfig;
     use rocketmq_common::common::TopicSysFlag;
+    use rocketmq_remoting::connection::ConnectionState;
     use rocketmq_remoting::local::LocalRequestHarness;
     use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
+    use tokio::time::sleep;
 
     use super::*;
 
@@ -840,7 +844,29 @@ mod tests {
         wrapper
     }
 
-    async fn register_test_broker(
+    fn start_unregister_service(bootstrap: &NameServerBootstrap) {
+        bootstrap.name_server_runtime.inner.route_info_manager().start();
+    }
+
+    fn shutdown_unregister_service(bootstrap: &NameServerBootstrap) {
+        bootstrap.name_server_runtime.inner.route_info_manager().shutdown();
+    }
+
+    async fn wait_until<F>(description: &str, mut condition: F)
+    where
+        F: FnMut() -> bool,
+    {
+        for _ in 0..100 {
+            if condition() {
+                return;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        panic!("timed out waiting for {description}");
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn register_test_broker_with_harness(
         bootstrap: &NameServerBootstrap,
         cluster_name: &CheetahString,
         broker_name: &CheetahString,
@@ -849,8 +875,10 @@ mod tests {
         zone_name: &CheetahString,
         enable_acting_master: bool,
         topic_config_wrapper: TopicConfigAndMappingSerializeWrapper,
+        filter_server_list: Vec<CheetahString>,
+        timeout_millis: Option<i64>,
+        harness: &LocalRequestHarness,
     ) {
-        let harness = LocalRequestHarness::new().await.unwrap();
         let result = bootstrap
             .name_server_runtime
             .inner
@@ -862,14 +890,41 @@ mod tests {
                 broker_id,
                 CheetahString::from_static_str("10.0.0.1:10912"),
                 Some(zone_name.clone()),
-                Some(30_000),
+                timeout_millis,
                 Some(enable_acting_master),
                 topic_config_wrapper,
-                vec![],
+                filter_server_list,
                 harness.channel(),
             );
 
         assert!(result.is_some());
+    }
+
+    async fn register_test_broker(
+        bootstrap: &NameServerBootstrap,
+        cluster_name: &CheetahString,
+        broker_name: &CheetahString,
+        broker_addr: &CheetahString,
+        broker_id: u64,
+        zone_name: &CheetahString,
+        enable_acting_master: bool,
+        topic_config_wrapper: TopicConfigAndMappingSerializeWrapper,
+    ) {
+        let harness = LocalRequestHarness::new().await.unwrap();
+        register_test_broker_with_harness(
+            bootstrap,
+            cluster_name,
+            broker_name,
+            broker_addr,
+            broker_id,
+            zone_name,
+            enable_acting_master,
+            topic_config_wrapper,
+            vec![],
+            Some(30_000),
+            &harness,
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1119,6 +1174,463 @@ mod tests {
         assert!(!PermName::is_writeable(queue_data.perm()));
         assert_eq!(broker_data.broker_addrs().get(&MASTER_ID), Some(&broker_addr));
         assert!(!broker_data.broker_addrs().contains_key(&1));
+    }
+
+    #[tokio::test]
+    async fn default_v2_scan_not_active_broker_cleans_route_views_via_batch_unregister() {
+        let mut bootstrap = build_bootstrap_with_default_v2();
+        let cluster_name = CheetahString::from_static_str("cluster-a");
+        let broker_name = CheetahString::from_static_str("broker-a");
+        let broker_addr = CheetahString::from_static_str("10.0.0.1:10911");
+        let zone_name = CheetahString::from_static_str("zone-a");
+        let topic_name = CheetahString::from_static_str("scan-cleanup-topic");
+        let harness = LocalRequestHarness::new().await.unwrap();
+
+        start_unregister_service(&bootstrap);
+        register_test_broker_with_harness(
+            &bootstrap,
+            &cluster_name,
+            &broker_name,
+            &broker_addr,
+            MASTER_ID,
+            &zone_name,
+            false,
+            topic_config_wrapper(&[("scan-cleanup-topic", 0, PermName::PERM_READ | PermName::PERM_WRITE)]),
+            vec![CheetahString::from_static_str("fs-a")],
+            Some(10),
+            &harness,
+        )
+        .await;
+
+        sleep(Duration::from_millis(30)).await;
+
+        let expired_count = bootstrap
+            .name_server_runtime
+            .inner
+            .route_info_manager_mut()
+            .scan_not_active_broker();
+        assert_eq!(expired_count, 1);
+
+        wait_until("expired broker cleanup", || {
+            let route_manager = bootstrap.name_server_runtime.inner.route_info_manager();
+            let cluster_info = route_manager.get_all_cluster_info();
+
+            route_manager.pickup_topic_route_data(&topic_name).is_none()
+                && route_manager
+                    .query_broker_topic_config(cluster_name.clone(), broker_addr.clone())
+                    .is_none()
+                && cluster_info
+                    .cluster_addr_table
+                    .as_ref()
+                    .is_none_or(|clusters| !clusters.contains_key(&cluster_name))
+                && cluster_info
+                    .broker_addr_table
+                    .as_ref()
+                    .is_none_or(|brokers| !brokers.contains_key(&broker_name))
+                && route_manager.get_topics_by_cluster(&cluster_name).topic_list.is_empty()
+        })
+        .await;
+
+        shutdown_unregister_service(&bootstrap);
+    }
+
+    #[tokio::test]
+    async fn default_v2_scan_not_active_broker_closes_expired_connection_before_batch_unregister() {
+        let mut bootstrap = build_bootstrap_with_default_v2();
+        let cluster_name = CheetahString::from_static_str("cluster-a");
+        let broker_name = CheetahString::from_static_str("broker-a");
+        let broker_addr = CheetahString::from_static_str("10.0.0.1:10911");
+        let zone_name = CheetahString::from_static_str("zone-a");
+        let harness = LocalRequestHarness::new().await.unwrap();
+
+        start_unregister_service(&bootstrap);
+        register_test_broker_with_harness(
+            &bootstrap,
+            &cluster_name,
+            &broker_name,
+            &broker_addr,
+            MASTER_ID,
+            &zone_name,
+            false,
+            topic_config_wrapper(&[("scan-close-topic", 0, PermName::PERM_READ | PermName::PERM_WRITE)]),
+            vec![],
+            Some(10),
+            &harness,
+        )
+        .await;
+
+        assert_eq!(harness.channel().connection_ref().state(), ConnectionState::Healthy);
+
+        sleep(Duration::from_millis(30)).await;
+
+        let expired_count = bootstrap
+            .name_server_runtime
+            .inner
+            .route_info_manager_mut()
+            .scan_not_active_broker();
+        assert_eq!(expired_count, 1);
+
+        wait_until("expired broker connection close", || {
+            harness.channel().connection_ref().state() == ConnectionState::Closed
+        })
+        .await;
+
+        shutdown_unregister_service(&bootstrap);
+    }
+
+    #[tokio::test]
+    async fn default_v2_connection_disconnected_by_socket_addr_matches_channel_destroy_cleanup() {
+        let mut bootstrap = build_bootstrap_with_default_v2();
+        let cluster_name = CheetahString::from_static_str("cluster-a");
+        let broker_name = CheetahString::from_static_str("broker-a");
+        let broker_addr = CheetahString::from_static_str("10.0.0.1:10911");
+        let zone_name = CheetahString::from_static_str("zone-a");
+        let topic_name = CheetahString::from_static_str("socket-disconnect-topic");
+        let harness = LocalRequestHarness::new().await.unwrap();
+
+        start_unregister_service(&bootstrap);
+        register_test_broker_with_harness(
+            &bootstrap,
+            &cluster_name,
+            &broker_name,
+            &broker_addr,
+            MASTER_ID,
+            &zone_name,
+            false,
+            topic_config_wrapper(&[("socket-disconnect-topic", 0, PermName::PERM_READ | PermName::PERM_WRITE)]),
+            vec![CheetahString::from_static_str("fs-a")],
+            Some(30_000),
+            &harness,
+        )
+        .await;
+
+        bootstrap
+            .name_server_runtime
+            .inner
+            .route_info_manager_mut()
+            .connection_disconnected(harness.remote_address());
+
+        wait_until("socket disconnect cleanup", || {
+            let route_manager = bootstrap.name_server_runtime.inner.route_info_manager();
+            let cluster_info = route_manager.get_all_cluster_info();
+
+            harness.channel().connection_ref().state() == ConnectionState::Closed
+                && route_manager.pickup_topic_route_data(&topic_name).is_none()
+                && route_manager
+                    .query_broker_topic_config(cluster_name.clone(), broker_addr.clone())
+                    .is_none()
+                && cluster_info
+                    .cluster_addr_table
+                    .as_ref()
+                    .is_none_or(|clusters| !clusters.contains_key(&cluster_name))
+                && cluster_info
+                    .broker_addr_table
+                    .as_ref()
+                    .is_none_or(|brokers| !brokers.contains_key(&broker_name))
+        })
+        .await;
+
+        shutdown_unregister_service(&bootstrap);
+    }
+
+    #[tokio::test]
+    async fn default_v2_duplicate_channel_destroy_submission_is_idempotent_for_acting_master_cleanup() {
+        let namesrv_config = NamesrvConfig {
+            support_acting_master: true,
+            ..NamesrvConfig::default()
+        };
+        let bootstrap = build_bootstrap_with_v2_config(namesrv_config);
+        let cluster_name = CheetahString::from_static_str("cluster-a");
+        let broker_name = CheetahString::from_static_str("broker-a");
+        let master_addr = CheetahString::from_static_str("10.0.0.1:10911");
+        let slave_addr = CheetahString::from_static_str("10.0.0.2:10911");
+        let zone_name = CheetahString::from_static_str("zone-a");
+        let topic_name = CheetahString::from_static_str("duplicate-unregister-topic");
+        let master_harness = LocalRequestHarness::new().await.unwrap();
+        let slave_harness = LocalRequestHarness::new().await.unwrap();
+
+        register_test_broker_with_harness(
+            &bootstrap,
+            &cluster_name,
+            &broker_name,
+            &master_addr,
+            MASTER_ID,
+            &zone_name,
+            true,
+            topic_config_wrapper(&[(
+                "duplicate-unregister-topic",
+                0,
+                PermName::PERM_READ | PermName::PERM_WRITE,
+            )]),
+            vec![],
+            Some(30_000),
+            &master_harness,
+        )
+        .await;
+        register_test_broker_with_harness(
+            &bootstrap,
+            &cluster_name,
+            &broker_name,
+            &slave_addr,
+            1,
+            &zone_name,
+            true,
+            TopicConfigAndMappingSerializeWrapper::default(),
+            vec![],
+            Some(30_000),
+            &slave_harness,
+        )
+        .await;
+
+        let master_channel = master_harness.channel();
+        bootstrap
+            .name_server_runtime
+            .inner
+            .route_info_manager()
+            .on_channel_destroy(&master_channel);
+        bootstrap
+            .name_server_runtime
+            .inner
+            .route_info_manager()
+            .on_channel_destroy(&master_channel);
+
+        start_unregister_service(&bootstrap);
+
+        wait_until("duplicate unregister cleanup", || {
+            let route_manager = bootstrap.name_server_runtime.inner.route_info_manager();
+            let cluster_info = route_manager.get_all_cluster_info();
+            let Some(route_data) = route_manager.pickup_topic_route_data(&topic_name) else {
+                return false;
+            };
+            let Some(route_broker_data) = route_data
+                .broker_datas
+                .iter()
+                .find(|broker_data| broker_data.broker_name() == &broker_name)
+            else {
+                return false;
+            };
+            let Some(route_queue_data) = route_data
+                .queue_datas
+                .iter()
+                .find(|queue_data| queue_data.broker_name() == &broker_name)
+            else {
+                return false;
+            };
+            let Some(cluster_broker_data) = cluster_info
+                .broker_addr_table
+                .as_ref()
+                .and_then(|brokers| brokers.get(&broker_name))
+            else {
+                return false;
+            };
+
+            route_manager
+                .query_broker_topic_config(cluster_name.clone(), master_addr.clone())
+                .is_none()
+                && route_manager
+                    .query_broker_topic_config(cluster_name.clone(), slave_addr.clone())
+                    .is_some()
+                && !PermName::is_writeable(route_queue_data.perm())
+                && route_broker_data.broker_addrs().get(&MASTER_ID) == Some(&slave_addr)
+                && !route_broker_data.broker_addrs().contains_key(&1)
+                && cluster_broker_data.broker_addrs().get(&1) == Some(&slave_addr)
+                && !cluster_broker_data.broker_addrs().contains_key(&MASTER_ID)
+        })
+        .await;
+
+        shutdown_unregister_service(&bootstrap);
+    }
+
+    #[tokio::test]
+    async fn default_v2_on_channel_destroy_cleans_removed_broker_and_preserves_survivor() {
+        let bootstrap = build_bootstrap_with_default_v2();
+        let cluster_name = CheetahString::from_static_str("cluster-a");
+        let removed_broker_name = CheetahString::from_static_str("broker-a");
+        let surviving_broker_name = CheetahString::from_static_str("broker-b");
+        let removed_broker_addr = CheetahString::from_static_str("10.0.0.1:10911");
+        let surviving_broker_addr = CheetahString::from_static_str("10.0.0.2:10911");
+        let zone_name = CheetahString::from_static_str("zone-a");
+        let topic_name = CheetahString::from_static_str("channel-destroy-topic");
+        let removed_harness = LocalRequestHarness::new().await.unwrap();
+        let surviving_harness = LocalRequestHarness::new().await.unwrap();
+
+        start_unregister_service(&bootstrap);
+        register_test_broker_with_harness(
+            &bootstrap,
+            &cluster_name,
+            &removed_broker_name,
+            &removed_broker_addr,
+            MASTER_ID,
+            &zone_name,
+            false,
+            topic_config_wrapper(&[("channel-destroy-topic", 0, PermName::PERM_READ | PermName::PERM_WRITE)]),
+            vec![CheetahString::from_static_str("fs-a")],
+            Some(30_000),
+            &removed_harness,
+        )
+        .await;
+        register_test_broker_with_harness(
+            &bootstrap,
+            &cluster_name,
+            &surviving_broker_name,
+            &surviving_broker_addr,
+            MASTER_ID,
+            &zone_name,
+            false,
+            topic_config_wrapper(&[("channel-destroy-topic", 0, PermName::PERM_READ | PermName::PERM_WRITE)]),
+            vec![CheetahString::from_static_str("fs-b")],
+            Some(30_000),
+            &surviving_harness,
+        )
+        .await;
+
+        let removed_channel = removed_harness.channel();
+        bootstrap
+            .name_server_runtime
+            .inner
+            .route_info_manager()
+            .on_channel_destroy(&removed_channel);
+
+        wait_until("channel destroy cleanup", || {
+            let route_manager = bootstrap.name_server_runtime.inner.route_info_manager();
+            let cluster_info = route_manager.get_all_cluster_info();
+            let Some(route_data) = route_manager.pickup_topic_route_data(&topic_name) else {
+                return false;
+            };
+
+            route_manager
+                .query_broker_topic_config(cluster_name.clone(), removed_broker_addr.clone())
+                .is_none()
+                && route_manager
+                    .query_broker_topic_config(cluster_name.clone(), surviving_broker_addr.clone())
+                    .is_some()
+                && route_data
+                    .broker_datas
+                    .iter()
+                    .all(|broker_data| broker_data.broker_name() != &removed_broker_name)
+                && route_data
+                    .broker_datas
+                    .iter()
+                    .any(|broker_data| broker_data.broker_name() == &surviving_broker_name)
+                && !route_data.filter_server_table.contains_key(&removed_broker_addr)
+                && route_data
+                    .filter_server_table
+                    .get(&surviving_broker_addr)
+                    .is_some_and(|servers| servers.len() == 1 && servers[0] == CheetahString::from_static_str("fs-b"))
+                && cluster_info
+                    .cluster_addr_table
+                    .as_ref()
+                    .and_then(|clusters| clusters.get(&cluster_name))
+                    .is_some_and(|brokers| brokers.len() == 1 && brokers.contains(&surviving_broker_name))
+                && cluster_info.broker_addr_table.as_ref().is_some_and(|brokers| {
+                    !brokers.contains_key(&removed_broker_name) && brokers.contains_key(&surviving_broker_name)
+                })
+        })
+        .await;
+
+        shutdown_unregister_service(&bootstrap);
+    }
+
+    #[tokio::test]
+    async fn default_v2_on_channel_destroy_reduces_to_read_only_acting_master() {
+        let namesrv_config = NamesrvConfig {
+            support_acting_master: true,
+            ..NamesrvConfig::default()
+        };
+        let bootstrap = build_bootstrap_with_v2_config(namesrv_config);
+        let cluster_name = CheetahString::from_static_str("cluster-a");
+        let broker_name = CheetahString::from_static_str("broker-a");
+        let master_addr = CheetahString::from_static_str("10.0.0.1:10911");
+        let slave_addr = CheetahString::from_static_str("10.0.0.2:10911");
+        let zone_name = CheetahString::from_static_str("zone-a");
+        let topic_name = CheetahString::from_static_str("acting-master-cleanup-topic");
+        let master_harness = LocalRequestHarness::new().await.unwrap();
+        let slave_harness = LocalRequestHarness::new().await.unwrap();
+
+        start_unregister_service(&bootstrap);
+        register_test_broker_with_harness(
+            &bootstrap,
+            &cluster_name,
+            &broker_name,
+            &master_addr,
+            MASTER_ID,
+            &zone_name,
+            true,
+            topic_config_wrapper(&[(
+                "acting-master-cleanup-topic",
+                0,
+                PermName::PERM_READ | PermName::PERM_WRITE,
+            )]),
+            vec![],
+            Some(30_000),
+            &master_harness,
+        )
+        .await;
+        register_test_broker_with_harness(
+            &bootstrap,
+            &cluster_name,
+            &broker_name,
+            &slave_addr,
+            1,
+            &zone_name,
+            true,
+            TopicConfigAndMappingSerializeWrapper::default(),
+            vec![],
+            Some(30_000),
+            &slave_harness,
+        )
+        .await;
+
+        let master_channel = master_harness.channel();
+        bootstrap
+            .name_server_runtime
+            .inner
+            .route_info_manager()
+            .on_channel_destroy(&master_channel);
+
+        wait_until("acting master cleanup", || {
+            let route_manager = bootstrap.name_server_runtime.inner.route_info_manager();
+            let cluster_info = route_manager.get_all_cluster_info();
+            let Some(route_data) = route_manager.pickup_topic_route_data(&topic_name) else {
+                return false;
+            };
+            let Some(route_broker_data) = route_data
+                .broker_datas
+                .iter()
+                .find(|broker_data| broker_data.broker_name() == &broker_name)
+            else {
+                return false;
+            };
+            let Some(route_queue_data) = route_data
+                .queue_datas
+                .iter()
+                .find(|queue_data| queue_data.broker_name() == &broker_name)
+            else {
+                return false;
+            };
+            let Some(cluster_broker_data) = cluster_info
+                .broker_addr_table
+                .as_ref()
+                .and_then(|brokers| brokers.get(&broker_name))
+            else {
+                return false;
+            };
+
+            route_manager
+                .query_broker_topic_config(cluster_name.clone(), master_addr.clone())
+                .is_none()
+                && route_manager
+                    .query_broker_topic_config(cluster_name.clone(), slave_addr.clone())
+                    .is_some()
+                && !PermName::is_writeable(route_queue_data.perm())
+                && route_broker_data.broker_addrs().get(&MASTER_ID) == Some(&slave_addr)
+                && !route_broker_data.broker_addrs().contains_key(&1)
+                && cluster_broker_data.broker_addrs().get(&1) == Some(&slave_addr)
+                && !cluster_broker_data.broker_addrs().contains_key(&MASTER_ID)
+        })
+        .await;
+
+        shutdown_unregister_service(&bootstrap);
     }
 
     #[tokio::test]

--- a/rocketmq-namesrv/src/route/route_info_manager_v2.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_v2.rs
@@ -19,6 +19,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
@@ -150,13 +151,21 @@ impl RouteInfoManagerV2 {
         self.un_register_service.mut_from_ref().start();
     }
 
-    /// Find broker info by socket address
+    /// Find broker info by channel identity
     #[inline]
-    fn find_broker_by_socket_addr(
-        broker_live_table: &BrokerLiveTable,
-        channel: &Channel,
-    ) -> Option<Arc<BrokerAddrInfo>> {
+    fn find_broker_by_channel(broker_live_table: &BrokerLiveTable, channel: &Channel) -> Option<Arc<BrokerAddrInfo>> {
         broker_live_table.get_broker_info_by_channel(channel)
+    }
+
+    /// Find broker info and live state by remote socket address.
+    fn find_broker_by_remote_addr(
+        broker_live_table: &BrokerLiveTable,
+        socket_addr: SocketAddr,
+    ) -> Option<(Arc<BrokerAddrInfo>, Arc<BrokerLiveInfo>)> {
+        broker_live_table
+            .get_all()
+            .into_iter()
+            .find(|(_, live_info)| live_info.remote_addr == socket_addr)
     }
 
     /// Find broker name by broker address
@@ -202,7 +211,7 @@ impl RouteInfoManagerV2 {
         let mut need_unregister = false;
 
         // Find broker by socket address and setup unregister request
-        if let Some(broker_addr_info) = Self::find_broker_by_socket_addr(&self.broker_live_table, channel) {
+        if let Some(broker_addr_info) = Self::find_broker_by_channel(&self.broker_live_table, channel) {
             need_unregister = self.setup_unregister_request(&mut unregister_request, &broker_addr_info);
         }
 
@@ -216,10 +225,24 @@ impl RouteInfoManagerV2 {
         }
     }
 
+    /// Handle broker disconnection when only the remote socket address is available.
+    pub fn connection_disconnected(&self, socket_addr: SocketAddr) {
+        if let Some((broker_addr_info, live_info)) =
+            Self::find_broker_by_remote_addr(&self.broker_live_table, socket_addr)
+        {
+            if let Some(channel) = live_info.channel.as_ref() {
+                channel.connection_ref().close();
+                self.on_channel_destroy(channel);
+            } else {
+                self.on_channel_destroy_by_addr_info(broker_addr_info);
+            }
+        }
+    }
+
     /// Shutdown the route manager
     pub fn shutdown(&self) {
         info!("Shutting down RouteInfoManager v2");
-        // Cleanup if needed
+        self.un_register_service.shutdown();
     }
 }
 
@@ -721,6 +744,7 @@ impl RouteInfoManagerV2 {
             channel.remote_address(),
             channel.channel_id_owned(),
         )
+        .with_channel(channel.clone())
         .with_timeout(timeout)
         .with_ha_server(ha_server_addr);
 
@@ -1561,12 +1585,17 @@ impl RouteInfoManagerV2 {
         if count > 0 {
             // Submit unregistration requests for each expired broker
             for broker_addr_info in expired_brokers {
-                // Get the live info to retrieve timeout value for logging
                 if let Some(live_info) = self.broker_live_table.get(&broker_addr_info) {
                     warn!(
                         "The broker channel expired, {} {}ms",
                         broker_addr_info, live_info.heartbeat_timeout_millis
                     );
+
+                    if let Some(channel) = live_info.channel.as_ref() {
+                        channel.connection_ref().close();
+                        self.on_channel_destroy(channel);
+                        continue;
+                    }
                 }
 
                 // Trigger channel destroy logic, which will submit to batch unregistration service

--- a/rocketmq-namesrv/src/route/route_info_manager_wrapper.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_wrapper.rs
@@ -106,10 +106,8 @@ impl RouteInfoManagerWrapper {
     pub fn connection_disconnected(&mut self, socket_addr: SocketAddr) {
         match self {
             RouteInfoManagerWrapper::V1(manager) => manager.connection_disconnected(socket_addr),
-            RouteInfoManagerWrapper::V2(_manager) => {
-                // V2 doesn't support socket_addr directly, needs channel
-                // This method is kept for v1 compatibility
-                // V2 should use on_channel_destroy instead
+            RouteInfoManagerWrapper::V2(manager) => {
+                manager.connection_disconnected(socket_addr);
             }
         }
     }

--- a/rocketmq-namesrv/src/route/tables/live_table.rs
+++ b/rocketmq-namesrv/src/route/tables/live_table.rs
@@ -47,6 +47,9 @@ pub struct BrokerLiveInfo {
 
     /// Channel ID for the broker connection
     pub channel_id: ChannelId,
+
+    /// Channel handle retained for lifecycle operations such as explicit close
+    pub channel: Option<Channel>,
 }
 
 impl BrokerLiveInfo {
@@ -63,6 +66,7 @@ impl BrokerLiveInfo {
             ha_server_addr: None,
             remote_addr,
             channel_id,
+            channel: None,
         }
     }
 
@@ -75,6 +79,12 @@ impl BrokerLiveInfo {
     /// Set custom heartbeat timeout
     pub fn with_timeout(mut self, timeout_millis: u64) -> Self {
         self.heartbeat_timeout_millis = timeout_millis;
+        self
+    }
+
+    /// Attach the current broker channel so lifecycle cleanup can explicitly close it.
+    pub fn with_channel(mut self, channel: Channel) -> Self {
+        self.channel = Some(channel);
         self
     }
 
@@ -352,7 +362,10 @@ impl BrokerLiveTable {
             if key_addr == broker_addr {
                 // Create new BrokerLiveInfo with updated timestamp
                 let old_info = entry.value();
-                let new_info = BrokerLiveInfo::new(timestamp, old_info.data_version.clone(), remote_addr, channel_id);
+                let mut new_info =
+                    BrokerLiveInfo::new(timestamp, old_info.data_version.clone(), remote_addr, channel_id);
+                new_info.ha_server_addr = old_info.ha_server_addr.clone();
+                new_info.channel = old_info.channel.clone();
 
                 *entry.value_mut() = Arc::new(new_info);
                 return;
@@ -377,6 +390,7 @@ impl BrokerLiveTable {
                 ha_server_addr: old_info.ha_server_addr.clone(),
                 remote_addr: old_info.remote_addr,
                 channel_id: old_info.channel_id.clone(),
+                channel: old_info.channel.clone(),
             };
             *entry.value_mut() = Arc::new(new_info);
         }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6985

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker connection cleanup and lifecycle management during disconnections and inactivity scanning.
  * Enhanced graceful shutdown procedures for broker name server services.

* **Refactor**
  * Optimized broker state tracking and connection handling mechanisms for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->