### PR TITLE
[ISSUE #6991]♻️Refactor topic management in RouteInfoManager to optimize broker topic retrieval and cleanup logic

### DIFF
--- a/rocketmq-namesrv/src/route/route_info_manager_v2.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_v2.rs
@@ -176,9 +176,8 @@ impl RouteInfoManagerV2 {
         broker_addr_table.remove(broker_name);
         cluster_addr_table.remove_broker(cluster_name, broker_name);
 
-        // Remove broker from all topics
-        let all_topics = topic_queue_table.get_all_topics();
-        for topic in all_topics {
+        // Remove broker from topics that actually contain it
+        for topic in topic_queue_table.topics_for_broker(broker_name) {
             topic_queue_table.remove_broker(topic.as_ref(), broker_name);
         }
 
@@ -763,18 +762,10 @@ impl RouteInfoManagerV2 {
 
     /// Get all topics registered by a specific broker
     fn topic_set_of_broker_name(&self, broker_name: &str) -> std::collections::HashSet<CheetahString> {
-        use std::collections::HashSet;
-
-        let mut topic_set = HashSet::new();
-        for (topic, queues) in self.topic_queue_table.iter_all_with_data() {
-            for queue_data in queues.iter() {
-                if queue_data.broker_name() == broker_name {
-                    topic_set.insert(CheetahString::from_string(topic));
-                    break;
-                }
-            }
-        }
-        topic_set
+        self.topic_queue_table
+            .topics_for_broker(broker_name)
+            .into_iter()
+            .collect()
     }
 
     /// Notify when minimum broker ID has changed (for master election)
@@ -1102,10 +1093,7 @@ impl RouteInfoManagerV2 {
 
     /// Clean up topics associated with a removed broker
     fn cleanup_topics_for_broker(&self, broker_name: &str) -> RouteResult<()> {
-        // Get all topics
-        let all_topics = self.topic_queue_table.get_all_topics();
-
-        for topic in all_topics {
+        for topic in self.topic_queue_table.topics_for_broker(broker_name) {
             // Remove broker from topic
             self.topic_queue_table.remove_broker(topic.as_ref(), broker_name);
         }
@@ -1521,22 +1509,8 @@ impl RouteInfoManagerV2 {
             return Err(RocketMQError::cluster_not_found(cluster_name));
         }
 
-        let all_topics = self.topic_queue_table.get_all_topics();
-        let mut cluster_topics = Vec::new();
-
-        for broker_name in broker_names {
-            for topic in &all_topics {
-                if self
-                    .topic_queue_table
-                    .get(topic.as_str(), broker_name.as_str())
-                    .is_some()
-                {
-                    cluster_topics.push(topic.clone());
-                }
-            }
-        }
-
-        Ok(cluster_topics)
+        let broker_names = broker_names.into_iter().collect::<HashSet<_>>();
+        Ok(self.topic_queue_table.topics_for_brokers_with_duplicates(&broker_names))
     }
 }
 
@@ -1780,10 +1754,8 @@ impl RouteInfoManagerV2 {
 
         let mut wipe_topic_count = 0;
 
-        // Iterate over all topics and directly look up the broker
-        for topic in self.topic_queue_table.get_all_topics() {
+        for topic in self.topic_queue_table.topics_for_broker(&broker_name) {
             if let Some(queue_data) = self.topic_queue_table.get(&topic, &broker_name) {
-                // Remove write permission
                 let perm = queue_data.perm() & !PermName::PERM_WRITE;
                 self.topic_queue_table
                     .update_queue_data_perm(&topic, &broker_name, perm as i32);
@@ -1816,14 +1788,11 @@ impl RouteInfoManagerV2 {
 
         let mut add_topic_count = 0;
 
-        // Iterate over all topics and directly look up the broker
-        for topic in self.topic_queue_table.get_all_topics() {
-            if let Some(_queue_data) = self.topic_queue_table.get(&topic, &broker_name) {
-                let perm = PermName::PERM_READ | PermName::PERM_WRITE;
-                self.topic_queue_table
-                    .update_queue_data_perm(&topic, &broker_name, perm as i32);
-                add_topic_count += 1;
-            }
+        for topic in self.topic_queue_table.topics_for_broker(&broker_name) {
+            let perm = PermName::PERM_READ | PermName::PERM_WRITE;
+            self.topic_queue_table
+                .update_queue_data_perm(&topic, &broker_name, perm as i32);
+            add_topic_count += 1;
         }
 
         Ok(add_topic_count)

--- a/rocketmq-namesrv/src/route/tables/topic_table.rs
+++ b/rocketmq-namesrv/src/route/tables/topic_table.rs
@@ -16,6 +16,7 @@
 //!
 //! Manages topic -> broker -> queue data mappings using nested DashMap.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -277,6 +278,37 @@ impl TopicQueueTable {
             })
             .collect()
     }
+
+    /// Collect all topics that contain queue data for a specific broker.
+    pub fn topics_for_broker(&self, broker_name: &str) -> Vec<TopicName> {
+        self.inner
+            .iter()
+            .filter(|entry| entry.value().contains_key(broker_name))
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    /// Collect topics for a broker set, preserving duplicate hits per matching broker.
+    ///
+    /// This matches Java NameServer semantics for `getTopicsByCluster`, where the same
+    /// topic can appear multiple times if multiple brokers in the cluster host it.
+    pub fn topics_for_brokers_with_duplicates(&self, broker_names: &HashSet<BrokerName>) -> Vec<TopicName> {
+        let mut topics = Vec::new();
+
+        for entry in self.inner.iter() {
+            let match_count = entry
+                .value()
+                .iter()
+                .filter(|broker_entry| broker_names.contains(broker_entry.key()))
+                .count();
+
+            for _ in 0..match_count {
+                topics.push(entry.key().clone());
+            }
+        }
+
+        topics
+    }
 }
 
 impl Default for TopicQueueTable {
@@ -287,6 +319,8 @@ impl Default for TopicQueueTable {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use cheetah_string::CheetahString;
     use rocketmq_common::common::TopicSysFlag;
 
@@ -396,6 +430,65 @@ mod tests {
             table.filter_topics_by_first_queue(|queue_data| TopicSysFlag::has_unit_flag(queue_data.topic_sys_flag()));
 
         assert_eq!(topics, vec![CheetahString::from_static_str("unit-topic")]);
+    }
+
+    #[test]
+    fn test_topics_for_broker_returns_matching_topics() {
+        let table = TopicQueueTable::new();
+
+        table.insert(
+            CheetahString::from_static_str("topic-a"),
+            CheetahString::from_static_str("broker-a"),
+            create_test_queue_data(8, 8),
+        );
+        table.insert(
+            CheetahString::from_static_str("topic-b"),
+            CheetahString::from_static_str("broker-b"),
+            create_test_queue_data(8, 8),
+        );
+        table.insert(
+            CheetahString::from_static_str("topic-c"),
+            CheetahString::from_static_str("broker-a"),
+            create_test_queue_data(8, 8),
+        );
+
+        let topics = table.topics_for_broker("broker-a");
+
+        assert_eq!(topics.len(), 2);
+        assert!(topics.contains(&CheetahString::from_static_str("topic-a")));
+        assert!(topics.contains(&CheetahString::from_static_str("topic-c")));
+    }
+
+    #[test]
+    fn test_topics_for_brokers_with_duplicates_preserves_match_count() {
+        let table = TopicQueueTable::new();
+        let broker_a = CheetahString::from_static_str("broker-a");
+        let broker_b = CheetahString::from_static_str("broker-b");
+
+        table.insert(
+            CheetahString::from_static_str("shared-topic"),
+            broker_a.clone(),
+            create_test_queue_data(8, 8),
+        );
+        table.insert(
+            CheetahString::from_static_str("shared-topic"),
+            broker_b.clone(),
+            create_test_queue_data(8, 8),
+        );
+        table.insert(
+            CheetahString::from_static_str("broker-a-only"),
+            broker_a.clone(),
+            create_test_queue_data(8, 8),
+        );
+
+        let broker_names = HashSet::from([broker_a, broker_b]);
+        let topics = table.topics_for_brokers_with_duplicates(&broker_names);
+
+        assert_eq!(
+            topics.iter().filter(|topic| topic.as_str() == "shared-topic").count(),
+            2
+        );
+        assert!(topics.contains(&CheetahString::from_static_str("broker-a-only")));
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #6991

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized broker management operations to efficiently target specific topics instead of scanning all topics, improving performance of broker registration, unregistration, and cluster topology operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->