### PR TITLE
[ISSUE #7008]🚀Implement LiteManagerProcessor for handling Lite subscription requests and responses

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -105,6 +105,7 @@ use crate::processor::client_manage_processor::ClientManageProcessor;
 use crate::processor::consumer_manage_processor::ConsumerManageProcessor;
 use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
 use crate::processor::end_transaction_processor::EndTransactionProcessor;
+use crate::processor::lite_manager_processor::LiteManagerProcessor;
 use crate::processor::lite_subscription_ctl_processor::LiteSubscriptionCtlProcessor;
 use crate::processor::notification_processor::NotificationProcessor;
 use crate::processor::peek_message_processor::PeekMessageProcessor;
@@ -788,6 +789,22 @@ impl BrokerRuntime {
             BrokerProcessorType::QueryAssignment(query_assignment_processor),
         );
 
+        broker_request_processor.register_processor(
+            RequestCode::GetBrokerLiteInfo as i32,
+            BrokerProcessorType::LiteManager(ArcMut::new(LiteManagerProcessor::new(self.inner.clone()))),
+        );
+        broker_request_processor.register_processor(
+            RequestCode::GetParentTopicInfo as i32,
+            BrokerProcessorType::LiteManager(ArcMut::new(LiteManagerProcessor::new(self.inner.clone()))),
+        );
+        broker_request_processor.register_processor(
+            RequestCode::GetLiteTopicInfo as i32,
+            BrokerProcessorType::LiteManager(ArcMut::new(LiteManagerProcessor::new(self.inner.clone()))),
+        );
+        broker_request_processor.register_processor(
+            RequestCode::GetLiteClientInfo as i32,
+            BrokerProcessorType::LiteManager(ArcMut::new(LiteManagerProcessor::new(self.inner.clone()))),
+        );
         broker_request_processor.register_processor(
             RequestCode::LiteSubscriptionCtl as i32,
             BrokerProcessorType::LiteSubscriptionCtl(ArcMut::new(LiteSubscriptionCtlProcessor::new(
@@ -3256,6 +3273,8 @@ fn need_register(change_list: &[bool]) -> bool {
 mod tests {
     use std::collections::BTreeMap;
     use std::collections::BTreeSet;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::net::TcpListener;
     use std::path::Path;
     use std::path::PathBuf;
@@ -3268,7 +3287,10 @@ mod tests {
     use bytes::Bytes;
     use cheetah_string::CheetahString;
     use dashmap::DashMap;
+    use rocketmq_common::common::attribute::subscription_group_attributes::LITE_BIND_TOPIC_ATTRIBUTE_NAME;
     use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_common::common::entity::ClientGroup;
+    use rocketmq_common::common::lite::to_lmq_name;
     use rocketmq_common::common::mix_all::MASTER_ID;
     use rocketmq_common::common::namesrv::namesrv_config::NamesrvConfig;
     use rocketmq_common::common::server::config::ServerConfig;
@@ -3291,10 +3313,18 @@ mod tests {
     use rocketmq_remoting::net::channel::ChannelInner;
     use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
     use rocketmq_remoting::protocol::body::broker_body::broker_member_group::GetBrokerMemberGroupResponseBody;
+    use rocketmq_remoting::protocol::body::get_broker_lite_info_response_body::GetBrokerLiteInfoResponseBody;
+    use rocketmq_remoting::protocol::body::get_lite_client_info_response_body::GetLiteClientInfoResponseBody;
+    use rocketmq_remoting::protocol::body::get_lite_topic_info_response_body::GetLiteTopicInfoResponseBody;
+    use rocketmq_remoting::protocol::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
     use rocketmq_remoting::protocol::header::controller::apply_broker_id_request_header::ApplyBrokerIdRequestHeader;
     use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
+    use rocketmq_remoting::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+    use rocketmq_remoting::protocol::header::get_lite_topic_info_request_header::GetLiteTopicInfoRequestHeader;
+    use rocketmq_remoting::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader;
     use rocketmq_remoting::protocol::header::namesrv::broker_request::GetBrokerMemberGroupRequestHeader;
     use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+    use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
     use rocketmq_remoting::protocol::RemotingDeserializable;
     use rocketmq_remoting::remoting::RemotingService;
     use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
@@ -3409,6 +3439,75 @@ mod tests {
         let response_table = ArcMut::new(HashMap::<i32, ResponseFuture>::new());
         let inner = ArcMut::new(ChannelInner::new(connection, response_table));
         Channel::new(inner, local_addr, local_addr)
+    }
+
+    fn lite_test_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "rocketmq-rust-broker-lite-manager-{label}-{}",
+            current_millis()
+        ))
+    }
+
+    async fn new_lite_test_runtime(label: &str) -> BrokerRuntime {
+        let temp_root = lite_test_root(label);
+        let broker_config = Arc::new(BrokerConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            auth_config_path: temp_root.join("auth.json").to_string_lossy().into_owned().into(),
+            ..BrokerConfig::default()
+        });
+        let message_store_config = Arc::new(MessageStoreConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            max_lmq_consume_queue_num: 32,
+            ..MessageStoreConfig::default()
+        });
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        assert!(runtime.initialize().await);
+        runtime
+    }
+
+    fn seed_lite_query_state(runtime: &mut BrokerRuntime) {
+        let inner = runtime.inner_for_test();
+        inner
+            .topic_config_manager_mut()
+            .update_topic_config(ArcMut::new(TopicConfig::with_queues("parent-topic", 1, 1)));
+
+        for group in ["group-a", "group-b"] {
+            let mut config = SubscriptionGroupConfig::new(CheetahString::from_static_str(group));
+            config.set_attributes(HashMap::from([(
+                CheetahString::from_string(format!("+{LITE_BIND_TOPIC_ATTRIBUTE_NAME}")),
+                CheetahString::from_static_str("parent-topic"),
+            )]));
+            inner
+                .subscription_group_manager_mut()
+                .update_subscription_group_config(&mut config);
+        }
+
+        let registry = inner.lite_subscription_registry();
+        let client_one = CheetahString::from_static_str("client-1");
+        let client_two = CheetahString::from_static_str("client-2");
+        let parent_topic = CheetahString::from_static_str("parent-topic");
+        let group_a = CheetahString::from_static_str("group-a");
+        let group_b = CheetahString::from_static_str("group-b");
+
+        registry.add_complete_subscription(
+            &client_one,
+            &group_a,
+            &parent_topic,
+            &HashSet::from([
+                CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq")),
+                CheetahString::from_string(to_lmq_name("parent-topic", "child-b").expect("child-b lmq")),
+            ]),
+            1,
+        );
+        registry.add_complete_subscription(
+            &client_two,
+            &group_b,
+            &parent_topic,
+            &HashSet::from([CheetahString::from_string(
+                to_lmq_name("parent-topic", "child-b").expect("child-b lmq"),
+            )]),
+            1,
+        );
     }
 
     async fn start_namesrv(port: u16, root: &Path) -> TestNameServer {
@@ -4067,6 +4166,190 @@ mod tests {
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::IllegalOperation);
 
         let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn get_broker_lite_info_returns_registry_aggregates() {
+        let mut runtime = new_lite_test_runtime("broker-lite-info").await;
+        seed_lite_query_state(&mut runtime);
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request = RemotingCommand::create_request_command(RequestCode::GetBrokerLiteInfo, EmptyHeader {});
+        let mut response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let body = GetBrokerLiteInfoResponseBody::decode(
+            response
+                .take_body()
+                .expect("GetBrokerLiteInfo response should contain a body")
+                .as_ref(),
+        )
+        .expect("decode broker lite info response body");
+        assert_eq!(
+            body.get_store_type(),
+            Some(&CheetahString::from_static_str("LocalFile"))
+        );
+        assert_eq!(body.get_max_lmq_num(), 32);
+        assert_eq!(body.get_current_lmq_num(), 2);
+        assert_eq!(body.get_lite_subscription_count(), 2);
+        assert_eq!(
+            body.get_topic_meta()
+                .get(&CheetahString::from_static_str("parent-topic")),
+            Some(&2)
+        );
+        assert_eq!(
+            body.get_group_meta()
+                .get(&CheetahString::from_static_str("parent-topic")),
+            Some(&HashSet::from([
+                CheetahString::from_static_str("group-a"),
+                CheetahString::from_static_str("group-b"),
+            ]))
+        );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn get_parent_topic_info_returns_group_and_lite_counts() {
+        let mut runtime = new_lite_test_runtime("parent-topic-info").await;
+        seed_lite_query_state(&mut runtime);
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = GetParentTopicInfoRequestHeader {
+            topic: CheetahString::from_static_str("parent-topic"),
+            rpc: None,
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::GetParentTopicInfo, header);
+        request.make_custom_header_to_net();
+        let mut response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let body = GetParentTopicInfoResponseBody::decode(
+            response
+                .take_body()
+                .expect("GetParentTopicInfo response should contain a body")
+                .as_ref(),
+        )
+        .expect("decode parent topic info response body");
+        assert_eq!(body.get_topic(), Some(&CheetahString::from_static_str("parent-topic")));
+        assert_eq!(body.get_ttl(), 0);
+        assert_eq!(body.get_lmq_num(), 2);
+        assert_eq!(body.get_lite_topic_count(), 2);
+        assert_eq!(
+            body.get_groups(),
+            &HashSet::from([
+                CheetahString::from_static_str("group-a"),
+                CheetahString::from_static_str("group-b"),
+            ])
+        );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn get_lite_topic_info_returns_subscribers_for_matching_lite_topic() {
+        let mut runtime = new_lite_test_runtime("lite-topic-info").await;
+        seed_lite_query_state(&mut runtime);
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = GetLiteTopicInfoRequestHeader {
+            parent_topic: CheetahString::from_static_str("parent-topic"),
+            lite_topic: CheetahString::from_static_str("child-b"),
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::GetLiteTopicInfo, header);
+        request.make_custom_header_to_net();
+        let mut response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let body = GetLiteTopicInfoResponseBody::decode(
+            response
+                .take_body()
+                .expect("GetLiteTopicInfo response should contain a body")
+                .as_ref(),
+        )
+        .expect("decode lite topic info response body");
+        assert_eq!(body.parent_topic(), &CheetahString::from_static_str("parent-topic"));
+        assert_eq!(body.lite_topic(), &CheetahString::from_static_str("child-b"));
+        assert!(!body.sharding_to_broker());
+        assert_eq!(body.subscriber().len(), 2);
+        assert!(body.subscriber().contains(&ClientGroup::from_parts(
+            CheetahString::from_static_str("client-1"),
+            CheetahString::from_static_str("group-a"),
+        )));
+        assert!(body.subscriber().contains(&ClientGroup::from_parts(
+            CheetahString::from_static_str("client-2"),
+            CheetahString::from_static_str("group-b"),
+        )));
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn get_lite_client_info_returns_topics_for_bound_client() {
+        let mut runtime = new_lite_test_runtime("lite-client-info").await;
+        seed_lite_query_state(&mut runtime);
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = GetLiteClientInfoRequestHeader {
+            parent_topic: Some(CheetahString::from_static_str("parent-topic")),
+            group: Some(CheetahString::from_static_str("group-a")),
+            client_id: Some(CheetahString::from_static_str("client-1")),
+            max_count: 32,
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::GetLiteClientInfo, header);
+        request.make_custom_header_to_net();
+        let mut response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let body = GetLiteClientInfoResponseBody::decode(
+            response
+                .take_body()
+                .expect("GetLiteClientInfo response should contain a body")
+                .as_ref(),
+        )
+        .expect("decode lite client info response body");
+        assert_eq!(
+            body.parent_topic(),
+            Some(&CheetahString::from_static_str("parent-topic"))
+        );
+        assert_eq!(body.group(), &CheetahString::from_static_str("group-a"));
+        assert_eq!(body.client_id(), &CheetahString::from_static_str("client-1"));
+        assert!(body.last_access_time() > 0);
+        assert_eq!(body.last_consume_time(), 0);
+        assert_eq!(body.lite_topic_count(), 2);
+        assert_eq!(
+            body.lite_topic_set(),
+            &HashSet::from([
+                CheetahString::from_static_str("child-a"),
+                CheetahString::from_static_str("child-b"),
+            ])
+        );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -31,6 +31,7 @@ use crate::processor::admin_broker_processor::AdminBrokerProcessor;
 use crate::processor::change_invisible_time_processor::ChangeInvisibleTimeProcessor;
 use crate::processor::consumer_manage_processor::ConsumerManageProcessor;
 use crate::processor::end_transaction_processor::EndTransactionProcessor;
+use crate::processor::lite_manager_processor::LiteManagerProcessor;
 use crate::processor::lite_subscription_ctl_processor::LiteSubscriptionCtlProcessor;
 use crate::processor::notification_processor::NotificationProcessor;
 use crate::processor::peek_message_processor::PeekMessageProcessor;
@@ -51,6 +52,7 @@ pub(crate) mod client_manage_processor;
 pub(crate) mod consumer_manage_processor;
 pub(crate) mod default_pull_message_result_handler;
 pub(crate) mod end_transaction_processor;
+pub(crate) mod lite_manager_processor;
 pub(crate) mod lite_subscription_ctl_processor;
 pub(crate) mod notification_processor;
 pub(crate) mod peek_message_processor;
@@ -81,6 +83,7 @@ pub enum BrokerProcessorType<MS: MessageStore, TS> {
     ClientManage(ArcMut<ClientManageProcessor<MS>>),
     ConsumerManage(ArcMut<ConsumerManageProcessor<MS>>),
     QueryAssignment(ArcMut<QueryAssignmentProcessor<MS>>),
+    LiteManager(ArcMut<LiteManagerProcessor<MS>>),
     LiteSubscriptionCtl(ArcMut<LiteSubscriptionCtlProcessor<MS>>),
     EndTransaction(ArcMut<EndTransactionProcessor<TS, MS>>),
     AdminBroker(ArcMut<AdminBrokerProcessor<MS>>),
@@ -112,6 +115,7 @@ where
             BrokerProcessorType::ClientManage(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::ConsumerManage(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::QueryAssignment(processor) => processor.process_request(channel, ctx, request).await,
+            BrokerProcessorType::LiteManager(processor) => processor.process_request(channel, ctx, request).await,
             BrokerProcessorType::LiteSubscriptionCtl(processor) => {
                 processor.process_request(channel, ctx, request).await
             }
@@ -136,6 +140,7 @@ where
             BrokerProcessorType::ClientManage(processor) => processor.reject_request(code),
             BrokerProcessorType::ConsumerManage(processor) => processor.reject_request(code),
             BrokerProcessorType::QueryAssignment(processor) => processor.reject_request(code),
+            BrokerProcessorType::LiteManager(processor) => processor.reject_request(code),
             BrokerProcessorType::LiteSubscriptionCtl(processor) => processor.reject_request(code),
             BrokerProcessorType::EndTransaction(processor) => processor.reject_request(code),
             BrokerProcessorType::AdminBroker(processor) => processor.reject_request(code),

--- a/rocketmq-broker/src/processor/lite_manager_processor.rs
+++ b/rocketmq-broker/src/processor/lite_manager_processor.rs
@@ -1,0 +1,432 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use cheetah_string::CheetahString;
+use rocketmq_common::common::entity::ClientGroup;
+use rocketmq_common::common::lite::get_lite_topic;
+use rocketmq_common::common::lite::to_lmq_name;
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::admin::topic_offset::TopicOffset;
+use rocketmq_remoting::protocol::body::get_broker_lite_info_response_body::GetBrokerLiteInfoResponseBody;
+use rocketmq_remoting::protocol::body::get_lite_client_info_response_body::GetLiteClientInfoResponseBody;
+use rocketmq_remoting::protocol::body::get_lite_topic_info_response_body::GetLiteTopicInfoResponseBody;
+use rocketmq_remoting::protocol::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
+use rocketmq_remoting::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+use rocketmq_remoting::protocol::header::get_lite_topic_info_request_header::GetLiteTopicInfoRequestHeader;
+use rocketmq_remoting::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::RemotingSerializable;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_remoting::runtime::processor::RequestProcessor;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::queue::consume_queue_store::ConsumeQueueStoreTrait;
+use rocketmq_store::queue::local_file_consume_queue_store::ConsumeQueueStore;
+use tracing::warn;
+
+use crate::broker_runtime::BrokerRuntimeInner;
+use crate::subscription::lite_subscription_registry::LiteSubscriptionRecord;
+
+pub(crate) struct LiteManagerProcessor<MS: MessageStore> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+}
+
+impl<MS: MessageStore> LiteManagerProcessor<MS> {
+    pub(crate) fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        Self { broker_runtime_inner }
+    }
+}
+
+impl<MS: MessageStore> RequestProcessor for LiteManagerProcessor<MS> {
+    async fn process_request(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        match RequestCode::from(request.code()) {
+            RequestCode::GetBrokerLiteInfo => self.get_broker_lite_info(request),
+            RequestCode::GetParentTopicInfo => self.get_parent_topic_info(request),
+            RequestCode::GetLiteTopicInfo => self.get_lite_topic_info(request),
+            RequestCode::GetLiteClientInfo => self.get_lite_client_info(request),
+            request_code => {
+                warn!("LiteManagerProcessor received unknown request code: {:?}", request_code);
+                Ok(Some(self.response_with_code(
+                    request,
+                    ResponseCode::RequestCodeNotSupported,
+                    format!("LiteManagerProcessor request code {} not supported", request.code()),
+                )))
+            }
+        }
+    }
+}
+
+impl<MS: MessageStore> LiteManagerProcessor<MS> {
+    fn get_broker_lite_info(
+        &self,
+        request: &RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let subscriptions = self
+            .broker_runtime_inner
+            .lite_subscription_registry()
+            .all_subscriptions();
+        let topic_meta = self.build_lite_topic_meta(&subscriptions);
+        let group_meta = self.build_lite_group_meta(&subscriptions);
+        let unique_lmq_count = topic_meta.values().copied().sum::<i32>();
+        let (store_lmq_num, cq_table_size) = self.queue_store_stats();
+
+        let mut body = GetBrokerLiteInfoResponseBody::new();
+        body.set_store_type(CheetahString::from_static_str(
+            self.broker_runtime_inner
+                .message_store_config()
+                .store_type
+                .get_store_type(),
+        ));
+        body.set_max_lmq_num(
+            self.broker_runtime_inner
+                .message_store_config()
+                .max_lmq_consume_queue_num as i32,
+        );
+        body.set_current_lmq_num(store_lmq_num.max(unique_lmq_count));
+        body.set_lite_subscription_count(
+            self.broker_runtime_inner
+                .lite_subscription_registry()
+                .active_subscription_num() as i32,
+        );
+        body.set_order_info_count(0);
+        body.set_cq_table_size(cq_table_size);
+        body.set_offset_table_size(
+            self.broker_runtime_inner
+                .consumer_offset_manager()
+                .offset_table()
+                .read()
+                .len() as i32,
+        );
+        body.set_event_map_size(0);
+        body.set_topic_meta(topic_meta);
+        body.set_group_meta(group_meta);
+
+        Ok(Some(self.response_with_body(request, &body)?))
+    }
+
+    fn get_parent_topic_info(
+        &self,
+        request: &RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_header = request.decode_command_custom_header::<GetParentTopicInfoRequestHeader>()?;
+        if !self
+            .broker_runtime_inner
+            .topic_config_manager()
+            .contains_topic(&request_header.topic)
+        {
+            return Ok(Some(self.response_with_code(
+                request,
+                ResponseCode::TopicNotExist,
+                format!("Topic [{}] not exist.", request_header.topic),
+            )));
+        }
+
+        let subscriptions = self
+            .broker_runtime_inner
+            .lite_subscription_registry()
+            .all_subscriptions()
+            .into_iter()
+            .filter(|subscription| subscription.topic == request_header.topic)
+            .collect::<Vec<_>>();
+        if subscriptions.is_empty() {
+            return Ok(Some(self.response_with_code(
+                request,
+                ResponseCode::QueryNotFound,
+                format!("Topic [{}] has no lite subscriptions.", request_header.topic),
+            )));
+        }
+
+        let groups = subscriptions
+            .iter()
+            .map(|subscription| subscription.group.clone())
+            .collect::<HashSet<_>>();
+        let lite_topic_set = subscriptions
+            .iter()
+            .flat_map(|subscription| subscription.lite_topic_set.iter())
+            .filter_map(|lmq_name| get_lite_topic(lmq_name.as_str()).map(CheetahString::from_string))
+            .collect::<HashSet<_>>();
+
+        let mut body = GetParentTopicInfoResponseBody::new();
+        body.set_topic(request_header.topic);
+        body.set_ttl(0);
+        body.set_groups(groups);
+        body.set_lmq_num(lite_topic_set.len() as i32);
+        body.set_lite_topic_count(lite_topic_set.len() as i32);
+
+        Ok(Some(self.response_with_body(request, &body)?))
+    }
+
+    fn get_lite_topic_info(
+        &self,
+        request: &RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_header = request.decode_command_custom_header::<GetLiteTopicInfoRequestHeader>()?;
+        if !self
+            .broker_runtime_inner
+            .topic_config_manager()
+            .contains_topic(&request_header.parent_topic)
+        {
+            return Ok(Some(self.response_with_code(
+                request,
+                ResponseCode::TopicNotExist,
+                format!("Topic [{}] not exist.", request_header.parent_topic),
+            )));
+        }
+
+        let Some(lmq_name) = to_lmq_name(request_header.parent_topic.as_str(), request_header.lite_topic.as_str())
+        else {
+            return Ok(Some(self.response_with_code(
+                request,
+                ResponseCode::InvalidParameter,
+                "parentTopic or liteTopic is blank.",
+            )));
+        };
+        let lmq_name = CheetahString::from_string(lmq_name);
+        let subscribers = self
+            .broker_runtime_inner
+            .lite_subscription_registry()
+            .all_subscriptions()
+            .into_iter()
+            .filter(|subscription| {
+                subscription.topic == request_header.parent_topic && subscription.lite_topic_set.contains(&lmq_name)
+            })
+            .map(|subscription| ClientGroup::from_parts(subscription.client_id, subscription.group))
+            .collect::<HashSet<_>>();
+        if subscribers.is_empty() {
+            return Ok(Some(self.response_with_code(
+                request,
+                ResponseCode::QueryNotFound,
+                format!(
+                    "Lite topic [{}] under [{}] has no subscribers.",
+                    request_header.lite_topic, request_header.parent_topic
+                ),
+            )));
+        }
+
+        let mut body = GetLiteTopicInfoResponseBody::new();
+        body.with_parent_topic(request_header.parent_topic)
+            .with_lite_topic(request_header.lite_topic)
+            .with_subscriber(subscribers)
+            .with_sharding_to_broker(false);
+        if let Some(topic_offset) = self.topic_offset_for_lmq(&lmq_name) {
+            body.with_topic_offset(topic_offset);
+        }
+
+        Ok(Some(self.response_with_body(request, &body)?))
+    }
+
+    fn get_lite_client_info(
+        &self,
+        request: &RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_header = request.decode_command_custom_header::<GetLiteClientInfoRequestHeader>()?;
+        let Some(parent_topic) = request_header.parent_topic.filter(|topic| !topic.is_empty()) else {
+            return Ok(Some(self.response_with_code(
+                request,
+                ResponseCode::InvalidParameter,
+                "parentTopic is blank.",
+            )));
+        };
+        let Some(group) = request_header.group.filter(|group| !group.is_empty()) else {
+            return Ok(Some(self.response_with_code(
+                request,
+                ResponseCode::InvalidParameter,
+                "group is blank.",
+            )));
+        };
+        let Some(client_id) = request_header.client_id.filter(|client_id| !client_id.is_empty()) else {
+            return Ok(Some(self.response_with_code(
+                request,
+                ResponseCode::InvalidParameter,
+                "clientId is blank.",
+            )));
+        };
+        if let Err((code, remark)) = self.validate_consumer_group(&group, &parent_topic) {
+            return Ok(Some(self.response_with_code(request, code, remark)));
+        }
+
+        let Some(subscription) = self
+            .broker_runtime_inner
+            .lite_subscription_registry()
+            .lite_subscription(&client_id, &group, &parent_topic)
+        else {
+            return Ok(Some(self.response_with_code(
+                request,
+                ResponseCode::QueryNotFound,
+                format!(
+                    "Client [{}] has no lite subscription on [{}]-[{}].",
+                    client_id, group, parent_topic
+                ),
+            )));
+        };
+
+        let lite_topic_set = self.decode_lite_topic_set(subscription.lite_topic_set(), request_header.max_count);
+        let mut body = GetLiteClientInfoResponseBody::new();
+        body.with_parent_topic(parent_topic)
+            .with_group(group)
+            .with_client_id(client_id)
+            .with_last_access_time(subscription.update_time().max(0) as u64)
+            .with_last_consume_time(0)
+            .with_lite_topic_count(lite_topic_set.len() as u32)
+            .with_lite_topic_set(lite_topic_set);
+
+        Ok(Some(self.response_with_body(request, &body)?))
+    }
+
+    fn build_lite_topic_meta(&self, subscriptions: &[LiteSubscriptionRecord]) -> HashMap<CheetahString, i32> {
+        subscriptions
+            .iter()
+            .fold(
+                HashMap::<CheetahString, HashSet<CheetahString>>::new(),
+                |mut acc, subscription| {
+                    acc.entry(subscription.topic.clone())
+                        .or_default()
+                        .extend(subscription.lite_topic_set.iter().cloned());
+                    acc
+                },
+            )
+            .into_iter()
+            .map(|(topic, lite_topics)| (topic, lite_topics.len() as i32))
+            .collect()
+    }
+
+    fn build_lite_group_meta(
+        &self,
+        subscriptions: &[LiteSubscriptionRecord],
+    ) -> HashMap<CheetahString, HashSet<CheetahString>> {
+        subscriptions.iter().fold(
+            HashMap::<CheetahString, HashSet<CheetahString>>::new(),
+            |mut acc, subscription| {
+                acc.entry(subscription.topic.clone())
+                    .or_default()
+                    .insert(subscription.group.clone());
+                acc
+            },
+        )
+    }
+
+    fn queue_store_stats(&self) -> (i32, i32) {
+        let Some(message_store) = self.broker_runtime_inner.message_store() else {
+            return (0, 0);
+        };
+        let Some(queue_store) = message_store.get_queue_store().downcast_ref::<ConsumeQueueStore>() else {
+            return (0, 0);
+        };
+
+        let consume_queue_table = queue_store.get_consume_queue_table();
+        let cq_table_size = consume_queue_table
+            .lock()
+            .values()
+            .map(|queue_map| queue_map.len() as i32)
+            .sum();
+        (queue_store.get_lmq_num(), cq_table_size)
+    }
+
+    fn topic_offset_for_lmq(&self, lmq_name: &CheetahString) -> Option<TopicOffset> {
+        let message_store = self.broker_runtime_inner.message_store()?;
+        let min_offset = message_store.get_min_offset_in_queue(lmq_name, 0);
+        let max_offset = message_store.get_max_offset_in_queue(lmq_name, 0);
+        let last_update_timestamp = if max_offset > 0 {
+            message_store.get_message_store_timestamp(lmq_name, 0, max_offset - 1)
+        } else {
+            -1
+        };
+
+        let mut topic_offset = TopicOffset::new();
+        topic_offset.set_min_offset(min_offset);
+        topic_offset.set_max_offset(max_offset);
+        topic_offset.set_last_update_timestamp(last_update_timestamp);
+        Some(topic_offset)
+    }
+
+    fn decode_lite_topic_set(&self, lmq_name_set: &HashSet<CheetahString>, max_count: i32) -> HashSet<CheetahString> {
+        let mut lite_topics = lmq_name_set
+            .iter()
+            .filter_map(|lmq_name| get_lite_topic(lmq_name.as_str()))
+            .collect::<BTreeSet<_>>();
+        if max_count > 0 && lite_topics.len() > max_count as usize {
+            lite_topics = lite_topics.into_iter().take(max_count as usize).collect();
+        }
+        lite_topics.into_iter().map(CheetahString::from_string).collect()
+    }
+
+    fn validate_consumer_group(
+        &self,
+        group: &CheetahString,
+        topic: &CheetahString,
+    ) -> Result<
+        std::sync::Arc<rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig>,
+        (ResponseCode, CheetahString),
+    > {
+        let group_config = self
+            .broker_runtime_inner
+            .subscription_group_manager()
+            .subscription_group_table()
+            .get(group)
+            .map(|entry| std::sync::Arc::clone(entry.value()))
+            .ok_or_else(|| {
+                (
+                    ResponseCode::SubscriptionGroupNotExist,
+                    CheetahString::from_string(format!("Group [{}] not exist.", group)),
+                )
+            })?;
+
+        if !group_config.consume_enable() {
+            return Err((
+                ResponseCode::IllegalOperation,
+                CheetahString::from_static_str("Consumer group is not allowed to consume."),
+            ));
+        }
+
+        match group_config.lite_bind_topic() {
+            Some(bind_topic) if bind_topic == topic => Ok(group_config),
+            _ => Err((
+                ResponseCode::InvalidParameter,
+                CheetahString::from_string(format!("Subscription [{}]-[{}] not match.", group, topic)),
+            )),
+        }
+    }
+
+    fn response_with_body<T: RemotingSerializable>(
+        &self,
+        request: &RemotingCommand,
+        body: &T,
+    ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
+        Ok(
+            RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                .set_body(body.encode()?)
+                .set_opaque(request.opaque()),
+        )
+    }
+
+    fn response_with_code(
+        &self,
+        request: &RemotingCommand,
+        code: ResponseCode,
+        remark: impl Into<CheetahString>,
+    ) -> RemotingCommand {
+        RemotingCommand::create_response_command_with_code_remark(code, remark).set_opaque(request.opaque())
+    }
+}

--- a/rocketmq-broker/src/subscription/lite_subscription_registry.rs
+++ b/rocketmq-broker/src/subscription/lite_subscription_registry.rs
@@ -43,6 +43,15 @@ pub(crate) struct LiteSubscriptionRegistry {
     client_channels: Arc<DashMap<CheetahString, Channel>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LiteSubscriptionRecord {
+    pub(crate) client_id: CheetahString,
+    pub(crate) group: CheetahString,
+    pub(crate) topic: CheetahString,
+    pub(crate) lite_topic_set: HashSet<CheetahString>,
+    pub(crate) update_time: i64,
+}
+
 impl LiteSubscriptionRegistry {
     pub(crate) fn update_client_channel(&self, client_id: &CheetahString, channel: Channel) {
         self.client_channels.insert(client_id.clone(), channel);
@@ -147,6 +156,19 @@ impl LiteSubscriptionRegistry {
 
     pub(crate) fn active_subscription_num(&self) -> usize {
         self.subscriptions.len()
+    }
+
+    pub(crate) fn all_subscriptions(&self) -> Vec<LiteSubscriptionRecord> {
+        self.subscriptions
+            .iter()
+            .map(|entry| LiteSubscriptionRecord {
+                client_id: entry.key().client_id.clone(),
+                group: entry.key().group.clone(),
+                topic: entry.key().topic.clone(),
+                lite_topic_set: entry.value().lite_topic_set().clone(),
+                update_time: entry.value().update_time(),
+            })
+            .collect()
     }
 
     fn cleanup_client_channel_if_unused(&self, client_id: &CheetahString) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7008

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Broker now supports four new information query operations to retrieve aggregated lite metadata, topic details, and client subscription information.

* **Tests**
  * Added test coverage for the new broker information query operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->