### PR TITLE
[ISSUE #7183]🚀feat(message): add direct consume and message track functionalities

### DIFF
--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/message.rs
@@ -32,10 +32,13 @@ use rocketmq_common::common::message::message_decoder;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::MessageConst;
+#[allow(deprecated)]
+use rocketmq_common::common::tools::message_track::MessageTrack;
 use rocketmq_common::common::topic::TopicValidator;
 use rocketmq_common::MessageDecoder::decode_message_id;
 use rocketmq_common::MessageDecoder::validate_message_id;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_remoting::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_remoting::runtime::RPCHook;
 use rocketmq_rust::ArcMut;
 use serde::Deserialize;
@@ -167,6 +170,18 @@ fn route_topic_queues(
         }
     }
     message_queues
+}
+
+#[allow(deprecated)]
+fn message_track_rows(tracks: Vec<MessageTrack>) -> Vec<MessageTrackRow> {
+    tracks
+        .into_iter()
+        .map(|track| MessageTrackRow {
+            consumer_group: track.consumer_group,
+            track_type: track.track_type.map(|track_type| track_type.to_string()),
+            exception_desc: track.exception_desc,
+        })
+        .collect()
 }
 
 async fn resolve_message_queues(
@@ -557,6 +572,176 @@ pub enum UniqueKeyDirectStatus {
 pub enum QueryMessageByUniqueKeyResult {
     Messages(Vec<MessageExt>),
     DirectStatus(UniqueKeyDirectStatus),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectConsumeMessageRequest {
+    topic: CheetahString,
+    msg_id: CheetahString,
+    consumer_group: CheetahString,
+    client_id: CheetahString,
+    cluster: Option<CheetahString>,
+    namesrv_addr: Option<String>,
+}
+
+impl DirectConsumeMessageRequest {
+    pub fn try_new(
+        topic: impl Into<String>,
+        msg_id: impl Into<String>,
+        consumer_group: impl Into<String>,
+        client_id: impl Into<String>,
+        cluster: Option<String>,
+    ) -> RocketMQResult<Self> {
+        Ok(Self {
+            topic: trim_required_cheetah("topic", topic)?,
+            msg_id: trim_required_cheetah("msgId", msg_id)?,
+            consumer_group: trim_required_cheetah("consumerGroup", consumer_group)?,
+            client_id: trim_required_cheetah("clientId", client_id)?,
+            cluster: trim_optional_string(cluster)
+                .map(|cluster| trim_required_cheetah("cluster", cluster))
+                .transpose()?,
+            namesrv_addr: None,
+        })
+    }
+
+    pub fn with_optional_namesrv_addr(mut self, namesrv_addr: Option<String>) -> Self {
+        self.namesrv_addr = trim_optional_string(namesrv_addr);
+        self
+    }
+
+    pub fn admin_builder(&self) -> AdminBuilder {
+        builder_with_namesrv(self.namesrv_addr.as_deref())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectConsumeMessageResultDetail {
+    pub order: bool,
+    pub auto_commit: bool,
+    pub consume_result: Option<String>,
+    pub remark: Option<String>,
+    pub spent_time_millis: u64,
+}
+
+impl DirectConsumeMessageResultDetail {
+    fn from_result(result: &ConsumeMessageDirectlyResult) -> Self {
+        Self {
+            order: result.order(),
+            auto_commit: result.auto_commit(),
+            consume_result: result.consume_result().map(ToString::to_string),
+            remark: result.remark().map(ToString::to_string),
+            spent_time_millis: result.spent_time_mills(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DirectConsumeMessageStatus {
+    Consumed(DirectConsumeMessageResultDetail),
+    NotPushConsumer,
+    RunningInfoFailed { error: String },
+    Failed { error: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectConsumeMessageResult {
+    pub topic: CheetahString,
+    pub msg_id: CheetahString,
+    pub consumer_group: CheetahString,
+    pub client_id: CheetahString,
+    pub status: DirectConsumeMessageStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageTrackRequest {
+    message_ids: Vec<CheetahString>,
+    topic: CheetahString,
+    cluster: Option<CheetahString>,
+    timeout_millis: u64,
+    namesrv_addr: Option<String>,
+}
+
+impl MessageTrackRequest {
+    pub fn try_new(
+        message_ids: Vec<String>,
+        topic: impl Into<String>,
+        cluster: Option<String>,
+        timeout_millis: u64,
+    ) -> RocketMQResult<Self> {
+        if message_ids.is_empty() {
+            return Err(ToolsError::validation_error("messageId", "At least one message ID is required").into());
+        }
+
+        let mut normalized_ids = Vec::with_capacity(message_ids.len());
+        for msg_id in message_ids {
+            validate_message_id(&msg_id).map_err(RocketMQError::IllegalArgument)?;
+            normalized_ids.push(trim_required_cheetah("messageId", msg_id)?);
+        }
+
+        Ok(Self {
+            message_ids: normalized_ids,
+            topic: trim_required_cheetah("topic", topic)?,
+            cluster: trim_optional_string(cluster)
+                .map(|cluster| trim_required_cheetah("cluster", cluster))
+                .transpose()?,
+            timeout_millis,
+            namesrv_addr: None,
+        })
+    }
+
+    pub fn with_optional_namesrv_addr(mut self, namesrv_addr: Option<String>) -> Self {
+        self.namesrv_addr = trim_optional_string(namesrv_addr);
+        self
+    }
+
+    pub fn message_ids(&self) -> &[CheetahString] {
+        &self.message_ids
+    }
+
+    pub fn admin_builder(&self) -> AdminBuilder {
+        let builder = builder_with_namesrv(self.namesrv_addr.as_deref());
+        if self.timeout_millis > 0 {
+            builder.timeout_millis(self.timeout_millis)
+        } else {
+            builder
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageTrackRow {
+    pub consumer_group: String,
+    pub track_type: Option<String>,
+    pub exception_desc: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MessageTrackOutcome {
+    Found {
+        broker_addr: String,
+        query_time_ms: u64,
+        tracks: Vec<MessageTrackRow>,
+    },
+    NotFound {
+        reason: String,
+        query_time_ms: u64,
+    },
+    Failed {
+        error: String,
+        query_time_ms: u64,
+    },
+    TimedOut,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageTrackEntry {
+    pub message_id: CheetahString,
+    pub outcome: MessageTrackOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageTrackResult {
+    pub entries: Vec<MessageTrackEntry>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -999,7 +1184,7 @@ impl MessageService {
     ) -> RocketMQResult<QueryMessageByIdResult> {
         let mut entries = Vec::with_capacity(request.message_ids.len());
         for message_id in &request.message_ids {
-            let query_future = Self::query_single_message_by_id(admin, message_id, &request.topic);
+            let query_future = Self::query_single_message_by_id(admin, message_id, &request.topic, None);
             let outcome = match tokio::time::timeout(Duration::from_millis(request.timeout_millis), query_future).await
             {
                 Ok(outcome) => outcome,
@@ -1017,11 +1202,14 @@ impl MessageService {
         admin: &DefaultMQAdminExt,
         message_id: &CheetahString,
         topic: &CheetahString,
+        cluster: Option<&CheetahString>,
     ) -> QueryMessageByIdOutcome {
         let start_time = Instant::now();
         let query_result = admin
             .query_message(
-                CheetahString::from_static_str(DEFAULT_CLUSTER),
+                cluster
+                    .cloned()
+                    .unwrap_or_else(|| CheetahString::from_static_str(DEFAULT_CLUSTER)),
                 topic.clone(),
                 message_id.clone(),
             )
@@ -1172,6 +1360,134 @@ impl MessageService {
         }
 
         Ok(QueryMessageByUniqueKeyResult::Messages(messages))
+    }
+
+    pub async fn direct_consume_message_by_request_with_rpc_hook(
+        request: DirectConsumeMessageRequest,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> RocketMQResult<DirectConsumeMessageResult> {
+        let mut admin = admin_builder_with_rpc_hook(request.admin_builder(), rpc_hook)
+            .build_and_start()
+            .await?;
+        let result = Self::direct_consume_message_with_admin(&admin, &request).await;
+        admin.shutdown().await;
+        result
+    }
+
+    pub async fn direct_consume_message_with_admin(
+        admin: &DefaultMQAdminExt,
+        request: &DirectConsumeMessageRequest,
+    ) -> RocketMQResult<DirectConsumeMessageResult> {
+        let running_info = admin
+            .get_consumer_running_info(
+                request.consumer_group.clone(),
+                request.client_id.clone(),
+                false,
+                Some(false),
+            )
+            .await;
+
+        let status = match running_info {
+            Ok(info) if info.is_push_type() => {
+                let cluster = request
+                    .cluster
+                    .clone()
+                    .unwrap_or_else(|| CheetahString::from_static_str(DEFAULT_CLUSTER));
+                match admin
+                    .consume_message_directly_ext(
+                        cluster,
+                        request.consumer_group.clone(),
+                        request.client_id.clone(),
+                        request.topic.clone(),
+                        request.msg_id.clone(),
+                    )
+                    .await
+                {
+                    Ok(result) => {
+                        DirectConsumeMessageStatus::Consumed(DirectConsumeMessageResultDetail::from_result(&result))
+                    }
+                    Err(error) => DirectConsumeMessageStatus::Failed {
+                        error: error.to_string(),
+                    },
+                }
+            }
+            Ok(_) => DirectConsumeMessageStatus::NotPushConsumer,
+            Err(error) => DirectConsumeMessageStatus::RunningInfoFailed {
+                error: error.to_string(),
+            },
+        };
+
+        Ok(DirectConsumeMessageResult {
+            topic: request.topic.clone(),
+            msg_id: request.msg_id.clone(),
+            consumer_group: request.consumer_group.clone(),
+            client_id: request.client_id.clone(),
+            status,
+        })
+    }
+
+    pub async fn message_track_by_request_with_rpc_hook(
+        request: MessageTrackRequest,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> RocketMQResult<MessageTrackResult> {
+        let mut admin = admin_builder_with_rpc_hook(request.admin_builder(), rpc_hook)
+            .build_and_start()
+            .await?;
+        let result = Self::message_track_with_admin(&admin, &request).await;
+        admin.shutdown().await;
+        result
+    }
+
+    pub async fn message_track_with_admin(
+        admin: &DefaultMQAdminExt,
+        request: &MessageTrackRequest,
+    ) -> RocketMQResult<MessageTrackResult> {
+        let mut entries = Vec::with_capacity(request.message_ids.len());
+        for message_id in &request.message_ids {
+            let track_future = Self::track_single_message_by_id(admin, request, message_id);
+            let outcome = match tokio::time::timeout(Duration::from_millis(request.timeout_millis), track_future).await
+            {
+                Ok(outcome) => outcome,
+                Err(_) => MessageTrackOutcome::TimedOut,
+            };
+            entries.push(MessageTrackEntry {
+                message_id: message_id.clone(),
+                outcome,
+            });
+        }
+
+        Ok(MessageTrackResult { entries })
+    }
+
+    async fn track_single_message_by_id(
+        admin: &DefaultMQAdminExt,
+        request: &MessageTrackRequest,
+        message_id: &CheetahString,
+    ) -> MessageTrackOutcome {
+        match Self::query_single_message_by_id(admin, message_id, &request.topic, request.cluster.as_ref()).await {
+            QueryMessageByIdOutcome::Found {
+                message,
+                broker_addr,
+                query_time_ms,
+            } => match admin.message_track_detail((*message).clone()).await {
+                Ok(tracks) => MessageTrackOutcome::Found {
+                    broker_addr,
+                    query_time_ms,
+                    tracks: message_track_rows(tracks),
+                },
+                Err(error) => MessageTrackOutcome::Failed {
+                    error: format!("Failed to query message track for '{message_id}': {error}"),
+                    query_time_ms,
+                },
+            },
+            QueryMessageByIdOutcome::NotFound { reason, query_time_ms } => {
+                MessageTrackOutcome::NotFound { reason, query_time_ms }
+            }
+            QueryMessageByIdOutcome::Failed { error, query_time_ms } => {
+                MessageTrackOutcome::Failed { error, query_time_ms }
+            }
+            QueryMessageByIdOutcome::TimedOut => MessageTrackOutcome::TimedOut,
+        }
     }
 
     pub async fn query_message_trace_by_id_by_request_with_rpc_hook(
@@ -1768,6 +2084,63 @@ mod tests {
     fn consume_request_requires_broker_before_queue() {
         let result = ConsumeMessagesRequest::try_new("topic", None, Some(0), None, None, None, None, 1);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn direct_consume_request_trims_required_fields() {
+        let request = DirectConsumeMessageRequest::try_new(
+            " TopicA ",
+            " MSGID ",
+            " GroupA ",
+            " ClientA ",
+            Some(" DefaultCluster ".to_string()),
+        )
+        .unwrap()
+        .with_optional_namesrv_addr(Some(" 127.0.0.1:9876 ".to_string()));
+
+        assert_eq!(request.topic.as_str(), "TopicA");
+        assert_eq!(request.msg_id.as_str(), "MSGID");
+        assert_eq!(request.consumer_group.as_str(), "GroupA");
+        assert_eq!(request.client_id.as_str(), "ClientA");
+        assert_eq!(request.cluster.as_ref().unwrap().as_str(), "DefaultCluster");
+        assert_eq!(request.namesrv_addr.as_deref(), Some("127.0.0.1:9876"));
+    }
+
+    #[test]
+    fn direct_consume_request_rejects_blank_target() {
+        let result = DirectConsumeMessageRequest::try_new("TopicA", "MSGID", " ", "ClientA", None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn message_track_request_validates_message_ids_and_topic() {
+        let request = MessageTrackRequest::try_new(
+            vec![" 7F0000010007D8260BF075769D36C348 ".into()],
+            " TopicA ",
+            Some(" DefaultCluster ".into()),
+            3000,
+        )
+        .unwrap()
+        .with_optional_namesrv_addr(Some(" 127.0.0.1:9876 ".into()));
+
+        assert_eq!(request.message_ids(), ["7F0000010007D8260BF075769D36C348"]);
+        assert_eq!(request.topic.as_str(), "TopicA");
+        assert_eq!(request.cluster.as_ref().unwrap().as_str(), "DefaultCluster");
+        assert_eq!(request.namesrv_addr.as_deref(), Some("127.0.0.1:9876"));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn message_track_rows_convert_track_type_to_display_text() {
+        let rows = message_track_rows(vec![MessageTrack {
+            consumer_group: "GroupA".to_string(),
+            track_type: Some(rocketmq_common::common::tools::track_type::TrackType::Consumed),
+            exception_desc: String::new(),
+        }]);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].consumer_group, "GroupA");
+        assert_eq!(rows[0].track_type.as_deref(), Some("CONSUMED"));
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/admin_facade.rs
@@ -135,11 +135,15 @@ use rocketmq_admin_core::core::lite::TriggerLiteDispatchResult;
 use rocketmq_admin_core::core::message::ConsumeMessagesRequest;
 use rocketmq_admin_core::core::message::DecodeMessageIdRequest;
 use rocketmq_admin_core::core::message::DecodeMessageIdResult;
+use rocketmq_admin_core::core::message::DirectConsumeMessageRequest;
+use rocketmq_admin_core::core::message::DirectConsumeMessageResult;
 use rocketmq_admin_core::core::message::DumpCompactionLogRequest;
 use rocketmq_admin_core::core::message::DumpCompactionLogResult;
 use rocketmq_admin_core::core::message::MessagePullEvent;
 use rocketmq_admin_core::core::message::MessageService;
 use rocketmq_admin_core::core::message::MessageTraceView;
+use rocketmq_admin_core::core::message::MessageTrackRequest;
+use rocketmq_admin_core::core::message::MessageTrackResult;
 use rocketmq_admin_core::core::message::PrintMessagesByQueueRequest;
 use rocketmq_admin_core::core::message::PrintMessagesRequest;
 use rocketmq_admin_core::core::message::QueryMessageByIdRequest;
@@ -1194,6 +1198,33 @@ impl TuiAdminFacade {
             end_time,
         )?
         .with_optional_namesrv_addr(self.namesrv_addr.clone()))
+    }
+
+    pub fn direct_consume_message_request(
+        &self,
+        topic: impl Into<String>,
+        msg_id: impl Into<String>,
+        consumer_group: impl Into<String>,
+        client_id: impl Into<String>,
+        cluster: Option<String>,
+    ) -> RocketMQResult<DirectConsumeMessageRequest> {
+        Ok(
+            DirectConsumeMessageRequest::try_new(topic, msg_id, consumer_group, client_id, cluster)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
+    }
+
+    pub fn message_track_request(
+        &self,
+        message_ids: impl AsRef<str>,
+        topic: impl Into<String>,
+        cluster: Option<String>,
+        timeout_millis: u64,
+    ) -> RocketMQResult<MessageTrackRequest> {
+        Ok(
+            MessageTrackRequest::try_new(split_message_ids(message_ids.as_ref()), topic, cluster, timeout_millis)?
+                .with_optional_namesrv_addr(self.namesrv_addr.clone()),
+        )
     }
 
     pub fn query_message_trace_by_id_request(
@@ -2631,6 +2662,35 @@ impl TuiAdminFacade {
         .await
     }
 
+    pub async fn direct_consume_message(
+        &self,
+        topic: impl Into<String>,
+        msg_id: impl Into<String>,
+        consumer_group: impl Into<String>,
+        client_id: impl Into<String>,
+        cluster: Option<String>,
+    ) -> RocketMQResult<DirectConsumeMessageResult> {
+        MessageService::direct_consume_message_by_request_with_rpc_hook(
+            self.direct_consume_message_request(topic, msg_id, consumer_group, client_id, cluster)?,
+            None,
+        )
+        .await
+    }
+
+    pub async fn message_track(
+        &self,
+        message_ids: impl AsRef<str>,
+        topic: impl Into<String>,
+        cluster: Option<String>,
+        timeout_millis: u64,
+    ) -> RocketMQResult<MessageTrackResult> {
+        MessageService::message_track_by_request_with_rpc_hook(
+            self.message_track_request(message_ids, topic, cluster, timeout_millis)?,
+            None,
+        )
+        .await
+    }
+
     pub async fn query_message_trace_by_id(
         &self,
         msg_id: impl Into<String>,
@@ -3928,6 +3988,26 @@ mod tests {
                 None,
             )
             .unwrap();
+
+        facade
+            .direct_consume_message_request(
+                " TopicA ",
+                " C0A8010100002A9F0000000000000064 ",
+                " GroupA ",
+                " client-a ",
+                Some(" DefaultCluster ".to_string()),
+            )
+            .unwrap();
+
+        let track = facade
+            .message_track_request(
+                " C0A8010100002A9F0000000000000064 ",
+                " TopicA ",
+                Some(" DefaultCluster ".to_string()),
+                3000,
+            )
+            .unwrap();
+        assert_eq!(track.message_ids().len(), 1);
     }
 
     #[test]
@@ -3970,6 +4050,14 @@ mod tests {
             None,
             None,
         ));
+        std::mem::drop(facade.direct_consume_message(
+            "TopicA",
+            "C0A8010100002A9F0000000000000064",
+            "GroupA",
+            "client-a",
+            None,
+        ));
+        std::mem::drop(facade.message_track("C0A8010100002A9F0000000000000064", "TopicA", None, 3000));
         std::mem::drop(facade.query_message_by_offset("TopicA", "broker-a", 0, 0, None));
         std::mem::drop(facade.query_message_trace_by_id("C0A8010100002A9F0000000000000064", None, None, None, 32));
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/commands.rs
@@ -1101,8 +1101,8 @@ where
             let result = facade
                 .query_message_by_unique_key(
                     form.required_string("msg_id")?,
-                    form.optional_string("consumer_group"),
-                    form.optional_string("client_id"),
+                    None,
+                    None,
                     form.required_string("topic")?,
                     form.bool_value("show_all")?,
                     form.optional_string("cluster"),
@@ -1111,6 +1111,29 @@ where
                 )
                 .await?;
             CommandResultViewModel::message_query_by_unique_key(spec.title, &result)
+        }
+        "message.direct_consume" => {
+            let result = facade
+                .direct_consume_message(
+                    form.required_string("topic")?,
+                    form.required_string("msg_id")?,
+                    form.required_string("consumer_group")?,
+                    form.required_string("client_id")?,
+                    form.optional_string("cluster"),
+                )
+                .await?;
+            CommandResultViewModel::direct_consume_message(spec.title, &result)
+        }
+        "message.track_by_id" => {
+            let result = facade
+                .message_track(
+                    form.required_string("message_ids")?,
+                    form.required_string("topic")?,
+                    form.optional_string("cluster"),
+                    form.number_u64("timeout_millis")?,
+                )
+                .await?;
+            CommandResultViewModel::message_track(spec.title, &result)
         }
         "message.query_by_offset" => {
             let result = facade
@@ -2890,7 +2913,7 @@ fn message_commands(commands: &mut Vec<CommandSpec>) {
             "message.query_by_unique_key",
             CommandCategory::Message,
             "Query Message By Unique Key",
-            "Query messages by unique message key and optional direct-consume target.",
+            "Query messages by unique message key.",
             RiskLevel::Safe,
             vec![
                 required_string(
@@ -2900,8 +2923,6 @@ fn message_commands(commands: &mut Vec<CommandSpec>) {
                     "7F0000010007D8260BF075769D36C348",
                 ),
                 required_string("topic", "Topic", "Topic name.", "TopicA"),
-                optional_string("consumer_group", "Consumer Group", "Optional consumer group.", "GroupA"),
-                optional_string("client_id", "Client ID", "Optional consumer client id.", "client-a"),
                 bool_arg("show_all", "Show All", "Show all matched messages.", false),
                 optional_string("cluster", "Cluster", "Optional cluster name.", "DefaultCluster"),
                 number(
@@ -2919,6 +2940,54 @@ fn message_commands(commands: &mut Vec<CommandSpec>) {
                     false,
                     None,
                     Some(0),
+                ),
+            ],
+            ResultViewKind::Table,
+            None,
+        ),
+        spec(
+            "message.direct_consume",
+            CommandCategory::Message,
+            "Direct Consume Message",
+            "Ask one push-consumer client to directly consume a message for diagnostics.",
+            RiskLevel::Mutating,
+            vec![
+                required_string("topic", "Topic", "Topic name.", "TopicA"),
+                required_string(
+                    "msg_id",
+                    "Message ID",
+                    "Message ID or unique message key.",
+                    "7F0000010007D8260BF075769D36C348",
+                ),
+                required_string("consumer_group", "Consumer Group", "Consumer group.", "GroupA"),
+                required_string("client_id", "Client ID", "Consumer client id.", "client-a"),
+                optional_string("cluster", "Cluster", "Optional cluster name.", "DefaultCluster"),
+            ],
+            ResultViewKind::Table,
+            None,
+        ),
+        spec(
+            "message.track_by_id",
+            CommandCategory::Message,
+            "Track Message By ID",
+            "Query message consumer track detail by message ID.",
+            RiskLevel::Safe,
+            vec![
+                required_string(
+                    "message_ids",
+                    "Message IDs",
+                    "Message IDs separated by comma, semicolon, or whitespace.",
+                    "7F0000010007D8260BF075769D36C348",
+                ),
+                required_string("topic", "Topic", "Topic name.", "TopicA"),
+                optional_string("cluster", "Cluster", "Optional cluster name.", "DefaultCluster"),
+                number(
+                    "timeout_millis",
+                    "Timeout",
+                    "Per-message track timeout in milliseconds.",
+                    true,
+                    Some(3000),
+                    Some(1),
                 ),
             ],
             ResultViewKind::Table,
@@ -3652,6 +3721,7 @@ impl DebugTail for CommandResultViewModel {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::collections::HashSet;
 
     use super::command_catalog;
@@ -3732,6 +3802,8 @@ mod tests {
             "message.query_by_id",
             "message.query_by_key",
             "message.query_by_unique_key",
+            "message.direct_consume",
+            "message.track_by_id",
             "message.query_by_offset",
             "message.query_trace_by_id",
         ] {
@@ -3744,6 +3816,43 @@ mod tests {
         let catalog = command_catalog();
         let ids = catalog.iter().map(|command| command.id).collect::<HashSet<_>>();
         assert_eq!(catalog.len(), ids.len());
+    }
+
+    #[test]
+    fn phase_six_command_catalog_category_snapshot() {
+        let catalog = command_catalog();
+        let mut counts = BTreeMap::new();
+        for command in &catalog {
+            *counts.entry(command.category).or_insert(0) += 1;
+            assert!(!command.id.trim().is_empty());
+            assert!(!command.title.trim().is_empty());
+            assert!(!command.description.trim().is_empty());
+        }
+
+        assert_eq!(catalog.len(), 102);
+        assert_eq!(
+            counts,
+            BTreeMap::from([
+                (CommandCategory::Auth, 12),
+                (CommandCategory::Broker, 15),
+                (CommandCategory::Cluster, 3),
+                (CommandCategory::Connection, 2),
+                (CommandCategory::Consumer, 8),
+                (CommandCategory::Container, 2),
+                (CommandCategory::Controller, 5),
+                (CommandCategory::Export, 6),
+                (CommandCategory::Ha, 2),
+                (CommandCategory::Lite, 6),
+                (CommandCategory::Message, 12),
+                (CommandCategory::NameServer, 6),
+                (CommandCategory::Offset, 5),
+                (CommandCategory::Producer, 4),
+                (CommandCategory::Queue, 2),
+                (CommandCategory::StaticTopic, 2),
+                (CommandCategory::Stats, 1),
+                (CommandCategory::Topic, 9),
+            ])
+        );
     }
 
     #[test]
@@ -4059,5 +4168,34 @@ mod tests {
             .args
             .iter()
             .any(|arg| arg.name == "broker_config_path" && arg.required));
+    }
+
+    #[test]
+    fn phase_five_catalog_exposes_message_direct_consume_and_track_commands() {
+        let catalog = command_catalog();
+
+        let direct = catalog
+            .iter()
+            .find(|command| command.id == "message.direct_consume")
+            .expect("direct consume command");
+        assert_eq!(direct.risk_level, RiskLevel::Mutating);
+        assert_eq!(direct.result_view_kind, ResultViewKind::Table);
+        assert!(direct
+            .args
+            .iter()
+            .any(|arg| arg.name == "consumer_group" && arg.required));
+        assert!(direct.args.iter().any(|arg| arg.name == "client_id" && arg.required));
+
+        let track = catalog
+            .iter()
+            .find(|command| command.id == "message.track_by_id")
+            .expect("message track command");
+        assert_eq!(track.risk_level, RiskLevel::Safe);
+        assert_eq!(track.result_view_kind, ResultViewKind::Table);
+        assert!(track.args.iter().any(|arg| arg.name == "message_ids" && arg.required));
+        assert!(track
+            .args
+            .iter()
+            .any(|arg| arg.name == "timeout_millis" && arg.required));
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/view_model.rs
@@ -31,9 +31,13 @@ use rocketmq_admin_core::core::export_data::ExportRocksDbConfigRpcResult;
 use rocketmq_admin_core::core::lite::TriggerLiteDispatchResult;
 use rocketmq_admin_core::core::message::DecodeMessageIdOutcome;
 use rocketmq_admin_core::core::message::DecodeMessageIdResult;
+use rocketmq_admin_core::core::message::DirectConsumeMessageResult;
+use rocketmq_admin_core::core::message::DirectConsumeMessageStatus;
 use rocketmq_admin_core::core::message::DumpCompactionLogResult;
 use rocketmq_admin_core::core::message::MessagePullEvent;
 use rocketmq_admin_core::core::message::MessageTraceView;
+use rocketmq_admin_core::core::message::MessageTrackOutcome;
+use rocketmq_admin_core::core::message::MessageTrackResult;
 use rocketmq_admin_core::core::message::QueryMessageByIdOutcome;
 use rocketmq_admin_core::core::message::QueryMessageByIdResult;
 use rocketmq_admin_core::core::message::QueryMessageByKeyResult;
@@ -768,6 +772,160 @@ impl CommandResultViewModel {
         };
 
         Self::table(title, &MESSAGE_DETAIL_HEADERS, rows)
+    }
+
+    pub fn direct_consume_message(title: impl Into<String>, result: &DirectConsumeMessageResult) -> Self {
+        let mut row = vec![
+            result.consumer_group.to_string(),
+            result.client_id.to_string(),
+            result.topic.to_string(),
+            result.msg_id.to_string(),
+        ];
+
+        match &result.status {
+            DirectConsumeMessageStatus::Consumed(detail) => {
+                row.extend([
+                    "consumed".to_string(),
+                    detail.consume_result.clone().unwrap_or_default(),
+                    detail.order.to_string(),
+                    detail.auto_commit.to_string(),
+                    detail.spent_time_millis.to_string(),
+                    detail.remark.clone().unwrap_or_default(),
+                ]);
+            }
+            DirectConsumeMessageStatus::NotPushConsumer => {
+                row.extend([
+                    "not-push-consumer".to_string(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    "target client is not a push consumer".to_string(),
+                ]);
+            }
+            DirectConsumeMessageStatus::RunningInfoFailed { error } => {
+                row.extend([
+                    "running-info-failed".to_string(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    sanitize_cell(error),
+                ]);
+            }
+            DirectConsumeMessageStatus::Failed { error } => {
+                row.extend([
+                    "failed".to_string(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    sanitize_cell(error),
+                ]);
+            }
+        }
+
+        Self::table(
+            title,
+            &[
+                "Consumer Group",
+                "Client ID",
+                "Topic",
+                "Message ID",
+                "Status",
+                "Consume Result",
+                "Order",
+                "Auto Commit",
+                "Spent Time",
+                "Remark",
+            ],
+            vec![row],
+        )
+    }
+
+    pub fn message_track(title: impl Into<String>, result: &MessageTrackResult) -> Self {
+        let mut rows = Vec::new();
+        for entry in &result.entries {
+            match &entry.outcome {
+                MessageTrackOutcome::Found {
+                    broker_addr,
+                    query_time_ms,
+                    tracks,
+                } if tracks.is_empty() => rows.push(vec![
+                    entry.message_id.to_string(),
+                    "found".to_string(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    broker_addr.clone(),
+                    query_time_ms.to_string(),
+                    "no consumer".to_string(),
+                ]),
+                MessageTrackOutcome::Found {
+                    broker_addr,
+                    query_time_ms,
+                    tracks,
+                } => {
+                    rows.extend(tracks.iter().map(|track| {
+                        vec![
+                            entry.message_id.to_string(),
+                            "found".to_string(),
+                            track.consumer_group.clone(),
+                            track.track_type.clone().unwrap_or_default(),
+                            sanitize_cell(&track.exception_desc),
+                            broker_addr.clone(),
+                            query_time_ms.to_string(),
+                            String::new(),
+                        ]
+                    }));
+                }
+                MessageTrackOutcome::NotFound { reason, query_time_ms } => rows.push(vec![
+                    entry.message_id.to_string(),
+                    "not-found".to_string(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    query_time_ms.to_string(),
+                    sanitize_cell(reason),
+                ]),
+                MessageTrackOutcome::Failed { error, query_time_ms } => rows.push(vec![
+                    entry.message_id.to_string(),
+                    "failed".to_string(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    query_time_ms.to_string(),
+                    sanitize_cell(error),
+                ]),
+                MessageTrackOutcome::TimedOut => rows.push(vec![
+                    entry.message_id.to_string(),
+                    "timed-out".to_string(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    "track query timed out".to_string(),
+                ]),
+            }
+        }
+
+        Self::table(
+            title,
+            &[
+                "Message ID",
+                "Status",
+                "Consumer Group",
+                "Track Type",
+                "Exception",
+                "Broker",
+                "Query Time",
+                "Note",
+            ],
+            rows,
+        )
     }
 
     pub fn decoded_message_ids(title: impl Into<String>, result: &DecodeMessageIdResult) -> Self {
@@ -1884,8 +2042,15 @@ mod tests {
     use rocketmq_admin_core::core::message::DecodeMessageIdEntry;
     use rocketmq_admin_core::core::message::DecodeMessageIdOutcome;
     use rocketmq_admin_core::core::message::DecodeMessageIdResult;
+    use rocketmq_admin_core::core::message::DirectConsumeMessageResult;
+    use rocketmq_admin_core::core::message::DirectConsumeMessageResultDetail;
+    use rocketmq_admin_core::core::message::DirectConsumeMessageStatus;
     use rocketmq_admin_core::core::message::MessagePullEvent;
     use rocketmq_admin_core::core::message::MessageTraceView;
+    use rocketmq_admin_core::core::message::MessageTrackEntry;
+    use rocketmq_admin_core::core::message::MessageTrackOutcome;
+    use rocketmq_admin_core::core::message::MessageTrackResult;
+    use rocketmq_admin_core::core::message::MessageTrackRow;
     use rocketmq_admin_core::core::message::QueryMessageByIdEntry;
     use rocketmq_admin_core::core::message::QueryMessageByIdOutcome;
     use rocketmq_admin_core::core::message::QueryMessageByIdResult;
@@ -3084,6 +3249,90 @@ mod tests {
         assert!(result.text_body().contains("undone-msgs"));
         assert!(result.text_body().contains("client-a stalled"));
         assert!(result.text_body().contains("max events reached"));
+    }
+
+    #[test]
+    fn phase_five_direct_consume_result_renders_as_table() {
+        let result = CommandResultViewModel::direct_consume_message(
+            "Direct Consume Message",
+            &DirectConsumeMessageResult {
+                topic: "TopicA".into(),
+                msg_id: "MSGID".into(),
+                consumer_group: "GroupA".into(),
+                client_id: "client-a".into(),
+                status: DirectConsumeMessageStatus::Consumed(DirectConsumeMessageResultDetail {
+                    order: false,
+                    auto_commit: true,
+                    consume_result: Some("CR_SUCCESS".to_string()),
+                    remark: Some("ok".to_string()),
+                    spent_time_millis: 12,
+                }),
+            },
+        );
+
+        assert_table(
+            &result,
+            &[
+                "Consumer Group",
+                "Client ID",
+                "Topic",
+                "Message ID",
+                "Status",
+                "Consume Result",
+                "Order",
+                "Auto Commit",
+                "Spent Time",
+                "Remark",
+            ],
+            &[
+                "GroupA",
+                "client-a",
+                "TopicA",
+                "MSGID",
+                "consumed",
+                "CR_SUCCESS",
+                "false",
+                "true",
+                "12",
+                "ok",
+            ],
+        );
+    }
+
+    #[test]
+    fn phase_five_message_track_result_renders_as_table() {
+        let result = CommandResultViewModel::message_track(
+            "Track Message By ID",
+            &MessageTrackResult {
+                entries: vec![MessageTrackEntry {
+                    message_id: "MSGID".into(),
+                    outcome: MessageTrackOutcome::Found {
+                        broker_addr: "127.0.0.1:10911".to_string(),
+                        query_time_ms: 7,
+                        tracks: vec![MessageTrackRow {
+                            consumer_group: "GroupA".to_string(),
+                            track_type: Some("CONSUMED".to_string()),
+                            exception_desc: String::new(),
+                        }],
+                    },
+                }],
+            },
+        );
+
+        assert_table(
+            &result,
+            &[
+                "Message ID",
+                "Status",
+                "Consumer Group",
+                "Track Type",
+                "Exception",
+                "Broker",
+                "Query Time",
+                "Note",
+            ],
+            &["MSGID", "found", "GroupA", "CONSUMED", "", "127.0.0.1:10911", "7", ""],
+        );
     }
 
     fn assert_table(result: &CommandResultViewModel, headers: &[&str], first_row: &[&str]) {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7183

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added direct message consumption capability for consumer groups with customizable client identification
  * Added message tracking functionality to query and monitor message flow across brokers
  * Enhanced message querying to support optional cluster specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->