### PR TITLE
[ISSUE #7086]🚀feat(dispatch): implement dispatch progress offset retrieval and refactor offset checks in message store

### DIFF
--- a/rocketmq-store/src/base/append_message_callback.rs
+++ b/rocketmq-store/src/base/append_message_callback.rs
@@ -36,7 +36,6 @@ use crate::base::message_status_enum::AppendMessageStatus;
 use crate::base::put_message_context::PutMessageContext;
 use crate::config::message_store_config::MessageStoreConfig;
 use crate::log_file::commit_log::get_message_num;
-use crate::log_file::commit_log::CommitLog;
 use crate::log_file::commit_log::BLANK_MAGIC_CODE;
 use crate::log_file::commit_log::CRC32_RESERVED_LEN;
 use crate::log_file::mapped_file::MappedFile;
@@ -151,11 +150,6 @@ impl AppendMessageCallback for DefaultAppendMessageCallback {
         put_message_context: &PutMessageContext,
     ) -> AppendMessageResult {
         let mut pre_encode_buffer = msg_inner.encoded_buff.take().unwrap(); // Assuming get_encoded_buff returns Option<ByteBuffer>
-        let is_multi_dispatch_msg =
-            self.message_store_config.enable_multi_dispatch && CommitLog::is_multi_dispatch_msg(msg_inner);
-        if is_multi_dispatch_msg {
-            unimplemented!("Multi dispatch message is not supported yet");
-        }
 
         let msg_len = i32::from_be_bytes(pre_encode_buffer[0..4].try_into().unwrap());
         //physic offset
@@ -356,14 +350,6 @@ impl AppendMessageCallback for DefaultAppendMessageCallback {
     ) -> AppendMessageResult {
         // Extract pre-encoded buffer (still contains metadata we need)
         let pre_encode_buffer = msg_inner.encoded_buff.take().unwrap();
-        let is_multi_dispatch_msg =
-            self.message_store_config.enable_multi_dispatch && CommitLog::is_multi_dispatch_msg(msg_inner);
-
-        if is_multi_dispatch_msg {
-            // Fall back to standard implementation for multi-dispatch
-            msg_inner.encoded_buff = Some(pre_encode_buffer);
-            return self.do_append(file_from_offset, mapped_file, max_blank, msg_inner, put_message_context);
-        }
 
         let msg_len = i32::from_be_bytes(pre_encode_buffer[0..4].try_into().unwrap());
 

--- a/rocketmq-store/src/base/commit_log_dispatcher.rs
+++ b/rocketmq-store/src/base/commit_log_dispatcher.rs
@@ -24,4 +24,12 @@ pub trait CommitLogDispatcher: Send + Sync + 'static {
             self.dispatch(request);
         }
     }
+
+    /// Returns the highest persisted CommitLog offset this dispatcher has already processed.
+    ///
+    /// The returned offset is used as a recovery/reput lower bound. `None` means the dispatcher
+    /// has no persisted progress to contribute.
+    fn dispatch_progress_offset(&self, _commit_log_min_offset: i64) -> Option<i64> {
+        None
+    }
 }

--- a/rocketmq-store/src/index/index_dispatch.rs
+++ b/rocketmq-store/src/index/index_dispatch.rs
@@ -40,4 +40,11 @@ impl CommitLogDispatcher for CommitLogDispatcherBuildIndex {
             self.index_service.build_index(dispatch_request);
         }
     }
+
+    fn dispatch_progress_offset(&self, _commit_log_min_offset: i64) -> Option<i64> {
+        self.message_store_config
+            .message_index_enable
+            .then(|| self.index_service.get_max_dispatch_commit_log_offset())
+            .flatten()
+    }
 }

--- a/rocketmq-store/src/index/index_file.rs
+++ b/rocketmq-store/src/index/index_file.rs
@@ -279,6 +279,11 @@ impl IndexFile {
         self.index_header.get_end_phy_offset()
     }
 
+    #[inline]
+    pub fn has_entries(&self) -> bool {
+        self.index_header.get_index_count() > 1
+    }
+
     pub fn is_time_matched(&self, begin: i64, end: i64) -> bool {
         let begin_timestamp = self.index_header.get_begin_timestamp();
         let end_timestamp = self.index_header.get_end_timestamp();

--- a/rocketmq-store/src/index/index_service.rs
+++ b/rocketmq-store/src/index/index_service.rs
@@ -122,6 +122,16 @@ impl IndexService {
             .map_or(0, |f| (f.get_file_size() * index_file_list.len()) as u64)
     }
 
+    #[inline]
+    pub fn get_max_dispatch_commit_log_offset(&self) -> Option<i64> {
+        self.index_file_list
+            .read()
+            .iter()
+            .rev()
+            .find(|index_file| index_file.has_entries())
+            .map(|index_file| index_file.get_end_phy_offset())
+    }
+
     pub fn delete_expired_file(&self, offset: u64) {
         let files = {
             let index_file_list = self.index_file_list.read();

--- a/rocketmq-store/src/message_encoder/message_ext_encoder.rs
+++ b/rocketmq-store/src/message_encoder/message_ext_encoder.rs
@@ -30,7 +30,6 @@ use crate::base::message_result::PutMessageResult;
 use crate::base::message_status_enum::PutMessageStatus;
 use crate::base::put_message_context::PutMessageContext;
 use crate::config::message_store_config::MessageStoreConfig;
-use crate::log_file::commit_log::CommitLog;
 use crate::log_file::commit_log::CRC32_RESERVED_LEN;
 
 pub struct MessageExtEncoder {
@@ -217,10 +216,6 @@ impl MessageExtEncoder {
 
     pub fn encode(&mut self, msg_inner: &MessageExtBrokerInner) -> Option<PutMessageResult> {
         self.byte_buf.clear();
-
-        if self.message_store_config.enable_multi_dispatch && CommitLog::is_multi_dispatch_msg(msg_inner) {
-            return self.encode_without_properties(msg_inner);
-        }
 
         // Serialize message
         let properties_data = msg_inner.properties_string().as_bytes();

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -521,16 +521,16 @@ impl LocalFileMessageStore {
         );
         let recover_consume_queue_start = Instant::now();
         self.recover_consume_queue().await;
-        let max_phy_offset_of_consume_queue = self.consume_queue_store.get_max_phy_offset_in_consume_queue_global();
+        let dispatch_recovery_offset = self.get_dispatch_recovery_offset();
         let recover_consume_queue = Instant::now()
             .saturating_duration_since(recover_consume_queue_start)
             .as_millis();
 
         let recover_commit_log_start = Instant::now();
         if last_exit_ok {
-            self.recover_normally(max_phy_offset_of_consume_queue).await;
+            self.recover_normally(dispatch_recovery_offset).await;
         } else {
-            self.recover_abnormally(max_phy_offset_of_consume_queue).await;
+            self.recover_abnormally(dispatch_recovery_offset).await;
         }
         let recover_commit_log = Instant::now()
             .saturating_duration_since(recover_commit_log_start)
@@ -690,6 +690,14 @@ impl LocalFileMessageStore {
         ConsumeQueueStoreTrait::check_self(&self.consume_queue_store);
     }
 
+    fn get_dispatch_recovery_offset(&self) -> i64 {
+        let commit_log_min_offset = self.commit_log.get_min_offset();
+        self.dispatcher
+            .min_dispatch_progress_offset(commit_log_min_offset)
+            .unwrap_or(commit_log_min_offset)
+            .max(commit_log_min_offset)
+    }
+
     pub fn next_offset_correction(&self, old_offset: i64, new_offset: i64) -> i64 {
         let mut next_offset = old_offset;
         if self.message_store_config.broker_role != BrokerRole::Slave || self.message_store_config.offset_check_in_slave
@@ -714,26 +722,20 @@ impl LocalFileMessageStore {
         self.message_arriving_listener = message_arriving_listener;
     }
 
-    fn do_recheck_reput_offset_from_cq(&self) {
+    fn do_recheck_reput_offset_from_dispatchers(&self) {
         let Some(reput_from_offset) = self.reput_message_service.reput_from_offset.as_ref() else {
             return;
         };
 
-        let cq_reput_from_offset = self.consume_queue_store.get_max_phy_offset_in_consume_queue_global();
-        let commit_log_min_offset = self.commit_log.get_min_offset();
         let commit_log_confirm_offset = self.commit_log.get_confirm_offset();
-        let normalized_from_cq = if cq_reput_from_offset < 0 {
-            commit_log_min_offset
-        } else {
-            cq_reput_from_offset.max(commit_log_min_offset)
-        };
-        let target_reput_from_offset = normalized_from_cq.min(commit_log_confirm_offset);
+        let dispatch_recovery_offset = self.get_dispatch_recovery_offset();
+        let target_reput_from_offset = dispatch_recovery_offset.min(commit_log_confirm_offset);
         let previous_reput_from_offset = reput_from_offset.swap(target_reput_from_offset, Ordering::SeqCst);
 
         if previous_reput_from_offset != target_reput_from_offset {
             info!(
-                "rechecked reputFromOffset from {} to {} using consume queue max physical offset {}",
-                previous_reput_from_offset, target_reput_from_offset, cq_reput_from_offset
+                "rechecked reputFromOffset from {} to {} using dispatch recovery offset {}",
+                previous_reput_from_offset, target_reput_from_offset, dispatch_recovery_offset
             );
         }
     }
@@ -744,10 +746,7 @@ impl LocalFileMessageStore {
 
     pub async fn reput_once(&mut self) {
         if self.reput_message_service.reput_from_offset.is_none() {
-            let start_offset = self
-                .consume_queue_store
-                .get_max_phy_offset_in_consume_queue_global()
-                .max(0);
+            let start_offset = self.get_dispatch_recovery_offset().max(0);
             self.reput_message_service.set_reput_from_offset(start_offset);
         }
         let Some(message_store) = self.message_store_arc.clone() else {
@@ -882,7 +881,7 @@ impl MessageStore for LocalFileMessageStore {
             self.notify_message_arrive_in_batch,
             self.message_store_arc.clone().unwrap(),
         );
-        self.do_recheck_reput_offset_from_cq();
+        self.do_recheck_reput_offset_from_dispatchers();
         self.flush_consume_queue_service.start();
         self.commit_log.start();
         self.consume_queue_store.start();
@@ -2235,6 +2234,14 @@ impl CommitLogDispatcherDefault {
     pub fn add_first_dispatcher(&mut self, dispatcher: Arc<dyn CommitLogDispatcher>) {
         self.dispatcher_vec.insert(0, dispatcher);
     }
+
+    #[inline]
+    pub fn min_dispatch_progress_offset(&self, commit_log_min_offset: i64) -> Option<i64> {
+        self.dispatcher_vec
+            .iter()
+            .filter_map(|dispatcher| dispatcher.dispatch_progress_offset(commit_log_min_offset))
+            .min()
+    }
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherDefault {
@@ -3109,6 +3116,7 @@ mod tests {
     use rocketmq_common::common::config::TopicConfig;
     use rocketmq_common::common::message::message_ext::MessageExt;
     use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+    use rocketmq_common::common::message::MessageConst;
     use rocketmq_common::common::message::MessageTrait;
     use rocketmq_common::common::topic::TopicValidator;
     use rocketmq_rust::ArcMut;
@@ -3754,7 +3762,54 @@ mod tests {
     }
 
     #[test]
-    fn do_recheck_reput_offset_from_cq_rewinds_to_dispatched_commitlog_offset() {
+    fn reput_once_initializes_from_minimum_dispatcher_progress() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_test_store(&temp_dir);
+        let topic = CheetahString::from_static_str("reput-init-offset-topic");
+
+        for (queue_offset, commit_log_offset) in [(0_i64, 100_i64), (1, 132_i64)] {
+            store
+                .consume_queue_store
+                .put_message_position_info_wrapper(&DispatchRequest {
+                    topic: topic.clone(),
+                    queue_id: 0,
+                    commit_log_offset,
+                    msg_size: 32,
+                    consume_queue_offset: queue_offset,
+                    store_timestamp: 1000 + queue_offset,
+                    success: true,
+                    ..DispatchRequest::default()
+                });
+        }
+
+        store.index_service.build_index(&DispatchRequest {
+            topic,
+            queue_id: 0,
+            commit_log_offset: 100,
+            msg_size: 32,
+            store_timestamp: 1000,
+            keys: CheetahString::from_static_str("lookup-key"),
+            success: true,
+            ..DispatchRequest::default()
+        });
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(store.reput_once());
+
+        let reput_from_offset = store
+            .reput_message_service
+            .reput_from_offset
+            .as_ref()
+            .expect("reput offset should exist")
+            .load(Ordering::SeqCst);
+        assert_eq!(reput_from_offset, 100);
+    }
+
+    #[test]
+    fn do_recheck_reput_offset_from_dispatchers_rewinds_to_dispatched_commitlog_offset() {
         let temp_dir = tempdir().unwrap();
         let mut store = ArcMut::new(LocalFileMessageStore::new(
             Arc::new(MessageStoreConfig {
@@ -3792,7 +3847,7 @@ mod tests {
                 });
         }
 
-        store.do_recheck_reput_offset_from_cq();
+        store.do_recheck_reput_offset_from_dispatchers();
 
         let reput_from_offset = store
             .reput_message_service
@@ -3801,6 +3856,106 @@ mod tests {
             .expect("reput offset should exist")
             .load(Ordering::SeqCst);
         assert_eq!(reput_from_offset, 164);
+    }
+
+    #[test]
+    fn do_recheck_reput_offset_from_dispatchers_uses_minimum_progress_across_cq_and_index() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = ArcMut::new(LocalFileMessageStore::new(
+            Arc::new(MessageStoreConfig {
+                store_path_root_dir: temp_dir.path().to_string_lossy().to_string().into(),
+                enable_controller_mode: true,
+                ..MessageStoreConfig::default()
+            }),
+            Arc::new(BrokerConfig {
+                enable_controller_mode: true,
+                ..BrokerConfig::default()
+            }),
+            Arc::new(DashMap::<CheetahString, ArcMut<TopicConfig>>::new()),
+            None,
+            false,
+        ));
+        let store_clone = store.clone();
+        store.set_message_store_arc(store_clone);
+        let topic = CheetahString::from_static_str("recheck-reput-offset-with-index-topic");
+
+        store.set_confirm_offset(256);
+        store.reput_message_service.set_reput_from_offset(256);
+
+        for (queue_offset, commit_log_offset) in [(0_i64, 100_i64), (1, 132_i64)] {
+            store
+                .consume_queue_store
+                .put_message_position_info_wrapper(&DispatchRequest {
+                    topic: topic.clone(),
+                    queue_id: 0,
+                    commit_log_offset,
+                    msg_size: 32,
+                    consume_queue_offset: queue_offset,
+                    store_timestamp: 1000 + queue_offset,
+                    success: true,
+                    ..DispatchRequest::default()
+                });
+        }
+
+        store.index_service.build_index(&DispatchRequest {
+            topic,
+            queue_id: 0,
+            commit_log_offset: 100,
+            msg_size: 32,
+            store_timestamp: 1000,
+            keys: CheetahString::from_static_str("lookup-key"),
+            success: true,
+            ..DispatchRequest::default()
+        });
+
+        store.do_recheck_reput_offset_from_dispatchers();
+
+        let reput_from_offset = store
+            .reput_message_service
+            .reput_from_offset
+            .as_ref()
+            .expect("reput offset should exist")
+            .load(Ordering::SeqCst);
+        assert_eq!(reput_from_offset, 100);
+    }
+
+    #[tokio::test]
+    async fn put_message_with_multi_dispatch_properties_dispatches_lmq_queues_after_reput() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_configured_test_store(
+            &temp_dir,
+            MessageStoreConfig {
+                enable_multi_dispatch: true,
+                enable_lmq: true,
+                flush_disk_type: FlushDiskType::AsyncFlush,
+                ..MessageStoreConfig::default()
+            },
+        );
+        let source_topic = CheetahString::from_static_str("multi-dispatch-source-topic");
+        let lmq_alpha = CheetahString::from_static_str("%LMQ%alpha");
+        let lmq_beta = CheetahString::from_static_str("%LMQ%beta");
+
+        let mut msg = MessageExtBrokerInner::default();
+        msg.set_topic(source_topic);
+        msg.message_ext_inner.set_queue_id(0);
+        msg.set_body(Bytes::from_static(b"multi-dispatch-body"));
+        msg.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_INNER_MULTI_DISPATCH),
+            CheetahString::from_static_str("%LMQ%alpha,%LMQ%beta"),
+        );
+
+        let put_result = store.put_message(msg).await;
+        assert_eq!(put_result.put_message_status(), PutMessageStatus::PutOk);
+
+        store.reput_once().await;
+
+        let alpha_queue = store.consume_queue_store.find_or_create_consume_queue(&lmq_alpha, 0);
+        let beta_queue = store.consume_queue_store.find_or_create_consume_queue(&lmq_beta, 0);
+
+        assert_eq!(alpha_queue.get_message_total_in_queue(), 1);
+        assert_eq!(beta_queue.get_message_total_in_queue(), 1);
+        assert_eq!(store.consume_queue_store.get_lmq_queue_offset("%LMQ%alpha-0"), 1);
+        assert_eq!(store.consume_queue_store.get_lmq_queue_offset("%LMQ%beta-0"), 1);
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/queue/build_consume_queue.rs
+++ b/rocketmq-store/src/queue/build_consume_queue.rs
@@ -40,4 +40,9 @@ impl CommitLogDispatcher for CommitLogDispatcherBuildConsumeQueue {
             _ => {}
         }
     }
+
+    fn dispatch_progress_offset(&self, _commit_log_min_offset: i64) -> Option<i64> {
+        let offset = self.consume_queue_store.get_max_phy_offset_in_consume_queue_global();
+        (offset >= 0).then_some(offset)
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7086

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message recovery logic by switching from consume-queue-based to dispatcher-based offset tracking for more reliable recovery offset calculation.

* **Refactor**
  * Removed unimplemented multi-dispatch message handling branches, simplifying the message append and encoding paths.
  * Enhanced dispatcher progress tracking infrastructure with new offset monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->