### PR TITLE
[ISSUE #7020]🚀Enhance PopLiteMessageProcessor with order info management and improve FIFO handling for pop requests

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -3328,6 +3328,7 @@ mod tests {
     use cheetah_string::CheetahString;
     use dashmap::DashMap;
     use rocketmq_common::common::attribute::subscription_group_attributes::LITE_BIND_TOPIC_ATTRIBUTE_NAME;
+    use rocketmq_common::common::attribute::Attribute;
     use rocketmq_common::common::config::TopicConfig;
     use rocketmq_common::common::entity::ClientGroup;
     use rocketmq_common::common::lite::to_lmq_name;
@@ -3339,6 +3340,7 @@ mod tests {
     use rocketmq_common::common::namesrv::namesrv_config::NamesrvConfig;
     use rocketmq_common::common::server::config::ServerConfig;
     use rocketmq_common::TimeUtils::current_millis;
+    use rocketmq_common::TopicAttributes;
     use rocketmq_controller::config::RaftPeer;
     use rocketmq_controller::config::StorageBackendType;
     use rocketmq_controller::controller::broker_heartbeat_manager::BrokerHeartbeatManager;
@@ -3370,6 +3372,7 @@ mod tests {
     use rocketmq_remoting::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader;
     use rocketmq_remoting::protocol::header::namesrv::broker_request::GetBrokerMemberGroupRequestHeader;
     use rocketmq_remoting::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
+    use rocketmq_remoting::protocol::header::pop_lite_message_response_header::PopLiteMessageResponseHeader;
     use rocketmq_remoting::protocol::header::trigger_lite_dispatch_request_header::TriggerLiteDispatchRequestHeader;
     use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
     use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
@@ -3520,9 +3523,17 @@ mod tests {
 
     fn seed_lite_query_state(runtime: &mut BrokerRuntime) {
         let inner = runtime.inner_for_test();
+        let mut topic_config = TopicConfig::with_queues("parent-topic", 1, 1);
+        topic_config.attributes.insert(
+            CheetahString::from_string(format!(
+                "+{}",
+                TopicAttributes::TopicAttributes::topic_message_type_attribute().name()
+            )),
+            CheetahString::from_static_str("LITE"),
+        );
         inner
             .topic_config_manager_mut()
-            .update_topic_config(ArcMut::new(TopicConfig::with_queues("parent-topic", 1, 1)));
+            .update_topic_config(ArcMut::new(topic_config));
 
         for group in ["group-a", "group-b"] {
             let mut config = SubscriptionGroupConfig::new(CheetahString::from_static_str(group));
@@ -4945,6 +4956,164 @@ mod tests {
             .lite_event_dispatcher()
             .pending_events(&CheetahString::from_static_str("client-1"))
             .is_empty());
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn pop_lite_message_blocks_fifo_for_different_attempt_id() {
+        let mut runtime = new_lite_test_runtime("pop-lite-fifo-block").await;
+        seed_lite_query_state(&mut runtime);
+        seed_lmq_message(&mut runtime, "child-a", b"lite-body-1").await;
+        seed_lmq_message(&mut runtime, "child-a", b"lite-body-2").await;
+        let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+
+        let (mut processor, _) = runtime.init_processor();
+        runtime.inner.lite_event_dispatcher().do_full_dispatch(
+            &CheetahString::from_static_str("client-1"),
+            &CheetahString::from_static_str("group-a"),
+            &HashSet::from([lmq_name.clone()]),
+        );
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let first_header = PopLiteMessageRequestHeader {
+            client_id: CheetahString::from_static_str("client-1"),
+            consumer_group: CheetahString::from_static_str("group-a"),
+            topic: CheetahString::from_static_str("parent-topic"),
+            max_msg_num: 1,
+            invisible_time: 5_000,
+            poll_time: 0,
+            born_time: current_millis() as i64,
+            attempt_id: Some(CheetahString::from_static_str("attempt-1")),
+            rpc: None,
+        };
+        let mut first_request = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, first_header);
+        first_request.make_custom_header_to_net();
+        let first_response = processor
+            .process_request(channel, ctx, &mut first_request)
+            .await
+            .expect("first pop lite should succeed")
+            .expect("first pop lite should return a response");
+        assert_eq!(ResponseCode::from(first_response.code()), ResponseCode::Success);
+        assert_eq!(
+            runtime.inner.consumer_offset_manager().query_offset(
+                &CheetahString::from_static_str("group-a"),
+                &lmq_name,
+                0
+            ),
+            1
+        );
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let second_header = PopLiteMessageRequestHeader {
+            client_id: CheetahString::from_static_str("client-1"),
+            consumer_group: CheetahString::from_static_str("group-a"),
+            topic: CheetahString::from_static_str("parent-topic"),
+            max_msg_num: 1,
+            invisible_time: 5_000,
+            poll_time: 0,
+            born_time: current_millis() as i64,
+            attempt_id: Some(CheetahString::from_static_str("attempt-2")),
+            rpc: None,
+        };
+        let mut second_request = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, second_header);
+        second_request.make_custom_header_to_net();
+        let second_response = processor
+            .process_request(channel, ctx, &mut second_request)
+            .await
+            .expect("second pop lite should succeed")
+            .expect("second pop lite should return a response");
+        assert_eq!(ResponseCode::from(second_response.code()), ResponseCode::PollingTimeout);
+        assert_eq!(
+            runtime.inner.consumer_offset_manager().query_offset(
+                &CheetahString::from_static_str("group-a"),
+                &lmq_name,
+                0
+            ),
+            1
+        );
+        assert_eq!(
+            runtime
+                .inner
+                .lite_event_dispatcher()
+                .pending_events(&CheetahString::from_static_str("client-1")),
+            vec![lmq_name.clone()]
+        );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn pop_lite_message_allows_same_attempt_id_to_continue_fifo_consumption() {
+        let mut runtime = new_lite_test_runtime("pop-lite-fifo-same-attempt").await;
+        seed_lite_query_state(&mut runtime);
+        seed_lmq_message(&mut runtime, "child-a", b"lite-body-1").await;
+        seed_lmq_message(&mut runtime, "child-a", b"lite-body-2").await;
+        let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+
+        let (mut processor, _) = runtime.init_processor();
+        runtime.inner.lite_event_dispatcher().do_full_dispatch(
+            &CheetahString::from_static_str("client-1"),
+            &CheetahString::from_static_str("group-a"),
+            &HashSet::from([lmq_name.clone()]),
+        );
+
+        let first_channel = create_test_channel().await;
+        let first_ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(first_channel.clone()));
+        let first_header = PopLiteMessageRequestHeader {
+            client_id: CheetahString::from_static_str("client-1"),
+            consumer_group: CheetahString::from_static_str("group-a"),
+            topic: CheetahString::from_static_str("parent-topic"),
+            max_msg_num: 1,
+            invisible_time: 5_000,
+            poll_time: 0,
+            born_time: current_millis() as i64,
+            attempt_id: Some(CheetahString::from_static_str("attempt-1")),
+            rpc: None,
+        };
+        let mut first_request = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, first_header);
+        first_request.make_custom_header_to_net();
+        let _ = processor
+            .process_request(first_channel, first_ctx, &mut first_request)
+            .await
+            .expect("first pop lite should succeed")
+            .expect("first pop lite should return a response");
+
+        let second_channel = create_test_channel().await;
+        let second_ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(second_channel.clone()));
+        let second_header = PopLiteMessageRequestHeader {
+            client_id: CheetahString::from_static_str("client-1"),
+            consumer_group: CheetahString::from_static_str("group-a"),
+            topic: CheetahString::from_static_str("parent-topic"),
+            max_msg_num: 1,
+            invisible_time: 5_000,
+            poll_time: 0,
+            born_time: current_millis() as i64,
+            attempt_id: Some(CheetahString::from_static_str("attempt-1")),
+            rpc: None,
+        };
+        let mut second_request = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, second_header);
+        second_request.make_custom_header_to_net();
+        let second_response = processor
+            .process_request(second_channel, second_ctx, &mut second_request)
+            .await
+            .expect("second pop lite should succeed")
+            .expect("second pop lite should return a response");
+        assert_eq!(ResponseCode::from(second_response.code()), ResponseCode::Success);
+        let second_header = second_response
+            .read_custom_header_ref::<PopLiteMessageResponseHeader>()
+            .expect("pop lite success response should keep an in-memory response header");
+        assert!(second_header.order_count_info.is_some());
+        assert_eq!(
+            runtime.inner.consumer_offset_manager().query_offset(
+                &CheetahString::from_static_str("group-a"),
+                &lmq_name,
+                0
+            ),
+            2
+        );
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-broker/src/lite.rs
+++ b/rocketmq-broker/src/lite.rs
@@ -14,3 +14,4 @@
 
 pub(crate) mod lite_event_dispatcher;
 pub(crate) mod lite_lifecycle_manager;
+pub(crate) mod memory_consumer_order_info_manager;

--- a/rocketmq-broker/src/lite/memory_consumer_order_info_manager.rs
+++ b/rocketmq-broker/src/lite/memory_consumer_order_info_manager.rs
@@ -1,0 +1,171 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_remoting::protocol::header::extra_info_util::ExtraInfoUtil;
+
+use crate::offset::manager::consumer_order_info_manager::OrderInfo;
+
+const TOPIC_GROUP_SEPARATOR: &str = "@";
+
+#[derive(Default)]
+pub(crate) struct MemoryConsumerOrderInfoManager {
+    table: Mutex<HashMap<CheetahString, HashMap<i32, OrderInfo>>>,
+}
+
+impl MemoryConsumerOrderInfoManager {
+    pub(crate) fn check_block(
+        &self,
+        attempt_id: &CheetahString,
+        topic: &CheetahString,
+        group: &CheetahString,
+        queue_id: i32,
+        invisible_time: u64,
+    ) -> bool {
+        self.table
+            .lock()
+            .get_mut(&build_key(topic, group))
+            .and_then(|queues| queues.get_mut(&queue_id))
+            .is_some_and(|order_info| order_info.need_block(attempt_id.as_str(), invisible_time))
+    }
+
+    pub(crate) fn clear_block(&self, topic: &CheetahString, group: &CheetahString, queue_id: i32) {
+        if let Some(queues) = self.table.lock().get_mut(&build_key(topic, group)) {
+            queues.remove(&queue_id);
+        }
+    }
+
+    pub(crate) fn update(
+        &self,
+        attempt_id: CheetahString,
+        topic: &CheetahString,
+        group: &CheetahString,
+        queue_id: i32,
+        pop_time: u64,
+        invisible_time: u64,
+        msg_queue_offset_list: Vec<u64>,
+        order_info_builder: &mut String,
+    ) {
+        let key = build_key(topic, group);
+        let mut table = self.table.lock();
+        let queues = table.entry(key).or_default();
+        let previous = queues.get(&queue_id).cloned();
+
+        let mut order_info = OrderInfo {
+            pop_time,
+            invisible_time: Some(invisible_time),
+            offset_list: OrderInfo::build_offset_list(msg_queue_offset_list),
+            offset_next_visible_time: HashMap::new(),
+            offset_consumed_count: HashMap::new(),
+            last_consume_timestamp: current_millis(),
+            commit_offset_bit: 0,
+            attempt_id: attempt_id.to_string(),
+        };
+
+        if let Some(previous) = previous {
+            order_info.merge_offset_consumed_count(
+                previous.attempt_id.as_str(),
+                previous.offset_list,
+                previous.offset_consumed_count,
+            );
+        }
+        queues.insert(queue_id, order_info.clone());
+
+        let mut min_consumed_times = i32::MAX;
+        for (offset, consumed_times) in &order_info.offset_consumed_count {
+            ExtraInfoUtil::build_queue_offset_order_count_info(
+                order_info_builder,
+                topic.as_str(),
+                queue_id as i64,
+                *offset as i64,
+                *consumed_times,
+            );
+            min_consumed_times = min_consumed_times.min(*consumed_times);
+        }
+
+        if order_info.offset_consumed_count.len() != order_info.offset_list.len() {
+            min_consumed_times = 0;
+        }
+        if min_consumed_times == i32::MAX {
+            min_consumed_times = 0;
+        }
+
+        ExtraInfoUtil::build_queue_id_order_count_info(
+            order_info_builder,
+            topic.as_str(),
+            queue_id,
+            min_consumed_times,
+        );
+    }
+
+    pub(crate) fn order_info_count(&self) -> usize {
+        self.table.lock().len()
+    }
+}
+
+fn build_key(topic: &CheetahString, group: &CheetahString) -> CheetahString {
+    CheetahString::from_string(format!("{topic}{TOPIC_GROUP_SEPARATOR}{group}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_creates_order_info_and_queue_level_count() {
+        let manager = MemoryConsumerOrderInfoManager::default();
+        let topic = CheetahString::from_static_str("%LMQ%$parent$child-a");
+        let group = CheetahString::from_static_str("group-a");
+        let mut builder = String::new();
+
+        manager.update(
+            CheetahString::from_static_str("attempt-1"),
+            &topic,
+            &group,
+            0,
+            1,
+            30_000,
+            vec![10, 11],
+            &mut builder,
+        );
+
+        assert!(builder.ends_with("0 0 0"));
+        assert_eq!(manager.order_info_count(), 1);
+    }
+
+    #[test]
+    fn different_attempt_is_blocked_before_invisible_timeout() {
+        let manager = MemoryConsumerOrderInfoManager::default();
+        let topic = CheetahString::from_static_str("%LMQ%$parent$child-a");
+        let group = CheetahString::from_static_str("group-a");
+        let mut builder = String::new();
+        manager.update(
+            CheetahString::from_static_str("attempt-1"),
+            &topic,
+            &group,
+            0,
+            current_millis(),
+            30_000,
+            vec![10],
+            &mut builder,
+        );
+
+        assert!(manager.check_block(&CheetahString::from_static_str("attempt-2"), &topic, &group, 0, 30_000,));
+        assert!(!manager.check_block(&CheetahString::from_static_str("attempt-1"), &topic, &group, 0, 30_000,));
+    }
+}

--- a/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
@@ -264,21 +264,21 @@ pub(crate) struct ConsumerOrderInfoWrapper {
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub(crate) struct OrderInfo {
     #[serde(rename = "popTime")]
-    pop_time: u64,
+    pub(crate) pop_time: u64,
     #[serde(rename = "i")]
-    invisible_time: Option<u64>,
+    pub(crate) invisible_time: Option<u64>,
     #[serde(rename = "0")]
-    offset_list: Vec<u64>,
+    pub(crate) offset_list: Vec<u64>,
     #[serde(rename = "ot")]
-    offset_next_visible_time: HashMap<u64, u64>,
+    pub(crate) offset_next_visible_time: HashMap<u64, u64>,
     #[serde(rename = "oc")]
-    offset_consumed_count: HashMap<u64, i32>,
+    pub(crate) offset_consumed_count: HashMap<u64, i32>,
     #[serde(rename = "l")]
-    last_consume_timestamp: u64,
+    pub(crate) last_consume_timestamp: u64,
     #[serde(rename = "cm")]
-    commit_offset_bit: u64,
+    pub(crate) commit_offset_bit: u64,
     #[serde(rename = "a")]
-    attempt_id: String,
+    pub(crate) attempt_id: String,
 }
 
 impl Display for OrderInfo {

--- a/rocketmq-broker/src/processor/pop_lite_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor.rs
@@ -17,8 +17,10 @@ use std::collections::HashSet;
 use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
+use rocketmq_common::common::attribute::topic_message_type::TopicMessageType;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::key_builder::POP_ORDER_REVIVE_QUEUE;
+use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -28,22 +30,40 @@ use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
 use rocketmq_rust::ArcMut;
+use rocketmq_store::base::get_message_result::GetMessageResult;
 use rocketmq_store::base::message_status_enum::GetMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
 
 use crate::broker_runtime::BrokerRuntimeInner;
+use crate::lite::memory_consumer_order_info_manager::MemoryConsumerOrderInfoManager;
 use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingService;
 use crate::long_polling::polling_result::PollingResult;
+use crate::processor::pop_message_processor::QueueLockManager;
 
 pub(crate) struct PopLiteMessageProcessor<MS: MessageStore> {
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     pop_lite_long_polling_service: ArcMut<PopLiteLongPollingService<MS, PopLiteMessageProcessor<MS>>>,
+    consumer_order_info_manager: MemoryConsumerOrderInfoManager,
+    queue_lock_manager: QueueLockManager,
+}
+
+enum PopLmqResult {
+    Fetched {
+        body: Bytes,
+        next_offset: i64,
+        fetched_count: i32,
+        order_count_info: String,
+    },
+    Requeue,
+    Skip,
 }
 
 impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
     pub(crate) fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
         Self {
             pop_lite_long_polling_service: ArcMut::new(PopLiteLongPollingService::new(broker_runtime_inner.clone())),
+            consumer_order_info_manager: MemoryConsumerOrderInfoManager::default(),
+            queue_lock_manager: QueueLockManager::new(),
             broker_runtime_inner,
         }
     }
@@ -62,10 +82,12 @@ impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
 
     pub(crate) fn start(&mut self) {
         PopLiteLongPollingService::start(self.pop_lite_long_polling_service.clone());
+        self.queue_lock_manager.start();
     }
 
     pub(crate) fn shutdown(&mut self) {
         self.pop_lite_long_polling_service.shutdown();
+        self.queue_lock_manager.shutdown();
     }
 
     pub(crate) fn pop_lite_long_polling_service(
@@ -131,6 +153,12 @@ impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
                 CheetahString::from_string(format!("topic [{}] not exist.", request_header.topic)),
             ));
         };
+        if topic_config.get_topic_message_type() != TopicMessageType::Lite {
+            return Some((
+                ResponseCode::InvalidParameter,
+                CheetahString::from_string(format!("the topic [{}] message type not match", request_header.topic)),
+            ));
+        }
         if !PermName::is_readable(topic_config.perm) {
             return Some((
                 ResponseCode::NoPermission,
@@ -183,75 +211,201 @@ impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
         &self,
         request_header: &PopLiteMessageRequestHeader,
         pending_events: Vec<CheetahString>,
-    ) -> (Option<Bytes>, HashSet<CheetahString>, i32) {
+    ) -> (Option<Bytes>, HashSet<CheetahString>, i32, Option<CheetahString>) {
         let Some(message_store) = self.broker_runtime_inner.message_store() else {
-            return (None, HashSet::new(), 0);
+            return (None, HashSet::new(), 0, None);
         };
 
         let mut remaining = request_header.max_msg_num;
         let mut body = BytesMut::new();
         let mut fetched_count = 0;
         let mut requeue_events = HashSet::new();
+        let mut order_count_infos = Vec::new();
         let mut event_iter = pending_events.into_iter();
+        let attempt_id = request_header.attempt_id.clone().unwrap_or_default();
 
         while remaining > 0 {
             let Some(lmq_name) = event_iter.next() else {
                 break;
             };
-            let consume_offset = self
-                .broker_runtime_inner
-                .consumer_offset_manager()
-                .query_offset(&request_header.consumer_group, &lmq_name, 0)
-                .max(0);
-            let Some(get_message_result) = message_store
-                .get_message(
-                    &request_header.consumer_group,
-                    &lmq_name,
-                    0,
-                    consume_offset,
-                    remaining,
-                    None,
-                )
-                .await
-            else {
-                continue;
-            };
-
-            if get_message_result.status() != Some(GetMessageStatus::Found) || get_message_result.message_count() <= 0 {
+            let lock_key = CheetahString::from_string(QueueLockManager::build_lock_key(
+                &lmq_name,
+                &request_header.consumer_group,
+                0,
+            ));
+            if !self.queue_lock_manager.try_lock_with_key(lock_key.clone()).await {
+                requeue_events.insert(lmq_name);
                 continue;
             }
 
-            body.extend_from_slice(&self.read_get_message_result(&get_message_result));
-            fetched_count += get_message_result.message_count();
-            remaining -= get_message_result.message_count();
+            let result = self
+                .pop_from_lmq(message_store.clone(), request_header, &attempt_id, &lmq_name, remaining)
+                .await;
+            self.queue_lock_manager.unlock_with_key(lock_key).await;
 
-            let next_offset = get_message_result.next_begin_offset();
-            self.broker_runtime_inner.consumer_offset_manager().commit_offset(
-                CheetahString::from_static_str("PopLiteMessageProcessor"),
-                &request_header.consumer_group,
-                &lmq_name,
-                0,
-                next_offset,
-            );
+            match result {
+                PopLmqResult::Fetched {
+                    body: chunk,
+                    next_offset,
+                    fetched_count: local_count,
+                    order_count_info,
+                } => {
+                    self.broker_runtime_inner.consumer_offset_manager().commit_offset(
+                        CheetahString::from_static_str("PopLiteMessageProcessor"),
+                        &request_header.consumer_group,
+                        &lmq_name,
+                        0,
+                        next_offset,
+                    );
+                    body.extend_from_slice(&chunk);
+                    fetched_count += local_count;
+                    remaining -= local_count;
+                    if !order_count_info.is_empty() {
+                        order_count_infos.push(order_count_info);
+                    }
 
-            let broker_offset = self
-                .broker_runtime_inner
-                .lite_lifecycle_manager()
-                .get_max_offset_in_queue(self.broker_runtime_inner.message_store(), &lmq_name);
-            if next_offset < broker_offset {
-                requeue_events.insert(lmq_name);
+                    let broker_offset = self
+                        .broker_runtime_inner
+                        .lite_lifecycle_manager()
+                        .get_max_offset_in_queue(self.broker_runtime_inner.message_store(), &lmq_name);
+                    if next_offset < broker_offset {
+                        requeue_events.insert(lmq_name);
+                    }
+                }
+                PopLmqResult::Requeue => {
+                    requeue_events.insert(lmq_name);
+                }
+                PopLmqResult::Skip => {}
             }
         }
 
         requeue_events.extend(event_iter);
         let body = if body.is_empty() { None } else { Some(body.freeze()) };
-        (body, requeue_events, fetched_count)
+        let order_count_info =
+            (!order_count_infos.is_empty()).then(|| CheetahString::from_string(order_count_infos.join(";")));
+        (body, requeue_events, fetched_count, order_count_info)
     }
 
-    fn read_get_message_result(
+    async fn pop_from_lmq(
         &self,
-        get_message_result: &rocketmq_store::base::get_message_result::GetMessageResult,
-    ) -> Bytes {
+        message_store: ArcMut<MS>,
+        request_header: &PopLiteMessageRequestHeader,
+        attempt_id: &CheetahString,
+        lmq_name: &CheetahString,
+        remaining: i32,
+    ) -> PopLmqResult {
+        if self.consumer_order_info_manager.check_block(
+            attempt_id,
+            lmq_name,
+            &request_header.consumer_group,
+            0,
+            request_header.invisible_time as u64,
+        ) {
+            return PopLmqResult::Requeue;
+        }
+
+        let consume_offset = self.get_pop_offset(&request_header.consumer_group, lmq_name);
+        let Some(get_message_result) = self
+            .get_message(
+                &message_store,
+                &request_header.consumer_group,
+                lmq_name,
+                consume_offset,
+                remaining,
+            )
+            .await
+        else {
+            return PopLmqResult::Skip;
+        };
+
+        if get_message_result.status() != Some(GetMessageStatus::Found) || get_message_result.message_count() <= 0 {
+            return PopLmqResult::Skip;
+        }
+
+        let fetched_count = get_message_result.message_count();
+        let mut order_count_info = String::new();
+        self.consumer_order_info_manager.update(
+            attempt_id.clone(),
+            lmq_name,
+            &request_header.consumer_group,
+            0,
+            current_millis(),
+            request_header.invisible_time as u64,
+            get_message_result.message_queue_offset().clone(),
+            &mut order_count_info,
+        );
+
+        PopLmqResult::Fetched {
+            body: self.read_get_message_result(&get_message_result),
+            next_offset: get_message_result.next_begin_offset(),
+            fetched_count,
+            order_count_info: Self::transform_order_count_info(&order_count_info, fetched_count as usize),
+        }
+    }
+
+    fn get_pop_offset(&self, group: &CheetahString, lmq_name: &CheetahString) -> i64 {
+        let mut offset = self
+            .broker_runtime_inner
+            .consumer_offset_manager()
+            .query_offset(group, lmq_name, 0)
+            .max(0);
+        if let Some(reset_offset) = self
+            .broker_runtime_inner
+            .consumer_offset_manager()
+            .query_then_erase_reset_offset(lmq_name, group, 0)
+        {
+            self.consumer_order_info_manager.clear_block(lmq_name, group, 0);
+            self.broker_runtime_inner.consumer_offset_manager().commit_offset(
+                CheetahString::from_static_str("ResetOffset"),
+                group,
+                lmq_name,
+                0,
+                reset_offset,
+            );
+            offset = reset_offset;
+        }
+        offset
+    }
+
+    async fn get_message(
+        &self,
+        message_store: &ArcMut<MS>,
+        group: &CheetahString,
+        lmq_name: &CheetahString,
+        offset: i64,
+        batch_size: i32,
+    ) -> Option<GetMessageResult> {
+        let result = message_store
+            .get_message(group, lmq_name, 0, offset, batch_size, None)
+            .await?;
+        if matches!(
+            result.status(),
+            Some(
+                GetMessageStatus::OffsetTooSmall
+                    | GetMessageStatus::OffsetOverflowBadly
+                    | GetMessageStatus::OffsetFoundNull
+                    | GetMessageStatus::NoMatchedMessage
+                    | GetMessageStatus::MessageWasRemoving
+                    | GetMessageStatus::NoMatchedLogicQueue
+            )
+        ) && result.next_begin_offset() >= 0
+        {
+            let correct_offset = result.next_begin_offset();
+            self.broker_runtime_inner.consumer_offset_manager().commit_offset(
+                CheetahString::from_static_str("CorrectOffset"),
+                group,
+                lmq_name,
+                0,
+                correct_offset,
+            );
+            return message_store
+                .get_message(group, lmq_name, 0, correct_offset, batch_size, None)
+                .await;
+        }
+        Some(result)
+    }
+
+    fn read_get_message_result(&self, get_message_result: &GetMessageResult) -> Bytes {
         let mut bytes_mut = BytesMut::with_capacity(get_message_result.buffer_total_size() as usize);
         for mapped in get_message_result.message_mapped_list() {
             if let Some(bytes) = mapped.bytes.as_ref() {
@@ -271,6 +425,23 @@ impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
     ) -> RemotingCommand {
         RemotingCommand::create_response_command_with_code_remark(code, remark).set_opaque(request.opaque())
     }
+
+    fn transform_order_count_info(order_count_info: &str, msg_count: usize) -> String {
+        if order_count_info.is_empty() {
+            return vec!["0"; msg_count].join(";");
+        }
+
+        let infos: Vec<&str> = order_count_info.split(';').collect();
+        if infos.len() > 1 {
+            return infos[..infos.len() - 1].join(";");
+        }
+
+        let split: Vec<&str> = order_count_info.split(MessageConst::KEY_SEPARATOR).collect();
+        if split.len() == 3 {
+            return vec![split[2]; msg_count].join(";");
+        }
+        vec!["0"; msg_count].join(";")
+    }
 }
 
 impl<MS: MessageStore> RequestProcessor for PopLiteMessageProcessor<MS> {
@@ -288,7 +459,8 @@ impl<MS: MessageStore> RequestProcessor for PopLiteMessageProcessor<MS> {
         let dispatcher = self.broker_runtime_inner.lite_event_dispatcher();
         dispatcher.touch_client(&request_header.client_id);
         let pending_events = dispatcher.take_pending_events(&request_header.client_id);
-        let (body, requeue_events, fetched_count) = self.pop_from_events(&request_header, pending_events).await;
+        let (body, requeue_events, fetched_count, order_count_info) =
+            self.pop_from_events(&request_header, pending_events).await;
         if !requeue_events.is_empty() {
             dispatcher.do_full_dispatch(
                 &request_header.client_id,
@@ -303,8 +475,7 @@ impl<MS: MessageStore> RequestProcessor for PopLiteMessageProcessor<MS> {
             revive_qid: POP_ORDER_REVIVE_QUEUE,
             start_offset_info: None,
             msg_offset_info: None,
-            order_count_info: (fetched_count > 0)
-                .then(|| CheetahString::from_string(vec!["0"; fetched_count as usize].join(";"))),
+            order_count_info: (fetched_count > 0).then_some(order_count_info).flatten(),
         };
         let mut response =
             RemotingCommand::create_response_command_with_header(response_header).set_opaque(request.opaque());
@@ -315,33 +486,46 @@ impl<MS: MessageStore> RequestProcessor for PopLiteMessageProcessor<MS> {
                 response.set_remark_mut("FOUND");
                 response.set_body_mut_ref(body);
             }
-            None => {
-                match self.pop_lite_long_polling_service.polling(
-                    ctx,
-                    request,
-                    &request_header.client_id,
-                    request_header.born_time,
-                    request_header.poll_time,
-                ) {
-                    PollingResult::PollingSuc => {
-                        if !dispatcher.pending_events(&request_header.client_id).is_empty() {
-                            self.pop_lite_long_polling_service
-                                .wake_up_client(&request_header.client_id);
-                        }
-                        return Ok(None);
+            None => match self.pop_lite_long_polling_service.polling(
+                ctx,
+                request,
+                &request_header.client_id,
+                request_header.born_time,
+                request_header.poll_time,
+            ) {
+                PollingResult::PollingSuc => {
+                    if !dispatcher.pending_events(&request_header.client_id).is_empty() {
+                        self.pop_lite_long_polling_service
+                            .wake_up_client(&request_header.client_id);
                     }
-                    PollingResult::PollingFull => {
-                        response.set_code_ref(ResponseCode::PollingFull);
-                        response.set_remark_mut("POP_LITE_POLLING_FULL");
-                    }
-                    _ => {
-                        response.set_code_ref(ResponseCode::PollingTimeout);
-                        response.set_remark_mut("NO_MESSAGE_IN_QUEUE");
-                    }
+                    return Ok(None);
                 }
-            }
+                PollingResult::PollingFull => {
+                    response.set_code_ref(ResponseCode::PollingFull);
+                    response.set_remark_mut("POP_LITE_POLLING_FULL");
+                }
+                _ => {
+                    response.set_code_ref(ResponseCode::PollingTimeout);
+                    response.set_remark_mut("NO_MESSAGE_IN_QUEUE");
+                }
+            },
         }
 
         Ok(Some(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
+
+    use super::*;
+
+    #[test]
+    fn transform_order_count_info_drops_queue_level_suffix_when_offset_entries_exist() {
+        let result =
+            PopLiteMessageProcessor::<LocalFileMessageStore>::transform_order_count_info("0 qo0%100 1;0 0 1", 1);
+
+        assert_eq!(result, "0 qo0%100 1");
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7020

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved FIFO message ordering enforcement—messages with different attempt IDs are now properly blocked to maintain order guarantees
  * Order count information is now tracked and included in message responses for better monitoring

* **Tests**
  * Added integration tests validating FIFO ordering and attempt ID handling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->