### PR TITLE
[ISSUE #7018]🚀Implement PopLiteLongPollingService and integrate with Lite message processing

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -257,6 +257,7 @@ impl BrokerRuntime {
             is_transaction_check_service_start: Arc::new(Default::default()),
             client_housekeeping_service: None,
             pop_message_processor: None,
+            pop_lite_message_processor: None,
             ack_message_processor: None,
             notification_processor: None,
             query_assignment_processor: None,
@@ -373,6 +374,10 @@ impl BrokerRuntime {
 
         if let Some(pop_message_processor) = self.inner.pop_message_processor.as_mut() {
             pop_message_processor.shutdown();
+        }
+
+        if let Some(pop_lite_message_processor) = self.inner.pop_lite_message_processor.as_mut() {
+            pop_lite_message_processor.shutdown();
         }
 
         if let Some(ack_message_processor) = self.inner.ack_message_processor.as_mut() {
@@ -639,6 +644,8 @@ impl BrokerRuntime {
 
         let pop_message_processor = PopMessageProcessor::new_arc_mut(self.inner.clone());
         self.inner.pop_message_processor = Some(pop_message_processor.clone());
+        let pop_lite_message_processor = PopLiteMessageProcessor::new_arc_mut(self.inner.clone());
+        self.inner.pop_lite_message_processor = Some(pop_lite_message_processor.clone());
         let ack_message_processor = ArcMut::new(AckMessageProcessor::new(
             self.inner.clone(),
             pop_message_processor.clone(),
@@ -696,7 +703,7 @@ impl BrokerRuntime {
         );
         broker_request_processor.register_processor(
             RequestCode::PopLiteMessage as i32,
-            BrokerProcessorType::PopLite(ArcMut::new(PopLiteMessageProcessor::new(self.inner.clone()))),
+            BrokerProcessorType::PopLite(pop_lite_message_processor),
         );
 
         //AckMessageProcessor
@@ -1082,6 +1089,9 @@ impl BrokerRuntime {
 
         if let Some(pop_message_processor) = self.inner.pop_message_processor.as_mut() {
             pop_message_processor.start();
+        }
+        if let Some(pop_lite_message_processor) = self.inner.pop_lite_message_processor.as_mut() {
+            pop_lite_message_processor.start();
         }
         if let Some(ack_message_processor) = self.inner.ack_message_processor.as_mut() {
             ack_message_processor.start();
@@ -1560,6 +1570,7 @@ pub(crate) struct BrokerRuntimeInner<MS: MessageStore> {
     client_housekeeping_service: Option<Arc<ClientHousekeepingService<MS>>>,
     //Processor
     pop_message_processor: Option<ArcMut<PopMessageProcessor<MS>>>,
+    pop_lite_message_processor: Option<ArcMut<PopLiteMessageProcessor<MS>>>,
     ack_message_processor: Option<ArcMut<AckMessageProcessor<MS>>>,
     notification_processor: Option<ArcMut<NotificationProcessor<MS>>>,
     query_assignment_processor: Option<ArcMut<QueryAssignmentProcessor<MS>>>,
@@ -4664,6 +4675,161 @@ mod tests {
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::PollingTimeout);
 
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn pop_lite_message_without_events_suspends_when_polling_enabled() {
+        let mut runtime = new_lite_test_runtime("pop-lite-suspend").await;
+        seed_lite_query_state(&mut runtime);
+
+        let (mut processor, _) = runtime.init_processor();
+        runtime
+            .inner
+            .pop_lite_message_processor
+            .as_mut()
+            .expect("pop lite processor should be initialized")
+            .start();
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = PopLiteMessageRequestHeader {
+            client_id: CheetahString::from_static_str("client-1"),
+            consumer_group: CheetahString::from_static_str("group-a"),
+            topic: CheetahString::from_static_str("parent-topic"),
+            max_msg_num: 1,
+            invisible_time: 60_000,
+            poll_time: 3_000,
+            born_time: current_millis() as i64,
+            attempt_id: None,
+            rpc: None,
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, header);
+        request.make_custom_header_to_net();
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed");
+
+        assert!(
+            response.is_none(),
+            "polling pop-lite should suspend instead of responding"
+        );
+        assert!(request.suspended());
+        assert_eq!(
+            runtime
+                .inner
+                .pop_lite_message_processor
+                .as_ref()
+                .expect("pop lite processor should be initialized")
+                .pop_lite_long_polling_service()
+                .get_polling_num("client-1"),
+            1
+        );
+
+        runtime
+            .inner
+            .pop_lite_message_processor
+            .as_mut()
+            .expect("pop lite processor should be initialized")
+            .shutdown();
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn trigger_lite_dispatch_wakes_suspended_pop_lite_request_and_advances_offset() {
+        let mut runtime = new_lite_test_runtime("pop-lite-trigger-wakeup").await;
+        seed_lite_query_state(&mut runtime);
+        seed_lmq_message(&mut runtime, "child-a", b"lite-body").await;
+        let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+
+        let (mut processor, _) = runtime.init_processor();
+        runtime
+            .inner
+            .pop_lite_message_processor
+            .as_mut()
+            .expect("pop lite processor should be initialized")
+            .start();
+
+        let pop_channel = create_test_channel().await;
+        let pop_ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(pop_channel.clone()));
+        let pop_header = PopLiteMessageRequestHeader {
+            client_id: CheetahString::from_static_str("client-1"),
+            consumer_group: CheetahString::from_static_str("group-a"),
+            topic: CheetahString::from_static_str("parent-topic"),
+            max_msg_num: 1,
+            invisible_time: 60_000,
+            poll_time: 3_000,
+            born_time: current_millis() as i64,
+            attempt_id: None,
+            rpc: None,
+        };
+        let mut pop_request = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, pop_header);
+        pop_request.make_custom_header_to_net();
+        let response = processor
+            .process_request(pop_channel, pop_ctx, &mut pop_request)
+            .await
+            .expect("pop lite should suspend cleanly");
+        assert!(
+            response.is_none(),
+            "suspended pop-lite should not produce an immediate response"
+        );
+
+        let trigger_channel = create_test_channel().await;
+        let trigger_ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(trigger_channel.clone()));
+        let trigger_header = TriggerLiteDispatchRequestHeader {
+            group: CheetahString::from_static_str("group-a"),
+            client_id: Some(CheetahString::from_static_str("client-1")),
+        };
+        let mut trigger_request =
+            RemotingCommand::create_request_command(RequestCode::TriggerLiteDispatch, trigger_header);
+        trigger_request.make_custom_header_to_net();
+        let trigger_response = processor
+            .process_request(trigger_channel, trigger_ctx, &mut trigger_request)
+            .await
+            .expect("trigger lite dispatch should succeed")
+            .expect("trigger lite dispatch should return a response");
+        assert_eq!(ResponseCode::from(trigger_response.code()), ResponseCode::Success);
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        loop {
+            if runtime.inner.consumer_offset_manager().query_offset(
+                &CheetahString::from_static_str("group-a"),
+                &lmq_name,
+                0,
+            ) == 1
+            {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "suspended pop-lite request should be woken and advance offset"
+            );
+            sleep(Duration::from_millis(20)).await;
+        }
+
+        assert_eq!(
+            runtime
+                .inner
+                .pop_lite_message_processor
+                .as_ref()
+                .expect("pop lite processor should be initialized")
+                .pop_lite_long_polling_service()
+                .get_polling_num("client-1"),
+            0
+        );
+        assert!(runtime
+            .inner
+            .lite_event_dispatcher()
+            .pending_events(&CheetahString::from_static_str("client-1"))
+            .is_empty());
+
+        runtime
+            .inner
+            .pop_lite_message_processor
+            .as_mut()
+            .expect("pop lite processor should be initialized")
+            .shutdown();
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 

--- a/rocketmq-broker/src/lite/lite_event_dispatcher.rs
+++ b/rocketmq-broker/src/lite/lite_event_dispatcher.rs
@@ -16,10 +16,12 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_common::TimeUtils::current_millis;
+use tokio::sync::mpsc::UnboundedSender;
 
 #[derive(Debug, Clone, Default)]
 struct ClientEventState {
@@ -31,9 +33,14 @@ struct ClientEventState {
 pub(crate) struct LiteEventDispatcher {
     client_events: Arc<DashMap<CheetahString, ClientEventState>>,
     client_last_access_time: Arc<DashMap<CheetahString, u64>>,
+    wakeup_sender: Arc<Mutex<Option<UnboundedSender<CheetahString>>>>,
 }
 
 impl LiteEventDispatcher {
+    pub(crate) fn set_wakeup_sender(&self, wakeup_sender: UnboundedSender<CheetahString>) {
+        *self.wakeup_sender.lock().expect("lite wakeup sender lock poisoned") = Some(wakeup_sender);
+    }
+
     pub(crate) fn touch_client(&self, client_id: &CheetahString) {
         self.client_last_access_time.insert(client_id.clone(), current_millis());
     }
@@ -60,11 +67,17 @@ impl LiteEventDispatcher {
             return 0;
         }
 
-        let mut entry = self.client_events.entry(client_id.clone()).or_default();
-        entry.group = group.clone();
-        let original_len = entry.events.len();
-        entry.events.extend(lmq_names.iter().cloned());
-        entry.events.len().saturating_sub(original_len)
+        let inserted = {
+            let mut entry = self.client_events.entry(client_id.clone()).or_default();
+            entry.group = group.clone();
+            let original_len = entry.events.len();
+            entry.events.extend(lmq_names.iter().cloned());
+            entry.events.len().saturating_sub(original_len)
+        };
+        if inserted > 0 {
+            self.notify_client(client_id);
+        }
+        inserted
     }
 
     pub(crate) fn do_full_dispatch_by_group(
@@ -90,6 +103,17 @@ impl LiteEventDispatcher {
             .remove(client_id)
             .map(|(_, entry)| entry.events.into_iter().collect())
             .unwrap_or_default()
+    }
+
+    fn notify_client(&self, client_id: &CheetahString) {
+        let sender = self
+            .wakeup_sender
+            .lock()
+            .expect("lite wakeup sender lock poisoned")
+            .clone();
+        if let Some(sender) = sender {
+            let _ = sender.send(client_id.clone());
+        }
     }
 }
 
@@ -142,5 +166,19 @@ mod tests {
             vec![CheetahString::from_static_str("%LMQ%$parent$child-a")]
         );
         assert_eq!(dispatcher.event_map_size(), 0);
+    }
+
+    #[tokio::test]
+    async fn do_full_dispatch_notifies_registered_wakeup_sender() {
+        let dispatcher = LiteEventDispatcher::default();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        dispatcher.set_wakeup_sender(sender);
+        let client_id = CheetahString::from_static_str("client-a");
+        let group = CheetahString::from_static_str("group-a");
+        let lmq_names = HashSet::from([CheetahString::from_static_str("%LMQ%$parent$child-a")]);
+
+        dispatcher.do_full_dispatch(&client_id, &group, &lmq_names);
+
+        assert_eq!(receiver.recv().await, Some(client_id));
     }
 }

--- a/rocketmq-broker/src/long_polling/long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) mod pop_lite_long_polling_service;
 pub(crate) mod pop_long_polling_service;
 pub(crate) mod pull_request_hold_service;

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
@@ -1,0 +1,231 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use crossbeam_skiplist::SkipSet;
+use dashmap::DashMap;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
+use rocketmq_remoting::runtime::processor::RequestProcessor;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+use tokio::select;
+use tokio::sync::mpsc::unbounded_channel;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::Notify;
+use tracing::error;
+
+use crate::broker_runtime::BrokerRuntimeInner;
+use crate::long_polling::polling_result::PollingResult;
+use crate::long_polling::pop_request::PopRequest;
+
+pub(crate) struct PopLiteLongPollingService<MS: MessageStore, RP> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+    polling_map: DashMap<CheetahString, SkipSet<Arc<PopRequest>>>,
+    total_polling_num: AtomicU64,
+    processor: Option<ArcMut<RP>>,
+    notify: Notify,
+    wakeup_tx: UnboundedSender<CheetahString>,
+    wakeup_rx: Option<UnboundedReceiver<CheetahString>>,
+}
+
+impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPollingService<MS, RP> {
+    pub(crate) fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        let (wakeup_tx, wakeup_rx) = unbounded_channel();
+        Self {
+            broker_runtime_inner: broker_runtime_inner.clone(),
+            polling_map: DashMap::with_capacity(broker_runtime_inner.broker_config().pop_polling_map_size),
+            total_polling_num: AtomicU64::new(0),
+            processor: None,
+            notify: Notify::new(),
+            wakeup_tx,
+            wakeup_rx: Some(wakeup_rx),
+        }
+    }
+
+    pub(crate) fn start(this: ArcMut<Self>) {
+        let mut wakeup_rx = this
+            .mut_from_ref()
+            .wakeup_rx
+            .take()
+            .expect("pop-lite long polling receiver should only be taken once");
+        tokio::spawn(async move {
+            loop {
+                select! {
+                    _ = this.notify.notified() => { break; }
+                    wakeup = wakeup_rx.recv() => {
+                        match wakeup {
+                            Some(client_id) => {
+                                this.wake_up_client(&client_id);
+                            }
+                            None => break,
+                        }
+                    }
+                    _ = tokio::time::sleep(tokio::time::Duration::from_millis(20)) => {}
+                }
+
+                if this.polling_map.is_empty() {
+                    continue;
+                }
+                for entry in this.polling_map.iter() {
+                    let queue = entry.value();
+                    if queue.is_empty() {
+                        continue;
+                    }
+                    loop {
+                        let Some(first) = queue.pop_front() else {
+                            break;
+                        };
+                        let first = first.value().clone();
+                        if !first.is_timeout() {
+                            queue.insert(first);
+                            break;
+                        }
+                        this.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+                        this.wake_up(first);
+                    }
+                }
+            }
+
+            for entry in this.polling_map.iter() {
+                let queue = entry.value();
+                while let Some(first) = queue.pop_front() {
+                    this.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+                    this.wake_up(first.value().clone());
+                }
+            }
+        });
+    }
+
+    pub(crate) fn shutdown(&mut self) {
+        self.notify.notify_waiters();
+    }
+
+    pub(crate) fn wakeup_sender(&self) -> UnboundedSender<CheetahString> {
+        self.wakeup_tx.clone()
+    }
+
+    pub(crate) fn polling(
+        &self,
+        ctx: ConnectionHandlerContext,
+        remoting_command: &mut RemotingCommand,
+        client_id: &CheetahString,
+        born_time: i64,
+        poll_time: i64,
+    ) -> PollingResult {
+        if poll_time <= 0 {
+            return PollingResult::NotPolling;
+        }
+
+        let expired = born_time.saturating_add(poll_time);
+        let request = Arc::new(PopRequest::new(
+            remoting_command.clone(),
+            ctx,
+            expired as u64,
+            None,
+            None,
+        ));
+
+        if self.total_polling_num.load(Ordering::SeqCst)
+            >= self.broker_runtime_inner.broker_config().max_pop_polling_size
+        {
+            return PollingResult::PollingFull;
+        }
+
+        if request.is_timeout() {
+            return PollingResult::PollingTimeout;
+        }
+
+        let queue = self.polling_map.entry(client_id.clone()).or_default();
+        if queue.len() > self.broker_runtime_inner.broker_config().pop_polling_size {
+            return PollingResult::PollingFull;
+        }
+
+        queue.insert(request);
+        remoting_command.set_suspended_ref(true);
+        self.total_polling_num.fetch_add(1, Ordering::SeqCst);
+        PollingResult::PollingSuc
+    }
+
+    pub(crate) fn wake_up_client(&self, client_id: &CheetahString) -> bool {
+        let Some(remoting_commands) = self.polling_map.get(client_id) else {
+            return false;
+        };
+        let Some(pop_request) = self.poll_request(remoting_commands.value()) else {
+            return false;
+        };
+        self.wake_up(pop_request)
+    }
+
+    fn wake_up(&self, pop_request: Arc<PopRequest>) -> bool {
+        if !pop_request.complete() {
+            return false;
+        }
+        match self.processor.clone() {
+            None => false,
+            Some(mut processor) => {
+                tokio::spawn(async move {
+                    let channel = pop_request.get_channel().clone();
+                    let ctx = pop_request.get_ctx().clone();
+                    let opaque = pop_request.get_remoting_command().opaque();
+                    let response = processor
+                        .process_request(channel, ctx, &mut pop_request.get_remoting_command().clone())
+                        .await;
+                    match response {
+                        Ok(result) => {
+                            if let Some(mut response) = result {
+                                let channel = pop_request.get_channel();
+                                response.set_opaque_mut(opaque);
+                                let _ = channel.channel_inner().send_oneway(response, 1000).await;
+                            }
+                        }
+                        Err(error) => {
+                            error!("Execute pop-lite request when wakeup run {}", error);
+                        }
+                    }
+                });
+                true
+            }
+        }
+    }
+
+    fn poll_request(&self, remoting_commands: &SkipSet<Arc<PopRequest>>) -> Option<Arc<PopRequest>> {
+        if remoting_commands.is_empty() {
+            return None;
+        }
+
+        loop {
+            let pop_request = remoting_commands.pop_front().map(|entry| entry.value().clone())?;
+            self.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+            if !pop_request.get_channel().connection_ref().is_healthy() {
+                continue;
+            }
+            return Some(pop_request);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn get_polling_num(&self, key: &str) -> i32 {
+        self.polling_map.get(key).map(|queue| queue.len() as i32).unwrap_or(0)
+    }
+
+    pub(crate) fn set_processor(&mut self, processor: ArcMut<RP>) {
+        self.processor = Some(processor);
+    }
+}

--- a/rocketmq-broker/src/processor/pop_lite_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor.rs
@@ -32,14 +32,46 @@ use rocketmq_store::base::message_status_enum::GetMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
 
 use crate::broker_runtime::BrokerRuntimeInner;
+use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingService;
+use crate::long_polling::polling_result::PollingResult;
 
 pub(crate) struct PopLiteMessageProcessor<MS: MessageStore> {
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+    pop_lite_long_polling_service: ArcMut<PopLiteLongPollingService<MS, PopLiteMessageProcessor<MS>>>,
 }
 
 impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
     pub(crate) fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        Self { broker_runtime_inner }
+        Self {
+            pop_lite_long_polling_service: ArcMut::new(PopLiteLongPollingService::new(broker_runtime_inner.clone())),
+            broker_runtime_inner,
+        }
+    }
+
+    pub(crate) fn new_arc_mut(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> ArcMut<Self> {
+        let mut processor = ArcMut::new(Self::new(broker_runtime_inner.clone()));
+        let wakeup_sender = processor.pop_lite_long_polling_service.wakeup_sender();
+        broker_runtime_inner
+            .lite_event_dispatcher()
+            .set_wakeup_sender(wakeup_sender);
+
+        let cloned = processor.clone();
+        processor.pop_lite_long_polling_service.set_processor(cloned);
+        processor
+    }
+
+    pub(crate) fn start(&mut self) {
+        PopLiteLongPollingService::start(self.pop_lite_long_polling_service.clone());
+    }
+
+    pub(crate) fn shutdown(&mut self) {
+        self.pop_lite_long_polling_service.shutdown();
+    }
+
+    pub(crate) fn pop_lite_long_polling_service(
+        &self,
+    ) -> &ArcMut<PopLiteLongPollingService<MS, PopLiteMessageProcessor<MS>>> {
+        &self.pop_lite_long_polling_service
     }
 
     fn pre_check(&self, request_header: &PopLiteMessageRequestHeader) -> Option<(ResponseCode, CheetahString)> {
@@ -245,7 +277,7 @@ impl<MS: MessageStore> RequestProcessor for PopLiteMessageProcessor<MS> {
     async fn process_request(
         &mut self,
         _channel: Channel,
-        _ctx: ConnectionHandlerContext,
+        ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<PopLiteMessageRequestHeader>()?;
@@ -284,8 +316,29 @@ impl<MS: MessageStore> RequestProcessor for PopLiteMessageProcessor<MS> {
                 response.set_body_mut_ref(body);
             }
             None => {
-                response.set_code_ref(ResponseCode::PollingTimeout);
-                response.set_remark_mut("NO_MESSAGE_IN_QUEUE");
+                match self.pop_lite_long_polling_service.polling(
+                    ctx,
+                    request,
+                    &request_header.client_id,
+                    request_header.born_time,
+                    request_header.poll_time,
+                ) {
+                    PollingResult::PollingSuc => {
+                        if !dispatcher.pending_events(&request_header.client_id).is_empty() {
+                            self.pop_lite_long_polling_service
+                                .wake_up_client(&request_header.client_id);
+                        }
+                        return Ok(None);
+                    }
+                    PollingResult::PollingFull => {
+                        response.set_code_ref(ResponseCode::PollingFull);
+                        response.set_remark_mut("POP_LITE_POLLING_FULL");
+                    }
+                    _ => {
+                        response.set_code_ref(ResponseCode::PollingTimeout);
+                        response.set_remark_mut("NO_MESSAGE_IN_QUEUE");
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7018

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented long-polling support for pop-lite message requests, enabling clients to suspend requests and wait for events instead of receiving immediate responses.
  * Added client notification system that wakes suspended requests when new events are dispatched.
  * Integrated per-client polling management with timeout handling and capacity limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->