### PR TITLE
[ISSUE #7172]🚀feat(consumer): add start monitoring command with event streaming and diagnostics

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/consumer/start_monitoring_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/consumer/start_monitoring_sub_command.rs
@@ -40,7 +40,11 @@ impl StartMonitoringSubCommand {
 
 impl CommandExecute for StartMonitoringSubCommand {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> rocketmq_error::RocketMQResult<()> {
-        ConsumerService::start_monitoring_by_request_with_rpc_hook(self.request(), rpc_hook)
+        let result = ConsumerService::start_monitoring_by_request_with_rpc_hook(self.request(), rpc_hook).await?;
+        for event in result.events {
+            println!("{event:?}");
+        }
+        Ok(())
     }
 }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
@@ -18,6 +18,10 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
@@ -39,7 +43,6 @@ use crate::admin::default_mq_admin_ext::DefaultMQAdminExt;
 use crate::core::admin::AdminBuilder;
 use crate::core::broker::BrokerTarget;
 use crate::core::resolver::BrokerAddressResolver;
-use crate::core::RocketMQError;
 use crate::core::RocketMQResult;
 use crate::core::ToolsError;
 
@@ -47,6 +50,13 @@ fn trim_optional_string(value: Option<String>) -> Option<String> {
     value
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+fn current_time_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
 }
 
 fn trim_required_cheetah(field: &'static str, value: impl Into<String>) -> RocketMQResult<CheetahString> {
@@ -397,22 +407,130 @@ impl ConsumerProgressRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StartMonitoringRequest {
     namesrv_addr: Option<String>,
+    round_count: u32,
+    round_interval_millis: u64,
+    include_undone_msgs: bool,
+    include_running_info: bool,
+    max_events: Option<usize>,
 }
 
 impl StartMonitoringRequest {
+    pub const DEFAULT_ROUND_COUNT: u32 = 1;
+    pub const DEFAULT_ROUND_INTERVAL_MILLIS: u64 = 60_000;
+
     pub fn new(namesrv_addr: Option<String>) -> Self {
         Self {
             namesrv_addr: trim_optional_string(namesrv_addr),
+            round_count: Self::DEFAULT_ROUND_COUNT,
+            round_interval_millis: Self::DEFAULT_ROUND_INTERVAL_MILLIS,
+            include_undone_msgs: true,
+            include_running_info: true,
+            max_events: None,
         }
+    }
+
+    pub fn try_new(
+        namesrv_addr: Option<String>,
+        round_count: u32,
+        round_interval_millis: u64,
+        include_undone_msgs: bool,
+        include_running_info: bool,
+        max_events: Option<usize>,
+    ) -> RocketMQResult<Self> {
+        if round_count == 0 {
+            return Err(ToolsError::validation_error("roundCount", "roundCount must be greater than zero").into());
+        }
+        if round_interval_millis == 0 {
+            return Err(ToolsError::validation_error(
+                "roundIntervalMillis",
+                "roundIntervalMillis must be greater than zero",
+            )
+            .into());
+        }
+        if max_events == Some(0) {
+            return Err(ToolsError::validation_error("maxEvents", "maxEvents must be greater than zero").into());
+        }
+        Ok(Self {
+            namesrv_addr: trim_optional_string(namesrv_addr),
+            round_count,
+            round_interval_millis,
+            include_undone_msgs,
+            include_running_info,
+            max_events,
+        })
     }
 
     pub fn namesrv_addr(&self) -> Option<&str> {
         self.namesrv_addr.as_deref()
     }
 
+    pub fn round_count(&self) -> u32 {
+        self.round_count
+    }
+
+    pub fn round_interval_millis(&self) -> u64 {
+        self.round_interval_millis
+    }
+
+    pub fn include_undone_msgs(&self) -> bool {
+        self.include_undone_msgs
+    }
+
+    pub fn include_running_info(&self) -> bool {
+        self.include_running_info
+    }
+
+    pub fn max_events(&self) -> Option<usize> {
+        self.max_events
+    }
+
     pub fn admin_builder(&self) -> AdminBuilder {
         builder_with_namesrv(self.namesrv_addr())
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MonitoringEvent {
+    BeginRound {
+        round: u32,
+        timestamp_millis: u64,
+    },
+    UndoneMsgs {
+        round: u32,
+        consumer_group: String,
+        topic: String,
+        undone_msgs_total: i64,
+        undone_msgs_single_mq: i64,
+        undone_msgs_delay_time_millis: Option<i64>,
+    },
+    ConsumerRunningInfo {
+        round: u32,
+        consumer_group: String,
+        client_count: usize,
+        subscription_consistent: Option<bool>,
+        process_queue_analysis: Vec<String>,
+    },
+    Error {
+        round: u32,
+        consumer_group: Option<String>,
+        operation: String,
+        error: String,
+    },
+    EndRound {
+        round: u32,
+        elapsed_millis: u64,
+        groups_scanned: usize,
+        events_emitted: usize,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MonitoringResult {
+    pub events: Vec<MonitoringEvent>,
+    pub rounds_completed: u32,
+    pub groups_scanned: usize,
+    pub error_count: usize,
+    pub truncated: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -878,13 +996,261 @@ impl ConsumerService {
         }
     }
 
-    pub fn start_monitoring_by_request_with_rpc_hook(
-        _request: StartMonitoringRequest,
-        _rpc_hook: Option<Arc<dyn RPCHook>>,
-    ) -> RocketMQResult<()> {
-        Err(RocketMQError::Internal(
-            "ConsumerService: MonitorService is not implemented yet".to_string(),
-        ))
+    pub async fn start_monitoring_by_request_with_rpc_hook(
+        request: StartMonitoringRequest,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> RocketMQResult<MonitoringResult> {
+        Self::start_monitoring_with_event_sink_by_request_with_rpc_hook(request, rpc_hook, |_| Ok(())).await
+    }
+
+    pub async fn start_monitoring_with_event_sink_by_request_with_rpc_hook<F>(
+        request: StartMonitoringRequest,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+        mut event_sink: F,
+    ) -> RocketMQResult<MonitoringResult>
+    where
+        F: FnMut(&MonitoringEvent) -> RocketMQResult<()>,
+    {
+        let mut admin = admin_builder_with_rpc_hook(request.admin_builder(), rpc_hook)
+            .build_and_start()
+            .await?;
+        let result = Self::start_monitoring_with_admin(&admin, &request, &mut event_sink).await;
+        admin.shutdown().await;
+        result
+    }
+
+    pub async fn start_monitoring_with_admin<F>(
+        admin: &DefaultMQAdminExt,
+        request: &StartMonitoringRequest,
+        event_sink: &mut F,
+    ) -> RocketMQResult<MonitoringResult>
+    where
+        F: FnMut(&MonitoringEvent) -> RocketMQResult<()>,
+    {
+        let mut events = Vec::new();
+        let mut truncated = false;
+        let mut groups_scanned = 0_usize;
+        let mut error_count = 0_usize;
+        let mut rounds_completed = 0_u32;
+
+        for round in 1..=request.round_count() {
+            let round_start = Instant::now();
+            let events_before_round = events.len();
+            Self::emit_monitoring_event(
+                &mut events,
+                request.max_events(),
+                &mut truncated,
+                event_sink,
+                MonitoringEvent::BeginRound {
+                    round,
+                    timestamp_millis: current_time_millis(),
+                },
+            )?;
+
+            match admin.fetch_all_topic_list().await {
+                Ok(topic_list) => {
+                    let mut retry_topics = topic_list
+                        .topic_list
+                        .into_iter()
+                        .filter(|topic| topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX))
+                        .collect::<Vec<_>>();
+                    retry_topics.sort();
+
+                    for retry_topic in retry_topics {
+                        let consumer_group = KeyBuilder::parse_group(&retry_topic);
+                        groups_scanned += 1;
+                        if request.include_undone_msgs() {
+                            match Self::query_consumer_progress_with_admin(
+                                admin,
+                                &ConsumerProgressRequest::try_new(
+                                    Some(consumer_group.clone()),
+                                    None,
+                                    false,
+                                    None,
+                                    None,
+                                )?,
+                            )
+                            .await
+                            {
+                                Ok(progress) => {
+                                    for event in
+                                        Self::monitoring_events_from_progress_result(round, &consumer_group, &progress)
+                                    {
+                                        Self::emit_monitoring_event(
+                                            &mut events,
+                                            request.max_events(),
+                                            &mut truncated,
+                                            event_sink,
+                                            event,
+                                        )?;
+                                    }
+                                }
+                                Err(error) => {
+                                    error_count += 1;
+                                    Self::emit_monitoring_event(
+                                        &mut events,
+                                        request.max_events(),
+                                        &mut truncated,
+                                        event_sink,
+                                        MonitoringEvent::Error {
+                                            round,
+                                            consumer_group: Some(consumer_group.clone()),
+                                            operation: "examineConsumeStats".to_string(),
+                                            error: error.to_string(),
+                                        },
+                                    )?;
+                                }
+                            }
+                        }
+
+                        if request.include_running_info() {
+                            match Self::query_consumer_running_info_with_admin(
+                                admin,
+                                &ConsumerRunningInfoRequest::try_new(consumer_group.clone(), None, None, false, None)?,
+                            )
+                            .await
+                            {
+                                Ok(running_info) => {
+                                    Self::emit_monitoring_event(
+                                        &mut events,
+                                        request.max_events(),
+                                        &mut truncated,
+                                        event_sink,
+                                        Self::monitoring_event_from_running_info_result(
+                                            round,
+                                            &consumer_group,
+                                            &running_info,
+                                        ),
+                                    )?;
+                                }
+                                Err(error) => {
+                                    error_count += 1;
+                                    Self::emit_monitoring_event(
+                                        &mut events,
+                                        request.max_events(),
+                                        &mut truncated,
+                                        event_sink,
+                                        MonitoringEvent::Error {
+                                            round,
+                                            consumer_group: Some(consumer_group),
+                                            operation: "consumerRunningInfo".to_string(),
+                                            error: error.to_string(),
+                                        },
+                                    )?;
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(error) => {
+                    error_count += 1;
+                    Self::emit_monitoring_event(
+                        &mut events,
+                        request.max_events(),
+                        &mut truncated,
+                        event_sink,
+                        MonitoringEvent::Error {
+                            round,
+                            consumer_group: None,
+                            operation: "fetchAllTopicList".to_string(),
+                            error: error.to_string(),
+                        },
+                    )?;
+                }
+            }
+
+            rounds_completed = round;
+            let events_emitted = events.len().saturating_sub(events_before_round);
+            Self::emit_monitoring_event(
+                &mut events,
+                request.max_events(),
+                &mut truncated,
+                event_sink,
+                MonitoringEvent::EndRound {
+                    round,
+                    elapsed_millis: round_start.elapsed().as_millis() as u64,
+                    groups_scanned,
+                    events_emitted,
+                },
+            )?;
+
+            if round < request.round_count() {
+                tokio::time::sleep(Duration::from_millis(request.round_interval_millis())).await;
+            }
+        }
+
+        Ok(MonitoringResult {
+            events,
+            rounds_completed,
+            groups_scanned,
+            error_count,
+            truncated,
+        })
+    }
+
+    pub fn monitoring_events_from_progress_result(
+        round: u32,
+        consumer_group: &str,
+        result: &ConsumerProgressResult,
+    ) -> Vec<MonitoringEvent> {
+        let ConsumerProgressResult::Group(progress) = result else {
+            return Vec::new();
+        };
+
+        let mut by_topic: BTreeMap<String, (i64, i64)> = BTreeMap::new();
+        for row in &progress.rows {
+            let lag = row.diff.max(0);
+            let entry = by_topic.entry(row.topic.to_string()).or_default();
+            entry.0 += lag;
+            entry.1 = entry.1.max(lag);
+        }
+
+        by_topic
+            .into_iter()
+            .map(
+                |(topic, (undone_msgs_total, undone_msgs_single_mq))| MonitoringEvent::UndoneMsgs {
+                    round,
+                    consumer_group: consumer_group.to_string(),
+                    topic,
+                    undone_msgs_total,
+                    undone_msgs_single_mq,
+                    undone_msgs_delay_time_millis: None,
+                },
+            )
+            .collect()
+    }
+
+    pub fn monitoring_event_from_running_info_result(
+        round: u32,
+        consumer_group: &str,
+        result: &ConsumerRunningInfoResult,
+    ) -> MonitoringEvent {
+        MonitoringEvent::ConsumerRunningInfo {
+            round,
+            consumer_group: consumer_group.to_string(),
+            client_count: result.items.len(),
+            subscription_consistent: result.subscription_consistent,
+            process_queue_analysis: result.process_queue_analysis.clone(),
+        }
+    }
+
+    fn emit_monitoring_event<F>(
+        events: &mut Vec<MonitoringEvent>,
+        max_events: Option<usize>,
+        truncated: &mut bool,
+        event_sink: &mut F,
+        event: MonitoringEvent,
+    ) -> RocketMQResult<()>
+    where
+        F: FnMut(&MonitoringEvent) -> RocketMQResult<()>,
+    {
+        if max_events.is_some_and(|max_events| events.len() >= max_events) {
+            *truncated = true;
+            return Ok(());
+        }
+        event_sink(&event)?;
+        events.push(event);
+        Ok(())
     }
 }
 
@@ -1025,11 +1391,122 @@ mod tests {
     }
 
     #[test]
-    fn start_monitoring_request_trims_namesrv() {
+    fn start_monitoring_request_trims_namesrv_and_validates_limits() {
         let request = StartMonitoringRequest::new(Some(" 127.0.0.1:9876 ".into()));
         assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+        assert_eq!(request.round_count(), StartMonitoringRequest::DEFAULT_ROUND_COUNT);
+        assert_eq!(
+            request.round_interval_millis(),
+            StartMonitoringRequest::DEFAULT_ROUND_INTERVAL_MILLIS
+        );
+        assert!(request.include_undone_msgs());
+        assert!(request.include_running_info());
+        assert_eq!(request.max_events(), None);
 
         let request = StartMonitoringRequest::new(Some(" ".into()));
         assert_eq!(request.namesrv_addr(), None);
+
+        let request =
+            StartMonitoringRequest::try_new(Some(" 127.0.0.1:9876 ".into()), 2, 1_000, true, false, Some(16)).unwrap();
+        assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+        assert_eq!(request.round_count(), 2);
+        assert_eq!(request.round_interval_millis(), 1_000);
+        assert!(request.include_undone_msgs());
+        assert!(!request.include_running_info());
+        assert_eq!(request.max_events(), Some(16));
+
+        assert!(StartMonitoringRequest::try_new(None, 0, 1_000, true, true, None).is_err());
+        assert!(StartMonitoringRequest::try_new(None, 1, 0, true, true, None).is_err());
+        assert!(StartMonitoringRequest::try_new(None, 1, 1_000, true, true, Some(0)).is_err());
+    }
+
+    #[test]
+    fn monitoring_progress_conversion_groups_lag_by_topic() {
+        let result = ConsumerProgressResult::Group(ConsumerGroupProgressResult {
+            rows: vec![
+                ConsumerProgressRow {
+                    topic: "TopicA".into(),
+                    broker_name: "broker-a".into(),
+                    queue_id: 0,
+                    broker_offset: 100,
+                    consumer_offset: 95,
+                    client_ip: None,
+                    diff: 5,
+                    inflight: 0,
+                    last_timestamp: 0,
+                },
+                ConsumerProgressRow {
+                    topic: "TopicA".into(),
+                    broker_name: "broker-a".into(),
+                    queue_id: 1,
+                    broker_offset: 120,
+                    consumer_offset: 117,
+                    client_ip: None,
+                    diff: 3,
+                    inflight: 0,
+                    last_timestamp: 0,
+                },
+                ConsumerProgressRow {
+                    topic: "TopicB".into(),
+                    broker_name: "broker-b".into(),
+                    queue_id: 0,
+                    broker_offset: 10,
+                    consumer_offset: 11,
+                    client_ip: None,
+                    diff: -1,
+                    inflight: 0,
+                    last_timestamp: 0,
+                },
+            ],
+            consume_tps: 10.0,
+            diff_total: 7,
+            inflight_total: 0,
+            show_client_ip: false,
+        });
+
+        let events = ConsumerService::monitoring_events_from_progress_result(3, "GroupA", &result);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            &events[0],
+            MonitoringEvent::UndoneMsgs {
+                round: 3,
+                consumer_group,
+                topic,
+                undone_msgs_total: 8,
+                undone_msgs_single_mq: 5,
+                undone_msgs_delay_time_millis: None,
+            } if consumer_group == "GroupA" && topic == "TopicA"
+        ));
+        assert!(matches!(
+            &events[1],
+            MonitoringEvent::UndoneMsgs {
+                topic,
+                undone_msgs_total: 0,
+                undone_msgs_single_mq: 0,
+                ..
+            } if topic == "TopicB"
+        ));
+    }
+
+    #[test]
+    fn monitoring_running_info_conversion_preserves_diagnostics() {
+        let result = ConsumerRunningInfoResult {
+            items: Vec::new(),
+            subscription_consistent: Some(false),
+            process_queue_analysis: vec!["client-a process queue stalled".to_string()],
+        };
+
+        let event = ConsumerService::monitoring_event_from_running_info_result(2, "GroupA", &result);
+        assert!(matches!(
+            event,
+            MonitoringEvent::ConsumerRunningInfo {
+                round: 2,
+                ref consumer_group,
+                client_count: 0,
+                subscription_consistent: Some(false),
+                ref process_queue_analysis,
+            } if consumer_group == "GroupA"
+                && process_queue_analysis == &vec!["client-a process queue stalled".to_string()]
+        ));
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
@@ -79,7 +79,10 @@ use rocketmq_admin_core::core::consumer::ConsumerRunningInfoRequest;
 use rocketmq_admin_core::core::consumer::ConsumerRunningInfoResult;
 use rocketmq_admin_core::core::consumer::ConsumerService;
 use rocketmq_admin_core::core::consumer::DeleteSubscriptionGroupRequest;
+use rocketmq_admin_core::core::consumer::MonitoringEvent;
+use rocketmq_admin_core::core::consumer::MonitoringResult;
 use rocketmq_admin_core::core::consumer::SetConsumeModeRequest;
+use rocketmq_admin_core::core::consumer::StartMonitoringRequest;
 use rocketmq_admin_core::core::consumer::UpdateSubscriptionGroupListRequest;
 use rocketmq_admin_core::core::consumer::UpdateSubscriptionGroupRequest;
 use rocketmq_admin_core::core::controller::ControllerConfigQueryRequest;
@@ -813,6 +816,24 @@ impl TuiAdminFacade {
             show_client_ip,
             cluster,
             self.namesrv_addr.clone(),
+        )
+    }
+
+    pub fn start_monitoring_request(
+        &self,
+        round_count: u32,
+        round_interval_millis: u64,
+        include_undone_msgs: bool,
+        include_running_info: bool,
+        max_events: Option<usize>,
+    ) -> RocketMQResult<StartMonitoringRequest> {
+        StartMonitoringRequest::try_new(
+            self.namesrv_addr.clone(),
+            round_count,
+            round_interval_millis,
+            include_undone_msgs,
+            include_running_info,
+            max_events,
         )
     }
 
@@ -2099,6 +2120,34 @@ impl TuiAdminFacade {
         .await
     }
 
+    pub async fn start_monitoring_with_progress<F>(
+        &self,
+        round_count: u32,
+        round_interval_millis: u64,
+        include_undone_msgs: bool,
+        include_running_info: bool,
+        max_events: usize,
+        mut progress: F,
+    ) -> RocketMQResult<MonitoringResult>
+    where
+        F: FnMut(String),
+    {
+        let request = self.start_monitoring_request(
+            round_count,
+            round_interval_millis,
+            include_undone_msgs,
+            include_running_info,
+            Some(max_events),
+        )?;
+        let mut event_count = 0usize;
+        ConsumerService::start_monitoring_with_event_sink_by_request_with_rpc_hook(request, None, |event| {
+            event_count += 1;
+            progress(monitoring_progress_message(event_count, event));
+            Ok(())
+        })
+        .await
+    }
+
     pub async fn clone_group_offset(
         &self,
         src_group: impl Into<String>,
@@ -2655,6 +2704,47 @@ impl TuiAdminFacade {
     }
 }
 
+fn monitoring_progress_message(event_count: usize, event: &MonitoringEvent) -> String {
+    let detail = match event {
+        MonitoringEvent::BeginRound { round, .. } => format!("begin round {round}"),
+        MonitoringEvent::UndoneMsgs {
+            round,
+            consumer_group,
+            topic,
+            undone_msgs_total,
+            ..
+        } => format!("round {round} {consumer_group}/{topic} lag {undone_msgs_total}"),
+        MonitoringEvent::ConsumerRunningInfo {
+            round,
+            consumer_group,
+            client_count,
+            subscription_consistent,
+            ..
+        } => format!(
+            "round {round} {consumer_group} running clients {client_count}, subscription consistent: {}",
+            subscription_consistent
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        ),
+        MonitoringEvent::Error {
+            round,
+            consumer_group,
+            operation,
+            error,
+        } => format!(
+            "round {round} {} {operation} failed: {error}",
+            consumer_group.as_deref().unwrap_or("cluster")
+        ),
+        MonitoringEvent::EndRound {
+            round,
+            elapsed_millis,
+            groups_scanned,
+            ..
+        } => format!("end round {round}, scanned {groups_scanned} groups in {elapsed_millis} ms"),
+    };
+    format!("monitor event {event_count}: {detail}")
+}
+
 const MESSAGE_EVENT_LIMIT_REACHED: &str = "__rocketmq_admin_tui_message_event_limit_reached__";
 
 fn message_pull_progress_message(event_count: usize, event: &MessagePullEvent) -> String {
@@ -2781,6 +2871,7 @@ fn split_message_ids(value: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::TuiAdminFacade;
+    use rocketmq_admin_core::core::consumer::MonitoringEvent;
     use rocketmq_admin_core::core::message::MessagePullEvent;
 
     #[test]
@@ -3064,6 +3155,16 @@ mod tests {
         assert_eq!(progress.consumer_group().unwrap().as_str(), "GroupA");
         assert!(progress.show_client_ip());
 
+        let monitoring = facade
+            .start_monitoring_request(2, 1_000, true, false, Some(32))
+            .unwrap();
+        assert_eq!(monitoring.namesrv_addr(), Some("127.0.0.1:9876"));
+        assert_eq!(monitoring.round_count(), 2);
+        assert_eq!(monitoring.round_interval_millis(), 1_000);
+        assert!(monitoring.include_undone_msgs());
+        assert!(!monitoring.include_running_info());
+        assert_eq!(monitoring.max_events(), Some(32));
+
         let reset = facade
             .reset_offset_by_time_request(" GroupA ", " TopicA ", 1234)
             .unwrap();
@@ -3135,6 +3236,7 @@ mod tests {
             false,
             Some("DefaultCluster".to_string()),
         ));
+        std::mem::drop(facade.start_monitoring_with_progress(1, 1_000, true, true, 16, |_| {}));
         std::mem::drop(facade.clone_group_offset("SourceGroup", "DestGroup", "TopicA", false));
         std::mem::drop(facade.query_consumer_status("GroupA", "TopicA", Some("client-a".to_string())));
         std::mem::drop(facade.skip_accumulated_message(
@@ -3562,6 +3664,25 @@ mod tests {
 
         assert!(message.contains("3"));
         assert!(message.contains("separator"));
+    }
+
+    #[test]
+    fn phase_five_monitoring_progress_messages_include_event_context() {
+        let message = super::monitoring_progress_message(
+            2,
+            &MonitoringEvent::UndoneMsgs {
+                round: 1,
+                consumer_group: "GroupA".to_string(),
+                topic: "TopicA".to_string(),
+                undone_msgs_total: 42,
+                undone_msgs_single_mq: 40,
+                undone_msgs_delay_time_millis: None,
+            },
+        );
+
+        assert!(message.contains("2"));
+        assert!(message.contains("GroupA/TopicA"));
+        assert!(message.contains("42"));
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
@@ -719,6 +719,21 @@ where
                 .await?;
             CommandResultViewModel::consumer_progress(spec.title, &result)
         }
+        "consumer.start_monitoring" => {
+            let max_events =
+                usize::try_from(form.number_u64("max_events")?).context("max_events is out of range for usize")?;
+            let result = facade
+                .start_monitoring_with_progress(
+                    form.number_u32("round_count")?,
+                    form.number_u64("round_interval_millis")?,
+                    form.bool_value("include_undone_msgs")?,
+                    form.bool_value("include_running_info")?,
+                    max_events,
+                    &mut progress,
+                )
+                .await?;
+            CommandResultViewModel::consumer_monitoring(spec.title, &result)
+        }
         "consumer.delete_subscription_group" => {
             let group = form.required_string("group_name")?;
             let result = facade
@@ -2159,6 +2174,53 @@ fn consumer_commands(commands: &mut Vec<CommandSpec>) {
             None,
         ),
         spec(
+            "consumer.start_monitoring",
+            CommandCategory::Consumer,
+            "Start Monitoring",
+            "Run bounded consumer monitoring rounds and stream typed monitor events.",
+            RiskLevel::Safe,
+            vec![
+                number(
+                    "round_count",
+                    "Rounds",
+                    "Monitoring round count.",
+                    true,
+                    Some(1),
+                    Some(1),
+                ),
+                number(
+                    "round_interval_millis",
+                    "Round Interval",
+                    "Delay between rounds in milliseconds.",
+                    true,
+                    Some(60_000),
+                    Some(1),
+                ),
+                bool_arg(
+                    "include_undone_msgs",
+                    "Undone Msgs",
+                    "Report consumer lag by topic.",
+                    true,
+                ),
+                bool_arg(
+                    "include_running_info",
+                    "Running Info",
+                    "Report consumer running-info diagnostics.",
+                    true,
+                ),
+                number(
+                    "max_events",
+                    "Max Events",
+                    "Maximum monitor events to keep.",
+                    true,
+                    Some(128),
+                    Some(1),
+                ),
+            ],
+            ResultViewKind::Table,
+            None,
+        ),
+        spec(
             "consumer.delete_subscription_group",
             CommandCategory::Consumer,
             "Delete Subscription Group",
@@ -3426,6 +3488,7 @@ mod tests {
             "consumer.config",
             "consumer.running_info",
             "consumer.progress",
+            "consumer.start_monitoring",
             "consumer.delete_subscription_group",
             "consumer.set_consume_mode",
             "offset.clone_group",
@@ -3629,5 +3692,29 @@ mod tests {
                 arg.name == "overwrite" && !arg.required && matches!(arg.kind, ArgKind::Bool { default: false })
             }));
         }
+    }
+
+    #[test]
+    fn phase_five_catalog_exposes_bounded_monitoring_command() {
+        let catalog = command_catalog();
+        let command = catalog
+            .iter()
+            .find(|command| command.id == "consumer.start_monitoring")
+            .unwrap();
+
+        assert_eq!(command.risk_level, RiskLevel::Safe);
+        assert_eq!(command.result_view_kind, ResultViewKind::Table);
+        assert!(command.args.iter().any(|arg| {
+            arg.name == "round_count"
+                && arg.required
+                && matches!(
+                    arg.kind,
+                    ArgKind::Number {
+                        default: Some(1),
+                        min: Some(1)
+                    }
+                )
+        }));
+        assert!(command.args.iter().any(|arg| arg.name == "max_events" && arg.required));
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
@@ -16,6 +16,8 @@ use rocketmq_admin_core::core::connection::ProducerConnectionQueryResult;
 use rocketmq_admin_core::core::consumer::ConsumerOperationResult;
 use rocketmq_admin_core::core::consumer::ConsumerProgressResult;
 use rocketmq_admin_core::core::consumer::ConsumerRunningInfoResult;
+use rocketmq_admin_core::core::consumer::MonitoringEvent;
+use rocketmq_admin_core::core::consumer::MonitoringResult;
 use rocketmq_admin_core::core::export_data::ExportConfigsResult;
 use rocketmq_admin_core::core::export_data::ExportFileWriteResult;
 use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbConfigType;
@@ -609,6 +611,21 @@ impl CommandResultViewModel {
                     .collect(),
             ),
         }
+    }
+
+    pub fn consumer_monitoring(title: impl Into<String>, result: &MonitoringResult) -> Self {
+        let mut rows = result.events.iter().map(monitoring_event_row).collect::<Vec<_>>();
+        if result.truncated {
+            rows.push(vec![
+                "truncated".to_string(),
+                result.rounds_completed.to_string(),
+                String::new(),
+                String::new(),
+                "max events reached".to_string(),
+                format!("groups: {}, errors: {}", result.groups_scanned, result.error_count),
+            ]);
+        }
+        Self::table(title, &["Event", "Round", "Group", "Topic", "Metric", "Detail"], rows)
     }
 
     pub fn message_query_by_key(title: impl Into<String>, result: &QueryMessageByKeyResult) -> Self {
@@ -1425,6 +1442,85 @@ fn empty_message_detail_row(message_id: &str, status: &str, note: &str) -> Vec<S
     ]
 }
 
+fn monitoring_event_row(event: &MonitoringEvent) -> Vec<String> {
+    match event {
+        MonitoringEvent::BeginRound {
+            round,
+            timestamp_millis,
+        } => vec![
+            "begin-round".to_string(),
+            round.to_string(),
+            String::new(),
+            String::new(),
+            "timestamp_millis".to_string(),
+            timestamp_millis.to_string(),
+        ],
+        MonitoringEvent::UndoneMsgs {
+            round,
+            consumer_group,
+            topic,
+            undone_msgs_total,
+            undone_msgs_single_mq,
+            undone_msgs_delay_time_millis,
+        } => vec![
+            "undone-msgs".to_string(),
+            round.to_string(),
+            consumer_group.clone(),
+            topic.clone(),
+            format!("total={undone_msgs_total}, single_mq={undone_msgs_single_mq}"),
+            undone_msgs_delay_time_millis
+                .map(|delay| format!("delay_ms={delay}"))
+                .unwrap_or_else(|| "delay_ms=not-sampled".to_string()),
+        ],
+        MonitoringEvent::ConsumerRunningInfo {
+            round,
+            consumer_group,
+            client_count,
+            subscription_consistent,
+            process_queue_analysis,
+        } => vec![
+            "running-info".to_string(),
+            round.to_string(),
+            consumer_group.clone(),
+            String::new(),
+            format!("clients={client_count}"),
+            format!(
+                "subscription_consistent={}, analysis={}",
+                subscription_consistent
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                process_queue_analysis.join("; ")
+            ),
+        ],
+        MonitoringEvent::Error {
+            round,
+            consumer_group,
+            operation,
+            error,
+        } => vec![
+            "error".to_string(),
+            round.to_string(),
+            consumer_group.clone().unwrap_or_default(),
+            String::new(),
+            operation.clone(),
+            error.clone(),
+        ],
+        MonitoringEvent::EndRound {
+            round,
+            elapsed_millis,
+            groups_scanned,
+            events_emitted,
+        } => vec![
+            "end-round".to_string(),
+            round.to_string(),
+            String::new(),
+            String::new(),
+            format!("groups={groups_scanned}, events={events_emitted}"),
+            format!("elapsed_ms={elapsed_millis}"),
+        ],
+    }
+}
+
 fn message_pull_event_row(event: &MessagePullEvent) -> Vec<String> {
     match event {
         MessagePullEvent::QueueRange {
@@ -1598,6 +1694,8 @@ mod tests {
     use rocketmq_admin_core::core::consumer::ConsumerProgressRow;
     use rocketmq_admin_core::core::consumer::ConsumerRunningInfoItem;
     use rocketmq_admin_core::core::consumer::ConsumerRunningInfoResult;
+    use rocketmq_admin_core::core::consumer::MonitoringEvent;
+    use rocketmq_admin_core::core::consumer::MonitoringResult;
     use rocketmq_admin_core::core::export_data::ExportConfigsResult;
     use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbConfigType;
     use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbEntry;
@@ -2595,6 +2693,49 @@ mod tests {
             &["queue-range", "TopicA", "broker-a", "1", "10..20", "", ""],
         );
         assert!(pull_events.text_body().contains("truncated after 2 events"));
+    }
+
+    #[test]
+    fn phase_five_monitoring_events_render_as_table() {
+        let result = CommandResultViewModel::consumer_monitoring(
+            "Start Monitoring",
+            &MonitoringResult {
+                events: vec![
+                    MonitoringEvent::BeginRound {
+                        round: 1,
+                        timestamp_millis: 1234,
+                    },
+                    MonitoringEvent::UndoneMsgs {
+                        round: 1,
+                        consumer_group: "GroupA".to_string(),
+                        topic: "TopicA".to_string(),
+                        undone_msgs_total: 42,
+                        undone_msgs_single_mq: 40,
+                        undone_msgs_delay_time_millis: None,
+                    },
+                    MonitoringEvent::ConsumerRunningInfo {
+                        round: 1,
+                        consumer_group: "GroupA".to_string(),
+                        client_count: 2,
+                        subscription_consistent: Some(false),
+                        process_queue_analysis: vec!["client-a stalled".to_string()],
+                    },
+                ],
+                rounds_completed: 1,
+                groups_scanned: 1,
+                error_count: 0,
+                truncated: true,
+            },
+        );
+
+        assert_table(
+            &result,
+            &["Event", "Round", "Group", "Topic", "Metric", "Detail"],
+            &["begin-round", "1", "", "", "timestamp_millis", "1234"],
+        );
+        assert!(result.text_body().contains("undone-msgs"));
+        assert!(result.text_body().contains("client-a stalled"));
+        assert!(result.text_body().contains("max events reached"));
     }
 
     fn assert_table(result: &CommandResultViewModel, headers: &[&str], first_row: &[&str]) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7172

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented consumer monitoring with configurable round-based iterations and interval controls.
  * Added monitoring parameters: include/exclude undone messages and running info, set event limits.
  * Consumer monitoring results now display as formatted event tables with round summaries.
  * New CLI command for starting consumer monitoring with event output.
  * New TUI command and interface for interactive consumer monitoring workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->