### PR TITLE
[ISSUE #7179]🚀feat(export): add export metrics command for broker runtime metrics aggregation

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -2319,9 +2319,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a59a0cb1c7f84471ad5cd38d768c2a29390d17f1ff2827cdf49bc53e8ac70b"
+checksum = "d7b0187df4e614e42405b49511b82ff7a1774fbd9a816060ee465067847cac22"
 dependencies = [
  "libc",
  "neli",
@@ -4563,6 +4563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5326,11 +5332,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -5550,9 +5557,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -1260,9 +1260,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a59a0cb1c7f84471ad5cd38d768c2a29390d17f1ff2827cdf49bc53e8ac70b"
+checksum = "d7b0187df4e614e42405b49511b82ff7a1774fbd9a816060ee465067847cac22"
 dependencies = [
  "libc",
  "neli",
@@ -2447,6 +2447,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2775,11 +2781,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -2911,9 +2918,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/export/export_metadata_in_rocks_db_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/export/export_metadata_in_rocks_db_sub_command.rs
@@ -38,7 +38,7 @@ pub struct ExportMetadataInRocksDBSubCommand {
         short = 't',
         long = "configType",
         required = true,
-        help = "Name of kv config, e.g. topics/subscriptionGroups"
+        help = "Name of kv config, e.g. topics/subscriptionGroups/consumerOffsets"
     )]
     config_type: String,
 
@@ -63,7 +63,7 @@ impl ExportMetadataInRocksDBSubCommand {
             }
             ExportMetadataInRocksDbResult::InvalidConfigType { config_type } => {
                 println!(
-                    "Invalid config type={}, Options: topics,subscriptionGroups",
+                    "Invalid config type={}, Options: topics,subscriptionGroups,consumerOffsets",
                     config_type
                 );
             }
@@ -133,6 +133,22 @@ mod tests {
         assert_eq!(
             request.normalized_config_type(),
             Some(ExportMetadataInRocksDbConfigType::Topics)
+        );
+    }
+
+    #[test]
+    fn export_metadata_in_rocksdb_sub_command_accepts_consumer_offsets() {
+        let command = ExportMetadataInRocksDBSubCommand {
+            path: " /tmp/metadata ".to_string(),
+            config_type: " consumerOffsets ".to_string(),
+            json_enable: true,
+        };
+
+        let request = command.request();
+
+        assert_eq!(
+            request.normalized_config_type(),
+            Some(ExportMetadataInRocksDbConfigType::ConsumerOffsets)
         );
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/export_data.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/export_data.rs
@@ -1,5 +1,7 @@
 //! Export admin service models and operations.
 
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -10,10 +12,17 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_common::common::config::TopicConfig;
+use rocketmq_common::common::mix_all;
+use rocketmq_common::common::mq_version::RocketMqVersion;
+use rocketmq_common::common::mq_version::CURRENT_VERSION;
+use rocketmq_common::common::stats::Stats;
+use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
+use rocketmq_remoting::protocol::body::kv_table::KVTable;
 use rocketmq_remoting::protocol::body::subscription_group_wrapper::SubscriptionGroupWrapper;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
+use rocketmq_remoting::protocol::subscription::broker_stats_data::BrokerStatsData;
 use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 use rocketmq_remoting::runtime::RPCHook;
 #[cfg(feature = "rocksdb-export")]
@@ -48,9 +57,11 @@ const EXPORT_BROKER_PROPERTY_KEYS: &[&str] = &[
     "autoCreateTopicEnable",
     "autoCreateSubscriptionGroup",
 ];
+const DEFAULT_EXPORT_METRICS_TIMEOUT_MILLIS: u64 = 10000;
 const DEFAULT_EXPORT_POP_RECORD_TIMEOUT_MILLIS: u64 = 30000;
 const TOPICS_JSON_CONFIG: &str = "topics";
 const SUBSCRIPTION_GROUP_JSON_CONFIG: &str = "subscriptionGroups";
+const CONSUMER_OFFSETS_JSON_CONFIG: &str = "consumerOffsets";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExportConfigsRequest {
@@ -94,6 +105,148 @@ pub struct ExportConfigsResult {
     pub broker_configs: HashMap<String, HashMap<String, String>>,
     pub master_broker_size: i64,
     pub slave_broker_size: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportMetricsRequest {
+    cluster_name: CheetahString,
+    timeout_millis: u64,
+    namesrv_addr: Option<String>,
+}
+
+impl ExportMetricsRequest {
+    pub fn try_new(cluster_name: impl Into<String>) -> RocketMQResult<Self> {
+        Ok(Self {
+            cluster_name: trim_required_cheetah("clusterName", cluster_name)?,
+            timeout_millis: DEFAULT_EXPORT_METRICS_TIMEOUT_MILLIS,
+            namesrv_addr: None,
+        })
+    }
+
+    pub fn with_timeout_millis(mut self, timeout_millis: u64) -> Self {
+        self.timeout_millis = timeout_millis;
+        self
+    }
+
+    pub fn with_optional_namesrv_addr(mut self, namesrv_addr: Option<String>) -> Self {
+        self.namesrv_addr = trim_optional_string(namesrv_addr);
+        self
+    }
+
+    pub fn cluster_name(&self) -> &CheetahString {
+        &self.cluster_name
+    }
+
+    pub fn timeout_millis(&self) -> u64 {
+        self.timeout_millis
+    }
+
+    pub fn namesrv_addr(&self) -> Option<&str> {
+        self.namesrv_addr.as_deref()
+    }
+
+    pub fn admin_builder(&self) -> AdminBuilder {
+        let builder = AdminBuilder::new();
+        match self.namesrv_addr() {
+            Some(addr) => builder.namesrv_addr(addr),
+            None => builder,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportMetricsResult {
+    pub evaluate_report: BTreeMap<String, ExportMetricsBrokerReport>,
+    pub total_data: ExportMetricsTotals,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportMetricsBrokerReport {
+    pub runtime_env: ExportMetricsRuntimeEnv,
+    pub runtime_quota: ExportMetricsRuntimeQuota,
+    pub runtime_version: ExportMetricsRuntimeVersion,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportMetricsRuntimeEnv {
+    pub cpu_num: Option<String>,
+    #[serde(rename = "totalMemKBytes")]
+    pub total_mem_kbytes: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportMetricsRuntimeQuota {
+    pub disk_ratio: ExportMetricsDiskRatio,
+    pub tps: ExportMetricsTps,
+    pub one_day_num: ExportMetricsOneDayNum,
+    pub message_average_size: Option<String>,
+    pub topic_size: usize,
+    pub group_size: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportMetricsDiskRatio {
+    pub commit_log_disk_ratio: Option<String>,
+    pub consume_queue_disk_ratio: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportMetricsTps {
+    pub normal_in_tps: f64,
+    pub normal_out_tps: f64,
+    pub trans_in_tps: f64,
+    pub schedule_in_tps: f64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportMetricsOneDayNum {
+    pub normal_one_day_in_num: i64,
+    pub normal_one_day_out_num: i64,
+    pub trans_one_day_in_num: u64,
+    pub schedule_one_day_in_num: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportMetricsRuntimeVersion {
+    pub rocketmq_version: String,
+    pub client_info: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportMetricsTotals {
+    pub total_tps: ExportMetricsTotalTps,
+    pub total_one_day_num: ExportMetricsOneDayNum,
+}
+
+impl ExportMetricsTotals {
+    pub fn accumulate(&mut self, quota: &ExportMetricsRuntimeQuota) {
+        self.total_tps.total_normal_in_tps += quota.tps.normal_in_tps;
+        self.total_tps.total_normal_out_tps += quota.tps.normal_out_tps;
+        self.total_tps.total_trans_in_tps += quota.tps.trans_in_tps;
+        self.total_tps.total_schedule_in_tps += quota.tps.schedule_in_tps;
+        self.total_one_day_num.normal_one_day_in_num += quota.one_day_num.normal_one_day_in_num;
+        self.total_one_day_num.normal_one_day_out_num += quota.one_day_num.normal_one_day_out_num;
+        self.total_one_day_num.trans_one_day_in_num += quota.one_day_num.trans_one_day_in_num;
+        self.total_one_day_num.schedule_one_day_in_num += quota.one_day_num.schedule_one_day_in_num;
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportMetricsTotalTps {
+    pub total_normal_in_tps: f64,
+    pub total_normal_out_tps: f64,
+    pub total_trans_in_tps: f64,
+    pub total_schedule_in_tps: f64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -210,6 +363,7 @@ impl ExportMetadataRequest {
 pub enum ExportMetadataInRocksDbConfigType {
     Topics,
     SubscriptionGroups,
+    ConsumerOffsets,
 }
 
 impl ExportMetadataInRocksDbConfigType {
@@ -218,6 +372,8 @@ impl ExportMetadataInRocksDbConfigType {
             Some(Self::Topics)
         } else if config_type.eq_ignore_ascii_case(SUBSCRIPTION_GROUP_JSON_CONFIG) {
             Some(Self::SubscriptionGroups)
+        } else if config_type.eq_ignore_ascii_case(CONSUMER_OFFSETS_JSON_CONFIG) {
+            Some(Self::ConsumerOffsets)
         } else {
             None
         }
@@ -227,6 +383,7 @@ impl ExportMetadataInRocksDbConfigType {
         match self {
             Self::Topics => "topicConfigTable",
             Self::SubscriptionGroups => "subscriptionGroupTable",
+            Self::ConsumerOffsets => "offsetTable",
         }
     }
 }
@@ -498,7 +655,7 @@ impl ExportService {
                 ))
             })?;
 
-            let entries = iterate_rocksdb_metadata(&db)?;
+            let entries = Self::convert_rocksdb_metadata_entries(config_type, iterate_rocksdb_metadata(&db)?)?;
             drop(db);
 
             Ok(ExportMetadataInRocksDbResult::Data {
@@ -506,6 +663,20 @@ impl ExportService {
                 json_enable: request.json_enable(),
                 entries,
             })
+        }
+    }
+
+    pub fn convert_rocksdb_metadata_entries(
+        config_type: ExportMetadataInRocksDbConfigType,
+        entries: Vec<ExportMetadataInRocksDbEntry>,
+    ) -> RocketMQResult<Vec<ExportMetadataInRocksDbEntry>> {
+        match config_type {
+            ExportMetadataInRocksDbConfigType::Topics | ExportMetadataInRocksDbConfigType::SubscriptionGroups => {
+                Ok(entries)
+            }
+            ExportMetadataInRocksDbConfigType::ConsumerOffsets => {
+                entries.into_iter().map(convert_consumer_offset_entry).collect()
+            }
         }
     }
 
@@ -568,6 +739,140 @@ impl ExportService {
             master_broker_size,
             slave_broker_size,
         })
+    }
+
+    pub async fn export_metrics_by_request_with_rpc_hook(
+        request: ExportMetricsRequest,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> RocketMQResult<ExportMetricsResult> {
+        let mut admin = admin_builder_with_rpc_hook(request.admin_builder(), rpc_hook)
+            .build_and_start()
+            .await?;
+        let result = Self::export_metrics_with_admin(&admin, &request).await;
+        admin.shutdown().await;
+        result
+    }
+
+    pub async fn export_metrics_with_admin(
+        admin: &DefaultMQAdminExt,
+        request: &ExportMetricsRequest,
+    ) -> RocketMQResult<ExportMetricsResult> {
+        let cluster_info = admin.examine_broker_cluster_info().await?;
+        let broker_names = resolve_export_metrics_broker_names(&cluster_info, request.cluster_name().as_str())?;
+        let broker_addr_table = cluster_info
+            .broker_addr_table
+            .as_ref()
+            .ok_or_else(|| RocketMQError::Internal("ExportService: broker address table is empty".to_string()))?;
+
+        let mut result = ExportMetricsResult::default();
+        for broker_name in broker_names {
+            let Some(broker_data) = broker_addr_table.get(&broker_name) else {
+                continue;
+            };
+            let Some(master_addr) = broker_data.broker_addrs().get(&mix_all::MASTER_ID) else {
+                continue;
+            };
+
+            let runtime_stats = admin.fetch_broker_runtime_stats(master_addr.clone()).await?;
+            let broker_config = admin.get_broker_config(master_addr.clone()).await?;
+            let subscription_group_wrapper = admin
+                .get_user_subscription_group(master_addr.clone(), request.timeout_millis())
+                .await?;
+            let topic_config_wrapper = admin
+                .get_user_topic_config(master_addr.clone(), false, request.timeout_millis())
+                .await?;
+            let trans_stats_data = admin
+                .view_broker_stats_data(
+                    master_addr.clone(),
+                    CheetahString::from_static_str(Stats::TOPIC_PUT_NUMS),
+                    CheetahString::from_static_str(TopicValidator::RMQ_SYS_TRANS_HALF_TOPIC),
+                )
+                .await
+                .ok();
+            let schedule_stats_data = admin
+                .view_broker_stats_data(
+                    master_addr.clone(),
+                    CheetahString::from_static_str(Stats::TOPIC_PUT_NUMS),
+                    CheetahString::from_static_str(TopicValidator::RMQ_SYS_SCHEDULE_TOPIC),
+                )
+                .await
+                .ok();
+            let client_info = collect_export_metrics_client_info(admin, &subscription_group_wrapper).await;
+            let topic_size = topic_config_wrapper
+                .topic_config_table()
+                .map(HashMap::len)
+                .unwrap_or_default();
+            let group_size = subscription_group_wrapper.get_subscription_group_table().len();
+            let report = Self::build_export_metrics_broker_report(
+                &runtime_stats,
+                &broker_config,
+                topic_size,
+                group_size,
+                trans_stats_data.as_ref(),
+                schedule_stats_data.as_ref(),
+                client_info,
+            );
+
+            result.total_data.accumulate(&report.runtime_quota);
+            result.evaluate_report.insert(broker_name.to_string(), report);
+        }
+
+        Ok(result)
+    }
+
+    pub fn build_export_metrics_broker_report(
+        runtime_stats: &KVTable,
+        broker_config: &HashMap<CheetahString, CheetahString>,
+        topic_size: usize,
+        group_size: usize,
+        trans_stats_data: Option<&BrokerStatsData>,
+        schedule_stats_data: Option<&BrokerStatsData>,
+        client_info: Vec<String>,
+    ) -> ExportMetricsBrokerReport {
+        let trans_one_day_in_num = trans_stats_data
+            .map(crate::core::stats::StatsService::compute_24_hour_sum)
+            .unwrap_or_default();
+        let schedule_one_day_in_num = schedule_stats_data
+            .map(crate::core::stats::StatsService::compute_24_hour_sum)
+            .unwrap_or_default();
+
+        ExportMetricsBrokerReport {
+            runtime_env: ExportMetricsRuntimeEnv {
+                cpu_num: map_value(broker_config, "clientCallbackExecutorThreads"),
+                total_mem_kbytes: kv_value(runtime_stats, "totalMemKBytes"),
+            },
+            runtime_quota: ExportMetricsRuntimeQuota {
+                disk_ratio: ExportMetricsDiskRatio {
+                    commit_log_disk_ratio: kv_value(runtime_stats, "commitLogDiskRatio"),
+                    consume_queue_disk_ratio: kv_value(runtime_stats, "consumeQueueDiskRatio"),
+                },
+                tps: ExportMetricsTps {
+                    normal_in_tps: parse_leading_f64(kv_value(runtime_stats, "putTps").as_deref()),
+                    normal_out_tps: parse_leading_f64(kv_value(runtime_stats, "getTransferredTps").as_deref()),
+                    trans_in_tps: trans_stats_data
+                        .map(|stats| stats.get_stats_minute().get_tps())
+                        .unwrap_or_default(),
+                    schedule_in_tps: schedule_stats_data
+                        .map(|stats| stats.get_stats_minute().get_tps())
+                        .unwrap_or_default(),
+                },
+                one_day_num: ExportMetricsOneDayNum {
+                    normal_one_day_in_num: kv_i64(runtime_stats, "msgPutTotalTodayMorning")
+                        - kv_i64(runtime_stats, "msgPutTotalYesterdayMorning"),
+                    normal_one_day_out_num: kv_i64(runtime_stats, "msgGetTotalTodayMorning")
+                        - kv_i64(runtime_stats, "msgGetTotalYesterdayMorning"),
+                    trans_one_day_in_num,
+                    schedule_one_day_in_num,
+                },
+                message_average_size: kv_value(runtime_stats, "putMessageAverageSize"),
+                topic_size,
+                group_size,
+            },
+            runtime_version: ExportMetricsRuntimeVersion {
+                rocketmq_version: CURRENT_VERSION.name().to_string(),
+                client_info: normalize_client_info(client_info),
+            },
+        }
     }
 
     pub async fn export_metadata_by_request_with_rpc_hook(
@@ -818,6 +1123,102 @@ fn resolve_export_pop_record_targets_from_cluster_info(
     });
     targets.dedup();
     targets
+}
+
+fn resolve_export_metrics_broker_names(
+    cluster_info: &ClusterInfo,
+    cluster_name: &str,
+) -> RocketMQResult<Vec<CheetahString>> {
+    let broker_names = cluster_info
+        .cluster_addr_table
+        .as_ref()
+        .and_then(|cluster_addr_table| cluster_addr_table.get(cluster_name))
+        .ok_or_else(|| {
+            RocketMQError::Internal(format!(
+                "ExportService: cluster {} does not exist or has no brokers",
+                cluster_name
+            ))
+        })?;
+    let mut broker_names = broker_names.iter().cloned().collect::<Vec<_>>();
+    broker_names.sort();
+    Ok(broker_names)
+}
+
+async fn collect_export_metrics_client_info(
+    admin: &DefaultMQAdminExt,
+    subscription_group_wrapper: &SubscriptionGroupWrapper,
+) -> Vec<String> {
+    let mut client_info = BTreeSet::new();
+    for entry in subscription_group_wrapper.get_subscription_group_table().iter() {
+        let group_name = entry.value().group_name().clone();
+        let Ok(connection) = admin.examine_consumer_connection_info(group_name, None).await else {
+            continue;
+        };
+        for connection in connection.get_connection_set() {
+            let version = if connection.get_version() < 0 {
+                RocketMqVersion::from_ordinal(0)
+            } else {
+                RocketMqVersion::from_ordinal(connection.get_version() as u32)
+            };
+            client_info.insert(format!("{}%{}", connection.get_language(), version.name()));
+        }
+    }
+    client_info.into_iter().collect()
+}
+
+fn kv_value(runtime_stats: &KVTable, key: &str) -> Option<String> {
+    runtime_stats
+        .table
+        .get(&CheetahString::from(key))
+        .map(ToString::to_string)
+}
+
+fn map_value(properties: &HashMap<CheetahString, CheetahString>, key: &str) -> Option<String> {
+    properties.get(&CheetahString::from(key)).map(ToString::to_string)
+}
+
+fn kv_i64(runtime_stats: &KVTable, key: &str) -> i64 {
+    kv_value(runtime_stats, key)
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or_default()
+}
+
+fn parse_leading_f64(value: Option<&str>) -> f64 {
+    value
+        .and_then(|value| value.split_whitespace().next())
+        .and_then(|value| value.parse::<f64>().ok())
+        .unwrap_or_default()
+}
+
+fn normalize_client_info(client_info: Vec<String>) -> Vec<String> {
+    let mut client_info = client_info
+        .into_iter()
+        .filter(|value| !value.trim().is_empty())
+        .collect::<Vec<_>>();
+    client_info.sort();
+    client_info.dedup();
+    client_info
+}
+
+fn convert_consumer_offset_entry(entry: ExportMetadataInRocksDbEntry) -> RocketMQResult<ExportMetadataInRocksDbEntry> {
+    let wrapper = serde_json::from_str::<serde_json::Value>(&entry.value).map_err(|error| {
+        RocketMQError::Internal(format!(
+            "ExportService: failed to parse consumerOffsets entry {}: {}",
+            entry.key, error
+        ))
+    })?;
+    let offset_table = wrapper
+        .get("offsetTable")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+    let value = serde_json::to_string(&offset_table).map_err(|error| {
+        RocketMQError::Internal(format!(
+            "ExportService: failed to serialize consumerOffsets entry {}: {}",
+            entry.key, error
+        ))
+    })?;
+
+    Ok(ExportMetadataInRocksDbEntry { key: entry.key, value })
 }
 
 #[cfg(feature = "rocksdb-export")]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/export_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/export_core_models.rs
@@ -14,9 +14,14 @@ use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbResult;
 use rocketmq_admin_core::core::export_data::ExportMetadataRequest;
 use rocketmq_admin_core::core::export_data::ExportMetadataScope;
 use rocketmq_admin_core::core::export_data::ExportMetadataTarget;
+use rocketmq_admin_core::core::export_data::ExportMetricsRequest;
+use rocketmq_admin_core::core::export_data::ExportMetricsTotals;
 use rocketmq_admin_core::core::export_data::ExportPopRecordRequest;
 use rocketmq_admin_core::core::export_data::ExportPopRecordTarget;
 use rocketmq_admin_core::core::export_data::ExportService;
+use rocketmq_remoting::protocol::body::broker_stats_item::BrokerStatsItem;
+use rocketmq_remoting::protocol::body::kv_table::KVTable;
+use rocketmq_remoting::protocol::subscription::broker_stats_data::BrokerStatsData;
 
 #[test]
 fn export_configs_request_trims_cluster_and_namesrv() {
@@ -135,6 +140,106 @@ fn export_pop_record_request_rejects_invalid_targets() {
 }
 
 #[test]
+fn export_metrics_request_trims_cluster_and_namesrv() {
+    let request = ExportMetricsRequest::try_new(" DefaultCluster ")
+        .unwrap()
+        .with_optional_namesrv_addr(Some(" 127.0.0.1:9876 ".to_string()))
+        .with_timeout_millis(5000);
+
+    assert_eq!(request.cluster_name().as_str(), "DefaultCluster");
+    assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+    assert_eq!(request.timeout_millis(), 5000);
+}
+
+#[test]
+fn export_metrics_report_parses_runtime_quota_like_java() {
+    let mut runtime_stats = KVTable::default();
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("totalMemKBytes"),
+        CheetahString::from_static_str("4096"),
+    );
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("commitLogDiskRatio"),
+        CheetahString::from_static_str("0.25"),
+    );
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("consumeQueueDiskRatio"),
+        CheetahString::from_static_str("0.10"),
+    );
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("putTps"),
+        CheetahString::from_static_str("123.5 1 1"),
+    );
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("getTransferredTps"),
+        CheetahString::from_static_str("45.25 1 1"),
+    );
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("msgPutTotalYesterdayMorning"),
+        CheetahString::from_static_str("100"),
+    );
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("msgPutTotalTodayMorning"),
+        CheetahString::from_static_str("160"),
+    );
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("msgGetTotalYesterdayMorning"),
+        CheetahString::from_static_str("30"),
+    );
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("msgGetTotalTodayMorning"),
+        CheetahString::from_static_str("80"),
+    );
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("putMessageAverageSize"),
+        CheetahString::from_static_str("512"),
+    );
+
+    let broker_config = HashMap::from([(
+        CheetahString::from_static_str("clientCallbackExecutorThreads"),
+        CheetahString::from_static_str("8"),
+    )]);
+    let trans_stats = BrokerStatsData::new(
+        BrokerStatsItem::new(10, 1.5, 0.0),
+        BrokerStatsItem::default(),
+        BrokerStatsItem::default(),
+    );
+    let schedule_stats = BrokerStatsData::new(
+        BrokerStatsItem::new(20, 2.5, 0.0),
+        BrokerStatsItem::default(),
+        BrokerStatsItem::default(),
+    );
+
+    let report = ExportService::build_export_metrics_broker_report(
+        &runtime_stats,
+        &broker_config,
+        12,
+        4,
+        Some(&trans_stats),
+        Some(&schedule_stats),
+        vec!["JAVA%V5_1_0".to_string()],
+    );
+    let mut totals = ExportMetricsTotals::default();
+    totals.accumulate(&report.runtime_quota);
+
+    assert_eq!(report.runtime_env.cpu_num.as_deref(), Some("8"));
+    assert_eq!(report.runtime_env.total_mem_kbytes.as_deref(), Some("4096"));
+    assert_eq!(report.runtime_quota.tps.normal_in_tps, 123.5);
+    assert_eq!(report.runtime_quota.tps.normal_out_tps, 45.25);
+    assert_eq!(report.runtime_quota.tps.trans_in_tps, 1.5);
+    assert_eq!(report.runtime_quota.tps.schedule_in_tps, 2.5);
+    assert_eq!(report.runtime_quota.one_day_num.normal_one_day_in_num, 60);
+    assert_eq!(report.runtime_quota.one_day_num.normal_one_day_out_num, 50);
+    assert_eq!(report.runtime_quota.one_day_num.trans_one_day_in_num, 10);
+    assert_eq!(report.runtime_quota.one_day_num.schedule_one_day_in_num, 20);
+    assert_eq!(report.runtime_quota.topic_size, 12);
+    assert_eq!(report.runtime_quota.group_size, 4);
+    assert_eq!(report.runtime_version.client_info, vec!["JAVA%V5_1_0"]);
+    assert_eq!(totals.total_tps.total_normal_in_tps, 123.5);
+    assert_eq!(totals.total_one_day_num.normal_one_day_out_num, 50);
+}
+
+#[test]
 fn export_metadata_in_rocksdb_request_trims_fields() {
     let request = ExportMetadataInRocksDbRequest::new(" /tmp/metadata ", " topics ", true);
 
@@ -154,6 +259,42 @@ fn export_metadata_in_rocksdb_request_recognizes_subscription_groups() {
     assert_eq!(
         request.normalized_config_type(),
         Some(ExportMetadataInRocksDbConfigType::SubscriptionGroups)
+    );
+}
+
+#[test]
+fn export_metadata_in_rocksdb_request_recognizes_consumer_offsets() {
+    let request = ExportMetadataInRocksDbRequest::new("/tmp/metadata", "consumerOffsets", true);
+
+    assert_eq!(
+        request.normalized_config_type(),
+        Some(ExportMetadataInRocksDbConfigType::ConsumerOffsets)
+    );
+    assert_eq!(
+        request.full_path().to_string_lossy().replace('\\', "/"),
+        "/tmp/metadata/consumerOffsets"
+    );
+    assert_eq!(
+        ExportMetadataInRocksDbConfigType::ConsumerOffsets.table_key(),
+        "offsetTable"
+    );
+}
+
+#[test]
+fn export_metadata_in_rocksdb_consumer_offsets_extracts_offset_table() {
+    let entries = vec![rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbEntry {
+        key: "GroupA@TopicA".to_string(),
+        value: r#"{"offsetTable":{"0":12,"1":34}}"#.to_string(),
+    }];
+
+    let entries =
+        ExportService::convert_rocksdb_metadata_entries(ExportMetadataInRocksDbConfigType::ConsumerOffsets, entries)
+            .unwrap();
+
+    assert_eq!(entries[0].key, "GroupA@TopicA");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&entries[0].value).unwrap(),
+        serde_json::json!({"0": 12, "1": 34})
     );
 }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
@@ -101,6 +101,8 @@ use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbRequest;
 use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbResult;
 use rocketmq_admin_core::core::export_data::ExportMetadataRequest;
 use rocketmq_admin_core::core::export_data::ExportMetadataResult;
+use rocketmq_admin_core::core::export_data::ExportMetricsRequest;
+use rocketmq_admin_core::core::export_data::ExportMetricsResult;
 use rocketmq_admin_core::core::export_data::ExportPopRecordRequest;
 use rocketmq_admin_core::core::export_data::ExportPopRecordResult;
 use rocketmq_admin_core::core::export_data::ExportService;
@@ -1169,6 +1171,19 @@ impl TuiAdminFacade {
 
     pub fn export_configs_request(&self, cluster_name: impl Into<String>) -> RocketMQResult<ExportConfigsRequest> {
         Ok(ExportConfigsRequest::try_new(cluster_name)?.with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn export_metrics_request(
+        &self,
+        cluster_name: impl Into<String>,
+        timeout_millis: Option<u64>,
+    ) -> RocketMQResult<ExportMetricsRequest> {
+        let request =
+            ExportMetricsRequest::try_new(cluster_name)?.with_optional_namesrv_addr(self.namesrv_addr.clone());
+        Ok(match timeout_millis {
+            Some(timeout_millis) => request.with_timeout_millis(timeout_millis),
+            None => request,
+        })
     }
 
     pub fn export_metadata_request(
@@ -2542,6 +2557,18 @@ impl TuiAdminFacade {
         ExportService::export_configs_by_request_with_rpc_hook(self.export_configs_request(cluster_name)?, None).await
     }
 
+    pub async fn export_metrics(
+        &self,
+        cluster_name: impl Into<String>,
+        timeout_millis: Option<u64>,
+    ) -> RocketMQResult<ExportMetricsResult> {
+        ExportService::export_metrics_by_request_with_rpc_hook(
+            self.export_metrics_request(cluster_name, timeout_millis)?,
+            None,
+        )
+        .await
+    }
+
     pub async fn export_metadata(
         &self,
         cluster_name: Option<String>,
@@ -3576,6 +3603,11 @@ mod tests {
         assert_eq!(export_configs.cluster_name().as_str(), "DefaultCluster");
         assert_eq!(export_configs.namesrv_addr(), Some("127.0.0.1:9876"));
 
+        let export_metrics = facade.export_metrics_request(" DefaultCluster ", Some(5000)).unwrap();
+        assert_eq!(export_metrics.cluster_name().as_str(), "DefaultCluster");
+        assert_eq!(export_metrics.namesrv_addr(), Some("127.0.0.1:9876"));
+        assert_eq!(export_metrics.timeout_millis(), 5000);
+
         let export_metadata = facade
             .export_metadata_request(Some(" DefaultCluster ".to_string()), None, false, true, true)
             .unwrap();
@@ -3629,6 +3661,7 @@ mod tests {
         let facade = TuiAdminFacade::with_namesrv_addr("127.0.0.1:9876");
 
         std::mem::drop(facade.export_configs("DefaultCluster"));
+        std::mem::drop(facade.export_metrics("DefaultCluster", Some(5000)));
         std::mem::drop(facade.export_metadata(Some("DefaultCluster".to_string()), None, false, false, false));
         std::mem::drop(facade.export_pop_records(None, Some("127.0.0.1:10911".to_string()), true, Some(5000)));
         std::mem::drop(facade.print_messages_with_progress("TopicA", "*", None, None, None, 64, |_| {}));

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
@@ -1150,6 +1150,21 @@ where
                 CommandResultViewModel::export_configs(spec.title, &result),
             )?
         }
+        "export.metrics" => {
+            let result = facade
+                .export_metrics(
+                    form.required_string("cluster_name")?,
+                    optional_u64_arg(form, "timeout_millis")?,
+                )
+                .await?;
+            export_output_or_view(
+                facade,
+                spec.title,
+                form,
+                &result,
+                CommandResultViewModel::export_metrics(spec.title, &result),
+            )?
+        }
         "export.metadata" => {
             let result = facade
                 .export_metadata(
@@ -2957,6 +2972,26 @@ fn export_commands(commands: &mut Vec<CommandSpec>) {
             None,
         ),
         spec(
+            "export.metrics",
+            CommandCategory::Export,
+            "Export Metrics",
+            "Aggregate broker runtime metrics for a cluster into the Java-compatible export model.",
+            RiskLevel::Safe,
+            with_export_output_args(vec![
+                required_string("cluster_name", "Cluster", "Cluster name.", "DefaultCluster"),
+                number(
+                    "timeout_millis",
+                    "Timeout",
+                    "Optional broker request timeout in milliseconds.",
+                    false,
+                    Some(10000),
+                    Some(1),
+                ),
+            ]),
+            ResultViewKind::Table,
+            None,
+        ),
+        spec(
             "export.metadata",
             CommandCategory::Export,
             "Export Metadata",
@@ -2994,7 +3029,7 @@ fn export_commands(commands: &mut Vec<CommandSpec>) {
                     "config_type",
                     "Config Type",
                     "RocksDB config type.",
-                    &["topics", "subscriptionGroups"],
+                    &["topics", "subscriptionGroups", "consumerOffsets"],
                     "topics",
                 ),
                 bool_arg(
@@ -3636,6 +3671,7 @@ mod tests {
             "message.print_by_queue",
             "message.consume",
             "export.configs",
+            "export.metrics",
             "export.metadata",
             "export.metadata_rocksdb",
             "export.pop_record",
@@ -3680,6 +3716,7 @@ mod tests {
 
         for command_id in [
             "export.configs",
+            "export.metrics",
             "export.metadata",
             "export.metadata_rocksdb",
             "export.pop_record",
@@ -3716,5 +3753,51 @@ mod tests {
                 )
         }));
         assert!(command.args.iter().any(|arg| arg.name == "max_events" && arg.required));
+    }
+
+    #[test]
+    fn phase_five_catalog_exposes_rocksdb_consumer_offsets() {
+        let catalog = command_catalog();
+        let command = catalog
+            .iter()
+            .find(|command| command.id == "export.metadata_rocksdb")
+            .unwrap();
+        let config_type = command.args.iter().find(|arg| arg.name == "config_type").unwrap();
+
+        assert!(matches!(
+            &config_type.kind,
+            ArgKind::Enum {
+                values,
+                ..
+            } if values.contains(&"consumerOffsets")
+        ));
+    }
+
+    #[test]
+    fn phase_five_catalog_exposes_export_metrics() {
+        let catalog = command_catalog();
+        let command = catalog.iter().find(|command| command.id == "export.metrics").unwrap();
+
+        assert_eq!(command.risk_level, RiskLevel::Safe);
+        assert_eq!(command.result_view_kind, ResultViewKind::Table);
+        assert!(command
+            .args
+            .iter()
+            .any(|arg| arg.name == "cluster_name" && arg.required));
+        assert!(command.args.iter().any(|arg| {
+            arg.name == "timeout_millis"
+                && !arg.required
+                && matches!(
+                    arg.kind,
+                    ArgKind::Number {
+                        default: Some(10000),
+                        min: Some(1)
+                    }
+                )
+        }));
+        assert!(command
+            .args
+            .iter()
+            .any(|arg| arg.name == "output_path" && !arg.required));
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
@@ -24,6 +24,7 @@ use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbConfigType;
 use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbResult;
 use rocketmq_admin_core::core::export_data::ExportMetadataResult;
 use rocketmq_admin_core::core::export_data::ExportMetadataScope;
+use rocketmq_admin_core::core::export_data::ExportMetricsResult;
 use rocketmq_admin_core::core::export_data::ExportPopRecordResult;
 use rocketmq_admin_core::core::lite::TriggerLiteDispatchResult;
 use rocketmq_admin_core::core::message::DecodeMessageIdOutcome;
@@ -937,6 +938,83 @@ impl CommandResultViewModel {
         Self::table(title, &["Type", "Target", "Key", "Value"], rows)
     }
 
+    pub fn export_metrics(title: impl Into<String>, result: &ExportMetricsResult) -> Self {
+        let mut rows = result
+            .evaluate_report
+            .iter()
+            .map(|(broker_name, report)| {
+                let quota = &report.runtime_quota;
+                vec![
+                    broker_name.clone(),
+                    optional_text(&report.runtime_env.cpu_num),
+                    optional_text(&report.runtime_env.total_mem_kbytes),
+                    optional_text(&quota.disk_ratio.commit_log_disk_ratio),
+                    optional_text(&quota.disk_ratio.consume_queue_disk_ratio),
+                    fixed_f64(quota.tps.normal_in_tps),
+                    fixed_f64(quota.tps.normal_out_tps),
+                    fixed_f64(quota.tps.trans_in_tps),
+                    fixed_f64(quota.tps.schedule_in_tps),
+                    quota.one_day_num.normal_one_day_in_num.to_string(),
+                    quota.one_day_num.normal_one_day_out_num.to_string(),
+                    quota.one_day_num.trans_one_day_in_num.to_string(),
+                    quota.one_day_num.schedule_one_day_in_num.to_string(),
+                    optional_text(&quota.message_average_size),
+                    quota.topic_size.to_string(),
+                    quota.group_size.to_string(),
+                    report.runtime_version.rocketmq_version.clone(),
+                    report.runtime_version.client_info.join(","),
+                ]
+            })
+            .collect::<Vec<_>>();
+
+        let totals = &result.total_data;
+        rows.push(vec![
+            "TOTAL".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            fixed_f64(totals.total_tps.total_normal_in_tps),
+            fixed_f64(totals.total_tps.total_normal_out_tps),
+            fixed_f64(totals.total_tps.total_trans_in_tps),
+            fixed_f64(totals.total_tps.total_schedule_in_tps),
+            totals.total_one_day_num.normal_one_day_in_num.to_string(),
+            totals.total_one_day_num.normal_one_day_out_num.to_string(),
+            totals.total_one_day_num.trans_one_day_in_num.to_string(),
+            totals.total_one_day_num.schedule_one_day_in_num.to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+        ]);
+
+        Self::table(
+            title,
+            &[
+                "Broker",
+                "CPU",
+                "Memory KB",
+                "CommitLog",
+                "ConsumeQueue",
+                "Normal In TPS",
+                "Normal Out TPS",
+                "Trans In TPS",
+                "Schedule In TPS",
+                "Normal 24h In",
+                "Normal 24h Out",
+                "Trans 24h In",
+                "Schedule 24h In",
+                "Avg Size",
+                "Topics",
+                "Groups",
+                "Version",
+                "Clients",
+            ],
+            rows,
+        )
+    }
+
     pub fn export_metadata(title: impl Into<String>, result: &ExportMetadataResult) -> Self {
         match result {
             ExportMetadataResult::BrokerTopic { wrapper } => {
@@ -1375,6 +1453,10 @@ fn optional_text<T: ToString>(value: &Option<T>) -> String {
     value.as_ref().map(ToString::to_string).unwrap_or_default()
 }
 
+fn fixed_f64(value: f64) -> String {
+    format!("{value:.2}")
+}
+
 const MESSAGE_DETAIL_HEADERS: [&str; 17] = [
     "Message ID",
     "Status",
@@ -1638,6 +1720,7 @@ fn export_rocksdb_config_type_name(config_type: ExportMetadataInRocksDbConfigTyp
     match config_type {
         ExportMetadataInRocksDbConfigType::Topics => "Topics",
         ExportMetadataInRocksDbConfigType::SubscriptionGroups => "SubscriptionGroups",
+        ExportMetadataInRocksDbConfigType::ConsumerOffsets => "ConsumerOffsets",
     }
 }
 
@@ -1700,6 +1783,16 @@ mod tests {
     use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbConfigType;
     use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbEntry;
     use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbResult;
+    use rocketmq_admin_core::core::export_data::ExportMetricsBrokerReport;
+    use rocketmq_admin_core::core::export_data::ExportMetricsDiskRatio;
+    use rocketmq_admin_core::core::export_data::ExportMetricsOneDayNum;
+    use rocketmq_admin_core::core::export_data::ExportMetricsResult;
+    use rocketmq_admin_core::core::export_data::ExportMetricsRuntimeEnv;
+    use rocketmq_admin_core::core::export_data::ExportMetricsRuntimeQuota;
+    use rocketmq_admin_core::core::export_data::ExportMetricsRuntimeVersion;
+    use rocketmq_admin_core::core::export_data::ExportMetricsTotalTps;
+    use rocketmq_admin_core::core::export_data::ExportMetricsTotals;
+    use rocketmq_admin_core::core::export_data::ExportMetricsTps;
     use rocketmq_admin_core::core::export_data::ExportPopRecordResult;
     use rocketmq_admin_core::core::export_data::ExportPopRecordTargetResult;
     use rocketmq_admin_core::core::message::DecodeMessageIdEntry;
@@ -1749,6 +1842,7 @@ mod tests {
     use rocketmq_remoting::protocol::LanguageCode;
     use rocketmq_rust::ArcMut;
 
+    use std::collections::BTreeMap;
     use std::collections::HashMap;
 
     use crate::admin_facade::MessagePullCapture;
@@ -2623,6 +2717,103 @@ mod tests {
             &["name-server", "", "address", "127.0.0.1:9876"],
         );
 
+        let export_metrics = CommandResultViewModel::export_metrics(
+            "Export Metrics",
+            &ExportMetricsResult {
+                evaluate_report: BTreeMap::from([(
+                    "broker-a".to_string(),
+                    ExportMetricsBrokerReport {
+                        runtime_env: ExportMetricsRuntimeEnv {
+                            cpu_num: Some("8".to_string()),
+                            total_mem_kbytes: Some("4096".to_string()),
+                        },
+                        runtime_quota: ExportMetricsRuntimeQuota {
+                            disk_ratio: ExportMetricsDiskRatio {
+                                commit_log_disk_ratio: Some("0.25".to_string()),
+                                consume_queue_disk_ratio: Some("0.10".to_string()),
+                            },
+                            tps: ExportMetricsTps {
+                                normal_in_tps: 123.5,
+                                normal_out_tps: 45.25,
+                                trans_in_tps: 1.5,
+                                schedule_in_tps: 2.5,
+                            },
+                            one_day_num: ExportMetricsOneDayNum {
+                                normal_one_day_in_num: 60,
+                                normal_one_day_out_num: 50,
+                                trans_one_day_in_num: 10,
+                                schedule_one_day_in_num: 20,
+                            },
+                            message_average_size: Some("512".to_string()),
+                            topic_size: 12,
+                            group_size: 4,
+                        },
+                        runtime_version: ExportMetricsRuntimeVersion {
+                            rocketmq_version: "V5_1_0".to_string(),
+                            client_info: vec!["JAVA%V5_1_0".to_string()],
+                        },
+                    },
+                )]),
+                total_data: ExportMetricsTotals {
+                    total_tps: ExportMetricsTotalTps {
+                        total_normal_in_tps: 123.5,
+                        total_normal_out_tps: 45.25,
+                        total_trans_in_tps: 1.5,
+                        total_schedule_in_tps: 2.5,
+                    },
+                    total_one_day_num: ExportMetricsOneDayNum {
+                        normal_one_day_in_num: 60,
+                        normal_one_day_out_num: 50,
+                        trans_one_day_in_num: 10,
+                        schedule_one_day_in_num: 20,
+                    },
+                },
+            },
+        );
+        assert_table(
+            &export_metrics,
+            &[
+                "Broker",
+                "CPU",
+                "Memory KB",
+                "CommitLog",
+                "ConsumeQueue",
+                "Normal In TPS",
+                "Normal Out TPS",
+                "Trans In TPS",
+                "Schedule In TPS",
+                "Normal 24h In",
+                "Normal 24h Out",
+                "Trans 24h In",
+                "Schedule 24h In",
+                "Avg Size",
+                "Topics",
+                "Groups",
+                "Version",
+                "Clients",
+            ],
+            &[
+                "broker-a",
+                "8",
+                "4096",
+                "0.25",
+                "0.10",
+                "123.50",
+                "45.25",
+                "1.50",
+                "2.50",
+                "60",
+                "50",
+                "10",
+                "20",
+                "512",
+                "12",
+                "4",
+                "V5_1_0",
+                "JAVA%V5_1_0",
+            ],
+        );
+
         let rocksdb = CommandResultViewModel::export_metadata_rocksdb(
             "Export Metadata In RocksDB",
             &ExportMetadataInRocksDbResult::Data {
@@ -2638,6 +2829,23 @@ mod tests {
             &rocksdb,
             &["Config Type", "Format", "Key", "Value"],
             &["Topics", "json", "TopicA", "{\"readQueueNums\":4}"],
+        );
+
+        let consumer_offsets = CommandResultViewModel::export_metadata_rocksdb(
+            "Export Metadata In RocksDB",
+            &ExportMetadataInRocksDbResult::Data {
+                config_type: ExportMetadataInRocksDbConfigType::ConsumerOffsets,
+                json_enable: true,
+                entries: vec![ExportMetadataInRocksDbEntry {
+                    key: "GroupA@TopicA".to_string(),
+                    value: "{\"0\":12}".to_string(),
+                }],
+            },
+        );
+        assert_table(
+            &consumer_offsets,
+            &["Config Type", "Format", "Key", "Value"],
+            &["ConsumerOffsets", "json", "GroupA@TopicA", "{\"0\":12}"],
         );
 
         let pop_records = CommandResultViewModel::export_pop_records(


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7179

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cluster broker metrics export to collect and display runtime statistics, including throughput (TPS), quotas, CPU/memory usage, and client version information.
  * Extended RocksDB metadata export to support consumer offsets data extraction.
  * New TUI command for querying and displaying aggregated broker metrics.

* **Improvements**
  * Enhanced export configuration validation for consumerOffsets option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->