### PR TITLE
[ISSUE #7144]🚀feat(cli): implement ExportPopRecordRequest and StartMonitoringRequest with corresponding methods and tests

### DIFF
--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -2067,7 +2067,9 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         _broker_addr: CheetahString,
         _timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()> {
-        unimplemented!("export_pop_records not implemented yet")
+        Err(RocketMQError::Internal(
+            "export_pop_records not implemented yet".to_string(),
+        ))
     }
 
     async fn switch_timer_engine(

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -5096,9 +5096,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -2632,9 +2632,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/consumer/start_monitoring_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/consumer/start_monitoring_sub_command.rs
@@ -15,6 +15,8 @@
 use std::sync::Arc;
 
 use clap::Parser;
+use rocketmq_admin_core::core::consumer::ConsumerService;
+use rocketmq_admin_core::core::consumer::StartMonitoringRequest;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::CommandExecute;
@@ -30,8 +32,28 @@ pub struct StartMonitoringSubCommand {
     namesrv_addr: Option<String>,
 }
 
+impl StartMonitoringSubCommand {
+    fn request(&self) -> StartMonitoringRequest {
+        StartMonitoringRequest::new(self.namesrv_addr.clone())
+    }
+}
+
 impl CommandExecute for StartMonitoringSubCommand {
-    async fn execute(&self, _rpc_hook: Option<Arc<dyn RPCHook>>) -> rocketmq_error::RocketMQResult<()> {
-        todo!("Depends on MonitorService implementation")
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> rocketmq_error::RocketMQResult<()> {
+        ConsumerService::start_monitoring_by_request_with_rpc_hook(self.request(), rpc_hook)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_monitoring_sub_command_builds_request() {
+        let command = StartMonitoringSubCommand::try_parse_from(["startMonitoring", "-n", " 127.0.0.1:9876 "]).unwrap();
+
+        let request = command.request();
+
+        assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/export/export_pop_record_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/export/export_pop_record_sub_command.rs
@@ -14,19 +14,15 @@
 
 use std::sync::Arc;
 
-use cheetah_string::CheetahString;
 use clap::Parser;
-use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
-use rocketmq_common::TimeUtils::current_millis;
-use rocketmq_error::RocketMQError;
+use rocketmq_admin_core::core::export_data::ExportPopRecordRequest;
+use rocketmq_admin_core::core::export_data::ExportPopRecordResult;
+use rocketmq_admin_core::core::export_data::ExportService;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::CommandExecute;
 use crate::commands::CommonArgs;
-use rocketmq_admin_core::admin::default_mq_admin_ext::DefaultMQAdminExt;
-
-const EXPORT_POP_RECORD_TIMEOUT_MILLIS: u64 = 30000;
 
 #[derive(Debug, Clone, Parser)]
 pub struct ExportPopRecordSubCommand {
@@ -62,104 +58,73 @@ pub struct ExportPopRecordSubCommand {
 }
 
 impl ExportPopRecordSubCommand {
-    async fn export(admin_ext: &DefaultMQAdminExt, broker_addr: &str, broker_name: &str, dry_run: bool) {
-        if !dry_run {
-            match admin_ext
-                .export_pop_records(CheetahString::from(broker_addr), EXPORT_POP_RECORD_TIMEOUT_MILLIS)
-                .await
-            {
-                Ok(()) => {
-                    println!(
-                        "Export broker records, brokerName={}, brokerAddr={}, dryRun={}",
-                        broker_name, broker_addr, dry_run
-                    );
-                }
-                Err(e) => {
-                    eprintln!(
-                        "Export broker records error, brokerName={}, brokerAddr={}, dryRun={}\n{}",
-                        broker_name, broker_addr, dry_run, e
-                    );
-                }
+    fn request(&self) -> RocketMQResult<ExportPopRecordRequest> {
+        ExportPopRecordRequest::try_new(self.cluster_name.clone(), self.broker_addr.clone(), self.dry_run)
+            .map(|request| request.with_optional_namesrv_addr(self.common_args.namesrv_addr.clone()))
+    }
+
+    fn print_result(result: &ExportPopRecordResult) {
+        for target in &result.targets {
+            if let Some(error) = &target.error {
+                eprintln!(
+                    "Export broker records error, brokerName={}, brokerAddr={}, dryRun={}\n{}",
+                    target.broker_name, target.broker_addr, target.dry_run, error
+                );
+            } else {
+                println!(
+                    "Export broker records, brokerName={}, brokerAddr={}, dryRun={}",
+                    target.broker_name, target.broker_addr, target.dry_run
+                );
             }
-        } else {
-            println!(
-                "Export broker records, brokerName={}, brokerAddr={}, dryRun={}",
-                broker_name, broker_addr, dry_run
-            );
         }
     }
 }
 
 impl CommandExecute for ExportPopRecordSubCommand {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
-        if self.broker_addr.is_none() && self.cluster_name.is_none() {
-            return Err(RocketMQError::IllegalArgument(
-                "ExportPopRecordSubCommand: Either brokerAddr (-b) or clusterName (-c) must be provided".into(),
-            ));
-        }
+        let result = ExportService::export_pop_records_by_request_with_rpc_hook(self.request()?, rpc_hook).await?;
+        Self::print_result(&result);
+        Ok(())
+    }
+}
 
-        let mut admin_ext = if let Some(rpc_hook) = rpc_hook {
-            DefaultMQAdminExt::with_rpc_hook(rpc_hook)
-        } else {
-            DefaultMQAdminExt::new()
-        };
-        admin_ext
-            .client_config_mut()
-            .set_instance_name(current_millis().to_string().into());
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocketmq_admin_core::core::export_data::ExportPopRecordTarget;
 
-        if let Some(addr) = &self.common_args.namesrv_addr {
-            admin_ext.set_namesrv_addr(addr.trim());
-        }
+    #[test]
+    fn export_pop_record_sub_command_builds_broker_request() {
+        let cmd = ExportPopRecordSubCommand::try_parse_from([
+            "exportPopRecord",
+            "-b",
+            " 127.0.0.1:10911 ",
+            "-n",
+            " 127.0.0.1:9876 ",
+            "-d",
+        ])
+        .unwrap();
 
-        admin_ext.start().await.map_err(|e| {
-            RocketMQError::Internal(format!("ExportPopRecordSubCommand: Failed to start MQAdminExt: {}", e))
-        })?;
+        let request = cmd.request().unwrap();
 
-        let result = if let Some(broker_addr) = &self.broker_addr {
-            let broker_addr = broker_addr.trim();
-            let broker_name = match admin_ext.get_broker_config(CheetahString::from(broker_addr)).await {
-                Ok(properties) => properties
-                    .get(&CheetahString::from("brokerName"))
-                    .cloned()
-                    .unwrap_or_else(|| CheetahString::from("")),
-                Err(_) => CheetahString::from(""),
-            };
-            Self::export(&admin_ext, broker_addr, broker_name.as_str(), self.dry_run).await;
-            Ok(())
-        } else if let Some(cluster_name) = &self.cluster_name {
-            let cluster_name = cluster_name.trim();
-            match admin_ext.examine_broker_cluster_info().await {
-                Ok(cluster_info) => {
-                    if let Some(cluster_addr_table) = &cluster_info.cluster_addr_table {
-                        if let Some(broker_name_set) = cluster_addr_table.get(&CheetahString::from(cluster_name)) {
-                            if let Some(broker_addr_table) = &cluster_info.broker_addr_table {
-                                for broker_name in broker_name_set {
-                                    if let Some(broker_data) = broker_addr_table.get(broker_name) {
-                                        for broker_addr in broker_data.broker_addrs().values() {
-                                            Self::export(
-                                                &admin_ext,
-                                                broker_addr.as_str(),
-                                                broker_name.as_str(),
-                                                self.dry_run,
-                                            )
-                                            .await;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
-                }
-                Err(e) => Err(e),
-            }
-        } else {
-            Err(RocketMQError::IllegalArgument(
-                "ExportPopRecordSubCommand: Either brokerAddr (-b) or clusterName (-c) must be provided".into(),
-            ))
-        };
+        assert_eq!(
+            request.target(),
+            &ExportPopRecordTarget::Broker("127.0.0.1:10911".into())
+        );
+        assert!(request.dry_run());
+        assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+    }
 
-        admin_ext.shutdown().await;
-        result
+    #[test]
+    fn export_pop_record_sub_command_builds_cluster_request() {
+        let cmd = ExportPopRecordSubCommand::try_parse_from(["exportPopRecord", "-c", " DefaultCluster "]).unwrap();
+
+        let request = cmd.request().unwrap();
+
+        assert_eq!(
+            request.target(),
+            &ExportPopRecordTarget::Cluster("DefaultCluster".into())
+        );
+        assert!(!request.dry_run());
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/admin/default_mq_admin_ext.rs
@@ -1173,7 +1173,9 @@ impl MQAdminExt for DefaultMQAdminExt {
         _broker_addr: CheetahString,
         _timeout: u64,
     ) -> rocketmq_error::RocketMQResult<()> {
-        unimplemented!("export_pop_records not implemented yet")
+        Err(rocketmq_error::RocketMQError::Internal(
+            "export_pop_records not implemented yet".to_string(),
+        ))
     }
 
     async fn switch_timer_engine(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
@@ -39,6 +39,7 @@ use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
 use crate::core::broker::BrokerTarget;
 use crate::core::resolver::BrokerAddressResolver;
+use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
 
@@ -390,6 +391,27 @@ impl ConsumerProgressRequest {
 
     pub fn admin_builder(&self) -> AdminBuilder {
         builder_with_namesrv(self.namesrv_addr.as_deref())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StartMonitoringRequest {
+    namesrv_addr: Option<String>,
+}
+
+impl StartMonitoringRequest {
+    pub fn new(namesrv_addr: Option<String>) -> Self {
+        Self {
+            namesrv_addr: trim_optional_string(namesrv_addr),
+        }
+    }
+
+    pub fn namesrv_addr(&self) -> Option<&str> {
+        self.namesrv_addr.as_deref()
+    }
+
+    pub fn admin_builder(&self) -> AdminBuilder {
+        builder_with_namesrv(self.namesrv_addr())
     }
 }
 
@@ -855,6 +877,15 @@ impl ConsumerService {
             Ok(ConsumerProgressResult::All(results))
         }
     }
+
+    pub fn start_monitoring_by_request_with_rpc_hook(
+        _request: StartMonitoringRequest,
+        _rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> RocketMQResult<()> {
+        Err(RocketMQError::Internal(
+            "ConsumerService: MonitorService is not implemented yet".to_string(),
+        ))
+    }
 }
 
 async fn get_message_queue_allocation_result_with_admin(
@@ -991,5 +1022,14 @@ mod tests {
 
         assert_eq!(request.consumer_group().unwrap().as_str(), "GroupA");
         assert!(request.show_client_ip());
+    }
+
+    #[test]
+    fn start_monitoring_request_trims_namesrv() {
+        let request = StartMonitoringRequest::new(Some(" 127.0.0.1:9876 ".into()));
+        assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+
+        let request = StartMonitoringRequest::new(Some(" ".into()));
+        assert_eq!(request.namesrv_addr(), None);
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/export_data.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/export_data.rs
@@ -7,6 +7,7 @@ use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_remoting::protocol::body::subscription_group_wrapper::SubscriptionGroupWrapper;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
 use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
@@ -39,6 +40,7 @@ const EXPORT_BROKER_PROPERTY_KEYS: &[&str] = &[
     "autoCreateTopicEnable",
     "autoCreateSubscriptionGroup",
 ];
+const DEFAULT_EXPORT_POP_RECORD_TIMEOUT_MILLIS: u64 = 30000;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExportConfigsRequest {
@@ -194,6 +196,100 @@ impl ExportMetadataRequest {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExportPopRecordTarget {
+    Broker(CheetahString),
+    Cluster(CheetahString),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportPopRecordRequest {
+    target: ExportPopRecordTarget,
+    dry_run: bool,
+    timeout_millis: u64,
+    namesrv_addr: Option<String>,
+}
+
+impl ExportPopRecordRequest {
+    pub fn try_new(cluster_name: Option<String>, broker_addr: Option<String>, dry_run: bool) -> RocketMQResult<Self> {
+        let cluster_name = trim_optional_string(cluster_name);
+        let broker_addr = trim_optional_string(broker_addr);
+        let target = match (cluster_name, broker_addr) {
+            (Some(cluster_name), None) => ExportPopRecordTarget::Cluster(CheetahString::from(cluster_name)),
+            (None, Some(broker_addr)) => ExportPopRecordTarget::Broker(CheetahString::from(broker_addr)),
+            (None, None) => {
+                return Err(ToolsError::validation_error(
+                    "target",
+                    "either brokerAddr or clusterName must be provided",
+                )
+                .into());
+            }
+            (Some(_), Some(_)) => {
+                return Err(ToolsError::validation_error(
+                    "target",
+                    "brokerAddr and clusterName cannot be provided together",
+                )
+                .into());
+            }
+        };
+
+        Ok(Self {
+            target,
+            dry_run,
+            timeout_millis: DEFAULT_EXPORT_POP_RECORD_TIMEOUT_MILLIS,
+            namesrv_addr: None,
+        })
+    }
+
+    pub fn with_optional_namesrv_addr(mut self, namesrv_addr: Option<String>) -> Self {
+        self.namesrv_addr = trim_optional_string(namesrv_addr);
+        self
+    }
+
+    pub fn with_timeout_millis(mut self, timeout_millis: u64) -> Self {
+        self.timeout_millis = timeout_millis;
+        self
+    }
+
+    pub fn target(&self) -> &ExportPopRecordTarget {
+        &self.target
+    }
+
+    pub fn dry_run(&self) -> bool {
+        self.dry_run
+    }
+
+    pub fn timeout_millis(&self) -> u64 {
+        self.timeout_millis
+    }
+
+    pub fn namesrv_addr(&self) -> Option<&str> {
+        self.namesrv_addr.as_deref()
+    }
+
+    pub fn admin_builder(&self) -> AdminBuilder {
+        let builder = AdminBuilder::new();
+        match self.namesrv_addr() {
+            Some(addr) => builder.namesrv_addr(addr),
+            None => builder,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportPopRecordTargetResult {
+    pub broker_name: String,
+    pub broker_addr: String,
+    pub dry_run: bool,
+    pub exported: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportPopRecordResult {
+    pub targets: Vec<ExportPopRecordTargetResult>,
+}
+
 #[derive(Debug)]
 pub enum ExportMetadataResult {
     BrokerTopic {
@@ -341,6 +437,125 @@ impl ExportService {
             }
         }
     }
+
+    pub async fn export_pop_records_by_request_with_rpc_hook(
+        request: ExportPopRecordRequest,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> RocketMQResult<ExportPopRecordResult> {
+        let mut admin = admin_builder_with_rpc_hook(request.admin_builder(), rpc_hook)
+            .build_and_start()
+            .await?;
+        let result = Self::export_pop_records_with_admin(&admin, &request).await;
+        admin.shutdown().await;
+        result
+    }
+
+    pub async fn export_pop_records_with_admin(
+        admin: &DefaultMQAdminExt,
+        request: &ExportPopRecordRequest,
+    ) -> RocketMQResult<ExportPopRecordResult> {
+        let targets = match request.target() {
+            ExportPopRecordTarget::Broker(broker_addr) => {
+                vec![Self::resolve_export_pop_record_broker_target(admin, broker_addr).await]
+            }
+            ExportPopRecordTarget::Cluster(cluster_name) => {
+                let cluster_info = admin.examine_broker_cluster_info().await?;
+                resolve_export_pop_record_targets_from_cluster_info(&cluster_info, cluster_name.as_str())
+            }
+        };
+
+        let mut results = Vec::with_capacity(targets.len());
+        for target in targets {
+            let (exported, error) = if request.dry_run() {
+                (false, None)
+            } else {
+                match admin
+                    .export_pop_records(
+                        CheetahString::from(target.broker_addr.as_str()),
+                        request.timeout_millis(),
+                    )
+                    .await
+                {
+                    Ok(()) => (true, None),
+                    Err(error) => (false, Some(error.to_string())),
+                }
+            };
+
+            results.push(ExportPopRecordTargetResult {
+                broker_name: target.broker_name,
+                broker_addr: target.broker_addr,
+                dry_run: request.dry_run(),
+                exported,
+                error,
+            });
+        }
+
+        Ok(ExportPopRecordResult { targets: results })
+    }
+
+    async fn resolve_export_pop_record_broker_target(
+        admin: &DefaultMQAdminExt,
+        broker_addr: &CheetahString,
+    ) -> ExportPopRecordBrokerTarget {
+        let broker_name = admin
+            .get_broker_config(broker_addr.clone())
+            .await
+            .ok()
+            .and_then(|properties| {
+                properties
+                    .get(&CheetahString::from_static_str("brokerName"))
+                    .map(ToString::to_string)
+            })
+            .unwrap_or_default();
+
+        ExportPopRecordBrokerTarget {
+            broker_name,
+            broker_addr: broker_addr.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExportPopRecordBrokerTarget {
+    broker_name: String,
+    broker_addr: String,
+}
+
+fn resolve_export_pop_record_targets_from_cluster_info(
+    cluster_info: &ClusterInfo,
+    cluster_name: &str,
+) -> Vec<ExportPopRecordBrokerTarget> {
+    let Some(cluster_addr_table) = cluster_info.cluster_addr_table.as_ref() else {
+        return Vec::new();
+    };
+    let Some(broker_name_set) = cluster_addr_table.get(cluster_name) else {
+        return Vec::new();
+    };
+    let Some(broker_addr_table) = cluster_info.broker_addr_table.as_ref() else {
+        return Vec::new();
+    };
+
+    let mut targets = Vec::new();
+    for broker_name in broker_name_set {
+        let Some(broker_data) = broker_addr_table.get(broker_name) else {
+            continue;
+        };
+
+        for broker_addr in broker_data.broker_addrs().values() {
+            targets.push(ExportPopRecordBrokerTarget {
+                broker_name: broker_name.to_string(),
+                broker_addr: broker_addr.to_string(),
+            });
+        }
+    }
+
+    targets.sort_by(|left, right| {
+        left.broker_name
+            .cmp(&right.broker_name)
+            .then_with(|| left.broker_addr.cmp(&right.broker_addr))
+    });
+    targets.dedup();
+    targets
 }
 
 pub fn filter_export_broker_properties(properties: &HashMap<CheetahString, CheetahString>) -> HashMap<String, String> {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/export_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/export_core_models.rs
@@ -6,6 +6,8 @@ use rocketmq_admin_core::core::export_data::ExportConfigsRequest;
 use rocketmq_admin_core::core::export_data::ExportMetadataRequest;
 use rocketmq_admin_core::core::export_data::ExportMetadataScope;
 use rocketmq_admin_core::core::export_data::ExportMetadataTarget;
+use rocketmq_admin_core::core::export_data::ExportPopRecordRequest;
+use rocketmq_admin_core::core::export_data::ExportPopRecordTarget;
 
 #[test]
 fn export_configs_request_trims_cluster_and_namesrv() {
@@ -85,4 +87,40 @@ fn export_metadata_request_rejects_invalid_targets() {
     )
     .is_err());
     assert!(ExportMetadataRequest::try_new(None, Some("127.0.0.1:10911".to_string()), false, false, false).is_err());
+}
+
+#[test]
+fn export_pop_record_request_trims_broker_target() {
+    let request = ExportPopRecordRequest::try_new(None, Some(" 127.0.0.1:10911 ".to_string()), true)
+        .unwrap()
+        .with_optional_namesrv_addr(Some(" 127.0.0.1:9876 ".to_string()));
+
+    assert_eq!(
+        request.target(),
+        &ExportPopRecordTarget::Broker("127.0.0.1:10911".into())
+    );
+    assert!(request.dry_run());
+    assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+}
+
+#[test]
+fn export_pop_record_request_trims_cluster_target() {
+    let request = ExportPopRecordRequest::try_new(Some(" DefaultCluster ".to_string()), None, false).unwrap();
+
+    assert_eq!(
+        request.target(),
+        &ExportPopRecordTarget::Cluster("DefaultCluster".into())
+    );
+    assert!(!request.dry_run());
+}
+
+#[test]
+fn export_pop_record_request_rejects_invalid_targets() {
+    assert!(ExportPopRecordRequest::try_new(None, None, false).is_err());
+    assert!(ExportPopRecordRequest::try_new(
+        Some("DefaultCluster".to_string()),
+        Some("127.0.0.1:10911".to_string()),
+        false,
+    )
+    .is_err());
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7144

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export pop records functionality is now fully implemented and operational.
  * Consumer start-monitoring command is now functional in the CLI tool.

* **Bug Fixes**
  * Improved error handling by replacing panic conditions with proper error returns for export operations.

* **Tests**
  * Added unit tests for export pop records request validation and consumer monitoring functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->