### PR TITLE
[ISSUE #7168]🚀feat(auth, broker, consumer, lite, static_topic): add new commands for user management, broker operations, consumer group updates, and static topic management

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
@@ -13,7 +13,16 @@
 // limitations under the License.
 
 use rocketmq_admin_core::core::admin::AdminBuilder;
+use rocketmq_admin_core::core::auth::AuthOperationResult;
 use rocketmq_admin_core::core::auth::AuthService;
+use rocketmq_admin_core::core::auth::CopyAclRequest;
+use rocketmq_admin_core::core::auth::CopyAclResult;
+use rocketmq_admin_core::core::auth::CopyUsersRequest;
+use rocketmq_admin_core::core::auth::CopyUsersResult;
+use rocketmq_admin_core::core::auth::CreateAclRequest;
+use rocketmq_admin_core::core::auth::CreateUserRequest;
+use rocketmq_admin_core::core::auth::DeleteAclRequest;
+use rocketmq_admin_core::core::auth::DeleteUserRequest;
 use rocketmq_admin_core::core::auth::GetAclRequest;
 use rocketmq_admin_core::core::auth::GetAclResult;
 use rocketmq_admin_core::core::auth::GetUserRequest;
@@ -22,6 +31,9 @@ use rocketmq_admin_core::core::auth::ListAclRequest;
 use rocketmq_admin_core::core::auth::ListAclResult;
 use rocketmq_admin_core::core::auth::ListUsersRequest;
 use rocketmq_admin_core::core::auth::ListUsersResult;
+use rocketmq_admin_core::core::auth::UpdateAclRequest;
+use rocketmq_admin_core::core::auth::UpdateUserRequest;
+use rocketmq_admin_core::core::broker::BrokerBooleanOperationResult;
 use rocketmq_admin_core::core::broker::BrokerConfigQueryRequest;
 use rocketmq_admin_core::core::broker::BrokerConfigQueryResult;
 use rocketmq_admin_core::core::broker::BrokerConfigUpdateApplyResult;
@@ -31,11 +43,21 @@ use rocketmq_admin_core::core::broker::BrokerConsumeStatsQueryRequest;
 use rocketmq_admin_core::core::broker::BrokerConsumeStatsResult;
 use rocketmq_admin_core::core::broker::BrokerEpochQueryRequest;
 use rocketmq_admin_core::core::broker::BrokerEpochQueryResult;
+use rocketmq_admin_core::core::broker::BrokerOperationResult;
+use rocketmq_admin_core::core::broker::BrokerOptionalTarget;
 use rocketmq_admin_core::core::broker::BrokerRuntimeStatsQueryRequest;
 use rocketmq_admin_core::core::broker::BrokerRuntimeStatsResult;
 use rocketmq_admin_core::core::broker::BrokerService;
+use rocketmq_admin_core::core::broker::CleanExpiredConsumeQueueReport;
+use rocketmq_admin_core::core::broker::CleanExpiredConsumeQueueRequest;
+use rocketmq_admin_core::core::broker::ColdDataFlowCtrGroupConfigRemoveRequest;
+use rocketmq_admin_core::core::broker::ColdDataFlowCtrGroupConfigUpdateRequest;
 use rocketmq_admin_core::core::broker::ColdDataFlowCtrInfoQueryRequest;
 use rocketmq_admin_core::core::broker::ColdDataFlowCtrInfoQueryResult;
+use rocketmq_admin_core::core::broker::CommitLogReadAheadRequest;
+use rocketmq_admin_core::core::broker::CommitLogReadAheadResult;
+use rocketmq_admin_core::core::broker::ResetMasterFlushOffsetRequest;
+use rocketmq_admin_core::core::broker::SwitchTimerEngineRequest;
 use rocketmq_admin_core::core::cluster::ClusterBrokerNameQueryRequest;
 use rocketmq_admin_core::core::cluster::ClusterBrokerNameQueryResult;
 use rocketmq_admin_core::core::cluster::ClusterListQueryRequest;
@@ -58,8 +80,12 @@ use rocketmq_admin_core::core::consumer::ConsumerRunningInfoResult;
 use rocketmq_admin_core::core::consumer::ConsumerService;
 use rocketmq_admin_core::core::consumer::DeleteSubscriptionGroupRequest;
 use rocketmq_admin_core::core::consumer::SetConsumeModeRequest;
+use rocketmq_admin_core::core::consumer::UpdateSubscriptionGroupListRequest;
+use rocketmq_admin_core::core::consumer::UpdateSubscriptionGroupRequest;
 use rocketmq_admin_core::core::controller::ControllerConfigQueryRequest;
 use rocketmq_admin_core::core::controller::ControllerConfigQueryResult;
+use rocketmq_admin_core::core::controller::ControllerConfigUpdateRequest;
+use rocketmq_admin_core::core::controller::ControllerMetadataCleanRequest;
 use rocketmq_admin_core::core::controller::ControllerMetadataQueryRequest;
 use rocketmq_admin_core::core::controller::ControllerMetadataQueryResult;
 use rocketmq_admin_core::core::controller::ControllerService;
@@ -79,6 +105,8 @@ use rocketmq_admin_core::core::lite::LiteTopicInfoQueryRequest;
 use rocketmq_admin_core::core::lite::LiteTopicInfoQueryResult;
 use rocketmq_admin_core::core::lite::ParentTopicInfoQueryRequest;
 use rocketmq_admin_core::core::lite::ParentTopicInfoQueryResult;
+use rocketmq_admin_core::core::lite::TriggerLiteDispatchRequest;
+use rocketmq_admin_core::core::lite::TriggerLiteDispatchResult;
 use rocketmq_admin_core::core::message::DecodeMessageIdRequest;
 use rocketmq_admin_core::core::message::DecodeMessageIdResult;
 use rocketmq_admin_core::core::message::MessageService;
@@ -123,6 +151,10 @@ use rocketmq_admin_core::core::queue::CheckRocksdbCqWriteProgressResult;
 use rocketmq_admin_core::core::queue::QueryConsumeQueueRequest;
 use rocketmq_admin_core::core::queue::QueryConsumeQueueResult;
 use rocketmq_admin_core::core::queue::QueueService;
+use rocketmq_admin_core::core::static_topic::RemappingStaticTopicRequest;
+use rocketmq_admin_core::core::static_topic::StaticTopicMappingPlan;
+use rocketmq_admin_core::core::static_topic::StaticTopicService;
+use rocketmq_admin_core::core::static_topic::UpdateStaticTopicRequest;
 use rocketmq_admin_core::core::stats::StatsAllQueryRequest;
 use rocketmq_admin_core::core::stats::StatsAllQueryResult;
 use rocketmq_admin_core::core::stats::StatsService;
@@ -149,6 +181,7 @@ use rocketmq_admin_core::core::topic::UpdateTopicResult;
 use rocketmq_admin_core::core::RocketMQResult;
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
 use rocketmq_remoting::protocol::admin::rollback_stats::RollbackStats;
+use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 
 #[derive(Debug, Clone, Default)]
 pub struct TuiAdminFacade {
@@ -190,6 +223,55 @@ impl TuiAdminFacade {
             .with_optional_namesrv_addr(self.namesrv_addr.clone()))
     }
 
+    pub fn auth_create_user_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+        user_type: Option<String>,
+    ) -> RocketMQResult<CreateUserRequest> {
+        Ok(
+            CreateUserRequest::try_new(broker_addr, cluster_name, username, password, user_type)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    pub fn auth_update_user_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        username: impl Into<String>,
+        password: Option<String>,
+        user_type: Option<String>,
+        user_status: Option<String>,
+    ) -> RocketMQResult<UpdateUserRequest> {
+        Ok(
+            UpdateUserRequest::try_new(broker_addr, cluster_name, username, password, user_type, user_status)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    pub fn auth_delete_user_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        username: impl Into<String>,
+    ) -> RocketMQResult<DeleteUserRequest> {
+        Ok(DeleteUserRequest::try_new(broker_addr, cluster_name, username)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn auth_copy_users_request(
+        &self,
+        from_broker: impl Into<String>,
+        to_broker: impl Into<String>,
+        usernames: Option<String>,
+    ) -> RocketMQResult<CopyUsersRequest> {
+        Ok(CopyUsersRequest::try_new(from_broker, to_broker, usernames)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
     pub fn auth_list_users_request(
         &self,
         broker_addr: Option<String>,
@@ -207,6 +289,73 @@ impl TuiAdminFacade {
         subject: impl Into<String>,
     ) -> RocketMQResult<GetAclRequest> {
         Ok(GetAclRequest::try_new(broker_addr, cluster_name, subject)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn auth_create_acl_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        subject: impl Into<String>,
+        resources: impl Into<String>,
+        actions: impl Into<String>,
+        decision: impl Into<String>,
+        source_ip: Option<String>,
+    ) -> RocketMQResult<CreateAclRequest> {
+        Ok(CreateAclRequest::try_new(
+            broker_addr,
+            cluster_name,
+            subject,
+            resources,
+            actions,
+            decision,
+            source_ip,
+        )?
+        .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn auth_update_acl_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        subject: impl Into<String>,
+        resources: impl Into<String>,
+        actions: impl Into<String>,
+        decision: impl Into<String>,
+        source_ip: Option<String>,
+    ) -> RocketMQResult<UpdateAclRequest> {
+        Ok(UpdateAclRequest::try_new(
+            broker_addr,
+            cluster_name,
+            subject,
+            resources,
+            actions,
+            decision,
+            source_ip,
+        )?
+        .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn auth_delete_acl_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        subject: impl Into<String>,
+        resource: Option<String>,
+    ) -> RocketMQResult<DeleteAclRequest> {
+        Ok(DeleteAclRequest::try_new(broker_addr, cluster_name, subject, resource)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn auth_copy_acl_request(
+        &self,
+        from_broker: impl Into<String>,
+        to_broker: impl Into<String>,
+        subjects: Option<String>,
+    ) -> RocketMQResult<CopyAclRequest> {
+        Ok(CopyAclRequest::try_new(from_broker, to_broker, subjects)?
             .with_optional_namesrv_addr(self.namesrv_addr.clone()))
     }
 
@@ -230,12 +379,40 @@ impl TuiAdminFacade {
             .with_optional_namesrv_addr(self.namesrv_addr.clone()))
     }
 
+    pub fn controller_config_update_request(
+        &self,
+        controller_address: impl Into<String>,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> RocketMQResult<ControllerConfigUpdateRequest> {
+        Ok(ControllerConfigUpdateRequest::try_new(controller_address, key, value)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
     pub fn controller_metadata_query_request(
         &self,
         controller_address: impl Into<String>,
     ) -> RocketMQResult<ControllerMetadataQueryRequest> {
         Ok(ControllerMetadataQueryRequest::try_new(controller_address)?
             .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn controller_metadata_clean_request(
+        &self,
+        controller_address: impl Into<String>,
+        broker_name: impl Into<String>,
+        broker_controller_ids_to_clean: Option<String>,
+        cluster_name: Option<String>,
+        clean_living_broker: bool,
+    ) -> RocketMQResult<ControllerMetadataCleanRequest> {
+        Ok(ControllerMetadataCleanRequest::try_new(
+            controller_address,
+            broker_name,
+            broker_controller_ids_to_clean,
+            cluster_name,
+            clean_living_broker,
+        )?
+        .with_optional_namesrv_addr(self.namesrv_addr.clone()))
     }
 
     pub fn namesrv_config_query_request(&self) -> RocketMQResult<NamesrvConfigQueryRequest> {
@@ -338,6 +515,98 @@ impl TuiAdminFacade {
             .with_optional_namesrv_addr(self.namesrv_addr.clone()))
     }
 
+    pub fn broker_optional_target_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<BrokerOptionalTarget> {
+        Ok(BrokerOptionalTarget::new(broker_addr, cluster_name)?.with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn clean_expired_consume_queue_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        topic: Option<String>,
+        dry_run: bool,
+    ) -> RocketMQResult<CleanExpiredConsumeQueueRequest> {
+        Ok(
+            CleanExpiredConsumeQueueRequest::try_new(broker_addr, cluster_name, topic, dry_run)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    pub fn reset_master_flush_offset_request(
+        &self,
+        broker_addr: Option<String>,
+        offset: Option<i64>,
+    ) -> RocketMQResult<ResetMasterFlushOffsetRequest> {
+        Ok(ResetMasterFlushOffsetRequest::try_new(broker_addr, offset)?
+            .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn cold_data_flow_ctr_group_config_update_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        consumer_group: impl Into<String>,
+        threshold: impl Into<String>,
+    ) -> RocketMQResult<ColdDataFlowCtrGroupConfigUpdateRequest> {
+        Ok(
+            ColdDataFlowCtrGroupConfigUpdateRequest::try_new(broker_addr, cluster_name, consumer_group, threshold)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    pub fn cold_data_flow_ctr_group_config_remove_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        consumer_group: impl Into<String>,
+    ) -> RocketMQResult<ColdDataFlowCtrGroupConfigRemoveRequest> {
+        Ok(
+            ColdDataFlowCtrGroupConfigRemoveRequest::try_new(broker_addr, cluster_name, consumer_group)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn commit_log_read_ahead_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        mode: Option<String>,
+        enable: bool,
+        disable: bool,
+        read_ahead_size: Option<String>,
+        read_ahead_size_key: Option<String>,
+        show_only: bool,
+    ) -> RocketMQResult<CommitLogReadAheadRequest> {
+        Ok(CommitLogReadAheadRequest::try_new(
+            broker_addr,
+            cluster_name,
+            mode,
+            enable,
+            disable,
+            read_ahead_size,
+            read_ahead_size_key,
+            show_only,
+        )?
+        .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn switch_timer_engine_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        engine_type: impl Into<String>,
+    ) -> RocketMQResult<SwitchTimerEngineRequest> {
+        Ok(
+            SwitchTimerEngineRequest::try_new(broker_addr, cluster_name, engine_type)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
     pub fn cluster_list_request(&self, more_stats: bool, cluster_name: Option<String>) -> ClusterListQueryRequest {
         ClusterListQueryRequest::new(more_stats, cluster_name).with_optional_namesrv_addr(self.namesrv_addr.clone())
     }
@@ -409,6 +678,87 @@ impl TuiAdminFacade {
             pop_share_queue_num,
         )?
         .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_subscription_group_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        group_name: impl Into<String>,
+        consume_enable: bool,
+        consume_from_min_enable: bool,
+        consume_broadcast_enable: bool,
+        consume_message_orderly: bool,
+        retry_queue_nums: i32,
+        retry_max_times: i32,
+        broker_id: u64,
+        which_broker_when_consume_slowly: u64,
+        notify_consumer_ids_changed_enable: bool,
+        group_sys_flag: i32,
+        consume_timeout_minute: i32,
+    ) -> RocketMQResult<UpdateSubscriptionGroupRequest> {
+        let config = subscription_group_config(
+            group_name,
+            consume_enable,
+            consume_from_min_enable,
+            consume_broadcast_enable,
+            consume_message_orderly,
+            retry_queue_nums,
+            retry_max_times,
+            broker_id,
+            which_broker_when_consume_slowly,
+            notify_consumer_ids_changed_enable,
+            group_sys_flag,
+            consume_timeout_minute,
+        );
+        Ok(
+            UpdateSubscriptionGroupRequest::try_new(broker_addr, cluster_name, config)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_subscription_group_list_request(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        group_names: impl AsRef<str>,
+        consume_enable: bool,
+        consume_from_min_enable: bool,
+        consume_broadcast_enable: bool,
+        consume_message_orderly: bool,
+        retry_queue_nums: i32,
+        retry_max_times: i32,
+        broker_id: u64,
+        which_broker_when_consume_slowly: u64,
+        notify_consumer_ids_changed_enable: bool,
+        group_sys_flag: i32,
+        consume_timeout_minute: i32,
+    ) -> RocketMQResult<UpdateSubscriptionGroupListRequest> {
+        let configs = split_csv(group_names.as_ref())
+            .into_iter()
+            .map(|group_name| {
+                subscription_group_config(
+                    group_name,
+                    consume_enable,
+                    consume_from_min_enable,
+                    consume_broadcast_enable,
+                    consume_message_orderly,
+                    retry_queue_nums,
+                    retry_max_times,
+                    broker_id,
+                    which_broker_when_consume_slowly,
+                    notify_consumer_ids_changed_enable,
+                    group_sys_flag,
+                    consume_timeout_minute,
+                )
+            })
+            .collect::<Vec<_>>();
+        Ok(
+            UpdateSubscriptionGroupListRequest::try_new(broker_addr, cluster_name, configs)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
     }
 
     pub fn consumer_running_info_request(
@@ -611,6 +961,45 @@ impl TuiAdminFacade {
     ) -> RocketMQResult<LiteClientInfoQueryRequest> {
         Ok(LiteClientInfoQueryRequest::try_new(parent_topic, group, client_id)?
             .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn trigger_lite_dispatch_request(
+        &self,
+        parent_topic: impl Into<String>,
+        group: impl Into<String>,
+        client_id: Option<String>,
+        broker_name: Option<String>,
+    ) -> RocketMQResult<TriggerLiteDispatchRequest> {
+        Ok(
+            TriggerLiteDispatchRequest::try_new(parent_topic, group, client_id, broker_name)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    pub fn update_static_topic_request(
+        &self,
+        topic: impl Into<String>,
+        broker_names: impl Into<String>,
+        queue_num: impl AsRef<str>,
+        cluster_names: Option<String>,
+    ) -> RocketMQResult<UpdateStaticTopicRequest> {
+        Ok(
+            UpdateStaticTopicRequest::try_new(topic, broker_names, queue_num, cluster_names)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    pub fn remapping_static_topic_request(
+        &self,
+        topic: impl Into<String>,
+        broker_names: Option<String>,
+        cluster_names: Option<String>,
+        force_replace: Option<bool>,
+    ) -> RocketMQResult<RemappingStaticTopicRequest> {
+        Ok(
+            RemappingStaticTopicRequest::try_new(topic, broker_names, cluster_names, force_replace)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
     }
 
     pub fn decode_message_id_request(&self, message_ids: impl AsRef<str>) -> RocketMQResult<DecodeMessageIdRequest> {
@@ -856,6 +1245,63 @@ impl TuiAdminFacade {
         .await
     }
 
+    pub async fn create_auth_user(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+        user_type: Option<String>,
+    ) -> RocketMQResult<AuthOperationResult> {
+        AuthService::create_user_by_request_with_rpc_hook(
+            self.auth_create_user_request(broker_addr, cluster_name, username, password, user_type)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn update_auth_user(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        username: impl Into<String>,
+        password: Option<String>,
+        user_type: Option<String>,
+        user_status: Option<String>,
+    ) -> RocketMQResult<AuthOperationResult> {
+        AuthService::update_user_by_request_with_rpc_hook(
+            self.auth_update_user_request(broker_addr, cluster_name, username, password, user_type, user_status)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn delete_auth_user(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        username: impl Into<String>,
+    ) -> RocketMQResult<AuthOperationResult> {
+        AuthService::delete_user_by_request_with_rpc_hook(
+            self.auth_delete_user_request(broker_addr, cluster_name, username)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn copy_auth_users(
+        &self,
+        from_broker: impl Into<String>,
+        to_broker: impl Into<String>,
+        usernames: Option<String>,
+    ) -> RocketMQResult<CopyUsersResult> {
+        AuthService::copy_users_by_request_with_rpc_hook(
+            self.auth_copy_users_request(from_broker, to_broker, usernames)?,
+            None,
+        )
+        .await
+    }
+
     pub async fn list_auth_users(
         &self,
         broker_addr: Option<String>,
@@ -877,6 +1323,85 @@ impl TuiAdminFacade {
     ) -> RocketMQResult<GetAclResult> {
         AuthService::get_acl_by_request_with_rpc_hook(
             self.auth_get_acl_request(broker_addr, cluster_name, subject)?,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_auth_acl(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        subject: impl Into<String>,
+        resources: impl Into<String>,
+        actions: impl Into<String>,
+        decision: impl Into<String>,
+        source_ip: Option<String>,
+    ) -> RocketMQResult<AuthOperationResult> {
+        AuthService::create_acl_by_request_with_rpc_hook(
+            self.auth_create_acl_request(
+                broker_addr,
+                cluster_name,
+                subject,
+                resources,
+                actions,
+                decision,
+                source_ip,
+            )?,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_auth_acl(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        subject: impl Into<String>,
+        resources: impl Into<String>,
+        actions: impl Into<String>,
+        decision: impl Into<String>,
+        source_ip: Option<String>,
+    ) -> RocketMQResult<AuthOperationResult> {
+        AuthService::update_acl_by_request_with_rpc_hook(
+            self.auth_update_acl_request(
+                broker_addr,
+                cluster_name,
+                subject,
+                resources,
+                actions,
+                decision,
+                source_ip,
+            )?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn delete_auth_acl(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        subject: impl Into<String>,
+        resource: Option<String>,
+    ) -> RocketMQResult<AuthOperationResult> {
+        AuthService::delete_acl_by_request_with_rpc_hook(
+            self.auth_delete_acl_request(broker_addr, cluster_name, subject, resource)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn copy_auth_acl(
+        &self,
+        from_broker: impl Into<String>,
+        to_broker: impl Into<String>,
+        subjects: Option<String>,
+    ) -> RocketMQResult<CopyAclResult> {
+        AuthService::copy_acl_by_request_with_rpc_hook(
+            self.auth_copy_acl_request(from_broker, to_broker, subjects)?,
             None,
         )
         .await
@@ -907,12 +1432,46 @@ impl TuiAdminFacade {
         .await
     }
 
+    pub async fn update_controller_config(
+        &self,
+        controller_address: impl Into<String>,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> RocketMQResult<()> {
+        ControllerService::update_controller_config_by_request_with_rpc_hook(
+            self.controller_config_update_request(controller_address, key, value)?,
+            None,
+        )
+        .await
+    }
+
     pub async fn query_controller_metadata(
         &self,
         controller_address: impl Into<String>,
     ) -> RocketMQResult<ControllerMetadataQueryResult> {
         ControllerService::query_controller_metadata_by_request_with_rpc_hook(
             self.controller_metadata_query_request(controller_address)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn clean_controller_metadata(
+        &self,
+        controller_address: impl Into<String>,
+        broker_name: impl Into<String>,
+        broker_controller_ids_to_clean: Option<String>,
+        cluster_name: Option<String>,
+        clean_living_broker: bool,
+    ) -> RocketMQResult<()> {
+        ControllerService::clean_controller_metadata_by_request_with_rpc_hook(
+            self.controller_metadata_clean_request(
+                controller_address,
+                broker_name,
+                broker_controller_ids_to_clean,
+                cluster_name,
+                clean_living_broker,
+            )?,
             None,
         )
         .await
@@ -1034,6 +1593,124 @@ impl TuiAdminFacade {
         .await
     }
 
+    pub async fn clean_expired_consume_queue(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        topic: Option<String>,
+        dry_run: bool,
+    ) -> RocketMQResult<CleanExpiredConsumeQueueReport> {
+        BrokerService::clean_expired_consume_queue_by_request_with_rpc_hook(
+            self.clean_expired_consume_queue_request(broker_addr, cluster_name, topic, dry_run)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn delete_expired_commit_log(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<BrokerBooleanOperationResult> {
+        BrokerService::delete_expired_commit_log_by_request_with_rpc_hook(
+            self.broker_optional_target_request(broker_addr, cluster_name)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn clean_unused_topic(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+    ) -> RocketMQResult<BrokerBooleanOperationResult> {
+        BrokerService::clean_unused_topic_by_request_with_rpc_hook(
+            self.broker_optional_target_request(broker_addr, cluster_name)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn reset_master_flush_offset(
+        &self,
+        broker_addr: Option<String>,
+        offset: Option<i64>,
+    ) -> RocketMQResult<()> {
+        BrokerService::reset_master_flush_offset_by_request_with_rpc_hook(
+            self.reset_master_flush_offset_request(broker_addr, offset)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn update_cold_data_flow_ctr_group_config(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        consumer_group: impl Into<String>,
+        threshold: impl Into<String>,
+    ) -> RocketMQResult<BrokerOperationResult> {
+        BrokerService::update_cold_data_flow_ctr_group_config_by_request_with_rpc_hook(
+            self.cold_data_flow_ctr_group_config_update_request(broker_addr, cluster_name, consumer_group, threshold)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn remove_cold_data_flow_ctr_group_config(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        consumer_group: impl Into<String>,
+    ) -> RocketMQResult<BrokerOperationResult> {
+        BrokerService::remove_cold_data_flow_ctr_group_config_by_request_with_rpc_hook(
+            self.cold_data_flow_ctr_group_config_remove_request(broker_addr, cluster_name, consumer_group)?,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn set_commit_log_read_ahead(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        mode: Option<String>,
+        enable: bool,
+        disable: bool,
+        read_ahead_size: Option<String>,
+        read_ahead_size_key: Option<String>,
+        show_only: bool,
+    ) -> RocketMQResult<CommitLogReadAheadResult> {
+        BrokerService::set_commit_log_read_ahead_by_request_with_rpc_hook(
+            self.commit_log_read_ahead_request(
+                broker_addr,
+                cluster_name,
+                mode,
+                enable,
+                disable,
+                read_ahead_size,
+                read_ahead_size_key,
+                show_only,
+            )?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn switch_timer_engine(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        engine_type: impl Into<String>,
+    ) -> RocketMQResult<BrokerOperationResult> {
+        BrokerService::switch_timer_engine_by_request_with_rpc_hook(
+            self.switch_timer_engine_request(broker_addr, cluster_name, engine_type)?,
+            None,
+        )
+        .await
+    }
+
     pub async fn query_cluster_list(
         &self,
         more_stats: bool,
@@ -1133,6 +1810,86 @@ impl TuiAdminFacade {
                 group_name,
                 mode,
                 pop_share_queue_num,
+            )?,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_subscription_group(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        group_name: impl Into<String>,
+        consume_enable: bool,
+        consume_from_min_enable: bool,
+        consume_broadcast_enable: bool,
+        consume_message_orderly: bool,
+        retry_queue_nums: i32,
+        retry_max_times: i32,
+        broker_id: u64,
+        which_broker_when_consume_slowly: u64,
+        notify_consumer_ids_changed_enable: bool,
+        group_sys_flag: i32,
+        consume_timeout_minute: i32,
+    ) -> RocketMQResult<ConsumerOperationResult> {
+        ConsumerService::update_subscription_group_by_request_with_rpc_hook(
+            self.update_subscription_group_request(
+                broker_addr,
+                cluster_name,
+                group_name,
+                consume_enable,
+                consume_from_min_enable,
+                consume_broadcast_enable,
+                consume_message_orderly,
+                retry_queue_nums,
+                retry_max_times,
+                broker_id,
+                which_broker_when_consume_slowly,
+                notify_consumer_ids_changed_enable,
+                group_sys_flag,
+                consume_timeout_minute,
+            )?,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_subscription_group_list(
+        &self,
+        broker_addr: Option<String>,
+        cluster_name: Option<String>,
+        group_names: impl AsRef<str>,
+        consume_enable: bool,
+        consume_from_min_enable: bool,
+        consume_broadcast_enable: bool,
+        consume_message_orderly: bool,
+        retry_queue_nums: i32,
+        retry_max_times: i32,
+        broker_id: u64,
+        which_broker_when_consume_slowly: u64,
+        notify_consumer_ids_changed_enable: bool,
+        group_sys_flag: i32,
+        consume_timeout_minute: i32,
+    ) -> RocketMQResult<ConsumerOperationResult> {
+        ConsumerService::update_subscription_group_list_by_request_with_rpc_hook(
+            self.update_subscription_group_list_request(
+                broker_addr,
+                cluster_name,
+                group_names,
+                consume_enable,
+                consume_from_min_enable,
+                consume_broadcast_enable,
+                consume_message_orderly,
+                retry_queue_nums,
+                retry_max_times,
+                broker_id,
+                which_broker_when_consume_slowly,
+                notify_consumer_ids_changed_enable,
+                group_sys_flag,
+                consume_timeout_minute,
             )?,
             None,
         )
@@ -1388,6 +2145,48 @@ impl TuiAdminFacade {
         .await
     }
 
+    pub async fn trigger_lite_dispatch(
+        &self,
+        parent_topic: impl Into<String>,
+        group: impl Into<String>,
+        client_id: Option<String>,
+        broker_name: Option<String>,
+    ) -> RocketMQResult<TriggerLiteDispatchResult> {
+        LiteService::trigger_lite_dispatch_by_request_with_rpc_hook(
+            self.trigger_lite_dispatch_request(parent_topic, group, client_id, broker_name)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn update_static_topic(
+        &self,
+        topic: impl Into<String>,
+        broker_names: impl Into<String>,
+        queue_num: impl AsRef<str>,
+        cluster_names: Option<String>,
+    ) -> RocketMQResult<StaticTopicMappingPlan> {
+        StaticTopicService::update_static_topic_by_request_with_rpc_hook(
+            self.update_static_topic_request(topic, broker_names, queue_num, cluster_names)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn remapping_static_topic(
+        &self,
+        topic: impl Into<String>,
+        broker_names: Option<String>,
+        cluster_names: Option<String>,
+        force_replace: Option<bool>,
+    ) -> RocketMQResult<StaticTopicMappingPlan> {
+        StaticTopicService::remapping_static_topic_by_request_with_rpc_hook(
+            self.remapping_static_topic_request(topic, broker_names, cluster_names, force_replace)?,
+            None,
+        )
+        .await
+    }
+
     pub fn decode_message_id(&self, message_ids: impl AsRef<str>) -> RocketMQResult<DecodeMessageIdResult> {
         let request = self.decode_message_id_request(message_ids)?;
         Ok(MessageService::decode_message_ids(&request))
@@ -1491,6 +2290,45 @@ impl TuiAdminFacade {
         )
         .await
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn subscription_group_config(
+    group_name: impl Into<String>,
+    consume_enable: bool,
+    consume_from_min_enable: bool,
+    consume_broadcast_enable: bool,
+    consume_message_orderly: bool,
+    retry_queue_nums: i32,
+    retry_max_times: i32,
+    broker_id: u64,
+    which_broker_when_consume_slowly: u64,
+    notify_consumer_ids_changed_enable: bool,
+    group_sys_flag: i32,
+    consume_timeout_minute: i32,
+) -> SubscriptionGroupConfig {
+    let mut config = SubscriptionGroupConfig::new(group_name.into().trim().into());
+    config.set_consume_enable(consume_enable);
+    config.set_consume_from_min_enable(consume_from_min_enable);
+    config.set_consume_broadcast_enable(consume_broadcast_enable);
+    config.set_consume_message_orderly(consume_message_orderly);
+    config.set_retry_queue_nums(retry_queue_nums);
+    config.set_retry_max_times(retry_max_times);
+    config.set_broker_id(broker_id);
+    config.set_which_broker_when_consume_slowly(which_broker_when_consume_slowly);
+    config.set_notify_consumer_ids_changed_enable(notify_consumer_ids_changed_enable);
+    config.set_group_sys_flag(group_sys_flag);
+    config.set_consume_timeout_minute(consume_timeout_minute);
+    config
+}
+
+fn split_csv(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
 }
 
 fn split_message_ids(value: &str) -> Vec<String> {
@@ -1879,6 +2717,291 @@ mod tests {
         std::mem::drop(facade.query_producer_info("127.0.0.1:10911"));
         std::mem::drop(facade.send_message_status("broker-a", 128, 2));
         std::mem::drop(facade.check_message_send_rt("TopicA", 2, 128));
+    }
+
+    #[test]
+    fn facade_builds_phase_three_mutating_requests_without_cli_types() {
+        let facade = TuiAdminFacade::with_namesrv_addr(" 127.0.0.1:9876 ");
+
+        let create_user = facade
+            .auth_create_user_request(
+                Some(" 127.0.0.1:10911 ".to_string()),
+                None,
+                " admin ",
+                " secret ",
+                Some(" NORMAL ".to_string()),
+            )
+            .unwrap();
+        assert_eq!(create_user.username().as_str(), "admin");
+        assert_eq!(create_user.password().as_str(), "secret");
+        assert_eq!(create_user.namesrv_addr(), Some("127.0.0.1:9876"));
+
+        let update_user = facade
+            .auth_update_user_request(
+                None,
+                Some(" DefaultCluster ".to_string()),
+                " admin ",
+                None,
+                Some(" SUPER ".to_string()),
+                None,
+            )
+            .unwrap();
+        assert_eq!(update_user.username().as_str(), "admin");
+        assert_eq!(update_user.user_type(), Some("SUPER"));
+
+        let delete_user = facade
+            .auth_delete_user_request(Some(" 127.0.0.1:10911 ".to_string()), None, " admin ")
+            .unwrap();
+        assert_eq!(delete_user.username().as_str(), "admin");
+
+        let copy_users = facade
+            .auth_copy_users_request(
+                " 127.0.0.1:10911 ",
+                " 127.0.0.2:10911 ",
+                Some(" admin,guest ".to_string()),
+            )
+            .unwrap();
+        assert_eq!(copy_users.from_broker().as_str(), "127.0.0.1:10911");
+        assert_eq!(copy_users.usernames().map(|names| names.len()), Some(2));
+
+        let create_acl = facade
+            .auth_create_acl_request(
+                Some(" 127.0.0.1:10911 ".to_string()),
+                None,
+                " User:admin ",
+                " Topic:TopicA,Group:GroupA ",
+                " PUB,SUB ",
+                " ALLOW ",
+                Some(" 127.0.0.1 ".to_string()),
+            )
+            .unwrap();
+        assert_eq!(create_acl.subject().as_str(), "User:admin");
+        assert_eq!(create_acl.resources().len(), 2);
+        assert_eq!(create_acl.actions().len(), 2);
+        assert_eq!(create_acl.namesrv_addr(), Some("127.0.0.1:9876"));
+
+        let delete_acl = facade
+            .auth_delete_acl_request(
+                None,
+                Some(" DefaultCluster ".to_string()),
+                " User:admin ",
+                Some(" Topic:TopicA ".to_string()),
+            )
+            .unwrap();
+        assert_eq!(delete_acl.subject().as_str(), "User:admin");
+        assert_eq!(delete_acl.resource(), Some("Topic:TopicA"));
+
+        let controller_update = facade
+            .controller_config_update_request(" 127.0.0.1:9878 ", " enableElectUncleanMaster ", " true ")
+            .unwrap();
+        assert_eq!(controller_update.controller_servers().len(), 1);
+        assert_eq!(controller_update.properties().len(), 1);
+
+        let controller_clean = facade
+            .controller_metadata_clean_request(
+                " 127.0.0.1:9878 ",
+                " broker-a ",
+                Some(" 1;2 ".to_string()),
+                Some(" DefaultCluster ".to_string()),
+                false,
+            )
+            .unwrap();
+        assert_eq!(controller_clean.broker_name().as_str(), "broker-a");
+        assert_eq!(
+            controller_clean.broker_controller_ids_to_clean().unwrap().as_str(),
+            "1;2"
+        );
+
+        let clean_cq = facade
+            .clean_expired_consume_queue_request(
+                Some(" 127.0.0.1:10911 ".to_string()),
+                None,
+                Some(" TopicA ".to_string()),
+                true,
+            )
+            .unwrap();
+        assert!(clean_cq.dry_run());
+        assert_eq!(clean_cq.topic().unwrap().as_str(), "TopicA");
+
+        let reset_flush = facade
+            .reset_master_flush_offset_request(Some(" 127.0.0.1:10912 ".to_string()), Some(1024))
+            .unwrap();
+        assert_eq!(reset_flush.broker_addr().as_str(), "127.0.0.1:10912");
+        assert_eq!(reset_flush.master_flush_offset(), 1024);
+
+        let read_ahead = facade
+            .commit_log_read_ahead_request(
+                Some(" 127.0.0.1:10911 ".to_string()),
+                None,
+                Some("0".to_string()),
+                false,
+                false,
+                Some("4096".to_string()),
+                None,
+                false,
+            )
+            .unwrap();
+        assert!(read_ahead.has_updates());
+
+        let lite = facade
+            .trigger_lite_dispatch_request(
+                " ParentTopic ",
+                " GroupA ",
+                Some(" client-a ".to_string()),
+                Some(" broker-a ".to_string()),
+            )
+            .unwrap();
+        assert_eq!(lite.parent_topic().as_str(), "ParentTopic");
+        assert_eq!(lite.group().as_str(), "GroupA");
+
+        let update_static = facade
+            .update_static_topic_request(
+                " StaticTopic ",
+                " broker-a,broker-b ",
+                " 4 ",
+                Some(" DefaultCluster ".into()),
+            )
+            .unwrap();
+        assert_eq!(update_static.topic().as_str(), "StaticTopic");
+        assert_eq!(update_static.broker_names().len(), 2);
+
+        let remap_static = facade
+            .remapping_static_topic_request(
+                " StaticTopic ",
+                Some(" broker-a ".to_string()),
+                Some(" DefaultCluster ".to_string()),
+                Some(true),
+            )
+            .unwrap();
+        assert_eq!(remap_static.topic().as_str(), "StaticTopic");
+        assert!(remap_static.force_replace());
+    }
+
+    #[test]
+    fn facade_exposes_phase_three_service_futures_without_cli_types() {
+        let facade = TuiAdminFacade::with_namesrv_addr("127.0.0.1:9876");
+
+        std::mem::drop(facade.create_auth_user(
+            Some("127.0.0.1:10911".to_string()),
+            None,
+            "admin",
+            "secret",
+            Some("NORMAL".to_string()),
+        ));
+        std::mem::drop(facade.update_auth_user(
+            None,
+            Some("DefaultCluster".to_string()),
+            "admin",
+            None,
+            Some("SUPER".to_string()),
+            None,
+        ));
+        std::mem::drop(facade.delete_auth_user(Some("127.0.0.1:10911".to_string()), None, "admin"));
+        std::mem::drop(facade.copy_auth_users("127.0.0.1:10911", "127.0.0.2:10911", Some("admin".to_string())));
+        std::mem::drop(facade.create_auth_acl(
+            Some("127.0.0.1:10911".to_string()),
+            None,
+            "User:admin",
+            "Topic:TopicA",
+            "PUB",
+            "ALLOW",
+            None,
+        ));
+        std::mem::drop(facade.update_auth_acl(
+            Some("127.0.0.1:10911".to_string()),
+            None,
+            "User:admin",
+            "Topic:TopicA",
+            "PUB",
+            "ALLOW",
+            None,
+        ));
+        std::mem::drop(facade.delete_auth_acl(
+            Some("127.0.0.1:10911".to_string()),
+            None,
+            "User:admin",
+            Some("Topic:TopicA".to_string()),
+        ));
+        std::mem::drop(facade.copy_auth_acl("127.0.0.1:10911", "127.0.0.2:10911", Some("User:admin".to_string())));
+        std::mem::drop(facade.update_controller_config("127.0.0.1:9878", "enableElectUncleanMaster", "true"));
+        std::mem::drop(facade.clean_controller_metadata(
+            "127.0.0.1:9878",
+            "broker-a",
+            Some("1;2".to_string()),
+            Some("DefaultCluster".to_string()),
+            false,
+        ));
+        std::mem::drop(facade.clean_expired_consume_queue(
+            Some("127.0.0.1:10911".to_string()),
+            None,
+            Some("TopicA".to_string()),
+            true,
+        ));
+        std::mem::drop(facade.delete_expired_commit_log(Some("127.0.0.1:10911".to_string()), None));
+        std::mem::drop(facade.clean_unused_topic(Some("127.0.0.1:10911".to_string()), None));
+        std::mem::drop(facade.reset_master_flush_offset(Some("127.0.0.1:10912".to_string()), Some(1024)));
+        std::mem::drop(facade.update_cold_data_flow_ctr_group_config(
+            Some("127.0.0.1:10911".to_string()),
+            None,
+            "GroupA",
+            "1024",
+        ));
+        std::mem::drop(facade.remove_cold_data_flow_ctr_group_config(
+            Some("127.0.0.1:10911".to_string()),
+            None,
+            "GroupA",
+        ));
+        std::mem::drop(facade.set_commit_log_read_ahead(
+            Some("127.0.0.1:10911".to_string()),
+            None,
+            Some("0".to_string()),
+            false,
+            false,
+            Some("4096".to_string()),
+            None,
+            false,
+        ));
+        std::mem::drop(facade.switch_timer_engine(Some("127.0.0.1:10911".to_string()), None, "R"));
+        std::mem::drop(facade.update_subscription_group(
+            Some("127.0.0.1:10911".to_string()),
+            None,
+            "GroupA",
+            true,
+            true,
+            true,
+            false,
+            1,
+            16,
+            0,
+            1,
+            true,
+            0,
+            15,
+        ));
+        std::mem::drop(facade.update_subscription_group_list(
+            Some("127.0.0.1:10911".to_string()),
+            None,
+            "GroupA,GroupB",
+            true,
+            true,
+            true,
+            false,
+            1,
+            16,
+            0,
+            1,
+            true,
+            0,
+            15,
+        ));
+        std::mem::drop(facade.trigger_lite_dispatch(
+            "ParentTopic",
+            "GroupA",
+            Some("client-a".to_string()),
+            Some("broker-a".to_string()),
+        ));
+        std::mem::drop(facade.update_static_topic("StaticTopic", "broker-a", "4", Some("DefaultCluster".to_string())));
+        std::mem::drop(facade.remapping_static_topic("StaticTopic", Some("broker-a".to_string()), None, Some(false)));
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
@@ -26,6 +26,7 @@ pub enum CommandCategory {
     Producer,
     Lite,
     Message,
+    StaticTopic,
 }
 
 impl CommandCategory {
@@ -46,6 +47,7 @@ impl CommandCategory {
             Self::Producer => "Producer",
             Self::Lite => "Lite",
             Self::Message => "Message",
+            Self::StaticTopic => "Static Topic",
         }
     }
 }
@@ -205,6 +207,7 @@ pub fn command_catalog() -> Vec<CommandSpec> {
     producer_commands(&mut commands);
     lite_commands(&mut commands);
     message_commands(&mut commands);
+    static_topic_commands(&mut commands);
     commands
 }
 
@@ -333,6 +336,52 @@ pub async fn execute_command(
                 .await?;
             CommandResultViewModel::from_serializable(spec.title, &result)
         }
+        "auth.user.create" => {
+            let result = facade
+                .create_auth_user(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.required_string("username")?,
+                    form.required_string("password")?,
+                    form.optional_string("user_type"),
+                )
+                .await?;
+            CommandResultViewModel::auth_operation(spec.title, &result)
+        }
+        "auth.user.update" => {
+            let result = facade
+                .update_auth_user(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.required_string("username")?,
+                    form.optional_string("password"),
+                    form.optional_string("user_type"),
+                    form.optional_string("user_status"),
+                )
+                .await?;
+            CommandResultViewModel::auth_operation(spec.title, &result)
+        }
+        "auth.user.delete" => {
+            let username = form.required_string("username")?;
+            let result = facade
+                .delete_auth_user(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    username.clone(),
+                )
+                .await?;
+            CommandResultViewModel::auth_operation(spec.title, &result).with_debug_tail(&username)
+        }
+        "auth.user.copy" => {
+            let result = facade
+                .copy_auth_users(
+                    form.required_string("from_broker")?,
+                    form.required_string("to_broker")?,
+                    form.optional_string("usernames"),
+                )
+                .await?;
+            CommandResultViewModel::auth_copy_users(spec.title, &result)
+        }
         "auth.acl.get" => {
             let result = facade
                 .query_auth_acl(
@@ -353,6 +402,56 @@ pub async fn execute_command(
                 )
                 .await?;
             CommandResultViewModel::from_serializable(spec.title, &result)
+        }
+        "auth.acl.create" => {
+            let result = facade
+                .create_auth_acl(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.required_string("subject")?,
+                    form.required_string("resources")?,
+                    form.required_string("actions")?,
+                    form.enum_string("decision")?,
+                    form.optional_string("source_ip"),
+                )
+                .await?;
+            CommandResultViewModel::auth_operation(spec.title, &result)
+        }
+        "auth.acl.update" => {
+            let result = facade
+                .update_auth_acl(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.required_string("subject")?,
+                    form.required_string("resources")?,
+                    form.required_string("actions")?,
+                    form.enum_string("decision")?,
+                    form.optional_string("source_ip"),
+                )
+                .await?;
+            CommandResultViewModel::auth_operation(spec.title, &result)
+        }
+        "auth.acl.delete" => {
+            let subject = form.required_string("subject")?;
+            let result = facade
+                .delete_auth_acl(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    subject.clone(),
+                    form.optional_string("resource"),
+                )
+                .await?;
+            CommandResultViewModel::auth_operation(spec.title, &result).with_debug_tail(&subject)
+        }
+        "auth.acl.copy" => {
+            let result = facade
+                .copy_auth_acl(
+                    form.required_string("from_broker")?,
+                    form.required_string("to_broker")?,
+                    form.optional_string("subjects"),
+                )
+                .await?;
+            CommandResultViewModel::auth_copy_acl(spec.title, &result)
         }
         "broker.config.query" => {
             let result = facade
@@ -412,6 +511,98 @@ pub async fn execute_command(
                 .await?;
             CommandResultViewModel::from_serializable(spec.title, &result)
         }
+        "broker.clean_expired_cq" => {
+            let result = facade
+                .clean_expired_consume_queue(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.optional_string("topic"),
+                    form.bool_value("dry_run")?,
+                )
+                .await?;
+            CommandResultViewModel::clean_expired_consume_queue(spec.title, &result)
+        }
+        "broker.delete_expired_commit_log" => {
+            let target = operation_target_label(
+                form.optional_string("broker_addr"),
+                form.optional_string("cluster_name"),
+                "all brokers",
+            );
+            let result = facade
+                .delete_expired_commit_log(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                )
+                .await?;
+            CommandResultViewModel::broker_boolean_operation(spec.title, target, &result)
+        }
+        "broker.clean_unused_topic" => {
+            let target = operation_target_label(
+                form.optional_string("broker_addr"),
+                form.optional_string("cluster_name"),
+                "all brokers",
+            );
+            let result = facade
+                .clean_unused_topic(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                )
+                .await?;
+            CommandResultViewModel::broker_boolean_operation(spec.title, target, &result)
+        }
+        "broker.reset_master_flush_offset" => {
+            let broker_addr = form.required_string("broker_addr")?;
+            facade
+                .reset_master_flush_offset(Some(broker_addr.clone()), Some(form.number_i64("offset")?))
+                .await?;
+            CommandResultViewModel::operation_success(spec.title, vec![broker_addr])
+        }
+        "broker.cold_data_flow_ctr_update" => {
+            let result = facade
+                .update_cold_data_flow_ctr_group_config(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.required_string("consumer_group")?,
+                    form.required_string("threshold")?,
+                )
+                .await?;
+            CommandResultViewModel::broker_operation(spec.title, &result)
+        }
+        "broker.cold_data_flow_ctr_remove" => {
+            let result = facade
+                .remove_cold_data_flow_ctr_group_config(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.required_string("consumer_group")?,
+                )
+                .await?;
+            CommandResultViewModel::broker_operation(spec.title, &result)
+        }
+        "broker.commit_log_read_ahead" => {
+            let result = facade
+                .set_commit_log_read_ahead(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.optional_string("mode"),
+                    form.bool_value("enable")?,
+                    form.bool_value("disable")?,
+                    form.optional_string("read_ahead_size"),
+                    form.optional_string("read_ahead_size_key"),
+                    form.bool_value("show_only")?,
+                )
+                .await?;
+            CommandResultViewModel::commit_log_read_ahead(spec.title, &result)
+        }
+        "broker.switch_timer_engine" => {
+            let result = facade
+                .switch_timer_engine(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.enum_string("engine_type")?,
+                )
+                .await?;
+            CommandResultViewModel::broker_operation(spec.title, &result)
+        }
         "cluster.list" => {
             let result = facade
                 .query_cluster_list(form.bool_value("more_stats")?, form.optional_string("cluster_name"))
@@ -447,11 +638,35 @@ pub async fn execute_command(
                 .await?;
             CommandResultViewModel::from_serializable(spec.title, &result)
         }
+        "controller.config.update" => {
+            let controller_address = form.required_string("controller_address")?;
+            facade
+                .update_controller_config(
+                    controller_address.clone(),
+                    form.required_string("key")?,
+                    form.required_string("value")?,
+                )
+                .await?;
+            CommandResultViewModel::operation_success(spec.title, vec![controller_address])
+        }
         "controller.metadata.query" => {
             let result = facade
                 .query_controller_metadata(form.required_string("controller_address")?)
                 .await?;
             CommandResultViewModel::from_serializable(spec.title, &result)
+        }
+        "controller.metadata.clean" => {
+            let broker_name = form.required_string("broker_name")?;
+            facade
+                .clean_controller_metadata(
+                    form.required_string("controller_address")?,
+                    broker_name.clone(),
+                    form.optional_string("broker_controller_ids"),
+                    form.optional_string("cluster_name"),
+                    form.bool_value("clean_living_broker")?,
+                )
+                .await?;
+            CommandResultViewModel::operation_success(spec.title, vec![broker_name])
         }
         "connection.consumer" => {
             let result = facade
@@ -520,6 +735,48 @@ pub async fn execute_command(
                 )
                 .await?;
             CommandResultViewModel::from_debug(spec.title, &result)
+        }
+        "consumer.update_subscription_group" => {
+            let result = facade
+                .update_subscription_group(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.required_string("group_name")?,
+                    form.bool_value("consume_enable")?,
+                    form.bool_value("consume_from_min_enable")?,
+                    form.bool_value("consume_broadcast_enable")?,
+                    form.bool_value("consume_message_orderly")?,
+                    form.number_i32("retry_queue_nums")?,
+                    form.number_i32("retry_max_times")?,
+                    form.number_u64("broker_id")?,
+                    form.number_u64("which_broker_when_consume_slowly")?,
+                    form.bool_value("notify_consumer_ids_changed_enable")?,
+                    form.number_i32("group_sys_flag")?,
+                    form.number_i32("consume_timeout_minute")?,
+                )
+                .await?;
+            CommandResultViewModel::consumer_operation(spec.title, &result)
+        }
+        "consumer.update_subscription_group_list" => {
+            let result = facade
+                .update_subscription_group_list(
+                    form.optional_string("broker_addr"),
+                    form.optional_string("cluster_name"),
+                    form.required_string("group_names")?,
+                    form.bool_value("consume_enable")?,
+                    form.bool_value("consume_from_min_enable")?,
+                    form.bool_value("consume_broadcast_enable")?,
+                    form.bool_value("consume_message_orderly")?,
+                    form.number_i32("retry_queue_nums")?,
+                    form.number_i32("retry_max_times")?,
+                    form.number_u64("broker_id")?,
+                    form.number_u64("which_broker_when_consume_slowly")?,
+                    form.bool_value("notify_consumer_ids_changed_enable")?,
+                    form.number_i32("group_sys_flag")?,
+                    form.number_i32("consume_timeout_minute")?,
+                )
+                .await?;
+            CommandResultViewModel::consumer_operation(spec.title, &result)
         }
         "offset.clone_group" => {
             facade
@@ -715,6 +972,17 @@ pub async fn execute_command(
                 .await?;
             CommandResultViewModel::from_serializable(spec.title, &result)
         }
+        "lite.trigger_dispatch" => {
+            let result = facade
+                .trigger_lite_dispatch(
+                    form.required_string("parent_topic")?,
+                    form.required_string("group")?,
+                    form.optional_string("client_id"),
+                    form.optional_string("broker_name"),
+                )
+                .await?;
+            CommandResultViewModel::lite_trigger_dispatch(spec.title, &result)
+        }
         "message.decode_id" => {
             let result = facade.decode_message_id(form.required_string("message_ids")?)?;
             CommandResultViewModel::decoded_message_ids(spec.title, &result)
@@ -782,6 +1050,30 @@ pub async fn execute_command(
                 )
                 .await?;
             CommandResultViewModel::message_trace(spec.title, &result)
+        }
+        "static_topic.update" => {
+            let topic = form.required_string("topic")?;
+            let result = facade
+                .update_static_topic(
+                    topic.clone(),
+                    form.required_string("broker_names")?,
+                    form.required_string("queue_num")?,
+                    form.optional_string("cluster_names"),
+                )
+                .await?;
+            CommandResultViewModel::operation_success(spec.title, vec![topic]).with_debug_tail(&result)
+        }
+        "static_topic.remap" => {
+            let topic = form.required_string("topic")?;
+            let result = facade
+                .remapping_static_topic(
+                    topic.clone(),
+                    form.optional_string("broker_names"),
+                    form.optional_string("cluster_names"),
+                    Some(form.bool_value("force_replace")?),
+                )
+                .await?;
+            CommandResultViewModel::operation_success(spec.title, vec![topic]).with_debug_tail(&result)
         }
         unknown => bail!("unknown command id: {unknown}"),
     };
@@ -1086,6 +1378,79 @@ fn auth_commands(commands: &mut Vec<CommandSpec>) {
             None,
         ),
         spec(
+            "auth.user.create",
+            CommandCategory::Auth,
+            "Create User",
+            "Create an ACL user on a broker or cluster.",
+            RiskLevel::Mutating,
+            broker_target_args_with(vec![
+                required_string("username", "Username", "ACL username.", "user-a"),
+                required_string("password", "Password", "ACL password.", "secret"),
+                optional_string("user_type", "User Type", "Optional user type.", "NORMAL"),
+            ]),
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
+            "auth.user.update",
+            CommandCategory::Auth,
+            "Update User",
+            "Update an ACL user password, type, or status.",
+            RiskLevel::Mutating,
+            broker_target_args_with(vec![
+                required_string("username", "Username", "ACL username.", "user-a"),
+                optional_string("password", "Password", "Optional new password.", "secret"),
+                optional_string("user_type", "User Type", "Optional user type.", "SUPER"),
+                optional_string("user_status", "User Status", "Optional user status.", "ENABLE"),
+            ]),
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
+            "auth.user.delete",
+            CommandCategory::Auth,
+            "Delete User",
+            "Delete an ACL user from a broker or cluster.",
+            RiskLevel::Dangerous,
+            broker_target_args_with(vec![required_string(
+                "username",
+                "Username",
+                "ACL username to delete.",
+                "user-a",
+            )]),
+            ResultViewKind::OperationSummary,
+            Some("username"),
+        ),
+        spec(
+            "auth.user.copy",
+            CommandCategory::Auth,
+            "Copy Users",
+            "Copy ACL users from one broker to another.",
+            RiskLevel::Mutating,
+            vec![
+                required_string(
+                    "from_broker",
+                    "From Broker",
+                    "Source broker address.",
+                    "127.0.0.1:10911",
+                ),
+                required_string(
+                    "to_broker",
+                    "To Broker",
+                    "Destination broker address.",
+                    "127.0.0.2:10911",
+                ),
+                optional_string(
+                    "usernames",
+                    "Usernames",
+                    "Optional comma-separated usernames.",
+                    "user-a,user-b",
+                ),
+            ],
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
             "auth.acl.get",
             CommandCategory::Auth,
             "Get ACL",
@@ -1121,6 +1486,90 @@ fn auth_commands(commands: &mut Vec<CommandSpec>) {
                 ),
             ]),
             ResultViewKind::Json,
+            None,
+        ),
+        spec(
+            "auth.acl.create",
+            CommandCategory::Auth,
+            "Create ACL",
+            "Create an ACL policy entry on a broker or cluster.",
+            RiskLevel::Mutating,
+            broker_target_args_with(vec![
+                required_string("subject", "Subject", "ACL subject.", "User:user-a"),
+                required_string("resources", "Resources", "Comma-separated resources.", "Topic:TopicA"),
+                required_string("actions", "Actions", "Comma-separated actions.", "PUB,SUB"),
+                enum_arg("decision", "Decision", "ACL decision.", &["ALLOW", "DENY"], "ALLOW"),
+                optional_string(
+                    "source_ip",
+                    "Source IP",
+                    "Optional comma-separated source IPs.",
+                    "127.0.0.1",
+                ),
+            ]),
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
+            "auth.acl.update",
+            CommandCategory::Auth,
+            "Update ACL",
+            "Update an ACL policy entry on a broker or cluster.",
+            RiskLevel::Mutating,
+            broker_target_args_with(vec![
+                required_string("subject", "Subject", "ACL subject.", "User:user-a"),
+                required_string("resources", "Resources", "Comma-separated resources.", "Topic:TopicA"),
+                required_string("actions", "Actions", "Comma-separated actions.", "PUB,SUB"),
+                enum_arg("decision", "Decision", "ACL decision.", &["ALLOW", "DENY"], "ALLOW"),
+                optional_string(
+                    "source_ip",
+                    "Source IP",
+                    "Optional comma-separated source IPs.",
+                    "127.0.0.1",
+                ),
+            ]),
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
+            "auth.acl.delete",
+            CommandCategory::Auth,
+            "Delete ACL",
+            "Delete an ACL subject or one subject/resource rule.",
+            RiskLevel::Dangerous,
+            broker_target_args_with(vec![
+                required_string("subject", "Subject", "ACL subject to delete.", "User:user-a"),
+                optional_string("resource", "Resource", "Optional resource to delete.", "Topic:TopicA"),
+            ]),
+            ResultViewKind::OperationSummary,
+            Some("subject"),
+        ),
+        spec(
+            "auth.acl.copy",
+            CommandCategory::Auth,
+            "Copy ACL",
+            "Copy ACL subjects from one broker to another.",
+            RiskLevel::Mutating,
+            vec![
+                required_string(
+                    "from_broker",
+                    "From Broker",
+                    "Source broker address.",
+                    "127.0.0.1:10911",
+                ),
+                required_string(
+                    "to_broker",
+                    "To Broker",
+                    "Destination broker address.",
+                    "127.0.0.2:10911",
+                ),
+                optional_string(
+                    "subjects",
+                    "Subjects",
+                    "Optional comma-separated subjects.",
+                    "User:user-a",
+                ),
+            ],
+            ResultViewKind::OperationSummary,
             None,
         ),
     ]);
@@ -1241,6 +1690,123 @@ fn broker_commands(commands: &mut Vec<CommandSpec>) {
             ResultViewKind::Json,
             None,
         ),
+        spec(
+            "broker.clean_expired_cq",
+            CommandCategory::Broker,
+            "Clean Expired CQ",
+            "Clean expired consume queue files by broker, cluster, topic, or global scope.",
+            RiskLevel::Dangerous,
+            broker_target_args_with(vec![
+                optional_string("topic", "Topic", "Optional topic scope.", "TopicA"),
+                bool_arg("dry_run", "Dry Run", "Only scan matching targets.", true),
+            ]),
+            ResultViewKind::OperationSummary,
+            Some("broker_addr"),
+        ),
+        spec(
+            "broker.delete_expired_commit_log",
+            CommandCategory::Broker,
+            "Delete Expired CommitLog",
+            "Delete expired CommitLog files by broker or cluster.",
+            RiskLevel::Dangerous,
+            broker_target_args(),
+            ResultViewKind::OperationSummary,
+            Some("broker_addr"),
+        ),
+        spec(
+            "broker.clean_unused_topic",
+            CommandCategory::Broker,
+            "Clean Unused Topic",
+            "Clean unused topics by broker or cluster.",
+            RiskLevel::Dangerous,
+            broker_target_args(),
+            ResultViewKind::OperationSummary,
+            Some("broker_addr"),
+        ),
+        spec(
+            "broker.reset_master_flush_offset",
+            CommandCategory::Broker,
+            "Reset Master Flush Offset",
+            "Reset master flush offset for a slave broker.",
+            RiskLevel::Dangerous,
+            vec![
+                required_string("broker_addr", "Broker Addr", "Slave broker address.", "127.0.0.1:10912"),
+                number("offset", "Offset", "Master flush offset.", true, Some(0), Some(0)),
+            ],
+            ResultViewKind::OperationSummary,
+            Some("broker_addr"),
+        ),
+        spec(
+            "broker.cold_data_flow_ctr_update",
+            CommandCategory::Broker,
+            "Update Cold Data Flow Control",
+            "Add or update a cold data flow control group threshold.",
+            RiskLevel::Mutating,
+            broker_target_args_with(vec![
+                required_string("consumer_group", "Consumer Group", "Consumer group.", "GroupA"),
+                required_string("threshold", "Threshold", "Cold data flow threshold.", "1024"),
+            ]),
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
+            "broker.cold_data_flow_ctr_remove",
+            CommandCategory::Broker,
+            "Remove Cold Data Flow Control",
+            "Remove a cold data flow control group threshold.",
+            RiskLevel::Dangerous,
+            broker_target_args_with(vec![required_string(
+                "consumer_group",
+                "Consumer Group",
+                "Consumer group to remove.",
+                "GroupA",
+            )]),
+            ResultViewKind::OperationSummary,
+            Some("consumer_group"),
+        ),
+        spec(
+            "broker.commit_log_read_ahead",
+            CommandCategory::Broker,
+            "Set CommitLog ReadAhead",
+            "Inspect or update commitlog read-ahead mode and size.",
+            RiskLevel::Mutating,
+            broker_target_args_with(vec![
+                optional_string("mode", "Mode", "Optional mode config value: 0 normal, 1 random.", "0"),
+                bool_arg("enable", "Enable", "Force normal read-ahead mode.", false),
+                bool_arg("disable", "Disable", "Force random read-ahead mode.", false),
+                optional_string("read_ahead_size", "ReadAhead Size", "Optional read-ahead size.", "4096"),
+                optional_string(
+                    "read_ahead_size_key",
+                    "Size Key",
+                    "Optional read-ahead size config key.",
+                    "mappedFileSizeCommitLog",
+                ),
+                bool_arg(
+                    "show_only",
+                    "Show Only",
+                    "Inspect current config without updates.",
+                    false,
+                ),
+            ]),
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
+            "broker.switch_timer_engine",
+            CommandCategory::Broker,
+            "Switch Timer Engine",
+            "Switch timer message engine type.",
+            RiskLevel::Dangerous,
+            broker_target_args_with(vec![enum_arg(
+                "engine_type",
+                "Engine Type",
+                "Timer engine type: R for RocksDB timeline, F for file time wheel.",
+                &["R", "F"],
+                "R",
+            )]),
+            ResultViewKind::OperationSummary,
+            Some("broker_addr"),
+        ),
     ]);
 }
 
@@ -1309,6 +1875,25 @@ fn controller_commands(commands: &mut Vec<CommandSpec>) {
             None,
         ),
         spec(
+            "controller.config.update",
+            CommandCategory::Controller,
+            "Update Controller Config",
+            "Update one controller configuration key on one or more controller addresses.",
+            RiskLevel::Mutating,
+            vec![
+                required_string(
+                    "controller_address",
+                    "Controller",
+                    "Controller address list separated by semicolon.",
+                    "127.0.0.1:9878",
+                ),
+                required_string("key", "Key", "Controller config key.", "enableElectUncleanMaster"),
+                required_string("value", "Value", "Controller config value.", "true"),
+            ],
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
             "controller.metadata.query",
             CommandCategory::Controller,
             "Query Controller Metadata",
@@ -1322,6 +1907,37 @@ fn controller_commands(commands: &mut Vec<CommandSpec>) {
             )],
             ResultViewKind::Json,
             None,
+        ),
+        spec(
+            "controller.metadata.clean",
+            CommandCategory::Controller,
+            "Clean Controller Metadata",
+            "Clean broker metadata from a controller.",
+            RiskLevel::Dangerous,
+            vec![
+                required_string(
+                    "controller_address",
+                    "Controller",
+                    "Controller address.",
+                    "127.0.0.1:9878",
+                ),
+                required_string("broker_name", "Broker Name", "Broker name to clean.", "broker-a"),
+                optional_string(
+                    "broker_controller_ids",
+                    "Broker Controller IDs",
+                    "Optional semicolon-separated controller ids.",
+                    "1;2",
+                ),
+                optional_string("cluster_name", "Cluster", "Cluster name.", "DefaultCluster"),
+                bool_arg(
+                    "clean_living_broker",
+                    "Clean Living Broker",
+                    "Allow cleaning living broker metadata.",
+                    false,
+                ),
+            ],
+            ResultViewKind::OperationSummary,
+            Some("broker_name"),
         ),
     ]);
 }
@@ -1441,6 +2057,31 @@ fn consumer_commands(commands: &mut Vec<CommandSpec>) {
                     Some(0),
                 ),
             ]),
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
+            "consumer.update_subscription_group",
+            CommandCategory::Consumer,
+            "Update Subscription Group",
+            "Create or update one subscription group config by broker or cluster.",
+            RiskLevel::Mutating,
+            subscription_group_args("group_name", "Group", "Consumer group.", "GroupA"),
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
+            "consumer.update_subscription_group_list",
+            CommandCategory::Consumer,
+            "Update Subscription Group List",
+            "Create or update several subscription group configs with the same settings.",
+            RiskLevel::Mutating,
+            subscription_group_args(
+                "group_names",
+                "Groups",
+                "Comma-separated consumer groups.",
+                "GroupA,GroupB",
+            ),
             ResultViewKind::OperationSummary,
             None,
         ),
@@ -1770,6 +2411,21 @@ fn lite_commands(commands: &mut Vec<CommandSpec>) {
             ResultViewKind::Json,
             None,
         ),
+        spec(
+            "lite.trigger_dispatch",
+            CommandCategory::Lite,
+            "Trigger Lite Dispatch",
+            "Trigger lite dispatch for a group and optional client or broker.",
+            RiskLevel::Mutating,
+            vec![
+                required_string("parent_topic", "Parent Topic", "Parent topic name.", "ParentTopicA"),
+                required_string("group", "Group", "Consumer group.", "GroupA"),
+                optional_string("client_id", "Client ID", "Optional client id.", "client-a"),
+                optional_string("broker_name", "Broker Name", "Optional broker name.", "broker-a"),
+            ],
+            ResultViewKind::OperationSummary,
+            None,
+        ),
     ]);
 }
 
@@ -1960,6 +2616,66 @@ fn message_commands(commands: &mut Vec<CommandSpec>) {
     ]);
 }
 
+fn static_topic_commands(commands: &mut Vec<CommandSpec>) {
+    commands.extend([
+        spec(
+            "static_topic.update",
+            CommandCategory::StaticTopic,
+            "Update Static Topic",
+            "Create or update static topic queue mapping across brokers and clusters.",
+            RiskLevel::Mutating,
+            vec![
+                required_string("topic", "Topic", "Static topic name.", "StaticTopicA"),
+                required_string(
+                    "broker_names",
+                    "Broker Names",
+                    "Comma-separated broker names.",
+                    "broker-a,broker-b",
+                ),
+                number("queue_num", "Queue Num", "Total queue count.", true, Some(4), Some(1)),
+                optional_string(
+                    "cluster_names",
+                    "Cluster Names",
+                    "Optional comma-separated clusters.",
+                    "DefaultCluster",
+                ),
+            ],
+            ResultViewKind::OperationSummary,
+            None,
+        ),
+        spec(
+            "static_topic.remap",
+            CommandCategory::StaticTopic,
+            "Remap Static Topic",
+            "Remap static topic queues across brokers and clusters.",
+            RiskLevel::Dangerous,
+            vec![
+                required_string("topic", "Topic", "Static topic name.", "StaticTopicA"),
+                optional_string(
+                    "broker_names",
+                    "Broker Names",
+                    "Optional comma-separated broker names.",
+                    "broker-a,broker-b",
+                ),
+                optional_string(
+                    "cluster_names",
+                    "Cluster Names",
+                    "Optional comma-separated clusters.",
+                    "DefaultCluster",
+                ),
+                bool_arg(
+                    "force_replace",
+                    "Force Replace",
+                    "Force replacing existing mapping.",
+                    false,
+                ),
+            ],
+            ResultViewKind::OperationSummary,
+            Some("topic"),
+        ),
+    ]);
+}
+
 fn spec(
     id: &'static str,
     category: CommandCategory,
@@ -2084,6 +2800,83 @@ fn broker_target_args_with(mut extra: Vec<ArgSpec>) -> Vec<ArgSpec> {
     args
 }
 
+fn subscription_group_args(
+    group_field: &'static str,
+    group_label: &'static str,
+    group_help: &'static str,
+    group_placeholder: &'static str,
+) -> Vec<ArgSpec> {
+    broker_target_args_with(vec![
+        required_string(group_field, group_label, group_help, group_placeholder),
+        bool_arg("consume_enable", "Consume Enable", "Enable consumption.", true),
+        bool_arg(
+            "consume_from_min_enable",
+            "Consume From Min",
+            "Enable consume from min offset.",
+            true,
+        ),
+        bool_arg(
+            "consume_broadcast_enable",
+            "Broadcast Enable",
+            "Enable broadcast consumption.",
+            true,
+        ),
+        bool_arg(
+            "consume_message_orderly",
+            "Orderly",
+            "Enable ordered consumption.",
+            false,
+        ),
+        number(
+            "retry_queue_nums",
+            "Retry Queues",
+            "Retry queue count.",
+            true,
+            Some(1),
+            Some(0),
+        ),
+        number(
+            "retry_max_times",
+            "Retry Max",
+            "Maximum retry count.",
+            true,
+            Some(16),
+            Some(0),
+        ),
+        number("broker_id", "Broker ID", "Broker id.", true, Some(0), Some(0)),
+        number(
+            "which_broker_when_consume_slowly",
+            "Slow Broker ID",
+            "Broker id used when consumption is slow.",
+            true,
+            Some(1),
+            Some(0),
+        ),
+        bool_arg(
+            "notify_consumer_ids_changed_enable",
+            "Notify Consumers",
+            "Notify clients after consumer ids change.",
+            true,
+        ),
+        number(
+            "group_sys_flag",
+            "Group Sys Flag",
+            "Group system flag.",
+            true,
+            Some(0),
+            Some(0),
+        ),
+        number(
+            "consume_timeout_minute",
+            "Timeout Minutes",
+            "Consume timeout in minutes.",
+            true,
+            Some(15),
+            Some(1),
+        ),
+    ])
+}
+
 fn topic_target(form: &CommandFormState) -> anyhow::Result<TopicTarget> {
     let target = form.required_string("target")?;
     match form.enum_string("target_type")?.as_str() {
@@ -2114,6 +2907,13 @@ fn message_request_mode(mode: String) -> anyhow::Result<MessageRequestMode> {
         "pop" => Ok(MessageRequestMode::Pop),
         value => bail!("invalid consume mode: {value}"),
     }
+}
+
+fn operation_target_label(broker_addr: Option<String>, cluster_name: Option<String>, fallback: &str) -> String {
+    broker_addr
+        .map(|broker_addr| format!("broker {broker_addr}"))
+        .or_else(|| cluster_name.map(|cluster_name| format!("cluster {cluster_name}")))
+        .unwrap_or_else(|| fallback.to_string())
 }
 
 trait DebugTail {
@@ -2251,5 +3051,60 @@ mod tests {
         let form = CommandFormState::for_command(command);
 
         assert_eq!(command.expected_confirmation(&form), Some("confirm".to_string()));
+    }
+
+    #[test]
+    fn phase_three_catalog_exposes_mutating_management_commands() {
+        let catalog = command_catalog();
+        let ids = catalog.iter().map(|command| command.id).collect::<HashSet<_>>();
+
+        for expected in [
+            "auth.user.create",
+            "auth.user.update",
+            "auth.user.delete",
+            "auth.user.copy",
+            "auth.acl.create",
+            "auth.acl.update",
+            "auth.acl.delete",
+            "auth.acl.copy",
+            "controller.config.update",
+            "controller.metadata.clean",
+            "broker.clean_expired_cq",
+            "broker.delete_expired_commit_log",
+            "broker.clean_unused_topic",
+            "broker.reset_master_flush_offset",
+            "broker.cold_data_flow_ctr_update",
+            "broker.cold_data_flow_ctr_remove",
+            "broker.commit_log_read_ahead",
+            "broker.switch_timer_engine",
+            "consumer.update_subscription_group",
+            "consumer.update_subscription_group_list",
+            "lite.trigger_dispatch",
+            "static_topic.update",
+            "static_topic.remap",
+        ] {
+            assert!(ids.contains(expected), "missing phase 3 command {expected}");
+        }
+    }
+
+    #[test]
+    fn phase_three_dangerous_commands_require_target_confirmation() {
+        let catalog = command_catalog();
+        let command = catalog.iter().find(|command| command.id == "auth.user.delete").unwrap();
+        assert_eq!(command.risk_level, RiskLevel::Dangerous);
+
+        let mut form = CommandFormState::for_command(command);
+        form.set_value("username", "admin-user".to_string());
+        assert_eq!(command.expected_confirmation(&form), Some("admin-user".to_string()));
+
+        let command = catalog
+            .iter()
+            .find(|command| command.id == "controller.metadata.clean")
+            .unwrap();
+        assert_eq!(command.risk_level, RiskLevel::Dangerous);
+
+        let mut form = CommandFormState::for_command(command);
+        form.set_value("broker_name", "broker-a".to_string());
+        assert_eq!(command.expected_confirmation(&form), Some("broker-a".to_string()));
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
@@ -1,13 +1,22 @@
 use std::fmt::Debug;
 
+use rocketmq_admin_core::core::auth::AuthOperationResult;
+use rocketmq_admin_core::core::auth::CopyAclResult;
+use rocketmq_admin_core::core::auth::CopyUsersResult;
+use rocketmq_admin_core::core::broker::BrokerBooleanOperationResult;
 use rocketmq_admin_core::core::broker::BrokerConsumeStatsResult;
+use rocketmq_admin_core::core::broker::BrokerOperationResult;
+use rocketmq_admin_core::core::broker::CleanExpiredConsumeQueueReport;
+use rocketmq_admin_core::core::broker::CommitLogReadAheadResult;
 use rocketmq_admin_core::core::cluster::ClusterListMode;
 use rocketmq_admin_core::core::cluster::ClusterListQueryResult;
 use rocketmq_admin_core::core::cluster::ClusterSendMessageRtResult;
 use rocketmq_admin_core::core::connection::ConsumerConnectionQueryResult;
 use rocketmq_admin_core::core::connection::ProducerConnectionQueryResult;
+use rocketmq_admin_core::core::consumer::ConsumerOperationResult;
 use rocketmq_admin_core::core::consumer::ConsumerProgressResult;
 use rocketmq_admin_core::core::consumer::ConsumerRunningInfoResult;
+use rocketmq_admin_core::core::lite::TriggerLiteDispatchResult;
 use rocketmq_admin_core::core::message::DecodeMessageIdOutcome;
 use rocketmq_admin_core::core::message::DecodeMessageIdResult;
 use rocketmq_admin_core::core::message::MessageTraceView;
@@ -181,6 +190,22 @@ impl CommandResultViewModel {
         })
     }
 
+    pub fn operation_summary(
+        title: impl Into<String>,
+        success_count: usize,
+        failure_count: usize,
+        targets: Vec<String>,
+        errors: Vec<String>,
+    ) -> Self {
+        Self::OperationSummary(OperationSummaryViewModel {
+            title: title.into(),
+            success_count,
+            failure_count,
+            targets,
+            errors,
+        })
+    }
+
     pub fn error(title: impl Into<String>, body: impl Into<String>) -> Self {
         Self::Text {
             title: title.into(),
@@ -190,6 +215,176 @@ impl CommandResultViewModel {
 
     pub fn key_value_sorted(title: impl Into<String>, rows: Vec<(String, String)>) -> Self {
         Self::KeyValue(KeyValueViewModel::sorted(title, rows))
+    }
+
+    pub fn auth_operation(title: impl Into<String>, result: &AuthOperationResult) -> Self {
+        let targets = result.broker_addrs.iter().map(ToString::to_string).collect::<Vec<_>>();
+        Self::operation_summary(title, targets.len(), 0, targets, Vec::new())
+    }
+
+    pub fn auth_copy_users(title: impl Into<String>, result: &CopyUsersResult) -> Self {
+        let mut targets = result
+            .copied_usernames
+            .iter()
+            .map(|username| format!("copied user: {username}"))
+            .collect::<Vec<_>>();
+        targets.extend(
+            result
+                .skipped_usernames
+                .iter()
+                .map(|username| format!("skipped user: {username}")),
+        );
+        let errors = result
+            .failures
+            .iter()
+            .map(|failure| format!("{}: {}", failure.broker_addr, failure.error))
+            .collect::<Vec<_>>();
+        Self::operation_summary(
+            title,
+            result.copied_usernames.len(),
+            result.failures.len(),
+            targets,
+            errors,
+        )
+    }
+
+    pub fn auth_copy_acl(title: impl Into<String>, result: &CopyAclResult) -> Self {
+        let mut targets = result
+            .copied_subjects
+            .iter()
+            .map(|subject| format!("copied subject: {subject}"))
+            .collect::<Vec<_>>();
+        targets.extend(
+            result
+                .skipped_subjects
+                .iter()
+                .map(|subject| format!("skipped subject: {subject}")),
+        );
+        let errors = result
+            .failures
+            .iter()
+            .map(|failure| format!("{}: {}", failure.broker_addr, failure.error))
+            .collect::<Vec<_>>();
+        Self::operation_summary(
+            title,
+            result.copied_subjects.len(),
+            result.failures.len(),
+            targets,
+            errors,
+        )
+    }
+
+    pub fn broker_operation(title: impl Into<String>, result: &BrokerOperationResult) -> Self {
+        let targets = result.broker_addrs.iter().map(ToString::to_string).collect::<Vec<_>>();
+        let errors = result
+            .failures
+            .iter()
+            .map(|failure| format!("{}: {}", failure.broker_addr, failure.error))
+            .collect::<Vec<_>>();
+        Self::operation_summary(title, result.broker_addrs.len(), result.failures.len(), targets, errors)
+    }
+
+    pub fn broker_boolean_operation(
+        title: impl Into<String>,
+        target: impl Into<String>,
+        result: &BrokerBooleanOperationResult,
+    ) -> Self {
+        let target = target.into();
+        let errors = if result.success {
+            Vec::new()
+        } else {
+            vec![format!("{target}: operation returned false")]
+        };
+        Self::operation_summary(
+            title,
+            usize::from(result.success),
+            usize::from(!result.success),
+            vec![target],
+            errors,
+        )
+    }
+
+    pub fn clean_expired_consume_queue(title: impl Into<String>, result: &CleanExpiredConsumeQueueReport) -> Self {
+        let mut targets = result
+            .targets
+            .iter()
+            .map(|target| {
+                if result.dry_run {
+                    format!("dry-run target: {target}")
+                } else {
+                    target.to_string()
+                }
+            })
+            .collect::<Vec<_>>();
+        targets.push(format!("scanned brokers: {}", result.scanned_brokers));
+        targets.push(format!("cleanup invocations: {}", result.cleanup_invocations));
+        let false_results = result
+            .target_results
+            .iter()
+            .filter(|target| !target.success)
+            .map(|target| format!("{}: operation returned false", target.broker_addr))
+            .collect::<Vec<_>>();
+        let mut errors = false_results;
+        errors.extend(
+            result
+                .failures
+                .iter()
+                .map(|failure| format!("{}: {}", failure.broker_addr, failure.error)),
+        );
+        Self::operation_summary(
+            title,
+            result.cleanup_successes,
+            result.cleanup_false_results + result.failures.len(),
+            targets,
+            errors,
+        )
+    }
+
+    pub fn commit_log_read_ahead(title: impl Into<String>, result: &CommitLogReadAheadResult) -> Self {
+        let targets = result
+            .sections
+            .iter()
+            .map(|section| {
+                let status = if section.applied { "applied" } else { "inspected" };
+                format!("{}: {status}", section.broker_addr)
+            })
+            .collect::<Vec<_>>();
+        let errors = result
+            .failures
+            .iter()
+            .map(|failure| format!("{}: {}", failure.broker_addr, failure.error))
+            .collect::<Vec<_>>();
+        Self::operation_summary(title, result.sections.len(), result.failures.len(), targets, errors)
+    }
+
+    pub fn consumer_operation(title: impl Into<String>, result: &ConsumerOperationResult) -> Self {
+        let mut targets = result.broker_addrs.iter().map(ToString::to_string).collect::<Vec<_>>();
+        targets.extend(result.warnings.iter().map(|warning| format!("warning: {warning}")));
+        let errors = result
+            .failures
+            .iter()
+            .map(|failure| format!("{}: {}", failure.broker_addr, failure.error))
+            .collect::<Vec<_>>();
+        Self::operation_summary(title, result.broker_addrs.len(), result.failures.len(), targets, errors)
+    }
+
+    pub fn lite_trigger_dispatch(title: impl Into<String>, result: &TriggerLiteDispatchResult) -> Self {
+        let targets = result
+            .entries
+            .iter()
+            .filter(|entry| entry.dispatched)
+            .map(|entry| entry.broker_name.to_string())
+            .collect::<Vec<_>>();
+        let errors = result
+            .entries
+            .iter()
+            .filter(|entry| !entry.dispatched)
+            .map(|entry| {
+                let error = entry.error.as_deref().unwrap_or("dispatch returned false");
+                format!("{}: {error}", entry.broker_name)
+            })
+            .collect::<Vec<_>>();
+        Self::operation_summary(title, targets.len(), errors.len(), targets, errors)
     }
 
     pub fn cluster_list(title: impl Into<String>, result: &ClusterListQueryResult) -> Self {
@@ -1048,8 +1243,11 @@ fn truncate_cell(value: &str, max_chars: usize) -> String {
 
 #[cfg(test)]
 mod tests {
+    use rocketmq_admin_core::core::auth::AuthOperationResult;
     use rocketmq_admin_core::core::broker::BrokerConsumeStatsResult;
     use rocketmq_admin_core::core::broker::BrokerConsumeStatsRow;
+    use rocketmq_admin_core::core::broker::BrokerOperationFailure;
+    use rocketmq_admin_core::core::broker::BrokerOperationResult;
     use rocketmq_admin_core::core::cluster::ClusterBaseInfoRow;
     use rocketmq_admin_core::core::cluster::ClusterListMode;
     use rocketmq_admin_core::core::cluster::ClusterListQueryResult;
@@ -1058,6 +1256,8 @@ mod tests {
     use rocketmq_admin_core::core::connection::ConsumerConnectionQueryResult;
     use rocketmq_admin_core::core::connection::ProducerConnectionQueryResult;
     use rocketmq_admin_core::core::consumer::ConsumerGroupProgressResult;
+    use rocketmq_admin_core::core::consumer::ConsumerOperationFailure;
+    use rocketmq_admin_core::core::consumer::ConsumerOperationResult;
     use rocketmq_admin_core::core::consumer::ConsumerProgressResult;
     use rocketmq_admin_core::core::consumer::ConsumerProgressRow;
     use rocketmq_admin_core::core::consumer::ConsumerRunningInfoItem;
@@ -1899,6 +2099,48 @@ mod tests {
         assert_table(&result, &["Attempt", "RT", "Result"], &["1", "12", "SEND_OK"]);
     }
 
+    #[test]
+    fn phase_three_operation_results_render_partial_failures_as_summary() {
+        let auth = CommandResultViewModel::auth_operation(
+            "Create User",
+            &AuthOperationResult {
+                broker_addrs: vec!["127.0.0.1:10911".into()],
+            },
+        );
+        assert_summary(&auth, 1, 0, &["127.0.0.1:10911"], &[]);
+
+        let broker = CommandResultViewModel::broker_operation(
+            "Cold Data Flow Control",
+            &BrokerOperationResult {
+                broker_addrs: vec!["127.0.0.1:10911".into()],
+                failures: vec![BrokerOperationFailure {
+                    broker_addr: "127.0.0.1:10912".into(),
+                    error: "timeout".to_string(),
+                }],
+            },
+        );
+        assert_summary(&broker, 1, 1, &["127.0.0.1:10911"], &["127.0.0.1:10912: timeout"]);
+
+        let consumer = CommandResultViewModel::consumer_operation(
+            "Update Subscription Group",
+            &ConsumerOperationResult {
+                broker_addrs: vec!["127.0.0.1:10911".into()],
+                failures: vec![ConsumerOperationFailure {
+                    broker_addr: "127.0.0.1:10912".into(),
+                    error: "rejected".to_string(),
+                }],
+                warnings: vec!["retry topic cleanup failed".to_string()],
+            },
+        );
+        assert_summary(
+            &consumer,
+            1,
+            1,
+            &["127.0.0.1:10911", "warning: retry topic cleanup failed"],
+            &["127.0.0.1:10912: rejected"],
+        );
+    }
+
     fn assert_table(result: &CommandResultViewModel, headers: &[&str], first_row: &[&str]) {
         let CommandResultViewModel::Table(table) = result else {
             panic!("expected table result, got {result:?}");
@@ -1910,6 +2152,28 @@ mod tests {
         assert_eq!(
             table.rows.first(),
             Some(&first_row.iter().map(|cell| (*cell).to_string()).collect::<Vec<_>>())
+        );
+    }
+
+    fn assert_summary(
+        result: &CommandResultViewModel,
+        success_count: usize,
+        failure_count: usize,
+        targets: &[&str],
+        errors: &[&str],
+    ) {
+        let CommandResultViewModel::OperationSummary(summary) = result else {
+            panic!("expected operation summary result, got {result:?}");
+        };
+        assert_eq!(summary.success_count, success_count);
+        assert_eq!(summary.failure_count, failure_count);
+        assert_eq!(
+            summary.targets,
+            targets.iter().map(|value| (*value).to_string()).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            summary.errors,
+            errors.iter().map(|value| (*value).to_string()).collect::<Vec<_>>()
         );
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7168

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication management: create, update, delete, and copy users and ACLs.
  * Added broker maintenance operations: clean expired queues, reset offsets, update configurations, and tune performance settings.
  * Added controller configuration management and metadata cleanup.
  * Added consumer subscription group update capabilities.
  * Added static topic management and remapping functionality.
  * Added lite dispatch triggering support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->