### PR TITLE
[ISSUE #7026]✨Enhance Lite subscription management with quota checks, offset reset options, and improved subscription handling

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -4387,7 +4387,7 @@ mod tests {
         );
         assert_eq!(body.get_max_lmq_num(), 32);
         assert_eq!(body.get_current_lmq_num(), 2);
-        assert_eq!(body.get_lite_subscription_count(), 2);
+        assert_eq!(body.get_lite_subscription_count(), 3);
         assert_eq!(
             body.get_topic_meta()
                 .get(&CheetahString::from_static_str("parent-topic")),

--- a/rocketmq-broker/src/lite/lite_sharding.rs
+++ b/rocketmq-broker/src/lite/lite_sharding.rs
@@ -85,7 +85,7 @@ mod tests {
     fn java_string_hash_code_matches_java_contract() {
         assert_eq!(java_string_hash_code(""), 0);
         assert_eq!(java_string_hash_code("abc"), 96_354);
-        assert_eq!(java_string_hash_code("lite_topic"), 1_608_266_772);
+        assert_eq!(java_string_hash_code("lite_topic"), 2_023_630_430);
     }
 
     #[test]

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -109,6 +109,16 @@ where
         }
     }
 
+    pub fn assign_reset_offset(&self, topic: &CheetahString, group: &CheetahString, queue_id: i32, offset: i64) {
+        let key = CheetahString::from_string(format!("{topic}{TOPIC_GROUP_SEPARATOR}{group}"));
+        self.consumer_offset_wrapper
+            .reset_offset_table
+            .write()
+            .entry(key)
+            .or_default()
+            .insert(queue_id, offset);
+    }
+
     pub fn clean_offset_by_topic(&self, topic: &CheetahString) {
         let mut offset_table = self.consumer_offset_wrapper.offset_table.write();
         let mut keys_to_remove = Vec::new();

--- a/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
+++ b/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
@@ -18,11 +18,13 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::lite::to_lmq_name;
 use rocketmq_common::common::lite::LiteSubscriptionAction;
+use rocketmq_common::common::lite::OffsetOption;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::lite_subscription_ctl_request_body::LiteSubscriptionCtlRequestBody;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
 use rocketmq_rust::ArcMut;
@@ -97,27 +99,76 @@ impl<MS: MessageStore> RequestProcessor for LiteSubscriptionCtlProcessor<MS> {
 
             match entry.action() {
                 LiteSubscriptionAction::PartialAdd => {
-                    if let Err((code, remark)) = self.validate_consumer_group(entry.group(), entry.topic()) {
-                        return Ok(Some(self.response_with_code(request, code, remark)));
+                    let group_config = match self.validate_consumer_group(entry.group(), entry.topic()) {
+                        Ok(group_config) => group_config,
+                        Err((code, remark)) => {
+                            return Ok(Some(self.response_with_code(request, code, remark)));
+                        }
                     };
+                    if let Err((code, remark)) =
+                        self.ensure_quota(entry.client_id(), entry.group(), entry.topic(), &lmq_name_set)
+                    {
+                        return Ok(Some(self.response_with_code(request, code, remark)));
+                    }
                     registry.update_client_channel(entry.client_id(), channel.clone());
                     self.broker_runtime_inner
                         .lite_event_dispatcher()
                         .touch_client(entry.client_id());
+                    let removed_lmq_names = if group_config.lite_sub_exclusive() {
+                        self.exclude_conflicting_subscriptions(
+                            entry.client_id(),
+                            entry.group(),
+                            entry.topic(),
+                            &lmq_name_set,
+                        )
+                    } else {
+                        HashSet::new()
+                    };
                     registry.add_partial_subscription(entry.client_id(), entry.group(), entry.topic(), &lmq_name_set);
+                    if group_config.reset_offset_in_exclusive_mode() {
+                        for lmq_name in &removed_lmq_names {
+                            self.reset_offset(
+                                entry.group(),
+                                lmq_name,
+                                Some(OffsetOption::policy(OffsetOption::POLICY_MIN_VALUE)),
+                            );
+                        }
+                    }
+                    for lmq_name in &lmq_name_set {
+                        self.reset_offset(entry.group(), lmq_name, entry.offset_option());
+                    }
                 }
                 LiteSubscriptionAction::PartialRemove => {
+                    let removed_lmq_names = registry
+                        .lite_subscription(entry.client_id(), entry.group(), entry.topic())
+                        .map(|subscription| {
+                            subscription
+                                .lite_topic_set()
+                                .intersection(&lmq_name_set)
+                                .cloned()
+                                .collect::<HashSet<_>>()
+                        })
+                        .unwrap_or_default();
                     registry.remove_partial_subscription(
                         entry.client_id(),
                         entry.group(),
                         entry.topic(),
                         &lmq_name_set,
                     );
+                    if self.should_reset_offset_on_unsubscribe(entry.group()) {
+                        for lmq_name in &removed_lmq_names {
+                            self.reset_offset(
+                                entry.group(),
+                                lmq_name,
+                                Some(OffsetOption::policy(OffsetOption::POLICY_MIN_VALUE)),
+                            );
+                        }
+                    }
                 }
                 LiteSubscriptionAction::CompleteAdd => {
                     if let Err((code, remark)) = self.validate_consumer_group(entry.group(), entry.topic()) {
                         return Ok(Some(self.response_with_code(request, code, remark)));
-                    };
+                    }
                     registry.update_client_channel(entry.client_id(), channel.clone());
                     self.broker_runtime_inner
                         .lite_event_dispatcher()
@@ -143,14 +194,45 @@ impl<MS: MessageStore> RequestProcessor for LiteSubscriptionCtlProcessor<MS> {
 }
 
 impl<MS: MessageStore> LiteSubscriptionCtlProcessor<MS> {
+    fn ensure_quota(
+        &self,
+        client_id: &CheetahString,
+        group: &CheetahString,
+        topic: &CheetahString,
+        lmq_name_set: &HashSet<CheetahString>,
+    ) -> Result<(), (ResponseCode, CheetahString)> {
+        let existing_topics = self
+            .broker_runtime_inner
+            .lite_subscription_registry()
+            .lite_subscription(client_id, group, topic)
+            .map(|subscription| subscription.lite_topic_set().clone())
+            .unwrap_or_default();
+        let additional_refs = lmq_name_set.difference(&existing_topics).count();
+        if additional_refs == 0 {
+            return Ok(());
+        }
+
+        let max_count = self.broker_runtime_inner.broker_config().max_lite_subscription_count as usize;
+        let projected_count = self
+            .broker_runtime_inner
+            .lite_subscription_registry()
+            .active_subscription_num()
+            .saturating_add(additional_refs);
+        if projected_count > max_count {
+            return Err((
+                ResponseCode::LiteSubscriptionQuotaExceeded,
+                CheetahString::from_string(format!("lite subscription quota exceeded {max_count}")),
+            ));
+        }
+
+        Ok(())
+    }
+
     fn validate_consumer_group(
         &self,
         group: &CheetahString,
         topic: &CheetahString,
-    ) -> Result<
-        Arc<rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig>,
-        (ResponseCode, CheetahString),
-    > {
+    ) -> Result<Arc<SubscriptionGroupConfig>, (ResponseCode, CheetahString)> {
         let group_config = self
             .broker_runtime_inner
             .subscription_group_manager()
@@ -180,6 +262,52 @@ impl<MS: MessageStore> LiteSubscriptionCtlProcessor<MS> {
         }
     }
 
+    fn find_consumer_group_config(&self, group: &CheetahString) -> Option<Arc<SubscriptionGroupConfig>> {
+        self.broker_runtime_inner
+            .subscription_group_manager()
+            .subscription_group_table()
+            .get(group)
+            .map(|entry| Arc::clone(entry.value()))
+    }
+
+    fn should_reset_offset_on_unsubscribe(&self, group: &CheetahString) -> bool {
+        self.find_consumer_group_config(group)
+            .is_some_and(|group_config| group_config.reset_offset_on_unsubscribe())
+    }
+
+    fn exclude_conflicting_subscriptions(
+        &self,
+        client_id: &CheetahString,
+        group: &CheetahString,
+        topic: &CheetahString,
+        lmq_name_set: &HashSet<CheetahString>,
+    ) -> HashSet<CheetahString> {
+        let registry = self.broker_runtime_inner.lite_subscription_registry();
+        let conflicts = registry
+            .all_subscriptions()
+            .into_iter()
+            .filter(|subscription| {
+                subscription.client_id != *client_id && subscription.group == *group && subscription.topic == *topic
+            })
+            .map(|subscription| {
+                let overlapping = subscription
+                    .lite_topic_set
+                    .intersection(lmq_name_set)
+                    .cloned()
+                    .collect::<HashSet<_>>();
+                (subscription.client_id, overlapping)
+            })
+            .filter(|(_, overlapping)| !overlapping.is_empty())
+            .collect::<Vec<_>>();
+
+        let mut removed_lmq_names = HashSet::new();
+        for (conflict_client_id, overlapping) in conflicts {
+            registry.remove_partial_subscription(&conflict_client_id, group, topic, &overlapping);
+            removed_lmq_names.extend(overlapping);
+        }
+        removed_lmq_names
+    }
+
     fn to_lmq_name_set(
         &self,
         topic: &CheetahString,
@@ -189,6 +317,48 @@ impl<MS: MessageStore> LiteSubscriptionCtlProcessor<MS> {
             .iter()
             .filter_map(|lite_topic| to_lmq_name(topic.as_str(), lite_topic.as_str()).map(CheetahString::from_string))
             .collect()
+    }
+
+    fn reset_offset(&self, group: &CheetahString, lmq_name: &CheetahString, offset_option: Option<OffsetOption>) {
+        let Some(offset_option) = offset_option else {
+            return;
+        };
+
+        let current_offset = self
+            .broker_runtime_inner
+            .consumer_offset_manager()
+            .query_offset(group, lmq_name, 0);
+        let target_offset = match offset_option.type_() {
+            rocketmq_common::common::lite::OffsetOptionType::Policy => match offset_option.value() {
+                value if value == OffsetOption::POLICY_MIN_VALUE => Some(0),
+                value if value == OffsetOption::POLICY_MAX_VALUE => Some(
+                    self.broker_runtime_inner
+                        .lite_lifecycle_manager()
+                        .get_max_offset_in_queue(self.broker_runtime_inner.message_store(), lmq_name),
+                ),
+                _ => None,
+            },
+            rocketmq_common::common::lite::OffsetOptionType::Offset => Some(offset_option.value()),
+            rocketmq_common::common::lite::OffsetOptionType::TailN => {
+                (current_offset >= 0).then_some((current_offset - offset_option.value()).max(0))
+            }
+            rocketmq_common::common::lite::OffsetOptionType::Timestamp => None,
+            _ => None,
+        };
+
+        if let Some(target_offset) = target_offset {
+            if current_offset != target_offset {
+                self.broker_runtime_inner.consumer_offset_manager().assign_reset_offset(
+                    lmq_name,
+                    group,
+                    0,
+                    target_offset,
+                );
+                if let Some(processor) = self.broker_runtime_inner.pop_lite_message_processor() {
+                    processor.clear_order_info(lmq_name, group);
+                }
+            }
+        }
     }
 
     fn response_with_code(
@@ -210,10 +380,14 @@ mod tests {
     use bytes::Bytes;
     use cheetah_string::CheetahString;
     use rocketmq_common::common::attribute::subscription_group_attributes::LITE_BIND_TOPIC_ATTRIBUTE_NAME;
+    use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_MODEL_ATTRIBUTE_NAME;
+    use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_RESET_OFFSET_EXCLUSIVE_ATTRIBUTE_NAME;
+    use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_RESET_OFFSET_UNSUBSCRIBE_ATTRIBUTE_NAME;
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
     use rocketmq_common::common::lite::to_lmq_name;
     use rocketmq_common::common::lite::LiteSubscriptionAction;
     use rocketmq_common::common::lite::LiteSubscriptionDTO;
+    use rocketmq_common::common::lite::OffsetOption;
     use rocketmq_remoting::base::response_future::ResponseFuture;
     use rocketmq_remoting::code::request_code::RequestCode;
     use rocketmq_remoting::code::response_code::ResponseCode;
@@ -236,10 +410,18 @@ mod tests {
     }
 
     async fn new_test_runtime(label: &str) -> BrokerRuntime {
+        new_test_runtime_with_max_subscription_count(label, BrokerConfig::default().max_lite_subscription_count).await
+    }
+
+    async fn new_test_runtime_with_max_subscription_count(
+        label: &str,
+        max_lite_subscription_count: u64,
+    ) -> BrokerRuntime {
         let temp_root = temp_test_root(label);
         let broker_config = std::sync::Arc::new(BrokerConfig {
             store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
             auth_config_path: temp_root.join("auth.json").to_string_lossy().into_owned().into(),
+            max_lite_subscription_count,
             ..BrokerConfig::default()
         });
         let message_store_config = std::sync::Arc::new(MessageStoreConfig {
@@ -264,21 +446,37 @@ mod tests {
         Channel::new(inner, local_addr, local_addr)
     }
 
+    fn seed_group_config(
+        inner: &mut ArcMut<
+            crate::broker_runtime::BrokerRuntimeInner<
+                rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore,
+            >,
+        >,
+        group: &str,
+        attributes: HashMap<CheetahString, CheetahString>,
+    ) {
+        let mut config =
+            rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig::new(
+                CheetahString::from(group),
+            );
+        config.set_attributes(attributes);
+        inner
+            .subscription_group_manager_mut()
+            .update_subscription_group_config(&mut config);
+    }
+
     #[tokio::test]
     async fn complete_add_updates_registry_with_lmq_names() {
         let mut runtime = new_test_runtime("processor-success").await;
         let mut inner = runtime.inner_for_test().clone();
-        let mut config =
-            rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig::new(
-                CheetahString::from_static_str("lite-group"),
-            );
-        config.set_attributes(HashMap::from([(
-            CheetahString::from_string(format!("+{LITE_BIND_TOPIC_ATTRIBUTE_NAME}")),
-            CheetahString::from_static_str("parent-topic"),
-        )]));
-        inner
-            .subscription_group_manager_mut()
-            .update_subscription_group_config(&mut config);
+        seed_group_config(
+            &mut inner,
+            "lite-group",
+            HashMap::from([(
+                CheetahString::from_string(format!("+{LITE_BIND_TOPIC_ATTRIBUTE_NAME}")),
+                CheetahString::from_static_str("parent-topic"),
+            )]),
+        );
 
         let dto = LiteSubscriptionDTO::new()
             .with_action(LiteSubscriptionAction::CompleteAdd)
@@ -312,6 +510,239 @@ mod tests {
         assert!(subscription.lite_topic_set().contains(&CheetahString::from_string(
             to_lmq_name("parent-topic", "child-a").expect("convert lite topic")
         )));
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn partial_add_returns_quota_exceeded_when_global_limit_is_hit() {
+        let mut runtime = new_test_runtime_with_max_subscription_count("quota-exceeded", 1).await;
+        let mut inner = runtime.inner_for_test().clone();
+        seed_group_config(
+            &mut inner,
+            "lite-group",
+            HashMap::from([(
+                CheetahString::from_string(format!("+{LITE_BIND_TOPIC_ATTRIBUTE_NAME}")),
+                CheetahString::from_static_str("parent-topic"),
+            )]),
+        );
+        inner.lite_subscription_registry().add_partial_subscription(
+            &CheetahString::from_static_str("client-1"),
+            &CheetahString::from_static_str("lite-group"),
+            &CheetahString::from_static_str("parent-topic"),
+            &HashSet::from([CheetahString::from_string(
+                to_lmq_name("parent-topic", "child-a").expect("convert lite topic"),
+            )]),
+        );
+
+        let dto = LiteSubscriptionDTO::new()
+            .with_action(LiteSubscriptionAction::PartialAdd)
+            .with_client_id(CheetahString::from_static_str("client-2"))
+            .with_group(CheetahString::from_static_str("lite-group"))
+            .with_topic(CheetahString::from_static_str("parent-topic"))
+            .with_lite_topic_set(HashSet::from([CheetahString::from_static_str("child-b")]));
+        let mut body = LiteSubscriptionCtlRequestBody::new();
+        body.set_subscription_set(vec![dto]);
+        let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
+            .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut processor = LiteSubscriptionCtlProcessor::new(inner.clone());
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor request should succeed")
+            .expect("processor should return a response");
+
+        assert_eq!(
+            ResponseCode::from(response.code()),
+            ResponseCode::LiteSubscriptionQuotaExceeded
+        );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn partial_add_with_offset_option_assigns_reset_offset() {
+        let mut runtime = new_test_runtime("offset-option").await;
+        let mut inner = runtime.inner_for_test().clone();
+        seed_group_config(
+            &mut inner,
+            "lite-group",
+            HashMap::from([(
+                CheetahString::from_string(format!("+{LITE_BIND_TOPIC_ATTRIBUTE_NAME}")),
+                CheetahString::from_static_str("parent-topic"),
+            )]),
+        );
+
+        let dto = LiteSubscriptionDTO::new()
+            .with_action(LiteSubscriptionAction::PartialAdd)
+            .with_client_id(CheetahString::from_static_str("client-id"))
+            .with_group(CheetahString::from_static_str("lite-group"))
+            .with_topic(CheetahString::from_static_str("parent-topic"))
+            .with_lite_topic_set(HashSet::from([CheetahString::from_static_str("child-a")]))
+            .with_offset_option(OffsetOption::offset(12));
+        let mut body = LiteSubscriptionCtlRequestBody::new();
+        body.set_subscription_set(vec![dto]);
+        let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
+            .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut processor = LiteSubscriptionCtlProcessor::new(inner.clone());
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor request should succeed")
+            .expect("processor should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let reset_offset = inner.consumer_offset_manager().query_then_erase_reset_offset(
+            &CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("convert lite topic")),
+            &CheetahString::from_static_str("lite-group"),
+            0,
+        );
+        assert_eq!(reset_offset, Some(12));
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn partial_remove_with_reset_offset_on_unsubscribe_assigns_min_offset() {
+        let mut runtime = new_test_runtime("reset-on-unsubscribe").await;
+        let mut inner = runtime.inner_for_test().clone();
+        seed_group_config(
+            &mut inner,
+            "lite-group",
+            HashMap::from([
+                (
+                    CheetahString::from_string(format!("+{LITE_BIND_TOPIC_ATTRIBUTE_NAME}")),
+                    CheetahString::from_static_str("parent-topic"),
+                ),
+                (
+                    CheetahString::from_string(format!("+{LITE_SUB_RESET_OFFSET_UNSUBSCRIBE_ATTRIBUTE_NAME}")),
+                    CheetahString::from_static_str("true"),
+                ),
+            ]),
+        );
+        inner.lite_subscription_registry().add_partial_subscription(
+            &CheetahString::from_static_str("client-id"),
+            &CheetahString::from_static_str("lite-group"),
+            &CheetahString::from_static_str("parent-topic"),
+            &HashSet::from([CheetahString::from_string(
+                to_lmq_name("parent-topic", "child-a").expect("convert lite topic"),
+            )]),
+        );
+
+        let dto = LiteSubscriptionDTO::new()
+            .with_action(LiteSubscriptionAction::PartialRemove)
+            .with_client_id(CheetahString::from_static_str("client-id"))
+            .with_group(CheetahString::from_static_str("lite-group"))
+            .with_topic(CheetahString::from_static_str("parent-topic"))
+            .with_lite_topic_set(HashSet::from([CheetahString::from_static_str("child-a")]));
+        let mut body = LiteSubscriptionCtlRequestBody::new();
+        body.set_subscription_set(vec![dto]);
+        let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
+            .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut processor = LiteSubscriptionCtlProcessor::new(inner.clone());
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor request should succeed")
+            .expect("processor should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let reset_offset = inner.consumer_offset_manager().query_then_erase_reset_offset(
+            &CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("convert lite topic")),
+            &CheetahString::from_static_str("lite-group"),
+            0,
+        );
+        assert_eq!(reset_offset, Some(0));
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn partial_add_in_exclusive_mode_excludes_previous_client_subscription() {
+        let mut runtime = new_test_runtime("exclusive-model").await;
+        let mut inner = runtime.inner_for_test().clone();
+        seed_group_config(
+            &mut inner,
+            "lite-group",
+            HashMap::from([
+                (
+                    CheetahString::from_string(format!("+{LITE_BIND_TOPIC_ATTRIBUTE_NAME}")),
+                    CheetahString::from_static_str("parent-topic"),
+                ),
+                (
+                    CheetahString::from_string(format!("+{LITE_SUB_MODEL_ATTRIBUTE_NAME}")),
+                    CheetahString::from_static_str("Exclusive"),
+                ),
+                (
+                    CheetahString::from_string(format!("+{LITE_SUB_RESET_OFFSET_EXCLUSIVE_ATTRIBUTE_NAME}")),
+                    CheetahString::from_static_str("true"),
+                ),
+            ]),
+        );
+        inner.lite_subscription_registry().add_partial_subscription(
+            &CheetahString::from_static_str("client-1"),
+            &CheetahString::from_static_str("lite-group"),
+            &CheetahString::from_static_str("parent-topic"),
+            &HashSet::from([CheetahString::from_string(
+                to_lmq_name("parent-topic", "child-a").expect("convert lite topic"),
+            )]),
+        );
+
+        let dto = LiteSubscriptionDTO::new()
+            .with_action(LiteSubscriptionAction::PartialAdd)
+            .with_client_id(CheetahString::from_static_str("client-2"))
+            .with_group(CheetahString::from_static_str("lite-group"))
+            .with_topic(CheetahString::from_static_str("parent-topic"))
+            .with_lite_topic_set(HashSet::from([CheetahString::from_static_str("child-a")]));
+        let mut body = LiteSubscriptionCtlRequestBody::new();
+        body.set_subscription_set(vec![dto]);
+        let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
+            .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut processor = LiteSubscriptionCtlProcessor::new(inner.clone());
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor request should succeed")
+            .expect("processor should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert!(inner
+            .lite_subscription_registry()
+            .lite_subscription(
+                &CheetahString::from_static_str("client-1"),
+                &CheetahString::from_static_str("lite-group"),
+                &CheetahString::from_static_str("parent-topic"),
+            )
+            .is_none());
+        let subscription = inner
+            .lite_subscription_registry()
+            .lite_subscription(
+                &CheetahString::from_static_str("client-2"),
+                &CheetahString::from_static_str("lite-group"),
+                &CheetahString::from_static_str("parent-topic"),
+            )
+            .expect("new exclusive subscriber should be retained");
+        assert!(subscription.lite_topic_set().contains(&CheetahString::from_string(
+            to_lmq_name("parent-topic", "child-a").expect("convert lite topic")
+        )));
+        let reset_offset = inner.consumer_offset_manager().query_then_erase_reset_offset(
+            &CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("convert lite topic")),
+            &CheetahString::from_static_str("lite-group"),
+            0,
+        );
+        assert_eq!(reset_offset, Some(0));
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-broker/src/processor/pop_lite_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor.rs
@@ -100,6 +100,10 @@ impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
         self.consumer_order_info_manager.order_info_count() as i32
     }
 
+    pub(crate) fn clear_order_info(&self, topic: &CheetahString, group: &CheetahString) {
+        self.consumer_order_info_manager.clear_block(topic, group, 0);
+    }
+
     fn pre_check(&self, request_header: &PopLiteMessageRequestHeader) -> Option<(ResponseCode, CheetahString)> {
         if request_header.client_id.is_empty() {
             return Some((

--- a/rocketmq-broker/src/subscription/lite_subscription_registry.rs
+++ b/rocketmq-broker/src/subscription/lite_subscription_registry.rs
@@ -155,7 +155,10 @@ impl LiteSubscriptionRegistry {
     }
 
     pub(crate) fn active_subscription_num(&self) -> usize {
-        self.subscriptions.len()
+        self.subscriptions
+            .iter()
+            .map(|entry| entry.value().lite_topic_set().len())
+            .sum()
     }
 
     pub(crate) fn all_subscriptions(&self) -> Vec<LiteSubscriptionRecord> {
@@ -208,5 +211,19 @@ mod tests {
 
         assert!(registry.lite_subscription(&client_id, &group, &topic).is_none());
         assert_eq!(registry.active_subscription_num(), 0);
+    }
+
+    #[test]
+    fn active_subscription_num_counts_lite_topic_references() {
+        let registry = LiteSubscriptionRegistry::default();
+        let client_id_a = CheetahString::from_static_str("client-a");
+        let client_id_b = CheetahString::from_static_str("client-b");
+        let group = CheetahString::from_static_str("group-a");
+        let topic = CheetahString::from_static_str("parent-topic");
+
+        registry.add_complete_subscription(&client_id_a, &group, &topic, &lmq_names("parent-topic", &["a", "b"]), 1);
+        registry.add_complete_subscription(&client_id_b, &group, &topic, &lmq_names("parent-topic", &["b"]), 1);
+
+        assert_eq!(registry.active_subscription_num(), 3);
     }
 }

--- a/rocketmq-remoting/src/code/response_code.rs
+++ b/rocketmq-remoting/src/code/response_code.rs
@@ -154,6 +154,7 @@ define_response_code! {
         ControllerElectMasterFailed = 2012,
         ControllerAlterSyncStateSetFailed = 2013,
         ControllerBrokerIdInvalid = 2014,
+        LiteSubscriptionQuotaExceeded = 2018,
     },
     default = SystemError
 }
@@ -288,6 +289,7 @@ mod tests {
             ResponseCode::ControllerAlterSyncStateSetFailed
         );
         assert_eq!(ResponseCode::from(2014), ResponseCode::ControllerBrokerIdInvalid);
+        assert_eq!(ResponseCode::from(2018), ResponseCode::LiteSubscriptionQuotaExceeded);
         assert_eq!(ResponseCode::from(9999), ResponseCode::SystemError); // Edge case - unknown
                                                                          // defaults to SystemError
     }

--- a/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
+++ b/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
@@ -16,7 +16,12 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use cheetah_string::CheetahString;
+use rocketmq_common::common::attribute::subscription_group_attributes::SubscriptionGroupAttributes;
 use rocketmq_common::common::attribute::subscription_group_attributes::LITE_BIND_TOPIC_ATTRIBUTE_NAME;
+use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_CLIENT_QUOTA_ATTRIBUTE_NAME;
+use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_MODEL_ATTRIBUTE_NAME;
+use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_RESET_OFFSET_EXCLUSIVE_ATTRIBUTE_NAME;
+use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_RESET_OFFSET_UNSUBSCRIBE_ATTRIBUTE_NAME;
 use rocketmq_common::common::mix_all::MASTER_ID;
 use serde::Deserialize;
 use serde::Serialize;
@@ -170,6 +175,39 @@ impl SubscriptionGroupConfig {
         self.attributes
             .get(&CheetahString::from_static_str(LITE_BIND_TOPIC_ATTRIBUTE_NAME))
             .filter(|value| !value.is_empty())
+    }
+
+    #[inline]
+    pub fn lite_sub_client_quota(&self) -> i32 {
+        self.attributes
+            .get(&CheetahString::from_static_str(LITE_SUB_CLIENT_QUOTA_ATTRIBUTE_NAME))
+            .and_then(|value| value.parse::<i64>().ok())
+            .unwrap_or(SubscriptionGroupAttributes::lite_sub_client_quota_attribute().default_value()) as i32
+    }
+
+    #[inline]
+    pub fn lite_sub_exclusive(&self) -> bool {
+        self.attributes
+            .get(&CheetahString::from_static_str(LITE_SUB_MODEL_ATTRIBUTE_NAME))
+            .is_some_and(|value| value == "Exclusive")
+    }
+
+    #[inline]
+    pub fn reset_offset_in_exclusive_mode(&self) -> bool {
+        self.attributes
+            .get(&CheetahString::from_static_str(
+                LITE_SUB_RESET_OFFSET_EXCLUSIVE_ATTRIBUTE_NAME,
+            ))
+            .is_some_and(|value| value.parse::<bool>().unwrap_or(false))
+    }
+
+    #[inline]
+    pub fn reset_offset_on_unsubscribe(&self) -> bool {
+        self.attributes
+            .get(&CheetahString::from_static_str(
+                LITE_SUB_RESET_OFFSET_UNSUBSCRIBE_ATTRIBUTE_NAME,
+            ))
+            .is_some_and(|value| value.parse::<bool>().unwrap_or(false))
     }
 
     #[inline]
@@ -339,5 +377,43 @@ mod subscription_group_config_tests {
 
         config.set_lite_bind_topic(None);
         assert!(config.lite_bind_topic().is_none());
+    }
+
+    #[test]
+    fn lite_subscription_attributes_use_java_defaults() {
+        let config = SubscriptionGroupConfig::default();
+
+        assert_eq!(config.lite_sub_client_quota(), 2000);
+        assert!(!config.lite_sub_exclusive());
+        assert!(!config.reset_offset_in_exclusive_mode());
+        assert!(!config.reset_offset_on_unsubscribe());
+    }
+
+    #[test]
+    fn lite_subscription_attributes_parse_from_attribute_map() {
+        let mut config = SubscriptionGroupConfig::default();
+        config.set_attributes(HashMap::from([
+            (
+                CheetahString::from_static_str(LITE_SUB_CLIENT_QUOTA_ATTRIBUTE_NAME),
+                CheetahString::from_static_str("128"),
+            ),
+            (
+                CheetahString::from_static_str(LITE_SUB_MODEL_ATTRIBUTE_NAME),
+                CheetahString::from_static_str("Exclusive"),
+            ),
+            (
+                CheetahString::from_static_str(LITE_SUB_RESET_OFFSET_EXCLUSIVE_ATTRIBUTE_NAME),
+                CheetahString::from_static_str("true"),
+            ),
+            (
+                CheetahString::from_static_str(LITE_SUB_RESET_OFFSET_UNSUBSCRIBE_ATTRIBUTE_NAME),
+                CheetahString::from_static_str("true"),
+            ),
+        ]));
+
+        assert_eq!(config.lite_sub_client_quota(), 128);
+        assert!(config.lite_sub_exclusive());
+        assert!(config.reset_offset_in_exclusive_mode());
+        assert!(config.reset_offset_on_unsubscribe());
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7026

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented lite subscription quota enforcement to prevent exceeding configured broker subscription limits
  * Enhanced offset reset behavior during subscription add and remove operations
  * Improved exclusive-mode conflict handling for overlapping subscriptions in the same group
  * Added new quota exceeded response code

* **Refactor**
  * Updated subscription registry logic for improved subscription counting accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->