### PR TITLE
[ISSUE #7010]🚀Add LiteGroupInfo handling and triggerLiteDispatch processor to LiteManager

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -806,6 +806,14 @@ impl BrokerRuntime {
             BrokerProcessorType::LiteManager(ArcMut::new(LiteManagerProcessor::new(self.inner.clone()))),
         );
         broker_request_processor.register_processor(
+            RequestCode::GetLiteGroupInfo as i32,
+            BrokerProcessorType::LiteManager(ArcMut::new(LiteManagerProcessor::new(self.inner.clone()))),
+        );
+        broker_request_processor.register_processor(
+            RequestCode::TriggerLiteDispatch as i32,
+            BrokerProcessorType::LiteManager(ArcMut::new(LiteManagerProcessor::new(self.inner.clone()))),
+        );
+        broker_request_processor.register_processor(
             RequestCode::LiteSubscriptionCtl as i32,
             BrokerProcessorType::LiteSubscriptionCtl(ArcMut::new(LiteSubscriptionCtlProcessor::new(
                 self.inner.clone(),
@@ -3315,14 +3323,17 @@ mod tests {
     use rocketmq_remoting::protocol::body::broker_body::broker_member_group::GetBrokerMemberGroupResponseBody;
     use rocketmq_remoting::protocol::body::get_broker_lite_info_response_body::GetBrokerLiteInfoResponseBody;
     use rocketmq_remoting::protocol::body::get_lite_client_info_response_body::GetLiteClientInfoResponseBody;
+    use rocketmq_remoting::protocol::body::get_lite_group_info_response_body::GetLiteGroupInfoResponseBody;
     use rocketmq_remoting::protocol::body::get_lite_topic_info_response_body::GetLiteTopicInfoResponseBody;
     use rocketmq_remoting::protocol::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
     use rocketmq_remoting::protocol::header::controller::apply_broker_id_request_header::ApplyBrokerIdRequestHeader;
     use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
     use rocketmq_remoting::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+    use rocketmq_remoting::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader;
     use rocketmq_remoting::protocol::header::get_lite_topic_info_request_header::GetLiteTopicInfoRequestHeader;
     use rocketmq_remoting::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader;
     use rocketmq_remoting::protocol::header::namesrv::broker_request::GetBrokerMemberGroupRequestHeader;
+    use rocketmq_remoting::protocol::header::trigger_lite_dispatch_request_header::TriggerLiteDispatchRequestHeader;
     use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
     use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
     use rocketmq_remoting::protocol::RemotingDeserializable;
@@ -3334,6 +3345,7 @@ mod tests {
     use rocketmq_store::base::message_store::MessageStore;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
     use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
+    use rocketmq_store::queue::consume_queue_store::ConsumeQueueStoreTrait;
     use rocketmq_store::timer::timer_message_store::TimerMessageStore;
     use tokio::sync::oneshot;
     use tokio::task::JoinHandle;
@@ -3507,6 +3519,33 @@ mod tests {
                 to_lmq_name("parent-topic", "child-b").expect("child-b lmq"),
             )]),
             1,
+        );
+    }
+
+    fn seed_lmq_offsets(runtime: &mut BrokerRuntime, offsets: &[(&str, i64)]) {
+        let inner = runtime.inner_for_test();
+        let mut topic_queue_table = HashMap::new();
+        for (lite_topic, offset) in offsets {
+            let lmq_name = to_lmq_name("parent-topic", lite_topic).expect("lmq name");
+            topic_queue_table.insert(CheetahString::from_string(format!("{lmq_name}-0")), *offset);
+        }
+        inner
+            .message_store_mut()
+            .as_mut()
+            .expect("message store should be initialized")
+            .consume_queue_store_mut()
+            .set_topic_queue_table(topic_queue_table);
+    }
+
+    fn seed_lmq_consumer_offset(runtime: &mut BrokerRuntime, group: &str, lite_topic: &str, offset: i64) {
+        let inner = runtime.inner_for_test();
+        let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", lite_topic).expect("lmq name"));
+        inner.consumer_offset_manager().commit_offset(
+            CheetahString::from_static_str("127.0.0.1"),
+            &CheetahString::from(group),
+            &lmq_name,
+            0,
+            offset,
         );
     }
 
@@ -4348,6 +4387,132 @@ mod tests {
                 CheetahString::from_static_str("child-b"),
             ])
         );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn get_lite_group_info_returns_offset_wrapper_for_specific_lite_topic() {
+        let mut runtime = new_lite_test_runtime("lite-group-info-topic").await;
+        seed_lite_query_state(&mut runtime);
+        seed_lmq_offsets(&mut runtime, &[("child-a", 8), ("child-b", 12)]);
+        seed_lmq_consumer_offset(&mut runtime, "group-a", "child-b", 0);
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = GetLiteGroupInfoRequestHeader {
+            group: CheetahString::from_static_str("group-a"),
+            lite_topic: CheetahString::from_static_str("child-b"),
+            top_k: 10,
+            rpc: None,
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::GetLiteGroupInfo, header);
+        request.make_custom_header_to_net();
+        let mut response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let body = GetLiteGroupInfoResponseBody::decode(
+            response
+                .take_body()
+                .expect("GetLiteGroupInfo response should contain a body")
+                .as_ref(),
+        )
+        .expect("decode lite group info response body");
+        assert_eq!(body.group(), &CheetahString::from_static_str("group-a"));
+        assert_eq!(body.parent_topic(), &CheetahString::from_static_str("parent-topic"));
+        assert_eq!(body.lite_topic(), &CheetahString::from_static_str("child-b"));
+        assert_eq!(body.total_lag_count(), 12);
+        assert_eq!(body.earliest_unconsumed_timestamp(), 0);
+        let offset_wrapper = body
+            .lite_topic_offset_wrapper()
+            .expect("specific lite topic should include offset wrapper");
+        assert_eq!(offset_wrapper.get_broker_offset(), 12);
+        assert_eq!(offset_wrapper.get_consumer_offset(), 0);
+        assert_eq!(offset_wrapper.get_last_timestamp(), 0);
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn get_lite_group_info_returns_topk_aggregates_for_group() {
+        let mut runtime = new_lite_test_runtime("lite-group-info-topk").await;
+        seed_lite_query_state(&mut runtime);
+        seed_lmq_offsets(&mut runtime, &[("child-a", 8), ("child-b", 12)]);
+        seed_lmq_consumer_offset(&mut runtime, "group-a", "child-a", 3);
+        seed_lmq_consumer_offset(&mut runtime, "group-a", "child-b", 0);
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = GetLiteGroupInfoRequestHeader {
+            group: CheetahString::from_static_str("group-a"),
+            lite_topic: CheetahString::from_static_str(""),
+            top_k: 1,
+            rpc: None,
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::GetLiteGroupInfo, header);
+        request.make_custom_header_to_net();
+        let mut response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let body = GetLiteGroupInfoResponseBody::decode(
+            response
+                .take_body()
+                .expect("GetLiteGroupInfo response should contain a body")
+                .as_ref(),
+        )
+        .expect("decode lite group info response body");
+        assert_eq!(body.group(), &CheetahString::from_static_str("group-a"));
+        assert_eq!(body.parent_topic(), &CheetahString::from_static_str("parent-topic"));
+        assert!(body.lite_topic().is_empty());
+        assert_eq!(body.total_lag_count(), 17);
+        assert_eq!(body.earliest_unconsumed_timestamp(), 0);
+        assert_eq!(body.lag_count_top_k().len(), 1);
+        assert_eq!(
+            body.lag_count_top_k()[0].lite_topic(),
+            &CheetahString::from_static_str("child-b")
+        );
+        assert_eq!(body.lag_count_top_k()[0].lag_count(), 12);
+        assert_eq!(body.lag_timestamp_top_k().len(), 1);
+        assert_eq!(body.lag_timestamp_top_k()[0].earliest_unconsumed_timestamp(), 0);
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn trigger_lite_dispatch_returns_illegal_operation_without_dispatcher() {
+        let mut runtime = new_lite_test_runtime("trigger-lite-dispatch").await;
+        seed_lite_query_state(&mut runtime);
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = TriggerLiteDispatchRequestHeader {
+            group: CheetahString::from_static_str("group-a"),
+            client_id: Some(CheetahString::from_static_str("client-1")),
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::TriggerLiteDispatch, header);
+        request.make_custom_header_to_net();
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::IllegalOperation);
+        assert!(response
+            .remark()
+            .expect("illegal operation should explain why")
+            .contains("LiteEventDispatcher"));
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-broker/src/processor/lite_manager_processor.rs
+++ b/rocketmq-broker/src/processor/lite_manager_processor.rs
@@ -23,14 +23,19 @@ use rocketmq_common::common::lite::to_lmq_name;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::admin::offset_wrapper::OffsetWrapper;
 use rocketmq_remoting::protocol::admin::topic_offset::TopicOffset;
 use rocketmq_remoting::protocol::body::get_broker_lite_info_response_body::GetBrokerLiteInfoResponseBody;
 use rocketmq_remoting::protocol::body::get_lite_client_info_response_body::GetLiteClientInfoResponseBody;
+use rocketmq_remoting::protocol::body::get_lite_group_info_response_body::GetLiteGroupInfoResponseBody;
 use rocketmq_remoting::protocol::body::get_lite_topic_info_response_body::GetLiteTopicInfoResponseBody;
 use rocketmq_remoting::protocol::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
+use rocketmq_remoting::protocol::body::lite_lag_info::LiteLagInfo;
 use rocketmq_remoting::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+use rocketmq_remoting::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader;
 use rocketmq_remoting::protocol::header::get_lite_topic_info_request_header::GetLiteTopicInfoRequestHeader;
 use rocketmq_remoting::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader;
+use rocketmq_remoting::protocol::header::trigger_lite_dispatch_request_header::TriggerLiteDispatchRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
@@ -66,6 +71,8 @@ impl<MS: MessageStore> RequestProcessor for LiteManagerProcessor<MS> {
             RequestCode::GetParentTopicInfo => self.get_parent_topic_info(request),
             RequestCode::GetLiteTopicInfo => self.get_lite_topic_info(request),
             RequestCode::GetLiteClientInfo => self.get_lite_client_info(request),
+            RequestCode::GetLiteGroupInfo => self.get_lite_group_info(request),
+            RequestCode::TriggerLiteDispatch => self.trigger_lite_dispatch(request),
             request_code => {
                 warn!("LiteManagerProcessor received unknown request code: {:?}", request_code);
                 Ok(Some(self.response_with_code(
@@ -295,6 +302,113 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
         Ok(Some(self.response_with_body(request, &body)?))
     }
 
+    fn get_lite_group_info(
+        &self,
+        request: &RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_header = request.decode_command_custom_header::<GetLiteGroupInfoRequestHeader>()?;
+        let group = request_header.group;
+        let lite_topic = request_header.lite_topic;
+        let top_k = request_header.top_k;
+        let bind_topic = match self.validate_lite_group(&group) {
+            Ok(bind_topic) => bind_topic,
+            Err((code, remark)) => return Ok(Some(self.response_with_code(request, code, remark))),
+        };
+
+        let mut body = GetLiteGroupInfoResponseBody::new();
+        body.with_group(group.clone())
+            .with_parent_topic(bind_topic.clone())
+            .with_lite_topic(lite_topic.clone());
+
+        if lite_topic.is_empty() {
+            let lag_infos = self.collect_group_lag_infos(&group, &bind_topic);
+            let total_lag_count = lag_infos.iter().map(|info| info.lag_count()).sum();
+            let earliest_unconsumed_timestamp = lag_infos
+                .iter()
+                .map(|info| info.earliest_unconsumed_timestamp())
+                .filter(|timestamp| *timestamp >= 0)
+                .min()
+                .unwrap_or(0);
+
+            let mut lag_count_top_k = lag_infos.clone();
+            lag_count_top_k.sort_by(|left, right| {
+                right
+                    .lag_count()
+                    .cmp(&left.lag_count())
+                    .then_with(|| left.lite_topic().as_str().cmp(right.lite_topic().as_str()))
+            });
+
+            let mut lag_timestamp_top_k = lag_infos;
+            lag_timestamp_top_k.sort_by(|left, right| {
+                left.earliest_unconsumed_timestamp()
+                    .cmp(&right.earliest_unconsumed_timestamp())
+                    .then_with(|| right.lag_count().cmp(&left.lag_count()))
+                    .then_with(|| left.lite_topic().as_str().cmp(right.lite_topic().as_str()))
+            });
+
+            let limit = if top_k > 0 {
+                top_k as usize
+            } else {
+                lag_count_top_k.len()
+            };
+            lag_count_top_k.truncate(limit);
+            lag_timestamp_top_k.truncate(limit);
+
+            body.with_total_lag_count(total_lag_count)
+                .with_earliest_unconsumed_timestamp(earliest_unconsumed_timestamp)
+                .with_lag_count_top_k(lag_count_top_k)
+                .with_lag_timestamp_top_k(lag_timestamp_top_k);
+        } else {
+            let Some(lmq_name) = to_lmq_name(bind_topic.as_str(), lite_topic.as_str()) else {
+                return Ok(Some(self.response_with_code(
+                    request,
+                    ResponseCode::InvalidParameter,
+                    "liteTopic is blank.",
+                )));
+            };
+            let lmq_name = CheetahString::from_string(lmq_name);
+            let broker_offset = self.lmq_broker_offset(&lmq_name);
+            if broker_offset > 0 {
+                let commit_offset = self
+                    .broker_runtime_inner
+                    .consumer_offset_manager()
+                    .query_offset(&group, &lmq_name, 0);
+                if commit_offset >= 0 {
+                    let mut offset_wrapper = OffsetWrapper::new();
+                    offset_wrapper.set_broker_offset(broker_offset);
+                    offset_wrapper.set_consumer_offset(commit_offset);
+                    offset_wrapper.set_last_timestamp(self.last_consumed_timestamp(&lmq_name, commit_offset));
+
+                    body.with_total_lag_count((broker_offset - commit_offset).max(0))
+                        .with_earliest_unconsumed_timestamp(
+                            self.earliest_unconsumed_timestamp(&lmq_name, commit_offset),
+                        )
+                        .with_lite_topic_offset_wrapper(offset_wrapper);
+                }
+            } else {
+                body.with_total_lag_count(-1).with_earliest_unconsumed_timestamp(-1);
+            }
+        }
+
+        Ok(Some(self.response_with_body(request, &body)?))
+    }
+
+    fn trigger_lite_dispatch(
+        &self,
+        request: &RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_header = request.decode_command_custom_header::<TriggerLiteDispatchRequestHeader>()?;
+        if let Err((code, remark)) = self.validate_lite_group(&request_header.group) {
+            return Ok(Some(self.response_with_code(request, code, remark)));
+        }
+
+        Ok(Some(self.response_with_code(
+            request,
+            ResponseCode::IllegalOperation,
+            "LiteEventDispatcher is not initialized.",
+        )))
+    }
+
     fn build_lite_topic_meta(&self, subscriptions: &[LiteSubscriptionRecord]) -> HashMap<CheetahString, i32> {
         subscriptions
             .iter()
@@ -327,11 +441,49 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
         )
     }
 
+    fn collect_group_lag_infos(&self, group: &CheetahString, parent_topic: &CheetahString) -> Vec<LiteLagInfo> {
+        let lite_topics = self
+            .broker_runtime_inner
+            .lite_subscription_registry()
+            .all_subscriptions()
+            .into_iter()
+            .filter(|subscription| subscription.group == *group && subscription.topic == *parent_topic)
+            .flat_map(|subscription| subscription.lite_topic_set.into_iter())
+            .filter_map(|lmq_name| get_lite_topic(lmq_name.as_str()).map(CheetahString::from_string))
+            .collect::<BTreeSet<_>>();
+
+        lite_topics
+            .into_iter()
+            .map(|lite_topic| {
+                let lmq_name =
+                    CheetahString::from_string(to_lmq_name(parent_topic.as_str(), lite_topic.as_str()).expect("lmq"));
+                let broker_offset = self.lmq_broker_offset(&lmq_name);
+                let commit_offset = self
+                    .broker_runtime_inner
+                    .consumer_offset_manager()
+                    .query_offset(group, &lmq_name, 0);
+                let lag_count = if broker_offset > 0 {
+                    (broker_offset - commit_offset.max(0)).max(0)
+                } else {
+                    0
+                };
+
+                let mut lag_info = LiteLagInfo::new();
+                lag_info
+                    .with_lite_topic(lite_topic)
+                    .with_lag_count(lag_count)
+                    .with_earliest_unconsumed_timestamp(if broker_offset > 0 {
+                        self.earliest_unconsumed_timestamp(&lmq_name, commit_offset)
+                    } else {
+                        -1
+                    });
+                lag_info
+            })
+            .collect()
+    }
+
     fn queue_store_stats(&self) -> (i32, i32) {
-        let Some(message_store) = self.broker_runtime_inner.message_store() else {
-            return (0, 0);
-        };
-        let Some(queue_store) = message_store.get_queue_store().downcast_ref::<ConsumeQueueStore>() else {
+        let Some(queue_store) = self.queue_store() else {
             return (0, 0);
         };
 
@@ -359,6 +511,49 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
         topic_offset.set_max_offset(max_offset);
         topic_offset.set_last_update_timestamp(last_update_timestamp);
         Some(topic_offset)
+    }
+
+    fn queue_store(&self) -> Option<&ConsumeQueueStore> {
+        self.broker_runtime_inner
+            .message_store()
+            .and_then(|message_store| message_store.get_queue_store().downcast_ref::<ConsumeQueueStore>())
+    }
+
+    fn lmq_broker_offset(&self, lmq_name: &CheetahString) -> i64 {
+        let Some(queue_store) = self.queue_store() else {
+            return 0;
+        };
+        queue_store.get_lmq_queue_offset(format!("{lmq_name}-0").as_str())
+    }
+
+    fn earliest_unconsumed_timestamp(&self, lmq_name: &CheetahString, commit_offset: i64) -> i64 {
+        if commit_offset <= 0 {
+            return 0;
+        }
+
+        self.broker_runtime_inner
+            .message_store()
+            .map(|message_store| {
+                message_store
+                    .get_message_store_timestamp(lmq_name, 0, commit_offset)
+                    .max(0)
+            })
+            .unwrap_or(0)
+    }
+
+    fn last_consumed_timestamp(&self, lmq_name: &CheetahString, commit_offset: i64) -> i64 {
+        if commit_offset <= 0 {
+            return 0;
+        }
+
+        self.broker_runtime_inner
+            .message_store()
+            .map(|message_store| {
+                message_store
+                    .get_message_store_timestamp(lmq_name, 0, commit_offset - 1)
+                    .max(0)
+            })
+            .unwrap_or(0)
     }
 
     fn decode_lite_topic_set(&self, lmq_name_set: &HashSet<CheetahString>, max_count: i32) -> HashSet<CheetahString> {
@@ -405,6 +600,29 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
             _ => Err((
                 ResponseCode::InvalidParameter,
                 CheetahString::from_string(format!("Subscription [{}]-[{}] not match.", group, topic)),
+            )),
+        }
+    }
+
+    fn validate_lite_group(&self, group: &CheetahString) -> Result<CheetahString, (ResponseCode, CheetahString)> {
+        let group_config = self
+            .broker_runtime_inner
+            .subscription_group_manager()
+            .subscription_group_table()
+            .get(group)
+            .map(|entry| std::sync::Arc::clone(entry.value()))
+            .ok_or_else(|| {
+                (
+                    ResponseCode::SubscriptionGroupNotExist,
+                    CheetahString::from_string(format!("Group [{}] not exist.", group)),
+                )
+            })?;
+
+        match group_config.lite_bind_topic() {
+            Some(bind_topic) if !bind_topic.is_empty() => Ok(bind_topic.clone()),
+            _ => Err((
+                ResponseCode::InvalidParameter,
+                CheetahString::from_string(format!("Group [{}] is not a LITE group.", group)),
             )),
         }
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7010

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lite subscription group information retrieval, including aggregated lag metrics and per-topic offset data
  * Enabled Lite event dispatch triggering for subscription groups

* **Tests**
  * Added comprehensive test coverage for Lite group information retrieval with offset and lag validation
  * Added validation tests for Lite dispatch operations with error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->