### PR TITLE
[ISSUE #7102]🚀feat(cli): integrate admin facade for managing RocketMQ configurations and add unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,6 +3585,7 @@ dependencies = [
  "anyhow",
  "crossterm",
  "ratatui",
+ "rocketmq-admin-core",
  "rocketmq-rust",
  "serde",
  "strum 0.28.0",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/Cargo.toml
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/Cargo.toml
@@ -28,6 +28,7 @@ description            = "A RocketMQ Rust terminal command management tool imple
 rust-version.workspace = true
 
 [dependencies]
+rocketmq-admin-core = { path = "../rocketmq-admin-core" }
 rocketmq-rust = { workspace = true }
 ratatui       = { version = "0.29.0" }
 crossterm     = { version = "0.28.1", features = ["event-stream"] }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
@@ -1,0 +1,40 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_admin_core::core::admin::AdminBuilder;
+
+#[derive(Debug, Clone, Default)]
+pub struct TuiAdminFacade {
+    namesrv_addr: Option<String>,
+}
+
+impl TuiAdminFacade {
+    pub fn with_namesrv_addr(addr: impl Into<String>) -> Self {
+        Self {
+            namesrv_addr: Some(addr.into()),
+        }
+    }
+
+    pub fn namesrv_addr(&self) -> Option<&str> {
+        self.namesrv_addr.as_deref()
+    }
+
+    pub fn admin_builder(&self) -> AdminBuilder {
+        let builder = AdminBuilder::new();
+        match &self.namesrv_addr {
+            Some(addr) => builder.namesrv_addr(addr),
+            None => builder,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs
@@ -17,6 +17,7 @@
 #![allow(unused_variables)]
 
 mod action;
+mod admin_facade;
 mod rocketmq_tui_app;
 mod ui;
 
@@ -30,4 +31,20 @@ async fn main() -> anyhow::Result<()> {
     let result = RocketmqTuiApp::default().run(terminal).await;
     ratatui::try_restore()?;
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_admin_core::core::admin::AdminBuilder;
+
+    use crate::admin_facade::TuiAdminFacade;
+
+    #[test]
+    fn admin_facade_builds_core_admin_builder() {
+        let facade = TuiAdminFacade::with_namesrv_addr("127.0.0.1:9876");
+
+        assert_eq!(facade.namesrv_addr(), Some("127.0.0.1:9876"));
+
+        let _builder: AdminBuilder = facade.admin_builder();
+    }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/rocketmq_tui_app.rs
@@ -26,10 +26,12 @@ use ratatui::DefaultTerminal;
 use ratatui::Frame;
 use tokio_stream::StreamExt;
 
+use crate::admin_facade::TuiAdminFacade;
 use crate::ui::search_input_widget::SearchInputWidget;
 
 #[derive(Default)]
 pub struct RocketmqTuiApp {
+    admin_facade: TuiAdminFacade,
     should_quit: bool,
     search_input: SearchInputWidget,
 }
@@ -37,9 +39,22 @@ pub struct RocketmqTuiApp {
 impl RocketmqTuiApp {
     pub fn new() -> Self {
         Self {
+            admin_facade: Default::default(),
             should_quit: false,
             search_input: Default::default(),
         }
+    }
+
+    pub fn with_admin_facade(admin_facade: TuiAdminFacade) -> Self {
+        Self {
+            admin_facade,
+            should_quit: false,
+            search_input: Default::default(),
+        }
+    }
+
+    pub fn admin_facade(&self) -> &TuiAdminFacade {
+        &self.admin_facade
     }
 
     pub fn should_quit(&self) -> bool {
@@ -150,5 +165,19 @@ impl RocketmqTuiApp {
                 .title("Progress Bar"),
             progress_bar,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::admin_facade::TuiAdminFacade;
+
+    #[test]
+    fn app_can_be_constructed_with_admin_facade() {
+        let facade = TuiAdminFacade::with_namesrv_addr("127.0.0.1:9876");
+        let app = RocketmqTuiApp::with_admin_facade(facade);
+
+        assert_eq!(app.admin_facade().namesrv_addr(), Some("127.0.0.1:9876"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7102

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * TUI application now supports configurable nameserver address for admin operations integration.

* **Tests**
  * Added unit tests to validate admin facade configuration and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->