### PR TITLE
[ISSUE #7006]Implement Lite subscription control processor and registry, adding support for partial and complete subscriptions

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -105,6 +105,7 @@ use crate::processor::client_manage_processor::ClientManageProcessor;
 use crate::processor::consumer_manage_processor::ConsumerManageProcessor;
 use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
 use crate::processor::end_transaction_processor::EndTransactionProcessor;
+use crate::processor::lite_subscription_ctl_processor::LiteSubscriptionCtlProcessor;
 use crate::processor::notification_processor::NotificationProcessor;
 use crate::processor::peek_message_processor::PeekMessageProcessor;
 use crate::processor::polling_info_processor::PollingInfoProcessor;
@@ -120,6 +121,7 @@ use crate::processor::BrokerProcessorType;
 use crate::processor::BrokerRequestProcessor;
 use crate::schedule::schedule_message_service::ScheduleMessageService;
 use crate::slave::slave_synchronize::SlaveSynchronize;
+use crate::subscription::lite_subscription_registry::LiteSubscriptionRegistry;
 use crate::subscription::manager::subscription_group_manager::SubscriptionGroupManager;
 use crate::topic::manager::topic_config_manager::TopicConfigManager;
 use crate::topic::manager::topic_queue_mapping_manager::TopicQueueMappingManager;
@@ -222,6 +224,7 @@ impl BrokerRuntime {
             broker_stats: None,
             schedule_message_service: None,
             timer_message_store: None,
+            lite_subscription_registry: Arc::new(LiteSubscriptionRegistry::default()),
             broker_outer_api,
             producer_manager,
             consumer_manager,
@@ -783,6 +786,13 @@ impl BrokerRuntime {
         broker_request_processor.register_processor(
             RequestCode::SetMessageRequestMode as i32,
             BrokerProcessorType::QueryAssignment(query_assignment_processor),
+        );
+
+        broker_request_processor.register_processor(
+            RequestCode::LiteSubscriptionCtl as i32,
+            BrokerProcessorType::LiteSubscriptionCtl(ArcMut::new(LiteSubscriptionCtlProcessor::new(
+                self.inner.clone(),
+            ))),
         );
 
         //EndTransactionProcessor
@@ -1486,6 +1496,7 @@ pub(crate) struct BrokerRuntimeInner<MS: MessageStore> {
     broker_stats: Option<BrokerStats<MS>>,
     schedule_message_service: Option<ArcMut<ScheduleMessageService<MS>>>,
     timer_message_store: Option<Arc<TimerMessageStore>>,
+    lite_subscription_registry: Arc<LiteSubscriptionRegistry>,
     broker_outer_api: BrokerOuterAPI,
     producer_manager: ProducerManager,
     consumer_manager: ConsumerManager,
@@ -1803,6 +1814,11 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     #[inline]
     pub fn message_store(&self) -> Option<&ArcMut<MS>> {
         self.message_store.as_ref()
+    }
+
+    #[inline]
+    pub fn lite_subscription_registry(&self) -> &LiteSubscriptionRegistry {
+        self.lite_subscription_registry.as_ref()
     }
 
     #[inline]
@@ -3249,6 +3265,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::controller::replicas_manager::RegisterState;
+    use bytes::Bytes;
     use cheetah_string::CheetahString;
     use dashmap::DashMap;
     use rocketmq_common::common::config::TopicConfig;
@@ -3264,19 +3281,26 @@ mod tests {
     use rocketmq_controller::ControllerConfig as TestControllerConfig;
     use rocketmq_controller::ControllerManager as TestControllerManager;
     use rocketmq_namesrv::bootstrap::Builder as NameServerBuilder;
+    use rocketmq_remoting::base::response_future::ResponseFuture;
     use rocketmq_remoting::clients::rocketmq_tokio_client::RocketmqDefaultClient;
     use rocketmq_remoting::clients::RemotingClient;
     use rocketmq_remoting::code::request_code::RequestCode;
     use rocketmq_remoting::code::response_code::ResponseCode;
+    use rocketmq_remoting::connection::Connection;
+    use rocketmq_remoting::net::channel::Channel;
+    use rocketmq_remoting::net::channel::ChannelInner;
     use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
     use rocketmq_remoting::protocol::body::broker_body::broker_member_group::GetBrokerMemberGroupResponseBody;
     use rocketmq_remoting::protocol::header::controller::apply_broker_id_request_header::ApplyBrokerIdRequestHeader;
+    use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
     use rocketmq_remoting::protocol::header::namesrv::broker_request::GetBrokerMemberGroupRequestHeader;
     use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
     use rocketmq_remoting::protocol::RemotingDeserializable;
     use rocketmq_remoting::remoting::RemotingService;
     use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
     use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
+    use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
+    use rocketmq_remoting::runtime::processor::RequestProcessor;
     use rocketmq_store::base::message_store::MessageStore;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
     use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
@@ -3372,6 +3396,19 @@ mod tests {
                 return base_port;
             }
         }
+    }
+
+    async fn create_test_channel() -> Channel {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
+        let local_addr = listener.local_addr().expect("local listener addr");
+        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
+        std_stream.set_nonblocking(true).expect("set nonblocking");
+        drop(listener);
+        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
+        let connection = Connection::new(tcp_stream);
+        let response_table = ArcMut::new(HashMap::<i32, ResponseFuture>::new());
+        let inner = ArcMut::new(ChannelInner::new(connection, response_table));
+        Channel::new(inner, local_addr, local_addr)
     }
 
     async fn start_namesrv(port: u16, root: &Path) -> TestNameServer {
@@ -3997,6 +4034,37 @@ mod tests {
             .expect("runtime should expose timer store");
 
         assert!(Arc::ptr_eq(&store_timer, &runtime_timer));
+
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn init_processor_routes_lite_subscription_ctl_requests_to_lite_processor() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-broker-runtime-lite-{}", current_millis()));
+        let broker_config = Arc::new(BrokerConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            auth_config_path: temp_root.join("auth.json").to_string_lossy().into_owned().into(),
+            ..BrokerConfig::default()
+        });
+        let message_store_config = Arc::new(MessageStoreConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        });
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        assert!(runtime.initialize().await);
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
+            .set_body(Bytes::from_static(b""));
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite subscription control should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::IllegalOperation);
 
         let _ = std::fs::remove_dir_all(temp_root);
     }

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -31,6 +31,7 @@ use crate::processor::admin_broker_processor::AdminBrokerProcessor;
 use crate::processor::change_invisible_time_processor::ChangeInvisibleTimeProcessor;
 use crate::processor::consumer_manage_processor::ConsumerManageProcessor;
 use crate::processor::end_transaction_processor::EndTransactionProcessor;
+use crate::processor::lite_subscription_ctl_processor::LiteSubscriptionCtlProcessor;
 use crate::processor::notification_processor::NotificationProcessor;
 use crate::processor::peek_message_processor::PeekMessageProcessor;
 use crate::processor::polling_info_processor::PollingInfoProcessor;
@@ -50,6 +51,7 @@ pub(crate) mod client_manage_processor;
 pub(crate) mod consumer_manage_processor;
 pub(crate) mod default_pull_message_result_handler;
 pub(crate) mod end_transaction_processor;
+pub(crate) mod lite_subscription_ctl_processor;
 pub(crate) mod notification_processor;
 pub(crate) mod peek_message_processor;
 pub(crate) mod polling_info_processor;
@@ -79,6 +81,7 @@ pub enum BrokerProcessorType<MS: MessageStore, TS> {
     ClientManage(ArcMut<ClientManageProcessor<MS>>),
     ConsumerManage(ArcMut<ConsumerManageProcessor<MS>>),
     QueryAssignment(ArcMut<QueryAssignmentProcessor<MS>>),
+    LiteSubscriptionCtl(ArcMut<LiteSubscriptionCtlProcessor<MS>>),
     EndTransaction(ArcMut<EndTransactionProcessor<TS, MS>>),
     AdminBroker(ArcMut<AdminBrokerProcessor<MS>>),
 }
@@ -109,6 +112,9 @@ where
             BrokerProcessorType::ClientManage(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::ConsumerManage(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::QueryAssignment(processor) => processor.process_request(channel, ctx, request).await,
+            BrokerProcessorType::LiteSubscriptionCtl(processor) => {
+                processor.process_request(channel, ctx, request).await
+            }
             BrokerProcessorType::EndTransaction(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::AdminBroker(processor) => processor.process_request(channel, ctx, request).await,
         }
@@ -130,6 +136,7 @@ where
             BrokerProcessorType::ClientManage(processor) => processor.reject_request(code),
             BrokerProcessorType::ConsumerManage(processor) => processor.reject_request(code),
             BrokerProcessorType::QueryAssignment(processor) => processor.reject_request(code),
+            BrokerProcessorType::LiteSubscriptionCtl(processor) => processor.reject_request(code),
             BrokerProcessorType::EndTransaction(processor) => processor.reject_request(code),
             BrokerProcessorType::AdminBroker(processor) => processor.reject_request(code),
         }

--- a/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
+++ b/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
@@ -1,0 +1,312 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use rocketmq_common::common::lite::to_lmq_name;
+use rocketmq_common::common::lite::LiteSubscriptionAction;
+use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::body::lite_subscription_ctl_request_body::LiteSubscriptionCtlRequestBody;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_remoting::runtime::processor::RequestProcessor;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+use tracing::warn;
+
+use crate::broker_runtime::BrokerRuntimeInner;
+
+pub(crate) struct LiteSubscriptionCtlProcessor<MS: MessageStore> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+}
+
+impl<MS: MessageStore> LiteSubscriptionCtlProcessor<MS> {
+    pub(crate) fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        Self { broker_runtime_inner }
+    }
+}
+
+impl<MS: MessageStore> RequestProcessor for LiteSubscriptionCtlProcessor<MS> {
+    async fn process_request(
+        &mut self,
+        channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let body = match request.body() {
+            Some(body) if !body.is_empty() => body,
+            _ => {
+                return Ok(Some(self.response_with_code(
+                    request,
+                    ResponseCode::IllegalOperation,
+                    "Request body is null.",
+                )));
+            }
+        };
+
+        let request_body = match SerdeJsonUtils::from_json_bytes::<LiteSubscriptionCtlRequestBody>(body.as_ref()) {
+            Ok(body) => body,
+            Err(error) => {
+                return Ok(Some(self.response_with_code(
+                    request,
+                    ResponseCode::IllegalOperation,
+                    format!("Failed to decode LiteSubscriptionCtlRequestBody: {error}"),
+                )));
+            }
+        };
+
+        if request_body.subscription_set().is_empty() {
+            return Ok(Some(self.response_with_code(
+                request,
+                ResponseCode::IllegalOperation,
+                "LiteSubscriptionCtlRequestBody is empty.",
+            )));
+        }
+
+        for entry in request_body.subscription_set() {
+            if entry.client_id().is_empty() {
+                warn!("clientId is blank, {}", entry);
+                continue;
+            }
+            if entry.group().is_empty() {
+                warn!("group is blank, {}", entry);
+                continue;
+            }
+            if entry.topic().is_empty() {
+                warn!("topic is blank, {}", entry);
+                continue;
+            }
+
+            let registry = self.broker_runtime_inner.lite_subscription_registry();
+            let lmq_name_set = self.to_lmq_name_set(entry.topic(), entry.lite_topic_set());
+
+            match entry.action() {
+                LiteSubscriptionAction::PartialAdd => {
+                    if let Err((code, remark)) = self.validate_consumer_group(entry.group(), entry.topic()) {
+                        return Ok(Some(self.response_with_code(request, code, remark)));
+                    };
+                    registry.update_client_channel(entry.client_id(), channel.clone());
+                    registry.add_partial_subscription(entry.client_id(), entry.group(), entry.topic(), &lmq_name_set);
+                }
+                LiteSubscriptionAction::PartialRemove => {
+                    registry.remove_partial_subscription(
+                        entry.client_id(),
+                        entry.group(),
+                        entry.topic(),
+                        &lmq_name_set,
+                    );
+                }
+                LiteSubscriptionAction::CompleteAdd => {
+                    if let Err((code, remark)) = self.validate_consumer_group(entry.group(), entry.topic()) {
+                        return Ok(Some(self.response_with_code(request, code, remark)));
+                    };
+                    registry.update_client_channel(entry.client_id(), channel.clone());
+                    registry.add_complete_subscription(
+                        entry.client_id(),
+                        entry.group(),
+                        entry.topic(),
+                        &lmq_name_set,
+                        entry.version(),
+                    );
+                }
+                LiteSubscriptionAction::CompleteRemove => {
+                    registry.remove_complete_subscription(entry.client_id());
+                }
+            }
+        }
+
+        Ok(Some(
+            RemotingCommand::create_response_command().set_opaque(request.opaque()),
+        ))
+    }
+}
+
+impl<MS: MessageStore> LiteSubscriptionCtlProcessor<MS> {
+    fn validate_consumer_group(
+        &self,
+        group: &CheetahString,
+        topic: &CheetahString,
+    ) -> Result<
+        Arc<rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig>,
+        (ResponseCode, CheetahString),
+    > {
+        let group_config = self
+            .broker_runtime_inner
+            .subscription_group_manager()
+            .subscription_group_table()
+            .get(group)
+            .map(|entry| Arc::clone(entry.value()))
+            .ok_or_else(|| {
+                (
+                    ResponseCode::SubscriptionGroupNotExist,
+                    CheetahString::from_string(format!("Group [{}] not exist.", group)),
+                )
+            })?;
+
+        if !group_config.consume_enable() {
+            return Err((
+                ResponseCode::IllegalOperation,
+                CheetahString::from_static_str("Consumer group is not allowed to consume."),
+            ));
+        }
+
+        match group_config.lite_bind_topic() {
+            Some(bind_topic) if bind_topic == topic => Ok(group_config),
+            _ => Err((
+                ResponseCode::InvalidParameter,
+                CheetahString::from_string(format!("Subscription [{}]-[{}] not match.", group, topic)),
+            )),
+        }
+    }
+
+    fn to_lmq_name_set(
+        &self,
+        topic: &CheetahString,
+        lite_topic_set: &HashSet<CheetahString>,
+    ) -> HashSet<CheetahString> {
+        lite_topic_set
+            .iter()
+            .filter_map(|lite_topic| to_lmq_name(topic.as_str(), lite_topic.as_str()).map(CheetahString::from_string))
+            .collect()
+    }
+
+    fn response_with_code(
+        &self,
+        request: &RemotingCommand,
+        code: ResponseCode,
+        remark: impl Into<CheetahString>,
+    ) -> RemotingCommand {
+        RemotingCommand::create_response_command_with_code_remark(code, remark).set_opaque(request.opaque())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+    use std::time::SystemTime;
+
+    use bytes::Bytes;
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::attribute::subscription_group_attributes::LITE_BIND_TOPIC_ATTRIBUTE_NAME;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::lite::to_lmq_name;
+    use rocketmq_common::common::lite::LiteSubscriptionAction;
+    use rocketmq_common::common::lite::LiteSubscriptionDTO;
+    use rocketmq_remoting::base::response_future::ResponseFuture;
+    use rocketmq_remoting::code::request_code::RequestCode;
+    use rocketmq_remoting::code::response_code::ResponseCode;
+    use rocketmq_remoting::connection::Connection;
+    use rocketmq_remoting::net::channel::ChannelInner;
+    use rocketmq_remoting::protocol::body::lite_subscription_ctl_request_body::LiteSubscriptionCtlRequestBody;
+    use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
+    use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+
+    use super::*;
+    use crate::broker_runtime::BrokerRuntime;
+
+    fn temp_test_root(label: &str) -> std::path::PathBuf {
+        let millis = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_millis();
+        std::env::temp_dir().join(format!("rocketmq-rust-lite-subscription-{label}-{millis}"))
+    }
+
+    async fn new_test_runtime(label: &str) -> BrokerRuntime {
+        let temp_root = temp_test_root(label);
+        let broker_config = std::sync::Arc::new(BrokerConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            auth_config_path: temp_root.join("auth.json").to_string_lossy().into_owned().into(),
+            ..BrokerConfig::default()
+        });
+        let message_store_config = std::sync::Arc::new(MessageStoreConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        });
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        assert!(runtime.initialize().await);
+        runtime
+    }
+
+    async fn create_test_channel() -> Channel {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
+        let local_addr = listener.local_addr().expect("local listener addr");
+        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
+        std_stream.set_nonblocking(true).expect("set nonblocking");
+        drop(listener);
+        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
+        let connection = Connection::new(tcp_stream);
+        let response_table = ArcMut::new(HashMap::<i32, ResponseFuture>::new());
+        let inner = ArcMut::new(ChannelInner::new(connection, response_table));
+        Channel::new(inner, local_addr, local_addr)
+    }
+
+    #[tokio::test]
+    async fn complete_add_updates_registry_with_lmq_names() {
+        let mut runtime = new_test_runtime("processor-success").await;
+        let mut inner = runtime.inner_for_test().clone();
+        let mut config =
+            rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig::new(
+                CheetahString::from_static_str("lite-group"),
+            );
+        config.set_attributes(HashMap::from([(
+            CheetahString::from_string(format!("+{LITE_BIND_TOPIC_ATTRIBUTE_NAME}")),
+            CheetahString::from_static_str("parent-topic"),
+        )]));
+        inner
+            .subscription_group_manager_mut()
+            .update_subscription_group_config(&mut config);
+
+        let dto = LiteSubscriptionDTO::new()
+            .with_action(LiteSubscriptionAction::CompleteAdd)
+            .with_client_id(CheetahString::from_static_str("client-id"))
+            .with_group(CheetahString::from_static_str("lite-group"))
+            .with_topic(CheetahString::from_static_str("parent-topic"))
+            .with_lite_topic_set(HashSet::from([CheetahString::from_static_str("child-a")]));
+        let mut body = LiteSubscriptionCtlRequestBody::new();
+        body.set_subscription_set(vec![dto]);
+        let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
+            .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut processor = LiteSubscriptionCtlProcessor::new(inner.clone());
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor request should succeed")
+            .expect("processor should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let subscription = inner
+            .lite_subscription_registry()
+            .lite_subscription(
+                &CheetahString::from_static_str("client-id"),
+                &CheetahString::from_static_str("lite-group"),
+                &CheetahString::from_static_str("parent-topic"),
+            )
+            .expect("registry should contain lite subscription");
+        assert!(subscription.lite_topic_set().contains(&CheetahString::from_string(
+            to_lmq_name("parent-topic", "child-a").expect("convert lite topic")
+        )));
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+}

--- a/rocketmq-broker/src/subscription.rs
+++ b/rocketmq-broker/src/subscription.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) mod lite_subscription_registry;
 pub(crate) mod manager;

--- a/rocketmq-broker/src/subscription/lite_subscription_registry.rs
+++ b/rocketmq-broker/src/subscription/lite_subscription_registry.rs
@@ -1,0 +1,190 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use dashmap::DashMap;
+use rocketmq_common::common::lite::LiteSubscription;
+use rocketmq_remoting::net::channel::Channel;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct LiteSubscriptionKey {
+    client_id: CheetahString,
+    group: CheetahString,
+    topic: CheetahString,
+}
+
+impl LiteSubscriptionKey {
+    pub(crate) fn new(client_id: CheetahString, group: CheetahString, topic: CheetahString) -> Self {
+        Self {
+            client_id,
+            group,
+            topic,
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct LiteSubscriptionRegistry {
+    subscriptions: Arc<DashMap<LiteSubscriptionKey, LiteSubscription>>,
+    client_channels: Arc<DashMap<CheetahString, Channel>>,
+}
+
+impl LiteSubscriptionRegistry {
+    pub(crate) fn update_client_channel(&self, client_id: &CheetahString, channel: Channel) {
+        self.client_channels.insert(client_id.clone(), channel);
+    }
+
+    pub(crate) fn add_partial_subscription(
+        &self,
+        client_id: &CheetahString,
+        group: &CheetahString,
+        topic: &CheetahString,
+        lmq_name_set: &HashSet<CheetahString>,
+    ) -> LiteSubscription {
+        let key = LiteSubscriptionKey::new(client_id.clone(), group.clone(), topic.clone());
+        if lmq_name_set.is_empty() {
+            return self
+                .lite_subscription(client_id, group, topic)
+                .unwrap_or_else(|| LiteSubscription::new(group.clone(), topic.clone()));
+        }
+
+        let mut entry = self
+            .subscriptions
+            .entry(key)
+            .or_insert_with(|| LiteSubscription::new(group.clone(), topic.clone()));
+        entry.add_lite_topic_set(lmq_name_set);
+        entry.clone()
+    }
+
+    pub(crate) fn remove_partial_subscription(
+        &self,
+        client_id: &CheetahString,
+        group: &CheetahString,
+        topic: &CheetahString,
+        lmq_name_set: &HashSet<CheetahString>,
+    ) -> Option<LiteSubscription> {
+        let key = LiteSubscriptionKey::new(client_id.clone(), group.clone(), topic.clone());
+        let mut entry = self.subscriptions.get_mut(&key)?;
+        entry.remove_lite_topic_set(lmq_name_set);
+        let snapshot = entry.clone();
+        let empty = entry.lite_topic_set().is_empty();
+        drop(entry);
+
+        if empty {
+            self.subscriptions.remove(&key);
+            self.cleanup_client_channel_if_unused(client_id);
+            None
+        } else {
+            Some(snapshot)
+        }
+    }
+
+    pub(crate) fn add_complete_subscription(
+        &self,
+        client_id: &CheetahString,
+        group: &CheetahString,
+        topic: &CheetahString,
+        lmq_name_set: &HashSet<CheetahString>,
+        _version: i64,
+    ) -> LiteSubscription {
+        let key = LiteSubscriptionKey::new(client_id.clone(), group.clone(), topic.clone());
+        let mut subscription = LiteSubscription::new(group.clone(), topic.clone());
+        subscription.set_lite_topic_set(lmq_name_set.clone());
+
+        if lmq_name_set.is_empty() {
+            self.subscriptions.remove(&key);
+            self.cleanup_client_channel_if_unused(client_id);
+        } else {
+            self.subscriptions.insert(key, subscription.clone());
+        }
+
+        subscription
+    }
+
+    pub(crate) fn remove_complete_subscription(&self, client_id: &CheetahString) -> usize {
+        let keys = self
+            .subscriptions
+            .iter()
+            .filter(|entry| entry.key().client_id == *client_id)
+            .map(|entry| entry.key().clone())
+            .collect::<Vec<_>>();
+        let removed = keys.len();
+        for key in keys {
+            self.subscriptions.remove(&key);
+        }
+        self.cleanup_client_channel_if_unused(client_id);
+        removed
+    }
+
+    pub(crate) fn lite_subscription(
+        &self,
+        client_id: &CheetahString,
+        group: &CheetahString,
+        topic: &CheetahString,
+    ) -> Option<LiteSubscription> {
+        self.subscriptions
+            .get(&LiteSubscriptionKey::new(
+                client_id.clone(),
+                group.clone(),
+                topic.clone(),
+            ))
+            .map(|entry| entry.clone())
+    }
+
+    pub(crate) fn active_subscription_num(&self) -> usize {
+        self.subscriptions.len()
+    }
+
+    fn cleanup_client_channel_if_unused(&self, client_id: &CheetahString) {
+        if self
+            .subscriptions
+            .iter()
+            .all(|entry| entry.key().client_id != *client_id)
+        {
+            self.client_channels.remove(client_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_common::common::lite::to_lmq_name;
+
+    use super::*;
+
+    fn lmq_names(parent_topic: &str, lite_topics: &[&str]) -> HashSet<CheetahString> {
+        lite_topics
+            .iter()
+            .map(|lite_topic| CheetahString::from_string(to_lmq_name(parent_topic, lite_topic).unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn complete_add_replaces_partial_topics_and_partial_remove_cleans_up_empty_subscription() {
+        let registry = LiteSubscriptionRegistry::default();
+        let client_id = CheetahString::from_static_str("client-id");
+        let group = CheetahString::from_static_str("group-a");
+        let topic = CheetahString::from_static_str("parent-topic");
+
+        registry.add_partial_subscription(&client_id, &group, &topic, &lmq_names("parent-topic", &["a", "b"]));
+        registry.add_complete_subscription(&client_id, &group, &topic, &lmq_names("parent-topic", &["b"]), 1);
+        registry.remove_partial_subscription(&client_id, &group, &topic, &lmq_names("parent-topic", &["b"]));
+
+        assert!(registry.lite_subscription(&client_id, &group, &topic).is_none());
+        assert_eq!(registry.active_subscription_num(), 0);
+    }
+}

--- a/rocketmq-common/src/common/attribute.rs
+++ b/rocketmq-common/src/common/attribute.rs
@@ -21,6 +21,7 @@ pub mod cleanup_policy;
 pub mod cq_type;
 pub mod enum_attribute;
 pub mod long_range_attribute;
+pub mod string_attribute;
 pub mod subscription_group_attributes;
 pub mod topic_attributes;
 pub mod topic_message_type;

--- a/rocketmq-common/src/common/attribute/string_attribute.rs
+++ b/rocketmq-common/src/common/attribute/string_attribute.rs
@@ -1,0 +1,58 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+
+use crate::common::attribute::Attribute;
+use crate::common::attribute::AttributeBase;
+
+#[derive(Debug, Clone)]
+pub struct StringAttribute {
+    attribute: AttributeBase,
+}
+
+impl StringAttribute {
+    pub fn new(name: CheetahString, changeable: bool) -> Self {
+        Self {
+            attribute: AttributeBase::new(name, changeable),
+        }
+    }
+}
+
+impl Attribute for StringAttribute {
+    fn verify(&self, _value: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn name(&self) -> &CheetahString {
+        self.attribute.name()
+    }
+
+    fn is_changeable(&self) -> bool {
+        self.attribute.is_changeable()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_attribute_accepts_empty_and_non_empty_values() {
+        let attribute = StringAttribute::new(CheetahString::from_static_str("lite.bind.topic"), true);
+
+        assert!(attribute.verify("").is_ok());
+        assert!(attribute.verify("parent-topic").is_ok());
+    }
+}

--- a/rocketmq-common/src/common/attribute/subscription_group_attributes.rs
+++ b/rocketmq-common/src/common/attribute/subscription_group_attributes.rs
@@ -4,7 +4,10 @@ use std::sync::OnceLock;
 
 use cheetah_string::CheetahString;
 
+use crate::common::attribute::string_attribute::StringAttribute;
 use crate::common::attribute::Attribute;
+
+pub const LITE_BIND_TOPIC_ATTRIBUTE_NAME: &str = "lite.bind.topic";
 
 pub struct SubscriptionGroupAttributes {}
 
@@ -12,6 +15,26 @@ impl SubscriptionGroupAttributes {
     #[allow(clippy::redundant_closure)]
     pub fn all() -> &'static HashMap<CheetahString, Arc<dyn Attribute>> {
         static ALL: OnceLock<HashMap<CheetahString, Arc<dyn Attribute>>> = OnceLock::new();
-        ALL.get_or_init(|| HashMap::new())
+        ALL.get_or_init(|| {
+            HashMap::from([(
+                CheetahString::from_static_str(LITE_BIND_TOPIC_ATTRIBUTE_NAME),
+                Arc::new(StringAttribute::new(
+                    CheetahString::from_static_str(LITE_BIND_TOPIC_ATTRIBUTE_NAME),
+                    true,
+                )) as Arc<dyn Attribute>,
+            )])
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_contains_lite_bind_topic_attribute() {
+        let all = SubscriptionGroupAttributes::all();
+
+        assert!(all.contains_key(&CheetahString::from_static_str(LITE_BIND_TOPIC_ATTRIBUTE_NAME)));
     }
 }

--- a/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
+++ b/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use cheetah_string::CheetahString;
+use rocketmq_common::common::attribute::subscription_group_attributes::LITE_BIND_TOPIC_ATTRIBUTE_NAME;
 use rocketmq_common::common::mix_all::MASTER_ID;
 use serde::Deserialize;
 use serde::Serialize;
@@ -165,6 +166,13 @@ impl SubscriptionGroupConfig {
     }
 
     #[inline]
+    pub fn lite_bind_topic(&self) -> Option<&CheetahString> {
+        self.attributes
+            .get(&CheetahString::from_static_str(LITE_BIND_TOPIC_ATTRIBUTE_NAME))
+            .filter(|value| !value.is_empty())
+    }
+
+    #[inline]
     pub fn set_group_name(&mut self, group_name: CheetahString) {
         self.group_name = group_name;
     }
@@ -238,6 +246,19 @@ impl SubscriptionGroupConfig {
     pub fn set_attributes(&mut self, attributes: HashMap<CheetahString, CheetahString>) {
         self.attributes = attributes;
     }
+
+    #[inline]
+    pub fn set_lite_bind_topic(&mut self, lite_bind_topic: Option<CheetahString>) {
+        let key = CheetahString::from_static_str(LITE_BIND_TOPIC_ATTRIBUTE_NAME);
+        match lite_bind_topic {
+            Some(value) if !value.is_empty() => {
+                self.attributes.insert(key, value);
+            }
+            _ => {
+                self.attributes.remove(&key);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -302,5 +323,21 @@ mod subscription_group_config_tests {
         assert_eq!(config.consume_timeout_minute(), 30);
         assert!(config.subscription_data_set().is_some());
         assert_eq!(config.attributes(), &HashMap::from([("key".into(), "value".into())]));
+    }
+
+    #[test]
+    fn lite_bind_topic_round_trips_through_attributes() {
+        let mut config = SubscriptionGroupConfig::default();
+
+        assert!(config.lite_bind_topic().is_none());
+
+        config.set_lite_bind_topic(Some("parent-topic".into()));
+        assert_eq!(
+            config.lite_bind_topic(),
+            Some(&CheetahString::from_static_str("parent-topic"))
+        );
+
+        config.set_lite_bind_topic(None);
+        assert!(config.lite_bind_topic().is_none());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7006

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added lite subscription management support to the broker for handling subscription control requests.
  * Introduced new configuration attribute for subscription groups to specify lite-bound topics, enabling fine-grained subscription control.
  * Implemented a registry system to track, manage, and validate client lite subscriptions with support for partial and complete subscription operations.

* **Tests**
  * Added test coverage for lite subscription request routing and registry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->