### PR TITLE
[ISSUE #7022]🚀Enhance Lite message processing with order info management and validation for parent topics

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -1879,6 +1879,11 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
+    pub fn pop_lite_message_processor(&self) -> Option<&ArcMut<PopLiteMessageProcessor<MS>>> {
+        self.pop_lite_message_processor.as_ref()
+    }
+
+    #[inline]
     pub fn message_store_unchecked(&self) -> &ArcMut<MS> {
         unsafe { self.message_store.as_ref().unwrap_unchecked() }
     }
@@ -3589,6 +3594,34 @@ mod tests {
             .set_topic_queue_table(topic_queue_table);
     }
 
+    fn set_parent_topic_message_type(runtime: &mut BrokerRuntime, message_type: &str) {
+        let topic_config = runtime
+            .inner_for_test()
+            .topic_config_manager()
+            .select_topic_config(&CheetahString::from_static_str("parent-topic"))
+            .expect("parent topic should exist");
+        topic_config.mut_from_ref().attributes.insert(
+            TopicAttributes::TopicAttributes::topic_message_type_attribute()
+                .name()
+                .clone(),
+            CheetahString::from_string(message_type.to_string()),
+        );
+    }
+
+    fn set_parent_topic_lite_expiration(runtime: &mut BrokerRuntime, expiration: i32) {
+        let topic_config = runtime
+            .inner_for_test()
+            .topic_config_manager()
+            .select_topic_config(&CheetahString::from_static_str("parent-topic"))
+            .expect("parent topic should exist");
+        topic_config.mut_from_ref().attributes.insert(
+            TopicAttributes::TopicAttributes::lite_topic_expiration_attribute()
+                .name()
+                .clone(),
+            CheetahString::from_string(expiration.to_string()),
+        );
+    }
+
     fn seed_lmq_consumer_offset(runtime: &mut BrokerRuntime, group: &str, lite_topic: &str, offset: i64) {
         let inner = runtime.inner_for_test();
         let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", lite_topic).expect("lmq name"));
@@ -4339,9 +4372,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_broker_lite_info_reports_pop_lite_order_info_count() {
+        let mut runtime = new_lite_test_runtime("broker-lite-order-info-count").await;
+        seed_lite_query_state(&mut runtime);
+        seed_lmq_message(&mut runtime, "child-a", b"lite-body").await;
+        let lmq_name = CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("child-a lmq"));
+
+        let (mut processor, _) = runtime.init_processor();
+        runtime.inner.lite_event_dispatcher().do_full_dispatch(
+            &CheetahString::from_static_str("client-1"),
+            &CheetahString::from_static_str("group-a"),
+            &HashSet::from([lmq_name]),
+        );
+
+        let pop_channel = create_test_channel().await;
+        let pop_ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(pop_channel.clone()));
+        let pop_header = PopLiteMessageRequestHeader {
+            client_id: CheetahString::from_static_str("client-1"),
+            consumer_group: CheetahString::from_static_str("group-a"),
+            topic: CheetahString::from_static_str("parent-topic"),
+            max_msg_num: 1,
+            invisible_time: 60_000,
+            poll_time: 0,
+            born_time: current_millis() as i64,
+            attempt_id: Some(CheetahString::from_static_str("attempt-1")),
+            rpc: None,
+        };
+        let mut pop_request = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, pop_header);
+        pop_request.make_custom_header_to_net();
+        let pop_response = processor
+            .process_request(pop_channel, pop_ctx, &mut pop_request)
+            .await
+            .expect("pop lite should succeed")
+            .expect("pop lite should return a response");
+        assert_eq!(ResponseCode::from(pop_response.code()), ResponseCode::Success);
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request = RemotingCommand::create_request_command(RequestCode::GetBrokerLiteInfo, EmptyHeader {});
+        let mut response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let body = GetBrokerLiteInfoResponseBody::decode(
+            response
+                .take_body()
+                .expect("GetBrokerLiteInfo response should contain a body")
+                .as_ref(),
+        )
+        .expect("decode broker lite info response body");
+        assert_eq!(body.get_order_info_count(), 1);
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
     async fn get_parent_topic_info_returns_group_and_lite_counts() {
         let mut runtime = new_lite_test_runtime("parent-topic-info").await;
         seed_lite_query_state(&mut runtime);
+        set_parent_topic_lite_expiration(&mut runtime, 600);
 
         let (mut processor, _) = runtime.init_processor();
         let channel = create_test_channel().await;
@@ -4367,7 +4459,7 @@ mod tests {
         )
         .expect("decode parent topic info response body");
         assert_eq!(body.get_topic(), Some(&CheetahString::from_static_str("parent-topic")));
-        assert_eq!(body.get_ttl(), 0);
+        assert_eq!(body.get_ttl(), 600);
         assert_eq!(body.get_lmq_num(), 2);
         assert_eq!(body.get_lite_topic_count(), 2);
         assert_eq!(
@@ -4377,6 +4469,32 @@ mod tests {
                 CheetahString::from_static_str("group-b"),
             ])
         );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn get_parent_topic_info_rejects_non_lite_parent_topic() {
+        let mut runtime = new_lite_test_runtime("parent-topic-info-non-lite").await;
+        seed_lite_query_state(&mut runtime);
+        set_parent_topic_message_type(&mut runtime, "NORMAL");
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = GetParentTopicInfoRequestHeader {
+            topic: CheetahString::from_static_str("parent-topic"),
+            rpc: None,
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::GetParentTopicInfo, header);
+        request.make_custom_header_to_net();
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
@@ -4421,6 +4539,32 @@ mod tests {
             CheetahString::from_static_str("client-2"),
             CheetahString::from_static_str("group-b"),
         )));
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn get_lite_topic_info_rejects_non_lite_parent_topic() {
+        let mut runtime = new_lite_test_runtime("lite-topic-info-non-lite").await;
+        seed_lite_query_state(&mut runtime);
+        set_parent_topic_message_type(&mut runtime, "NORMAL");
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = GetLiteTopicInfoRequestHeader {
+            parent_topic: CheetahString::from_static_str("parent-topic"),
+            lite_topic: CheetahString::from_static_str("child-b"),
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::GetLiteTopicInfo, header);
+        request.make_custom_header_to_net();
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
@@ -4471,6 +4615,34 @@ mod tests {
                 CheetahString::from_static_str("child-b"),
             ])
         );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn get_lite_client_info_rejects_non_lite_parent_topic() {
+        let mut runtime = new_lite_test_runtime("lite-client-info-non-lite").await;
+        seed_lite_query_state(&mut runtime);
+        set_parent_topic_message_type(&mut runtime, "NORMAL");
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = GetLiteClientInfoRequestHeader {
+            parent_topic: Some(CheetahString::from_static_str("parent-topic")),
+            group: Some(CheetahString::from_static_str("group-a")),
+            client_id: Some(CheetahString::from_static_str("client-1")),
+            max_count: 32,
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::GetLiteClientInfo, header);
+        request.make_custom_header_to_net();
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-broker/src/processor/lite_manager_processor.rs
+++ b/rocketmq-broker/src/processor/lite_manager_processor.rs
@@ -17,6 +17,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use cheetah_string::CheetahString;
+use rocketmq_common::common::attribute::topic_message_type::TopicMessageType;
+use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::entity::ClientGroup;
 use rocketmq_common::common::lite::get_lite_topic;
 use rocketmq_common::common::lite::to_lmq_name;
@@ -117,7 +119,11 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
                 .lite_subscription_registry()
                 .active_subscription_num() as i32,
         );
-        body.set_order_info_count(0);
+        body.set_order_info_count(
+            self.broker_runtime_inner
+                .pop_lite_message_processor()
+                .map_or(0, |processor| processor.order_info_count()),
+        );
         body.set_cq_table_size(cq_table_size);
         body.set_offset_table_size(
             self.broker_runtime_inner
@@ -138,17 +144,10 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
         request: &RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<GetParentTopicInfoRequestHeader>()?;
-        if !self
-            .broker_runtime_inner
-            .topic_config_manager()
-            .contains_topic(&request_header.topic)
-        {
-            return Ok(Some(self.response_with_code(
-                request,
-                ResponseCode::TopicNotExist,
-                format!("Topic [{}] not exist.", request_header.topic),
-            )));
-        }
+        let topic_config = match self.validate_lite_parent_topic(&request_header.topic) {
+            Ok(topic_config) => topic_config,
+            Err((code, remark)) => return Ok(Some(self.response_with_code(request, code, remark))),
+        };
 
         let subscriptions = self
             .broker_runtime_inner
@@ -176,7 +175,7 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
 
         let mut body = GetParentTopicInfoResponseBody::new();
         body.set_topic(request_header.topic);
-        body.set_ttl(0);
+        body.set_ttl(topic_config.get_lite_topic_expiration());
         body.set_groups(groups);
         body.set_lmq_num(lite_topic_count);
         body.set_lite_topic_count(lite_topic_count);
@@ -189,16 +188,8 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
         request: &RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<GetLiteTopicInfoRequestHeader>()?;
-        if !self
-            .broker_runtime_inner
-            .topic_config_manager()
-            .contains_topic(&request_header.parent_topic)
-        {
-            return Ok(Some(self.response_with_code(
-                request,
-                ResponseCode::TopicNotExist,
-                format!("Topic [{}] not exist.", request_header.parent_topic),
-            )));
+        if let Err((code, remark)) = self.validate_lite_parent_topic(&request_header.parent_topic) {
+            return Ok(Some(self.response_with_code(request, code, remark)));
         }
 
         let Some(lmq_name) = to_lmq_name(request_header.parent_topic.as_str(), request_header.lite_topic.as_str())
@@ -269,6 +260,9 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
                 "clientId is blank.",
             )));
         };
+        if let Err((code, remark)) = self.validate_lite_parent_topic(&parent_topic) {
+            return Ok(Some(self.response_with_code(request, code, remark)));
+        }
         if let Err((code, remark)) = self.validate_consumer_group(&group, &parent_topic) {
             return Ok(Some(self.response_with_code(request, code, remark)));
         }
@@ -675,6 +669,31 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
                 CheetahString::from_string(format!("Subscription [{}]-[{}] not match.", group, topic)),
             )),
         }
+    }
+
+    fn validate_lite_parent_topic(
+        &self,
+        topic: &CheetahString,
+    ) -> Result<ArcMut<TopicConfig>, (ResponseCode, CheetahString)> {
+        let topic_config = self
+            .broker_runtime_inner
+            .topic_config_manager()
+            .select_topic_config(topic)
+            .ok_or_else(|| {
+                (
+                    ResponseCode::TopicNotExist,
+                    CheetahString::from_string(format!("Topic [{}] not exist.", topic)),
+                )
+            })?;
+
+        if topic_config.get_topic_message_type() != TopicMessageType::Lite {
+            return Err((
+                ResponseCode::InvalidParameter,
+                CheetahString::from_string(format!("Topic [{}] type not match.", topic)),
+            ));
+        }
+
+        Ok(topic_config)
     }
 
     fn validate_lite_group(&self, group: &CheetahString) -> Result<CheetahString, (ResponseCode, CheetahString)> {

--- a/rocketmq-broker/src/processor/pop_lite_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor.rs
@@ -96,6 +96,10 @@ impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
         &self.pop_lite_long_polling_service
     }
 
+    pub(crate) fn order_info_count(&self) -> i32 {
+        self.consumer_order_info_manager.order_info_count() as i32
+    }
+
     fn pre_check(&self, request_header: &PopLiteMessageRequestHeader) -> Option<(ResponseCode, CheetahString)> {
         if request_header.client_id.is_empty() {
             return Some((

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -2259,14 +2259,30 @@ mod tests {
 
         assert_eq!(timer_message_store.process_once().await, 1);
 
-        let rolled_slot_time = now_floor + 4_000;
         let original_slot_time = timer_message_store.ceil_time_ms(deliver_ms as i64);
-        let slot = timer_message_store.get_timer_wheel_slot(rolled_slot_time).unwrap();
+        let active_slots = timer_message_store
+            .timer_wheel
+            .lock()
+            .as_ref()
+            .map(TimerWheel::slots_snapshot)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|slot| slot.num > 0)
+            .collect::<Vec<_>>();
+        assert_eq!(active_slots.len(), 1);
+
+        let slot = active_slots[0];
+        let rolled_slot_time = slot.time_ms;
         let entries = timer_message_store.load_slot_entries(slot).unwrap();
+        let now_after_process = timer_message_store.floor_time_ms(current_millis() as i64);
 
         assert!(timer_message_store.get_timer_wheel_slot(original_slot_time).is_none());
         assert_eq!(slot.num, 1);
+        assert_eq!(entries.len(), 1);
         assert_ne!(entries[0].record.magic & MAGIC_ROLL, 0);
+        assert!(rolled_slot_time >= now_floor + timer_message_store.timer_roll_window_ms());
+        assert!(rolled_slot_time <= now_after_process + timer_message_store.timer_roll_window_ms());
+        assert!(rolled_slot_time < original_slot_time);
         assert_eq!(entries[0].record.deliver_time_ms, rolled_slot_time);
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7022

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed order information count reporting for lite messages (previously always returned 0).
  * Fixed time-to-live (TTL) value reporting for lite topics (previously always returned 0).
  * Added validation to reject non-lite topics in lite-specific operations, preventing incorrect behavior.

* **Tests**
  * Added comprehensive test coverage for lite broker and manager functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->