### PR TITLE
[ISSUE #7058]🚀feat(dispatch): implement bounded dispatch with deferred overflow handling and add export rocksdb config request header

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -4961,6 +4961,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn trigger_lite_dispatch_respects_broker_max_client_event_count_fallback() {
+        let mut runtime = new_lite_test_runtime("trigger-lite-dispatch-max-client-event-count").await;
+        seed_lite_query_state(&mut runtime);
+        seed_lmq_offsets(&mut runtime, &[("child-a", 8), ("child-b", 12)]);
+        let mut broker_config = runtime.inner_for_test().broker_config().clone();
+        broker_config.max_client_event_count = 1;
+        runtime.inner_for_test().set_broker_config(broker_config);
+
+        let (mut processor, _) = runtime.init_processor();
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let header = TriggerLiteDispatchRequestHeader {
+            group: CheetahString::from_static_str("group-a"),
+            client_id: Some(CheetahString::from_static_str("client-1")),
+        };
+        let mut request = RemotingCommand::create_request_command(RequestCode::TriggerLiteDispatch, header);
+        request.make_custom_header_to_net();
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor dispatch should succeed")
+            .expect("lite manager should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+
+        let pending_events = runtime
+            .inner
+            .lite_event_dispatcher()
+            .pending_events(&CheetahString::from_static_str("client-1"));
+        assert_eq!(pending_events.len(), 1);
+        assert!(pending_events[0].ends_with("child-a") || pending_events[0].ends_with("child-b"));
+
+        let drained_events = runtime
+            .inner
+            .lite_event_dispatcher()
+            .take_pending_events(&CheetahString::from_static_str("client-1"));
+        assert_eq!(drained_events.len(), 2);
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
     async fn pop_lite_message_without_events_returns_polling_timeout() {
         let mut runtime = new_lite_test_runtime("pop-lite-route").await;
         seed_lite_query_state(&mut runtime);

--- a/rocketmq-broker/src/lite/lite_event_dispatcher.rs
+++ b/rocketmq-broker/src/lite/lite_event_dispatcher.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -23,15 +24,78 @@ use dashmap::DashMap;
 use rocketmq_common::TimeUtils::current_millis;
 use tokio::sync::mpsc::UnboundedSender;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 struct ClientEventState {
     group: CheetahString,
+    events: VecDeque<CheetahString>,
+    event_set: HashSet<CheetahString>,
+    max_event_count: usize,
+}
+
+impl Default for ClientEventState {
+    fn default() -> Self {
+        Self {
+            group: CheetahString::new(),
+            events: VecDeque::new(),
+            event_set: HashSet::new(),
+            max_event_count: usize::MAX,
+        }
+    }
+}
+
+impl ClientEventState {
+    fn set_limit(&mut self, max_event_count: usize) {
+        self.max_event_count = normalize_limit(max_event_count);
+    }
+
+    fn offer(&mut self, event: CheetahString) -> bool {
+        if self.event_set.contains(&event) {
+            return true;
+        }
+        if self.events.len() >= self.max_event_count {
+            return false;
+        }
+        self.event_set.insert(event.clone());
+        self.events.push_back(event);
+        true
+    }
+
+    fn drain(&mut self) -> Vec<CheetahString> {
+        let drained = self.events.drain(..).collect::<Vec<_>>();
+        self.event_set.clear();
+        drained
+    }
+
+    fn pending_events(&self) -> Vec<CheetahString> {
+        self.events.iter().cloned().collect()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct DeferredDispatchState {
+    group: CheetahString,
     events: BTreeSet<CheetahString>,
+    due_time: u64,
+    delay_millis: u64,
+    max_event_count: usize,
+}
+
+fn normalize_limit(max_event_count: usize) -> usize {
+    if max_event_count == 0 {
+        usize::MAX
+    } else {
+        max_event_count
+    }
 }
 
 #[derive(Clone, Default)]
 pub(crate) struct LiteEventDispatcher {
     client_events: Arc<DashMap<CheetahString, ClientEventState>>,
+    deferred_dispatches: Arc<DashMap<CheetahString, DeferredDispatchState>>,
     client_last_access_time: Arc<DashMap<CheetahString, u64>>,
     wakeup_sender: Arc<Mutex<Option<UnboundedSender<CheetahString>>>>,
 }
@@ -62,18 +126,58 @@ impl LiteEventDispatcher {
         group: &CheetahString,
         lmq_names: &HashSet<CheetahString>,
     ) -> usize {
+        self.do_full_dispatch_with_limit(client_id, group, lmq_names, usize::MAX, 0)
+    }
+
+    pub(crate) fn do_full_dispatch_with_limit(
+        &self,
+        client_id: &CheetahString,
+        group: &CheetahString,
+        lmq_names: &HashSet<CheetahString>,
+        max_event_count: usize,
+        full_dispatch_delay_millis: u64,
+    ) -> usize {
+        let now = current_millis();
+        self.scan(now);
         self.touch_client(client_id);
         if lmq_names.is_empty() {
             return 0;
         }
 
+        let deferred_snapshot = self
+            .deferred_dispatches
+            .get(client_id)
+            .map(|entry| entry.events.clone())
+            .unwrap_or_default();
+        let mut overflow = BTreeSet::new();
+        let ordered_lmq_names = lmq_names.iter().cloned().collect::<BTreeSet<_>>();
         let inserted = {
             let mut entry = self.client_events.entry(client_id.clone()).or_default();
             entry.group = group.clone();
+            entry.set_limit(max_event_count);
             let original_len = entry.events.len();
-            entry.events.extend(lmq_names.iter().cloned());
+            for lmq_name in ordered_lmq_names {
+                if entry.event_set.contains(&lmq_name) || deferred_snapshot.contains(&lmq_name) {
+                    continue;
+                }
+                if !entry.offer(lmq_name.clone()) {
+                    overflow.insert(lmq_name);
+                }
+            }
             entry.events.len().saturating_sub(original_len)
         };
+
+        if !overflow.is_empty() {
+            self.schedule_deferred_dispatch(
+                client_id,
+                group,
+                &overflow,
+                now.saturating_add(full_dispatch_delay_millis),
+                full_dispatch_delay_millis,
+                max_event_count,
+            );
+        }
+
         if inserted > 0 {
             self.notify_client(client_id);
         }
@@ -85,24 +189,152 @@ impl LiteEventDispatcher {
         group: &CheetahString,
         dispatch_map: &HashMap<CheetahString, HashSet<CheetahString>>,
     ) -> usize {
+        self.do_full_dispatch_by_group_with_limit(group, dispatch_map, usize::MAX, 0)
+    }
+
+    pub(crate) fn do_full_dispatch_by_group_with_limit(
+        &self,
+        group: &CheetahString,
+        dispatch_map: &HashMap<CheetahString, HashSet<CheetahString>>,
+        max_event_count: usize,
+        full_dispatch_delay_millis: u64,
+    ) -> usize {
         dispatch_map
             .iter()
-            .map(|(client_id, lmq_names)| self.do_full_dispatch(client_id, group, lmq_names))
+            .map(|(client_id, lmq_names)| {
+                self.do_full_dispatch_with_limit(
+                    client_id,
+                    group,
+                    lmq_names,
+                    max_event_count,
+                    full_dispatch_delay_millis,
+                )
+            })
             .sum()
     }
 
     pub(crate) fn pending_events(&self, client_id: &CheetahString) -> Vec<CheetahString> {
+        self.scan(current_millis());
         self.client_events
             .get(client_id)
-            .map(|entry| entry.events.iter().cloned().collect())
+            .map(|entry| entry.pending_events())
             .unwrap_or_default()
     }
 
     pub(crate) fn take_pending_events(&self, client_id: &CheetahString) -> Vec<CheetahString> {
+        let now = current_millis();
+        self.scan(now);
+        self.touch_client(client_id);
+
+        let mut drained = self.drain_client_events(client_id);
+        if self.promote_deferred_events(client_id, now, true) > 0 {
+            drained.extend(self.drain_client_events(client_id));
+        }
+        self.cleanup_client_state(client_id);
+        drained
+    }
+
+    fn scan(&self, now: u64) {
+        let due_clients = self
+            .deferred_dispatches
+            .iter()
+            .filter(|entry| entry.due_time <= now)
+            .map(|entry| entry.key().clone())
+            .collect::<Vec<_>>();
+
+        for client_id in due_clients {
+            self.promote_deferred_events(&client_id, now, false);
+            self.cleanup_client_state(&client_id);
+        }
+    }
+
+    fn drain_client_events(&self, client_id: &CheetahString) -> Vec<CheetahString> {
         self.client_events
-            .remove(client_id)
-            .map(|(_, entry)| entry.events.into_iter().collect())
+            .get_mut(client_id)
+            .map(|mut entry| entry.drain())
             .unwrap_or_default()
+    }
+
+    fn promote_deferred_events(&self, client_id: &CheetahString, now: u64, force: bool) -> usize {
+        let Some(snapshot) = self
+            .deferred_dispatches
+            .get(client_id)
+            .map(|entry| entry.value().clone())
+        else {
+            return 0;
+        };
+        if !force && snapshot.due_time > now {
+            return 0;
+        }
+
+        let mut state = snapshot;
+        let inserted = {
+            let mut entry = self.client_events.entry(client_id.clone()).or_default();
+            entry.group = state.group.clone();
+            entry.set_limit(state.max_event_count);
+            let mut promoted = 0;
+            let candidates = state.events.iter().cloned().collect::<Vec<_>>();
+            for lmq_name in candidates {
+                if entry.event_set.contains(&lmq_name) {
+                    state.events.remove(&lmq_name);
+                    continue;
+                }
+                if entry.offer(lmq_name.clone()) {
+                    state.events.remove(&lmq_name);
+                    promoted += 1;
+                } else {
+                    break;
+                }
+            }
+            promoted
+        };
+
+        if state.events.is_empty() {
+            self.deferred_dispatches.remove(client_id);
+        } else {
+            state.due_time = now.saturating_add(state.delay_millis);
+            self.deferred_dispatches.insert(client_id.clone(), state);
+        }
+
+        if inserted > 0 {
+            self.notify_client(client_id);
+        }
+        inserted
+    }
+
+    fn schedule_deferred_dispatch(
+        &self,
+        client_id: &CheetahString,
+        group: &CheetahString,
+        lmq_names: &BTreeSet<CheetahString>,
+        due_time: u64,
+        delay_millis: u64,
+        max_event_count: usize,
+    ) {
+        let mut entry = self.deferred_dispatches.entry(client_id.clone()).or_default();
+        entry.group = group.clone();
+        entry.delay_millis = delay_millis;
+        entry.max_event_count = normalize_limit(max_event_count);
+        entry.due_time = if entry.events.is_empty() {
+            due_time
+        } else {
+            entry.due_time.min(due_time)
+        };
+        entry.events.extend(lmq_names.iter().cloned());
+    }
+
+    fn cleanup_client_state(&self, client_id: &CheetahString) {
+        let has_deferred = self
+            .deferred_dispatches
+            .get(client_id)
+            .is_some_and(|entry| !entry.events.is_empty());
+        let should_remove = self
+            .client_events
+            .get(client_id)
+            .is_some_and(|entry| entry.is_empty() && !has_deferred);
+        if should_remove {
+            self.client_events.remove(client_id);
+        }
     }
 
     fn notify_client(&self, client_id: &CheetahString) {
@@ -166,6 +398,38 @@ mod tests {
             vec![CheetahString::from_static_str("%LMQ%$parent$child-a")]
         );
         assert_eq!(dispatcher.event_map_size(), 0);
+    }
+
+    #[test]
+    fn bounded_dispatch_defers_overflow_and_releases_it_on_consume() {
+        let dispatcher = LiteEventDispatcher::default();
+        let client_id = CheetahString::from_static_str("client-a");
+        let group = CheetahString::from_static_str("group-a");
+        let lmq_names = HashSet::from([
+            CheetahString::from_static_str("%LMQ%$parent$child-a"),
+            CheetahString::from_static_str("%LMQ%$parent$child-b"),
+            CheetahString::from_static_str("%LMQ%$parent$child-c"),
+        ]);
+
+        let inserted = dispatcher.do_full_dispatch_with_limit(&client_id, &group, &lmq_names, 2, 10_000);
+
+        assert_eq!(inserted, 2);
+        assert_eq!(
+            dispatcher.pending_events(&client_id),
+            vec![
+                CheetahString::from_static_str("%LMQ%$parent$child-a"),
+                CheetahString::from_static_str("%LMQ%$parent$child-b"),
+            ]
+        );
+        assert_eq!(
+            dispatcher.take_pending_events(&client_id),
+            vec![
+                CheetahString::from_static_str("%LMQ%$parent$child-a"),
+                CheetahString::from_static_str("%LMQ%$parent$child-b"),
+                CheetahString::from_static_str("%LMQ%$parent$child-c"),
+            ]
+        );
+        assert!(dispatcher.pending_events(&client_id).is_empty());
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -269,7 +269,11 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .get_cold_data_flow_ctr_info(channel, ctx, request_code, request)
                     .await
             }
-            RequestCode::SetCommitlogReadMode => Ok(get_unknown_cmd_response(request_code)),
+            RequestCode::SetCommitlogReadMode => {
+                self.broker_config_request_handler
+                    .set_commitlog_read_mode(channel, ctx, request_code, request)
+                    .await
+            }
             RequestCode::SearchOffsetByTimestamp => {
                 self.message_related_handler
                     .search_offset_by_timestamp(channel, ctx, request_code, request)
@@ -451,6 +455,11 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .check_rocksdb_cq_write_progress(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::ExportRocksdbConfigToJson => {
+                self.broker_config_request_handler
+                    .export_rocksdb_config_to_json(channel, ctx, request_code, request)
+                    .await
+            }
             RequestCode::UpdateAndGetGroupForbidden => {
                 self.subscription_group_handler
                     .update_and_get_group_forbidden(channel, ctx, request_code, request)
@@ -461,13 +470,30 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .get_subscription_group_config(channel, ctx, request_code, request)
                     .await
             }
-            RequestCode::UpdateAndCreateAclConfig => Ok(get_unknown_cmd_response(request_code)),
-            RequestCode::DeleteAclConfig => Ok(get_unknown_cmd_response(request_code)),
-            RequestCode::GetBrokerClusterAclInfo => Ok(get_unknown_cmd_response(request_code)),
-            RequestCode::UpdateGlobalWhiteAddrsConfig => Ok(get_unknown_cmd_response(request_code)),
+            RequestCode::UpdateAndCreateAclConfig => Ok(get_legacy_acl_cmd_response(
+                request_code,
+                "legacy ACL config API is deprecated; use AuthCreateAcl/AuthUpdateAcl instead",
+            )),
+            RequestCode::DeleteAclConfig => Ok(get_legacy_acl_cmd_response(
+                request_code,
+                "legacy ACL config API is deprecated; use AuthDeleteAcl instead",
+            )),
+            RequestCode::GetBrokerClusterAclInfo => Ok(get_legacy_acl_cmd_response(
+                request_code,
+                "legacy broker ACL cluster info API is deprecated; use AuthListAcl instead",
+            )),
+            RequestCode::UpdateGlobalWhiteAddrsConfig => Ok(get_legacy_acl_cmd_response(
+                request_code,
+                "global white address config API is not supported in the current auth runtime",
+            )),
             RequestCode::ResumeCheckHalfMessage => {
                 self.message_related_handler
                     .resume_check_half_message(channel, ctx, request_code, request)
+                    .await
+            }
+            RequestCode::PopRollback => {
+                self.message_related_handler
+                    .pop_rollback(channel, ctx, request_code, request)
                     .await
             }
             RequestCode::GetTopicConfig => {
@@ -560,6 +586,11 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                     .list_acl(channel, ctx, request_code, request)
                     .await
             }
+            RequestCode::SwitchTimerEngine => {
+                self.broker_config_request_handler
+                    .switch_timer_engine(channel, ctx, request_code, request)
+                    .await
+            }
             _ => Ok(get_unknown_cmd_response(request_code)),
         }
     }
@@ -575,4 +606,40 @@ fn get_unknown_cmd_response(request_code: RequestCode) -> Option<RemotingCommand
         ResponseCode::RequestCodeNotSupported,
         format!(" request type {} not supported", request_code.to_i32()),
     ))
+}
+
+fn get_legacy_acl_cmd_response(request_code: RequestCode, remark: &str) -> Option<RemotingCommand> {
+    warn!(
+        "legacy acl request type {:?}-{} is deprecated: {}",
+        request_code,
+        request_code.to_i32(),
+        remark
+    );
+    Some(RemotingCommand::create_response_command_with_code_remark(
+        ResponseCode::RequestCodeNotSupported,
+        remark,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_acl_responses_are_explicitly_deprecated() {
+        let response = get_legacy_acl_cmd_response(
+            RequestCode::UpdateAndCreateAclConfig,
+            "legacy ACL config API is deprecated; use AuthCreateAcl/AuthUpdateAcl instead",
+        )
+        .expect("legacy acl response should exist");
+
+        assert_eq!(
+            ResponseCode::from(response.code()),
+            ResponseCode::RequestCodeNotSupported
+        );
+        assert!(response
+            .remark()
+            .expect("legacy acl response should carry remark")
+            .contains("deprecated"));
+    }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -15,16 +15,24 @@
 use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_common::common::config_manager::ConfigManager;
+use rocketmq_common::common::constant::file_readahead_mode::READ_AHEAD_MODE;
+use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::mix_all;
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::kv_table::KVTable;
+use rocketmq_remoting::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigToJsonRequestHeader;
+use rocketmq_remoting::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigType;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::utils::ffi::MADV_NORMAL;
+use rocketmq_store::utils::ffi::MADV_RANDOM;
 use sysinfo::Disks;
 
 use crate::broker_runtime::BrokerRuntimeInner;
@@ -45,9 +53,58 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         _request_code: RequestCode,
-        _request: &mut RemotingCommand,
+        request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        todo!()
+        let response = RemotingCommand::create_response_command().set_opaque(request.opaque());
+        let Some(body) = request.body() else {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("broker config body is empty"),
+            ));
+        };
+
+        let body = String::from_utf8_lossy(body.as_ref());
+        let Some(properties) = mix_all::string_to_properties(&body) else {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("broker config body format is invalid"),
+            ));
+        };
+        if properties.is_empty() {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("broker config body is empty"),
+            ));
+        }
+
+        let mut updated_config = self.broker_runtime_inner.broker_config().clone();
+        let unsupported_keys = match Self::apply_supported_broker_config_properties(&mut updated_config, &properties) {
+            Ok(unsupported_keys) => unsupported_keys,
+            Err(remark) => {
+                return Ok(Some(
+                    response.set_code(ResponseCode::InvalidParameter).set_remark(remark),
+                ));
+            }
+        };
+        if !unsupported_keys.is_empty() {
+            return Ok(Some(response.set_code(ResponseCode::InvalidParameter).set_remark(
+                format!("unsupported broker config keys: {}", unsupported_keys.join(",")),
+            )));
+        }
+
+        let inner = self.broker_runtime_inner.mut_from_ref();
+        inner.set_broker_config(updated_config);
+        let broker_config_arc = inner.broker_config_arc();
+        inner.producer_manager_mut().set_broker_config(broker_config_arc);
+
+        Ok(Some(
+            response
+                .set_code(ResponseCode::Success)
+                .set_remark("update broker config success"),
+        ))
     }
 
     pub async fn get_broker_config(
@@ -97,6 +154,104 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         Ok(Some(response))
     }
 
+    pub async fn set_commitlog_read_mode(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let response = RemotingCommand::create_response_command();
+        let Some(ext_fields) = request.get_ext_fields() else {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::SystemError)
+                    .set_remark("set commitlog readahead mode param error"),
+            ));
+        };
+
+        let Some(mode_text) = ext_fields.get(READ_AHEAD_MODE) else {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::SystemError)
+                    .set_remark("set commitlog readahead mode param error"),
+            ));
+        };
+
+        let Ok(mode) = mode_text.parse::<i32>() else {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("set commitlog readahead mode param value error"),
+            ));
+        };
+
+        if mode != MADV_NORMAL && mode != MADV_RANDOM {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("set commitlog readahead mode param value error"),
+            ));
+        }
+
+        match self
+            .broker_runtime_inner
+            .mut_from_ref()
+            .message_store_mut()
+            .as_mut()
+            .expect("message store should exist")
+            .set_commitlog_read_mode(mode)
+        {
+            Ok(()) => {
+                Ok(Some(response.set_code(ResponseCode::Success).set_remark(format!(
+                    "set commitlog readahead mode success, mode: {mode}"
+                ))))
+            }
+            Err(error) => Ok(Some(
+                response
+                    .set_code(ResponseCode::SystemError)
+                    .set_remark(format!("set commitlog readahead mode failed: {error}")),
+            )),
+        }
+    }
+
+    pub async fn export_rocksdb_config_to_json(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let response = RemotingCommand::create_response_command();
+        let request_header = request.decode_command_custom_header::<ExportRocksdbConfigToJsonRequestHeader>()?;
+        let config_types = match request_header.fetch_config_type() {
+            Ok(config_types) => config_types,
+            Err(error) => {
+                return Ok(Some(
+                    response.set_code(ResponseCode::InvalidParameter).set_remark(error),
+                ));
+            }
+        };
+
+        for config_type in config_types {
+            match config_type {
+                ExportRocksdbConfigType::Topics => {
+                    self.broker_runtime_inner.topic_config_manager().persist();
+                }
+                ExportRocksdbConfigType::SubscriptionGroups => {
+                    self.broker_runtime_inner.subscription_group_manager().persist();
+                }
+                ExportRocksdbConfigType::ConsumerOffsets => {
+                    self.broker_runtime_inner.consumer_offset_manager().persist();
+                }
+            }
+        }
+
+        Ok(Some(
+            response.set_code(ResponseCode::Success).set_remark("export done."),
+        ))
+    }
+
     pub async fn get_timer_metrics(
         &mut self,
         _channel: Channel,
@@ -115,6 +270,173 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         Ok(Some(self.build_timer_checkpoint_response()))
+    }
+
+    pub async fn switch_timer_engine(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let response = RemotingCommand::create_response_command();
+
+        if !self.broker_runtime_inner.message_store_config().is_timer_wheel_enable() {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("broker timerWheelEnable is false"),
+            ));
+        }
+
+        let Some(ext_fields) = request.get_ext_fields() else {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("param error, extFields is null"),
+            ));
+        };
+
+        let Some(engine_type) = ext_fields.get(MessageConst::TIMER_ENGINE_TYPE) else {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("param error"),
+            ));
+        };
+
+        if engine_type.as_str() == MessageConst::TIMER_ENGINE_ROCKSDB_TIMELINE {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("timerRocksDBEnable must be configured true when broker start"),
+            ));
+        }
+
+        if engine_type.as_str() != MessageConst::TIMER_ENGINE_FILE_TIME_WHEEL {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("param error"),
+            ));
+        }
+
+        let Some(timer_message_store) = self.broker_runtime_inner.timer_message_store().cloned() else {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::SystemError)
+                    .set_remark("switch timer engine error"),
+            ));
+        };
+
+        timer_message_store.set_should_running_dequeue(true);
+        timer_message_store.start();
+
+        Ok(Some(
+            response
+                .set_code(ResponseCode::Success)
+                .set_remark("switch timer engine success"),
+        ))
+    }
+
+    fn apply_supported_broker_config_properties(
+        broker_config: &mut BrokerConfig,
+        properties: &HashMap<CheetahString, CheetahString>,
+    ) -> Result<Vec<String>, CheetahString> {
+        let mut unsupported_keys = Vec::new();
+
+        for (key, value) in properties {
+            match key.as_str() {
+                "enableLiteEventMode" => {
+                    broker_config.enable_lite_event_mode = Self::parse_bool_property(key, value)?;
+                }
+                "liteEventCheckInterval" => {
+                    broker_config.lite_event_check_interval = Self::parse_u64_property(key, value)?;
+                }
+                "liteTtlCheckInterval" => {
+                    broker_config.lite_ttl_check_interval = Self::parse_u64_property(key, value)?;
+                }
+                "liteSubscriptionCheckInterval" => {
+                    broker_config.lite_subscription_check_interval = Self::parse_u64_property(key, value)?;
+                }
+                "liteSubscriptionCheckTimeoutMills" => {
+                    broker_config.lite_subscription_check_timeout_mills = Self::parse_u64_property(key, value)?;
+                }
+                "maxLiteSubscriptionCount" => {
+                    broker_config.max_lite_subscription_count = Self::parse_positive_u64_property(key, value)?;
+                }
+                "enableLitePopLog" => {
+                    broker_config.enable_lite_pop_log = Self::parse_bool_property(key, value)?;
+                }
+                "maxClientEventCount" => {
+                    broker_config.max_client_event_count = Self::parse_positive_i32_property(key, value)?;
+                }
+                "liteEventFullDispatchDelayTime" => {
+                    broker_config.lite_event_full_dispatch_delay_time = Self::parse_u64_property(key, value)?;
+                }
+                "liteLagLatencyCollectEnable" => {
+                    broker_config.lite_lag_latency_collect_enable = Self::parse_bool_property(key, value)?;
+                }
+                "liteLagLatencyMetricsEnable" => {
+                    broker_config.lite_lag_latency_metrics_enable = Self::parse_bool_property(key, value)?;
+                }
+                "liteLagCountMetricsEnable" => {
+                    broker_config.lite_lag_count_metrics_enable = Self::parse_bool_property(key, value)?;
+                }
+                "liteLagLatencyTopK" => {
+                    broker_config.lite_lag_latency_top_k = Self::parse_positive_i32_property(key, value)?;
+                }
+                "validateSystemTopicWhenUpdateTopic" => {
+                    broker_config.validate_system_topic_when_update_topic = Self::parse_bool_property(key, value)?;
+                }
+                "enableMixedMessageType" => {
+                    broker_config.enable_mixed_message_type = Self::parse_bool_property(key, value)?;
+                }
+                _ => unsupported_keys.push(key.to_string()),
+            }
+        }
+
+        unsupported_keys.sort();
+        Ok(unsupported_keys)
+    }
+
+    fn parse_bool_property(key: &CheetahString, value: &CheetahString) -> Result<bool, CheetahString> {
+        value.parse::<bool>().map_err(|_| {
+            CheetahString::from_string(format!("broker config [{}] expects boolean, got [{}]", key, value))
+        })
+    }
+
+    fn parse_u64_property(key: &CheetahString, value: &CheetahString) -> Result<u64, CheetahString> {
+        value.parse::<u64>().map_err(|_| {
+            CheetahString::from_string(format!(
+                "broker config [{}] expects unsigned integer, got [{}]",
+                key, value
+            ))
+        })
+    }
+
+    fn parse_positive_u64_property(key: &CheetahString, value: &CheetahString) -> Result<u64, CheetahString> {
+        let parsed = Self::parse_u64_property(key, value)?;
+        if parsed == 0 {
+            return Err(CheetahString::from_string(format!(
+                "broker config [{}] expects positive integer, got [{}]",
+                key, value
+            )));
+        }
+        Ok(parsed)
+    }
+
+    fn parse_positive_i32_property(key: &CheetahString, value: &CheetahString) -> Result<i32, CheetahString> {
+        let parsed = value.parse::<i32>().map_err(|_| {
+            CheetahString::from_string(format!("broker config [{}] expects integer, got [{}]", key, value))
+        })?;
+        if parsed <= 0 {
+            return Err(CheetahString::from_string(format!(
+                "broker config [{}] expects positive integer, got [{}]",
+                key, value
+            )));
+        }
+        Ok(parsed)
     }
 
     fn build_timer_metrics_response(&self) -> RemotingCommand {
@@ -340,22 +662,78 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::env;
     use std::fs;
     use std::sync::Arc;
+    use std::time::SystemTime;
 
     use cheetah_string::CheetahString;
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_common::common::config_manager::ConfigManager;
+    use rocketmq_common::common::constant::file_readahead_mode::READ_AHEAD_MODE;
+    use rocketmq_common::common::message::MessageConst;
     use rocketmq_common::TimeUtils::current_millis;
+    use rocketmq_remoting::base::response_future::ResponseFuture;
+    use rocketmq_remoting::code::request_code::RequestCode;
     use rocketmq_remoting::code::response_code::ResponseCode;
+    use rocketmq_remoting::connection::Connection;
+    use rocketmq_remoting::net::channel::Channel;
+    use rocketmq_remoting::net::channel::ChannelInner;
+    use rocketmq_remoting::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigToJsonRequestHeader;
+    use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+    use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
+    use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
+    use rocketmq_rust::ArcMut;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
     use rocketmq_store::timer::timer_checkpoint::TimerCheckpointSnapshot;
     use rocketmq_store::timer::timer_message_store::TimerMessageStore;
     use rocketmq_store::timer::timer_metrics::TimerMetricsSerializeWrapper;
+    use rocketmq_store::utils::ffi::MADV_NORMAL;
+    use rocketmq_store::utils::ffi::MADV_RANDOM;
 
     use crate::broker_runtime::BrokerRuntime;
 
     use super::BrokerConfigRequestHandler;
+
+    fn temp_test_root(label: &str) -> std::path::PathBuf {
+        let millis = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_millis();
+        std::env::temp_dir().join(format!("rocketmq-rust-admin-broker-config-{label}-{millis}"))
+    }
+
+    async fn new_test_runtime(label: &str, timer_wheel_enable: bool) -> BrokerRuntime {
+        let temp_root = temp_test_root(label);
+        let broker_config = Arc::new(BrokerConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            auth_config_path: temp_root.join("auth.json").to_string_lossy().into_owned().into(),
+            ..BrokerConfig::default()
+        });
+        let message_store_config = Arc::new(MessageStoreConfig {
+            timer_wheel_enable,
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        });
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        assert!(runtime.initialize().await);
+        runtime
+    }
+
+    async fn create_test_channel() -> Channel {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
+        let local_addr = listener.local_addr().expect("local listener addr");
+        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
+        std_stream.set_nonblocking(true).expect("set nonblocking");
+        drop(listener);
+        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
+        let connection = Connection::new(tcp_stream);
+        let response_table = ArcMut::new(HashMap::<i32, ResponseFuture>::new());
+        let inner = ArcMut::new(ChannelInner::new(connection, response_table));
+        Channel::new(inner, local_addr, local_addr)
+    }
 
     #[tokio::test]
     async fn build_timer_metrics_response_returns_encoded_timer_metrics() {
@@ -403,5 +781,225 @@ mod tests {
         assert!(snapshot.last_read_time_ms() > 0);
         assert_eq!(snapshot.master_timer_queue_offset(), 0);
         let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn set_commitlog_read_mode_updates_store_config() {
+        let mut runtime = new_test_runtime("commitlog-read-mode", false).await;
+        let inner = runtime.inner_for_test().clone();
+        let mut handler = BrokerConfigRequestHandler::new(inner.clone());
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request =
+            RemotingCommand::create_remoting_command(RequestCode::SetCommitlogReadMode).set_ext_fields(HashMap::new());
+        request.add_ext_field(CheetahString::from_static_str(READ_AHEAD_MODE), MADV_NORMAL.to_string());
+
+        let response = handler
+            .set_commitlog_read_mode(channel, ctx, RequestCode::SetCommitlogReadMode, &mut request)
+            .await
+            .expect("set commitlog read mode should succeed")
+            .expect("set commitlog read mode should return response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert!(
+            inner
+                .message_store()
+                .expect("message store should exist")
+                .get_message_store_config()
+                .data_read_ahead_enable
+        );
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request =
+            RemotingCommand::create_remoting_command(RequestCode::SetCommitlogReadMode).set_ext_fields(HashMap::new());
+        request.add_ext_field(CheetahString::from_static_str(READ_AHEAD_MODE), MADV_RANDOM.to_string());
+
+        let response = handler
+            .set_commitlog_read_mode(channel, ctx, RequestCode::SetCommitlogReadMode, &mut request)
+            .await
+            .expect("set commitlog read mode should succeed")
+            .expect("set commitlog read mode should return response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert!(
+            !inner
+                .message_store()
+                .expect("message store should exist")
+                .get_message_store_config()
+                .data_read_ahead_enable
+        );
+
+        let _ = fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn update_broker_config_applies_supported_runtime_properties() {
+        let mut runtime = new_test_runtime("update-broker-config", false).await;
+        let inner = runtime.inner_for_test().clone();
+        let mut handler = BrokerConfigRequestHandler::new(inner.clone());
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request = RemotingCommand::create_remoting_command(RequestCode::UpdateBrokerConfig).set_body(
+            "enableLiteEventMode=false\nmaxLiteSubscriptionCount=5\nmaxClientEventCount=7\\
+             nliteEventFullDispatchDelayTime=1234",
+        );
+
+        let response = handler
+            .update_broker_config(channel, ctx, RequestCode::UpdateBrokerConfig, &mut request)
+            .await
+            .expect("update broker config should return broker response")
+            .expect("update broker config should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert!(!inner.broker_config().enable_lite_event_mode);
+        assert_eq!(inner.broker_config().max_lite_subscription_count, 5);
+        assert_eq!(inner.broker_config().max_client_event_count, 7);
+        assert_eq!(inner.broker_config().lite_event_full_dispatch_delay_time, 1234);
+
+        let _ = fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn update_broker_config_rejects_unsupported_or_invalid_keys() {
+        let mut runtime = new_test_runtime("update-broker-config-invalid", false).await;
+        let inner = runtime.inner_for_test().clone();
+        let mut handler = BrokerConfigRequestHandler::new(inner.clone());
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request = RemotingCommand::create_remoting_command(RequestCode::UpdateBrokerConfig)
+            .set_body("unknownKey=true\nmaxClientEventCount=0");
+
+        let response = handler
+            .update_broker_config(channel, ctx, RequestCode::UpdateBrokerConfig, &mut request)
+            .await
+            .expect("update broker config should return broker response")
+            .expect("update broker config should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
+        assert!(response
+            .remark()
+            .is_some_and(|remark| remark.contains("maxClientEventCount")));
+        assert_eq!(inner.broker_config().max_client_event_count, 100);
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request =
+            RemotingCommand::create_remoting_command(RequestCode::UpdateBrokerConfig).set_body("unknownKey=true");
+
+        let response = handler
+            .update_broker_config(channel, ctx, RequestCode::UpdateBrokerConfig, &mut request)
+            .await
+            .expect("update broker config should return broker response")
+            .expect("update broker config should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
+        assert!(response
+            .remark()
+            .is_some_and(|remark| remark.contains("unsupported broker config keys: unknownKey")));
+
+        let _ = fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn export_rocksdb_config_to_json_persists_requested_managers() {
+        let mut runtime = new_test_runtime("export-config", false).await;
+        let mut inner = runtime.inner_for_test().clone();
+        inner
+            .topic_config_manager_mut()
+            .update_topic_config(ArcMut::new(TopicConfig::with_queues("export-topic", 1, 1)));
+
+        let mut subscription_group_config = SubscriptionGroupConfig::default();
+        subscription_group_config.set_group_name(CheetahString::from_static_str("export-group"));
+        inner
+            .subscription_group_manager_mut()
+            .update_subscription_group_config(&mut subscription_group_config);
+        inner.consumer_offset_manager().commit_offset(
+            CheetahString::from_static_str("client"),
+            &CheetahString::from_static_str("export-group"),
+            &CheetahString::from_static_str("export-topic"),
+            0,
+            7,
+        );
+
+        let mut handler = BrokerConfigRequestHandler::new(inner.clone());
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::ExportRocksdbConfigToJson,
+            ExportRocksdbConfigToJsonRequestHeader {
+                config_type: CheetahString::from_static_str("topics;subscriptionGroups;consumerOffsets;"),
+            },
+        );
+        request.make_custom_header_to_net();
+
+        let response = handler
+            .export_rocksdb_config_to_json(channel, ctx, RequestCode::ExportRocksdbConfigToJson, &mut request)
+            .await
+            .expect("export config should succeed")
+            .expect("export config should return response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let topic_json =
+            fs::read_to_string(inner.topic_config_manager().config_file_path()).expect("topic config file");
+        let group_json =
+            fs::read_to_string(inner.subscription_group_manager().config_file_path()).expect("group config file");
+        let offset_json =
+            fs::read_to_string(inner.consumer_offset_manager().config_file_path()).expect("offset config file");
+        assert!(topic_json.contains("export-topic"));
+        assert!(group_json.contains("export-group"));
+        assert!(offset_json.contains("export-topic@export-group"));
+
+        let _ = fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn switch_timer_engine_accepts_file_time_wheel_and_rejects_rocksdb() {
+        let mut runtime = new_test_runtime("switch-timer-engine", true).await;
+        let inner = runtime.inner_for_test().clone();
+        let mut handler = BrokerConfigRequestHandler::new(inner.clone());
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut file_request =
+            RemotingCommand::create_remoting_command(RequestCode::SwitchTimerEngine).set_ext_fields(HashMap::new());
+        file_request.add_ext_field(
+            CheetahString::from_static_str(MessageConst::TIMER_ENGINE_TYPE),
+            MessageConst::TIMER_ENGINE_FILE_TIME_WHEEL,
+        );
+
+        let response = handler
+            .switch_timer_engine(channel, ctx, RequestCode::SwitchTimerEngine, &mut file_request)
+            .await
+            .expect("switch timer engine should succeed")
+            .expect("switch timer engine should return response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert!(inner
+            .timer_message_store()
+            .expect("timer message store should exist")
+            .is_should_running_dequeue());
+
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut rocksdb_request =
+            RemotingCommand::create_remoting_command(RequestCode::SwitchTimerEngine).set_ext_fields(HashMap::new());
+        rocksdb_request.add_ext_field(
+            CheetahString::from_static_str(MessageConst::TIMER_ENGINE_TYPE),
+            MessageConst::TIMER_ENGINE_ROCKSDB_TIMELINE,
+        );
+
+        let response = handler
+            .switch_timer_engine(channel, ctx, RequestCode::SwitchTimerEngine, &mut rocksdb_request)
+            .await
+            .expect("switch timer engine should succeed")
+            .expect("switch timer engine should return response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
+
+        let _ = fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
@@ -41,6 +41,7 @@ use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::filter::MessageFilter;
 use serde::Serialize;
+use std::time::Duration;
 
 use crate::broker_runtime::BrokerRuntimeInner;
 use crate::filter::expression_message_filter::ExpressionMessageFilter;
@@ -285,6 +286,35 @@ where
         Ok(Some(response.set_body(body.encode()?)))
     }
 
+    pub async fn pop_rollback(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        _request_code: RequestCode,
+        _request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let response = RemotingCommand::create_response_command();
+        let Some(pop_message_processor) = self.broker_runtime_inner.pop_message_processor().cloned() else {
+            return Ok(Some(response.set_code(ResponseCode::Success)));
+        };
+
+        let pop_buffer_merge_service = pop_message_processor.pop_buffer_merge_service().clone();
+        pop_buffer_merge_service.shutdown();
+        match pop_buffer_merge_service.wait_for_shutdown(Duration::from_secs(5)).await {
+            Ok(()) => {
+                crate::processor::processor_service::pop_buffer_merge_service::PopBufferMergeService::start(
+                    pop_buffer_merge_service,
+                );
+                Ok(Some(response.set_code(ResponseCode::Success)))
+            }
+            Err(error) => Ok(Some(
+                response
+                    .set_code(ResponseCode::SystemError)
+                    .set_remark(error.to_string()),
+            )),
+        }
+    }
+
     async fn rewrite_request_for_static_topic(
         &mut self,
         request_header: &SearchOffsetRequestHeader,
@@ -457,6 +487,7 @@ mod tests {
     use rocketmq_remoting::net::channel::Channel;
     use rocketmq_remoting::net::channel::ChannelInner;
     use rocketmq_remoting::protocol::body::query_consume_queue_response_body::QueryConsumeQueueResponseBody;
+    use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
     use rocketmq_remoting::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
     use rocketmq_remoting::protocol::header::resume_check_half_message_request_header::ResumeCheckHalfMessageRequestHeader;
     use rocketmq_remoting::protocol::heartbeat::consume_type::ConsumeType;
@@ -649,6 +680,52 @@ mod tests {
         assert_eq!(body.filter_data, Some(CheetahString::from_static_str("null")));
         assert_eq!(body.subscription_data.expect("subscription data").topic, "topic-a");
         assert_eq!(body.queue_data.expect("queue data").len(), 1);
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn pop_rollback_drains_pop_buffer_and_restarts_service() {
+        let mut runtime = new_test_runtime("pop-rollback").await;
+        runtime.init_processor_for_test();
+        let inner = runtime.inner_for_test().clone();
+        let pop_message_processor = inner
+            .pop_message_processor()
+            .cloned()
+            .expect("pop message processor should exist");
+        pop_message_processor.mut_from_ref().start();
+
+        let service = pop_message_processor.pop_buffer_merge_service().clone();
+        service
+            .mut_from_ref()
+            .add_ck_mock(
+                CheetahString::from_static_str("group-a"),
+                CheetahString::from_static_str("topic-a"),
+                0,
+                1,
+                60_000,
+                rocketmq_common::TimeUtils::current_millis() as u64,
+                0,
+                1,
+                inner.broker_config().broker_name().clone(),
+            )
+            .await;
+        assert!(service.get_offset_total_size().await > 0);
+
+        let mut handler = MessageRelatedHandler::new(inner.clone());
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request = RemotingCommand::create_request_command(RequestCode::PopRollback, EmptyHeader::default());
+        request.make_custom_header_to_net();
+
+        let response = handler
+            .pop_rollback(channel, ctx, RequestCode::PopRollback, &mut request)
+            .await
+            .expect("pop rollback should succeed")
+            .expect("pop rollback should return response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert_eq!(service.get_offset_total_size().await, 0);
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-broker/src/processor/lite_manager_processor.rs
+++ b/rocketmq-broker/src/processor/lite_manager_processor.rs
@@ -375,14 +375,26 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
         };
 
         let dispatcher = self.broker_runtime_inner.lite_event_dispatcher();
+        let (max_event_count, dispatch_delay_millis) = self.lite_dispatch_policy(&group);
         if let Some(client_id) = client_id.filter(|client_id| !client_id.is_empty()) {
             let lmq_names = self.dispatchable_lmq_for_client(&client_id, &group, &bind_topic);
             if !lmq_names.is_empty() {
-                dispatcher.do_full_dispatch(&client_id, &group, &lmq_names);
+                dispatcher.do_full_dispatch_with_limit(
+                    &client_id,
+                    &group,
+                    &lmq_names,
+                    max_event_count,
+                    dispatch_delay_millis,
+                );
             }
         } else {
             let dispatch_map = self.dispatchable_lmq_by_group(&group, &bind_topic);
-            dispatcher.do_full_dispatch_by_group(&group, &dispatch_map);
+            dispatcher.do_full_dispatch_by_group_with_limit(
+                &group,
+                &dispatch_map,
+                max_event_count,
+                dispatch_delay_millis,
+            );
         }
 
         Ok(Some(
@@ -589,6 +601,19 @@ impl<MS: MessageStore> LiteManagerProcessor<MS> {
             lite_topics = lite_topics.into_iter().take(max_count as usize).collect();
         }
         lite_topics.into_iter().map(CheetahString::from_string).collect()
+    }
+
+    fn lite_dispatch_policy(&self, group: &CheetahString) -> (usize, u64) {
+        let broker_config = self.broker_runtime_inner.broker_config();
+        let max_event_count = self
+            .broker_runtime_inner
+            .subscription_group_manager()
+            .find_subscription_group_config(group)
+            .map(|config| config.max_client_event_count())
+            .filter(|count| *count > 0)
+            .unwrap_or(broker_config.max_client_event_count)
+            .max(1) as usize;
+        (max_event_count, broker_config.lite_event_full_dispatch_delay_time)
     }
 
     fn validate_consumer_group(

--- a/rocketmq-broker/src/processor/pop_lite_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor.rs
@@ -104,6 +104,19 @@ impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
         self.consumer_order_info_manager.clear_block(topic, group, 0);
     }
 
+    fn lite_dispatch_policy(&self, group: &CheetahString) -> (usize, u64) {
+        let broker_config = self.broker_runtime_inner.broker_config();
+        let max_event_count = self
+            .broker_runtime_inner
+            .subscription_group_manager()
+            .find_subscription_group_config(group)
+            .map(|config| config.max_client_event_count())
+            .filter(|count| *count > 0)
+            .unwrap_or(broker_config.max_client_event_count)
+            .max(1) as usize;
+        (max_event_count, broker_config.lite_event_full_dispatch_delay_time)
+    }
+
     fn pre_check(&self, request_header: &PopLiteMessageRequestHeader) -> Option<(ResponseCode, CheetahString)> {
         if request_header.client_id.is_empty() {
             return Some((
@@ -470,10 +483,13 @@ impl<MS: MessageStore> RequestProcessor for PopLiteMessageProcessor<MS> {
         let (body, requeue_events, fetched_count, order_count_info) =
             self.pop_from_events(&request_header, pending_events).await;
         if !requeue_events.is_empty() {
-            dispatcher.do_full_dispatch(
+            let (max_event_count, dispatch_delay_millis) = self.lite_dispatch_policy(&request_header.consumer_group);
+            dispatcher.do_full_dispatch_with_limit(
                 &request_header.client_id,
                 &request_header.consumer_group,
                 &requeue_events,
+                max_event_count,
+                dispatch_delay_millis,
             );
         }
 

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -203,6 +203,10 @@ mod defaults {
         false
     }
 
+    pub fn max_client_event_count() -> i32 {
+        100
+    }
+
     pub fn lite_event_full_dispatch_delay_time() -> u64 {
         10_000
     }
@@ -720,6 +724,9 @@ pub struct BrokerConfig {
     #[serde(default = "defaults::enable_lite_pop_log")]
     pub enable_lite_pop_log: bool,
 
+    #[serde(default = "defaults::max_client_event_count")]
+    pub max_client_event_count: i32,
+
     #[serde(default = "defaults::lite_event_full_dispatch_delay_time")]
     pub lite_event_full_dispatch_delay_time: u64,
 
@@ -1033,6 +1040,7 @@ impl Default for BrokerConfig {
             lite_subscription_check_timeout_mills: defaults::lite_subscription_check_timeout_mills(),
             max_lite_subscription_count: defaults::max_lite_subscription_count(),
             enable_lite_pop_log: defaults::enable_lite_pop_log(),
+            max_client_event_count: defaults::max_client_event_count(),
             lite_event_full_dispatch_delay_time: defaults::lite_event_full_dispatch_delay_time(),
             lite_lag_latency_collect_enable: defaults::lite_lag_latency_collect_enable(),
             lite_lag_latency_metrics_enable: defaults::lite_lag_latency_metrics_enable(),
@@ -1309,6 +1317,10 @@ impl BrokerConfig {
         );
         properties.insert("enableLitePopLog".into(), self.enable_lite_pop_log.to_string().into());
         properties.insert(
+            "maxClientEventCount".into(),
+            self.max_client_event_count.to_string().into(),
+        );
+        properties.insert(
             "liteEventFullDispatchDelayTime".into(),
             self.lite_event_full_dispatch_delay_time.to_string().into(),
         );
@@ -1458,6 +1470,7 @@ mod tests {
         assert_eq!(config.lite_subscription_check_timeout_mills, 180_000);
         assert_eq!(config.max_lite_subscription_count, 100_000);
         assert!(!config.enable_lite_pop_log);
+        assert_eq!(config.max_client_event_count, 100);
         assert_eq!(config.lite_event_full_dispatch_delay_time, 10_000);
         assert!(!config.lite_lag_latency_collect_enable);
         assert!(!config.lite_lag_latency_metrics_enable);
@@ -1505,6 +1518,10 @@ mod tests {
         assert_eq!(
             properties.get("enableLitePopLog").map(|value| value.as_str()),
             Some("false")
+        );
+        assert_eq!(
+            properties.get("maxClientEventCount").map(|value| value.as_str()),
+            Some("100")
         );
         assert_eq!(
             properties

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -35,6 +35,7 @@ pub mod empty_header;
 pub mod end_transaction_request_header;
 pub mod exchange_ha_info_request_header;
 pub mod exchange_ha_info_response_header;
+pub mod export_rocksdb_config_to_json_request_header;
 pub mod extra_info_util;
 pub mod get_acl_request_header;
 pub mod get_all_topic_config_response_header;

--- a/rocketmq-remoting/src/protocol/header/export_rocksdb_config_to_json_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/export_rocksdb_config_to_json_request_header.rs
@@ -1,0 +1,84 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+const CONFIG_TYPE_SEPARATOR: char = ';';
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExportRocksdbConfigType {
+    Topics,
+    SubscriptionGroups,
+    ConsumerOffsets,
+}
+
+impl ExportRocksdbConfigType {
+    pub fn parse_many(config_type: &str) -> Result<Vec<Self>, String> {
+        config_type
+            .split(CONFIG_TYPE_SEPARATOR)
+            .filter(|segment| !segment.trim().is_empty())
+            .map(|segment| match segment.trim().to_ascii_lowercase().as_str() {
+                "topics" => Ok(Self::Topics),
+                "subscriptiongroups" => Ok(Self::SubscriptionGroups),
+                "consumeroffsets" => Ok(Self::ConsumerOffsets),
+                other => Err(format!("unknown config type: {other}")),
+            })
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportRocksdbConfigToJsonRequestHeader {
+    #[required]
+    pub config_type: CheetahString,
+}
+
+impl ExportRocksdbConfigToJsonRequestHeader {
+    pub fn fetch_config_type(&self) -> Result<Vec<ExportRocksdbConfigType>, String> {
+        ExportRocksdbConfigType::parse_many(self.config_type.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn export_rocksdb_config_to_json_request_header_parses_from_map() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("configType"),
+            CheetahString::from_static_str("topics;subscriptionGroups;consumerOffsets;"),
+        );
+
+        let header = <ExportRocksdbConfigToJsonRequestHeader as FromMap>::from(&map)
+            .expect("header should decode from ext fields");
+
+        assert_eq!(
+            header.fetch_config_type().expect("config types should parse"),
+            vec![
+                ExportRocksdbConfigType::Topics,
+                ExportRocksdbConfigType::SubscriptionGroups,
+                ExportRocksdbConfigType::ConsumerOffsets,
+            ]
+        );
+    }
+}

--- a/rocketmq-remoting/src/protocol/headers.rs
+++ b/rocketmq-remoting/src/protocol/headers.rs
@@ -136,6 +136,7 @@ pub mod admin {
     pub use super::super::header::create_topic_request_header::CreateTopicRequestHeader;
     pub use super::super::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
     pub use super::super::header::delete_topic_request_header::DeleteTopicRequestHeader;
+    pub use super::super::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigToJsonRequestHeader;
     pub use super::super::header::get_all_topic_config_response_header::GetAllTopicConfigResponseHeader;
     pub use super::super::header::get_consume_stats_in_broker_header::GetConsumeStatsInBrokerHeader;
     pub use super::super::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader;

--- a/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
+++ b/rocketmq-remoting/src/protocol/subscription/subscription_group_config.rs
@@ -18,6 +18,7 @@ use std::collections::HashSet;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::attribute::subscription_group_attributes::SubscriptionGroupAttributes;
 use rocketmq_common::common::attribute::subscription_group_attributes::LITE_BIND_TOPIC_ATTRIBUTE_NAME;
+use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_CLIENT_MAX_EVENT_COUNT_ATTRIBUTE_NAME;
 use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_CLIENT_QUOTA_ATTRIBUTE_NAME;
 use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_MODEL_ATTRIBUTE_NAME;
 use rocketmq_common::common::attribute::subscription_group_attributes::LITE_SUB_RESET_OFFSET_EXCLUSIVE_ATTRIBUTE_NAME;
@@ -190,6 +191,16 @@ impl SubscriptionGroupConfig {
         self.attributes
             .get(&CheetahString::from_static_str(LITE_SUB_MODEL_ATTRIBUTE_NAME))
             .is_some_and(|value| value == "Exclusive")
+    }
+
+    #[inline]
+    pub fn max_client_event_count(&self) -> i32 {
+        self.attributes
+            .get(&CheetahString::from_static_str(
+                LITE_SUB_CLIENT_MAX_EVENT_COUNT_ATTRIBUTE_NAME,
+            ))
+            .and_then(|value| value.parse::<i32>().ok())
+            .unwrap_or(-1)
     }
 
     #[inline]
@@ -385,6 +396,7 @@ mod subscription_group_config_tests {
 
         assert_eq!(config.lite_sub_client_quota(), 2000);
         assert!(!config.lite_sub_exclusive());
+        assert_eq!(config.max_client_event_count(), -1);
         assert!(!config.reset_offset_in_exclusive_mode());
         assert!(!config.reset_offset_on_unsubscribe());
     }
@@ -402,6 +414,10 @@ mod subscription_group_config_tests {
                 CheetahString::from_static_str("Exclusive"),
             ),
             (
+                CheetahString::from_static_str(LITE_SUB_CLIENT_MAX_EVENT_COUNT_ATTRIBUTE_NAME),
+                CheetahString::from_static_str("256"),
+            ),
+            (
                 CheetahString::from_static_str(LITE_SUB_RESET_OFFSET_EXCLUSIVE_ATTRIBUTE_NAME),
                 CheetahString::from_static_str("true"),
             ),
@@ -413,6 +429,7 @@ mod subscription_group_config_tests {
 
         assert_eq!(config.lite_sub_client_quota(), 128);
         assert!(config.lite_sub_exclusive());
+        assert_eq!(config.max_client_event_count(), 256);
         assert!(config.reset_offset_in_exclusive_mode());
         assert!(config.reset_offset_on_unsubscribe());
     }

--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -421,6 +421,9 @@ pub trait MessageStoreInner: Sync + 'static {
 
     fn get_commit_log_mut(&mut self) -> &mut CommitLog;
 
+    /// Update commitlog read mode and synchronize any cached store config snapshots.
+    fn set_commitlog_read_mode(&mut self, read_ahead_mode: i32) -> Result<(), StoreError>;
+
     /// Get running flags
     fn get_running_flags(&self) -> &RunningFlags;
 

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -86,6 +86,9 @@ use crate::message_store::local_file_message_store::LocalFileMessageStore;
 use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
 use crate::queue::local_file_consume_queue_store::ConsumeQueueStore;
 use crate::store_error::StoreError;
+use crate::utils::ffi::madvise;
+use crate::utils::ffi::MADV_NORMAL;
+use crate::utils::ffi::MADV_RANDOM;
 
 // Message's MAGIC CODE daa320a7
 pub const MESSAGE_MAGIC_CODE: i32 = -626843481;
@@ -1690,6 +1693,38 @@ impl CommitLog {
 
     pub fn sync_broker_role(&mut self, broker_role: BrokerRole) {
         Arc::make_mut(&mut self.message_store_config).broker_role = broker_role;
+    }
+
+    pub fn set_data_read_ahead_enable(&mut self, enabled: bool) {
+        Arc::make_mut(&mut self.message_store_config).data_read_ahead_enable = enabled;
+    }
+
+    pub fn is_data_read_ahead_enable(&self) -> bool {
+        self.message_store_config.data_read_ahead_enable
+    }
+
+    pub fn scan_file_and_set_read_mode(&self, read_ahead_mode: i32) -> usize {
+        if read_ahead_mode != MADV_NORMAL && read_ahead_mode != MADV_RANDOM {
+            return 0;
+        }
+
+        let mapped_files = self.mapped_file_queue.get_mapped_files().load();
+        let mut updated = 0;
+        for mapped_file in mapped_files.iter() {
+            let mmap = mapped_file.get_mapped_file();
+            let result = madvise(mmap.as_ptr(), mmap.len(), read_ahead_mode);
+            if result == 0 {
+                updated += 1;
+            } else {
+                warn!(
+                    "failed to apply read mode {} for {}: result={}",
+                    read_ahead_mode,
+                    mapped_file.get_file_name(),
+                    result
+                );
+            }
+        }
+        updated
     }
 }
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -123,6 +123,7 @@ use crate::store_path_config_helper::get_abort_file;
 use crate::store_path_config_helper::get_store_checkpoint;
 use crate::store_path_config_helper::get_store_path_consume_queue;
 use crate::timer::timer_message_store::TimerMessageStore;
+use crate::utils::ffi::MADV_NORMAL;
 use crate::utils::store_util::TOTAL_PHYSICAL_MEMORY_SIZE;
 
 ///Using local files to store message data, which is also the default method.
@@ -1829,6 +1830,14 @@ impl MessageStore for LocalFileMessageStore {
 
     fn get_commit_log_mut(&mut self) -> &mut CommitLog {
         self.commit_log.as_mut()
+    }
+
+    fn set_commitlog_read_mode(&mut self, read_ahead_mode: i32) -> Result<(), StoreError> {
+        let data_read_ahead_enable = read_ahead_mode == MADV_NORMAL;
+        Arc::make_mut(&mut self.message_store_config).data_read_ahead_enable = data_read_ahead_enable;
+        self.commit_log.set_data_read_ahead_enable(data_read_ahead_enable);
+        self.commit_log.scan_file_and_set_read_mode(read_ahead_mode);
+        Ok(())
     }
 
     fn get_running_flags(&self) -> &RunningFlags {

--- a/rocketmq-store/src/utils.rs
+++ b/rocketmq-store/src/utils.rs
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod ffi;
+pub mod ffi;
 pub(crate) mod store_util;

--- a/rocketmq-store/src/utils/ffi.rs
+++ b/rocketmq-store/src/utils/ffi.rs
@@ -15,10 +15,10 @@
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 
-pub(crate) const MADV_NORMAL: i32 = 0;
-pub(crate) const MADV_RANDOM: i32 = 1;
-pub(crate) const MADV_WILLNEED: i32 = 3;
-pub(crate) const MADV_DONTNEED: i32 = 4;
+pub const MADV_NORMAL: i32 = 0;
+pub const MADV_RANDOM: i32 = 1;
+pub const MADV_WILLNEED: i32 = 3;
+pub const MADV_DONTNEED: i32 = 4;
 
 #[inline]
 pub fn get_page_size() -> usize {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7058

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event dispatch now respects configurable `max_client_event_count` limits per client and subscription group
  * Added admin command support for RocksDB configuration export
  * Added commit log read-ahead mode control for performance tuning
  * Added timer engine switching capability
  * Added pop message rollback handler

* **Chores**
  * Made FFI memory advisory constants publicly accessible

<!-- end of auto-generated comment: release notes by coderabbit.ai -->