### PR TITLE
[ISSUE #7164]update CommandResultViewModel methods to render results as tables for improved clarity

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
@@ -392,7 +392,7 @@ pub async fn execute_command(
                     form.bool_value("is_order")?,
                 )
                 .await?;
-            CommandResultViewModel::from_debug(spec.title, &result)
+            CommandResultViewModel::broker_consume_stats(spec.title, &result)
         }
         "broker.epoch" => {
             let result = facade
@@ -416,7 +416,7 @@ pub async fn execute_command(
             let result = facade
                 .query_cluster_list(form.bool_value("more_stats")?, form.optional_string("cluster_name"))
                 .await?;
-            CommandResultViewModel::from_debug(spec.title, &result)
+            CommandResultViewModel::cluster_list(spec.title, &result)
         }
         "cluster.broker_names" => {
             let result = facade
@@ -439,7 +439,7 @@ pub async fn execute_command(
                     form.optional_string("cluster_name"),
                 )
                 .await?;
-            CommandResultViewModel::from_debug(spec.title, &result)
+            CommandResultViewModel::cluster_send_message_rt(spec.title, &result)
         }
         "controller.config.query" => {
             let result = facade
@@ -494,7 +494,7 @@ pub async fn execute_command(
                     form.optional_string("cluster"),
                 )
                 .await?;
-            CommandResultViewModel::from_debug(spec.title, &result)
+            CommandResultViewModel::consumer_progress(spec.title, &result)
         }
         "consumer.delete_subscription_group" => {
             let group = form.required_string("group_name")?;
@@ -609,7 +609,7 @@ pub async fn execute_command(
                     form.optional_string("consumer_group"),
                 )
                 .await?;
-            CommandResultViewModel::from_debug(spec.title, &result)
+            CommandResultViewModel::consume_queue(spec.title, &result)
         }
         "queue.rocksdb_cq_progress" => {
             let result = facade
@@ -619,7 +619,7 @@ pub async fn execute_command(
                     form.optional_i64("check_from")?,
                 )
                 .await?;
-            CommandResultViewModel::from_debug(spec.title, &result)
+            CommandResultViewModel::rocksdb_cq_progress(spec.title, &result)
         }
         "ha.status" => {
             let result = facade
@@ -697,7 +697,7 @@ pub async fn execute_command(
         }
         "message.decode_id" => {
             let result = facade.decode_message_id(form.required_string("message_ids")?)?;
-            CommandResultViewModel::from_serializable(spec.title, &result)
+            CommandResultViewModel::decoded_message_ids(spec.title, &result)
         }
         "message.query_by_key" => {
             let result = facade
@@ -712,7 +712,7 @@ pub async fn execute_command(
                     form.optional_string("last_key"),
                 )
                 .await?;
-            CommandResultViewModel::from_serializable(spec.title, &result)
+            CommandResultViewModel::message_query_by_key(spec.title, &result)
         }
         "message.query_by_offset" => {
             let result = facade
@@ -736,7 +736,7 @@ pub async fn execute_command(
                     form.number_i32("max_num")?,
                 )
                 .await?;
-            CommandResultViewModel::from_serializable(spec.title, &result)
+            CommandResultViewModel::message_trace(spec.title, &result)
         }
         unknown => bail!("unknown command id: {unknown}"),
     };
@@ -1170,7 +1170,7 @@ fn broker_commands(commands: &mut Vec<CommandSpec>) {
                 ),
                 bool_arg("is_order", "Is Order", "Whether this is ordered consumption.", false),
             ],
-            ResultViewKind::Text,
+            ResultViewKind::Table,
             None,
         ),
         spec(
@@ -1361,7 +1361,7 @@ fn consumer_commands(commands: &mut Vec<CommandSpec>) {
                 bool_arg("show_client_ip", "Show Client IP", "Show client IP in rows.", false),
                 optional_string("cluster", "Cluster", "Optional cluster name.", "DefaultCluster"),
             ],
-            ResultViewKind::Text,
+            ResultViewKind::Table,
             None,
         ),
         spec(
@@ -1512,7 +1512,7 @@ fn queue_commands(commands: &mut Vec<CommandSpec>) {
                 ),
                 optional_string("consumer_group", "Consumer Group", "Optional consumer group.", "GroupA"),
             ],
-            ResultViewKind::Text,
+            ResultViewKind::Table,
             None,
         ),
         spec(
@@ -1533,7 +1533,7 @@ fn queue_commands(commands: &mut Vec<CommandSpec>) {
                     Some(0),
                 ),
             ],
-            ResultViewKind::Text,
+            ResultViewKind::Table,
             None,
         ),
     ]);
@@ -1693,7 +1693,7 @@ fn message_commands(commands: &mut Vec<CommandSpec>) {
                 "Message IDs separated by comma, semicolon, or whitespace.",
                 "7F0000010007D8260BF075769D36C348",
             )],
-            ResultViewKind::Json,
+            ResultViewKind::Table,
             None,
         ),
         spec(
@@ -1733,7 +1733,7 @@ fn message_commands(commands: &mut Vec<CommandSpec>) {
                 enum_arg("key_type", "Key Type", "K for key, T for tag.", &["K", "T"], "K"),
                 optional_string("last_key", "Last Key", "Optional pagination key.", "last-key"),
             ],
-            ResultViewKind::Json,
+            ResultViewKind::Table,
             None,
         ),
         spec(
@@ -1796,7 +1796,7 @@ fn message_commands(commands: &mut Vec<CommandSpec>) {
                     Some(1),
                 ),
             ],
-            ResultViewKind::Json,
+            ResultViewKind::Table,
             None,
         ),
     ]);

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
@@ -1,5 +1,16 @@
 use std::fmt::Debug;
 
+use rocketmq_admin_core::core::broker::BrokerConsumeStatsResult;
+use rocketmq_admin_core::core::cluster::ClusterListMode;
+use rocketmq_admin_core::core::cluster::ClusterListQueryResult;
+use rocketmq_admin_core::core::cluster::ClusterSendMessageRtResult;
+use rocketmq_admin_core::core::consumer::ConsumerProgressResult;
+use rocketmq_admin_core::core::message::DecodeMessageIdOutcome;
+use rocketmq_admin_core::core::message::DecodeMessageIdResult;
+use rocketmq_admin_core::core::message::MessageTraceView;
+use rocketmq_admin_core::core::message::QueryMessageByKeyResult;
+use rocketmq_admin_core::core::queue::CheckRocksdbCqWriteProgressResult;
+use rocketmq_admin_core::core::queue::QueryConsumeQueueResult;
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,6 +178,377 @@ impl CommandResultViewModel {
         Self::KeyValue(KeyValueViewModel::sorted(title, rows))
     }
 
+    pub fn cluster_list(title: impl Into<String>, result: &ClusterListQueryResult) -> Self {
+        match &result.mode {
+            ClusterListMode::Base => Self::table(
+                title,
+                &[
+                    "Cluster",
+                    "Broker",
+                    "Broker ID",
+                    "Address",
+                    "Version",
+                    "In TPS",
+                    "Out TPS",
+                    "Active",
+                ],
+                result
+                    .base_rows
+                    .iter()
+                    .map(|row| {
+                        vec![
+                            row.cluster_name.clone(),
+                            row.broker_name.clone(),
+                            row.broker_id.to_string(),
+                            row.broker_addr.to_string(),
+                            row.version.clone(),
+                            row.in_tps.clone(),
+                            row.out_tps.clone(),
+                            row.broker_active.to_string(),
+                        ]
+                    })
+                    .collect(),
+            ),
+            ClusterListMode::MoreStats => Self::table(
+                title,
+                &[
+                    "Cluster",
+                    "Broker",
+                    "In Yesterday",
+                    "Out Yesterday",
+                    "In Today",
+                    "Out Today",
+                ],
+                result
+                    .more_stats_rows
+                    .iter()
+                    .map(|row| {
+                        vec![
+                            row.cluster_name.clone(),
+                            row.broker_name.clone(),
+                            row.in_total_yesterday.to_string(),
+                            row.out_total_yesterday.to_string(),
+                            row.in_total_today.to_string(),
+                            row.out_total_today.to_string(),
+                        ]
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    pub fn cluster_send_message_rt(title: impl Into<String>, result: &ClusterSendMessageRtResult) -> Self {
+        let mut rows = result
+            .rows
+            .iter()
+            .map(|row| {
+                vec![
+                    row.cluster_name.clone(),
+                    row.broker_name.clone(),
+                    row.rt.to_string(),
+                    row.success_count.to_string(),
+                    row.fail_count.to_string(),
+                ]
+            })
+            .collect::<Vec<_>>();
+
+        rows.extend(result.missing_clusters.iter().map(|cluster| {
+            vec![
+                cluster.clone(),
+                "(missing)".to_string(),
+                String::new(),
+                String::new(),
+                String::new(),
+            ]
+        }));
+
+        Self::table(title, &["Cluster", "Broker", "RT", "Success", "Failed"], rows)
+    }
+
+    pub fn broker_consume_stats(title: impl Into<String>, result: &BrokerConsumeStatsResult) -> Self {
+        Self::table(
+            title,
+            &[
+                "Topic",
+                "Group",
+                "Broker",
+                "Queue ID",
+                "Broker Offset",
+                "Consumer Offset",
+                "Diff",
+                "Last Timestamp",
+            ],
+            result
+                .rows
+                .iter()
+                .map(|row| {
+                    vec![
+                        row.topic.to_string(),
+                        row.group.to_string(),
+                        row.broker_name.to_string(),
+                        row.queue_id.to_string(),
+                        row.broker_offset.to_string(),
+                        row.consumer_offset.to_string(),
+                        row.diff.to_string(),
+                        row.last_timestamp.to_string(),
+                    ]
+                })
+                .collect(),
+        )
+    }
+
+    pub fn consumer_progress(title: impl Into<String>, result: &ConsumerProgressResult) -> Self {
+        match result {
+            ConsumerProgressResult::Group(progress) => {
+                let headers = if progress.show_client_ip {
+                    vec![
+                        "Topic",
+                        "Broker",
+                        "Queue ID",
+                        "Broker Offset",
+                        "Consumer Offset",
+                        "Client IP",
+                        "Diff",
+                        "Inflight",
+                        "Last Timestamp",
+                    ]
+                } else {
+                    vec![
+                        "Topic",
+                        "Broker",
+                        "Queue ID",
+                        "Broker Offset",
+                        "Consumer Offset",
+                        "Diff",
+                        "Inflight",
+                        "Last Timestamp",
+                    ]
+                };
+                let rows = progress
+                    .rows
+                    .iter()
+                    .map(|row| {
+                        let mut cells = vec![
+                            row.topic.to_string(),
+                            row.broker_name.to_string(),
+                            row.queue_id.to_string(),
+                            row.broker_offset.to_string(),
+                            row.consumer_offset.to_string(),
+                        ];
+                        if progress.show_client_ip {
+                            cells.push(optional_text(&row.client_ip));
+                        }
+                        cells.extend([
+                            row.diff.to_string(),
+                            row.inflight.to_string(),
+                            row.last_timestamp.to_string(),
+                        ]);
+                        cells
+                    })
+                    .collect();
+
+                Self::table(title, &headers, rows)
+            }
+            ConsumerProgressResult::All(groups) => Self::table(
+                title,
+                &[
+                    "Group",
+                    "Version",
+                    "Count",
+                    "Consume Type",
+                    "Message Model",
+                    "Consume TPS",
+                    "Diff Total",
+                ],
+                groups
+                    .iter()
+                    .map(|group| {
+                        vec![
+                            group.group.clone(),
+                            group.version.to_string(),
+                            group.count.to_string(),
+                            format!("{:?}", group.consume_type),
+                            format!("{:?}", group.message_model),
+                            group.consume_tps.to_string(),
+                            group.diff_total.to_string(),
+                        ]
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    pub fn message_query_by_key(title: impl Into<String>, result: &QueryMessageByKeyResult) -> Self {
+        Self::table(
+            title,
+            &["Message ID", "Queue ID", "Queue Offset", "Index Key"],
+            result
+                .rows
+                .iter()
+                .map(|row| {
+                    vec![
+                        row.message_id.to_string(),
+                        row.queue_id.to_string(),
+                        row.queue_offset.to_string(),
+                        optional_text(&row.index_key),
+                    ]
+                })
+                .collect(),
+        )
+    }
+
+    pub fn decoded_message_ids(title: impl Into<String>, result: &DecodeMessageIdResult) -> Self {
+        Self::table(
+            title,
+            &[
+                "Message ID",
+                "Status",
+                "Broker",
+                "CommitLog Offset",
+                "Offset Hex",
+                "Error",
+            ],
+            result
+                .entries
+                .iter()
+                .map(|entry| match &entry.outcome {
+                    DecodeMessageIdOutcome::Decoded {
+                        broker_ip,
+                        broker_port,
+                        commit_log_offset,
+                        offset_hex,
+                    } => vec![
+                        entry.message_id.to_string(),
+                        "decoded".to_string(),
+                        format!("{broker_ip}:{broker_port}"),
+                        commit_log_offset.to_string(),
+                        offset_hex.to_string(),
+                        String::new(),
+                    ],
+                    DecodeMessageIdOutcome::Invalid { error } => vec![
+                        entry.message_id.to_string(),
+                        "invalid".to_string(),
+                        String::new(),
+                        String::new(),
+                        String::new(),
+                        error.to_string(),
+                    ],
+                })
+                .collect(),
+        )
+    }
+
+    pub fn message_trace(title: impl Into<String>, traces: &[MessageTraceView]) -> Self {
+        Self::table(
+            title,
+            &[
+                "Type",
+                "Group",
+                "Client Host",
+                "Timestamp",
+                "Cost",
+                "Status",
+                "Topic",
+                "Tags",
+                "Keys",
+                "Store Host",
+            ],
+            traces
+                .iter()
+                .map(|trace| {
+                    vec![
+                        trace.msg_type.clone(),
+                        trace.group_name.clone(),
+                        trace.client_host.clone(),
+                        trace.time_stamp.to_string(),
+                        trace.cost_time.to_string(),
+                        trace.status.clone(),
+                        optional_text(&trace.topic),
+                        optional_text(&trace.tags),
+                        optional_text(&trace.keys),
+                        optional_text(&trace.store_host),
+                    ]
+                })
+                .collect(),
+        )
+    }
+
+    pub fn consume_queue(title: impl Into<String>, result: &QueryConsumeQueueResult) -> Self {
+        let rows = result
+            .response_body
+            .queue_data
+            .as_deref()
+            .map(|queue_data| {
+                queue_data
+                    .iter()
+                    .map(|row| {
+                        vec![
+                            result.broker_addr.to_string(),
+                            row.physic_offset.to_string(),
+                            row.physic_size.to_string(),
+                            row.tags_code.to_string(),
+                            optional_text(&row.extend_data_json),
+                            optional_text(&row.bit_map),
+                            row.eval.to_string(),
+                            optional_text(&row.msg),
+                        ]
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Self::table(
+            title,
+            &[
+                "Broker Addr",
+                "Physical Offset",
+                "Physical Size",
+                "Tags Code",
+                "Ext",
+                "Bitmap",
+                "Eval",
+                "Message",
+            ],
+            rows,
+        )
+    }
+
+    pub fn rocksdb_cq_progress(title: impl Into<String>, result: &CheckRocksdbCqWriteProgressResult) -> Self {
+        let mut rows = result
+            .entries
+            .iter()
+            .map(|entry| {
+                vec![
+                    entry.broker_name.to_string(),
+                    entry.broker_addr.to_string(),
+                    format!("{:?}", entry.result.get_check_status()),
+                    optional_text(&entry.result.check_result),
+                    String::new(),
+                ]
+            })
+            .collect::<Vec<_>>();
+
+        rows.extend(result.failures.iter().map(|failure| {
+            vec![
+                failure.broker_name.to_string(),
+                failure.broker_addr.to_string(),
+                "Failed".to_string(),
+                String::new(),
+                failure.error.clone(),
+            ]
+        }));
+
+        Self::table(title, &["Broker", "Address", "Status", "Check Result", "Error"], rows)
+    }
+
+    fn table(title: impl Into<String>, headers: &[&str], rows: Vec<Vec<String>>) -> Self {
+        Self::Table(TableViewModel {
+            title: title.into(),
+            headers: headers.iter().map(|header| (*header).to_string()).collect(),
+            rows,
+        })
+    }
+
     pub fn title(&self) -> &str {
         match self {
             Self::Table(value) => &value.title,
@@ -210,8 +592,36 @@ impl CommandResultViewModel {
     }
 }
 
+fn optional_text<T: ToString>(value: &Option<T>) -> String {
+    value.as_ref().map(ToString::to_string).unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
+    use rocketmq_admin_core::core::broker::BrokerConsumeStatsResult;
+    use rocketmq_admin_core::core::broker::BrokerConsumeStatsRow;
+    use rocketmq_admin_core::core::cluster::ClusterBaseInfoRow;
+    use rocketmq_admin_core::core::cluster::ClusterListMode;
+    use rocketmq_admin_core::core::cluster::ClusterListQueryResult;
+    use rocketmq_admin_core::core::cluster::ClusterSendMessageRtResult;
+    use rocketmq_admin_core::core::cluster::ClusterSendMessageRtRow;
+    use rocketmq_admin_core::core::consumer::ConsumerGroupProgressResult;
+    use rocketmq_admin_core::core::consumer::ConsumerProgressResult;
+    use rocketmq_admin_core::core::consumer::ConsumerProgressRow;
+    use rocketmq_admin_core::core::message::DecodeMessageIdEntry;
+    use rocketmq_admin_core::core::message::DecodeMessageIdOutcome;
+    use rocketmq_admin_core::core::message::DecodeMessageIdResult;
+    use rocketmq_admin_core::core::message::MessageTraceView;
+    use rocketmq_admin_core::core::message::QueryMessageByKeyResult;
+    use rocketmq_admin_core::core::message::QueryMessageByKeyRow;
+    use rocketmq_admin_core::core::queue::CheckRocksdbCqWriteProgressEntry;
+    use rocketmq_admin_core::core::queue::CheckRocksdbCqWriteProgressResult;
+    use rocketmq_admin_core::core::queue::QueryConsumeQueueResult;
+    use rocketmq_admin_core::core::queue::QueueOperationFailure;
+    use rocketmq_remoting::protocol::body::check_rocksdb_cqwrite_progress_response_body::CheckRocksdbCqWriteResult;
+    use rocketmq_remoting::protocol::body::consume_queue_data::ConsumeQueueData;
+    use rocketmq_remoting::protocol::body::query_consume_queue_response_body::QueryConsumeQueueResponseBody;
+
     use super::CommandResultViewModel;
     use super::KeyValueViewModel;
     use super::OperationSummaryViewModel;
@@ -303,6 +713,320 @@ mod tests {
                 ("a".to_string(), "second".to_string()),
                 ("z".to_string(), "last".to_string()),
             ]
+        );
+    }
+
+    #[test]
+    fn phase_two_cluster_and_diagnostics_results_render_as_tables() {
+        let cluster = CommandResultViewModel::cluster_list(
+            "Cluster List",
+            &ClusterListQueryResult {
+                mode: ClusterListMode::Base,
+                base_rows: vec![ClusterBaseInfoRow {
+                    cluster_name: "DefaultCluster".to_string(),
+                    broker_name: "broker-a".to_string(),
+                    broker_id: 0,
+                    broker_addr: "127.0.0.1:10911".into(),
+                    version: "5.0.0".to_string(),
+                    in_tps: "12.5".to_string(),
+                    out_tps: "9.5".to_string(),
+                    timer_progress: "0".to_string(),
+                    page_cache_lock_time_millis: "1".to_string(),
+                    hour: "10".to_string(),
+                    space: "1G".to_string(),
+                    broker_active: true,
+                }],
+                more_stats_rows: Vec::new(),
+            },
+        );
+        assert_table(
+            &cluster,
+            &[
+                "Cluster",
+                "Broker",
+                "Broker ID",
+                "Address",
+                "Version",
+                "In TPS",
+                "Out TPS",
+                "Active",
+            ],
+            &[
+                "DefaultCluster",
+                "broker-a",
+                "0",
+                "127.0.0.1:10911",
+                "5.0.0",
+                "12.5",
+                "9.5",
+                "true",
+            ],
+        );
+
+        let send_rt = CommandResultViewModel::cluster_send_message_rt(
+            "Send RT",
+            &ClusterSendMessageRtResult {
+                missing_clusters: vec!["missing".to_string()],
+                rows: vec![ClusterSendMessageRtRow {
+                    cluster_name: "DefaultCluster".to_string(),
+                    broker_name: "broker-a".to_string(),
+                    rt: 3.25,
+                    success_count: 4,
+                    fail_count: 1,
+                }],
+            },
+        );
+        assert_table(
+            &send_rt,
+            &["Cluster", "Broker", "RT", "Success", "Failed"],
+            &["DefaultCluster", "broker-a", "3.25", "4", "1"],
+        );
+
+        let consume_stats = CommandResultViewModel::broker_consume_stats(
+            "Broker Consume Stats",
+            &BrokerConsumeStatsResult {
+                broker_addr: Some("127.0.0.1:10911".into()),
+                total_diff: 10,
+                total_inflight_diff: 2,
+                rows: vec![BrokerConsumeStatsRow {
+                    topic: "TopicA".into(),
+                    group: "GroupA".into(),
+                    broker_name: "broker-a".into(),
+                    queue_id: 1,
+                    broker_offset: 100,
+                    consumer_offset: 90,
+                    diff: 10,
+                    last_timestamp: 1234,
+                }],
+            },
+        );
+        assert_table(
+            &consume_stats,
+            &[
+                "Topic",
+                "Group",
+                "Broker",
+                "Queue ID",
+                "Broker Offset",
+                "Consumer Offset",
+                "Diff",
+                "Last Timestamp",
+            ],
+            &["TopicA", "GroupA", "broker-a", "1", "100", "90", "10", "1234"],
+        );
+    }
+
+    #[test]
+    fn phase_two_consumer_and_message_results_render_as_tables() {
+        let progress = CommandResultViewModel::consumer_progress(
+            "Consumer Progress",
+            &ConsumerProgressResult::Group(ConsumerGroupProgressResult {
+                rows: vec![ConsumerProgressRow {
+                    topic: "TopicA".into(),
+                    broker_name: "broker-a".into(),
+                    queue_id: 1,
+                    broker_offset: 100,
+                    consumer_offset: 95,
+                    client_ip: Some("127.0.0.1".to_string()),
+                    diff: 5,
+                    inflight: 1,
+                    last_timestamp: 1234,
+                }],
+                consume_tps: 7.5,
+                diff_total: 5,
+                inflight_total: 1,
+                show_client_ip: true,
+            }),
+        );
+        assert_table(
+            &progress,
+            &[
+                "Topic",
+                "Broker",
+                "Queue ID",
+                "Broker Offset",
+                "Consumer Offset",
+                "Client IP",
+                "Diff",
+                "Inflight",
+                "Last Timestamp",
+            ],
+            &["TopicA", "broker-a", "1", "100", "95", "127.0.0.1", "5", "1", "1234"],
+        );
+
+        let by_key = CommandResultViewModel::message_query_by_key(
+            "Query Message By Key",
+            &QueryMessageByKeyResult {
+                rows: vec![QueryMessageByKeyRow {
+                    message_id: "msg-1".into(),
+                    queue_id: 2,
+                    queue_offset: 42,
+                    index_key: Some("order-1".to_string()),
+                }],
+            },
+        );
+        assert_table(
+            &by_key,
+            &["Message ID", "Queue ID", "Queue Offset", "Index Key"],
+            &["msg-1", "2", "42", "order-1"],
+        );
+
+        let decoded = CommandResultViewModel::decoded_message_ids(
+            "Decode Message ID",
+            &DecodeMessageIdResult {
+                entries: vec![
+                    DecodeMessageIdEntry {
+                        message_id: "msg-1".into(),
+                        outcome: DecodeMessageIdOutcome::Decoded {
+                            broker_ip: "127.0.0.1".to_string(),
+                            broker_port: 10911,
+                            commit_log_offset: 64,
+                            offset_hex: "40".to_string(),
+                        },
+                    },
+                    DecodeMessageIdEntry {
+                        message_id: "bad".into(),
+                        outcome: DecodeMessageIdOutcome::Invalid {
+                            error: "invalid id".to_string(),
+                        },
+                    },
+                ],
+            },
+        );
+        assert_table(
+            &decoded,
+            &[
+                "Message ID",
+                "Status",
+                "Broker",
+                "CommitLog Offset",
+                "Offset Hex",
+                "Error",
+            ],
+            &["msg-1", "decoded", "127.0.0.1:10911", "64", "40", ""],
+        );
+        assert!(decoded.text_body().contains("invalid id"));
+
+        let trace = CommandResultViewModel::message_trace(
+            "Query Message Trace",
+            &[MessageTraceView {
+                msg_type: "Pub".to_string(),
+                group_name: "GroupA".to_string(),
+                client_host: "127.0.0.1".to_string(),
+                time_stamp: 1234,
+                cost_time: 8,
+                status: "SUCCESS".to_string(),
+                topic: Some("TopicA".to_string()),
+                tags: Some("TagA".to_string()),
+                keys: Some("order-1".to_string()),
+                store_host: Some("127.0.0.1:10911".to_string()),
+            }],
+        );
+        assert_table(
+            &trace,
+            &[
+                "Type",
+                "Group",
+                "Client Host",
+                "Timestamp",
+                "Cost",
+                "Status",
+                "Topic",
+                "Tags",
+                "Keys",
+                "Store Host",
+            ],
+            &[
+                "Pub",
+                "GroupA",
+                "127.0.0.1",
+                "1234",
+                "8",
+                "SUCCESS",
+                "TopicA",
+                "TagA",
+                "order-1",
+                "127.0.0.1:10911",
+            ],
+        );
+    }
+
+    #[test]
+    fn phase_two_queue_results_render_as_tables() {
+        let consume_queue = CommandResultViewModel::consume_queue(
+            "Query Consume Queue",
+            &QueryConsumeQueueResult {
+                broker_addr: "127.0.0.1:10911".into(),
+                response_body: QueryConsumeQueueResponseBody {
+                    subscription_data: None,
+                    filter_data: Some("filter-data".into()),
+                    queue_data: Some(vec![ConsumeQueueData {
+                        physic_offset: 123,
+                        physic_size: 4,
+                        tags_code: 7,
+                        extend_data_json: Some("{\"a\":1}".into()),
+                        bit_map: None,
+                        eval: true,
+                        msg: Some("hello".into()),
+                    }]),
+                    max_queue_index: 10,
+                    min_queue_index: 1,
+                },
+            },
+        );
+        assert_table(
+            &consume_queue,
+            &[
+                "Broker Addr",
+                "Physical Offset",
+                "Physical Size",
+                "Tags Code",
+                "Ext",
+                "Bitmap",
+                "Eval",
+                "Message",
+            ],
+            &["127.0.0.1:10911", "123", "4", "7", "{\"a\":1}", "", "true", "hello"],
+        );
+
+        let progress = CommandResultViewModel::rocksdb_cq_progress(
+            "RocksDB CQ Write Progress",
+            &CheckRocksdbCqWriteProgressResult {
+                cluster_found: true,
+                entries: vec![CheckRocksdbCqWriteProgressEntry {
+                    broker_name: "broker-a".into(),
+                    broker_addr: "127.0.0.1:10911".into(),
+                    result: CheckRocksdbCqWriteResult {
+                        check_result: Some("ok".into()),
+                        check_status: 0,
+                    },
+                }],
+                failures: vec![QueueOperationFailure {
+                    broker_name: "broker-b".into(),
+                    broker_addr: "127.0.0.1:10912".into(),
+                    error: "timeout".to_string(),
+                }],
+            },
+        );
+        assert_table(
+            &progress,
+            &["Broker", "Address", "Status", "Check Result", "Error"],
+            &["broker-a", "127.0.0.1:10911", "CheckOk", "ok", ""],
+        );
+        assert!(progress.text_body().contains("timeout"));
+    }
+
+    fn assert_table(result: &CommandResultViewModel, headers: &[&str], first_row: &[&str]) {
+        let CommandResultViewModel::Table(table) = result else {
+            panic!("expected table result, got {result:?}");
+        };
+        assert_eq!(
+            table.headers,
+            headers.iter().map(|header| (*header).to_string()).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            table.rows.first(),
+            Some(&first_row.iter().map(|cell| (*cell).to_string()).collect::<Vec<_>>())
         );
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7164

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Multiple admin query results now display in table format for enhanced readability, including broker statistics, cluster information, consumer progress, and message queries.

* **Tests**
  * Added test coverage for updated result display formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->