### PR TITLE
[ISSUE #7048]🚀feat(filter): implement SQL92 expression compilation and evaluation, enhance consumer filter management

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -198,8 +198,9 @@ impl BrokerRuntime {
             broker_config.get_broker_addr().into(),
         );
         let producer_manager = ProducerManager::new();
+        let consumer_filter_manager = ConsumerFilterManager::new(broker_config.clone(), message_store_config.clone());
         let consumer_ids_change_listener: Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static> =
-            Arc::new(DefaultConsumerIdsChangeListener {});
+            Arc::new(DefaultConsumerIdsChangeListener::new(consumer_filter_manager.clone()));
         let consumer_manager =
             ConsumerManager::new_with_broker_stats(consumer_ids_change_listener.clone(), broker_config.clone());
 
@@ -221,7 +222,7 @@ impl BrokerRuntime {
                 None,
             ),
             subscription_group_manager: None,
-            consumer_filter_manager: Some(ConsumerFilterManager::new(broker_config, message_store_config.clone())),
+            consumer_filter_manager: Some(consumer_filter_manager),
 
             consumer_order_info_manager: None,
             message_store: None,

--- a/rocketmq-broker/src/client/default_consumer_ids_change_listener.rs
+++ b/rocketmq-broker/src/client/default_consumer_ids_change_listener.rs
@@ -13,19 +13,92 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::HashSet;
 
-use tracing::warn;
+use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 
 use crate::client::consumer_group_event::ConsumerGroupEvent;
 use crate::client::consumer_ids_change_listener::ConsumerIdsChangeListener;
+use crate::filter::manager::consumer_filter_manager::ConsumerFilterManager;
 
-#[derive(Default)]
-pub struct DefaultConsumerIdsChangeListener {}
+#[derive(Clone)]
+pub struct DefaultConsumerIdsChangeListener {
+    consumer_filter_manager: ConsumerFilterManager,
+}
+
+impl DefaultConsumerIdsChangeListener {
+    pub fn new(consumer_filter_manager: ConsumerFilterManager) -> Self {
+        Self {
+            consumer_filter_manager,
+        }
+    }
+}
 
 impl ConsumerIdsChangeListener for DefaultConsumerIdsChangeListener {
-    fn handle(&self, _event: ConsumerGroupEvent, _group: &str, _args: &[&dyn Any]) {}
+    fn handle(&self, event: ConsumerGroupEvent, group: &str, args: &[&dyn Any]) {
+        match event {
+            ConsumerGroupEvent::Register => {
+                let Some(subscriptions) = args
+                    .first()
+                    .and_then(|argument| argument.downcast_ref::<HashSet<SubscriptionData>>())
+                else {
+                    return;
+                };
+                self.consumer_filter_manager.register(group, subscriptions);
+            }
+            ConsumerGroupEvent::Unregister => {
+                self.consumer_filter_manager.unregister(group);
+            }
+            ConsumerGroupEvent::Change | ConsumerGroupEvent::ClientRegister | ConsumerGroupEvent::ClientUnregister => {}
+        }
+    }
 
-    fn shutdown(&self) {
-        warn!("DefaultConsumerIdsChangeListener shutdown not implemented");
+    fn shutdown(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::filter::expression_type::ExpressionType;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+
+    use super::*;
+
+    #[test]
+    fn register_event_populates_consumer_filter_manager() {
+        let manager = ConsumerFilterManager::new(
+            Arc::new(BrokerConfig::default()),
+            Arc::new(MessageStoreConfig::default()),
+        );
+        let listener = DefaultConsumerIdsChangeListener::new(manager.clone());
+        let subscriptions = HashSet::from([SubscriptionData {
+            topic: CheetahString::from_slice("TopicTest"),
+            sub_string: CheetahString::from_slice("color = 'blue'"),
+            expression_type: CheetahString::from_static_str(ExpressionType::SQL92),
+            sub_version: 3,
+            ..Default::default()
+        }]);
+
+        listener.handle(ConsumerGroupEvent::Register, "GroupTest", &[&subscriptions as &dyn Any]);
+
+        assert!(manager
+            .get_consumer_filter_data(
+                &CheetahString::from_slice("TopicTest"),
+                &CheetahString::from_slice("GroupTest"),
+            )
+            .is_some());
+
+        listener.handle(ConsumerGroupEvent::Unregister, "GroupTest", &[]);
+        assert!(manager
+            .get_consumer_filter_data(
+                &CheetahString::from_slice("TopicTest"),
+                &CheetahString::from_slice("GroupTest"),
+            )
+            .unwrap()
+            .is_dead());
     }
 }

--- a/rocketmq-broker/src/filter/commit_log_dispatcher_calc_bit_map.rs
+++ b/rocketmq-broker/src/filter/commit_log_dispatcher_calc_bit_map.rs
@@ -99,3 +99,62 @@ impl CommitLogDispatcher for CommitLogDispatcherCalcBitMap {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::filter::expression_type::ExpressionType;
+    use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
+    use rocketmq_store::base::dispatch_request::DispatchRequest;
+
+    use super::*;
+    use crate::filter::manager::consumer_filter_manager::ConsumerFilterManager;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+
+    #[test]
+    fn dispatch_sets_bitmap_for_matching_sql_filter() {
+        let broker_config = Arc::new(BrokerConfig {
+            enable_calc_filter_bit_map: true,
+            ..BrokerConfig::default()
+        });
+        let manager = ConsumerFilterManager::new(broker_config.clone(), Arc::new(MessageStoreConfig::default()));
+        let subscriptions = HashSet::from([SubscriptionData {
+            topic: CheetahString::from_slice("TopicTest"),
+            sub_string: CheetahString::from_slice("color = 'blue'"),
+            expression_type: CheetahString::from_static_str(ExpressionType::SQL92),
+            sub_version: 1,
+            ..Default::default()
+        }]);
+        manager.register("GroupTest", &subscriptions);
+
+        let dispatcher = CommitLogDispatcherCalcBitMap::new(broker_config, manager.clone());
+        let mut request = DispatchRequest {
+            topic: CheetahString::from_slice("TopicTest"),
+            properties_map: Some(HashMap::from([(
+                CheetahString::from_slice("color"),
+                CheetahString::from_slice("blue"),
+            )])),
+            ..Default::default()
+        };
+
+        dispatcher.dispatch(&mut request);
+
+        let filter_data = manager
+            .get_consumer_filter_data(
+                &CheetahString::from_slice("TopicTest"),
+                &CheetahString::from_slice("GroupTest"),
+            )
+            .unwrap();
+        let bits =
+            rocketmq_filter::utils::bits_array::BitsArray::from_bytes(request.bit_map.as_ref().unwrap()).unwrap();
+
+        assert!(manager
+            .bloom_filter()
+            .unwrap()
+            .is_hit(filter_data.bloom_filter_data().unwrap(), &bits)
+            .unwrap());
+    }
+}

--- a/rocketmq-broker/src/filter/consumer_filter_data.rs
+++ b/rocketmq-broker/src/filter/consumer_filter_data.rs
@@ -31,7 +31,7 @@ pub struct ConsumerFilterData {
     expression: Option<CheetahString>,
     expression_type: Option<CheetahString>,
     #[serde(skip)]
-    compiled_expression: Option<Arc<Box<dyn Expression + Send + Sync + 'static>>>,
+    compiled_expression: Option<Arc<dyn Expression + Send + Sync + 'static>>,
     born_time: u64,
     dead_time: u64,
     bloom_filter_data: Option<BloomFilterData>,
@@ -103,8 +103,25 @@ impl ConsumerFilterData {
         self.client_version = client_version;
     }
 
-    pub fn compiled_expression(&self) -> &Option<Arc<Box<dyn Expression + Send + Sync + 'static>>> {
+    pub fn compiled_expression(&self) -> &Option<Arc<dyn Expression + Send + Sync + 'static>> {
         &self.compiled_expression
+    }
+
+    pub fn set_compiled_expression(&mut self, compiled_expression: Box<dyn Expression + Send + Sync + 'static>) {
+        self.compiled_expression = Some(Arc::from(compiled_expression));
+    }
+
+    pub fn is_dead(&self) -> bool {
+        self.dead_time >= self.born_time
+    }
+
+    pub fn how_long_after_death(&self) -> Option<u64> {
+        self.is_dead()
+            .then(|| rocketmq_common::TimeUtils::current_millis().saturating_sub(self.dead_time))
+    }
+
+    pub fn is_msg_in_live(&self, msg_store_time: u64) -> bool {
+        msg_store_time > self.born_time
     }
 }
 

--- a/rocketmq-broker/src/filter/expression_message_filter.rs
+++ b/rocketmq-broker/src/filter/expression_message_filter.rs
@@ -76,7 +76,49 @@ impl MessageFilter for ExpressionMessageFilter {
             }
             subscription_data.code_set.contains(&(tags_code.unwrap() as i32))
         } else {
-            unimplemented!("SQL92 expression type is not supported yet.")
+            let Some(filter_data) = self.consumer_filter_data.as_ref() else {
+                return true;
+            };
+
+            if filter_data.expression().is_none()
+                || filter_data.expression_type().is_none()
+                || filter_data.compiled_expression().is_none()
+                || filter_data.bloom_filter_data().is_none()
+            {
+                return true;
+            }
+
+            let Some(cq_ext_unit) = cq_ext_unit else {
+                return true;
+            };
+
+            if !filter_data.is_msg_in_live(cq_ext_unit.msg_store_time() as u64) {
+                return true;
+            }
+
+            let Some(filter_bit_map) = cq_ext_unit.filter_bit_map() else {
+                return true;
+            };
+
+            if !self.bloom_data_valid
+                || filter_bit_map.len() * u8::BITS as usize
+                    != filter_data.bloom_filter_data().unwrap().bit_num() as usize
+            {
+                return true;
+            }
+
+            let Ok(bits_array) = rocketmq_filter::utils::bits_array::BitsArray::from_bytes(filter_bit_map) else {
+                return true;
+            };
+
+            self.consumer_filter_manager
+                .bloom_filter()
+                .and_then(|bloom_filter| {
+                    bloom_filter
+                        .is_hit(filter_data.bloom_filter_data().unwrap(), &bits_array)
+                        .ok()
+                })
+                .unwrap_or(true)
         }
     }
 
@@ -123,5 +165,68 @@ impl MessageFilter for ExpressionMessageFilter {
         } else {
             true
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+    use rocketmq_store::filter::MessageFilter;
+
+    use super::*;
+
+    fn new_manager() -> ConsumerFilterManager {
+        ConsumerFilterManager::new(
+            Arc::new(BrokerConfig::default()),
+            Arc::new(MessageStoreConfig::default()),
+        )
+    }
+
+    fn sql_subscription(topic: &str, expression: &str) -> SubscriptionData {
+        SubscriptionData {
+            topic: CheetahString::from_slice(topic),
+            sub_string: CheetahString::from_slice(expression),
+            expression_type: CheetahString::from_static_str(ExpressionType::SQL92),
+            sub_version: 11,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn sql_consume_queue_path_checks_bloom_bitmap() {
+        let manager = new_manager();
+        let subscriptions = HashSet::from([sql_subscription("TopicTest", "color = 'blue'")]);
+        manager.register("GroupTest", &subscriptions);
+
+        let filter_data = manager
+            .get_consumer_filter_data(
+                &CheetahString::from_slice("TopicTest"),
+                &CheetahString::from_slice("GroupTest"),
+            )
+            .unwrap();
+
+        let mut bits =
+            rocketmq_filter::utils::bits_array::BitsArray::create(manager.bloom_filter().unwrap().m() as usize);
+        manager
+            .bloom_filter()
+            .unwrap()
+            .hash_to(filter_data.bloom_filter_data().unwrap(), &mut bits)
+            .unwrap();
+
+        let cq_ext_unit = CqExtUnit::new(0, filter_data.born_time() as i64 + 1, Some(bits.bytes().to_vec()));
+        let filter = ExpressionMessageFilter::new(
+            Some(sql_subscription("TopicTest", "color = 'blue'")),
+            Some(filter_data.clone()),
+            Arc::new(manager.clone()),
+        );
+
+        assert!(filter.is_matched_by_consume_queue(None, Some(&cq_ext_unit)));
+
+        let miss = CqExtUnit::new(0, filter_data.born_time() as i64 + 1, Some(vec![0; bits.byte_length()]));
+        assert!(!filter.is_matched_by_consume_queue(None, Some(&miss)));
     }
 }

--- a/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
+++ b/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+use std::str;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
@@ -19,18 +21,23 @@ use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::common::filter::expression_type::ExpressionType;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_filter::filter::FilterFactory;
 use rocketmq_filter::utils::bloom_filter::BloomFilter;
+use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
 
 use crate::broker_path_config_helper::get_consumer_filter_path;
 use crate::filter::consumer_filter_data::ConsumerFilterData;
 use crate::filter::manager::consumer_filter_wrapper::ConsumerFilterWrapper;
+use crate::filter::manager::consumer_filter_wrapper::FilterDataMapByTopic;
 
 const MS_24_HOUR: u64 = 24 * 60 * 60 * 1000;
+const LOAD_DEAD_MARKER_MS: u64 = 30 * 1000;
 
 #[derive(Clone)]
 pub(crate) struct ConsumerFilterManager {
-    broker_config: Arc<BrokerConfig>,
+    _broker_config: Arc<BrokerConfig>,
     message_store_config: Arc<MessageStoreConfig>,
     consumer_filter_wrapper: Arc<parking_lot::RwLock<ConsumerFilterWrapper>>,
     bloom_filter: Option<BloomFilter>,
@@ -47,38 +54,13 @@ impl ConsumerFilterManager {
         let broker_config_mut = Arc::make_mut(&mut broker_config);
         broker_config_mut.bit_map_length_consume_queue_ext = bloom_filter.m();
         ConsumerFilterManager {
-            broker_config,
+            _broker_config: broker_config,
             message_store_config,
             consumer_filter_wrapper,
             bloom_filter: Some(bloom_filter),
         }
     }
-}
 
-//Fully implemented will be removed
-#[allow(unused_variables)]
-impl ConfigManager for ConsumerFilterManager {
-    fn decode0(&mut self, key: &[u8], body: &[u8]) {
-        todo!()
-    }
-
-    fn stop(&mut self) -> bool {
-        todo!()
-    }
-
-    fn config_file_path(&self) -> String {
-        get_consumer_filter_path(self.message_store_config.store_path_root_dir.as_str())
-    }
-
-    fn encode_pretty(&self, pretty_format: bool) -> String {
-        "".to_string()
-    }
-
-    fn decode(&self, json_string: &str) {}
-}
-
-#[allow(unused_variables)]
-impl ConsumerFilterManager {
     pub fn build(
         topic: CheetahString,
         consumer_group: CheetahString,
@@ -90,6 +72,11 @@ impl ConsumerFilterManager {
             return None;
         }
 
+        let expression_text = expression.as_ref().filter(|value| !value.is_empty())?;
+        let expression_type = type_.as_ref()?;
+        let filter = FilterFactory::instance().get(expression_type.as_str())?;
+        let compiled = filter.compile(expression_text.as_str()).ok()?;
+
         let mut consumer_filter_data = ConsumerFilterData::default();
         consumer_filter_data.set_topic(topic);
         consumer_filter_data.set_consumer_group(consumer_group);
@@ -98,8 +85,39 @@ impl ConsumerFilterManager {
         consumer_filter_data.set_expression(expression);
         consumer_filter_data.set_expression_type(type_);
         consumer_filter_data.set_client_version(client_version);
+        consumer_filter_data.set_compiled_expression(compiled);
 
         Some(consumer_filter_data)
+    }
+
+    pub fn register(&self, consumer_group: &str, subscriptions: &HashSet<SubscriptionData>) {
+        let mut active_topics = HashSet::with_capacity(subscriptions.len());
+        for subscription in subscriptions {
+            active_topics.insert(subscription.topic.to_string());
+            self.register_subscription(consumer_group, subscription);
+        }
+
+        let now = current_millis();
+        let mut wrapper = self.consumer_filter_wrapper.write();
+        for by_topic in wrapper.filter_data_by_topic.values_mut() {
+            if let Some(filter_data) = by_topic.filter_data_map.get_mut(consumer_group) {
+                if !active_topics.contains(filter_data.topic().as_str()) && !filter_data.is_dead() {
+                    filter_data.set_dead_time(now);
+                }
+            }
+        }
+    }
+
+    pub fn unregister(&self, consumer_group: &str) {
+        let now = current_millis();
+        let mut wrapper = self.consumer_filter_wrapper.write();
+        for by_topic in wrapper.filter_data_by_topic.values_mut() {
+            if let Some(filter_data) = by_topic.filter_data_map.get_mut(consumer_group) {
+                if !filter_data.is_dead() {
+                    filter_data.set_dead_time(now);
+                }
+            }
+        }
     }
 
     pub fn get_consumer_filter_data(
@@ -107,7 +125,12 @@ impl ConsumerFilterManager {
         topic: &CheetahString,
         consumer_group: &CheetahString,
     ) -> Option<ConsumerFilterData> {
-        None
+        self.consumer_filter_wrapper
+            .read()
+            .filter_data_by_topic
+            .get(topic.as_str())
+            .and_then(|by_topic| by_topic.filter_data_map.get(consumer_group.as_str()))
+            .cloned()
     }
 
     pub fn bloom_filter(&self) -> Option<&BloomFilter> {
@@ -115,6 +138,306 @@ impl ConsumerFilterManager {
     }
 
     pub fn get(&self, topic: &CheetahString) -> Option<Vec<ConsumerFilterData>> {
-        unimplemented!("get method not implemented");
+        let wrapper = self.consumer_filter_wrapper.read();
+        let by_topic = wrapper.filter_data_by_topic.get(topic.as_str())?;
+        if by_topic.filter_data_map.is_empty() {
+            None
+        } else {
+            Some(by_topic.filter_data_map.values().cloned().collect())
+        }
+    }
+
+    fn register_subscription(&self, consumer_group: &str, subscription: &SubscriptionData) -> bool {
+        self.register_entry(
+            subscription.topic.as_str(),
+            consumer_group,
+            subscription.sub_string.as_str(),
+            subscription.expression_type.as_str(),
+            subscription.sub_version as u64,
+        )
+    }
+
+    fn register_entry(
+        &self,
+        topic: &str,
+        consumer_group: &str,
+        expression: &str,
+        type_: &str,
+        client_version: u64,
+    ) -> bool {
+        if ExpressionType::is_tag_type(Some(type_)) || expression.is_empty() {
+            return false;
+        }
+
+        let bloom_filter_data = match self.bloom_filter.as_ref() {
+            Some(filter) => filter.generate(&format!("{consumer_group}#{topic}")),
+            None => return false,
+        };
+
+        let mut wrapper = self.consumer_filter_wrapper.write();
+        let by_topic = wrapper
+            .filter_data_by_topic
+            .entry(topic.to_string())
+            .or_insert_with(|| FilterDataMapByTopic {
+                filter_data_map: Default::default(),
+                topic: topic.to_string(),
+            });
+
+        let existing = by_topic.filter_data_map.get(consumer_group).cloned();
+        match existing {
+            None => {
+                let mut filter_data = match Self::build(
+                    CheetahString::from_slice(topic),
+                    CheetahString::from_slice(consumer_group),
+                    Some(CheetahString::from_slice(expression)),
+                    Some(CheetahString::from_slice(type_)),
+                    client_version,
+                ) {
+                    Some(filter_data) => filter_data,
+                    None => return false,
+                };
+                filter_data.set_bloom_filter_data(Some(bloom_filter_data));
+                by_topic.filter_data_map.insert(consumer_group.to_string(), filter_data);
+                true
+            }
+            Some(old) if client_version <= old.client_version() => {
+                if client_version == old.client_version() && old.is_dead() {
+                    if let Some(old) = by_topic.filter_data_map.get_mut(consumer_group) {
+                        old.set_dead_time(0);
+                    }
+                    return true;
+                }
+                false
+            }
+            Some(old) => {
+                let changed = old.expression().map(|value| value.as_str()) != Some(expression)
+                    || old.expression_type().map(|value| value.as_str()) != Some(type_)
+                    || old.bloom_filter_data() != Some(&bloom_filter_data);
+
+                if changed {
+                    let mut filter_data = match Self::build(
+                        CheetahString::from_slice(topic),
+                        CheetahString::from_slice(consumer_group),
+                        Some(CheetahString::from_slice(expression)),
+                        Some(CheetahString::from_slice(type_)),
+                        client_version,
+                    ) {
+                        Some(filter_data) => filter_data,
+                        None => {
+                            by_topic.filter_data_map.remove(consumer_group);
+                            return false;
+                        }
+                    };
+                    filter_data.set_bloom_filter_data(Some(bloom_filter_data));
+                    by_topic.filter_data_map.insert(consumer_group.to_string(), filter_data);
+                    true
+                } else {
+                    if let Some(old) = by_topic.filter_data_map.get_mut(consumer_group) {
+                        old.set_client_version(client_version);
+                        if old.is_dead() {
+                            old.set_dead_time(0);
+                        }
+                    }
+                    true
+                }
+            }
+        }
+    }
+
+    fn compile_filter_data(&self, filter_data: &mut ConsumerFilterData) -> bool {
+        let Some(expression) = filter_data.expression() else {
+            return false;
+        };
+        let Some(expression_type) = filter_data.expression_type() else {
+            return false;
+        };
+        let Some(filter) = FilterFactory::instance().get(expression_type.as_str()) else {
+            return false;
+        };
+        let Ok(compiled) = filter.compile(expression.as_str()) else {
+            return false;
+        };
+        filter_data.set_compiled_expression(compiled);
+        true
+    }
+
+    fn clean(&self) {
+        let mut wrapper = self.consumer_filter_wrapper.write();
+        wrapper.filter_data_by_topic.retain(|_, by_topic| {
+            by_topic.filter_data_map.retain(|_, filter_data| {
+                filter_data
+                    .how_long_after_death()
+                    .map(|elapsed| elapsed < MS_24_HOUR)
+                    .unwrap_or(true)
+            });
+            !by_topic.filter_data_map.is_empty()
+        });
+    }
+}
+
+impl ConfigManager for ConsumerFilterManager {
+    fn decode0(&mut self, _key: &[u8], body: &[u8]) {
+        if let Ok(json_string) = str::from_utf8(body) {
+            self.decode(json_string);
+        }
+    }
+
+    fn stop(&mut self) -> bool {
+        true
+    }
+
+    fn config_file_path(&self) -> String {
+        get_consumer_filter_path(self.message_store_config.store_path_root_dir.as_str())
+    }
+
+    fn encode_pretty(&self, pretty_format: bool) -> String {
+        self.clean();
+        let wrapper = self.consumer_filter_wrapper.read().clone();
+        if pretty_format {
+            wrapper.serialize_json_pretty().unwrap_or_default()
+        } else {
+            wrapper.serialize_json().unwrap_or_default()
+        }
+    }
+
+    fn decode(&self, json_string: &str) {
+        if json_string.is_empty() {
+            return;
+        }
+
+        let Ok(mut wrapper) = serde_json::from_str::<ConsumerFilterWrapper>(json_string) else {
+            return;
+        };
+
+        let mut bloom_changed = false;
+        let now = current_millis();
+        wrapper.filter_data_by_topic.retain(|_, by_topic| {
+            by_topic.filter_data_map.retain(|_, filter_data| {
+                if !self.compile_filter_data(filter_data) {
+                    return false;
+                }
+
+                if !self
+                    .bloom_filter
+                    .as_ref()
+                    .is_some_and(|bloom_filter| bloom_filter.is_valid(filter_data.bloom_filter_data()))
+                {
+                    bloom_changed = true;
+                    return false;
+                }
+
+                if filter_data.dead_time() == 0 {
+                    let dead_time = now.saturating_sub(LOAD_DEAD_MARKER_MS).max(filter_data.born_time());
+                    filter_data.set_dead_time(dead_time);
+                }
+
+                true
+            });
+
+            !by_topic.filter_data_map.is_empty()
+        });
+
+        if !bloom_changed {
+            *self.consumer_filter_wrapper.write() = wrapper;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocketmq_filter::expression::MessageEvaluationContext;
+    use rocketmq_filter::expression::Value;
+
+    fn new_manager() -> ConsumerFilterManager {
+        ConsumerFilterManager::new(
+            Arc::new(BrokerConfig::default()),
+            Arc::new(MessageStoreConfig::default()),
+        )
+    }
+
+    fn sql_subscription(topic: &str, expression: &str, version: i64) -> SubscriptionData {
+        SubscriptionData {
+            topic: CheetahString::from_slice(topic),
+            sub_string: CheetahString::from_slice(expression),
+            expression_type: CheetahString::from_static_str(ExpressionType::SQL92),
+            sub_version: version,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn build_compiles_sql_expression() {
+        let filter_data = ConsumerFilterManager::build(
+            CheetahString::from_slice("TopicTest"),
+            CheetahString::from_slice("GroupTest"),
+            Some(CheetahString::from_slice("color = 'blue'")),
+            Some(CheetahString::from_static_str(ExpressionType::SQL92)),
+            7,
+        )
+        .expect("SQL filter should be built");
+
+        let mut context = MessageEvaluationContext::default();
+        context.put("color", "blue");
+
+        assert_eq!(
+            filter_data
+                .compiled_expression()
+                .as_ref()
+                .unwrap()
+                .evaluate(&context)
+                .unwrap(),
+            Value::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn register_and_get_consumer_filter_data() {
+        let manager = new_manager();
+        let subscriptions = HashSet::from([sql_subscription("TopicTest", "color = 'blue'", 9)]);
+
+        manager.register("GroupTest", &subscriptions);
+
+        let filter_data = manager
+            .get_consumer_filter_data(
+                &CheetahString::from_slice("TopicTest"),
+                &CheetahString::from_slice("GroupTest"),
+            )
+            .expect("registered filter data should be stored");
+
+        assert!(filter_data.compiled_expression().is_some());
+        assert!(filter_data.bloom_filter_data().is_some());
+    }
+
+    #[test]
+    fn decode_restores_compiled_expression() {
+        let manager = new_manager();
+        let subscriptions = HashSet::from([sql_subscription("TopicTest", "color = 'blue'", 9)]);
+        manager.register("GroupTest", &subscriptions);
+
+        let encoded = manager.encode_pretty(false);
+
+        let restored = new_manager();
+        restored.decode(&encoded);
+        let filter_data = restored
+            .get_consumer_filter_data(
+                &CheetahString::from_slice("TopicTest"),
+                &CheetahString::from_slice("GroupTest"),
+            )
+            .expect("decoded filter data should exist");
+
+        let mut context = MessageEvaluationContext::default();
+        context.put("color", "blue");
+
+        assert!(filter_data.dead_time() >= filter_data.born_time());
+        assert_eq!(
+            filter_data
+                .compiled_expression()
+                .as_ref()
+                .unwrap()
+                .evaluate(&context)
+                .unwrap(),
+            Value::Boolean(true)
+        );
     }
 }

--- a/rocketmq-broker/src/filter/manager/consumer_filter_wrapper.rs
+++ b/rocketmq-broker/src/filter/manager/consumer_filter_wrapper.rs
@@ -22,12 +22,12 @@ use crate::filter::consumer_filter_data::ConsumerFilterData;
 #[derive(Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsumerFilterWrapper {
-    filter_data_by_topic: HashMap<String /* Topic */, FilterDataMapByTopic>,
+    pub(crate) filter_data_by_topic: HashMap<String /* Topic */, FilterDataMapByTopic>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct FilterDataMapByTopic {
-    filter_data_map: HashMap<String /* consumer group */, ConsumerFilterData>,
-    topic: String,
+    pub(crate) filter_data_map: HashMap<String /* consumer group */, ConsumerFilterData>,
+    pub(crate) topic: String,
 }

--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -504,6 +504,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn check_client_config_accepts_valid_property_filter_when_enabled() {
+        let mut runtime = new_test_runtime("check-client-filter-enabled-valid", true).await;
+        let inner = runtime.inner_for_test().clone();
+        let processor = ClientManageProcessor::new(inner);
+        let mut request = check_request(SubscriptionData {
+            topic: "topic-a".into(),
+            sub_string: "a > 1 AND color = 'blue'".into(),
+            expression_type: ExpressionType::SQL92.into(),
+            ..Default::default()
+        });
+
+        let response = processor
+            .check_client_config(&mut request)
+            .expect("check client config should succeed")
+            .expect("processor should return response");
+
+        assert_eq!(
+            RemotingResponseCode::from(response.code()),
+            RemotingResponseCode::Success
+        );
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn check_client_config_rejects_invalid_property_filter_when_enabled() {
+        let mut runtime = new_test_runtime("check-client-filter-enabled-invalid", true).await;
+        let inner = runtime.inner_for_test().clone();
+        let processor = ClientManageProcessor::new(inner);
+        let mut request = check_request(SubscriptionData {
+            topic: "topic-a".into(),
+            sub_string: "a >".into(),
+            expression_type: ExpressionType::SQL92.into(),
+            ..Default::default()
+        });
+
+        let response = processor
+            .check_client_config(&mut request)
+            .expect("check client config should succeed")
+            .expect("processor should return response");
+
+        assert_eq!(
+            RemotingResponseCode::from(response.code()),
+            RemotingResponseCode::SubscriptionParseFailed
+        );
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
     async fn heart_beat_v2_without_sub_registers_consumer_and_marks_sub_change() {
         let mut runtime = new_test_runtime("heartbeat-v2-without-sub", false).await;
         let inner = runtime.inner_for_test().clone();

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -348,8 +348,8 @@ where
             );
             let message_filter = if !ExpressionType::is_tag_type(Some(subscription_data.expression_type.as_str())) {
                 let consumer_filter_data = ConsumerFilterManager::build(
-                    request_header.consumer_group.clone(),
                     request_header.topic.clone(),
+                    request_header.consumer_group.clone(),
                     request_header.exp.clone(),
                     request_header.exp_type.clone(),
                     current_millis(),

--- a/rocketmq-filter/src/filter.rs
+++ b/rocketmq-filter/src/filter.rs
@@ -82,6 +82,7 @@
 mod filter_factory;
 mod filter_spi;
 mod filter_sql_filter;
+mod sql_runtime;
 
 pub use filter_factory::FilterFactory;
 pub use filter_spi::Filter;

--- a/rocketmq-filter/src/filter/filter_sql_filter.rs
+++ b/rocketmq-filter/src/filter/filter_sql_filter.rs
@@ -41,6 +41,7 @@ use rocketmq_common::common::filter::expression_type::ExpressionType;
 use crate::expression::Expression;
 use crate::filter::filter_spi::Filter;
 use crate::filter::filter_spi::FilterError;
+use crate::filter::sql_runtime;
 
 /// SQL-92 expression filter implementation.
 ///
@@ -90,8 +91,8 @@ impl SqlFilter {
 }
 
 impl Filter for SqlFilter {
-    fn compile(&self, _expr: &str) -> Result<Box<dyn Expression>, FilterError> {
-        unimplemented!("SQL-92 expression compilation is not yet implemented");
+    fn compile(&self, expr: &str) -> Result<Box<dyn Expression>, FilterError> {
+        sql_runtime::compile_expression(expr)
     }
 
     fn of_type(&self) -> &str {
@@ -101,7 +102,14 @@ impl Filter for SqlFilter {
 
 #[cfg(test)]
 mod tests {
+    use ahash::RandomState;
+    use std::collections::HashMap;
+
+    use cheetah_string::CheetahString;
+
     use super::*;
+    use crate::expression::MessageEvaluationContext;
+    use crate::expression::Value;
 
     #[test]
     fn test_sql_filter_of_type() {
@@ -120,5 +128,27 @@ mod tests {
         let filter = SqlFilter::new();
         let cloned = filter.clone();
         assert_eq!(filter.of_type(), cloned.of_type());
+    }
+
+    #[test]
+    fn test_sql_filter_compile_and_evaluate() {
+        let filter = SqlFilter::new();
+        let expression = filter
+            .compile("color = 'blue' AND retries >= 3")
+            .expect("SQL92 expression should compile");
+
+        let mut properties = HashMap::with_hasher(RandomState::default());
+        properties.insert(CheetahString::from_slice("color"), CheetahString::from_slice("blue"));
+        properties.insert(CheetahString::from_slice("retries"), CheetahString::from_slice("3"));
+        let context = MessageEvaluationContext::from_properties(properties);
+
+        assert_eq!(expression.evaluate(&context).unwrap(), Value::Boolean(true));
+    }
+
+    #[test]
+    fn test_sql_filter_rejects_invalid_expression() {
+        let filter = SqlFilter::new();
+
+        assert!(filter.compile("color = ").is_err());
     }
 }

--- a/rocketmq-filter/src/filter/sql_runtime.rs
+++ b/rocketmq-filter/src/filter/sql_runtime.rs
@@ -1,0 +1,744 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::fmt;
+
+use cheetah_string::CheetahString;
+
+use crate::expression::EvaluationContext;
+use crate::expression::EvaluationError;
+use crate::expression::Expression;
+use crate::expression::Value;
+use crate::filter::filter_spi::FilterError;
+
+pub(crate) fn compile_expression(expr: &str) -> Result<Box<dyn Expression>, FilterError> {
+    let trimmed = expr.trim();
+    if trimmed.is_empty() {
+        return Err(FilterError::new("empty SQL92 expression"));
+    }
+
+    let mut parser = Parser::new(trimmed)?;
+    let root = parser.parse_expression()?;
+    parser.expect_end()?;
+
+    Ok(Box::new(SqlExpression {
+        source: trimmed.to_string(),
+        root,
+    }))
+}
+
+struct SqlExpression {
+    source: String,
+    root: ExprNode,
+}
+
+impl Expression for SqlExpression {
+    fn evaluate(&self, context: &dyn EvaluationContext) -> Result<Value, EvaluationError> {
+        self.root.evaluate(context)
+    }
+}
+
+impl fmt::Display for SqlExpression {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.source)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum ExprNode {
+    Literal(Value),
+    Property(CheetahString),
+    BooleanCast(Box<ExprNode>),
+    Not(Box<ExprNode>),
+    Logical {
+        op: LogicalOp,
+        left: Box<ExprNode>,
+        right: Box<ExprNode>,
+    },
+    Compare {
+        op: CompareOp,
+        left: Box<ExprNode>,
+        right: Box<ExprNode>,
+    },
+    IsNull {
+        expr: Box<ExprNode>,
+        negated: bool,
+    },
+}
+
+impl ExprNode {
+    fn evaluate(&self, context: &dyn EvaluationContext) -> Result<Value, EvaluationError> {
+        match self {
+            ExprNode::Literal(value) => Ok(value.clone()),
+            ExprNode::Property(name) => Ok(context
+                .get(name.as_str())
+                .cloned()
+                .map(Value::String)
+                .unwrap_or(Value::Null)),
+            ExprNode::BooleanCast(expr) => Ok(match expr.evaluate(context)? {
+                Value::Null => Value::Null,
+                value => match coerce_bool(&value) {
+                    Some(boolean) => Value::Boolean(boolean),
+                    None => Value::Boolean(false),
+                },
+            }),
+            ExprNode::Not(expr) => Ok(match expr.evaluate_bool(context)? {
+                Some(value) => Value::Boolean(!value),
+                None => Value::Null,
+            }),
+            ExprNode::Logical { op, left, right } => Ok(match op.eval(left, right, context)? {
+                Some(value) => Value::Boolean(value),
+                None => Value::Null,
+            }),
+            ExprNode::Compare { op, left, right } => Ok(match op.eval(left, right, context)? {
+                Some(value) => Value::Boolean(value),
+                None => Value::Null,
+            }),
+            ExprNode::IsNull { expr, negated } => {
+                let is_null = matches!(expr.evaluate(context)?, Value::Null);
+                Ok(Value::Boolean(if *negated { !is_null } else { is_null }))
+            }
+        }
+    }
+
+    fn evaluate_bool(&self, context: &dyn EvaluationContext) -> Result<Option<bool>, EvaluationError> {
+        match self.evaluate(context)? {
+            Value::Null => Ok(None),
+            value => Ok(coerce_bool(&value)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogicalOp {
+    And,
+    Or,
+}
+
+impl LogicalOp {
+    fn eval(
+        self,
+        left: &ExprNode,
+        right: &ExprNode,
+        context: &dyn EvaluationContext,
+    ) -> Result<Option<bool>, EvaluationError> {
+        let left = left.evaluate_bool(context)?;
+        match self {
+            LogicalOp::And => {
+                if left == Some(false) {
+                    return Ok(Some(false));
+                }
+                let right = right.evaluate_bool(context)?;
+                Ok(match (left, right) {
+                    (Some(true), Some(false)) | (None, Some(false)) => Some(false),
+                    (Some(true), Some(true)) => Some(true),
+                    (Some(true), None) | (None, Some(true)) | (None, None) => None,
+                    _ => unreachable!("left was already checked for false"),
+                })
+            }
+            LogicalOp::Or => {
+                if left == Some(true) {
+                    return Ok(Some(true));
+                }
+                let right = right.evaluate_bool(context)?;
+                Ok(match (left, right) {
+                    (Some(false), Some(true)) | (None, Some(true)) => Some(true),
+                    (Some(false), Some(false)) => Some(false),
+                    (Some(false), None) | (None, Some(false)) | (None, None) => None,
+                    _ => unreachable!("left was already checked for true"),
+                })
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompareOp {
+    Eq,
+    Ne,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+}
+
+impl CompareOp {
+    fn eval(
+        self,
+        left: &ExprNode,
+        right: &ExprNode,
+        context: &dyn EvaluationContext,
+    ) -> Result<Option<bool>, EvaluationError> {
+        let left = left.evaluate(context)?;
+        let right = right.evaluate(context)?;
+
+        if matches!(left, Value::Null) || matches!(right, Value::Null) {
+            return Ok(None);
+        }
+
+        if let (Some(left), Some(right)) = (coerce_numeric(&left), coerce_numeric(&right)) {
+            return Ok(Some(match self {
+                CompareOp::Eq => numeric_eq(left, right),
+                CompareOp::Ne => !numeric_eq(left, right),
+                CompareOp::Gt => left.partial_cmp(&right) == Some(Ordering::Greater),
+                CompareOp::Gte => {
+                    matches!(
+                        left.partial_cmp(&right),
+                        Some(Ordering::Greater) | Some(Ordering::Equal)
+                    )
+                }
+                CompareOp::Lt => left.partial_cmp(&right) == Some(Ordering::Less),
+                CompareOp::Lte => {
+                    matches!(left.partial_cmp(&right), Some(Ordering::Less) | Some(Ordering::Equal))
+                }
+            }));
+        }
+
+        if let (Some(left), Some(right)) = (coerce_boolean_literal(&left), coerce_boolean_literal(&right)) {
+            return Ok(match self {
+                CompareOp::Eq => Some(left == right),
+                CompareOp::Ne => Some(left != right),
+                CompareOp::Gt | CompareOp::Gte | CompareOp::Lt | CompareOp::Lte => None,
+            });
+        }
+
+        let left = stringify_value(&left);
+        let right = stringify_value(&right);
+        let order = left.cmp(&right);
+
+        Ok(Some(match self {
+            CompareOp::Eq => order == Ordering::Equal,
+            CompareOp::Ne => order != Ordering::Equal,
+            CompareOp::Gt => order == Ordering::Greater,
+            CompareOp::Gte => matches!(order, Ordering::Greater | Ordering::Equal),
+            CompareOp::Lt => order == Ordering::Less,
+            CompareOp::Lte => matches!(order, Ordering::Less | Ordering::Equal),
+        }))
+    }
+}
+
+fn coerce_bool(value: &Value) -> Option<bool> {
+    match value {
+        Value::Boolean(boolean) => Some(*boolean),
+        Value::Long(number) => Some(*number != 0),
+        Value::Double(number) => Some(*number != 0.0),
+        Value::String(string) => {
+            if string.eq_ignore_ascii_case("true") {
+                Some(true)
+            } else if string.eq_ignore_ascii_case("false") {
+                Some(false)
+            } else {
+                None
+            }
+        }
+        Value::Null => None,
+    }
+}
+
+fn coerce_boolean_literal(value: &Value) -> Option<bool> {
+    match value {
+        Value::Boolean(boolean) => Some(*boolean),
+        Value::String(string) if string.eq_ignore_ascii_case("true") => Some(true),
+        Value::String(string) if string.eq_ignore_ascii_case("false") => Some(false),
+        _ => None,
+    }
+}
+
+fn coerce_numeric(value: &Value) -> Option<f64> {
+    match value {
+        Value::Long(number) => Some(*number as f64),
+        Value::Double(number) => Some(*number),
+        Value::String(string) => {
+            if let Ok(number) = string.parse::<i64>() {
+                Some(number as f64)
+            } else {
+                string.parse::<f64>().ok()
+            }
+        }
+        _ => None,
+    }
+}
+
+fn numeric_eq(left: f64, right: f64) -> bool {
+    (left - right).abs() <= f64::EPSILON
+}
+
+fn stringify_value(value: &Value) -> String {
+    match value {
+        Value::Boolean(boolean) => boolean.to_string(),
+        Value::String(string) => string.to_string(),
+        Value::Long(number) => number.to_string(),
+        Value::Double(number) => number.to_string(),
+        Value::Null => "null".to_string(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Ident(CheetahString),
+    String(CheetahString),
+    Long(i64),
+    Double(f64),
+    Boolean(bool),
+    Null,
+    LParen,
+    RParen,
+    Eq,
+    Ne,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+    And,
+    Or,
+    Not,
+    Is,
+    End,
+}
+
+struct Lexer<'a> {
+    input: &'a str,
+    bytes: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> Lexer<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            input,
+            bytes: input.as_bytes(),
+            cursor: 0,
+        }
+    }
+
+    fn next_token(&mut self) -> Result<Token, FilterError> {
+        self.skip_whitespace();
+        if self.cursor >= self.bytes.len() {
+            return Ok(Token::End);
+        }
+
+        let byte = self.bytes[self.cursor];
+        match byte {
+            b'(' => {
+                self.cursor += 1;
+                Ok(Token::LParen)
+            }
+            b')' => {
+                self.cursor += 1;
+                Ok(Token::RParen)
+            }
+            b'=' => {
+                self.cursor += 1;
+                Ok(Token::Eq)
+            }
+            b'!' => {
+                if self.peek_byte(1) == Some(b'=') {
+                    self.cursor += 2;
+                    Ok(Token::Ne)
+                } else {
+                    Err(FilterError::new(format!(
+                        "unexpected token '!' at position {}",
+                        self.cursor
+                    )))
+                }
+            }
+            b'<' => {
+                if self.peek_byte(1) == Some(b'=') {
+                    self.cursor += 2;
+                    Ok(Token::Lte)
+                } else if self.peek_byte(1) == Some(b'>') {
+                    self.cursor += 2;
+                    Ok(Token::Ne)
+                } else {
+                    self.cursor += 1;
+                    Ok(Token::Lt)
+                }
+            }
+            b'>' => {
+                if self.peek_byte(1) == Some(b'=') {
+                    self.cursor += 2;
+                    Ok(Token::Gte)
+                } else {
+                    self.cursor += 1;
+                    Ok(Token::Gt)
+                }
+            }
+            b'\'' => self.read_string(),
+            b'-' if self.peek_byte(1).is_some_and(|next| next.is_ascii_digit()) => self.read_number(),
+            b'0'..=b'9' => self.read_number(),
+            _ if is_ident_start(byte) => self.read_identifier(),
+            _ => Err(FilterError::new(format!(
+                "unexpected token '{}' at position {}",
+                self.bytes[self.cursor] as char, self.cursor
+            ))),
+        }
+    }
+
+    fn read_string(&mut self) -> Result<Token, FilterError> {
+        self.cursor += 1;
+        let mut string = String::new();
+        while self.cursor < self.bytes.len() {
+            let byte = self.bytes[self.cursor];
+            if byte == b'\'' {
+                if self.peek_byte(1) == Some(b'\'') {
+                    string.push('\'');
+                    self.cursor += 2;
+                    continue;
+                }
+                self.cursor += 1;
+                return Ok(Token::String(CheetahString::from_string(string)));
+            }
+
+            string.push(byte as char);
+            self.cursor += 1;
+        }
+
+        Err(FilterError::new("unterminated string literal"))
+    }
+
+    fn read_number(&mut self) -> Result<Token, FilterError> {
+        let start = self.cursor;
+        self.cursor += 1;
+        while self.cursor < self.bytes.len() && self.bytes[self.cursor].is_ascii_digit() {
+            self.cursor += 1;
+        }
+
+        let mut is_double = false;
+        if self.cursor < self.bytes.len() && self.bytes[self.cursor] == b'.' {
+            is_double = true;
+            self.cursor += 1;
+            while self.cursor < self.bytes.len() && self.bytes[self.cursor].is_ascii_digit() {
+                self.cursor += 1;
+            }
+        }
+
+        let token = &self.input[start..self.cursor];
+        if is_double {
+            token
+                .parse::<f64>()
+                .map(Token::Double)
+                .map_err(|error| FilterError::new(format!("invalid number '{token}': {error}")))
+        } else {
+            token
+                .parse::<i64>()
+                .map(Token::Long)
+                .map_err(|error| FilterError::new(format!("invalid number '{token}': {error}")))
+        }
+    }
+
+    fn read_identifier(&mut self) -> Result<Token, FilterError> {
+        let start = self.cursor;
+        self.cursor += 1;
+        while self.cursor < self.bytes.len() && is_ident_part(self.bytes[self.cursor]) {
+            self.cursor += 1;
+        }
+
+        let ident = &self.input[start..self.cursor];
+        let upper = ident.to_ascii_uppercase();
+        match upper.as_str() {
+            "AND" => Ok(Token::And),
+            "OR" => Ok(Token::Or),
+            "NOT" => Ok(Token::Not),
+            "IS" => Ok(Token::Is),
+            "TRUE" => Ok(Token::Boolean(true)),
+            "FALSE" => Ok(Token::Boolean(false)),
+            "NULL" => Ok(Token::Null),
+            _ => Ok(Token::Ident(CheetahString::from_slice(ident))),
+        }
+    }
+
+    fn peek_byte(&self, offset: usize) -> Option<u8> {
+        self.bytes.get(self.cursor + offset).copied()
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.cursor < self.bytes.len() && self.bytes[self.cursor].is_ascii_whitespace() {
+            self.cursor += 1;
+        }
+    }
+}
+
+fn is_ident_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$')
+}
+
+fn is_ident_part(byte: u8) -> bool {
+    is_ident_start(byte) || byte.is_ascii_digit() || matches!(byte, b'.')
+}
+
+struct Parser {
+    tokens: Vec<Token>,
+    cursor: usize,
+}
+
+impl Parser {
+    fn new(expr: &str) -> Result<Self, FilterError> {
+        let mut lexer = Lexer::new(expr);
+        let mut tokens = Vec::new();
+        loop {
+            let token = lexer.next_token()?;
+            let is_end = token == Token::End;
+            tokens.push(token);
+            if is_end {
+                break;
+            }
+        }
+
+        Ok(Self { tokens, cursor: 0 })
+    }
+
+    fn parse_expression(&mut self) -> Result<ExprNode, FilterError> {
+        self.parse_or()
+    }
+
+    fn parse_or(&mut self) -> Result<ExprNode, FilterError> {
+        let mut expr = self.parse_and()?;
+        while self.consume(TokenKind::Or) {
+            let right = self.parse_and()?;
+            expr = ExprNode::Logical {
+                op: LogicalOp::Or,
+                left: Box::new(expr),
+                right: Box::new(right),
+            };
+        }
+        Ok(expr)
+    }
+
+    fn parse_and(&mut self) -> Result<ExprNode, FilterError> {
+        let mut expr = self.parse_not()?;
+        while self.consume(TokenKind::And) {
+            let right = self.parse_not()?;
+            expr = ExprNode::Logical {
+                op: LogicalOp::And,
+                left: Box::new(expr),
+                right: Box::new(right),
+            };
+        }
+        Ok(expr)
+    }
+
+    fn parse_not(&mut self) -> Result<ExprNode, FilterError> {
+        if self.consume(TokenKind::Not) {
+            return Ok(ExprNode::Not(Box::new(self.parse_not()?)));
+        }
+
+        self.parse_primary()
+    }
+
+    fn parse_primary(&mut self) -> Result<ExprNode, FilterError> {
+        if self.consume(TokenKind::LParen) {
+            let expr = self.parse_expression()?;
+            self.expect(TokenKind::RParen)?;
+            return Ok(expr);
+        }
+
+        let left = self.parse_value()?;
+        if self.consume(TokenKind::Is) {
+            let negated = self.consume(TokenKind::Not);
+            self.expect(TokenKind::Null)?;
+            return Ok(ExprNode::IsNull {
+                expr: Box::new(left),
+                negated,
+            });
+        }
+
+        if let Some(op) = self.parse_compare_op() {
+            let right = self.parse_value()?;
+            return Ok(ExprNode::Compare {
+                op,
+                left: Box::new(left),
+                right: Box::new(right),
+            });
+        }
+
+        Ok(ExprNode::BooleanCast(Box::new(left)))
+    }
+
+    fn parse_value(&mut self) -> Result<ExprNode, FilterError> {
+        match self.next() {
+            Token::Ident(name) => Ok(ExprNode::Property(name)),
+            Token::String(value) => Ok(ExprNode::Literal(Value::String(value))),
+            Token::Long(value) => Ok(ExprNode::Literal(Value::Long(value))),
+            Token::Double(value) => Ok(ExprNode::Literal(Value::Double(value))),
+            Token::Boolean(value) => Ok(ExprNode::Literal(Value::Boolean(value))),
+            Token::Null => Ok(ExprNode::Literal(Value::Null)),
+            token => Err(FilterError::new(format!("unexpected token {token:?}"))),
+        }
+    }
+
+    fn parse_compare_op(&mut self) -> Option<CompareOp> {
+        if self.consume(TokenKind::Eq) {
+            Some(CompareOp::Eq)
+        } else if self.consume(TokenKind::Ne) {
+            Some(CompareOp::Ne)
+        } else if self.consume(TokenKind::Gte) {
+            Some(CompareOp::Gte)
+        } else if self.consume(TokenKind::Gt) {
+            Some(CompareOp::Gt)
+        } else if self.consume(TokenKind::Lte) {
+            Some(CompareOp::Lte)
+        } else if self.consume(TokenKind::Lt) {
+            Some(CompareOp::Lt)
+        } else {
+            None
+        }
+    }
+
+    fn expect_end(&self) -> Result<(), FilterError> {
+        match self.peek() {
+            Token::End => Ok(()),
+            token => Err(FilterError::new(format!("unexpected trailing token {token:?}"))),
+        }
+    }
+
+    fn expect(&mut self, kind: TokenKind) -> Result<(), FilterError> {
+        if self.consume(kind) {
+            Ok(())
+        } else {
+            Err(FilterError::new(format!("expected {}", kind.as_str())))
+        }
+    }
+
+    fn consume(&mut self, kind: TokenKind) -> bool {
+        if kind.matches(self.peek()) {
+            self.cursor += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn next(&mut self) -> Token {
+        let token = self.peek().clone();
+        self.cursor += 1;
+        token
+    }
+
+    fn peek(&self) -> &Token {
+        self.tokens
+            .get(self.cursor)
+            .unwrap_or_else(|| self.tokens.last().expect("parser always has EOF"))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TokenKind {
+    LParen,
+    RParen,
+    Eq,
+    Ne,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+    And,
+    Or,
+    Not,
+    Is,
+    Null,
+}
+
+impl TokenKind {
+    fn matches(self, token: &Token) -> bool {
+        matches!(
+            (self, token),
+            (TokenKind::LParen, Token::LParen)
+                | (TokenKind::RParen, Token::RParen)
+                | (TokenKind::Eq, Token::Eq)
+                | (TokenKind::Ne, Token::Ne)
+                | (TokenKind::Gt, Token::Gt)
+                | (TokenKind::Gte, Token::Gte)
+                | (TokenKind::Lt, Token::Lt)
+                | (TokenKind::Lte, Token::Lte)
+                | (TokenKind::And, Token::And)
+                | (TokenKind::Or, Token::Or)
+                | (TokenKind::Not, Token::Not)
+                | (TokenKind::Is, Token::Is)
+                | (TokenKind::Null, Token::Null)
+        )
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            TokenKind::LParen => "(",
+            TokenKind::RParen => ")",
+            TokenKind::Eq => "=",
+            TokenKind::Ne => "<>",
+            TokenKind::Gt => ">",
+            TokenKind::Gte => ">=",
+            TokenKind::Lt => "<",
+            TokenKind::Lte => "<=",
+            TokenKind::And => "AND",
+            TokenKind::Or => "OR",
+            TokenKind::Not => "NOT",
+            TokenKind::Is => "IS",
+            TokenKind::Null => "NULL",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ahash::RandomState;
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::expression::MessageEvaluationContext;
+
+    fn evaluate(expr: &str, properties: &[(&str, &str)]) -> Value {
+        let compiled = compile_expression(expr).expect("expression should compile");
+        let mut map = HashMap::with_hasher(RandomState::default());
+        for (key, value) in properties {
+            map.insert(CheetahString::from_slice(key), CheetahString::from_slice(value));
+        }
+        let context = MessageEvaluationContext::from_properties(map);
+        compiled.evaluate(&context).expect("evaluation should succeed")
+    }
+
+    #[test]
+    fn compile_rejects_invalid_sql() {
+        assert!(compile_expression("a =").is_err());
+    }
+
+    #[test]
+    fn evaluate_string_and_numeric_comparisons() {
+        let value = evaluate(
+            "color = 'blue' AND retries >= 3",
+            &[("color", "blue"), ("retries", "3")],
+        );
+        assert_eq!(value, Value::Boolean(true));
+    }
+
+    #[test]
+    fn evaluate_not_and_parentheses() {
+        let value = evaluate(
+            "NOT (color = 'red' OR retries < 2)",
+            &[("color", "blue"), ("retries", "3")],
+        );
+        assert_eq!(value, Value::Boolean(true));
+    }
+
+    #[test]
+    fn evaluate_is_null() {
+        let value = evaluate("missing IS NULL", &[("color", "blue")]);
+        assert_eq!(value, Value::Boolean(true));
+    }
+
+    #[test]
+    fn evaluate_boolean_literals() {
+        let value = evaluate("TRUE AND NOT FALSE", &[]);
+        assert_eq!(value, Value::Boolean(true));
+    }
+}

--- a/rocketmq-filter/src/utils/bloom_filter.rs
+++ b/rocketmq-filter/src/utils/bloom_filter.rs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::hash::Hasher;
-
-use ahash::AHasher;
 use rocketmq_error::FilterError;
 use rocketmq_error::RocketMQResult;
+use std::convert::TryInto;
 
 use crate::utils::bits_array::BitsArray;
 use crate::utils::bloom_filter_data::BloomFilterData;
@@ -102,7 +100,7 @@ impl BloomFilter {
     pub fn calc_bit_positions(&self, s: &str) -> Vec<i32> {
         let mut bit_positions = vec![0i32; self.k as usize];
 
-        // Use AHash for best performance and security
+        // Match Java RocketMQ exactly: Hashing.murmur3_128().hashString(str, UTF_8).asLong()
         let hash64 = Self::hash_string(s);
 
         let hash1 = hash64 as i32;
@@ -215,12 +213,98 @@ impl BloomFilter {
         }
     }
 
-    /// Hash string using AHash (fastest Rust hash, DoS resistant).
+    /// Hash string using MurmurHash3 x64 128, matching the Java implementation.
     #[inline]
     fn hash_string(s: &str) -> u64 {
-        let mut hasher = AHasher::default();
-        hasher.write(s.as_bytes());
-        hasher.finish()
+        let (h1, _) = Self::murmur3_x64_128(s.as_bytes(), 0);
+        h1
+    }
+
+    fn murmur3_x64_128(bytes: &[u8], seed: u32) -> (u64, u64) {
+        const C1: u64 = 0x87c3_7b91_1142_53d5;
+        const C2: u64 = 0x4cf5_ad43_2745_937f;
+
+        let mut h1 = seed as u64;
+        let mut h2 = seed as u64;
+
+        let block_count = bytes.len() / 16;
+        for index in 0..block_count {
+            let offset = index * 16;
+            let mut k1 = u64::from_le_bytes(bytes[offset..offset + 8].try_into().expect("slice is exactly 8 bytes"));
+            let mut k2 = u64::from_le_bytes(
+                bytes[offset + 8..offset + 16]
+                    .try_into()
+                    .expect("slice is exactly 8 bytes"),
+            );
+
+            k1 = k1.wrapping_mul(C1);
+            k1 = k1.rotate_left(31);
+            k1 = k1.wrapping_mul(C2);
+            h1 ^= k1;
+
+            h1 = h1.rotate_left(27);
+            h1 = h1.wrapping_add(h2);
+            h1 = h1.wrapping_mul(5).wrapping_add(0x52dc_e729);
+
+            k2 = k2.wrapping_mul(C2);
+            k2 = k2.rotate_left(33);
+            k2 = k2.wrapping_mul(C1);
+            h2 ^= k2;
+
+            h2 = h2.rotate_left(31);
+            h2 = h2.wrapping_add(h1);
+            h2 = h2.wrapping_mul(5).wrapping_add(0x3849_5ab5);
+        }
+
+        let tail = &bytes[block_count * 16..];
+        let mut k1 = 0u64;
+        let mut k2 = 0u64;
+
+        for (index, byte) in tail.iter().enumerate() {
+            if index < 8 {
+                k1 |= (*byte as u64) << (index * 8);
+            } else {
+                k2 |= (*byte as u64) << ((index - 8) * 8);
+            }
+        }
+
+        if tail.len() > 8 {
+            k2 = k2.wrapping_mul(C2);
+            k2 = k2.rotate_left(33);
+            k2 = k2.wrapping_mul(C1);
+            h2 ^= k2;
+        }
+
+        if !tail.is_empty() {
+            k1 = k1.wrapping_mul(C1);
+            k1 = k1.rotate_left(31);
+            k1 = k1.wrapping_mul(C2);
+            h1 ^= k1;
+        }
+
+        h1 ^= bytes.len() as u64;
+        h2 ^= bytes.len() as u64;
+
+        h1 = h1.wrapping_add(h2);
+        h2 = h2.wrapping_add(h1);
+
+        h1 = Self::fmix64(h1);
+        h2 = Self::fmix64(h2);
+
+        h1 = h1.wrapping_add(h2);
+        h2 = h2.wrapping_add(h1);
+
+        (h1, h2)
+    }
+
+    #[inline]
+    fn fmix64(mut value: u64) -> u64 {
+        value ^= value >> 33;
+        value = value.wrapping_mul(0xff51_afd7_ed55_8ccd);
+        value ^= value >> 33;
+        value = value.wrapping_mul(0xc4ce_b9fe_1a85_ec53);
+        value ^= value >> 33;
+        value
     }
 
     /// Calculate log base m of n: log_m(n)
@@ -302,6 +386,12 @@ mod tests {
         // Same input should produce same positions
         let positions2 = filter.calc_bit_positions("test_key");
         assert_eq!(positions, positions2);
+    }
+
+    #[test]
+    fn test_empty_string_matches_java_zero_hash() {
+        let filter = BloomFilter::create_by_fn(10, 100).unwrap();
+        assert_eq!(filter.calc_bit_positions(""), vec![0; filter.k() as usize]);
     }
 
     #[test]

--- a/rocketmq-filter/src/utils/bloom_filter_data.rs
+++ b/rocketmq-filter/src/utils/bloom_filter_data.rs
@@ -15,7 +15,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct BloomFilterData {
     bit_pos: Vec<i32>,


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7048

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SQL92 property filter expressions now compile and evaluate at runtime
  * Bloom filter-based message filtering for non-tag subscriptions fully implemented
  * Consumer group filter registration and lifecycle management now operational

* **Bug Fixes**
  * Resolved runtime panics for unimplemented SQL filter and bloom filter operations
  * Improved filter data lifecycle with born/dead time state tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->