### PR TITLE
[ISSUE #7050]🚀feat(filter): enhance SQL92 expression support with new operators and improve evaluation context

### DIFF
--- a/rocketmq-broker/src/filter/commit_log_dispatcher_calc_bit_map.rs
+++ b/rocketmq-broker/src/filter/commit_log_dispatcher_calc_bit_map.rs
@@ -68,7 +68,7 @@ impl CommitLogDispatcher for CommitLogDispatcherCalcBitMap {
                 continue;
             }
 
-            let context = MessageEvaluationContext::new(&request.properties_map);
+            let context = MessageEvaluationContext::new(request.properties_map.as_ref());
             let ret = filter_data.compiled_expression().as_ref().unwrap().evaluate(&context);
 
             debug!(

--- a/rocketmq-broker/src/filter/consumer_filter_data.rs
+++ b/rocketmq-broker/src/filter/consumer_filter_data.rs
@@ -31,7 +31,7 @@ pub struct ConsumerFilterData {
     expression: Option<CheetahString>,
     expression_type: Option<CheetahString>,
     #[serde(skip)]
-    compiled_expression: Option<Arc<dyn Expression + Send + Sync + 'static>>,
+    compiled_expression: Option<Arc<dyn Expression + 'static>>,
     born_time: u64,
     dead_time: u64,
     bloom_filter_data: Option<BloomFilterData>,
@@ -103,12 +103,16 @@ impl ConsumerFilterData {
         self.client_version = client_version;
     }
 
-    pub fn compiled_expression(&self) -> &Option<Arc<dyn Expression + Send + Sync + 'static>> {
+    pub fn compiled_expression(&self) -> &Option<Arc<dyn Expression + 'static>> {
         &self.compiled_expression
     }
 
-    pub fn set_compiled_expression(&mut self, compiled_expression: Box<dyn Expression + Send + Sync + 'static>) {
+    pub fn set_compiled_expression(&mut self, compiled_expression: Box<dyn Expression + 'static>) {
         self.compiled_expression = Some(Arc::from(compiled_expression));
+    }
+
+    pub fn set_compiled_expression_arc(&mut self, compiled_expression: Arc<dyn Expression + 'static>) {
+        self.compiled_expression = Some(compiled_expression);
     }
 
     pub fn is_dead(&self) -> bool {

--- a/rocketmq-broker/src/filter/expression_message_filter.rs
+++ b/rocketmq-broker/src/filter/expression_message_filter.rs
@@ -148,14 +148,14 @@ impl MessageFilter for ExpressionMessageFilter {
             return true;
         }
 
-        let temp_properties = match (properties, msg_buffer) {
+        let decoded_properties = match (properties, msg_buffer) {
             (None, Some(bytes)) => {
                 let mut bytes_ = Bytes::copy_from_slice(bytes);
                 message_decoder::decode_properties(&mut bytes_)
             }
             _ => None,
         };
-        let context = MessageEvaluationContext::new(&temp_properties);
+        let context = MessageEvaluationContext::new(properties.or(decoded_properties.as_ref()));
         if let Some(filter) = real_filter_data.compiled_expression() {
             match filter.evaluate(&context) {
                 Ok(rocketmq_filter::expression::Value::Boolean(b)) => b,
@@ -170,6 +170,7 @@ impl MessageFilter for ExpressionMessageFilter {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::collections::HashSet;
 
     use cheetah_string::CheetahString;
@@ -208,6 +209,62 @@ mod tests {
                 &CheetahString::from_slice("GroupTest"),
             )
             .unwrap();
+
+        let mut bits =
+            rocketmq_filter::utils::bits_array::BitsArray::create(manager.bloom_filter().unwrap().m() as usize);
+        manager
+            .bloom_filter()
+            .unwrap()
+            .hash_to(filter_data.bloom_filter_data().unwrap(), &mut bits)
+            .unwrap();
+
+        let cq_ext_unit = CqExtUnit::new(0, filter_data.born_time() as i64 + 1, Some(bits.bytes().to_vec()));
+        let filter = ExpressionMessageFilter::new(
+            Some(sql_subscription("TopicTest", "color = 'blue'")),
+            Some(filter_data.clone()),
+            Arc::new(manager.clone()),
+        );
+
+        assert!(filter.is_matched_by_consume_queue(None, Some(&cq_ext_unit)));
+
+        let miss = CqExtUnit::new(0, filter_data.born_time() as i64 + 1, Some(vec![0; bits.byte_length()]));
+        assert!(!filter.is_matched_by_consume_queue(None, Some(&miss)));
+    }
+
+    #[test]
+    fn commit_log_uses_provided_properties_without_decoding_buffer() {
+        let manager = new_manager();
+        let filter_data = manager
+            .resolve(
+                CheetahString::from_slice("TopicTest"),
+                CheetahString::from_slice("GroupTest"),
+                Some(CheetahString::from_slice("color = 'blue'")),
+                Some(CheetahString::from_static_str(ExpressionType::SQL92)),
+                11,
+            )
+            .expect("resolved request-scoped filter data should exist");
+        let filter = ExpressionMessageFilter::new(
+            Some(sql_subscription("TopicTest", "color = 'blue'")),
+            Some(filter_data),
+            Arc::new(manager),
+        );
+        let properties = HashMap::from([(CheetahString::from_slice("color"), CheetahString::from_slice("blue"))]);
+
+        assert!(filter.is_matched_by_commit_log(Some(&[]), Some(&properties)));
+    }
+
+    #[test]
+    fn request_scoped_sql_filter_data_still_uses_consume_queue_bloom_filtering() {
+        let manager = new_manager();
+        let filter_data = manager
+            .resolve(
+                CheetahString::from_slice("TopicTest"),
+                CheetahString::from_slice("GroupTest"),
+                Some(CheetahString::from_slice("color = 'blue'")),
+                Some(CheetahString::from_static_str(ExpressionType::SQL92)),
+                11,
+            )
+            .expect("resolved request-scoped filter data should exist");
 
         let mut bits =
             rocketmq_filter::utils::bits_array::BitsArray::create(manager.bloom_filter().unwrap().m() as usize);

--- a/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
+++ b/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
@@ -17,12 +17,16 @@ use std::str;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::common::filter::expression_type::ExpressionType;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_filter::expression::Expression;
 use rocketmq_filter::filter::FilterFactory;
 use rocketmq_filter::utils::bloom_filter::BloomFilter;
+use rocketmq_filter::utils::bloom_filter_data::BloomFilterData;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
@@ -41,6 +45,8 @@ pub(crate) struct ConsumerFilterManager {
     message_store_config: Arc<MessageStoreConfig>,
     consumer_filter_wrapper: Arc<parking_lot::RwLock<ConsumerFilterWrapper>>,
     bloom_filter: Option<BloomFilter>,
+    compiled_expression_cache: Arc<DashMap<String, Arc<dyn Expression + 'static>>>,
+    failed_expression_cache: Arc<DashMap<String, String>>,
 }
 
 impl ConsumerFilterManager {
@@ -58,6 +64,8 @@ impl ConsumerFilterManager {
             message_store_config,
             consumer_filter_wrapper,
             bloom_filter: Some(bloom_filter),
+            compiled_expression_cache: Arc::new(DashMap::new()),
+            failed_expression_cache: Arc::new(DashMap::new()),
         }
     }
 
@@ -88,6 +96,39 @@ impl ConsumerFilterManager {
         consumer_filter_data.set_compiled_expression(compiled);
 
         Some(consumer_filter_data)
+    }
+
+    pub fn resolve(
+        &self,
+        topic: CheetahString,
+        consumer_group: CheetahString,
+        expression: Option<CheetahString>,
+        type_: Option<CheetahString>,
+        client_version: u64,
+    ) -> Option<ConsumerFilterData> {
+        if ExpressionType::is_tag_type(type_.as_deref()) {
+            return None;
+        }
+
+        if let Some(existing) = self
+            .get_consumer_filter_data(&topic, &consumer_group)
+            .filter(|filter_data| !filter_data.is_dead())
+            .filter(|filter_data| filter_data.expression() == expression.as_ref())
+            .filter(|filter_data| filter_data.expression_type() == type_.as_ref())
+            .filter(|filter_data| filter_data.client_version() >= client_version)
+        {
+            return Some(existing);
+        }
+
+        let bloom_filter_data = self.generate_bloom_filter_data(consumer_group.as_str(), topic.as_str())?;
+        self.build_with_compiled_expression(
+            topic,
+            consumer_group,
+            expression,
+            type_,
+            client_version,
+            Some(bloom_filter_data),
+        )
     }
 
     pub fn register(&self, consumer_group: &str, subscriptions: &HashSet<SubscriptionData>) {
@@ -169,9 +210,8 @@ impl ConsumerFilterManager {
             return false;
         }
 
-        let bloom_filter_data = match self.bloom_filter.as_ref() {
-            Some(filter) => filter.generate(&format!("{consumer_group}#{topic}")),
-            None => return false,
+        let Some(bloom_filter_data) = self.generate_bloom_filter_data(consumer_group, topic) else {
+            return false;
         };
 
         let mut wrapper = self.consumer_filter_wrapper.write();
@@ -186,17 +226,17 @@ impl ConsumerFilterManager {
         let existing = by_topic.filter_data_map.get(consumer_group).cloned();
         match existing {
             None => {
-                let mut filter_data = match Self::build(
+                let filter_data = match self.build_with_compiled_expression(
                     CheetahString::from_slice(topic),
                     CheetahString::from_slice(consumer_group),
                     Some(CheetahString::from_slice(expression)),
                     Some(CheetahString::from_slice(type_)),
                     client_version,
+                    Some(bloom_filter_data.clone()),
                 ) {
                     Some(filter_data) => filter_data,
                     None => return false,
                 };
-                filter_data.set_bloom_filter_data(Some(bloom_filter_data));
                 by_topic.filter_data_map.insert(consumer_group.to_string(), filter_data);
                 true
             }
@@ -215,12 +255,13 @@ impl ConsumerFilterManager {
                     || old.bloom_filter_data() != Some(&bloom_filter_data);
 
                 if changed {
-                    let mut filter_data = match Self::build(
+                    let filter_data = match self.build_with_compiled_expression(
                         CheetahString::from_slice(topic),
                         CheetahString::from_slice(consumer_group),
                         Some(CheetahString::from_slice(expression)),
                         Some(CheetahString::from_slice(type_)),
                         client_version,
+                        Some(bloom_filter_data.clone()),
                     ) {
                         Some(filter_data) => filter_data,
                         None => {
@@ -228,7 +269,6 @@ impl ConsumerFilterManager {
                             return false;
                         }
                     };
-                    filter_data.set_bloom_filter_data(Some(bloom_filter_data));
                     by_topic.filter_data_map.insert(consumer_group.to_string(), filter_data);
                     true
                 } else {
@@ -244,6 +284,90 @@ impl ConsumerFilterManager {
         }
     }
 
+    fn generate_bloom_filter_data(&self, consumer_group: &str, topic: &str) -> Option<BloomFilterData> {
+        self.bloom_filter
+            .as_ref()
+            .map(|filter| filter.generate(&format!("{consumer_group}#{topic}")))
+    }
+
+    fn cache_key(expression_type: &str, expression: &str) -> String {
+        format!("{expression_type}\u{0}{expression}")
+    }
+
+    fn clear_compile_caches(&self) {
+        self.compiled_expression_cache.clear();
+        self.failed_expression_cache.clear();
+    }
+
+    #[cfg(test)]
+    fn cached_expression_count(&self) -> usize {
+        self.compiled_expression_cache.len()
+    }
+
+    #[cfg(test)]
+    fn cached_compile_failure_count(&self) -> usize {
+        self.failed_expression_cache.len()
+    }
+
+    fn compile_with_cache(&self, expression_type: &str, expression: &str) -> Option<Arc<dyn Expression + 'static>> {
+        let cache_key = Self::cache_key(expression_type, expression);
+        if self.failed_expression_cache.contains_key(&cache_key) {
+            return None;
+        }
+        match self.compiled_expression_cache.entry(cache_key) {
+            Entry::Occupied(entry) => Some(entry.get().clone()),
+            Entry::Vacant(entry) => {
+                let Some(filter) = FilterFactory::instance().get(expression_type) else {
+                    self.failed_expression_cache
+                        .insert(entry.key().clone(), format!("unknown filter type: {expression_type}"));
+                    return None;
+                };
+                let compiled = match filter.compile(expression) {
+                    Ok(compiled) => Arc::<dyn Expression + 'static>::from(compiled),
+                    Err(error) => {
+                        self.failed_expression_cache
+                            .insert(entry.key().clone(), error.to_string());
+                        return None;
+                    }
+                };
+                self.failed_expression_cache.remove(entry.key());
+                entry.insert(compiled.clone());
+                Some(compiled)
+            }
+        }
+    }
+
+    fn build_with_compiled_expression(
+        &self,
+        topic: CheetahString,
+        consumer_group: CheetahString,
+        expression: Option<CheetahString>,
+        type_: Option<CheetahString>,
+        client_version: u64,
+        bloom_filter_data: Option<BloomFilterData>,
+    ) -> Option<ConsumerFilterData> {
+        if ExpressionType::is_tag_type(type_.as_deref()) {
+            return None;
+        }
+
+        let expression_text = expression.as_ref().filter(|value| !value.is_empty())?;
+        let expression_type = type_.as_ref()?;
+        let compiled = self.compile_with_cache(expression_type.as_str(), expression_text.as_str())?;
+
+        let mut consumer_filter_data = ConsumerFilterData::default();
+        consumer_filter_data.set_topic(topic);
+        consumer_filter_data.set_consumer_group(consumer_group);
+        consumer_filter_data.set_born_time(current_millis());
+        consumer_filter_data.set_dead_time(0);
+        consumer_filter_data.set_expression(expression);
+        consumer_filter_data.set_expression_type(type_);
+        consumer_filter_data.set_client_version(client_version);
+        consumer_filter_data.set_bloom_filter_data(bloom_filter_data);
+        consumer_filter_data.set_compiled_expression_arc(compiled);
+
+        Some(consumer_filter_data)
+    }
+
     fn compile_filter_data(&self, filter_data: &mut ConsumerFilterData) -> bool {
         let Some(expression) = filter_data.expression() else {
             return false;
@@ -251,13 +375,10 @@ impl ConsumerFilterManager {
         let Some(expression_type) = filter_data.expression_type() else {
             return false;
         };
-        let Some(filter) = FilterFactory::instance().get(expression_type.as_str()) else {
+        let Some(compiled) = self.compile_with_cache(expression_type.as_str(), expression.as_str()) else {
             return false;
         };
-        let Ok(compiled) = filter.compile(expression.as_str()) else {
-            return false;
-        };
-        filter_data.set_compiled_expression(compiled);
+        filter_data.set_compiled_expression_arc(compiled);
         true
     }
 
@@ -283,6 +404,7 @@ impl ConfigManager for ConsumerFilterManager {
     }
 
     fn stop(&mut self) -> bool {
+        self.clear_compile_caches();
         true
     }
 
@@ -345,9 +467,19 @@ impl ConfigManager for ConsumerFilterManager {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
     use super::*;
+    use rocketmq_common::common::config_manager::ConfigManager;
+    use rocketmq_filter::expression::EvaluationContext;
+    use rocketmq_filter::expression::EvaluationError;
+    use rocketmq_filter::expression::Expression;
     use rocketmq_filter::expression::MessageEvaluationContext;
+    use rocketmq_filter::expression::Value as ExprValue;
     use rocketmq_filter::expression::Value;
+    use rocketmq_filter::filter::Filter;
+    use rocketmq_filter::filter::FilterError;
 
     fn new_manager() -> ConsumerFilterManager {
         ConsumerFilterManager::new(
@@ -371,14 +503,18 @@ mod tests {
         let filter_data = ConsumerFilterManager::build(
             CheetahString::from_slice("TopicTest"),
             CheetahString::from_slice("GroupTest"),
-            Some(CheetahString::from_slice("color = 'blue'")),
+            Some(CheetahString::from_slice(
+                "region IN ('hz', 'sh') AND name CONTAINS 'rocket' AND score BETWEEN 0 AND 100",
+            )),
             Some(CheetahString::from_static_str(ExpressionType::SQL92)),
             7,
         )
         .expect("SQL filter should be built");
 
         let mut context = MessageEvaluationContext::default();
-        context.put("color", "blue");
+        context.put("region", "sh");
+        context.put("name", "rocketmq-rust");
+        context.put("score", "99");
 
         assert_eq!(
             filter_data
@@ -407,6 +543,186 @@ mod tests {
 
         assert!(filter_data.compiled_expression().is_some());
         assert!(filter_data.bloom_filter_data().is_some());
+    }
+
+    #[test]
+    fn resolve_reuses_registered_filter_data_for_matching_subscription() {
+        let manager = new_manager();
+        let subscriptions = HashSet::from([sql_subscription("TopicTest", "color = 'blue'", 9)]);
+        manager.register("GroupTest", &subscriptions);
+
+        let registered = manager
+            .get_consumer_filter_data(
+                &CheetahString::from_slice("TopicTest"),
+                &CheetahString::from_slice("GroupTest"),
+            )
+            .expect("registered filter data should exist");
+
+        let resolved = manager
+            .resolve(
+                CheetahString::from_slice("TopicTest"),
+                CheetahString::from_slice("GroupTest"),
+                Some(CheetahString::from_slice("color = 'blue'")),
+                Some(CheetahString::from_static_str(ExpressionType::SQL92)),
+                9,
+            )
+            .expect("resolved filter data should exist");
+
+        assert!(resolved.bloom_filter_data().is_some());
+        assert!(std::sync::Arc::ptr_eq(
+            registered.compiled_expression().as_ref().unwrap(),
+            resolved.compiled_expression().as_ref().unwrap()
+        ));
+    }
+
+    #[test]
+    fn resolve_builds_request_scoped_filter_data_with_bloom_and_cached_expression() {
+        let manager = new_manager();
+
+        let first = manager
+            .resolve(
+                CheetahString::from_slice("TopicTest"),
+                CheetahString::from_slice("GroupTest"),
+                Some(CheetahString::from_slice("color = 'blue'")),
+                Some(CheetahString::from_static_str(ExpressionType::SQL92)),
+                9,
+            )
+            .expect("resolved filter data should exist");
+        let second = manager
+            .resolve(
+                CheetahString::from_slice("TopicTest"),
+                CheetahString::from_slice("GroupTest"),
+                Some(CheetahString::from_slice("color = 'blue'")),
+                Some(CheetahString::from_static_str(ExpressionType::SQL92)),
+                10,
+            )
+            .expect("resolved filter data should exist");
+
+        assert!(manager
+            .get_consumer_filter_data(
+                &CheetahString::from_slice("TopicTest"),
+                &CheetahString::from_slice("GroupTest"),
+            )
+            .is_none());
+        assert!(first.bloom_filter_data().is_some());
+        assert!(second.bloom_filter_data().is_some());
+        assert!(std::sync::Arc::ptr_eq(
+            first.compiled_expression().as_ref().unwrap(),
+            second.compiled_expression().as_ref().unwrap()
+        ));
+    }
+
+    #[derive(Debug)]
+    struct FailingFilter {
+        filter_type: String,
+        compile_count: Arc<AtomicUsize>,
+    }
+
+    impl Filter for FailingFilter {
+        fn compile(&self, _expr: &str) -> Result<Box<dyn Expression>, FilterError> {
+            self.compile_count.fetch_add(1, Ordering::Relaxed);
+            Err(FilterError::new("expected test compile failure"))
+        }
+
+        fn of_type(&self) -> &str {
+            self.filter_type.as_str()
+        }
+    }
+
+    #[derive(Debug)]
+    struct LiteralTrueExpression;
+
+    impl std::fmt::Display for LiteralTrueExpression {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "true")
+        }
+    }
+
+    impl Expression for LiteralTrueExpression {
+        fn evaluate(&self, _context: &dyn EvaluationContext) -> Result<ExprValue, EvaluationError> {
+            Ok(ExprValue::Boolean(true))
+        }
+    }
+
+    #[derive(Debug)]
+    struct PassingFilter {
+        filter_type: String,
+    }
+
+    impl Filter for PassingFilter {
+        fn compile(&self, _expr: &str) -> Result<Box<dyn Expression>, FilterError> {
+            Ok(Box::new(LiteralTrueExpression))
+        }
+
+        fn of_type(&self) -> &str {
+            self.filter_type.as_str()
+        }
+    }
+
+    #[test]
+    fn resolve_negative_cache_avoids_recompiling_same_invalid_expression() {
+        let filter_type = format!("COUNT_FAIL_{}", current_millis());
+        let compile_count = Arc::new(AtomicUsize::new(0));
+        rocketmq_filter::filter::FilterFactory::instance().register(Arc::new(FailingFilter {
+            filter_type: filter_type.clone(),
+            compile_count: compile_count.clone(),
+        }));
+
+        let manager = new_manager();
+        let first = manager.resolve(
+            CheetahString::from_slice("TopicTest"),
+            CheetahString::from_slice("GroupTest"),
+            Some(CheetahString::from_slice("bad expression")),
+            Some(CheetahString::from_string(filter_type.clone())),
+            9,
+        );
+        let second = manager.resolve(
+            CheetahString::from_slice("TopicTest"),
+            CheetahString::from_slice("GroupTest"),
+            Some(CheetahString::from_slice("bad expression")),
+            Some(CheetahString::from_string(filter_type.clone())),
+            10,
+        );
+
+        assert!(first.is_none());
+        assert!(second.is_none());
+        assert_eq!(compile_count.load(Ordering::Relaxed), 1);
+        assert_eq!(manager.cached_compile_failure_count(), 1);
+
+        let _ = rocketmq_filter::filter::FilterFactory::instance().unregister(filter_type.as_str());
+    }
+
+    #[test]
+    fn stop_clears_compile_caches() {
+        let passing_type = format!("COUNT_PASS_{}", current_millis());
+        rocketmq_filter::filter::FilterFactory::instance().register(Arc::new(PassingFilter {
+            filter_type: passing_type.clone(),
+        }));
+
+        let mut manager = new_manager();
+        let _ = manager.resolve(
+            CheetahString::from_slice("TopicTest"),
+            CheetahString::from_slice("GroupTest"),
+            Some(CheetahString::from_slice("ok")),
+            Some(CheetahString::from_string(passing_type.clone())),
+            9,
+        );
+        let _ = manager.resolve(
+            CheetahString::from_slice("TopicTest"),
+            CheetahString::from_slice("GroupTest"),
+            Some(CheetahString::from_slice("bad")),
+            Some(CheetahString::from_string("UNKNOWN_FILTER_TYPE".to_string())),
+            10,
+        );
+
+        assert_eq!(manager.cached_expression_count(), 1);
+        assert_eq!(manager.cached_compile_failure_count(), 1);
+
+        assert!(manager.stop());
+        assert_eq!(manager.cached_expression_count(), 0);
+        assert_eq!(manager.cached_compile_failure_count(), 0);
+
+        let _ = rocketmq_filter::filter::FilterFactory::instance().unregister(passing_type.as_str());
     }
 
     #[test]

--- a/rocketmq-broker/src/filter/message_evaluation_context.rs
+++ b/rocketmq-broker/src/filter/message_evaluation_context.rs
@@ -18,11 +18,11 @@ use cheetah_string::CheetahString;
 use rocketmq_filter::expression::evaluation_context::EvaluationContext;
 
 pub struct MessageEvaluationContext<'a> {
-    properties: &'a Option<HashMap<CheetahString, CheetahString>>,
+    properties: Option<&'a HashMap<CheetahString, CheetahString>>,
 }
 
 impl<'a> MessageEvaluationContext<'a> {
-    pub fn new(properties: &'a Option<HashMap<CheetahString, CheetahString>>) -> Self {
+    pub fn new(properties: Option<&'a HashMap<CheetahString, CheetahString>>) -> Self {
         Self { properties }
     }
 }
@@ -30,12 +30,11 @@ impl<'a> MessageEvaluationContext<'a> {
 impl<'a> EvaluationContext for MessageEvaluationContext<'a> {
     fn get(&self, name: &str) -> Option<&CheetahString> {
         self.properties
-            .as_ref()
             .and_then(|props| props.get(&CheetahString::from_slice(name)))
     }
 
     fn key_values(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-        self.properties.clone()
+        self.properties.cloned()
     }
 }
 
@@ -51,8 +50,7 @@ mod tests {
     async fn get_returns_value_when_key_exists() {
         let mut properties = HashMap::new();
         properties.insert(CheetahString::from_slice("key1"), CheetahString::from_slice("value1"));
-        let binding = Some(properties);
-        let context = MessageEvaluationContext::new(&binding);
+        let context = MessageEvaluationContext::new(Some(&properties));
 
         let result = context.get("key1");
 
@@ -63,8 +61,7 @@ mod tests {
     async fn get_returns_none_when_key_does_not_exist() {
         let mut properties = HashMap::new();
         properties.insert(CheetahString::from_slice("key1"), CheetahString::from_slice("value1"));
-        let binding = Some(properties);
-        let context = MessageEvaluationContext::new(&binding);
+        let context = MessageEvaluationContext::new(Some(&properties));
 
         let result = context.get("key2");
 
@@ -73,7 +70,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_returns_none_when_properties_are_none() {
-        let context = MessageEvaluationContext::new(&None);
+        let context = MessageEvaluationContext::new(None);
 
         let result = context.get("key1");
 
@@ -85,8 +82,7 @@ mod tests {
         let mut properties = HashMap::new();
         properties.insert(CheetahString::from_slice("key1"), CheetahString::from_slice("value1"));
         properties.insert(CheetahString::from_slice("key2"), CheetahString::from_slice("value2"));
-        let binding = Some(properties.clone());
-        let context = MessageEvaluationContext::new(&binding);
+        let context = MessageEvaluationContext::new(Some(&properties));
 
         let result = context.key_values();
 
@@ -95,7 +91,7 @@ mod tests {
 
     #[tokio::test]
     async fn key_values_returns_none_when_properties_are_none() {
-        let context = MessageEvaluationContext::new(&None);
+        let context = MessageEvaluationContext::new(None);
 
         let result = context.key_values();
 

--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -510,7 +510,7 @@ mod tests {
         let processor = ClientManageProcessor::new(inner);
         let mut request = check_request(SubscriptionData {
             topic: "topic-a".into(),
-            sub_string: "a > 1 AND color = 'blue'".into(),
+            sub_string: "region IN ('hz', 'sh') AND name CONTAINS 'rocket' AND score BETWEEN 0 AND 100".into(),
             expression_type: ExpressionType::SQL92.into(),
             ..Default::default()
         });

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -71,7 +71,6 @@ use tracing::warn;
 
 use crate::broker_runtime::BrokerRuntimeInner;
 use crate::filter::expression_message_filter::ExpressionMessageFilter;
-use crate::filter::manager::consumer_filter_manager::ConsumerFilterManager;
 use crate::long_polling::long_polling_service::pop_long_polling_service::PopLongPollingService;
 use crate::long_polling::polling_header::PollingHeader;
 use crate::long_polling::polling_result::PollingResult;
@@ -347,7 +346,7 @@ where
                 &retry_subscription_data,
             );
             let message_filter = if !ExpressionType::is_tag_type(Some(subscription_data.expression_type.as_str())) {
-                let consumer_filter_data = ConsumerFilterManager::build(
+                let consumer_filter_data = self.broker_runtime_inner.consumer_filter_manager().resolve(
                     request_header.topic.clone(),
                     request_header.consumer_group.clone(),
                     request_header.exp.clone(),

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -61,7 +61,6 @@ use crate::coldctr::cold_data_pull_request_hold_service::NO_SUSPEND_KEY;
 use crate::filter::consumer_filter_data::ConsumerFilterData;
 use crate::filter::expression_for_retry_message_filter::ExpressionForRetryMessageFilter;
 use crate::filter::expression_message_filter::ExpressionMessageFilter;
-use crate::filter::manager::consumer_filter_manager::ConsumerFilterManager;
 use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
 use crate::processor::pull_message_result_handler::PullMessageResultHandler;
 
@@ -304,7 +303,7 @@ where
             &subscription_data,
         );
         let consumer_filter_data = if !ExpressionType::is_tag_type(Some(subscription_data.expression_type.as_str())) {
-            let consumer_filter_data = ConsumerFilterManager::build(
+            let consumer_filter_data = self.broker_runtime_inner.consumer_filter_manager().resolve(
                 request_header.topic.clone(),
                 request_header.consumer_group.clone(),
                 request_header.subscription.clone(),

--- a/rocketmq-filter/src/filter/sql_runtime.rs
+++ b/rocketmq-filter/src/filter/sql_runtime.rs
@@ -16,6 +16,7 @@ use std::cmp::Ordering;
 use std::fmt;
 
 use cheetah_string::CheetahString;
+use rocketmq_common::TimeUtils::current_millis;
 
 use crate::expression::EvaluationContext;
 use crate::expression::EvaluationError;
@@ -60,6 +61,7 @@ impl fmt::Display for SqlExpression {
 enum ExprNode {
     Literal(Value),
     Property(CheetahString),
+    Now,
     BooleanCast(Box<ExprNode>),
     Not(Box<ExprNode>),
     Logical {
@@ -76,6 +78,23 @@ enum ExprNode {
         expr: Box<ExprNode>,
         negated: bool,
     },
+    InList {
+        expr: Box<ExprNode>,
+        items: Vec<Value>,
+        negated: bool,
+    },
+    Between {
+        expr: Box<ExprNode>,
+        low: Box<ExprNode>,
+        high: Box<ExprNode>,
+        negated: bool,
+    },
+    StringMatch {
+        op: StringMatchOp,
+        expr: Box<ExprNode>,
+        search: CheetahString,
+        negated: bool,
+    },
 }
 
 impl ExprNode {
@@ -87,6 +106,7 @@ impl ExprNode {
                 .cloned()
                 .map(Value::String)
                 .unwrap_or(Value::Null)),
+            ExprNode::Now => Ok(Value::Long(current_millis() as i64)),
             ExprNode::BooleanCast(expr) => Ok(match expr.evaluate(context)? {
                 Value::Null => Value::Null,
                 value => match coerce_bool(&value) {
@@ -102,13 +122,88 @@ impl ExprNode {
                 Some(value) => Value::Boolean(value),
                 None => Value::Null,
             }),
-            ExprNode::Compare { op, left, right } => Ok(match op.eval(left, right, context)? {
-                Some(value) => Value::Boolean(value),
-                None => Value::Null,
-            }),
+            ExprNode::Compare { op, left, right } => {
+                let left = left.evaluate(context)?;
+                let right = right.evaluate(context)?;
+                Ok(match eval_compare_values(*op, &left, &right)? {
+                    Some(value) => Value::Boolean(value),
+                    None => Value::Null,
+                })
+            }
             ExprNode::IsNull { expr, negated } => {
                 let is_null = matches!(expr.evaluate(context)?, Value::Null);
                 Ok(Value::Boolean(if *negated { !is_null } else { is_null }))
+            }
+            ExprNode::InList { expr, items, negated } => {
+                let value = expr.evaluate(context)?;
+                if matches!(value, Value::Null) {
+                    return Ok(Value::Null);
+                }
+
+                let mut matched = false;
+                for item in items {
+                    if eval_compare_values(CompareOp::Eq, &value, item)? == Some(true) {
+                        matched = true;
+                        break;
+                    }
+                }
+
+                Ok(Value::Boolean(if *negated { !matched } else { matched }))
+            }
+            ExprNode::Between {
+                expr,
+                low,
+                high,
+                negated,
+            } => {
+                let value = expr.evaluate(context)?;
+                let low = low.evaluate(context)?;
+                let high = high.evaluate(context)?;
+
+                let result = if *negated {
+                    let lower = eval_compare_values(CompareOp::Lt, &value, &low)?;
+                    let upper = eval_compare_values(CompareOp::Gt, &value, &high)?;
+                    match (lower, upper) {
+                        (Some(true), _) | (_, Some(true)) => Some(true),
+                        (Some(false), Some(false)) => Some(false),
+                        _ => None,
+                    }
+                } else {
+                    let lower = eval_compare_values(CompareOp::Gte, &value, &low)?;
+                    let upper = eval_compare_values(CompareOp::Lte, &value, &high)?;
+                    match (lower, upper) {
+                        (Some(false), _) | (_, Some(false)) => Some(false),
+                        (Some(true), Some(true)) => Some(true),
+                        _ => None,
+                    }
+                };
+
+                Ok(match result {
+                    Some(value) => Value::Boolean(value),
+                    None => Value::Null,
+                })
+            }
+            ExprNode::StringMatch {
+                op,
+                expr,
+                search,
+                negated,
+            } => {
+                if search.is_empty() {
+                    return Ok(Value::Boolean(false));
+                }
+
+                let Value::String(subject) = expr.evaluate(context)? else {
+                    return Ok(Value::Boolean(false));
+                };
+
+                let matched = match op {
+                    StringMatchOp::Contains => subject.contains(search.as_str()),
+                    StringMatchOp::StartsWith => subject.starts_with(search.as_str()),
+                    StringMatchOp::EndsWith => subject.ends_with(search.as_str()),
+                };
+
+                Ok(Value::Boolean(if *negated { !matched } else { matched }))
             }
         }
     }
@@ -174,58 +269,51 @@ enum CompareOp {
     Lte,
 }
 
-impl CompareOp {
-    fn eval(
-        self,
-        left: &ExprNode,
-        right: &ExprNode,
-        context: &dyn EvaluationContext,
-    ) -> Result<Option<bool>, EvaluationError> {
-        let left = left.evaluate(context)?;
-        let right = right.evaluate(context)?;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StringMatchOp {
+    Contains,
+    StartsWith,
+    EndsWith,
+}
 
-        if matches!(left, Value::Null) || matches!(right, Value::Null) {
-            return Ok(None);
-        }
+fn eval_compare_values(op: CompareOp, left: &Value, right: &Value) -> Result<Option<bool>, EvaluationError> {
+    if matches!(left, Value::Null) || matches!(right, Value::Null) {
+        return Ok(None);
+    }
 
-        if let (Some(left), Some(right)) = (coerce_numeric(&left), coerce_numeric(&right)) {
-            return Ok(Some(match self {
-                CompareOp::Eq => numeric_eq(left, right),
-                CompareOp::Ne => !numeric_eq(left, right),
-                CompareOp::Gt => left.partial_cmp(&right) == Some(Ordering::Greater),
-                CompareOp::Gte => {
-                    matches!(
-                        left.partial_cmp(&right),
-                        Some(Ordering::Greater) | Some(Ordering::Equal)
-                    )
-                }
-                CompareOp::Lt => left.partial_cmp(&right) == Some(Ordering::Less),
-                CompareOp::Lte => {
-                    matches!(left.partial_cmp(&right), Some(Ordering::Less) | Some(Ordering::Equal))
-                }
-            }));
-        }
+    if let (Some(left), Some(right)) = (coerce_numeric(left), coerce_numeric(right)) {
+        let ordering = left.partial_cmp(&right).ok_or_else(|| {
+            EvaluationError::InvalidOperation(CheetahString::from_static_str(
+                "numeric comparison returned no ordering",
+            ))
+        })?;
 
-        if let (Some(left), Some(right)) = (coerce_boolean_literal(&left), coerce_boolean_literal(&right)) {
-            return Ok(match self {
-                CompareOp::Eq => Some(left == right),
-                CompareOp::Ne => Some(left != right),
-                CompareOp::Gt | CompareOp::Gte | CompareOp::Lt | CompareOp::Lte => None,
-            });
-        }
+        return Ok(Some(match op {
+            CompareOp::Eq => numeric_eq(left, right),
+            CompareOp::Ne => !numeric_eq(left, right),
+            CompareOp::Gt => ordering == Ordering::Greater,
+            CompareOp::Gte => matches!(ordering, Ordering::Greater | Ordering::Equal),
+            CompareOp::Lt => ordering == Ordering::Less,
+            CompareOp::Lte => matches!(ordering, Ordering::Less | Ordering::Equal),
+        }));
+    }
 
-        let left = stringify_value(&left);
-        let right = stringify_value(&right);
-        let order = left.cmp(&right);
+    if let (Some(left), Some(right)) = (coerce_boolean_literal(left), coerce_boolean_literal(right)) {
+        return match op {
+            CompareOp::Eq => Ok(Some(left == right)),
+            CompareOp::Ne => Ok(Some(left != right)),
+            CompareOp::Gt | CompareOp::Gte | CompareOp::Lt | CompareOp::Lte => Err(EvaluationError::InvalidOperation(
+                CheetahString::from_static_str("boolean ordering comparison is not supported"),
+            )),
+        };
+    }
 
-        Ok(Some(match self {
-            CompareOp::Eq => order == Ordering::Equal,
-            CompareOp::Ne => order != Ordering::Equal,
-            CompareOp::Gt => order == Ordering::Greater,
-            CompareOp::Gte => matches!(order, Ordering::Greater | Ordering::Equal),
-            CompareOp::Lt => order == Ordering::Less,
-            CompareOp::Lte => matches!(order, Ordering::Less | Ordering::Equal),
-        }))
+    match op {
+        CompareOp::Eq => Ok(Some(stringify_value(left) == stringify_value(right))),
+        CompareOp::Ne => Ok(Some(stringify_value(left) != stringify_value(right))),
+        CompareOp::Gt | CompareOp::Gte | CompareOp::Lt | CompareOp::Lte => Err(EvaluationError::InvalidOperation(
+            CheetahString::from_static_str("ordering comparison requires numeric operands"),
+        )),
     }
 }
 
@@ -263,8 +351,10 @@ fn coerce_numeric(value: &Value) -> Option<f64> {
         Value::String(string) => {
             if let Ok(number) = string.parse::<i64>() {
                 Some(number as f64)
+            } else if let Ok(number) = string.parse::<f64>() {
+                number.is_finite().then_some(number)
             } else {
-                string.parse::<f64>().ok()
+                None
             }
         }
         _ => None,
@@ -285,6 +375,13 @@ fn stringify_value(value: &Value) -> String {
     }
 }
 
+fn literal_value(node: &ExprNode) -> Option<&Value> {
+    match node {
+        ExprNode::Literal(value) => Some(value),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 enum Token {
     Ident(CheetahString),
@@ -293,8 +390,10 @@ enum Token {
     Double(f64),
     Boolean(bool),
     Null,
+    Now,
     LParen,
     RParen,
+    Comma,
     Eq,
     Ne,
     Gt,
@@ -305,6 +404,11 @@ enum Token {
     Or,
     Not,
     Is,
+    In,
+    Between,
+    Contains,
+    StartsWith,
+    EndsWith,
     End,
 }
 
@@ -338,6 +442,10 @@ impl<'a> Lexer<'a> {
             b')' => {
                 self.cursor += 1;
                 Ok(Token::RParen)
+            }
+            b',' => {
+                self.cursor += 1;
+                Ok(Token::Comma)
             }
             b'=' => {
                 self.cursor += 1;
@@ -424,12 +532,30 @@ impl<'a> Lexer<'a> {
             }
         }
 
+        if self.cursor < self.bytes.len() && matches!(self.bytes[self.cursor], b'e' | b'E') {
+            is_double = true;
+            self.cursor += 1;
+            if self.cursor < self.bytes.len() && matches!(self.bytes[self.cursor], b'+' | b'-') {
+                self.cursor += 1;
+            }
+            let exponent_start = self.cursor;
+            while self.cursor < self.bytes.len() && self.bytes[self.cursor].is_ascii_digit() {
+                self.cursor += 1;
+            }
+            if exponent_start == self.cursor {
+                return Err(FilterError::new("invalid exponent in numeric literal"));
+            }
+        }
+
         let token = &self.input[start..self.cursor];
         if is_double {
-            token
+            let value = token
                 .parse::<f64>()
-                .map(Token::Double)
-                .map_err(|error| FilterError::new(format!("invalid number '{token}': {error}")))
+                .map_err(|error| FilterError::new(format!("invalid number '{token}': {error}")))?;
+            if !value.is_finite() {
+                return Err(FilterError::new(format!("invalid number '{token}': overflow")));
+            }
+            Ok(Token::Double(value))
         } else {
             token
                 .parse::<i64>()
@@ -452,9 +578,15 @@ impl<'a> Lexer<'a> {
             "OR" => Ok(Token::Or),
             "NOT" => Ok(Token::Not),
             "IS" => Ok(Token::Is),
+            "IN" => Ok(Token::In),
+            "BETWEEN" => Ok(Token::Between),
+            "CONTAINS" => Ok(Token::Contains),
+            "STARTSWITH" => Ok(Token::StartsWith),
+            "ENDSWITH" => Ok(Token::EndsWith),
             "TRUE" => Ok(Token::Boolean(true)),
             "FALSE" => Ok(Token::Boolean(false)),
             "NULL" => Ok(Token::Null),
+            "NOW" => Ok(Token::Now),
             _ => Ok(Token::Ident(CheetahString::from_slice(ident))),
         }
     }
@@ -554,6 +686,28 @@ impl Parser {
             });
         }
 
+        let negated_special = self.consume(TokenKind::Not);
+        if self.consume(TokenKind::In) {
+            return self.parse_in_list(left, negated_special);
+        }
+        if self.consume(TokenKind::Between) {
+            return self.parse_between(left, negated_special);
+        }
+        if self.consume(TokenKind::Contains) {
+            return self.parse_string_match(left, StringMatchOp::Contains, negated_special);
+        }
+        if self.consume(TokenKind::StartsWith) {
+            return self.parse_string_match(left, StringMatchOp::StartsWith, negated_special);
+        }
+        if self.consume(TokenKind::EndsWith) {
+            return self.parse_string_match(left, StringMatchOp::EndsWith, negated_special);
+        }
+        if negated_special {
+            return Err(FilterError::new(
+                "expected IN, BETWEEN, CONTAINS, STARTSWITH or ENDSWITH after NOT",
+            ));
+        }
+
         if let Some(op) = self.parse_compare_op() {
             let right = self.parse_value()?;
             return Ok(ExprNode::Compare {
@@ -574,8 +728,79 @@ impl Parser {
             Token::Double(value) => Ok(ExprNode::Literal(Value::Double(value))),
             Token::Boolean(value) => Ok(ExprNode::Literal(Value::Boolean(value))),
             Token::Null => Ok(ExprNode::Literal(Value::Null)),
+            Token::Now => Ok(ExprNode::Now),
             token => Err(FilterError::new(format!("unexpected token {token:?}"))),
         }
+    }
+
+    fn parse_constant_value(&mut self) -> Result<Value, FilterError> {
+        match self.next() {
+            Token::String(value) => Ok(Value::String(value)),
+            Token::Long(value) => Ok(Value::Long(value)),
+            Token::Double(value) => Ok(Value::Double(value)),
+            Token::Boolean(value) => Ok(Value::Boolean(value)),
+            Token::Null => Ok(Value::Null),
+            token => Err(FilterError::new(format!("expected literal value, got {token:?}"))),
+        }
+    }
+
+    fn parse_in_list(&mut self, left: ExprNode, negated: bool) -> Result<ExprNode, FilterError> {
+        self.expect(TokenKind::LParen)?;
+        let mut items = vec![self.parse_constant_value()?];
+        while self.consume(TokenKind::Comma) {
+            items.push(self.parse_constant_value()?);
+        }
+        self.expect(TokenKind::RParen)?;
+        Ok(ExprNode::InList {
+            expr: Box::new(left),
+            items,
+            negated,
+        })
+    }
+
+    fn parse_between(&mut self, left: ExprNode, negated: bool) -> Result<ExprNode, FilterError> {
+        let low = self.parse_value()?;
+        self.expect(TokenKind::And)?;
+        let high = self.parse_value()?;
+
+        if let (Some(low), Some(high)) = (literal_value(&low), literal_value(&high)) {
+            if matches!(low, Value::Null) || matches!(high, Value::Null) {
+                return Err(FilterError::new("Illegal values of between, values can not be null"));
+            }
+            if let Some(false) =
+                eval_compare_values(CompareOp::Lte, low, high).map_err(|error| FilterError::new(error.to_string()))?
+            {
+                return Err(FilterError::new(format!(
+                    "Illegal values of between, left value({low}) must less than or equal to right value({high})"
+                )));
+            }
+        }
+
+        Ok(ExprNode::Between {
+            expr: Box::new(left),
+            low: Box::new(low),
+            high: Box::new(high),
+            negated,
+        })
+    }
+
+    fn parse_string_match(
+        &mut self,
+        left: ExprNode,
+        op: StringMatchOp,
+        negated: bool,
+    ) -> Result<ExprNode, FilterError> {
+        let Token::String(search) = self.next() else {
+            return Err(FilterError::new(
+                "string match operators require a quoted string literal",
+            ));
+        };
+        Ok(ExprNode::StringMatch {
+            op,
+            expr: Box::new(left),
+            search,
+            negated,
+        })
     }
 
     fn parse_compare_op(&mut self) -> Option<CompareOp> {
@@ -633,10 +858,12 @@ impl Parser {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TokenKind {
+    Null,
     LParen,
     RParen,
+    Comma,
     Eq,
     Ne,
     Gt,
@@ -647,15 +874,21 @@ enum TokenKind {
     Or,
     Not,
     Is,
-    Null,
+    In,
+    Between,
+    Contains,
+    StartsWith,
+    EndsWith,
 }
 
 impl TokenKind {
     fn matches(self, token: &Token) -> bool {
         matches!(
             (self, token),
-            (TokenKind::LParen, Token::LParen)
+            (TokenKind::Null, Token::Null)
+                | (TokenKind::LParen, Token::LParen)
                 | (TokenKind::RParen, Token::RParen)
+                | (TokenKind::Comma, Token::Comma)
                 | (TokenKind::Eq, Token::Eq)
                 | (TokenKind::Ne, Token::Ne)
                 | (TokenKind::Gt, Token::Gt)
@@ -666,16 +899,22 @@ impl TokenKind {
                 | (TokenKind::Or, Token::Or)
                 | (TokenKind::Not, Token::Not)
                 | (TokenKind::Is, Token::Is)
-                | (TokenKind::Null, Token::Null)
+                | (TokenKind::In, Token::In)
+                | (TokenKind::Between, Token::Between)
+                | (TokenKind::Contains, Token::Contains)
+                | (TokenKind::StartsWith, Token::StartsWith)
+                | (TokenKind::EndsWith, Token::EndsWith)
         )
     }
 
     fn as_str(self) -> &'static str {
         match self {
+            TokenKind::Null => "NULL",
             TokenKind::LParen => "(",
             TokenKind::RParen => ")",
+            TokenKind::Comma => ",",
             TokenKind::Eq => "=",
-            TokenKind::Ne => "<>",
+            TokenKind::Ne => "!=",
             TokenKind::Gt => ">",
             TokenKind::Gte => ">=",
             TokenKind::Lt => "<",
@@ -684,61 +923,174 @@ impl TokenKind {
             TokenKind::Or => "OR",
             TokenKind::Not => "NOT",
             TokenKind::Is => "IS",
-            TokenKind::Null => "NULL",
+            TokenKind::In => "IN",
+            TokenKind::Between => "BETWEEN",
+            TokenKind::Contains => "CONTAINS",
+            TokenKind::StartsWith => "STARTSWITH",
+            TokenKind::EndsWith => "ENDSWITH",
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use ahash::RandomState;
-    use std::collections::HashMap;
-
-    use super::*;
+    use super::compile_expression;
+    use crate::expression::EmptyEvaluationContext;
+    use crate::expression::EvaluationError;
     use crate::expression::MessageEvaluationContext;
+    use crate::expression::Value;
 
-    fn evaluate(expr: &str, properties: &[(&str, &str)]) -> Value {
-        let compiled = compile_expression(expr).expect("expression should compile");
-        let mut map = HashMap::with_hasher(RandomState::default());
-        for (key, value) in properties {
-            map.insert(CheetahString::from_slice(key), CheetahString::from_slice(value));
+    fn evaluate(expr: &str, pairs: &[(&str, &str)]) -> Result<Value, EvaluationError> {
+        let expression = compile_expression(expr).expect("expression should compile");
+        let mut context = MessageEvaluationContext::new();
+        for (key, value) in pairs {
+            context.put(*key, *value);
         }
-        let context = MessageEvaluationContext::from_properties(map);
-        compiled.evaluate(&context).expect("evaluation should succeed")
+        expression.evaluate(&context)
+    }
+
+    fn compile_error(expr: &str) -> String {
+        match compile_expression(expr) {
+            Ok(_) => panic!("expression should be rejected"),
+            Err(error) => error.to_string(),
+        }
     }
 
     #[test]
-    fn compile_rejects_invalid_sql() {
-        assert!(compile_expression("a =").is_err());
+    fn compile_rejects_empty_expression() {
+        let error = compile_error("   ");
+        assert!(error.contains("empty SQL92 expression"));
     }
 
     #[test]
-    fn evaluate_string_and_numeric_comparisons() {
+    fn evaluate_basic_comparison() {
         let value = evaluate(
             "color = 'blue' AND retries >= 3",
             &[("color", "blue"), ("retries", "3")],
-        );
+        )
+        .expect("evaluation should succeed");
         assert_eq!(value, Value::Boolean(true));
     }
 
     #[test]
-    fn evaluate_not_and_parentheses() {
-        let value = evaluate(
-            "NOT (color = 'red' OR retries < 2)",
-            &[("color", "blue"), ("retries", "3")],
-        );
-        assert_eq!(value, Value::Boolean(true));
+    fn evaluate_boolean_cast_and_null_logic() {
+        let expression = compile_expression("flag OR missing").expect("expression should compile");
+        let mut context = MessageEvaluationContext::new();
+        context.put("flag", "false");
+        assert_eq!(expression.evaluate(&context).unwrap(), Value::Null);
+
+        let expression = compile_expression("flag AND missing").expect("expression should compile");
+        assert_eq!(expression.evaluate(&context).unwrap(), Value::Boolean(false));
     }
 
     #[test]
     fn evaluate_is_null() {
-        let value = evaluate("missing IS NULL", &[("color", "blue")]);
+        let value = evaluate("missing IS NULL", &[]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+
+        let value = evaluate("present IS NOT NULL", &[("present", "x")]).expect("evaluation should succeed");
         assert_eq!(value, Value::Boolean(true));
     }
 
     #[test]
-    fn evaluate_boolean_literals() {
-        let value = evaluate("TRUE AND NOT FALSE", &[]);
+    fn evaluate_in_and_not_in() {
+        let value = evaluate("region IN ('hz', 'sh', 'bj')", &[("region", "sh")]).expect("evaluation should succeed");
         assert_eq!(value, Value::Boolean(true));
+
+        let value =
+            evaluate("region NOT IN ('hz', 'sh', 'bj')", &[("region", "cd")]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+
+        let value = evaluate("region NOT IN ('hz', 'sh', 'bj')", &[]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Null);
+    }
+
+    #[test]
+    fn evaluate_between_and_not_between() {
+        let value = evaluate("price BETWEEN 10 AND 20", &[("price", "15")]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+
+        let value = evaluate("price NOT BETWEEN 10 AND 20", &[("price", "25")]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+    }
+
+    #[test]
+    fn evaluate_string_match_extensions() {
+        let value = evaluate("name CONTAINS 'mq'", &[("name", "rocketmq-rust")]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+
+        let value =
+            evaluate("name STARTSWITH 'rocket'", &[("name", "rocketmq-rust")]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+
+        let value = evaluate("name ENDSWITH 'rust'", &[("name", "rocketmq-rust")]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+
+        let value =
+            evaluate("name NOT CONTAINS 'java'", &[("name", "rocketmq-rust")]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+
+        let value = evaluate("missing NOT CONTAINS 'java'", &[]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(false));
+    }
+
+    #[test]
+    fn evaluate_now_keyword() {
+        let before = rocketmq_common::TimeUtils::current_millis() as i64 - 1;
+        let value = evaluate("ts <= NOW", &[("ts", &before.to_string())]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+    }
+
+    #[test]
+    fn evaluate_boolean_literal_comparison() {
+        let value =
+            evaluate("a = TRUE OR b = FALSE", &[("a", "true"), ("b", "true")]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+    }
+
+    #[test]
+    fn ordering_comparison_rejects_non_numeric_strings() {
+        let error = evaluate("a BETWEEN 0 AND 100", &[("a", "abc")]).expect_err("evaluation should fail");
+        assert!(matches!(error, EvaluationError::InvalidOperation(_)));
+        assert!(error.to_string().contains("numeric operands"));
+    }
+
+    #[test]
+    fn compile_rejects_illegal_between_bounds() {
+        let error = compile_error("a BETWEEN 10 AND 0");
+        assert!(error.contains("Illegal values of between"));
+    }
+
+    #[test]
+    fn compile_rejects_non_string_contains_operand() {
+        let error = compile_error("a CONTAINS 1");
+        assert!(error.contains("string match operators require a quoted string literal"));
+    }
+
+    #[test]
+    fn compile_rejects_invalid_number_exponent() {
+        let error = compile_error("a = 1e");
+        assert!(error.contains("invalid exponent"));
+    }
+
+    #[test]
+    fn compile_supports_escaped_quotes() {
+        let value = evaluate("name = 'rock''et'", &[("name", "rock'et")]).expect("evaluation should succeed");
+        assert_eq!(value, Value::Boolean(true));
+    }
+
+    #[test]
+    fn compile_rejects_trailing_tokens() {
+        let error = compile_error("a = 1 2");
+        assert!(error.contains("unexpected trailing token"));
+    }
+
+    #[test]
+    fn evaluate_missing_value_as_null() {
+        let expression = compile_expression("missing").expect("expression should compile");
+        let value = expression
+            .evaluate(&EmptyEvaluationContext)
+            .expect("evaluation should succeed");
+        assert_eq!(value, Value::Null);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7050

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for new SQL filter expression operators: `IN`/`NOT IN`, `BETWEEN`/`NOT BETWEEN`, `CONTAINS`, `STARTSWITH`, `ENDSWITH`, and `NOW()` function.
  * Implemented expression caching to improve filter compilation performance.

* **Improvements**
  * Enhanced message filtering logic with better property handling and fallback mechanisms.
  * Improved filter data resolution for more consistent behavior across brokers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->