### PR TITLE
[ISSUE #7128]🚀feat(cli): implement LiteGroupInfoQueryRequest and refactor GetLiteGroupInfoSubCommand for improved group info retrieval

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/lite/get_lite_group_info_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/lite/get_lite_group_info_sub_command.rs
@@ -16,17 +16,17 @@ use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use clap::Parser;
-use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::utils::util_all::time_millis_to_human_string2;
-use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::admin::offset_wrapper::OffsetWrapper;
 use rocketmq_remoting::protocol::body::lite_lag_info::LiteLagInfo;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::CommandExecute;
-use rocketmq_admin_core::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use rocketmq_admin_core::core::lite::LiteGroupInfoQueryRequest;
+use rocketmq_admin_core::core::lite::LiteGroupInfoQueryResult;
+use rocketmq_admin_core::core::lite::LiteService;
 
 #[derive(Debug, Clone, Parser)]
 pub struct GetLiteGroupInfoSubCommand {
@@ -45,163 +45,81 @@ pub struct GetLiteGroupInfoSubCommand {
 
 impl CommandExecute for GetLiteGroupInfoSubCommand {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
-        let mut default_mqadmin_ext = if let Some(rpc_hook) = rpc_hook {
-            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
-        } else {
-            DefaultMQAdminExt::new()
-        };
-
-        default_mqadmin_ext
-            .client_config_mut()
-            .set_instance_name(current_millis().to_string().into());
-
-        let operation_result = async {
-            MQAdminExt::start(&mut default_mqadmin_ext).await.map_err(|e| {
-                RocketMQError::Internal(format!("GetLiteGroupInfoSubCommand: Failed to start MQAdminExt: {}", e))
-            })?;
-
-            let parent_topic = self.parent_topic.trim();
-            let group = self.group.trim();
-            let top_k = self.top_k.unwrap_or(20);
-            let lite_topic = self.lite_topic.as_deref().map(|s| s.trim().to_string());
-            let query_by_lite_topic = lite_topic.as_ref().is_some_and(|s| !s.is_empty());
-
-            let topic_route_data = default_mqadmin_ext
-                .examine_topic_route_info(CheetahString::from(parent_topic))
-                .await
-                .map_err(|e| {
-                    RocketMQError::Internal(format!(
-                        "GetLiteGroupInfoSubCommand: Failed to examine topic route info: {}",
-                        e
-                    ))
-                })?;
-
-            let topic_route_data = topic_route_data.ok_or_else(|| {
-                RocketMQError::Internal(format!(
-                    "GetLiteGroupInfoSubCommand: Topic route not found for: {}",
-                    parent_topic
-                ))
-            })?;
-
-            println!("Lite Group Info: [{}] [{}]", group, parent_topic);
-
-            let mut total_lag_count: i64 = 0;
-            let mut earliest_unconsumed_timestamp: i64 = current_millis() as i64;
-            let mut lag_count_top_k: Vec<LiteLagInfo> = Vec::new();
-            let mut lag_timestamp_top_k: Vec<LiteLagInfo> = Vec::new();
-
-            if query_by_lite_topic {
-                println!(
-                    "{:<50} {:<16} {:<16} {:<16} {:<30}",
-                    "#Broker Name", "#BrokerOffset", "#ConsumeOffset", "#LagCount", "#LastUpdate"
-                );
-            }
-
-            for broker_data in &topic_route_data.broker_datas {
-                let broker_addr = match broker_data.select_broker_addr() {
-                    Some(addr) => addr,
-                    None => continue,
-                };
-
-                let lite_topic_str = lite_topic.as_deref().map(CheetahString::from).unwrap_or_default();
-
-                match default_mqadmin_ext
-                    .get_lite_group_info(broker_addr.clone(), CheetahString::from(group), lite_topic_str, top_k)
-                    .await
-                {
-                    Ok(body) => {
-                        if body.total_lag_count() > 0 {
-                            total_lag_count += body.total_lag_count();
-                        }
-                        if body.earliest_unconsumed_timestamp() > 0 {
-                            earliest_unconsumed_timestamp =
-                                earliest_unconsumed_timestamp.min(body.earliest_unconsumed_timestamp());
-                        }
-
-                        Self::print_offset_wrapper(
-                            query_by_lite_topic,
-                            broker_data.broker_name(),
-                            body.lite_topic_offset_wrapper(),
-                        );
-
-                        lag_count_top_k.extend_from_slice(body.lag_count_top_k());
-                        lag_timestamp_top_k.extend_from_slice(body.lag_timestamp_top_k());
-                    }
-                    Err(_) => {
-                        println!("[{}] error.", broker_data.broker_name());
-                    }
-                }
-            }
-
-            println!("Total Lag Count: {}", total_lag_count);
-            let lag_time = current_millis() as i64 - earliest_unconsumed_timestamp;
-            println!(
-                "Min Unconsumed Timestamp: {} ({} s ago)\n",
-                earliest_unconsumed_timestamp,
-                lag_time / 1000
-            );
-
-            if query_by_lite_topic {
-                return Ok(());
-            }
-
-            // Sort and print topK by lag count
-            lag_count_top_k.sort_by_key(|b| std::cmp::Reverse(b.lag_count()));
-            println!("------TopK by lag count-----");
-            println!(
-                "{:<6} {:<40} {:<12} {:<30}",
-                "NO", "Lite Topic", "Lag Count", "UnconsumedTimestamp"
-            );
-            for (i, info) in lag_count_top_k.iter().enumerate() {
-                let timestamp_str = if info.earliest_unconsumed_timestamp() > 0 {
-                    time_millis_to_human_string2(info.earliest_unconsumed_timestamp())
-                } else {
-                    "-".to_string()
-                };
-                println!(
-                    "{:<6} {:<40} {:<12} {:<30}",
-                    i + 1,
-                    info.lite_topic(),
-                    info.lag_count(),
-                    timestamp_str
-                );
-            }
-
-            // Sort and print topK by lag time
-            lag_timestamp_top_k.sort_by(|a, b| {
-                a.earliest_unconsumed_timestamp()
-                    .cmp(&b.earliest_unconsumed_timestamp())
-            });
-            println!("\n------TopK by lag time------");
-            println!(
-                "{:<6} {:<40} {:<12} {:<30}",
-                "NO", "Lite Topic", "Lag Count", "UnconsumedTimestamp"
-            );
-            for (i, info) in lag_timestamp_top_k.iter().enumerate() {
-                let timestamp_str = if info.earliest_unconsumed_timestamp() > 0 {
-                    time_millis_to_human_string2(info.earliest_unconsumed_timestamp())
-                } else {
-                    "-".to_string()
-                };
-                println!(
-                    "{:<6} {:<40} {:<12} {:<30}",
-                    i + 1,
-                    info.lite_topic(),
-                    info.lag_count(),
-                    timestamp_str
-                );
-            }
-
-            Ok(())
-        }
-        .await;
-
-        MQAdminExt::shutdown(&mut default_mqadmin_ext).await;
-        operation_result
+        let result = LiteService::query_lite_group_info_by_request_with_rpc_hook(self.request()?, rpc_hook).await?;
+        Self::print_result(&result);
+        Ok(())
     }
 }
 
 impl GetLiteGroupInfoSubCommand {
+    fn request(&self) -> RocketMQResult<LiteGroupInfoQueryRequest> {
+        LiteGroupInfoQueryRequest::try_new(
+            self.parent_topic.clone(),
+            self.group.clone(),
+            self.lite_topic.clone(),
+            self.top_k,
+        )
+    }
+
+    fn print_result(result: &LiteGroupInfoQueryResult) {
+        println!("Lite Group Info: [{}] [{}]", result.group, result.parent_topic);
+
+        if result.query_by_lite_topic() {
+            println!(
+                "{:<50} {:<16} {:<16} {:<16} {:<30}",
+                "#Broker Name", "#BrokerOffset", "#ConsumeOffset", "#LagCount", "#LastUpdate"
+            );
+        }
+
+        for entry in &result.entries {
+            match &entry.body {
+                Some(body) => Self::print_offset_wrapper(
+                    result.query_by_lite_topic(),
+                    &entry.broker_name,
+                    body.lite_topic_offset_wrapper(),
+                ),
+                None => println!("[{}] error.", entry.broker_name),
+            }
+        }
+
+        println!("Total Lag Count: {}", result.total_lag_count);
+        let lag_time = current_millis() as i64 - result.earliest_unconsumed_timestamp;
+        println!(
+            "Min Unconsumed Timestamp: {} ({} s ago)\n",
+            result.earliest_unconsumed_timestamp,
+            lag_time / 1000
+        );
+
+        if result.query_by_lite_topic() {
+            return;
+        }
+
+        Self::print_lag_top_k("------TopK by lag count-----", &result.lag_count_top_k);
+        Self::print_lag_top_k("\n------TopK by lag time------", &result.lag_timestamp_top_k);
+    }
+
+    fn print_lag_top_k(title: &str, lag_infos: &[LiteLagInfo]) {
+        println!("{title}");
+        println!(
+            "{:<6} {:<40} {:<12} {:<30}",
+            "NO", "Lite Topic", "Lag Count", "UnconsumedTimestamp"
+        );
+        for (i, info) in lag_infos.iter().enumerate() {
+            let timestamp_str = if info.earliest_unconsumed_timestamp() > 0 {
+                time_millis_to_human_string2(info.earliest_unconsumed_timestamp())
+            } else {
+                "-".to_string()
+            };
+            println!(
+                "{:<6} {:<40} {:<12} {:<30}",
+                i + 1,
+                info.lite_topic(),
+                info.lag_count(),
+                timestamp_str
+            );
+        }
+    }
+
     fn print_offset_wrapper(
         query_by_lite_topic: bool,
         broker_name: &CheetahString,
@@ -231,5 +149,45 @@ impl GetLiteGroupInfoSubCommand {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_lite_group_info_sub_command_builds_default_top_k_request() {
+        let cmd =
+            GetLiteGroupInfoSubCommand::try_parse_from(["getLiteGroupInfo", "-p", " ParentTopic ", "-g", " GroupA "])
+                .unwrap();
+
+        let request = cmd.request().unwrap();
+
+        assert_eq!(request.parent_topic().as_str(), "ParentTopic");
+        assert_eq!(request.group().as_str(), "GroupA");
+        assert_eq!(request.lite_topic(), None);
+        assert_eq!(request.top_k(), 20);
+    }
+
+    #[test]
+    fn get_lite_group_info_sub_command_builds_lite_topic_request() {
+        let cmd = GetLiteGroupInfoSubCommand::try_parse_from([
+            "getLiteGroupInfo",
+            "-p",
+            "ParentTopic",
+            "-g",
+            "GroupA",
+            "-l",
+            " LiteTopic ",
+            "-k",
+            "5",
+        ])
+        .unwrap();
+
+        let request = cmd.request().unwrap();
+
+        assert_eq!(request.lite_topic().map(|topic| topic.as_str()), Some("LiteTopic"));
+        assert_eq!(request.top_k(), 5);
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/lite.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/lite.rs
@@ -4,9 +4,12 @@ use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::body::get_broker_lite_info_response_body::GetBrokerLiteInfoResponseBody;
+use rocketmq_remoting::protocol::body::get_lite_group_info_response_body::GetLiteGroupInfoResponseBody;
 use rocketmq_remoting::protocol::body::get_lite_topic_info_response_body::GetLiteTopicInfoResponseBody;
 use rocketmq_remoting::protocol::body::get_parent_topic_info_response_body::GetParentTopicInfoResponseBody;
+use rocketmq_remoting::protocol::body::lite_lag_info::LiteLagInfo;
 use rocketmq_remoting::runtime::RPCHook;
 use serde::Deserialize;
 use serde::Serialize;
@@ -197,6 +200,94 @@ pub struct LiteTopicInfoQueryResult {
     pub entries: Vec<LiteTopicInfoEntry>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LiteGroupInfoQueryRequest {
+    parent_topic: CheetahString,
+    group: CheetahString,
+    lite_topic: Option<CheetahString>,
+    top_k: i32,
+    namesrv_addr: Option<String>,
+}
+
+impl LiteGroupInfoQueryRequest {
+    pub fn try_new(
+        parent_topic: impl Into<String>,
+        group: impl Into<String>,
+        lite_topic: Option<String>,
+        top_k: Option<i32>,
+    ) -> RocketMQResult<Self> {
+        Ok(Self {
+            parent_topic: trim_required_cheetah("parentTopic", parent_topic)?,
+            group: trim_required_cheetah("group", group)?,
+            lite_topic: trim_optional_string(lite_topic).map(CheetahString::from),
+            top_k: top_k.unwrap_or(20),
+            namesrv_addr: None,
+        })
+    }
+
+    pub fn with_optional_namesrv_addr(mut self, namesrv_addr: Option<String>) -> Self {
+        self.namesrv_addr = trim_optional_string(namesrv_addr);
+        self
+    }
+
+    pub fn parent_topic(&self) -> &CheetahString {
+        &self.parent_topic
+    }
+
+    pub fn group(&self) -> &CheetahString {
+        &self.group
+    }
+
+    pub fn lite_topic(&self) -> Option<&CheetahString> {
+        self.lite_topic.as_ref()
+    }
+
+    pub fn query_by_lite_topic(&self) -> bool {
+        self.lite_topic.is_some()
+    }
+
+    pub fn top_k(&self) -> i32 {
+        self.top_k
+    }
+
+    pub fn namesrv_addr(&self) -> Option<&str> {
+        self.namesrv_addr.as_deref()
+    }
+
+    pub fn admin_builder(&self) -> AdminBuilder {
+        let builder = AdminBuilder::new();
+        match self.namesrv_addr() {
+            Some(addr) => builder.namesrv_addr(addr),
+            None => builder,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiteGroupInfoEntry {
+    pub broker_name: CheetahString,
+    pub body: Option<GetLiteGroupInfoResponseBody>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiteGroupInfoQueryResult {
+    pub parent_topic: CheetahString,
+    pub group: CheetahString,
+    pub lite_topic: Option<CheetahString>,
+    pub total_lag_count: i64,
+    pub earliest_unconsumed_timestamp: i64,
+    pub lag_count_top_k: Vec<LiteLagInfo>,
+    pub lag_timestamp_top_k: Vec<LiteLagInfo>,
+    pub entries: Vec<LiteGroupInfoEntry>,
+}
+
+impl LiteGroupInfoQueryResult {
+    pub fn query_by_lite_topic(&self) -> bool {
+        self.lite_topic.is_some()
+    }
+}
+
 pub struct LiteService;
 
 impl LiteService {
@@ -362,6 +453,88 @@ impl LiteService {
         Ok(LiteTopicInfoQueryResult {
             parent_topic: request.parent_topic().clone(),
             lite_topic: request.lite_topic().clone(),
+            entries,
+        })
+    }
+
+    pub async fn query_lite_group_info_by_request_with_rpc_hook(
+        request: LiteGroupInfoQueryRequest,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> RocketMQResult<LiteGroupInfoQueryResult> {
+        let mut admin = admin_builder_with_rpc_hook(request.admin_builder(), rpc_hook)
+            .build_and_start()
+            .await?;
+        let result = Self::query_lite_group_info_with_admin(&admin, &request).await;
+        admin.shutdown().await;
+        result
+    }
+
+    pub async fn query_lite_group_info_with_admin(
+        admin: &DefaultMQAdminExt,
+        request: &LiteGroupInfoQueryRequest,
+    ) -> RocketMQResult<LiteGroupInfoQueryResult> {
+        let route = admin
+            .examine_topic_route_info(request.parent_topic().clone())
+            .await?
+            .ok_or_else(|| {
+                ToolsError::internal(format!(
+                    "Topic route not found for parentTopic '{}'",
+                    request.parent_topic()
+                ))
+            })?;
+
+        let mut total_lag_count = 0;
+        let mut earliest_unconsumed_timestamp = current_millis() as i64;
+        let mut lag_count_top_k = Vec::new();
+        let mut lag_timestamp_top_k = Vec::new();
+        let mut entries = Vec::new();
+
+        for broker_data in &route.broker_datas {
+            let Some(broker_addr) = broker_data.select_broker_addr() else {
+                continue;
+            };
+            let broker_name = broker_data.broker_name().clone();
+            let lite_topic = request.lite_topic().cloned().unwrap_or_default();
+
+            match admin
+                .get_lite_group_info(broker_addr, request.group().clone(), lite_topic, request.top_k())
+                .await
+            {
+                Ok(body) => {
+                    if body.total_lag_count() > 0 {
+                        total_lag_count += body.total_lag_count();
+                    }
+                    if body.earliest_unconsumed_timestamp() > 0 {
+                        earliest_unconsumed_timestamp =
+                            earliest_unconsumed_timestamp.min(body.earliest_unconsumed_timestamp());
+                    }
+                    lag_count_top_k.extend_from_slice(body.lag_count_top_k());
+                    lag_timestamp_top_k.extend_from_slice(body.lag_timestamp_top_k());
+                    entries.push(LiteGroupInfoEntry {
+                        broker_name,
+                        body: Some(body),
+                        error: None,
+                    });
+                }
+                Err(error) => entries.push(LiteGroupInfoEntry {
+                    broker_name,
+                    body: None,
+                    error: Some(error.to_string()),
+                }),
+            }
+        }
+
+        lag_count_top_k.sort_by_key(|item| std::cmp::Reverse(item.lag_count()));
+        lag_timestamp_top_k.sort_by_key(|item| item.earliest_unconsumed_timestamp());
+
+        Ok(LiteGroupInfoQueryResult {
+            parent_topic: request.parent_topic().clone(),
+            group: request.group().clone(),
+            lite_topic: request.lite_topic().cloned(),
+            total_lag_count,
+            earliest_unconsumed_timestamp,
+            lag_count_top_k,
+            lag_timestamp_top_k,
             entries,
         })
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/lite_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/lite_core_models.rs
@@ -1,5 +1,6 @@
 use rocketmq_admin_core::core::lite::BrokerLiteInfoQueryRequest;
 use rocketmq_admin_core::core::lite::BrokerLiteInfoTarget;
+use rocketmq_admin_core::core::lite::LiteGroupInfoQueryRequest;
 use rocketmq_admin_core::core::lite::LiteTopicInfoQueryRequest;
 use rocketmq_admin_core::core::lite::ParentTopicInfoQueryRequest;
 
@@ -67,4 +68,24 @@ fn lite_topic_info_query_request_trims_parent_and_lite_topic() {
 fn lite_topic_info_query_request_rejects_blank_fields() {
     assert!(LiteTopicInfoQueryRequest::try_new(" ", "LiteTopic").is_err());
     assert!(LiteTopicInfoQueryRequest::try_new("ParentTopic", " ").is_err());
+}
+
+#[test]
+fn lite_group_info_query_request_trims_fields_and_defaults_top_k() {
+    let request =
+        LiteGroupInfoQueryRequest::try_new(" ParentTopic ", " GroupA ", Some(" LiteTopic ".to_string()), None)
+            .unwrap()
+            .with_optional_namesrv_addr(Some(" 127.0.0.1:9876 ".to_string()));
+
+    assert_eq!(request.parent_topic().as_str(), "ParentTopic");
+    assert_eq!(request.group().as_str(), "GroupA");
+    assert_eq!(request.lite_topic().map(|topic| topic.as_str()), Some("LiteTopic"));
+    assert_eq!(request.top_k(), 20);
+    assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+}
+
+#[test]
+fn lite_group_info_query_request_rejects_blank_required_fields() {
+    assert!(LiteGroupInfoQueryRequest::try_new(" ", "GroupA", None, Some(5)).is_err());
+    assert!(LiteGroupInfoQueryRequest::try_new("ParentTopic", " ", None, Some(5)).is_err());
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7128

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced lite group information query functionality enabling filtered analysis by lite topic with optional configurable limit.
  * Implemented top-K lag metrics providing sorted results by both lag count and earliest unconsumed timestamp for enhanced monitoring.

* **Refactor**
  * Redesigned the lite group query workflow with improved request and result data structures for clearer API usage and better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->