### PR TITLE
[ISSUE #7084]✨enhance(consume-queue): add integration tests for timer recovery and extend consume queue functionality

### DIFF
--- a/rocketmq-broker/src/filter/expression_message_filter.rs
+++ b/rocketmq-broker/src/filter/expression_message_filter.rs
@@ -168,13 +168,27 @@ impl MessageFilter for ExpressionMessageFilter {
 mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
-
-    use cheetah_string::CheetahString;
-    use rocketmq_common::common::broker::broker_config::BrokerConfig;
-    use rocketmq_store::config::message_store_config::MessageStoreConfig;
-    use rocketmq_store::filter::MessageFilter;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use std::sync::Arc;
 
     use super::*;
+    use bytes::Bytes;
+    use cheetah_string::CheetahString;
+    use dashmap::DashMap;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+    use rocketmq_common::common::message::MessageTrait;
+    use rocketmq_common::MessageDecoder::message_properties_to_string;
+    use rocketmq_remoting::protocol::filter::filter_api::FilterAPI;
+    use rocketmq_rust::ArcMut;
+    use rocketmq_store::base::message_status_enum::GetMessageStatus;
+    use rocketmq_store::base::message_status_enum::PutMessageStatus;
+    use rocketmq_store::base::message_store::MessageStore;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+    use rocketmq_store::filter::MessageFilter;
+    use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
 
     fn new_manager() -> ConsumerFilterManager {
         ConsumerFilterManager::new(
@@ -191,6 +205,54 @@ mod tests {
             sub_version: 11,
             ..Default::default()
         }
+    }
+
+    fn temp_test_root(label: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "rocketmq-rust-expression-filter-{}-{}",
+            std::process::id(),
+            label
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("create temp test root");
+        path
+    }
+
+    fn new_store(temp_root: &Path, topic: &CheetahString) -> ArcMut<LocalFileMessageStore> {
+        let topic_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>> = Arc::new(DashMap::new());
+        topic_table.insert(
+            topic.clone(),
+            ArcMut::new(TopicConfig::with_queues(topic.as_str(), 1, 1)),
+        );
+
+        let mut store = ArcMut::new(LocalFileMessageStore::new(
+            Arc::new(MessageStoreConfig {
+                store_path_root_dir: temp_root.to_string_lossy().to_string().into(),
+                read_uncommitted: true,
+                mapped_file_size_commit_log: 4096,
+                mapped_file_size_consume_queue: 200,
+                ..MessageStoreConfig::default()
+            }),
+            Arc::new(BrokerConfig::default()),
+            topic_table,
+            None,
+            false,
+        ));
+        let store_clone = store.clone();
+        store.set_message_store_arc(store_clone);
+        store
+    }
+
+    fn build_tagged_message(topic: &CheetahString, tag: &str, body: &'static [u8]) -> MessageExtBrokerInner {
+        let mut msg = MessageExtBrokerInner::default();
+        msg.set_topic(topic.clone());
+        msg.message_ext_inner.set_queue_id(0);
+        msg.set_body(Bytes::from_static(body));
+        msg.set_wait_store_msg_ok(false);
+        msg.set_tags(CheetahString::from_string(tag.to_string()));
+        msg.properties_string = message_properties_to_string(msg.get_properties());
+        msg
     }
 
     #[test]
@@ -281,5 +343,41 @@ mod tests {
 
         let miss = CqExtUnit::new(0, filter_data.born_time() as i64 + 1, Some(vec![0; bits.byte_length()]));
         assert!(!filter.is_matched_by_consume_queue(None, Some(&miss)));
+    }
+
+    #[tokio::test]
+    async fn tag_filter_skips_non_matching_messages_in_store_read_path() {
+        let topic = CheetahString::from_static_str("TopicTest");
+        let group = CheetahString::from_static_str("GroupTest");
+        let temp_root = temp_test_root("store-read-path");
+        let subscription = FilterAPI::build_subscription_data(&topic, &CheetahString::from_static_str("blue"))
+            .expect("tag subscription should build");
+        let filter = ExpressionMessageFilter::new(Some(subscription), None, Arc::new(new_manager()));
+
+        let mut store = new_store(&temp_root, &topic);
+        store.init().await.expect("init store");
+        assert!(store.load().await, "load store");
+
+        let first_put = store
+            .put_message(build_tagged_message(&topic, "red", b"phase6-red"))
+            .await;
+        assert_eq!(first_put.put_message_status(), PutMessageStatus::PutOk);
+        let second_put = store
+            .put_message(build_tagged_message(&topic, "blue", b"phase6-blue"))
+            .await;
+        assert_eq!(second_put.put_message_status(), PutMessageStatus::PutOk);
+        store.reput_once().await;
+
+        let result = store
+            .get_message(&group, &topic, 0, 0, 32, Some(Arc::new(filter)))
+            .await
+            .expect("get message result");
+
+        assert_eq!(result.status(), Some(GetMessageStatus::Found));
+        assert_eq!(result.message_count(), 1);
+        assert_eq!(result.message_queue_offset(), &vec![1]);
+        assert_eq!(result.next_begin_offset(), 2);
+
+        let _ = std::fs::remove_dir_all(temp_root);
     }
 }

--- a/rocketmq-store/src/queue/batch_consume_queue.rs
+++ b/rocketmq-store/src/queue/batch_consume_queue.rs
@@ -15,13 +15,18 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use bytes::Buf;
+use bytes::BufMut;
+use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use rocketmq_common::common::attribute::cq_type::CQType;
 use rocketmq_common::common::boundary_type::BoundaryType;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use tracing::info;
+use tracing::warn;
 
 use crate::base::dispatch_request::DispatchRequest;
 use crate::base::swappable::Swappable;
@@ -29,37 +34,40 @@ use crate::config::message_store_config::MessageStoreConfig;
 use crate::consume_queue::mapped_file_queue::MappedFileQueue;
 use crate::filter::MessageFilter;
 use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::MappedFile;
 use crate::queue::consume_queue::ConsumeQueueTrait;
 use crate::queue::queue_offset_operator::QueueOffsetOperator;
 use crate::queue::CqUnit;
 use crate::queue::FileQueueLifeCycle;
 
-const CQ_STORE_UNIT_SIZE: i32 = 46;
-const MSG_TAG_OFFSET_INDEX: i32 = 12;
+pub(crate) const CQ_STORE_UNIT_SIZE: i32 = 46;
 const MSG_STORE_TIME_OFFSET_INDEX: i32 = 20;
 const MSG_BASE_OFFSET_INDEX: i32 = 28;
 const MSG_BATCH_SIZE_INDEX: i32 = 36;
-const MSG_COMPACT_OFFSET_INDEX: i32 = 38;
 const MSG_COMPACT_OFFSET_LENGTH: i32 = 4;
 const INVALID_POS: i32 = -1;
 
-///
-/// BatchConsumeQueue's store unit. Format:
-///
-/// ┌─────────────────────────┬───────────┬────────────┬──────────┐
-/// │CommitLog Physical Offset│ Body Size │Tag HashCode│Store time│
-/// │        (8 Bytes)        │ (4 Bytes) │ (8 Bytes)  │(8 Bytes) │
-/// ├─────────────────────────┼───────────┼────────────┼──────────┤
-/// │       msgBaseOffset     │ batchSize │compOffset  │ reserved │
-/// │         (8 Bytes)       │ (2 Bytes) │ (4 Bytes)  │(4 Bytes) │
-///Store Unit
-/// BatchConsumeQueue's store unit. Size:
-/// CommitLog Physical Offset(8) + Body Size(4) + Tag HashCode(8) + Store time(8) +
-/// msgBaseOffset(8) + batchSize(2) + compactedOffset(4) + reserved(4)= 46 Bytes
+#[derive(Clone, Debug)]
+struct BatchQueueEntry {
+    pos: i64,
+    size: i32,
+    tags_code: i64,
+    store_time: i64,
+    msg_base_offset: i64,
+    batch_size: i16,
+    compacted_offset: i32,
+    raw: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BatchRecordPosition {
+    file_index: usize,
+    position: i32,
+}
+
 pub struct BatchConsumeQueue {
     message_store_config: Arc<MessageStoreConfig>,
     mapped_file_queue: MappedFileQueue,
-    //message_store: Arc<RwLock<dyn MessageStore>>,
     topic: CheetahString,
     queue_id: i32,
     byte_buffer_item: Vec<u8>,
@@ -99,18 +107,16 @@ impl BatchConsumeQueue {
             MappedFileQueue::new(queue_dir.to_string_lossy().to_string(), mapped_file_size as u64, None)
         };
 
-        let byte_buffer_item = vec![0u8; CQ_STORE_UNIT_SIZE as usize];
-
         BatchConsumeQueue {
             message_store_config,
             mapped_file_queue,
             topic,
             queue_id,
-            byte_buffer_item,
+            byte_buffer_item: vec![0u8; CQ_STORE_UNIT_SIZE as usize],
             store_path,
             mapped_file_size,
             max_msg_phy_offset_in_commit_log: Arc::new(AtomicI64::new(-1)),
-            min_logic_offset: Arc::new(AtomicI64::new(0)),
+            min_logic_offset: Arc::new(AtomicI64::new(-1)),
             max_offset_in_queue: Arc::new(AtomicI64::new(0)),
             min_offset_in_queue: Arc::new(AtomicI64::new(-1)),
             commit_log_size: commit_log_size as i32,
@@ -118,15 +124,230 @@ impl BatchConsumeQueue {
             time_cache: Arc::new(parking_lot::RwLock::new(BTreeMap::new())),
         }
     }
+
+    fn encode_unit(
+        offset: i64,
+        size: i32,
+        tags_code: i64,
+        store_time: i64,
+        msg_base_offset: i64,
+        batch_size: i16,
+        compacted_offset: i32,
+    ) -> Vec<u8> {
+        let mut bytes = BytesMut::with_capacity(CQ_STORE_UNIT_SIZE as usize);
+        bytes.put_i64(offset);
+        bytes.put_i32(size);
+        bytes.put_i64(tags_code);
+        bytes.put_i64(store_time);
+        bytes.put_i64(msg_base_offset);
+        bytes.put_i16(batch_size);
+        bytes.put_i32(compacted_offset);
+        bytes.put_i32(0);
+        bytes.to_vec()
+    }
+
+    fn read_entry(mapped_file: &Arc<DefaultMappedFile>, position: i32) -> Option<BatchQueueEntry> {
+        if position < 0 || position + CQ_STORE_UNIT_SIZE > mapped_file.get_read_position() {
+            return None;
+        }
+
+        let mut bytes = mapped_file.get_bytes(position as usize, CQ_STORE_UNIT_SIZE as usize)?;
+        let raw = bytes.as_ref().to_vec();
+        let pos = bytes.get_i64();
+        let size = bytes.get_i32();
+        let tags_code = bytes.get_i64();
+        let store_time = bytes.get_i64();
+        let msg_base_offset = bytes.get_i64();
+        let batch_size = bytes.get_i16();
+        let compacted_offset = bytes.get_i32();
+        let _reserved = bytes.get_i32();
+
+        if pos < 0 || size <= 0 || msg_base_offset < 0 || batch_size <= 0 {
+            return None;
+        }
+
+        Some(BatchQueueEntry {
+            pos,
+            size,
+            tags_code,
+            store_time,
+            msg_base_offset,
+            batch_size,
+            compacted_offset,
+            raw,
+        })
+    }
+
+    fn read_first_valid_entry(mapped_file: &Arc<DefaultMappedFile>) -> Option<(i32, BatchQueueEntry)> {
+        let mut position = 0;
+        while position + CQ_STORE_UNIT_SIZE <= mapped_file.get_read_position() {
+            if let Some(entry) = Self::read_entry(mapped_file, position) {
+                return Some((position, entry));
+            }
+            position += CQ_STORE_UNIT_SIZE;
+        }
+        None
+    }
+
+    fn read_last_valid_entry(mapped_file: &Arc<DefaultMappedFile>) -> Option<(i32, BatchQueueEntry)> {
+        let mut position = mapped_file.get_read_position() - CQ_STORE_UNIT_SIZE;
+        while position >= 0 {
+            if let Some(entry) = Self::read_entry(mapped_file, position) {
+                return Some((position, entry));
+            }
+            if position < CQ_STORE_UNIT_SIZE {
+                break;
+            }
+            position -= CQ_STORE_UNIT_SIZE;
+        }
+        None
+    }
+
+    fn find_record_position_in_snapshot(
+        files: &[Arc<DefaultMappedFile>],
+        queue_offset: i64,
+    ) -> Option<(BatchRecordPosition, BatchQueueEntry)> {
+        let mut candidate: Option<(BatchRecordPosition, BatchQueueEntry)> = None;
+
+        for (file_index, mapped_file) in files.iter().enumerate() {
+            let mut position = 0;
+            while position + CQ_STORE_UNIT_SIZE <= mapped_file.get_read_position() {
+                let Some(entry) = Self::read_entry(mapped_file, position) else {
+                    break;
+                };
+                if entry.msg_base_offset <= queue_offset {
+                    candidate = Some((BatchRecordPosition { file_index, position }, entry));
+                    position += CQ_STORE_UNIT_SIZE;
+                    continue;
+                }
+                return candidate;
+            }
+        }
+
+        candidate
+    }
+
+    fn find_record_position(&self, queue_offset: i64) -> Option<(Vec<Arc<DefaultMappedFile>>, BatchRecordPosition)> {
+        let normalized_offset = if self.get_min_offset_in_queue() >= 0 {
+            queue_offset.max(self.get_min_offset_in_queue())
+        } else {
+            queue_offset
+        };
+        let files = self.mapped_file_queue.snapshot();
+        let (position, _) = Self::find_record_position_in_snapshot(&files, normalized_offset)?;
+        Some((files, position))
+    }
+
+    fn entry_to_cq_unit(entry: BatchQueueEntry) -> CqUnit {
+        CqUnit {
+            queue_offset: entry.msg_base_offset,
+            size: entry.size,
+            pos: entry.pos,
+            batch_num: entry.batch_size,
+            tags_code: entry.tags_code,
+            native_buffer: entry.raw,
+            compacted_offset: entry.compacted_offset,
+            ..CqUnit::default()
+        }
+    }
+
+    fn revise_min_offset_in_queue(&self) {
+        for mapped_file in self.mapped_file_queue.iter() {
+            if let Some((position, entry)) = Self::read_first_valid_entry(&mapped_file) {
+                self.min_logic_offset.store(
+                    mapped_file.get_file_from_offset() as i64 + position as i64,
+                    Ordering::Release,
+                );
+                self.min_offset_in_queue.store(entry.msg_base_offset, Ordering::Release);
+                return;
+            }
+        }
+
+        self.min_logic_offset.store(-1, Ordering::Release);
+        self.min_offset_in_queue.store(-1, Ordering::Release);
+    }
+
+    fn revise_max_offset_in_queue(&self) {
+        for mapped_file in self.mapped_file_queue.iter_reversed() {
+            if let Some((_, entry)) = Self::read_last_valid_entry(&mapped_file) {
+                self.max_offset_in_queue
+                    .store(entry.msg_base_offset + entry.batch_size as i64, Ordering::Release);
+                self.max_msg_phy_offset_in_commit_log
+                    .store(entry.pos + entry.size as i64, Ordering::Release);
+                return;
+            }
+        }
+
+        self.max_offset_in_queue.store(0, Ordering::Release);
+        self.max_msg_phy_offset_in_commit_log.store(-1, Ordering::Release);
+    }
+
+    fn revise_max_and_min_offset_in_queue(&self) {
+        self.revise_min_offset_in_queue();
+        self.revise_max_offset_in_queue();
+    }
+
+    fn put_batch_message_position_info(
+        &mut self,
+        offset: i64,
+        size: i32,
+        tags_code: i64,
+        store_time: i64,
+        msg_base_offset: i64,
+        batch_size: i16,
+    ) -> bool {
+        if offset + size as i64 <= self.get_max_physic_offset() {
+            warn!(
+                "Build batch consume queue repeatedly, maxMsgPhyOffsetInCommitLog={} offset={} topic={} queue_id={}",
+                self.get_max_physic_offset(),
+                offset,
+                self.topic,
+                self.queue_id
+            );
+            return true;
+        }
+
+        let record = Self::encode_unit(
+            offset,
+            size,
+            tags_code,
+            store_time,
+            msg_base_offset,
+            batch_size,
+            INVALID_POS,
+        );
+        let start_offset = self.mapped_file_queue.get_max_offset().max(0) as u64;
+        let Some(mapped_file) = self
+            .mapped_file_queue
+            .get_last_mapped_file_mut_start_offset(start_offset, true)
+        else {
+            return false;
+        };
+
+        let is_new_file = mapped_file.get_read_position() < CQ_STORE_UNIT_SIZE;
+        if mapped_file.append_message_bytes(&record) {
+            self.max_msg_phy_offset_in_commit_log
+                .store(offset + size as i64, Ordering::Release);
+            self.max_offset_in_queue
+                .store(msg_base_offset + batch_size as i64, Ordering::Release);
+            if is_new_file && self.min_offset_in_queue.load(Ordering::Acquire) < 0 {
+                self.min_logic_offset
+                    .store(mapped_file.get_file_from_offset() as i64, Ordering::Release);
+                self.min_offset_in_queue.store(msg_base_offset, Ordering::Release);
+            }
+            return true;
+        }
+
+        false
+    }
 }
 
-#[allow(unused_variables)]
 impl FileQueueLifeCycle for BatchConsumeQueue {
     #[inline]
     fn load(&mut self) -> bool {
         let result = self.mapped_file_queue.load();
         info!(
-            "Load batch consume queue {}-{}  {} {}",
+            "Load batch consume queue {}-{} {} {}",
             self.topic,
             self.queue_id,
             if result { "OK" } else { "Failed" },
@@ -137,156 +358,382 @@ impl FileQueueLifeCycle for BatchConsumeQueue {
 
     #[inline]
     fn recover(&mut self) {
-        todo!()
+        let mapped_files = self.mapped_file_queue.snapshot();
+        if mapped_files.is_empty() {
+            self.revise_max_and_min_offset_in_queue();
+            return;
+        }
+
+        let mut index = mapped_files.len().saturating_sub(3);
+        let mut mapped_file = mapped_files[index].clone();
+        let mut process_offset = mapped_file.get_file_from_offset();
+        let mut mapped_file_offset;
+
+        loop {
+            let read_position = mapped_file.get_read_position();
+            mapped_file_offset = 0;
+
+            while mapped_file_offset + CQ_STORE_UNIT_SIZE <= read_position {
+                let Some(entry) = Self::read_entry(&mapped_file, mapped_file_offset) else {
+                    info!(
+                        "Recover current batch consume queue file over, file={} mappedFileOffset={}",
+                        mapped_file.get_file_name(),
+                        mapped_file_offset
+                    );
+                    break;
+                };
+
+                mapped_file_offset += CQ_STORE_UNIT_SIZE;
+                self.max_msg_phy_offset_in_commit_log
+                    .store(entry.pos + entry.size as i64, Ordering::Release);
+            }
+
+            if mapped_file_offset == read_position {
+                index += 1;
+                if index >= mapped_files.len() {
+                    info!(
+                        "Recover last batch consume queue file over, last mapped file={}",
+                        mapped_file.get_file_name()
+                    );
+                    break;
+                }
+
+                mapped_file = mapped_files[index].clone();
+                process_offset = mapped_file.get_file_from_offset();
+                continue;
+            }
+
+            info!(
+                "Recover current batch consume queue file over, file={} processOffset={}",
+                mapped_file.get_file_name(),
+                process_offset + mapped_file_offset as u64
+            );
+            break;
+        }
+
+        process_offset += mapped_file_offset as u64;
+        self.mapped_file_queue.set_flushed_where(process_offset as i64);
+        self.mapped_file_queue.set_committed_where(process_offset as i64);
+        self.mapped_file_queue.truncate_dirty_files(process_offset as i64);
+        self.revise_max_and_min_offset_in_queue();
     }
 
     #[inline]
     fn check_self(&self) {
-        todo!()
+        self.mapped_file_queue.check_self();
     }
 
     #[inline]
     fn flush(&self, flush_least_pages: i32) -> bool {
-        todo!()
+        self.mapped_file_queue.flush(flush_least_pages)
     }
 
     #[inline]
     fn destroy(&mut self) {
-        todo!()
+        self.max_msg_phy_offset_in_commit_log.store(-1, Ordering::Release);
+        self.min_logic_offset.store(-1, Ordering::Release);
+        self.min_offset_in_queue.store(-1, Ordering::Release);
+        self.max_offset_in_queue.store(0, Ordering::Release);
+        self.mapped_file_queue.destroy();
+        self.offset_cache.write().clear();
+        self.time_cache.write().clear();
     }
 
     #[inline]
     fn truncate_dirty_logic_files(&mut self, max_commit_log_pos: i64) {
-        todo!()
+        loop {
+            let Some(mapped_file) = self.mapped_file_queue.get_last_mapped_file() else {
+                break;
+            };
+
+            mapped_file.set_wrote_position(0);
+            mapped_file.set_committed_position(0);
+            mapped_file.set_flushed_position(0);
+
+            let mut remove_file = false;
+            let mut stop = false;
+            let mut position = 0;
+
+            while position + CQ_STORE_UNIT_SIZE <= self.mapped_file_size as i32 {
+                let Some(entry) = Self::read_entry(&mapped_file, position) else {
+                    stop = true;
+                    break;
+                };
+
+                if position == 0 && entry.pos >= max_commit_log_pos {
+                    remove_file = true;
+                    break;
+                }
+
+                if entry.pos >= max_commit_log_pos {
+                    stop = true;
+                    break;
+                }
+
+                position += CQ_STORE_UNIT_SIZE;
+                mapped_file.set_wrote_position(position);
+                mapped_file.set_committed_position(position);
+                mapped_file.set_flushed_position(position);
+                self.max_msg_phy_offset_in_commit_log
+                    .store(entry.pos + entry.size as i64, Ordering::Release);
+
+                if position == self.mapped_file_size as i32 {
+                    stop = true;
+                    break;
+                }
+            }
+
+            if remove_file {
+                self.mapped_file_queue.delete_last_mapped_file();
+                continue;
+            }
+
+            if stop {
+                break;
+            }
+        }
+
+        self.revise_max_and_min_offset_in_queue();
     }
 
     #[inline]
     fn delete_expired_file(&self, min_commit_log_pos: i64) -> i32 {
-        todo!()
+        self.mapped_file_queue
+            .delete_expired_file_by_offset(min_commit_log_pos, CQ_STORE_UNIT_SIZE)
     }
 
     #[inline]
     fn roll_next_file(&self, next_begin_offset: i64) -> i64 {
-        todo!()
+        let files = self.mapped_file_queue.snapshot();
+        let Some((position, _)) = Self::find_record_position_in_snapshot(&files, next_begin_offset) else {
+            return self.get_max_offset_in_queue();
+        };
+
+        let next_file_index = position.file_index + 1;
+        if let Some(next_file) = files.get(next_file_index) {
+            if let Some((_, entry)) = Self::read_first_valid_entry(next_file) {
+                return entry.msg_base_offset;
+            }
+        }
+
+        self.get_max_offset_in_queue()
     }
 
     #[inline]
     fn is_first_file_available(&self) -> bool {
-        todo!()
+        self.mapped_file_queue
+            .get_first_mapped_file()
+            .is_some_and(|mapped_file| mapped_file.is_available())
     }
 
     #[inline]
     fn is_first_file_exist(&self) -> bool {
-        todo!()
+        self.mapped_file_queue.get_first_mapped_file().is_some()
     }
 }
 
 impl Swappable for BatchConsumeQueue {
     #[inline]
     fn swap_map(&self, reserve_num: i32, force_swap_interval_ms: i64, normal_swap_interval_ms: i64) {
-        todo!()
+        self.mapped_file_queue
+            .swap_map(reserve_num, force_swap_interval_ms, normal_swap_interval_ms);
     }
 
     #[inline]
     fn clean_swapped_map(&self, force_clean_swap_interval_ms: i64) {
-        todo!()
+        self.mapped_file_queue.clean_swapped_map(force_clean_swap_interval_ms);
     }
 }
 
 impl ConsumeQueueTrait for BatchConsumeQueue {
     #[inline]
     fn get_topic(&self) -> &CheetahString {
-        todo!()
+        &self.topic
     }
 
     #[inline]
     fn get_queue_id(&self) -> i32 {
-        todo!()
+        self.queue_id
     }
 
     #[inline]
     fn get(&self, index: i64) -> Option<CqUnit> {
-        todo!()
+        if self.get_min_offset_in_queue() >= 0
+            && (index < self.get_min_offset_in_queue() || index >= self.get_max_offset_in_queue())
+        {
+            return None;
+        }
+
+        let files = self.mapped_file_queue.snapshot();
+        let (_, entry) = Self::find_record_position_in_snapshot(&files, index)?;
+        Some(Self::entry_to_cq_unit(entry))
     }
 
     #[inline]
     fn get_cq_unit_and_store_time(&self, index: i64) -> Option<(CqUnit, i64)> {
-        todo!()
+        if self.get_min_offset_in_queue() >= 0
+            && (index < self.get_min_offset_in_queue() || index >= self.get_max_offset_in_queue())
+        {
+            return None;
+        }
+
+        let files = self.mapped_file_queue.snapshot();
+        let (_, entry) = Self::find_record_position_in_snapshot(&files, index)?;
+        let store_time = entry.store_time;
+        Some((Self::entry_to_cq_unit(entry), store_time))
     }
 
     #[inline]
     fn get_earliest_unit_and_store_time(&self) -> Option<(CqUnit, i64)> {
-        todo!()
+        let min_offset = self.get_min_offset_in_queue();
+        if min_offset < 0 {
+            return None;
+        }
+        self.get_cq_unit_and_store_time(min_offset)
     }
 
     #[inline]
     fn get_earliest_unit(&self) -> Option<CqUnit> {
-        todo!()
+        let min_offset = self.get_min_offset_in_queue();
+        if min_offset < 0 {
+            return None;
+        }
+        self.get(min_offset)
     }
 
     #[inline]
     fn get_latest_unit(&self) -> Option<CqUnit> {
-        todo!()
+        let max_offset = self.get_max_offset_in_queue();
+        let min_offset = self.get_min_offset_in_queue();
+        if min_offset < 0 || max_offset <= min_offset {
+            return None;
+        }
+        self.get(max_offset - 1)
     }
 
     #[inline]
     fn get_last_offset(&self) -> i64 {
-        todo!()
+        self.get_latest_unit()
+            .map(|cq_unit| cq_unit.pos + cq_unit.size as i64)
+            .unwrap_or(-1)
     }
 
     #[inline]
     fn get_min_offset_in_queue(&self) -> i64 {
-        todo!()
+        self.min_offset_in_queue.load(Ordering::Acquire)
     }
 
     #[inline]
     fn get_max_offset_in_queue(&self) -> i64 {
-        todo!()
+        self.max_offset_in_queue.load(Ordering::Acquire)
     }
 
     #[inline]
     fn get_message_total_in_queue(&self) -> i64 {
-        todo!()
+        let min_offset = self.get_min_offset_in_queue();
+        if min_offset < 0 {
+            return 0;
+        }
+        self.get_max_offset_in_queue() - min_offset
     }
 
     #[inline]
     fn get_offset_in_queue_by_time(&self, timestamp: i64) -> i64 {
-        todo!()
+        self.get_offset_in_queue_by_time_with_boundary(timestamp, BoundaryType::Lower)
     }
 
     #[inline]
     fn get_max_physic_offset(&self) -> i64 {
-        todo!()
+        self.max_msg_phy_offset_in_commit_log.load(Ordering::Acquire)
     }
 
     #[inline]
     fn get_min_logic_offset(&self) -> i64 {
-        todo!()
+        self.min_logic_offset.load(Ordering::Acquire)
     }
 
     #[inline]
     fn get_cq_type(&self) -> CQType {
-        todo!()
+        CQType::BatchCQ
     }
 
     #[inline]
     fn get_total_size(&self) -> i64 {
-        todo!()
+        self.mapped_file_queue.get_total_file_size()
     }
 
     #[inline]
     fn get_unit_size(&self) -> i32 {
-        todo!()
+        CQ_STORE_UNIT_SIZE
     }
 
     #[inline]
     fn correct_min_offset(&self, min_commit_log_offset: i64) {
-        todo!()
+        if self.get_max_physic_offset() < 0 {
+            return;
+        }
+
+        let mut next_min_offset = self.get_min_offset_in_queue();
+        let mut next_logic_offset = self.get_min_logic_offset();
+        let mut found_valid = false;
+
+        for mapped_file in self.mapped_file_queue.iter() {
+            let mut position = 0;
+            while position + CQ_STORE_UNIT_SIZE <= mapped_file.get_read_position() {
+                let Some(entry) = Self::read_entry(&mapped_file, position) else {
+                    break;
+                };
+
+                if entry.pos < min_commit_log_offset {
+                    next_min_offset = entry.msg_base_offset + entry.batch_size as i64;
+                    next_logic_offset =
+                        mapped_file.get_file_from_offset() as i64 + position as i64 + CQ_STORE_UNIT_SIZE as i64;
+                    position += CQ_STORE_UNIT_SIZE;
+                    continue;
+                }
+
+                next_min_offset = entry.msg_base_offset;
+                next_logic_offset = mapped_file.get_file_from_offset() as i64 + position as i64;
+                found_valid = true;
+                break;
+            }
+
+            if found_valid {
+                break;
+            }
+        }
+
+        self.min_offset_in_queue.store(next_min_offset, Ordering::Release);
+        self.min_logic_offset.store(next_logic_offset, Ordering::Release);
     }
 
     #[inline]
     fn put_message_position_info_wrapper(&mut self, request: &DispatchRequest) {
-        todo!()
+        if request.msg_base_offset < 0 || request.batch_size <= 0 {
+            warn!(
+                "unexpected dispatch request in batch consume queue topic={} queue={} commit_log_offset={}",
+                self.topic, self.queue_id, request.commit_log_offset
+            );
+            return;
+        }
+
+        for _ in 0..30 {
+            if self.put_batch_message_position_info(
+                request.commit_log_offset,
+                request.msg_size,
+                request.tags_code,
+                request.store_timestamp,
+                request.msg_base_offset,
+                request.batch_size,
+            ) {
+                return;
+            }
+        }
+
+        warn!(
+            "batch consume queue can not write, topic={} queue={} store_path={} commit_log_size={}",
+            self.topic, self.queue_id, self.store_path, self.commit_log_size
+        );
     }
 
     #[inline]
@@ -296,22 +743,59 @@ impl ConsumeQueueTrait for BatchConsumeQueue {
         msg: &MessageExtBrokerInner,
         message_num: i16,
     ) {
-        todo!()
+        queue_offset_assigner.increase_batch_queue_offset(
+            &CheetahString::from_string(format!("{}-{}", msg.topic(), msg.queue_id())),
+            message_num,
+        );
     }
 
     #[inline]
     fn assign_queue_offset(&self, queue_offset_operator: &QueueOffsetOperator, msg: &mut MessageExtBrokerInner) {
-        todo!()
+        let queue_offset = queue_offset_operator.get_batch_queue_offset(&CheetahString::from_string(format!(
+            "{}-{}",
+            msg.topic(),
+            msg.queue_id()
+        )));
+        msg.message_ext_inner.queue_offset = queue_offset;
     }
 
     #[inline]
     fn estimate_message_count(&self, from: i64, to: i64, filter: &dyn MessageFilter) -> i64 {
-        todo!()
+        let start = from.max(self.get_min_offset_in_queue());
+        let end = to.min(self.get_max_offset_in_queue() - 1);
+        if start < 0 || end < start {
+            return 0;
+        }
+
+        let mut count = 0;
+        let Some(iter) = self.iterate_from(start) else {
+            return 0;
+        };
+
+        for cq_unit in iter {
+            let batch_start = cq_unit.queue_offset;
+            let batch_end = batch_start + cq_unit.batch_num as i64 - 1;
+            if batch_start > end {
+                break;
+            }
+            if batch_end < start {
+                continue;
+            }
+            if filter.is_matched_by_consume_queue(Some(cq_unit.tags_code), None) {
+                count += batch_end.min(end) - batch_start.max(start) + 1;
+            }
+        }
+        count
     }
 
     #[inline]
     fn iterate_from(&self, start_index: i64) -> Option<Box<dyn Iterator<Item = CqUnit> + Send + '_>> {
-        todo!()
+        let (files, position) = self.find_record_position(start_index)?;
+        Some(Box::new(BatchConsumeQueueIterator {
+            files,
+            file_index: position.file_index,
+            position: position.position,
+        }))
     }
 
     fn iterate_from_with_count(
@@ -319,10 +803,234 @@ impl ConsumeQueueTrait for BatchConsumeQueue {
         start_index: i64,
         _count: i32,
     ) -> Option<Box<dyn Iterator<Item = CqUnit> + Send + '_>> {
-        todo!()
+        self.iterate_from(start_index)
     }
 
     fn get_offset_in_queue_by_time_with_boundary(&self, timestamp: i64, boundary_type: BoundaryType) -> i64 {
-        todo!()
+        let mut candidate = None;
+        let mut last_seen = None;
+
+        for mapped_file in self.mapped_file_queue.iter() {
+            let mut position = 0;
+            while position + CQ_STORE_UNIT_SIZE <= mapped_file.get_read_position() {
+                let Some(entry) = Self::read_entry(&mapped_file, position) else {
+                    break;
+                };
+                last_seen = Some(entry.msg_base_offset);
+                if entry.store_time < timestamp {
+                    position += CQ_STORE_UNIT_SIZE;
+                    continue;
+                }
+
+                match boundary_type {
+                    BoundaryType::Lower => return entry.msg_base_offset,
+                    BoundaryType::Upper => {
+                        candidate = Some(entry.msg_base_offset);
+                        position += CQ_STORE_UNIT_SIZE;
+                        continue;
+                    }
+                }
+            }
+
+            if let Some(offset) = candidate {
+                return offset;
+            }
+        }
+
+        candidate.or(last_seen).unwrap_or(-1)
+    }
+}
+
+struct BatchConsumeQueueIterator {
+    files: Vec<Arc<DefaultMappedFile>>,
+    file_index: usize,
+    position: i32,
+}
+
+impl Iterator for BatchConsumeQueueIterator {
+    type Item = CqUnit;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(mapped_file) = self.files.get(self.file_index) {
+            let read_position = mapped_file.get_read_position();
+            if self.position + CQ_STORE_UNIT_SIZE > read_position {
+                self.file_index += 1;
+                self.position = 0;
+                continue;
+            }
+
+            let entry = BatchConsumeQueue::read_entry(mapped_file, self.position)?;
+            self.position += CQ_STORE_UNIT_SIZE;
+            return Some(BatchConsumeQueue::entry_to_cq_unit(entry));
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::BufMut;
+    use cheetah_string::CheetahString;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn create_batch_consume_queue(store_path: CheetahString, mapped_file_size: usize) -> BatchConsumeQueue {
+        BatchConsumeQueue::new(
+            CheetahString::from_static_str("BatchTopic"),
+            1,
+            store_path,
+            mapped_file_size,
+            None,
+            Arc::new(MessageStoreConfig::default()),
+        )
+    }
+
+    fn dispatch_request(
+        commit_log_offset: i64,
+        msg_size: i32,
+        store_timestamp: i64,
+        msg_base_offset: i64,
+        batch_size: i16,
+    ) -> DispatchRequest {
+        DispatchRequest {
+            topic: CheetahString::from_static_str("BatchTopic"),
+            queue_id: 1,
+            commit_log_offset,
+            msg_size,
+            tags_code: 7,
+            store_timestamp,
+            msg_base_offset,
+            batch_size,
+            success: true,
+            ..DispatchRequest::default()
+        }
+    }
+
+    fn encode_invalid_record(
+        offset: i64,
+        size: i32,
+        tags_code: i64,
+        store_time: i64,
+        msg_base_offset: i64,
+        batch_size: i16,
+    ) -> Vec<u8> {
+        let mut bytes = BytesMut::with_capacity(CQ_STORE_UNIT_SIZE as usize);
+        bytes.put_i64(offset);
+        bytes.put_i32(size);
+        bytes.put_i64(tags_code);
+        bytes.put_i64(store_time);
+        bytes.put_i64(msg_base_offset);
+        bytes.put_i16(batch_size);
+        bytes.put_i32(INVALID_POS);
+        bytes.put_i32(0);
+        bytes.to_vec()
+    }
+
+    #[test]
+    fn batch_consume_queue_put_and_get_round_trip() {
+        let root = tempdir().expect("tempdir");
+        let store_path = CheetahString::from_string(root.path().join("batch-cq").to_string_lossy().to_string());
+        let mut consume_queue = create_batch_consume_queue(store_path, (CQ_STORE_UNIT_SIZE * 4) as usize);
+
+        consume_queue.put_message_position_info_wrapper(&dispatch_request(100, 40, 1_000, 0, 3));
+        consume_queue.put_message_position_info_wrapper(&dispatch_request(140, 32, 2_000, 3, 2));
+
+        let first = consume_queue.get(0).expect("first batch");
+        assert_eq!(first.queue_offset, 0);
+        assert_eq!(first.batch_num, 3);
+        assert_eq!(first.pos, 100);
+        assert_eq!(first.size, 40);
+        assert_eq!(first.tags_code, 7);
+        assert_eq!(first.native_buffer.len(), CQ_STORE_UNIT_SIZE as usize);
+
+        let same_first = consume_queue.get(2).expect("same batch");
+        assert_eq!(same_first.queue_offset, 0);
+        assert_eq!(same_first.batch_num, 3);
+
+        let second = consume_queue.get(3).expect("second batch");
+        assert_eq!(second.queue_offset, 3);
+        assert_eq!(second.batch_num, 2);
+        assert_eq!(second.pos, 140);
+
+        let (stored, store_time) = consume_queue.get_cq_unit_and_store_time(3).expect("store time");
+        assert_eq!(stored.queue_offset, 3);
+        assert_eq!(store_time, 2_000);
+
+        let iterated: Vec<_> = consume_queue.iterate_from(1).expect("iterator").take(2).collect();
+        assert_eq!(iterated.len(), 2);
+        assert_eq!(iterated[0].queue_offset, 0);
+        assert_eq!(iterated[1].queue_offset, 3);
+
+        assert_eq!(consume_queue.get_min_offset_in_queue(), 0);
+        assert_eq!(consume_queue.get_max_offset_in_queue(), 5);
+        assert_eq!(consume_queue.get_message_total_in_queue(), 5);
+        assert_eq!(consume_queue.get_last_offset(), 172);
+        assert_eq!(consume_queue.get_offset_in_queue_by_time(1_500), 3);
+        assert_eq!(
+            consume_queue.get_offset_in_queue_by_time_with_boundary(2_000, BoundaryType::Upper),
+            3
+        );
+    }
+
+    #[test]
+    fn batch_consume_queue_recover_truncates_dirty_tail() {
+        let root = tempdir().expect("tempdir");
+        let store_path = CheetahString::from_string(root.path().join("batch-cq").to_string_lossy().to_string());
+        let mut consume_queue = create_batch_consume_queue(store_path.clone(), (CQ_STORE_UNIT_SIZE * 4) as usize);
+
+        consume_queue.put_message_position_info_wrapper(&dispatch_request(100, 40, 1_000, 0, 3));
+        consume_queue.put_message_position_info_wrapper(&dispatch_request(140, 32, 2_000, 3, 2));
+        let mapped_file = consume_queue
+            .mapped_file_queue
+            .get_last_mapped_file()
+            .expect("mapped file");
+        let dirty_record = encode_invalid_record(200, 24, 8, 3_000, -1, 1);
+        assert!(mapped_file.put_slice(&dirty_record, (CQ_STORE_UNIT_SIZE * 2) as usize));
+        mapped_file.set_wrote_position(CQ_STORE_UNIT_SIZE * 3);
+        mapped_file.set_committed_position(CQ_STORE_UNIT_SIZE * 3);
+        consume_queue.flush(0);
+
+        drop(consume_queue);
+
+        let mut recovered = create_batch_consume_queue(store_path, (CQ_STORE_UNIT_SIZE * 4) as usize);
+        assert!(recovered.load());
+        recovered.recover();
+
+        assert_eq!(recovered.get_min_offset_in_queue(), 0);
+        assert_eq!(recovered.get_max_offset_in_queue(), 5);
+        assert_eq!(recovered.get_message_total_in_queue(), 5);
+        assert_eq!(recovered.get_max_physic_offset(), 172);
+        assert!(recovered.get(5).is_none());
+    }
+
+    #[test]
+    fn batch_consume_queue_delete_expired_file_and_correct_min_offset() {
+        let root = tempdir().expect("tempdir");
+        let store_path = CheetahString::from_string(root.path().join("batch-cq").to_string_lossy().to_string());
+        let mut consume_queue = create_batch_consume_queue(store_path, (CQ_STORE_UNIT_SIZE * 2) as usize);
+
+        consume_queue.put_message_position_info_wrapper(&dispatch_request(100, 40, 1_000, 0, 3));
+        consume_queue.put_message_position_info_wrapper(&dispatch_request(200, 40, 2_000, 3, 3));
+        consume_queue.put_message_position_info_wrapper(&dispatch_request(300, 40, 3_000, 6, 2));
+
+        let first_file = consume_queue
+            .mapped_file_queue
+            .get_first_mapped_file()
+            .expect("first file");
+        first_file.shutdown(0);
+
+        assert_eq!(consume_queue.delete_expired_file(250), 1);
+        consume_queue.correct_min_offset(250);
+
+        assert_eq!(consume_queue.get_min_offset_in_queue(), 6);
+        assert_eq!(consume_queue.get_max_offset_in_queue(), 8);
+        assert_eq!(consume_queue.get_message_total_in_queue(), 2);
+        assert!(consume_queue.get(3).is_none());
+        let latest = consume_queue.get(6).expect("remaining batch");
+        assert_eq!(latest.queue_offset, 6);
+        assert_eq!(latest.batch_num, 2);
     }
 }

--- a/rocketmq-store/src/queue/consume_queue_ext.rs
+++ b/rocketmq-store/src/queue/consume_queue_ext.rs
@@ -14,12 +14,18 @@
 
 use std::path::PathBuf;
 
+use bytes::Buf;
 use cheetah_string::CheetahString;
 use rocketmq_rust::ArcMut;
+use tracing::error;
 use tracing::info;
+use tracing::warn;
 
 use crate::consume_queue::cq_ext_unit::CqExtUnit;
+use crate::consume_queue::cq_ext_unit::MAX_EXT_UNIT_SIZE;
 use crate::consume_queue::mapped_file_queue::MappedFileQueue;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::MappedFile;
 
 const END_BLANK_DATA_LENGTH: usize = 4;
 
@@ -52,6 +58,7 @@ impl ConsumeQueueExt {
             mapped_file_size as u64,
             None,
         ));
+        let _ = bit_map_length;
         Self {
             mapped_file_queue,
             topic,
@@ -64,12 +71,81 @@ impl ConsumeQueueExt {
     pub fn is_ext_addr(address: i64) -> bool {
         address <= MAX_ADDR
     }
-}
 
-impl ConsumeQueueExt {
-    pub fn truncate_by_max_address(&self, max_address: i64) {}
+    #[inline]
+    fn decorate(offset: i64) -> i64 {
+        if !Self::is_ext_addr(offset) {
+            offset + i64::MIN
+        } else {
+            offset
+        }
+    }
 
-    pub fn truncate_by_min_address(&self, min_address: i64) {}
+    #[inline]
+    fn undecorate(address: i64) -> i64 {
+        if Self::is_ext_addr(address) {
+            address - i64::MIN
+        } else {
+            address
+        }
+    }
+
+    #[inline]
+    fn fill_to_end(&self, mapped_file: &DefaultMappedFile, wrote_position: i32) {
+        let end_marker_len = i16::BITS as usize / 8;
+        if wrote_position as usize + end_marker_len <= self.mapped_file_size as usize {
+            let _ = mapped_file.put_slice(&(-1i16).to_be_bytes(), wrote_position as usize);
+        }
+        mapped_file.set_wrote_position(self.mapped_file_size);
+    }
+
+    pub fn truncate_by_max_address(&self, max_address: i64) {
+        if !Self::is_ext_addr(max_address) {
+            return;
+        }
+
+        info!("Truncate consume queue ext by max {}.", max_address);
+
+        let mut cq_ext_unit = CqExtUnit::default();
+        if !self.get(max_address, &mut cq_ext_unit) {
+            error!("[BUG] address {} of consume queue extend not found!", max_address);
+            return;
+        }
+
+        let real_offset = Self::undecorate(max_address);
+        self.mapped_file_queue
+            .mut_from_ref()
+            .truncate_dirty_files(real_offset + cq_ext_unit.size() as i64);
+    }
+
+    pub fn truncate_by_min_address(&self, min_address: i64) {
+        if !Self::is_ext_addr(min_address) {
+            return;
+        }
+
+        info!("Truncate consume queue ext by min {}.", min_address);
+
+        let real_offset = Self::undecorate(min_address);
+        let mut will_remove_files = Vec::new();
+        let mapped_files = self.mapped_file_queue.get_mapped_files().load().clone();
+
+        for mapped_file in mapped_files.iter() {
+            let file_tail_offset = mapped_file.get_file_from_offset() as i64 + self.mapped_file_size as i64;
+            if file_tail_offset < real_offset {
+                info!(
+                    "Destroy consume queue ext by min: file={}, fileTailOffset={}, minOffset={}",
+                    mapped_file.get_file_name(),
+                    file_tail_offset,
+                    real_offset
+                );
+                if mapped_file.destroy(1000) {
+                    will_remove_files.push(mapped_file.clone());
+                }
+            }
+        }
+
+        self.mapped_file_queue.delete_expired_file(will_remove_files);
+    }
 
     pub fn load(&mut self) -> bool {
         let result = self.mapped_file_queue.load();
@@ -83,21 +159,261 @@ impl ConsumeQueueExt {
         result
     }
 
-    pub fn recover(&mut self) {}
+    pub fn recover(&mut self) {
+        let mapped_files = self.mapped_file_queue.get_mapped_files().load().clone();
+        if mapped_files.is_empty() {
+            return;
+        }
+
+        let mut process_offset = 0i64;
+        for (index, mapped_file) in mapped_files.iter().enumerate() {
+            let read_position = mapped_file.get_read_position() as usize;
+            let mut mapped_file_offset = 0usize;
+
+            loop {
+                let size_prefix_len = i16::BITS as usize / 8;
+                if mapped_file_offset + size_prefix_len > read_position {
+                    break;
+                }
+
+                let remaining = read_position - mapped_file_offset;
+                let Some(mut buffer) = mapped_file.get_bytes_readable_checked(mapped_file_offset, remaining) else {
+                    break;
+                };
+
+                let before = buffer.remaining();
+                let mut ext_unit = CqExtUnit::default();
+                ext_unit.read_by_skip(&mut buffer);
+                let consumed = before - buffer.remaining();
+
+                if ext_unit.size() > 0 && consumed == ext_unit.size() as usize {
+                    mapped_file_offset += ext_unit.size() as usize;
+                    continue;
+                }
+
+                break;
+            }
+
+            process_offset = mapped_file.get_file_from_offset() as i64 + mapped_file_offset as i64;
+
+            if mapped_file_offset != read_position && index < mapped_files.len() - 1 {
+                info!(
+                    "Recover next consume queue extend file, {}",
+                    mapped_file.get_file_name()
+                );
+            }
+        }
+
+        self.mapped_file_queue.set_flushed_where(process_offset);
+        self.mapped_file_queue.set_committed_where(process_offset);
+        self.mapped_file_queue
+            .mut_from_ref()
+            .truncate_dirty_files(process_offset);
+    }
 
     pub fn put(&self, cq_ext_unit: CqExtUnit) -> i64 {
-        unimplemented!()
+        const RETRY_TIMES: i32 = 3;
+
+        let size = cq_ext_unit.calc_unit_size();
+        if size > MAX_EXT_UNIT_SIZE as i32 {
+            error!(
+                "Size of cq ext unit is greater than {}, {}",
+                MAX_EXT_UNIT_SIZE, cq_ext_unit
+            );
+            return 1;
+        }
+
+        if self.mapped_file_queue.get_max_offset() + size as i64 > MAX_REAL_OFFSET {
+            warn!(
+                "Capacity of ext is maximum!{}, {}",
+                self.mapped_file_queue.get_max_offset(),
+                size
+            );
+            return 1;
+        }
+
+        for _ in 0..RETRY_TIMES {
+            let mapped_file = {
+                let queue = self.mapped_file_queue.mut_from_ref();
+                match queue.get_last_mapped_file() {
+                    Some(mapped_file) if !mapped_file.is_full() => mapped_file,
+                    _ => match queue.get_last_mapped_file_mut_start_offset(0, true) {
+                        Some(mapped_file) => mapped_file,
+                        None => {
+                            error!("Create mapped file when save consume queue extend, {}", cq_ext_unit);
+                            continue;
+                        }
+                    },
+                }
+            };
+
+            let wrote_position = mapped_file.get_wrote_position();
+            let blank_size = self.mapped_file_size - wrote_position - END_BLANK_DATA_LENGTH as i32;
+
+            if size > blank_size {
+                self.fill_to_end(mapped_file.as_ref(), wrote_position);
+                info!(
+                    "No enough space(need:{}, has:{}) of file {}, so fill to end",
+                    size,
+                    blank_size,
+                    mapped_file.get_file_name()
+                );
+                continue;
+            }
+
+            let mut ext_unit = cq_ext_unit.clone();
+            let data = ext_unit.write();
+            if mapped_file.append_message_offset_length(&data, 0, size as usize) {
+                return Self::decorate(wrote_position as i64 + mapped_file.get_file_from_offset() as i64);
+            }
+        }
+
+        1
     }
 
     pub fn destroy(&mut self) {
         self.mapped_file_queue.destroy();
     }
 
-    pub fn get(&self, address: i64, cq_ext_unit: &CqExtUnit) -> bool {
-        unimplemented!()
+    pub fn get(&self, address: i64, cq_ext_unit: &mut CqExtUnit) -> bool {
+        if !Self::is_ext_addr(address) {
+            return false;
+        }
+
+        let real_offset = Self::undecorate(address);
+        let Some(mapped_file) = self
+            .mapped_file_queue
+            .find_mapped_file_by_offset(real_offset, real_offset == 0)
+        else {
+            return false;
+        };
+
+        let pos = (real_offset % self.mapped_file_size as i64) as usize;
+        let readable = mapped_file.get_read_position() as usize;
+        if pos >= readable {
+            warn!("[BUG] Consume queue extend unit({}) is not found!", real_offset);
+            return false;
+        }
+
+        let Some(mut buffer) = mapped_file.get_bytes_readable_checked(pos, readable - pos) else {
+            warn!("[BUG] Consume queue extend unit({}) is not found!", real_offset);
+            return false;
+        };
+
+        cq_ext_unit.read(&mut buffer)
+    }
+
+    pub fn flush(&self, flush_least_pages: i32) -> bool {
+        self.mapped_file_queue.flush(flush_least_pages)
+    }
+
+    pub fn get_total_size(&self) -> i64 {
+        self.mapped_file_queue.get_total_file_size()
     }
 
     pub fn check_self(&self) {
+        let _ = self.store_path.as_str();
         self.mapped_file_queue.check_self()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn new_test_ext(temp_dir: &tempfile::TempDir, mapped_file_size: i32) -> ConsumeQueueExt {
+        ConsumeQueueExt::new(
+            CheetahString::from_static_str("cqext-topic"),
+            0,
+            CheetahString::from_string(temp_dir.path().to_string_lossy().to_string()),
+            mapped_file_size,
+            64,
+        )
+    }
+
+    #[test]
+    fn cqext_put_and_get_round_trip() {
+        let temp_dir = tempdir().unwrap();
+        let ext = new_test_ext(&temp_dir, 64);
+        let original = CqExtUnit::new(12345, 67890, Some(vec![1, 2, 3, 4]));
+
+        let address = ext.put(original.clone());
+        assert!(ConsumeQueueExt::is_ext_addr(address));
+
+        let mut restored = CqExtUnit::default();
+        assert!(ext.get(address, &mut restored));
+        assert_eq!(restored, original);
+    }
+
+    #[test]
+    fn cqext_recover_truncates_dirty_tail() {
+        let temp_dir = tempdir().unwrap();
+        let ext = new_test_ext(&temp_dir, 64);
+        let _first_addr = ext.put(CqExtUnit::new(11, 101, Some(vec![1, 2])));
+        let second = CqExtUnit::new(22, 202, Some(vec![3, 4, 5]));
+        let second_addr = ext.put(second.clone());
+
+        let queue = ext.mapped_file_queue.mut_from_ref();
+        let mapped_file = queue.get_last_mapped_file().expect("mapped file");
+        let dirty_pos = mapped_file.get_wrote_position() as usize;
+        assert!(mapped_file.put_slice(&[0x7F, 0xFF, 0xAA], dirty_pos));
+        mapped_file.set_wrote_position(dirty_pos as i32 + 3);
+
+        let mut reloaded = new_test_ext(&temp_dir, 64);
+        assert!(reloaded.load());
+        reloaded.recover();
+
+        let mut restored = CqExtUnit::default();
+        assert!(reloaded.get(second_addr, &mut restored));
+        assert_eq!(restored, second);
+        assert_eq!(
+            reloaded.mapped_file_queue.get_max_offset(),
+            ConsumeQueueExt::undecorate(second_addr) + restored.size() as i64
+        );
+    }
+
+    #[test]
+    fn cqext_truncate_by_min_address_removes_older_files() {
+        let temp_dir = tempdir().unwrap();
+        let ext = new_test_ext(&temp_dir, 64);
+
+        let addresses: Vec<i64> = (0..5)
+            .map(|index| ext.put(CqExtUnit::new(100 + index, 1000 + index, None)))
+            .collect();
+
+        assert_eq!(ext.mapped_file_queue.get_mapped_files_size(), 2);
+
+        ext.truncate_by_min_address(addresses[4]);
+
+        assert_eq!(ext.mapped_file_queue.get_mapped_files_size(), 1);
+        let first_file = ext
+            .mapped_file_queue
+            .get_first_mapped_file()
+            .expect("remaining mapped file");
+        assert_eq!(
+            first_file.get_file_from_offset() as i64,
+            ConsumeQueueExt::undecorate(addresses[3])
+        );
+    }
+
+    #[test]
+    fn cqext_truncate_by_max_address_discards_newer_units() {
+        let temp_dir = tempdir().unwrap();
+        let ext = new_test_ext(&temp_dir, 64);
+
+        let first_addr = ext.put(CqExtUnit::new(11, 101, None));
+        let second_addr = ext.put(CqExtUnit::new(22, 202, Some(vec![1, 2, 3])));
+        let third_addr = ext.put(CqExtUnit::new(33, 303, Some(vec![4, 5, 6, 7])));
+
+        ext.truncate_by_max_address(second_addr);
+
+        let mut first = CqExtUnit::default();
+        let mut second = CqExtUnit::default();
+        let mut third = CqExtUnit::default();
+        assert!(ext.get(first_addr, &mut first));
+        assert!(ext.get(second_addr, &mut second));
+        assert!(!ext.get(third_addr, &mut third));
     }
 }

--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -159,6 +159,9 @@ impl ConsumeQueueStore {
     }
 
     fn encode_cq_unit(cq_unit: &CqUnit) -> Bytes {
+        if !cq_unit.native_buffer.is_empty() {
+            return Bytes::copy_from_slice(&cq_unit.native_buffer);
+        }
         let mut bytes = BytesMut::with_capacity(CQ_STORE_UNIT_SIZE as usize);
         bytes.put_i64(cq_unit.pos);
         bytes.put_i32(cq_unit.size);
@@ -786,5 +789,74 @@ impl ConsumeQueueStore {
     #[inline]
     fn get_life_cycle(&self, topic: &CheetahString, queue_id: i32) -> ArcConsumeQueue {
         self.find_or_create_consume_queue(topic, queue_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Buf;
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_rust::ArcMut;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::queue::batch_consume_queue;
+
+    #[test]
+    fn batch_consume_queue_store_get_returns_full_batch_unit() {
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let broker_config = Arc::new(BrokerConfig::default());
+        let store = ConsumeQueueStore::new(message_store_config.clone(), broker_config);
+        let root = tempdir().expect("tempdir");
+        let store_path = CheetahString::from_string(root.path().join("batch-cq").to_string_lossy().to_string());
+        let topic = CheetahString::from_static_str("BatchTopic");
+        let queue_id = 1;
+
+        let mut batch_queue = BatchConsumeQueue::new(
+            topic.clone(),
+            queue_id,
+            store_path,
+            (batch_consume_queue::CQ_STORE_UNIT_SIZE * 2) as usize,
+            None,
+            message_store_config,
+        );
+        batch_queue.put_message_position_info_wrapper(&DispatchRequest {
+            topic: topic.clone(),
+            queue_id,
+            commit_log_offset: 100,
+            msg_size: 32,
+            tags_code: 7,
+            store_timestamp: 1_000,
+            msg_base_offset: 0,
+            batch_size: 3,
+            success: true,
+            ..DispatchRequest::default()
+        });
+
+        store
+            .inner
+            .consume_queue_table
+            .lock()
+            .entry(topic.clone())
+            .or_default()
+            .insert(queue_id, ArcMut::new(Box::new(batch_queue)));
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let bytes = runtime.block_on(store.get(&topic, queue_id, 0));
+
+        assert_eq!(bytes.len(), batch_consume_queue::CQ_STORE_UNIT_SIZE as usize);
+        let mut bytes = bytes;
+        assert_eq!(bytes.get_i64(), 100);
+        assert_eq!(bytes.get_i32(), 32);
+        assert_eq!(bytes.get_i64(), 7);
+        assert_eq!(bytes.get_i64(), 1_000);
+        assert_eq!(bytes.get_i64(), 0);
+        assert_eq!(bytes.get_i16(), 3);
     }
 }

--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -713,7 +713,11 @@ impl<MS: MessageStore> FileQueueLifeCycle for ConsumeQueue<MS> {
 
     #[inline]
     fn flush(&self, flush_least_pages: i32) -> bool {
-        self.mapped_file_queue.flush(flush_least_pages)
+        let mut result = self.mapped_file_queue.flush(flush_least_pages);
+        if self.is_ext_read_enable() {
+            result &= self.consume_queue_ext.as_ref().unwrap().flush(flush_least_pages);
+        }
+        result
     }
 
     #[inline]
@@ -866,12 +870,17 @@ impl<MS: MessageStore> ConsumeQueueTrait for ConsumeQueue<MS> {
 
     #[inline]
     fn get_total_size(&self) -> i64 {
-        self.mapped_file_queue
+        let mut total_size: i64 = self
+            .mapped_file_queue
             .get_mapped_files()
             .load()
             .iter()
             .map(|mapped_file| mapped_file.get_file_size() as i64)
-            .sum()
+            .sum();
+        if self.is_ext_read_enable() {
+            total_size += self.consume_queue_ext.as_ref().unwrap().get_total_size();
+        }
+        total_size
     }
 
     #[inline]
@@ -1118,7 +1127,7 @@ struct ConsumeQueueIterator {
 }
 
 impl ConsumeQueueIterator {
-    fn get_ext(&self, offset: i64, cq_ext_unit: &CqExtUnit) -> bool {
+    fn get_ext(&self, offset: i64, cq_ext_unit: &mut CqExtUnit) -> bool {
         match self.consume_queue_ext.as_ref() {
             None => false,
             Some(value) => value.get(offset, cq_ext_unit),
@@ -1153,8 +1162,8 @@ impl Iterator for ConsumeQueueIterator {
                 };
 
                 if ConsumeQueueExt::is_ext_addr(cq_unit.tags_code) {
-                    let cq_ext_unit = CqExtUnit::default();
-                    let ext_ret = self.get_ext(cq_unit.tags_code, &cq_ext_unit);
+                    let mut cq_ext_unit = CqExtUnit::default();
+                    let ext_ret = self.get_ext(cq_unit.tags_code, &mut cq_ext_unit);
                     if ext_ret {
                         cq_unit.tags_code = cq_ext_unit.tags_code();
                         cq_unit.cq_ext_unit = Some(cq_ext_unit);
@@ -1186,18 +1195,29 @@ mod tests {
     use crate::base::dispatch_request::DispatchRequest;
     use crate::config::message_store_config::MessageStoreConfig;
     use crate::message_store::local_file_message_store::LocalFileMessageStore;
+    use crate::queue::file_queue_life_cycle::FileQueueLifeCycle;
     use crate::store_path_config_helper::get_store_path_consume_queue;
 
     fn new_test_store(
         temp_dir: &tempfile::TempDir,
         mapped_file_size_consume_queue: usize,
     ) -> ArcMut<LocalFileMessageStore> {
-        let mut store = ArcMut::new(LocalFileMessageStore::new(
-            Arc::new(MessageStoreConfig {
-                store_path_root_dir: temp_dir.path().to_string_lossy().to_string().into(),
+        new_configured_test_store(
+            temp_dir,
+            MessageStoreConfig {
                 mapped_file_size_consume_queue,
                 ..MessageStoreConfig::default()
-            }),
+            },
+        )
+    }
+
+    fn new_configured_test_store(
+        temp_dir: &tempfile::TempDir,
+        mut config: MessageStoreConfig,
+    ) -> ArcMut<LocalFileMessageStore> {
+        config.store_path_root_dir = temp_dir.path().to_string_lossy().to_string().into();
+        let mut store = ArcMut::new(LocalFileMessageStore::new(
+            Arc::new(config),
             Arc::new(BrokerConfig::default()),
             Arc::new(DashMap::<CheetahString, ArcMut<TopicConfig>>::new()),
             None,
@@ -1214,6 +1234,24 @@ mod tests {
         mapped_file_size_consume_queue: usize,
     ) -> ConsumeQueue<LocalFileMessageStore> {
         let store = new_test_store(temp_dir, mapped_file_size_consume_queue);
+        ConsumeQueue::new(
+            topic.clone(),
+            0,
+            CheetahString::from_string(get_store_path_consume_queue(
+                store.get_message_store_config().store_path_root_dir.as_str(),
+            )),
+            mapped_file_size_consume_queue as i32,
+            store,
+        )
+    }
+
+    fn new_configured_test_consume_queue(
+        temp_dir: &tempfile::TempDir,
+        topic: &CheetahString,
+        config: MessageStoreConfig,
+    ) -> ConsumeQueue<LocalFileMessageStore> {
+        let mapped_file_size_consume_queue = config.mapped_file_size_consume_queue;
+        let store = new_configured_test_store(temp_dir, config);
         ConsumeQueue::new(
             topic.clone(),
             0,
@@ -1277,5 +1315,90 @@ mod tests {
         consume_queue.swap_map(3, 0, 0);
         consume_queue.clean_swapped_map(0);
         assert_eq!(consume_queue.mapped_file_queue.get_mapped_files_size(), 2);
+    }
+
+    #[test]
+    fn consume_queue_round_trips_cqext_bitmap_on_iterate() {
+        let temp_dir = tempdir().unwrap();
+        let topic = CheetahString::from_static_str("single-cq-cqext-topic");
+        let mut consume_queue = new_configured_test_consume_queue(
+            &temp_dir,
+            &topic,
+            MessageStoreConfig {
+                enable_consume_queue_ext: true,
+                mapped_file_size_consume_queue: (2 * CQ_STORE_UNIT_SIZE) as usize,
+                mapped_file_size_consume_queue_ext: 64,
+                ..MessageStoreConfig::default()
+            },
+        );
+
+        let bitmap = vec![0xAB, 0xCD, 0xEF];
+        consume_queue.put_message_position_info_wrapper(&DispatchRequest {
+            topic: topic.clone(),
+            queue_id: 0,
+            commit_log_offset: 123,
+            msg_size: 32,
+            tags_code: 456,
+            consume_queue_offset: 0,
+            store_timestamp: 7890,
+            bit_map: Some(bitmap.clone()),
+            success: true,
+            ..DispatchRequest::default()
+        });
+
+        let cq_unit = consume_queue.get(0).expect("consume queue unit");
+        assert_eq!(cq_unit.tags_code, 456);
+        let cq_ext_unit = cq_unit.cq_ext_unit.expect("cq ext unit");
+        assert_eq!(cq_ext_unit.tags_code(), 456);
+        assert_eq!(cq_ext_unit.msg_store_time(), 7890);
+        assert_eq!(cq_ext_unit.filter_bit_map(), Some(bitmap.as_slice()));
+    }
+
+    #[test]
+    fn consume_queue_flush_and_total_size_include_cqext() {
+        let temp_dir = tempdir().unwrap();
+        let topic = CheetahString::from_static_str("single-cq-cqext-flush-topic");
+        let mut consume_queue = new_configured_test_consume_queue(
+            &temp_dir,
+            &topic,
+            MessageStoreConfig {
+                enable_consume_queue_ext: true,
+                mapped_file_size_consume_queue: (2 * CQ_STORE_UNIT_SIZE) as usize,
+                mapped_file_size_consume_queue_ext: 64,
+                ..MessageStoreConfig::default()
+            },
+        );
+
+        consume_queue.put_message_position_info_wrapper(&DispatchRequest {
+            topic: topic.clone(),
+            queue_id: 0,
+            commit_log_offset: 321,
+            msg_size: 32,
+            tags_code: 654,
+            consume_queue_offset: 0,
+            store_timestamp: 9876,
+            bit_map: Some(vec![1, 2, 3, 4]),
+            success: true,
+            ..DispatchRequest::default()
+        });
+
+        let ext_queue = consume_queue
+            .consume_queue_ext
+            .as_ref()
+            .expect("consume queue ext should exist");
+        let base_total_size: i64 = consume_queue
+            .mapped_file_queue
+            .get_mapped_files()
+            .load()
+            .iter()
+            .map(|mapped_file| mapped_file.get_file_size() as i64)
+            .sum();
+
+        let _ = consume_queue.flush(0);
+        let _ = ext_queue.flush(0);
+        assert_eq!(
+            consume_queue.get_total_size(),
+            base_total_size + ext_queue.get_total_size()
+        );
     }
 }

--- a/rocketmq-store/tests/timer_recovery_integration_tests.rs
+++ b/rocketmq-store/tests/timer_recovery_integration_tests.rs
@@ -1,0 +1,190 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for timer recovery semantics across LocalFileMessageStore restarts.
+//!
+//! These tests exercise the default store path where LocalFileMessageStore
+//! auto-initializes the timer subsystem, instead of wiring TimerMessageStore
+//! manually inside the timer module's unit tests.
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use dashmap::DashMap;
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_common::common::config::TopicConfig;
+use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_common::common::message::MessageConst;
+use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::MessageDecoder::message_properties_to_string;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::config::message_store_config::MessageStoreConfig;
+use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
+use rocketmq_store::store_path_config_helper::get_timer_check_path;
+use rocketmq_store::timer::timer_checkpoint::TimerCheckpoint;
+use rocketmq_store::timer::timer_message_store::TIMER_OUT_MS;
+use rocketmq_store::timer::timer_message_store::TIMER_TOPIC;
+use tempfile::TempDir;
+
+fn timer_store_config(temp_dir: &TempDir) -> MessageStoreConfig {
+    MessageStoreConfig {
+        store_path_root_dir: temp_dir.path().to_string_lossy().to_string().into(),
+        read_uncommitted: true,
+        mapped_file_size_commit_log: 4096,
+        mapped_file_size_consume_queue: 200,
+        timer_precision_ms: 100,
+        timer_roll_window_slot: 512,
+        ..MessageStoreConfig::default()
+    }
+}
+
+fn new_test_store(temp_dir: &TempDir) -> ArcMut<LocalFileMessageStore> {
+    let real_topic = CheetahString::from_static_str("phase6-timer-real-topic");
+    let broker_config = Arc::new(BrokerConfig::default());
+    let topic_config_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>> = Arc::new(DashMap::new());
+    topic_config_table.insert(real_topic, ArcMut::new(TopicConfig::default()));
+    topic_config_table.insert(
+        CheetahString::from_static_str(TIMER_TOPIC),
+        ArcMut::new(TopicConfig::default()),
+    );
+
+    let mut store = ArcMut::new(LocalFileMessageStore::new(
+        Arc::new(timer_store_config(temp_dir)),
+        broker_config,
+        topic_config_table,
+        None,
+        false,
+    ));
+    let store_clone = store.clone();
+    store.set_message_store_arc(store_clone);
+    store
+}
+
+fn build_timer_message(real_topic: &CheetahString, deliver_ms: u64) -> MessageExtBrokerInner {
+    let mut msg = MessageExtBrokerInner::default();
+    msg.set_topic(CheetahString::from_static_str(TIMER_TOPIC));
+    msg.message_ext_inner.queue_id = 0;
+    msg.set_body(Bytes::from_static(b"phase6-timer-body"));
+    msg.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC),
+        real_topic.clone(),
+    );
+    msg.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_REAL_QUEUE_ID),
+        CheetahString::from_string("0".to_string()),
+    );
+    msg.put_property(
+        CheetahString::from_static_str(TIMER_OUT_MS),
+        CheetahString::from_string(deliver_ms.to_string()),
+    );
+    msg.properties_string = message_properties_to_string(msg.get_properties());
+    msg
+}
+
+#[tokio::test]
+async fn restart_with_auto_initialized_timer_store_redelivers_due_message() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let real_topic = CheetahString::from_static_str("phase6-timer-real-topic");
+
+    let mut writer = new_test_store(&temp_dir);
+    writer.init().await.expect("init writer");
+    assert!(writer.load().await, "load writer");
+
+    let timer_message_store = writer
+        .get_timer_message_store()
+        .cloned()
+        .expect("timer message store should be auto-initialized");
+
+    let put_result = writer
+        .put_message(build_timer_message(
+            &real_topic,
+            current_millis().saturating_sub(2_000) as u64,
+        ))
+        .await;
+    assert!(put_result.is_ok(), "put timer message");
+
+    writer.reput_once().await;
+    assert_eq!(timer_message_store.process_once().await, 1);
+    writer.shutdown().await;
+    drop(writer);
+
+    let mut reloaded = new_test_store(&temp_dir);
+    reloaded.init().await.expect("init reloaded store");
+    assert!(reloaded.load().await, "load reloaded store");
+
+    let reloaded_timer_message_store = reloaded
+        .get_timer_message_store()
+        .cloned()
+        .expect("timer message store should be auto-initialized after restart");
+    reloaded_timer_message_store.set_should_running_dequeue(true);
+
+    let delivered = reloaded_timer_message_store.process_once().await;
+    reloaded.reput_once().await;
+
+    assert_eq!(delivered, 1);
+    assert_eq!(reloaded.get_max_offset_in_queue(&real_topic, 0), 1);
+    assert_eq!(
+        reloaded_timer_message_store.curr_queue_offset.load(Ordering::Relaxed),
+        1
+    );
+}
+
+#[tokio::test]
+async fn restart_revises_lagging_timer_checkpoint_in_default_store_path() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let real_topic = CheetahString::from_static_str("phase6-timer-real-topic");
+
+    let mut writer = new_test_store(&temp_dir);
+    writer.init().await.expect("init writer");
+    assert!(writer.load().await, "load writer");
+
+    let timer_message_store = writer
+        .get_timer_message_store()
+        .cloned()
+        .expect("timer message store should be auto-initialized");
+
+    let put_result = writer
+        .put_message(build_timer_message(&real_topic, current_millis() as u64 + 60_000))
+        .await;
+    assert!(put_result.is_ok(), "put timer message");
+
+    writer.reput_once().await;
+    assert_eq!(timer_message_store.process_once().await, 1);
+    writer.shutdown().await;
+    drop(writer);
+
+    let checkpoint = TimerCheckpoint::new(get_timer_check_path(temp_dir.path().to_string_lossy().as_ref()))
+        .expect("open timer checkpoint");
+    checkpoint.set_last_timer_queue_offset(99);
+    checkpoint.set_master_timer_queue_offset(99);
+    checkpoint.flush().expect("flush timer checkpoint");
+
+    let mut reloaded = new_test_store(&temp_dir);
+    reloaded.init().await.expect("init reloaded store");
+    assert!(reloaded.load().await, "load reloaded store");
+
+    let reloaded_timer_message_store = reloaded
+        .get_timer_message_store()
+        .cloned()
+        .expect("timer message store should be auto-initialized after restart");
+
+    assert_eq!(
+        reloaded_timer_message_store.curr_queue_offset.load(Ordering::Relaxed),
+        1
+    );
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7084

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented batch consume queue with full lifecycle management and persistence.
  * Added consume queue extension support with address decoration and recovery logic.
  * Enabled timer message recovery across message store restarts.
  * Enhanced tag-based message filtering.

* **Tests**
  * Added integration tests for timer recovery scenarios and message filtering validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->