### PR TITLE
[ISSUE #7152]🚀feat(cli): enhance TuiAdminFacade with new cluster and consumer operations, add tests for CLI commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,6 +3587,8 @@ dependencies = [
  "crossterm",
  "ratatui",
  "rocketmq-admin-core",
+ "rocketmq-common",
+ "rocketmq-remoting",
  "rocketmq-rust",
  "serde",
  "strum 0.28.0",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/README.md
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/README.md
@@ -16,6 +16,20 @@ for both platforms.
 
 This CLI tool is built on top of [`rocketmq-admin-core`](../rocketmq-admin-core), which provides the core business logic.
 
+## Current Crate Boundary
+
+`rocketmq-admin-cli` is the command-line adapter. It owns `clap` command parsing, shell completion, confirmation prompts, progress/output rendering, and CLI-compatible command names. Business operations should flow through `rocketmq-admin-core` request DTOs and services.
+
+```text
+CLI args
+  -> core request DTO
+  -> core service
+  -> structured result
+  -> CLI renderer
+```
+
+Future TUI/GUI adapters should depend on `rocketmq-admin-core`, not on this CLI crate.
+
 ## ✨ Features
 
 - 🚀 **High Performance**: Built with Rust for blazing-fast execution
@@ -297,16 +311,17 @@ cargo build --release
 
 ### Adding New Commands
 
-1. Add command definition in `rocketmq-admin-core/src/commands/`
-2. Implement the `CommandExecute` trait
-3. Add command to appropriate category enum
-4. Update documentation and tests
+1. Add CLI argument parsing and rendering in `rocketmq-admin-cli/src/commands/`.
+2. Add or reuse request/response DTOs and service methods in `rocketmq-admin-core/src/core/`.
+3. Convert CLI args into core requests, call the core service, then render structured results in the CLI layer.
+4. Add core service tests plus CLI parse/help/smoke tests.
 
 Example:
 
 ```rust
-// In rocketmq-admin-core/src/commands/topic_commands/my_command.rs
+// In rocketmq-admin-cli/src/commands/topic/my_command.rs
 use crate::commands::CommandExecute;
+use rocketmq_admin_core::core::topic::TopicService;
 
 #[derive(clap::Args)]
 pub struct MyTopicCommand {
@@ -316,7 +331,9 @@ pub struct MyTopicCommand {
 
 impl CommandExecute for MyTopicCommand {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
-        // Implementation here
+        let request = self.request()?;
+        let result = TopicService::some_operation_by_request_with_rpc_hook(request, rpc_hook).await?;
+        Self::print_result(result);
         Ok(())
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/tests/cli_help.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/tests/cli_help.rs
@@ -23,3 +23,79 @@ fn help_output_exposes_admin_cli() {
         "help output should expose shell completion, got: {stdout}"
     );
 }
+
+#[test]
+fn bash_completion_output_exposes_root_command() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rocketmq-admin-cli"))
+        .args(["--generate-completion", "bash"])
+        .output()
+        .expect("run rocketmq-admin-cli --generate-completion bash");
+
+    assert!(
+        output.status.success(),
+        "expected completion generation to exit successfully, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_rocketmq-admin-cli"),
+        "bash completion should include the root completion function, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("complete"),
+        "bash completion should include the shell registration line, got: {stdout}"
+    );
+}
+
+#[test]
+fn topic_help_exposes_migrated_topic_commands() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rocketmq-admin-cli"))
+        .args(["topic", "--help"])
+        .output()
+        .expect("run rocketmq-admin-cli topic --help");
+
+    assert!(
+        output.status.success(),
+        "expected topic help to exit successfully, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for command in [
+        "topicList",
+        "deleteTopic",
+        "updateOrderConf",
+        "updateTopic",
+        "allocateMQ",
+    ] {
+        assert!(
+            stdout.contains(command),
+            "topic help should expose migrated command {command}, got: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn broker_help_exposes_update_broker_config_slice() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rocketmq-admin-cli"))
+        .args(["broker", "--help"])
+        .output()
+        .expect("run rocketmq-admin-cli broker --help");
+
+    assert!(
+        output.status.success(),
+        "expected broker help to exit successfully, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("updateBrokerConfig"),
+        "broker help should expose the migrated updateBrokerConfig slice, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("getBrokerConfig"),
+        "broker help should expose broker config query command, got: {stdout}"
+    );
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/README.md
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/README.md
@@ -1,5 +1,37 @@
-# The Rust Implementation of Apache RocketMQ tools
+# RocketMQ Admin Core
 
-## Overview
+`rocketmq-admin-core` is the reusable admin capability layer for RocketMQ Rust tools.
 
-This module is mainly the implementation of the [Apache RocketMQ](https://github.com/apache/rocketmq) tools, containing all the functionalities of the Java version rocketmq-tools.
+## Responsibilities
+
+- Defines admin request/response DTOs and service APIs.
+- Owns RocketMQ admin RPC orchestration and domain validation.
+- Provides reusable helpers for broker, cluster, topic, consumer, offset, queue, HA, stats, export, auth, controller, and related admin domains.
+- Exposes structured results for adapters such as CLI and TUI.
+
+## Non-Responsibilities
+
+- CLI argument parsing.
+- Shell completion generation.
+- Terminal prompt, progress bar, color, or table rendering.
+- TUI state, layout, event handling, or view-model rendering.
+
+## Adapter Boundary
+
+The intended call chain is:
+
+```text
+adapter args or UI state
+  -> core request DTO
+  -> core service
+  -> structured result
+  -> adapter renderer or view model
+```
+
+`rocketmq-admin-cli` owns `clap`, completion, terminal rendering, confirmation prompts, and command-line output. `rocketmq-admin-tui` owns Ratatui UI state and calls core services through its facade.
+
+## Features
+
+- Default build avoids the RocksDB dependency.
+- `rocksdb-export` enables RocksDB metadata export support for CLI commands that need it.
+

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/Cargo.toml
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/Cargo.toml
@@ -29,6 +29,8 @@ rust-version.workspace = true
 
 [dependencies]
 rocketmq-admin-core = { path = "../rocketmq-admin-core" }
+rocketmq-common     = { workspace = true }
+rocketmq-remoting   = { workspace = true }
 rocketmq-rust = { workspace = true }
 ratatui       = { version = "0.29.0" }
 crossterm     = { version = "0.28.1", features = ["event-stream"] }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/README.md
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/README.md
@@ -1,13 +1,28 @@
-## Rocketmq-tui
+# RocketMQ Admin TUI
 
-A RocketMQ Rust terminal command management tool implemented based on [Ratatui](https://github.com/ratatui/ratatui).
+`rocketmq-admin-tui` is the terminal UI adapter for RocketMQ admin operations.
 
-### How to run
+## Architecture
 
-```shell
-cargo run -p rocketmq-tui
+The TUI depends on `rocketmq-admin-core` for admin capabilities and does not depend on `rocketmq-admin-cli`.
+
+```text
+TUI event/state
+  -> TuiAdminFacade
+  -> rocketmq-admin-core request DTO
+  -> rocketmq-admin-core service
+  -> TUI view model
 ```
 
-### design
+`TuiAdminFacade` currently exposes compile-checked core service access for topic, nameserver, broker, cluster, connection, consumer, offset, queue, HA, stats, and producer-oriented admin operations. New screens should reuse the facade or core DTO/service APIs instead of calling CLI command modules.
+
+## How to Run
+
+```shell
+cargo run -p rocketmq-admin-tui
+```
+
+## Design
 
 ![](../../../resources/rocketmq-cli-ui.png)
+

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
@@ -23,6 +23,33 @@ use rocketmq_admin_core::core::broker::BrokerConsumeStatsResult;
 use rocketmq_admin_core::core::broker::BrokerRuntimeStatsQueryRequest;
 use rocketmq_admin_core::core::broker::BrokerRuntimeStatsResult;
 use rocketmq_admin_core::core::broker::BrokerService;
+use rocketmq_admin_core::core::cluster::ClusterBrokerNameQueryRequest;
+use rocketmq_admin_core::core::cluster::ClusterBrokerNameQueryResult;
+use rocketmq_admin_core::core::cluster::ClusterListQueryRequest;
+use rocketmq_admin_core::core::cluster::ClusterListQueryResult;
+use rocketmq_admin_core::core::cluster::ClusterSendMessageRtRequest;
+use rocketmq_admin_core::core::cluster::ClusterSendMessageRtResult;
+use rocketmq_admin_core::core::cluster::ClusterService;
+use rocketmq_admin_core::core::connection::ConnectionService;
+use rocketmq_admin_core::core::connection::ConsumerConnectionQueryRequest;
+use rocketmq_admin_core::core::connection::ConsumerConnectionQueryResult;
+use rocketmq_admin_core::core::connection::ProducerConnectionQueryRequest;
+use rocketmq_admin_core::core::connection::ProducerConnectionQueryResult;
+use rocketmq_admin_core::core::consumer::ConsumerConfigQueryRequest;
+use rocketmq_admin_core::core::consumer::ConsumerConfigQueryResult;
+use rocketmq_admin_core::core::consumer::ConsumerOperationResult;
+use rocketmq_admin_core::core::consumer::ConsumerProgressRequest;
+use rocketmq_admin_core::core::consumer::ConsumerProgressResult;
+use rocketmq_admin_core::core::consumer::ConsumerRunningInfoRequest;
+use rocketmq_admin_core::core::consumer::ConsumerRunningInfoResult;
+use rocketmq_admin_core::core::consumer::ConsumerService;
+use rocketmq_admin_core::core::consumer::DeleteSubscriptionGroupRequest;
+use rocketmq_admin_core::core::consumer::SetConsumeModeRequest;
+use rocketmq_admin_core::core::ha::HaService;
+use rocketmq_admin_core::core::ha::HaStatusQueryRequest;
+use rocketmq_admin_core::core::ha::HaStatusQueryResult;
+use rocketmq_admin_core::core::ha::SyncStateSetQueryRequest;
+use rocketmq_admin_core::core::ha::SyncStateSetQueryResult;
 use rocketmq_admin_core::core::namesrv::KvConfigDeleteRequest;
 use rocketmq_admin_core::core::namesrv::KvConfigUpdateRequest;
 use rocketmq_admin_core::core::namesrv::KvConfigUpdateResult;
@@ -33,6 +60,26 @@ use rocketmq_admin_core::core::namesrv::NamesrvConfigUpdateRequest;
 use rocketmq_admin_core::core::namesrv::NamesrvConfigUpdateResult;
 use rocketmq_admin_core::core::namesrv::WritePermRequest;
 use rocketmq_admin_core::core::namesrv::WritePermResult;
+use rocketmq_admin_core::core::offset::CloneGroupOffsetRequest;
+use rocketmq_admin_core::core::offset::ConsumerStatusQueryRequest;
+use rocketmq_admin_core::core::offset::ConsumerStatusResult;
+use rocketmq_admin_core::core::offset::OffsetService;
+use rocketmq_admin_core::core::offset::ResetOffsetByTimeOldRequest;
+use rocketmq_admin_core::core::offset::ResetOffsetByTimeRequest;
+use rocketmq_admin_core::core::offset::ResetOffsetByTimeResult;
+use rocketmq_admin_core::core::offset::SkipAccumulatedMessageRequest;
+use rocketmq_admin_core::core::offset::SkipAccumulatedMessageResult;
+use rocketmq_admin_core::core::producer::ProducerInfoQueryRequest;
+use rocketmq_admin_core::core::producer::ProducerInfoQueryResult;
+use rocketmq_admin_core::core::producer::ProducerService;
+use rocketmq_admin_core::core::queue::CheckRocksdbCqWriteProgressRequest;
+use rocketmq_admin_core::core::queue::CheckRocksdbCqWriteProgressResult;
+use rocketmq_admin_core::core::queue::QueryConsumeQueueRequest;
+use rocketmq_admin_core::core::queue::QueryConsumeQueueResult;
+use rocketmq_admin_core::core::queue::QueueService;
+use rocketmq_admin_core::core::stats::StatsAllQueryRequest;
+use rocketmq_admin_core::core::stats::StatsAllQueryResult;
+use rocketmq_admin_core::core::stats::StatsService;
 use rocketmq_admin_core::core::topic::AllocateMqQueryRequest;
 use rocketmq_admin_core::core::topic::AllocatedMqQueryResult;
 use rocketmq_admin_core::core::topic::DeleteTopicRequest;
@@ -54,6 +101,8 @@ use rocketmq_admin_core::core::topic::UpdateTopicPermResult;
 use rocketmq_admin_core::core::topic::UpdateTopicRequest;
 use rocketmq_admin_core::core::topic::UpdateTopicResult;
 use rocketmq_admin_core::core::RocketMQResult;
+use rocketmq_common::common::message::message_enum::MessageRequestMode;
+use rocketmq_remoting::protocol::admin::rollback_stats::RollbackStats;
 
 #[derive(Debug, Clone, Default)]
 pub struct TuiAdminFacade {
@@ -159,6 +208,215 @@ impl TuiAdminFacade {
             BrokerConsumeStatsQueryRequest::try_new(broker_addr, timeout_millis, diff_level, is_order)?
                 .with_optional_namesrv_addr(self.namesrv_addr.clone()),
         )
+    }
+
+    pub fn cluster_list_request(&self, more_stats: bool, cluster_name: Option<String>) -> ClusterListQueryRequest {
+        ClusterListQueryRequest::new(more_stats, cluster_name).with_optional_namesrv_addr(self.namesrv_addr.clone())
+    }
+
+    pub fn cluster_broker_names_request(&self, cluster_name: Option<String>) -> ClusterBrokerNameQueryRequest {
+        ClusterBrokerNameQueryRequest::new(cluster_name).with_optional_namesrv_addr(self.namesrv_addr.clone())
+    }
+
+    pub fn cluster_send_message_rt_request(
+        &self,
+        amount: u64,
+        size: u64,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<ClusterSendMessageRtRequest> {
+        Ok(ClusterSendMessageRtRequest::try_new(amount, size, cluster_name)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn consumer_connection_request(
+        &self,
+        consumer_group: impl Into<String>,
+        broker_addr: Option<String>,
+    ) -> RocketMQResult<ConsumerConnectionQueryRequest> {
+        Ok(ConsumerConnectionQueryRequest::try_new(consumer_group, broker_addr)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn producer_connection_request(
+        &self,
+        producer_group: impl Into<String>,
+        topic: impl Into<String>,
+    ) -> RocketMQResult<ProducerConnectionQueryRequest> {
+        Ok(ProducerConnectionQueryRequest::try_new(producer_group, topic)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn consumer_config_request(&self, group_name: impl Into<String>) -> RocketMQResult<ConsumerConfigQueryRequest> {
+        Ok(ConsumerConfigQueryRequest::try_new(group_name)?.with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn delete_subscription_group_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        group_name: impl Into<String>,
+        remove_offset: bool,
+    ) -> RocketMQResult<DeleteSubscriptionGroupRequest> {
+        Ok(
+            DeleteSubscriptionGroupRequest::try_new(broker_addr, cluster_name, group_name, remove_offset)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    pub fn set_consume_mode_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        topic_name: impl Into<String>,
+        group_name: impl Into<String>,
+        mode: MessageRequestMode,
+        pop_share_queue_num: Option<i32>,
+    ) -> RocketMQResult<SetConsumeModeRequest> {
+        Ok(SetConsumeModeRequest::try_new(
+            broker_addr,
+            cluster_name,
+            topic_name,
+            group_name,
+            mode,
+            pop_share_queue_num,
+        )?
+        .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn consumer_running_info_request(
+        &self,
+        group_name: impl Into<String>,
+        client_id: Option<String>,
+        broker_addr: Option<String>,
+        jstack: bool,
+    ) -> RocketMQResult<ConsumerRunningInfoRequest> {
+        ConsumerRunningInfoRequest::try_new(group_name, client_id, broker_addr, jstack, self.namesrv_addr.clone())
+    }
+
+    pub fn consumer_progress_request(
+        &self,
+        consumer_group: Option<String>,
+        topic_name: Option<String>,
+        show_client_ip: bool,
+        cluster: Option<String>,
+    ) -> RocketMQResult<ConsumerProgressRequest> {
+        ConsumerProgressRequest::try_new(
+            consumer_group,
+            topic_name,
+            show_client_ip,
+            cluster,
+            self.namesrv_addr.clone(),
+        )
+    }
+
+    pub fn clone_group_offset_request(
+        &self,
+        src_group: impl Into<String>,
+        dest_group: impl Into<String>,
+        topic: impl Into<String>,
+        offline: bool,
+    ) -> RocketMQResult<CloneGroupOffsetRequest> {
+        Ok(CloneGroupOffsetRequest::try_new(src_group, dest_group, topic, offline)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn consumer_status_request(
+        &self,
+        group: impl Into<String>,
+        topic: impl Into<String>,
+        origin_client_id: Option<String>,
+    ) -> RocketMQResult<ConsumerStatusQueryRequest> {
+        Ok(ConsumerStatusQueryRequest::try_new(group, topic, origin_client_id)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn skip_accumulated_message_request(
+        &self,
+        group: impl Into<String>,
+        topic: impl Into<String>,
+        cluster: Option<String>,
+        force: Option<bool>,
+    ) -> RocketMQResult<SkipAccumulatedMessageRequest> {
+        SkipAccumulatedMessageRequest::try_new(group, topic, cluster, force, self.namesrv_addr.clone())
+    }
+
+    pub fn reset_offset_by_time_request(
+        &self,
+        group: impl Into<String>,
+        topic: impl Into<String>,
+        timestamp: u64,
+    ) -> RocketMQResult<ResetOffsetByTimeRequest> {
+        Ok(ResetOffsetByTimeRequest::try_new(group, topic, timestamp)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn reset_offset_by_time_old_request(
+        &self,
+        group: impl Into<String>,
+        topic: impl Into<String>,
+        timestamp: u64,
+        force: Option<bool>,
+        cluster: Option<String>,
+    ) -> RocketMQResult<ResetOffsetByTimeOldRequest> {
+        ResetOffsetByTimeOldRequest::try_new(group, topic, timestamp, force, cluster, self.namesrv_addr.clone())
+    }
+
+    pub fn query_consume_queue_request(
+        &self,
+        topic: impl Into<String>,
+        queue_id: i32,
+        index: u64,
+        count: i32,
+        broker_addr: Option<String>,
+        consumer_group: Option<String>,
+    ) -> RocketMQResult<QueryConsumeQueueRequest> {
+        Ok(
+            QueryConsumeQueueRequest::try_new(topic, queue_id, index, count, broker_addr, consumer_group)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    pub fn check_rocksdb_cq_write_progress_request(
+        &self,
+        cluster_name: impl Into<String>,
+        topic: Option<String>,
+        check_from: Option<i64>,
+    ) -> RocketMQResult<CheckRocksdbCqWriteProgressRequest> {
+        CheckRocksdbCqWriteProgressRequest::try_new(
+            cluster_name,
+            self.namesrv_addr.clone().unwrap_or_default(),
+            topic,
+            check_from,
+        )
+    }
+
+    pub fn ha_status_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<HaStatusQueryRequest> {
+        Ok(HaStatusQueryRequest::try_new(broker_addr, cluster_name)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn sync_state_set_request(
+        &self,
+        controller_address: impl Into<String>,
+        broker_name: Option<String>,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<SyncStateSetQueryRequest> {
+        Ok(
+            SyncStateSetQueryRequest::try_new(controller_address, broker_name, cluster_name)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    pub fn stats_all_request(&self, active_topic: bool, topic: Option<String>) -> StatsAllQueryRequest {
+        StatsAllQueryRequest::new(active_topic, topic).with_optional_namesrv_addr(self.namesrv_addr.clone())
+    }
+
+    pub fn producer_info_request(&self, broker_addr: impl Into<String>) -> RocketMQResult<ProducerInfoQueryRequest> {
+        Ok(ProducerInfoQueryRequest::try_new(broker_addr)?.with_optional_namesrv_addr(self.namesrv_addr.clone()))
     }
 
     pub fn topic_cluster_request(&self, topic: impl Into<String>) -> RocketMQResult<TopicClusterQueryRequest> {
@@ -387,6 +645,272 @@ impl TuiAdminFacade {
             is_order,
         )?)
         .await
+    }
+
+    pub async fn query_cluster_list(
+        &self,
+        more_stats: bool,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<ClusterListQueryResult> {
+        ClusterService::query_cluster_list_by_request_with_rpc_hook(
+            self.cluster_list_request(more_stats, cluster_name),
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_cluster_broker_names(
+        &self,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<ClusterBrokerNameQueryResult> {
+        ClusterService::query_cluster_broker_names_by_request_with_rpc_hook(
+            self.cluster_broker_names_request(cluster_name),
+            None,
+        )
+        .await
+    }
+
+    pub async fn check_cluster_send_message_rt(
+        &self,
+        amount: u64,
+        size: u64,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<ClusterSendMessageRtResult> {
+        ClusterService::send_message_rt_by_request_with_rpc_hook(
+            self.cluster_send_message_rt_request(amount, size, cluster_name)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_consumer_connection(
+        &self,
+        consumer_group: impl Into<String>,
+        broker_addr: Option<String>,
+    ) -> RocketMQResult<ConsumerConnectionQueryResult> {
+        ConnectionService::query_consumer_connection_by_request_with_rpc_hook(
+            self.consumer_connection_request(consumer_group, broker_addr)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_producer_connection(
+        &self,
+        producer_group: impl Into<String>,
+        topic: impl Into<String>,
+    ) -> RocketMQResult<ProducerConnectionQueryResult> {
+        ConnectionService::query_producer_connection_by_request_with_rpc_hook(
+            self.producer_connection_request(producer_group, topic)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_consumer_config(
+        &self,
+        group_name: impl Into<String>,
+    ) -> RocketMQResult<ConsumerConfigQueryResult> {
+        ConsumerService::query_consumer_config_by_request_with_rpc_hook(self.consumer_config_request(group_name)?, None)
+            .await
+    }
+
+    pub async fn delete_subscription_group(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        group_name: impl Into<String>,
+        remove_offset: bool,
+    ) -> RocketMQResult<ConsumerOperationResult> {
+        ConsumerService::delete_subscription_group_by_request_with_rpc_hook(
+            self.delete_subscription_group_request(broker_addr, cluster_name, group_name, remove_offset)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn set_consume_mode(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        topic_name: impl Into<String>,
+        group_name: impl Into<String>,
+        mode: MessageRequestMode,
+        pop_share_queue_num: Option<i32>,
+    ) -> RocketMQResult<ConsumerOperationResult> {
+        ConsumerService::set_consume_mode_by_request_with_rpc_hook(
+            self.set_consume_mode_request(
+                broker_addr,
+                cluster_name,
+                topic_name,
+                group_name,
+                mode,
+                pop_share_queue_num,
+            )?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_consumer_running_info(
+        &self,
+        group_name: impl Into<String>,
+        client_id: Option<String>,
+        broker_addr: Option<String>,
+        jstack: bool,
+    ) -> RocketMQResult<ConsumerRunningInfoResult> {
+        ConsumerService::query_consumer_running_info_by_request_with_rpc_hook(
+            self.consumer_running_info_request(group_name, client_id, broker_addr, jstack)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_consumer_progress(
+        &self,
+        consumer_group: Option<String>,
+        topic_name: Option<String>,
+        show_client_ip: bool,
+        cluster: Option<String>,
+    ) -> RocketMQResult<ConsumerProgressResult> {
+        ConsumerService::query_consumer_progress_by_request_with_rpc_hook(
+            self.consumer_progress_request(consumer_group, topic_name, show_client_ip, cluster)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn clone_group_offset(
+        &self,
+        src_group: impl Into<String>,
+        dest_group: impl Into<String>,
+        topic: impl Into<String>,
+        offline: bool,
+    ) -> RocketMQResult<()> {
+        OffsetService::clone_group_offset_by_request_with_rpc_hook(
+            self.clone_group_offset_request(src_group, dest_group, topic, offline)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_consumer_status(
+        &self,
+        group: impl Into<String>,
+        topic: impl Into<String>,
+        origin_client_id: Option<String>,
+    ) -> RocketMQResult<ConsumerStatusResult> {
+        OffsetService::query_consumer_status_by_request_with_rpc_hook(
+            self.consumer_status_request(group, topic, origin_client_id)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn skip_accumulated_message(
+        &self,
+        group: impl Into<String>,
+        topic: impl Into<String>,
+        cluster: Option<String>,
+        force: Option<bool>,
+    ) -> RocketMQResult<SkipAccumulatedMessageResult> {
+        OffsetService::skip_accumulated_message_by_request_with_rpc_hook(
+            self.skip_accumulated_message_request(group, topic, cluster, force)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn reset_offset_by_time(
+        &self,
+        group: impl Into<String>,
+        topic: impl Into<String>,
+        timestamp: u64,
+    ) -> RocketMQResult<ResetOffsetByTimeResult> {
+        OffsetService::reset_offset_by_time_by_request_with_rpc_hook(
+            self.reset_offset_by_time_request(group, topic, timestamp)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn reset_offset_by_time_old(
+        &self,
+        group: impl Into<String>,
+        topic: impl Into<String>,
+        timestamp: u64,
+        force: Option<bool>,
+        cluster: Option<String>,
+    ) -> RocketMQResult<Vec<RollbackStats>> {
+        OffsetService::reset_offset_by_time_old_by_request_with_rpc_hook(
+            self.reset_offset_by_time_old_request(group, topic, timestamp, force, cluster)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_consume_queue(
+        &self,
+        topic: impl Into<String>,
+        queue_id: i32,
+        index: u64,
+        count: i32,
+        broker_addr: Option<String>,
+        consumer_group: Option<String>,
+    ) -> RocketMQResult<QueryConsumeQueueResult> {
+        QueueService::query_consume_queue_by_request_with_rpc_hook(
+            self.query_consume_queue_request(topic, queue_id, index, count, broker_addr, consumer_group)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn check_rocksdb_cq_write_progress(
+        &self,
+        cluster_name: impl Into<String>,
+        topic: Option<String>,
+        check_from: Option<i64>,
+    ) -> RocketMQResult<CheckRocksdbCqWriteProgressResult> {
+        QueueService::check_rocksdb_cq_write_progress_by_request_with_rpc_hook(
+            self.check_rocksdb_cq_write_progress_request(cluster_name, topic, check_from)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_ha_status(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<HaStatusQueryResult> {
+        HaService::query_ha_status_by_request_with_rpc_hook(self.ha_status_request(broker_addr, cluster_name)?, None)
+            .await
+    }
+
+    pub async fn query_sync_state_set(
+        &self,
+        controller_address: impl Into<String>,
+        broker_name: Option<String>,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<SyncStateSetQueryResult> {
+        HaService::query_sync_state_set_by_request_with_rpc_hook(
+            self.sync_state_set_request(controller_address, broker_name, cluster_name)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn query_stats_all(
+        &self,
+        active_topic: bool,
+        topic: Option<String>,
+    ) -> RocketMQResult<StatsAllQueryResult> {
+        StatsService::query_stats_all_by_request_with_rpc_hook(self.stats_all_request(active_topic, topic), None).await
+    }
+
+    pub async fn query_producer_info(&self, broker_addr: impl Into<String>) -> RocketMQResult<ProducerInfoQueryResult> {
+        ProducerService::query_producer_info_by_request_with_rpc_hook(self.producer_info_request(broker_addr)?, None)
+            .await
     }
 }
 
@@ -645,5 +1169,115 @@ mod tests {
             .unwrap();
         std::mem::drop(facade.build_broker_config_update_plan(update_request.clone()));
         std::mem::drop(facade.apply_broker_config_update(update_request));
+    }
+
+    #[test]
+    fn facade_builds_operational_requests_without_cli_types() {
+        let facade = TuiAdminFacade::with_namesrv_addr(" 127.0.0.1:9876 ");
+
+        let cluster_list = facade.cluster_list_request(true, Some(" DefaultCluster ".to_string()));
+        assert_eq!(cluster_list.namesrv_addr(), Some("127.0.0.1:9876"));
+        assert_eq!(
+            cluster_list.cluster_name().map(|value| value.as_str()),
+            Some("DefaultCluster")
+        );
+
+        let consumer_connection = facade
+            .consumer_connection_request(" GroupA ", Some(" 127.0.0.1:10911 ".to_string()))
+            .unwrap();
+        assert_eq!(consumer_connection.consumer_group().as_str(), "GroupA");
+        assert_eq!(consumer_connection.broker_addr(), Some("127.0.0.1:10911"));
+
+        let progress = facade
+            .consumer_progress_request(
+                Some(" GroupA ".to_string()),
+                Some(" TopicA ".to_string()),
+                true,
+                Some(" DefaultCluster ".to_string()),
+            )
+            .unwrap();
+        assert_eq!(progress.consumer_group().unwrap().as_str(), "GroupA");
+        assert!(progress.show_client_ip());
+
+        let reset = facade
+            .reset_offset_by_time_request(" GroupA ", " TopicA ", 1234)
+            .unwrap();
+        assert_eq!(reset.group().as_str(), "GroupA");
+        assert_eq!(reset.namesrv_addr(), Some("127.0.0.1:9876"));
+
+        let queue = facade
+            .query_consume_queue_request(
+                " TopicA ",
+                1,
+                10,
+                20,
+                Some(" 127.0.0.1:10911 ".to_string()),
+                Some(" GroupA ".to_string()),
+            )
+            .unwrap();
+        assert_eq!(queue.topic().as_str(), "TopicA");
+        assert_eq!(queue.namesrv_addr(), Some("127.0.0.1:9876"));
+
+        let ha = facade
+            .ha_status_request(Some(" 127.0.0.1:10911 ".to_string()), None)
+            .unwrap();
+        assert_eq!(ha.namesrv_addr(), Some("127.0.0.1:9876"));
+    }
+
+    #[test]
+    fn facade_exposes_operational_service_futures_without_cli_types() {
+        let facade = TuiAdminFacade::with_namesrv_addr("127.0.0.1:9876");
+
+        std::mem::drop(facade.query_cluster_list(false, Some("DefaultCluster".to_string())));
+        std::mem::drop(facade.query_cluster_broker_names(Some("DefaultCluster".to_string())));
+        std::mem::drop(facade.check_cluster_send_message_rt(2, 128, Some("DefaultCluster".to_string())));
+        std::mem::drop(facade.query_consumer_connection("GroupA", Some("127.0.0.1:10911".to_string())));
+        std::mem::drop(facade.query_producer_connection("ProducerGroupA", "TopicA"));
+        std::mem::drop(facade.query_consumer_config("GroupA"));
+        std::mem::drop(facade.query_consumer_running_info(
+            "GroupA",
+            Some("client-a".to_string()),
+            Some("127.0.0.1:10911".to_string()),
+            false,
+        ));
+        std::mem::drop(facade.query_consumer_progress(
+            Some("GroupA".to_string()),
+            Some("TopicA".to_string()),
+            false,
+            Some("DefaultCluster".to_string()),
+        ));
+        std::mem::drop(facade.clone_group_offset("SourceGroup", "DestGroup", "TopicA", false));
+        std::mem::drop(facade.query_consumer_status("GroupA", "TopicA", Some("client-a".to_string())));
+        std::mem::drop(facade.skip_accumulated_message(
+            "GroupA",
+            "TopicA",
+            Some("DefaultCluster".to_string()),
+            Some(true),
+        ));
+        std::mem::drop(facade.reset_offset_by_time("GroupA", "TopicA", 1234));
+        std::mem::drop(facade.reset_offset_by_time_old(
+            "GroupA",
+            "TopicA",
+            1234,
+            Some(true),
+            Some("DefaultCluster".to_string()),
+        ));
+        std::mem::drop(facade.query_consume_queue(
+            "TopicA",
+            1,
+            10,
+            20,
+            Some("127.0.0.1:10911".to_string()),
+            Some("GroupA".to_string()),
+        ));
+        std::mem::drop(facade.check_rocksdb_cq_write_progress(
+            "DefaultCluster",
+            Some("TopicA".to_string()),
+            Some(1000),
+        ));
+        std::mem::drop(facade.query_ha_status(Some("127.0.0.1:10911".to_string()), None));
+        std::mem::drop(facade.query_sync_state_set("127.0.0.1:9878", Some("broker-a".to_string()), None));
+        std::mem::drop(facade.query_stats_all(false, Some("TopicA".to_string())));
+        std::mem::drop(facade.query_producer_info("127.0.0.1:10911"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7152

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TUI adapter with expanded support for cluster operations, consumer and producer management, subscription group handling, offset management, consume-queue inspection, and system statistics queries.

* **Documentation**
  * Clarified architecture and responsibility boundaries across admin CLI, core, and TUI components.

* **Tests**
  * Added CLI help and shell completion verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->