### PR TITLE
[ISSUE #7064]🚀feat(commit-log): implement shutdown and destroy methods with proper resource management and add tests for commit log functionality

### DIFF
--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -408,7 +408,7 @@ impl MappedFileQueue {
     }
 
     #[inline]
-    pub(crate) fn delete_expired_file(&mut self, files: Vec<Arc<DefaultMappedFile>>) {
+    pub(crate) fn delete_expired_file(&self, files: Vec<Arc<DefaultMappedFile>>) {
         let mut files = files;
         let current_files = self.mapped_files.load();
         if !files.is_empty() {
@@ -488,7 +488,7 @@ impl MappedFileQueue {
     ///
     /// # Returns
     /// Number of files deleted
-    pub fn delete_expired_file_by_offset(&mut self, offset: i64, unit_size: i32) -> i32 {
+    pub fn delete_expired_file_by_offset(&self, offset: i64, unit_size: i32) -> i32 {
         let mfs = (**self.mapped_files.load()).clone();
         let mut files = Vec::new();
         let mut delete_count = 0;

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -339,11 +339,14 @@ impl CommitLog {
     }
 
     pub fn shutdown(&mut self) {
-        error!("shutdown commit log unimplemented");
+        self.flush();
+        self.flush_manager.shutdown();
     }
 
     pub fn destroy(&mut self) {
-        error!("destroy commit log unimplemented");
+        self.shutdown();
+        self.mapped_file_queue.destroy();
+        self.mapped_file_queue.set_committed_where(0);
     }
 
     pub fn get_message(&self, offset: i64, size: i32) -> Option<SelectMappedBufferResult> {
@@ -2051,18 +2054,21 @@ fn is_mapped_file_matched_recover(
 }
 
 impl Swappable for CommitLog {
-    fn swap_map(&self, _reserve_num: i32, _force_swap_interval_ms: i64, _normal_swap_interval_ms: i64) {
-        todo!()
+    fn swap_map(&self, reserve_num: i32, force_swap_interval_ms: i64, normal_swap_interval_ms: i64) {
+        self.mapped_file_queue
+            .swap_map(reserve_num, force_swap_interval_ms, normal_swap_interval_ms);
     }
 
-    fn clean_swapped_map(&self, _force_clean_swap_interval_ms: i64) {
-        todo!()
+    fn clean_swapped_map(&self, force_clean_swap_interval_ms: i64) {
+        self.mapped_file_queue.clean_swapped_map(force_clean_swap_interval_ms);
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::path::Path;
+    use std::path::PathBuf;
     use std::sync::Arc;
 
     use super::*;
@@ -2168,5 +2174,57 @@ mod tests {
         assert_eq!(store.get_confirm_offset(), 6);
 
         let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn shutdown_flushes_pending_commitlog_data() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-commitlog-shutdown-{}", current_millis()));
+        let mut store = new_test_message_store(&temp_root, BrokerRole::SyncMaster, false);
+        store.init().await.expect("init message store");
+
+        store
+            .get_commit_log_mut()
+            .append_data(0, &[1, 2, 3, 4], 0, 4)
+            .await
+            .expect("append data");
+
+        assert_eq!(store.get_commit_log().get_flushed_where(), 0);
+        assert_eq!(store.get_commit_log().get_max_offset(), 4);
+
+        store.get_commit_log_mut().shutdown();
+
+        assert_eq!(store.get_commit_log().get_flushed_where(), 4);
+        assert_eq!(
+            store.get_commit_log().get_flushed_where(),
+            store.get_commit_log().get_max_offset()
+        );
+
+        let _ = fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn destroy_removes_commitlog_files_and_resets_offsets() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-commitlog-destroy-{}", current_millis()));
+        let mut store = new_test_message_store(&temp_root, BrokerRole::SyncMaster, false);
+        store.init().await.expect("init message store");
+
+        store
+            .get_commit_log_mut()
+            .append_data(0, &[1, 2, 3, 4], 0, 4)
+            .await
+            .expect("append data");
+
+        let commitlog_dir = PathBuf::from(store.get_message_store_config().get_store_path_commit_log());
+        assert!(commitlog_dir.exists());
+        assert!(!store.get_commit_log().is_mapped_files_empty());
+
+        store.get_commit_log_mut().destroy();
+
+        assert!(store.get_commit_log().is_mapped_files_empty());
+        assert_eq!(store.get_commit_log().get_flushed_where(), 0);
+        assert_eq!(store.get_commit_log().get_max_offset(), 0);
+        assert!(!commitlog_dir.exists());
+
+        let _ = fs::remove_dir_all(temp_root);
     }
 }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -2102,7 +2102,9 @@ impl MessageStore for LocalFileMessageStore {
         to: i64,
         filter: &dyn MessageFilter,
     ) -> i64 {
-        todo!()
+        self.get_consume_queue(topic, queue_id)
+            .map(|logic_queue| logic_queue.estimate_message_count(from, to, filter))
+            .unwrap_or(0)
     }
 
     fn recover_topic_queue_table(&mut self) {
@@ -2922,6 +2924,7 @@ pub fn parse_delay_level(level_string: &str) -> (BTreeMap<i32, i64>, i32) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::collections::HashSet;
     use std::sync::Arc;
     use std::thread;
@@ -2943,10 +2946,14 @@ mod tests {
     use super::LocalFileMessageStore;
     use crate::base::dispatch_request::DispatchRequest;
     use crate::base::message_result::PutMessageResult;
+    use crate::base::message_status_enum::PutMessageStatus;
     use crate::base::message_store::MessageStore;
     use crate::base::store_checkpoint::StoreCheckpoint;
+    use crate::config::flush_disk_type::FlushDiskType;
     use crate::config::message_store_config::MessageStoreConfig;
+    use crate::filter::MessageFilter;
     use crate::hook::put_message_hook::PutMessageHook;
+    use crate::queue::consume_queue::ConsumeQueueTrait;
     use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
     use crate::store_path_config_helper::get_store_checkpoint;
 
@@ -3140,6 +3147,40 @@ mod tests {
     }
 
     #[test]
+    fn consume_queue_reports_basic_runtime_metadata() {
+        let temp_dir = tempdir().unwrap();
+        let store = new_test_store(&temp_dir);
+        let topic = CheetahString::from_static_str("consume-queue-metadata-topic");
+
+        store
+            .consume_queue_store
+            .put_message_position_info_wrapper(&DispatchRequest {
+                topic: topic.clone(),
+                queue_id: 1,
+                commit_log_offset: 123,
+                msg_size: 32,
+                consume_queue_offset: 0,
+                store_timestamp: 5678,
+                success: true,
+                ..DispatchRequest::default()
+            });
+
+        let consume_queue = store.consume_queue_store.find_or_create_consume_queue(&topic, 1);
+        let expected_roll = store.message_store_config_ref().get_mapped_file_size_consume_queue() as i64
+            / consume_queue.get_unit_size() as i64;
+
+        assert_eq!(consume_queue.get_message_total_in_queue(), 1);
+        assert_eq!(consume_queue.get_last_offset(), 155);
+        assert_eq!(consume_queue.roll_next_file(1), expected_roll);
+        assert!(consume_queue.is_first_file_exist());
+        assert!(consume_queue.is_first_file_available());
+        assert_eq!(
+            consume_queue.get_total_size(),
+            store.message_store_config_ref().get_mapped_file_size_consume_queue() as i64
+        );
+    }
+
+    #[test]
     fn flush_consume_queue_service_start_persists_logic_checkpoint_to_disk() {
         let temp_dir = tempdir().unwrap();
         let mut store = ArcMut::new(LocalFileMessageStore::new(
@@ -3194,5 +3235,82 @@ mod tests {
         }
 
         store.flush_consume_queue_service.shutdown();
+    }
+
+    #[tokio::test]
+    async fn default_local_path_supports_consume_queue_time_queries_and_estimation() {
+        struct MatchAllFilter;
+
+        impl MessageFilter for MatchAllFilter {
+            fn is_matched_by_consume_queue(
+                &self,
+                _tags_code: Option<i64>,
+                _cq_ext_unit: Option<&crate::consume_queue::cq_ext_unit::CqExtUnit>,
+            ) -> bool {
+                true
+            }
+
+            fn is_matched_by_commit_log(
+                &self,
+                _msg_buffer: Option<&[u8]>,
+                _properties: Option<&HashMap<CheetahString, CheetahString>>,
+            ) -> bool {
+                true
+            }
+        }
+
+        let temp_dir = tempdir().unwrap();
+        let mut store = ArcMut::new(LocalFileMessageStore::new(
+            Arc::new(MessageStoreConfig {
+                store_path_root_dir: temp_dir.path().to_string_lossy().to_string().into(),
+                flush_disk_type: FlushDiskType::AsyncFlush,
+                ..MessageStoreConfig::default()
+            }),
+            Arc::new(BrokerConfig::default()),
+            Arc::new(DashMap::<CheetahString, ArcMut<TopicConfig>>::new()),
+            None,
+            false,
+        ));
+        let store_clone = store.clone();
+        store.set_message_store_arc(store_clone);
+        let topic = CheetahString::from_static_str("consume-queue-time-query-topic");
+
+        let mut first = MessageExtBrokerInner::default();
+        first.set_topic(topic.clone());
+        first.message_ext_inner.set_queue_id(0);
+        first.set_body(Bytes::from_static(b"first-body"));
+
+        let first_result = store.put_message(first).await;
+        assert_eq!(first_result.put_message_status(), PutMessageStatus::PutOk);
+
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        let mut second = MessageExtBrokerInner::default();
+        second.set_topic(topic.clone());
+        second.message_ext_inner.set_queue_id(0);
+        second.set_body(Bytes::from_static(b"second-body"));
+
+        let second_result = store.put_message(second).await;
+        assert_eq!(second_result.put_message_status(), PutMessageStatus::PutOk);
+
+        store.reput_once().await;
+
+        let first_store_time = store.get_message_store_timestamp(&topic, 0, 0);
+        let second_store_time = store.get_message_store_timestamp(&topic, 0, 1);
+
+        assert!(first_store_time > 0);
+        assert!(second_store_time >= first_store_time);
+        assert_eq!(store.get_earliest_message_time(&topic, 0), first_store_time);
+        assert_eq!(store.get_offset_in_queue_by_time(&topic, 0, first_store_time), 0);
+
+        let consume_queue = store.consume_queue_store.find_or_create_consume_queue(&topic, 0);
+        assert_eq!(
+            consume_queue.get_offset_in_queue_by_time(second_store_time),
+            if second_store_time == first_store_time { 0 } else { 1 }
+        );
+        assert_eq!(store.estimate_message_count(&topic, 0, 0, 1, &MatchAllFilter), 2);
+
+        let latest = consume_queue.get_latest_unit().expect("latest cq unit");
+        assert_eq!(latest.queue_offset, 1);
     }
 }

--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -734,34 +734,39 @@ impl<MS: MessageStore> FileQueueLifeCycle for ConsumeQueue<MS> {
 
     #[inline]
     fn delete_expired_file(&self, min_commit_log_pos: i64) -> i32 {
-        todo!()
+        self.mapped_file_queue
+            .delete_expired_file_by_offset(min_commit_log_pos, CQ_STORE_UNIT_SIZE)
     }
 
     #[inline]
     fn roll_next_file(&self, next_begin_offset: i64) -> i64 {
-        todo!()
+        let units_per_file = self.mapped_file_size as i64 / CQ_STORE_UNIT_SIZE as i64;
+        next_begin_offset + units_per_file - next_begin_offset % units_per_file
     }
 
     #[inline]
     fn is_first_file_available(&self) -> bool {
-        todo!()
+        self.mapped_file_queue
+            .get_first_mapped_file()
+            .is_some_and(|mapped_file| mapped_file.is_available())
     }
 
     #[inline]
     fn is_first_file_exist(&self) -> bool {
-        todo!()
+        self.mapped_file_queue.get_first_mapped_file().is_some()
     }
 }
 
 impl<MS: MessageStore> Swappable for ConsumeQueue<MS> {
     #[inline]
     fn swap_map(&self, reserve_num: i32, force_swap_interval_ms: i64, normal_swap_interval_ms: i64) {
-        todo!()
+        self.mapped_file_queue
+            .swap_map(reserve_num, force_swap_interval_ms, normal_swap_interval_ms);
     }
 
     #[inline]
-    fn clean_swapped_map(&self, _force_clean_swap_interval_ms: i64) {
-        todo!()
+    fn clean_swapped_map(&self, force_clean_swap_interval_ms: i64) {
+        self.mapped_file_queue.clean_swapped_map(force_clean_swap_interval_ms);
     }
 }
 
@@ -795,22 +800,34 @@ impl<MS: MessageStore> ConsumeQueueTrait for ConsumeQueue<MS> {
 
     #[inline]
     fn get_earliest_unit_and_store_time(&self) -> Option<(CqUnit, i64)> {
-        todo!()
+        let min_offset = self.get_min_offset_in_queue();
+        self.get_cq_unit_and_store_time(min_offset)
     }
 
     #[inline]
     fn get_earliest_unit(&self) -> Option<CqUnit> {
-        todo!()
+        self.get(self.get_min_offset_in_queue())
     }
 
     #[inline]
     fn get_latest_unit(&self) -> Option<CqUnit> {
-        todo!()
+        let max_offset = self.get_max_offset_in_queue();
+        if max_offset <= self.get_min_offset_in_queue() {
+            return None;
+        }
+        self.get(max_offset - 1)
     }
 
     #[inline]
     fn get_last_offset(&self) -> i64 {
-        todo!()
+        let max_offset_in_queue = self.get_max_offset_in_queue();
+        if max_offset_in_queue <= self.get_min_offset_in_queue() {
+            return -1;
+        }
+
+        self.get(max_offset_in_queue - 1)
+            .map(|cq_unit| cq_unit.pos + cq_unit.size as i64)
+            .unwrap_or(-1)
     }
 
     #[inline]
@@ -825,12 +842,12 @@ impl<MS: MessageStore> ConsumeQueueTrait for ConsumeQueue<MS> {
 
     #[inline]
     fn get_message_total_in_queue(&self) -> i64 {
-        todo!()
+        self.get_max_offset_in_queue() - self.get_min_offset_in_queue()
     }
 
     #[inline]
     fn get_offset_in_queue_by_time(&self, timestamp: i64) -> i64 {
-        todo!()
+        self.get_offset_in_queue_by_time_with_boundary(timestamp, BoundaryType::Lower)
     }
 
     #[inline]
@@ -850,7 +867,12 @@ impl<MS: MessageStore> ConsumeQueueTrait for ConsumeQueue<MS> {
 
     #[inline]
     fn get_total_size(&self) -> i64 {
-        todo!()
+        self.mapped_file_queue
+            .get_mapped_files()
+            .load()
+            .iter()
+            .map(|mapped_file| mapped_file.get_file_size() as i64)
+            .sum()
     }
 
     #[inline]
@@ -1078,7 +1100,33 @@ impl<MS: MessageStore> ConsumeQueueTrait for ConsumeQueue<MS> {
 
     #[inline]
     fn estimate_message_count(&self, from: i64, to: i64, filter: &dyn MessageFilter) -> i64 {
-        todo!()
+        let start = from.max(self.get_min_offset_in_queue());
+        let end = to.min(self.get_max_offset_in_queue() - 1);
+        if end < start {
+            return 0;
+        }
+
+        let mut count = 0;
+        for index in start..=end {
+            let Some(cq_unit) = self.get(index) else {
+                continue;
+            };
+
+            if !filter.is_matched_by_consume_queue(Some(cq_unit.tags_code), cq_unit.cq_ext_unit.as_ref()) {
+                continue;
+            }
+
+            let matched_commit_log = self
+                .message_store
+                .get_commit_log()
+                .get_message(cq_unit.pos, cq_unit.size)
+                .map(|buffer| filter.is_matched_by_commit_log(Some(buffer.get_buffer()), None))
+                .unwrap_or_else(|| filter.is_matched_by_commit_log(None, None));
+            if matched_commit_log {
+                count += 1;
+            }
+        }
+        count
     }
 
     #[inline]
@@ -1172,5 +1220,114 @@ impl Iterator for ConsumeQueueIterator {
                 Some(cq_unit)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cheetah_string::CheetahString;
+    use dashmap::DashMap;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_rust::ArcMut;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::base::dispatch_request::DispatchRequest;
+    use crate::config::message_store_config::MessageStoreConfig;
+    use crate::message_store::local_file_message_store::LocalFileMessageStore;
+    use crate::store_path_config_helper::get_store_path_consume_queue;
+
+    fn new_test_store(
+        temp_dir: &tempfile::TempDir,
+        mapped_file_size_consume_queue: usize,
+    ) -> ArcMut<LocalFileMessageStore> {
+        let mut store = ArcMut::new(LocalFileMessageStore::new(
+            Arc::new(MessageStoreConfig {
+                store_path_root_dir: temp_dir.path().to_string_lossy().to_string().into(),
+                mapped_file_size_consume_queue,
+                ..MessageStoreConfig::default()
+            }),
+            Arc::new(BrokerConfig::default()),
+            Arc::new(DashMap::<CheetahString, ArcMut<TopicConfig>>::new()),
+            None,
+            false,
+        ));
+        let store_clone = store.clone();
+        store.set_message_store_arc(store_clone);
+        store
+    }
+
+    fn new_test_consume_queue(
+        temp_dir: &tempfile::TempDir,
+        topic: &CheetahString,
+        mapped_file_size_consume_queue: usize,
+    ) -> ConsumeQueue<LocalFileMessageStore> {
+        let store = new_test_store(temp_dir, mapped_file_size_consume_queue);
+        ConsumeQueue::new(
+            topic.clone(),
+            0,
+            CheetahString::from_string(get_store_path_consume_queue(
+                store.get_message_store_config().store_path_root_dir.as_str(),
+            )),
+            mapped_file_size_consume_queue as i32,
+            store,
+        )
+    }
+
+    #[test]
+    fn delete_expired_file_removes_shutdown_rolled_file() {
+        let temp_dir = tempdir().unwrap();
+        let topic = CheetahString::from_static_str("single-cq-delete-expired-topic");
+        let mut consume_queue = new_test_consume_queue(&temp_dir, &topic, (2 * CQ_STORE_UNIT_SIZE) as usize);
+
+        for (queue_offset, commit_log_offset) in [(0_i64, 0_i64), (1, 32), (2, 64)] {
+            consume_queue.put_message_position_info_wrapper(&DispatchRequest {
+                topic: topic.clone(),
+                queue_id: 0,
+                commit_log_offset,
+                msg_size: 32,
+                consume_queue_offset: queue_offset,
+                store_timestamp: 1000 + queue_offset,
+                success: true,
+                ..DispatchRequest::default()
+            });
+        }
+
+        assert_eq!(consume_queue.mapped_file_queue.get_mapped_files_size(), 2);
+        let first_file = consume_queue
+            .mapped_file_queue
+            .get_first_mapped_file()
+            .expect("first mapped file");
+        first_file.shutdown(0);
+
+        assert_eq!(consume_queue.delete_expired_file(64), 1);
+        assert_eq!(consume_queue.mapped_file_queue.get_mapped_files_size(), 1);
+    }
+
+    #[test]
+    fn swap_methods_delegate_without_panicking() {
+        let temp_dir = tempdir().unwrap();
+        let topic = CheetahString::from_static_str("single-cq-swap-topic");
+        let mut consume_queue = new_test_consume_queue(&temp_dir, &topic, (2 * CQ_STORE_UNIT_SIZE) as usize);
+
+        for (queue_offset, commit_log_offset) in [(0_i64, 0_i64), (1, 32), (2, 64), (3, 96)] {
+            consume_queue.put_message_position_info_wrapper(&DispatchRequest {
+                topic: topic.clone(),
+                queue_id: 0,
+                commit_log_offset,
+                msg_size: 32,
+                consume_queue_offset: queue_offset,
+                store_timestamp: 2000 + queue_offset,
+                success: true,
+                ..DispatchRequest::default()
+            });
+        }
+
+        consume_queue.swap_map(3, 0, 0);
+        consume_queue.clean_swapped_map(0);
+        assert_eq!(consume_queue.mapped_file_queue.get_mapped_files_size(), 2);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7064

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message count estimation now available for topic/queue time ranges.
  * Full consume queue lifecycle operations and offset tracking implemented.

* **Bug Fixes**
  * CommitLog shutdown and destroy operations now properly execute with coordinated cleanup.
  * Swap mapping operations now correctly delegate to underlying file queues.

* **Refactor**
  * Optimized file queue operations to use immutable references for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->