### PR TITLE
[ISSUE #7096]✨enhance(benchmarks): add sync flush benchmark and improve store initialization for performance testing

### DIFF
--- a/rocketmq-store/benches/commit_log_performance.rs
+++ b/rocketmq-store/benches/commit_log_performance.rs
@@ -21,6 +21,7 @@ use std::hint::black_box;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Instant;
 
 use cheetah_string::CheetahString;
 use criterion::criterion_group;
@@ -49,10 +50,19 @@ struct BenchStore {
 }
 
 fn new_async_flush_bench_store() -> BenchStore {
+    new_bench_store(FlushDiskType::AsyncFlush)
+}
+
+fn new_sync_flush_bench_store() -> BenchStore {
+    new_bench_store(FlushDiskType::SyncFlush)
+}
+
+fn new_bench_store(flush_disk_type: FlushDiskType) -> BenchStore {
     let temp_dir = TempDir::new().expect("create temp dir for benchmark");
     let mut message_store_config = MessageStoreConfig {
         store_path_root_dir: temp_dir.path().to_string_lossy().to_string().into(),
-        flush_disk_type: FlushDiskType::AsyncFlush,
+        flush_disk_type,
+        ha_listen_port: 0,
         ..MessageStoreConfig::default()
     };
     message_store_config.mapped_file_size_commit_log = 1024 * 1024 * 256;
@@ -213,10 +223,59 @@ fn bench_reput_once_after_batch(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_sync_flush_tail_latency_baseline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("phase6/sync_flush_tail_latency_baseline");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("single_1KiB_message", |b| {
+        let runtime = Runtime::new().expect("create runtime");
+        let bench_store = new_sync_flush_bench_store();
+        runtime.block_on(async {
+            bench_store
+                .store
+                .clone()
+                .mut_from_ref()
+                .init()
+                .await
+                .expect("init sync flush benchmark store");
+            assert!(bench_store.store.clone().mut_from_ref().load().await, "load store");
+            bench_store
+                .store
+                .clone()
+                .mut_from_ref()
+                .start()
+                .await
+                .expect("start sync flush benchmark store");
+        });
+        let counter = AtomicU64::new(0);
+
+        b.iter(|| {
+            let key_seed = counter.fetch_add(1, Ordering::Relaxed);
+            let msg = create_test_message("BenchSyncFlushTopic", 0, 1024, key_seed);
+            let (status, elapsed) = runtime.block_on(async {
+                let started = Instant::now();
+                let status = bench_store
+                    .store
+                    .clone()
+                    .mut_from_ref()
+                    .put_message(msg)
+                    .await
+                    .put_message_status();
+                (status, started.elapsed())
+            });
+            black_box((status, elapsed));
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_async_flush_single_message,
     bench_async_flush_multi_queue,
     bench_reput_once_after_batch,
+    bench_sync_flush_tail_latency_baseline,
 );
 criterion_main!(benches);

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -2723,7 +2723,9 @@ impl ReputMessageService {
 
     #[inline]
     pub fn behind(&self) -> i64 {
-        let inner = self.inner.as_ref().unwrap();
+        let Some(inner) = self.inner.as_ref() else {
+            return 0;
+        };
         inner.message_store.get_confirm_offset() - inner.reput_from_offset.load(Ordering::Relaxed)
     }
 }

--- a/rocketmq-store/tests/commitlog_recovery_tests.rs
+++ b/rocketmq-store/tests/commitlog_recovery_tests.rs
@@ -39,6 +39,7 @@ use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_status_enum::GetMessageStatus;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::base::store_enum::StoreType;
 use rocketmq_store::config::flush_disk_type::FlushDiskType;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
 use rocketmq_store::log_file::commit_log_recovery::RecoveryContext;
@@ -70,6 +71,7 @@ fn phase6_store_config() -> MessageStoreConfig {
         flush_disk_type: FlushDiskType::AsyncFlush,
         mapped_file_size_commit_log: 4096,
         mapped_file_size_consume_queue: 200,
+        ha_listen_port: 0,
         ..MessageStoreConfig::default()
     }
 }
@@ -95,6 +97,61 @@ fn corrupt_commitlog_tail(commitlog_file: &Path, offset: i64, payload: &[u8]) {
     file.seek(SeekFrom::Start(offset as u64)).expect("seek commitlog tail");
     file.write_all(payload).expect("write dirty tail");
     file.sync_data().expect("sync dirty tail");
+}
+
+#[derive(Debug, PartialEq)]
+struct StoreParitySnapshot {
+    get_status: Option<GetMessageStatus>,
+    get_message_count: i32,
+    query_message_count: usize,
+    max_offset_in_queue: i64,
+    total_in_queue: i64,
+    max_phy_offset: i64,
+}
+
+async fn collect_restart_snapshot(store_type: StoreType, topic: &CheetahString) -> StoreParitySnapshot {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let group = CheetahString::from_static_str("phase6-store-parity-group");
+    let key = CheetahString::from_static_str("phase6-store-parity-key");
+    let mut config = phase6_store_config();
+    config.store_type = store_type;
+
+    let mut writer = new_test_store(&temp_dir, config.clone());
+    writer.init().await.expect("init writer");
+    assert!(writer.load().await, "load writer");
+
+    for body in [b"phase6-parity-first".as_slice(), b"phase6-parity-second".as_slice()] {
+        let mut msg = build_test_message(topic, 0, body);
+        msg.set_keys(key.clone());
+        let put_result = writer.put_message(msg).await;
+        assert_eq!(put_result.put_message_status(), PutMessageStatus::PutOk);
+    }
+
+    writer.reput_once().await;
+    writer.shutdown().await;
+    drop(writer);
+
+    let mut reloaded = new_test_store(&temp_dir, config);
+    reloaded.init().await.expect("init reloaded store");
+    assert!(reloaded.load().await, "load reloaded store");
+
+    let get_result = reloaded
+        .get_message(&group, topic, 0, 0, 32, None)
+        .await
+        .expect("get parity messages");
+    let query_result = reloaded
+        .query_message(topic, &key, 32, 0, i64::MAX)
+        .await
+        .expect("query parity messages");
+
+    StoreParitySnapshot {
+        get_status: get_result.status(),
+        get_message_count: get_result.message_count(),
+        query_message_count: query_result.message_maped_list.len(),
+        max_offset_in_queue: reloaded.get_max_offset_in_queue(topic, 0),
+        total_in_queue: reloaded.get_message_total_in_queue(topic, 0),
+        max_phy_offset: reloaded.get_max_phy_offset(),
+    }
 }
 
 #[test]
@@ -296,4 +353,17 @@ async fn load_clears_stale_consume_queue_when_commitlog_is_missing() {
         !topic_queue_dir.exists(),
         "stale topic consume queue should be removed when commitlog is missing"
     );
+}
+
+#[tokio::test]
+async fn file_store_vs_rocksdb_behavior_parity_after_restart() {
+    let topic = CheetahString::from_static_str("phase6-store-parity-topic");
+
+    let local_snapshot = collect_restart_snapshot(StoreType::LocalFile, &topic).await;
+    let rocksdb_snapshot = collect_restart_snapshot(StoreType::RocksDB, &topic).await;
+
+    assert_eq!(local_snapshot, rocksdb_snapshot);
+    assert_eq!(local_snapshot.get_status, Some(GetMessageStatus::Found));
+    assert_eq!(local_snapshot.get_message_count, 2);
+    assert_eq!(local_snapshot.query_message_count, 2);
 }

--- a/rocketmq-store/tests/ha_semantics_tests.rs
+++ b/rocketmq-store/tests/ha_semantics_tests.rs
@@ -14,6 +14,7 @@
 
 //! Integration tests for store-facing HA semantics.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -34,12 +35,18 @@ use rocketmq_store::message_store::local_file_message_store::LocalFileMessageSto
 use tempfile::TempDir;
 
 fn new_test_store(message_store_config: MessageStoreConfig) -> ArcMut<LocalFileMessageStore> {
-    let broker_config = Arc::new(BrokerConfig::default());
+    new_test_store_with_broker_config(message_store_config, BrokerConfig::default())
+}
+
+fn new_test_store_with_broker_config(
+    message_store_config: MessageStoreConfig,
+    broker_config: BrokerConfig,
+) -> ArcMut<LocalFileMessageStore> {
     let topic_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>> = Arc::new(DashMap::new());
 
     let mut store = ArcMut::new(LocalFileMessageStore::new(
         Arc::new(message_store_config),
-        broker_config,
+        Arc::new(broker_config),
         topic_table,
         None,
         false,
@@ -110,4 +117,50 @@ async fn wait_store_msg_ok_false_skips_ha_wait_and_returns_put_ok() {
     assert_eq!(result.put_message_status(), PutMessageStatus::PutOk);
 
     store.shutdown().await;
+}
+
+#[tokio::test]
+async fn controller_role_failover_smoke_keeps_confirm_offset_at_master_tail() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let topic = CheetahString::from_static_str("phase6-ha-failover-smoke-topic");
+    let mut store = new_test_store_with_broker_config(
+        MessageStoreConfig {
+            store_path_root_dir: temp_dir.path().to_string_lossy().to_string().into(),
+            broker_role: BrokerRole::AsyncMaster,
+            flush_disk_type: FlushDiskType::AsyncFlush,
+            mapped_file_size_commit_log: 4096,
+            mapped_file_size_consume_queue: 200,
+            ha_listen_port: 0,
+            enable_controller_mode: true,
+            all_ack_in_sync_state_set: false,
+            ..MessageStoreConfig::default()
+        },
+        BrokerConfig {
+            enable_controller_mode: true,
+            ..BrokerConfig::default()
+        },
+    );
+
+    store.init().await.expect("init controller-mode store");
+    store.sync_controller_sync_state_set(1, &HashSet::from([1_i64]));
+
+    for round in 0..3 {
+        let body = match round {
+            0 => b"phase6-ha-failover-round-0".as_slice(),
+            1 => b"phase6-ha-failover-round-1".as_slice(),
+            _ => b"phase6-ha-failover-round-2".as_slice(),
+        };
+        let result = store.put_message(build_message(&topic, body)).await;
+        assert_eq!(result.put_message_status(), PutMessageStatus::PutOk);
+
+        let max_phy_offset = store.get_max_phy_offset();
+        store.set_confirm_offset(0);
+        store.sync_broker_role(BrokerRole::Slave);
+        assert_eq!(store.get_confirm_offset(), 0);
+
+        store.sync_broker_role(BrokerRole::AsyncMaster);
+        assert_eq!(store.get_confirm_offset(), max_phy_offset);
+    }
+
+    assert_eq!(store.get_max_offset_in_queue(&topic, 0), 0);
 }

--- a/rocketmq-store/tests/timer_recovery_integration_tests.rs
+++ b/rocketmq-store/tests/timer_recovery_integration_tests.rs
@@ -188,3 +188,44 @@ async fn restart_revises_lagging_timer_checkpoint_in_default_store_path() {
         1
     );
 }
+
+#[tokio::test]
+async fn timer_restart_soak_smoke_preserves_indexed_queue_checkpoint() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let real_topic = CheetahString::from_static_str("phase6-timer-real-topic");
+
+    let mut writer = new_test_store(&temp_dir);
+    writer.init().await.expect("init writer");
+    assert!(writer.load().await, "load writer");
+
+    let timer_message_store = writer
+        .get_timer_message_store()
+        .cloned()
+        .expect("timer message store should be auto-initialized");
+    let put_result = writer
+        .put_message(build_timer_message(&real_topic, current_millis() as u64 + 60_000))
+        .await;
+    assert!(put_result.is_ok(), "put timer message");
+
+    writer.reput_once().await;
+    assert_eq!(timer_message_store.process_once().await, 1);
+    writer.shutdown().await;
+    drop(writer);
+
+    for _ in 0..3 {
+        let mut reloaded = new_test_store(&temp_dir);
+        reloaded.init().await.expect("init reloaded store");
+        assert!(reloaded.load().await, "load reloaded store");
+
+        let reloaded_timer_message_store = reloaded
+            .get_timer_message_store()
+            .cloned()
+            .expect("timer message store should be auto-initialized after restart");
+        assert_eq!(
+            reloaded_timer_message_store.curr_queue_offset.load(Ordering::Relaxed),
+            1
+        );
+
+        reloaded.shutdown().await;
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7096

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential panic in message service handling when internal state is unavailable.

* **Tests**
  * Added sync flush tail latency benchmarking.
  * Added message store backend parity validation after restart.
  * Added failover behavior and offset tracking tests.
  * Added timer message queue checkpoint persistence tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->