### PR TITLE
[ISSUE #7075]🚀refactor(allocate-mapped-file-service): refactor allocation to use blocking thread for file allocation and clean up expired consumer queues synchronously

### DIFF
--- a/rocketmq-store/src/base/allocate_mapped_file_service.rs
+++ b/rocketmq-store/src/base/allocate_mapped_file_service.rs
@@ -19,6 +19,7 @@ use std::fmt::Formatter;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
@@ -60,7 +61,7 @@ pub struct AllocateMappedFileService {
     notify: Arc<Notify>,
 
     /// Background worker handle
-    worker_handle: Arc<parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    worker_handle: Arc<parking_lot::Mutex<Option<thread::JoinHandle<()>>>>,
 
     /// TransientStorePool reference (optional)
     transient_store_pool: Option<Arc<TransientStorePool>>,
@@ -70,6 +71,22 @@ pub struct AllocateMappedFileService {
 
     /// Whether to fast fail when no buffer available in pool
     fast_fail_if_no_buffer: bool,
+}
+
+impl Clone for AllocateMappedFileService {
+    fn clone(&self) -> Self {
+        Self {
+            request_table: self.request_table.clone(),
+            request_queue: self.request_queue.clone(),
+            has_exception: self.has_exception.clone(),
+            stopped: self.stopped.clone(),
+            notify: self.notify.clone(),
+            worker_handle: self.worker_handle.clone(),
+            transient_store_pool: self.transient_store_pool.clone(),
+            transient_store_pool_enable: self.transient_store_pool_enable,
+            fast_fail_if_no_buffer: self.fast_fail_if_no_buffer,
+        }
+    }
 }
 
 impl Default for AllocateMappedFileService {
@@ -125,20 +142,34 @@ impl AllocateMappedFileService {
         let notify = self.notify.clone();
         let transient_store_pool = self.transient_store_pool.clone();
 
-        let handle = tokio::spawn(async move {
-            Self::run_worker(
-                request_table,
-                request_queue,
-                has_exception,
-                stopped,
-                notify,
-                transient_store_pool,
-            )
-            .await;
-        });
-
-        *self.worker_handle.lock() = Some(handle);
-        info!("AllocateMappedFileService started");
+        match thread::Builder::new()
+            .name("allocate-mapped-file-service".to_string())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("AllocateMappedFileService runtime should build");
+                runtime.block_on(async move {
+                    Self::run_worker(
+                        request_table,
+                        request_queue,
+                        has_exception,
+                        stopped,
+                        notify,
+                        transient_store_pool,
+                    )
+                    .await;
+                });
+            }) {
+            Ok(handle) => {
+                *self.worker_handle.lock() = Some(handle);
+                info!("AllocateMappedFileService started");
+            }
+            Err(error) => {
+                self.has_exception.store(true, Ordering::Relaxed);
+                error!("AllocateMappedFileService failed to start worker thread: {}", error);
+            }
+        }
     }
 
     /// Main worker loop - corresponds to Java's run() method
@@ -472,6 +503,74 @@ impl AllocateMappedFileService {
         self.submit_request(file_path, file_size).await
     }
 
+    pub fn allocate_mapped_file_blocking(
+        &self,
+        file_path: String,
+        file_size: u64,
+    ) -> Result<Arc<DefaultMappedFile>, RocketMQError> {
+        let service = self.clone();
+        let error_path = file_path.clone();
+        let allocate = move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|error| RocketMQError::StorageWriteFailed {
+                    path: file_path.clone(),
+                    reason: format!("failed to build allocation runtime: {error}"),
+                })?;
+            runtime.block_on(async move { service.allocate_mapped_file(file_path, file_size).await })
+        };
+
+        if tokio::runtime::Handle::try_current().is_ok() {
+            thread::spawn(allocate)
+                .join()
+                .map_err(|_| RocketMQError::StorageWriteFailed {
+                    path: error_path,
+                    reason: "allocation thread panicked".to_string(),
+                })?
+        } else {
+            allocate()
+        }
+    }
+
+    pub fn submit_request_in_background(&self, file_path: String, file_size: u64) {
+        let mut can_submit_request = true;
+        if self.transient_store_pool_enable && self.fast_fail_if_no_buffer {
+            if let Some(ref pool) = self.transient_store_pool {
+                let queue_size = self.request_queue.read().len();
+                can_submit_request = pool.available_buffer_nums().saturating_sub(queue_size) > 0;
+            }
+        }
+
+        if !can_submit_request {
+            warn!(
+                "[NOTIFYME]TransientStorePool is not enough, so skip background preallocate mapped file, \
+                 RequestQueueSize: {}, StorePoolSize: {}",
+                self.request_queue.read().len(),
+                self.transient_store_pool
+                    .as_ref()
+                    .map_or(0, |pool| pool.available_buffer_nums())
+            );
+            return;
+        }
+
+        let req = Arc::new(AllocateRequest::new(file_path.clone(), file_size as i32));
+        let put_ok = {
+            let mut table = self.request_table.write();
+            if let std::collections::hash_map::Entry::Vacant(entry) = table.entry(file_path) {
+                entry.insert(req.clone());
+                true
+            } else {
+                false
+            }
+        };
+
+        if put_ok {
+            self.request_queue.write().push(req);
+            self.notify.notify_one();
+        }
+    }
+
     /// Shutdown the service - corresponds to Java's shutdown()
     pub async fn shutdown(&self) {
         info!("AllocateMappedFileService: shutting down");
@@ -482,7 +581,7 @@ impl AllocateMappedFileService {
         // Wait for worker to complete
         let handle = self.worker_handle.lock().take();
         if let Some(handle) = handle {
-            let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+            let _ = tokio::task::spawn_blocking(move || handle.join()).await;
         }
 
         // Clean up pre-allocated files
@@ -594,5 +693,29 @@ impl Ord for AllocateRequest {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // Reverse ordering: smaller offsets come out first (min-heap behavior)
         other.file_offset().cmp(&self.file_offset())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn allocate_mapped_file_blocking_works_inside_runtime() {
+        let temp_dir = tempdir().expect("temp dir");
+        let file_path = temp_dir.path().join("00000000000000000000");
+        let service = AllocateMappedFileService::new();
+        service.start();
+
+        let mapped_file = service
+            .allocate_mapped_file_blocking(file_path.to_string_lossy().to_string(), 1024)
+            .expect("allocate mapped file");
+
+        assert_eq!(mapped_file.get_file_size(), 1024);
+        assert!(file_path.exists(), "mapped file should be created on disk");
+
+        service.shutdown().await;
     }
 }

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -308,23 +308,18 @@ impl MappedFileQueue {
 
         // Try async allocation if service available
         if let Some(ref service) = self.allocate_mapped_file_service {
-            if let Ok(rt) = tokio::runtime::Handle::try_current() {
-                match rt.block_on(async {
-                    service
-                        .allocate_mapped_file(file_path_str.clone(), self.mapped_file_size)
-                        .await
-                }) {
-                    Ok(pre_allocated) => {
-                        // Trigger pre-allocation of N+2 file
-                        std::mem::drop(
-                            service.submit_request(next_file_path.to_string_lossy().to_string(), self.mapped_file_size),
-                        );
-                        // Return Arc directly
-                        return Some(pre_allocated);
-                    }
-                    Err(e) => {
-                        warn!("Pre-allocation failed: {}, using sync creation", e);
-                    }
+            match service.allocate_mapped_file_blocking(file_path_str.clone(), self.mapped_file_size) {
+                Ok(pre_allocated) => {
+                    // Trigger pre-allocation of N+2 file
+                    service.submit_request_in_background(
+                        next_file_path.to_string_lossy().to_string(),
+                        self.mapped_file_size,
+                    );
+                    // Return Arc directly
+                    return Some(pre_allocated);
+                }
+                Err(e) => {
+                    warn!("Pre-allocation failed: {}, using sync creation", e);
                 }
             }
         }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -73,7 +73,6 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::ensure_dir_ok;
 use rocketmq_error::RocketMQResult;
 use rocketmq_rust::ArcMut;
-use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 use tokio::sync::Notify;
 use tracing::error;
@@ -1744,24 +1743,7 @@ impl MessageStore for LocalFileMessageStore {
 
     fn clean_expired_consumer_queue(&self) {
         let min_commit_log_offset = self.get_min_phy_offset();
-        let consume_queue_store = self.consume_queue_store.clone();
-        let clean_expired = move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("clean expired consumer queue runtime should build");
-            runtime.block_on(async move {
-                consume_queue_store.clean_expired(min_commit_log_offset).await;
-            });
-        };
-
-        if Handle::try_current().is_ok() {
-            thread::spawn(clean_expired)
-                .join()
-                .expect("clean expired consumer queue thread should complete");
-        } else {
-            clean_expired();
-        }
+        self.consume_queue_store.clean_expired_sync(min_commit_log_offset);
     }
 
     fn check_in_mem_by_consume_offset(
@@ -2939,24 +2921,7 @@ impl CleanConsumeQueueService {
         self.index_service
             .delete_expired_file(min_commit_log_offset.max(0) as u64);
 
-        let consume_queue_store = self.consume_queue_store.clone();
-        let clean_expired = move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("clean consume queue runtime should build");
-            runtime.block_on(async move {
-                consume_queue_store.clean_expired(min_commit_log_offset).await;
-            });
-        };
-
-        if Handle::try_current().is_ok() {
-            thread::spawn(clean_expired)
-                .join()
-                .expect("clean consume queue thread should complete");
-        } else {
-            clean_expired();
-        }
+        self.consume_queue_store.clean_expired_sync(min_commit_log_offset);
     }
 }
 

--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -72,6 +72,86 @@ impl Inner {
 }
 
 impl ConsumeQueueStore {
+    pub fn clean_expired_sync(&self, min_commit_log_offset: i64) {
+        // Collect queues to remove
+        let mut queues_to_destroy = Vec::new();
+        let mut topics_to_remove = Vec::new();
+
+        {
+            let mut consume_queue_table = self.inner.consume_queue_table.lock();
+            let topics: Vec<CheetahString> = consume_queue_table.keys().cloned().collect();
+
+            for topic in topics {
+                // Skip system topics
+                if TopicValidator::is_system_topic(&topic) {
+                    continue;
+                }
+
+                if let Some(queue_table) = consume_queue_table.get_mut(&topic) {
+                    let queue_ids: Vec<i32> = queue_table.keys().cloned().collect();
+                    let mut queues_to_remove = Vec::new();
+
+                    for queue_id in queue_ids {
+                        if let Some(consume_queue) = queue_table.get(&queue_id) {
+                            let max_cl_offset_in_queue = consume_queue.get_max_physic_offset();
+                            let message_total_in_queue = consume_queue.get_message_total_in_queue();
+                            let queue_trimmed_to_empty =
+                                message_total_in_queue <= 0 && consume_queue.get_min_offset_in_queue() > 0;
+
+                            if max_cl_offset_in_queue == -1 {
+                                tracing::warn!(
+                                    "maybe ConsumeQueue was created just now. topic={} queueId={} maxPhysicOffset={} \
+                                     minLogicOffset={}.",
+                                    consume_queue.get_topic(),
+                                    consume_queue.get_queue_id(),
+                                    consume_queue.get_max_physic_offset(),
+                                    consume_queue.get_min_logic_offset()
+                                );
+                            } else if max_cl_offset_in_queue < min_commit_log_offset || queue_trimmed_to_empty {
+                                tracing::info!(
+                                    "cleanExpiredConsumerQueue: {} {} consumer queue destroyed, minCommitLogOffset: \
+                                     {} maxCLOffsetInConsumeQueue: {} messageTotalInQueue: {} minOffsetInQueue: {}",
+                                    topic,
+                                    queue_id,
+                                    min_commit_log_offset,
+                                    max_cl_offset_in_queue,
+                                    message_total_in_queue,
+                                    consume_queue.get_min_offset_in_queue()
+                                );
+
+                                queues_to_remove.push(queue_id);
+                            }
+                        }
+                    }
+
+                    // Remove expired queues and collect for destruction
+                    for queue_id in queues_to_remove {
+                        if let Some(consume_queue) = queue_table.remove(&queue_id) {
+                            queues_to_destroy.push((topic.clone(), queue_id, consume_queue));
+                        }
+                    }
+
+                    // If all queues removed, mark topic for removal
+                    if queue_table.is_empty() {
+                        topics_to_remove.push(topic.clone());
+                    }
+                }
+            }
+
+            // Remove empty topics
+            for topic in &topics_to_remove {
+                consume_queue_table.remove(topic);
+                tracing::info!("cleanExpiredConsumerQueue: {},topic destroyed", topic);
+            }
+        }
+
+        // Now destroy queues and remove from offset table (outside the lock)
+        for (topic, queue_id, mut consume_queue) in queues_to_destroy {
+            self.inner.queue_offset_operator.remove(&topic, queue_id);
+            consume_queue.destroy();
+        }
+    }
+
     fn find_consume_queue(&self, topic: &CheetahString, queue_id: i32) -> Option<ArcConsumeQueue> {
         let table = self.inner.consume_queue_table.lock();
         let queue_table = table.get(topic)?;
@@ -215,86 +295,7 @@ impl ConsumeQueueStoreTrait for ConsumeQueueStore {
     }
 
     async fn clean_expired(&self, min_commit_log_offset: i64) {
-        // Collect queues to remove
-        let mut queues_to_destroy = Vec::new();
-        let mut topics_to_remove = Vec::new();
-
-        {
-            let mut consume_queue_table = self.inner.consume_queue_table.lock();
-            let topics: Vec<CheetahString> = consume_queue_table.keys().cloned().collect();
-
-            for topic in topics {
-                // Skip system topics
-                if TopicValidator::is_system_topic(&topic) {
-                    continue;
-                }
-
-                if let Some(queue_table) = consume_queue_table.get_mut(&topic) {
-                    let queue_ids: Vec<i32> = queue_table.keys().cloned().collect();
-                    let mut queues_to_remove = Vec::new();
-
-                    for queue_id in queue_ids {
-                        if let Some(consume_queue) = queue_table.get(&queue_id) {
-                            let max_cl_offset_in_queue = consume_queue.get_max_physic_offset();
-                            let message_total_in_queue = consume_queue.get_message_total_in_queue();
-                            let queue_trimmed_to_empty =
-                                message_total_in_queue <= 0 && consume_queue.get_min_offset_in_queue() > 0;
-
-                            if max_cl_offset_in_queue == -1 {
-                                tracing::warn!(
-                                    "maybe ConsumeQueue was created just now. topic={} queueId={} maxPhysicOffset={} \
-                                     minLogicOffset={}.",
-                                    consume_queue.get_topic(),
-                                    consume_queue.get_queue_id(),
-                                    consume_queue.get_max_physic_offset(),
-                                    consume_queue.get_min_logic_offset()
-                                );
-                            } else if max_cl_offset_in_queue < min_commit_log_offset || queue_trimmed_to_empty {
-                                tracing::info!(
-                                    "cleanExpiredConsumerQueue: {} {} consumer queue destroyed, minCommitLogOffset: \
-                                     {} maxCLOffsetInConsumeQueue: {} messageTotalInQueue: {} minOffsetInQueue: {}",
-                                    topic,
-                                    queue_id,
-                                    min_commit_log_offset,
-                                    max_cl_offset_in_queue,
-                                    message_total_in_queue,
-                                    consume_queue.get_min_offset_in_queue()
-                                );
-
-                                queues_to_remove.push(queue_id);
-                            }
-                        }
-                    }
-
-                    // Remove expired queues and collect for destruction
-                    for queue_id in queues_to_remove {
-                        if let Some(consume_queue) = queue_table.remove(&queue_id) {
-                            queues_to_destroy.push((topic.clone(), queue_id, consume_queue));
-                        }
-                    }
-
-                    // If all queues removed, mark topic for removal
-                    if queue_table.is_empty() {
-                        topics_to_remove.push(topic.clone());
-                    }
-                }
-            }
-
-            // Remove empty topics
-            for topic in &topics_to_remove {
-                consume_queue_table.remove(topic);
-                tracing::info!("cleanExpiredConsumerQueue: {},topic destroyed", topic);
-            }
-        }
-
-        // Now destroy queues and remove from offset table (outside the lock)
-        for (topic, queue_id, mut consume_queue) in queues_to_destroy {
-            // Remove from topic queue table
-            self.inner.queue_offset_operator.remove(&topic, queue_id);
-
-            // Destroy the removed queue instance directly to avoid re-creating it via get_life_cycle.
-            consume_queue.destroy();
-        }
+        self.clean_expired_sync(min_commit_log_offset);
     }
 
     fn check_self(&self) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7075

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced file allocation service to support synchronous operations alongside background pre-allocation, improving compatibility across different execution contexts.
  * Optimized queue cleanup performance by streamlining the cleanup execution path.
  * Added cloning support for file allocation service to enable easier concurrent usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->