### PR TITLE
[ISSUE #7160]✨enh(ui): enhance table and key-value view models with sorting and viewport support

### DIFF
--- a/rocketmq-store/src/log_file/commit_log_recovery.rs
+++ b/rocketmq-store/src/log_file/commit_log_recovery.rs
@@ -139,14 +139,11 @@ impl<'a> BatchMessageIterator<'a> {
                 // Message spans beyond current buffer, fetch larger chunk
                 if msg_size > PARSE_BATCH_SIZE {
                     // Large message, fetch directly
-                    if let Some(msg_bytes) = self.mapped_file.get_bytes(self.current_offset, msg_size) {
-                        self.current_offset += msg_size;
-                        // Clear buffer to force refill on next call
-                        self.buffer = Bytes::new();
-                        return Some((msg_bytes, absolute_offset, msg_size));
-                    } else {
-                        return None;
-                    }
+                    let msg_bytes = self.mapped_file.get_bytes(self.current_offset, msg_size)?;
+                    self.current_offset += msg_size;
+                    // Clear buffer to force refill on next call
+                    self.buffer = Bytes::new();
+                    return Some((msg_bytes, absolute_offset, msg_size));
                 } else {
                     // Refill buffer and retry
                     if !self.refill_buffer() {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
@@ -351,14 +351,14 @@ pub async fn execute_command(
             let result = facade
                 .query_cluster_broker_names(form.optional_string("cluster_name"))
                 .await?;
-            CommandResultViewModel::KeyValue(crate::view_model::KeyValueViewModel {
-                title: spec.title.to_string(),
-                rows: result
+            CommandResultViewModel::key_value_sorted(
+                spec.title,
+                result
                     .broker_names_by_cluster
                     .iter()
                     .map(|(cluster, brokers)| (cluster.clone(), brokers.join(", ")))
                     .collect(),
-            })
+            )
         }
         "cluster.send_message_rt" => {
             let result = facade

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/ui.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/ui.rs
@@ -278,18 +278,25 @@ fn render_result(frame: &mut Frame, area: Rect, state: &AppState) {
 
     match result {
         CommandResultViewModel::Table(table) if !table.headers.is_empty() => {
-            let widths = table.headers.iter().map(|_| Constraint::Length(24)).collect::<Vec<_>>();
-            let header = Row::new(table.headers.iter().map(|header| {
+            let viewport = table.viewport(state.result_horizontal_scroll as usize, area.width.saturating_sub(2));
+            let title = table_title_with_scroll_hints(result.title(), viewport.hidden_left, viewport.hidden_right);
+            let widths = viewport
+                .widths
+                .iter()
+                .copied()
+                .map(Constraint::Length)
+                .collect::<Vec<_>>();
+            let header = Row::new(viewport.headers.iter().map(|header| {
                 Cell::from(header.clone()).style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
             }));
-            let rows = table
+            let rows = viewport
                 .rows
                 .iter()
                 .skip(state.result_scroll as usize)
                 .map(|row| Row::new(row.iter().map(|cell| Cell::from(cell.clone()))));
             let widget = Table::new(rows, widths)
                 .header(header)
-                .block(focused_block(result.title(), state.focus == FocusArea::Result));
+                .block(focused_block(&title, state.focus == FocusArea::Result));
             frame.render_widget(widget, area);
         }
         _ => {
@@ -395,6 +402,15 @@ fn truncate(value: &str, max_len: usize) -> String {
         let mut truncated = value.chars().take(max_len.saturating_sub(3)).collect::<String>();
         truncated.push_str("...");
         truncated
+    }
+}
+
+fn table_title_with_scroll_hints(title: &str, hidden_left: bool, hidden_right: bool) -> String {
+    match (hidden_left, hidden_right) {
+        (true, true) => format!("< {title} >"),
+        (true, false) => format!("< {title}"),
+        (false, true) => format!("{title} >"),
+        (false, false) => title.to_string(),
     }
 }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
@@ -10,9 +10,105 @@ pub struct TableViewModel {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableViewport {
+    pub headers: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+    pub widths: Vec<u16>,
+    pub hidden_left: bool,
+    pub hidden_right: bool,
+}
+
+impl TableViewModel {
+    const MIN_COLUMN_WIDTH: u16 = 8;
+    const MAX_COLUMN_WIDTH: u16 = 32;
+
+    pub fn viewport(&self, first_column: usize, available_width: u16) -> TableViewport {
+        if self.headers.is_empty() {
+            return TableViewport {
+                headers: Vec::new(),
+                rows: Vec::new(),
+                widths: Vec::new(),
+                hidden_left: false,
+                hidden_right: false,
+            };
+        }
+
+        let first_column = first_column.min(self.headers.len() - 1);
+        let available_width = available_width.max(Self::MIN_COLUMN_WIDTH);
+        let mut used_width = 0_u16;
+        let mut columns = Vec::new();
+
+        for column in first_column..self.headers.len() {
+            let width = self.column_width(column).min(available_width);
+            let separator_width = u16::from(!columns.is_empty());
+            if !columns.is_empty() && used_width.saturating_add(separator_width).saturating_add(width) > available_width
+            {
+                break;
+            }
+            used_width = used_width.saturating_add(separator_width).saturating_add(width);
+            columns.push((column, width));
+        }
+
+        let headers = columns
+            .iter()
+            .map(|(column, _)| self.headers[*column].clone())
+            .collect::<Vec<_>>();
+        let rows = self
+            .rows
+            .iter()
+            .map(|row| {
+                columns
+                    .iter()
+                    .map(|(column, _)| row.get(*column).cloned().unwrap_or_default())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let hidden_right = columns
+            .last()
+            .map(|(column, _)| column + 1 < self.headers.len())
+            .unwrap_or(false);
+
+        TableViewport {
+            headers,
+            rows,
+            widths: columns.into_iter().map(|(_, width)| width).collect(),
+            hidden_left: first_column > 0,
+            hidden_right,
+        }
+    }
+
+    fn column_width(&self, column: usize) -> u16 {
+        let header_width = self
+            .headers
+            .get(column)
+            .map(|header| header.chars().count())
+            .unwrap_or_default();
+        let cell_width = self
+            .rows
+            .iter()
+            .filter_map(|row| row.get(column))
+            .map(|cell| cell.chars().count())
+            .max()
+            .unwrap_or_default();
+        let width = header_width.max(cell_width).saturating_add(2);
+        width.clamp(Self::MIN_COLUMN_WIDTH as usize, Self::MAX_COLUMN_WIDTH as usize) as u16
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyValueViewModel {
     pub title: String,
     pub rows: Vec<(String, String)>,
+}
+
+impl KeyValueViewModel {
+    pub fn sorted(title: impl Into<String>, mut rows: Vec<(String, String)>) -> Self {
+        rows.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+        Self {
+            title: title.into(),
+            rows,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -65,6 +161,10 @@ impl CommandResultViewModel {
             title: title.into(),
             body: body.into(),
         }
+    }
+
+    pub fn key_value_sorted(title: impl Into<String>, rows: Vec<(String, String)>) -> Self {
+        Self::KeyValue(KeyValueViewModel::sorted(title, rows))
     }
 
     pub fn title(&self) -> &str {
@@ -140,5 +240,69 @@ mod tests {
             errors: vec!["failed".to_string()],
         });
         assert!(summary.text_body().contains("topic-a"));
+    }
+
+    #[test]
+    fn table_viewport_slices_columns_by_horizontal_scroll() {
+        let table = TableViewModel {
+            title: "table".to_string(),
+            headers: vec![
+                "cluster".to_string(),
+                "broker".to_string(),
+                "addr".to_string(),
+                "status".to_string(),
+            ],
+            rows: vec![vec![
+                "cluster-a".to_string(),
+                "broker-a".to_string(),
+                "127.0.0.1:10911".to_string(),
+                "online".to_string(),
+            ]],
+        };
+
+        let viewport = table.viewport(1, 18);
+
+        assert!(viewport.hidden_left);
+        assert!(viewport.hidden_right);
+        assert_eq!(viewport.headers, vec!["broker"]);
+        assert_eq!(viewport.rows[0], vec!["broker-a"]);
+        assert_eq!(viewport.widths.len(), 1);
+    }
+
+    #[test]
+    fn table_viewport_clamps_out_of_range_scroll_to_last_column() {
+        let table = TableViewModel {
+            title: "table".to_string(),
+            headers: vec!["a".to_string(), "b".to_string()],
+            rows: vec![vec!["1".to_string(), "2".to_string()]],
+        };
+
+        let viewport = table.viewport(99, 80);
+
+        assert!(viewport.hidden_left);
+        assert!(!viewport.hidden_right);
+        assert_eq!(viewport.headers, vec!["b"]);
+        assert_eq!(viewport.rows[0], vec!["2"]);
+    }
+
+    #[test]
+    fn key_value_view_model_sorts_rows_by_key_then_value() {
+        let key_value = KeyValueViewModel::sorted(
+            "kv",
+            vec![
+                ("z".to_string(), "last".to_string()),
+                ("a".to_string(), "second".to_string()),
+                ("a".to_string(), "first".to_string()),
+            ],
+        );
+
+        assert_eq!(
+            key_value.rows,
+            vec![
+                ("a".to_string(), "first".to_string()),
+                ("a".to_string(), "second".to_string()),
+                ("z".to_string(), "last".to_string()),
+            ]
+        );
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7160

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added horizontal scroll indicators to tables in the admin terminal UI when content extends beyond visible width.
  * Broker cluster names now display in sorted order.

* **Improvements**
  * Enhanced large table rendering with better viewport management for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->