### PR TITLE
[ISSUE #7028]🚀Add versioning to LiteSubscription and related components for improved subscription management

### DIFF
--- a/rocketmq-broker/src/lite/lite_lifecycle_manager.rs
+++ b/rocketmq-broker/src/lite/lite_lifecycle_manager.rs
@@ -96,6 +96,7 @@ mod tests {
                     CheetahString::from_string(to_lmq_name("parent-topic", "child-b").expect("lmq")),
                 ]),
                 update_time: 1,
+                version: 0,
             },
             LiteSubscriptionRecord {
                 client_id: CheetahString::from_static_str("client-b"),
@@ -105,6 +106,7 @@ mod tests {
                     to_lmq_name("parent-topic", "child-b").expect("lmq"),
                 )]),
                 update_time: 2,
+                version: 0,
             },
         ];
 

--- a/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
+++ b/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
@@ -515,6 +515,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn complete_add_ignores_stale_version_snapshot() {
+        let mut runtime = new_test_runtime("processor-stale-version").await;
+        let mut inner = runtime.inner_for_test().clone();
+        seed_group_config(
+            &mut inner,
+            "lite-group",
+            HashMap::from([(
+                CheetahString::from_string(format!("+{LITE_BIND_TOPIC_ATTRIBUTE_NAME}")),
+                CheetahString::from_static_str("parent-topic"),
+            )]),
+        );
+
+        let mut body = LiteSubscriptionCtlRequestBody::new();
+        body.set_subscription_set(vec![LiteSubscriptionDTO::new()
+            .with_action(LiteSubscriptionAction::CompleteAdd)
+            .with_client_id(CheetahString::from_static_str("client-id"))
+            .with_group(CheetahString::from_static_str("lite-group"))
+            .with_topic(CheetahString::from_static_str("parent-topic"))
+            .with_lite_topic_set(HashSet::from([
+                CheetahString::from_static_str("child-a"),
+                CheetahString::from_static_str("child-b"),
+            ]))
+            .with_version(5)]);
+        let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {})
+            .set_body(Bytes::from(serde_json::to_vec(&body).expect("serialize request body")));
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut processor = LiteSubscriptionCtlProcessor::new(inner.clone());
+        let response = processor
+            .process_request(channel.clone(), ctx.clone(), &mut request)
+            .await
+            .expect("processor request should succeed")
+            .expect("processor should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+
+        let mut stale_body = LiteSubscriptionCtlRequestBody::new();
+        stale_body.set_subscription_set(vec![LiteSubscriptionDTO::new()
+            .with_action(LiteSubscriptionAction::CompleteAdd)
+            .with_client_id(CheetahString::from_static_str("client-id"))
+            .with_group(CheetahString::from_static_str("lite-group"))
+            .with_topic(CheetahString::from_static_str("parent-topic"))
+            .with_lite_topic_set(HashSet::from([CheetahString::from_static_str("child-c")]))
+            .with_version(4)]);
+        let mut stale_request =
+            RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {}).set_body(
+                Bytes::from(serde_json::to_vec(&stale_body).expect("serialize stale request body")),
+            );
+
+        let stale_response = processor
+            .process_request(channel, ctx, &mut stale_request)
+            .await
+            .expect("processor stale request should succeed")
+            .expect("processor should return a response");
+
+        assert_eq!(ResponseCode::from(stale_response.code()), ResponseCode::Success);
+        let subscription = inner
+            .lite_subscription_registry()
+            .lite_subscription(
+                &CheetahString::from_static_str("client-id"),
+                &CheetahString::from_static_str("lite-group"),
+                &CheetahString::from_static_str("parent-topic"),
+            )
+            .expect("registry should retain the latest complete snapshot");
+        assert_eq!(subscription.version(), 5);
+        assert_eq!(
+            subscription.lite_topic_set(),
+            &HashSet::from([
+                CheetahString::from_string(to_lmq_name("parent-topic", "child-a").expect("convert child-a")),
+                CheetahString::from_string(to_lmq_name("parent-topic", "child-b").expect("convert child-b")),
+            ])
+        );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
     async fn partial_add_returns_quota_exceeded_when_global_limit_is_hit() {
         let mut runtime = new_test_runtime_with_max_subscription_count("quota-exceeded", 1).await;
         let mut inner = runtime.inner_for_test().clone();

--- a/rocketmq-broker/src/subscription/lite_subscription_registry.rs
+++ b/rocketmq-broker/src/subscription/lite_subscription_registry.rs
@@ -50,6 +50,7 @@ pub(crate) struct LiteSubscriptionRecord {
     pub(crate) topic: CheetahString,
     pub(crate) lite_topic_set: HashSet<CheetahString>,
     pub(crate) update_time: i64,
+    pub(crate) version: i64,
 }
 
 impl LiteSubscriptionRegistry {
@@ -108,11 +109,18 @@ impl LiteSubscriptionRegistry {
         group: &CheetahString,
         topic: &CheetahString,
         lmq_name_set: &HashSet<CheetahString>,
-        _version: i64,
+        version: i64,
     ) -> LiteSubscription {
         let key = LiteSubscriptionKey::new(client_id.clone(), group.clone(), topic.clone());
+        if let Some(existing) = self.subscriptions.get(&key) {
+            if version < existing.version() {
+                return existing.clone();
+            }
+        }
+
         let mut subscription = LiteSubscription::new(group.clone(), topic.clone());
         subscription.set_lite_topic_set(lmq_name_set.clone());
+        subscription.set_version(version);
 
         if lmq_name_set.is_empty() {
             self.subscriptions.remove(&key);
@@ -170,6 +178,7 @@ impl LiteSubscriptionRegistry {
                 topic: entry.key().topic.clone(),
                 lite_topic_set: entry.value().lite_topic_set().clone(),
                 update_time: entry.value().update_time(),
+                version: entry.value().version(),
             })
             .collect()
     }
@@ -225,5 +234,26 @@ mod tests {
         registry.add_complete_subscription(&client_id_b, &group, &topic, &lmq_names("parent-topic", &["b"]), 1);
 
         assert_eq!(registry.active_subscription_num(), 3);
+    }
+
+    #[test]
+    fn complete_add_ignores_stale_version_updates() {
+        let registry = LiteSubscriptionRegistry::default();
+        let client_id = CheetahString::from_static_str("client-a");
+        let group = CheetahString::from_static_str("group-a");
+        let topic = CheetahString::from_static_str("parent-topic");
+
+        registry.add_complete_subscription(&client_id, &group, &topic, &lmq_names("parent-topic", &["a", "b"]), 5);
+        let ignored =
+            registry.add_complete_subscription(&client_id, &group, &topic, &lmq_names("parent-topic", &["c"]), 4);
+
+        assert_eq!(ignored.version(), 5);
+        assert_eq!(ignored.lite_topic_set(), &lmq_names("parent-topic", &["a", "b"]));
+
+        let stored = registry
+            .lite_subscription(&client_id, &group, &topic)
+            .expect("subscription should remain stored");
+        assert_eq!(stored.version(), 5);
+        assert_eq!(stored.lite_topic_set(), &lmq_names("parent-topic", &["a", "b"]));
     }
 }

--- a/rocketmq-common/src/common/lite/lite_subscription.rs
+++ b/rocketmq-common/src/common/lite/lite_subscription.rs
@@ -23,6 +23,7 @@ pub struct LiteSubscription {
     pub topic: CheetahString,
     pub lite_topic_set: HashSet<CheetahString>,
     pub update_time: i64,
+    pub version: i64,
 }
 
 impl LiteSubscription {
@@ -34,6 +35,7 @@ impl LiteSubscription {
             topic,
             lite_topic_set: HashSet::new(),
             update_time: Self::current_time_millis(),
+            version: 0,
         }
     }
 
@@ -49,6 +51,13 @@ impl LiteSubscription {
     #[inline]
     pub fn with_update_time(mut self, update_time: i64) -> Self {
         self.update_time = update_time;
+        self
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn with_version(mut self, version: i64) -> Self {
+        self.version = version;
         self
     }
 
@@ -123,6 +132,17 @@ impl LiteSubscription {
         self.update_time = update_time;
     }
 
+    #[must_use]
+    #[inline]
+    pub const fn version(&self) -> i64 {
+        self.version
+    }
+
+    #[inline]
+    pub fn set_version(&mut self, version: i64) {
+        self.version = version;
+    }
+
     #[inline]
     fn refresh_update_time(&mut self) {
         self.update_time = Self::current_time_millis();
@@ -142,8 +162,8 @@ impl fmt::Display for LiteSubscription {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "LiteSubscription {{ group: {}, topic: {}, lite_topic_set: {:?}, update_time: {} }}",
-            self.group, self.topic, self.lite_topic_set, self.update_time
+            "LiteSubscription {{ group: {}, topic: {}, lite_topic_set: {:?}, update_time: {}, version: {} }}",
+            self.group, self.topic, self.lite_topic_set, self.update_time, self.version
         )
     }
 }
@@ -158,12 +178,14 @@ mod tests {
         set.insert("lite_topic".into());
         let subscription = LiteSubscription::new("group".into(), "topic".into())
             .with_lite_topic_set(set.clone())
-            .with_update_time(100);
+            .with_update_time(100)
+            .with_version(2);
 
         assert_eq!(subscription.group(), "group");
         assert_eq!(subscription.topic(), "topic");
         assert_eq!(subscription.lite_topic_set(), &set);
         assert_eq!(subscription.update_time(), 100);
+        assert_eq!(subscription.version(), 2);
     }
 
     #[test]
@@ -194,11 +216,13 @@ mod tests {
         set.insert("topic1".into());
         subscription.set_lite_topic_set(set.clone());
         subscription.set_update_time(200);
+        subscription.set_version(3);
 
         assert_eq!(subscription.group(), "new_group");
         assert_eq!(subscription.topic(), "new_topic");
         assert_eq!(subscription.lite_topic_set(), &set);
         assert_eq!(subscription.update_time(), 200);
+        assert_eq!(subscription.version(), 3);
     }
 
     #[test]
@@ -207,5 +231,6 @@ mod tests {
         let display = format!("{}", subscription);
         assert!(display.contains("group: group"));
         assert!(display.contains("topic: topic"));
+        assert!(display.contains("version: 0"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7028

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version tracking to subscription records for improved data consistency.
  * Implemented version-aware update logic to prevent stale subscription data from overwriting newer versions.

* **Tests**
  * Added tests validating stale version rejection behavior in subscription management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->