### PR TITLE
[ISSUE #7196]✨enh(stats): add benchmarks for StoreStatsService performance and runtime info

### DIFF
--- a/rocketmq-store/Cargo.toml
+++ b/rocketmq-store/Cargo.toml
@@ -134,6 +134,10 @@ name    = "commit_log_performance"
 harness = false
 
 [[bench]]
+name    = "store_stats_service"
+harness = false
+
+[[bench]]
 name              = "io_uring_performance"
 harness           = false
 required-features = ["io_uring"]

--- a/rocketmq-store/benches/store_stats_service.rs
+++ b/rocketmq-store/benches/store_stats_service.rs
@@ -1,0 +1,81 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! StoreStatsService hot-path and runtime-info performance baselines.
+//!
+//! Run with:
+//! `cargo bench -p rocketmq-store --bench store_stats_service`
+
+use std::hint::black_box;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use rocketmq_store::base::store_stats_service::StoreStatsService;
+
+fn bench_hot_path_updates(c: &mut Criterion) {
+    let mut group = c.benchmark_group("store_stats_service_hot_path");
+
+    for topic_count in [1usize, 16, 128] {
+        let stats = StoreStatsService::new(None);
+        let topics = (0..topic_count)
+            .map(|index| format!("topic-{index}"))
+            .collect::<Vec<_>>();
+
+        group.bench_with_input(
+            BenchmarkId::new("put_topic_times_and_size", topic_count),
+            &topics,
+            |b, topics| {
+                let mut index = 0usize;
+                b.iter(|| {
+                    let topic = &topics[index % topics.len()];
+                    stats.add_single_put_message_topic_times_total(black_box(topic), 1);
+                    stats.add_single_put_message_topic_size_total(black_box(topic), 128);
+                    index = index.wrapping_add(1);
+                });
+            },
+        );
+    }
+
+    let stats = StoreStatsService::new(None);
+    group.bench_function("put_latency_record", |b| {
+        let mut value = 0u64;
+        b.iter(|| {
+            stats.set_put_message_entire_time_max(black_box(value % 10_000));
+            value = value.wrapping_add(1);
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_runtime_info(c: &mut Criterion) {
+    let stats = StoreStatsService::new(None);
+    for topic_index in 0..256 {
+        let topic = format!("topic-{topic_index}");
+        stats.add_single_put_message_topic_times_total(&topic, 10);
+        stats.add_single_put_message_topic_size_total(&topic, 1024);
+    }
+    for value in 1..=1_000 {
+        stats.set_put_message_entire_time_max(value);
+    }
+
+    c.bench_function("store_stats_service_runtime_info_256_topics", |b| {
+        b.iter(|| black_box(stats.get_runtime_info()));
+    });
+}
+
+criterion_group!(benches, bench_hot_path_updates, bench_runtime_info);
+criterion_main!(benches);

--- a/rocketmq-store/src/base/store_stats_service.rs
+++ b/rocketmq-store/src/base/store_stats_service.rs
@@ -683,6 +683,7 @@ mod call_snapshot_tests {
     use std::thread;
 
     use super::*;
+    use tokio::task;
 
     #[test]
     fn calculates_tps_for_non_zero_duration() {
@@ -786,5 +787,115 @@ mod call_snapshot_tests {
 
         assert_eq!(stats.get_message_entire_time_max.load(Ordering::Relaxed), 10);
         assert_eq!(stats.dispatch_max_buffer.load(Ordering::Relaxed), 100);
+    }
+
+    #[test]
+    fn sampling_keeps_only_java_compatible_ten_minute_window() {
+        let stats = StoreStatsService::new(None);
+
+        for index in 0..(MAX_SNAPSHOT_RECORDS + 10) {
+            stats.add_single_put_message_topic_times_total("topic-a", 1);
+            stats.get_message_times_total_found().store(index, Ordering::Relaxed);
+            stats.get_message_times_total_miss().store(index * 2, Ordering::Relaxed);
+            stats
+                .get_message_transferred_msg_count()
+                .store(index * 3, Ordering::Relaxed);
+            stats.sampling();
+        }
+
+        assert_eq!(stats.put_times_list.lock().len(), MAX_SNAPSHOT_RECORDS);
+        assert_eq!(stats.get_times_found_list.lock().len(), MAX_SNAPSHOT_RECORDS);
+        assert_eq!(stats.get_times_miss_list.lock().len(), MAX_SNAPSHOT_RECORDS);
+        assert_eq!(stats.transferred_msg_count_list.lock().len(), MAX_SNAPSHOT_RECORDS);
+        assert_eq!(stats.put_times_list.lock().front().unwrap().call_times_total, 11);
+    }
+
+    #[test]
+    fn runtime_info_reports_java_compatible_fields_and_values() {
+        let stats = StoreStatsService::new(None);
+        stats.add_single_put_message_topic_times_total("topic-a", 4);
+        stats.add_single_put_message_topic_size_total("topic-a", 100);
+        stats.get_put_message_failed_times().store(2, Ordering::Relaxed);
+        stats.set_put_message_entire_time_max(50);
+        stats.set_get_message_entire_time_max(9);
+        stats.set_dispatch_max_buffer(256);
+        stats.reset_put_message_distribute_time();
+        stats.reset_put_message_time_buckets();
+
+        let runtime_info = stats.get_runtime_info();
+
+        for key in [
+            "bootTimestamp",
+            "runtime",
+            "putMessageEntireTimeMax",
+            "putMessageTimesTotal",
+            "putMessageFailedTimes",
+            "putMessageSizeTotal",
+            "putMessageDistributeTime",
+            "putMessageAverageSize",
+            "dispatchMaxBuffer",
+            "getMessageEntireTimeMax",
+            "putTps",
+            "getFoundTps",
+            "getMissTps",
+            "getTotalTps",
+            "getTransferredTps",
+            "putLatency99",
+            "putLatency999",
+        ] {
+            assert!(runtime_info.contains_key(key), "missing runtime info key {key}");
+        }
+
+        assert_eq!(runtime_info["putMessageTimesTotal"], "4");
+        assert_eq!(runtime_info["putMessageFailedTimes"], "2");
+        assert_eq!(runtime_info["putMessageSizeTotal"], "100");
+        assert_eq!(runtime_info["putMessageAverageSize"], "25");
+        assert_eq!(runtime_info["putMessageEntireTimeMax"], "50");
+        assert_eq!(runtime_info["getMessageEntireTimeMax"], "9");
+        assert_eq!(runtime_info["dispatchMaxBuffer"], "256");
+        assert!(runtime_info["runtime"].starts_with("[ 0 days, 0 hours"));
+        assert!(runtime_info["putMessageDistributeTime"].contains("[50~100ms]:1"));
+    }
+
+    #[test]
+    fn print_tps_rotates_latency_snapshots_for_percentile_queries() {
+        let stats = StoreStatsService::new(None);
+        for value in 1..=100 {
+            stats.set_put_message_entire_time_max(value);
+        }
+        stats.last_print_timestamp.store(0, Ordering::Release);
+
+        stats.print_tps();
+
+        assert!(stats.find_put_message_entire_time_px(0.99) >= 90.0);
+        assert!(stats.put_message_distribute_time_to_string().contains("[10~50ms]:40"));
+        assert_eq!(
+            stats
+                .put_message_time_buckets
+                .iter()
+                .map(|bucket| bucket.load(Ordering::Relaxed))
+                .sum::<u64>(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn start_shutdown_are_idempotent_and_restartable() {
+        let stats = Arc::new(StoreStatsService::new(None));
+
+        stats.start();
+        stats.start();
+        assert!(stats.worker_handle.lock().is_some());
+        assert!(!stats.stopped.load(Ordering::Acquire));
+
+        task::yield_now().await;
+        stats.shutdown();
+        stats.shutdown();
+        assert!(stats.worker_handle.lock().is_none());
+        assert!(stats.stopped.load(Ordering::Acquire));
+
+        stats.start();
+        assert!(stats.worker_handle.lock().is_some());
+        stats.shutdown();
     }
 }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -3312,6 +3312,7 @@ mod tests {
     use std::time::Duration;
     use std::time::Instant;
 
+    use bytes::BufMut;
     use bytes::Bytes;
     use bytes::BytesMut;
     use cheetah_string::CheetahString;
@@ -3319,11 +3320,13 @@ mod tests {
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
     use rocketmq_common::common::broker::broker_role::BrokerRole;
     use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_common::common::message::message_batch::MessageExtBatch;
     use rocketmq_common::common::message::message_ext::MessageExt;
     use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
     use rocketmq_common::common::message::MessageConst;
     use rocketmq_common::common::message::MessageTrait;
     use rocketmq_common::common::topic::TopicValidator;
+    use rocketmq_common::CRC32Utils::crc32;
     use rocketmq_rust::ArcMut;
     use tempfile::tempdir;
 
@@ -3382,6 +3385,39 @@ mod tests {
         let msg_size = bytes.get_i32();
         let tags_code = bytes.get_i64();
         (commit_log_offset, msg_size, tags_code)
+    }
+
+    fn build_test_message(topic: &CheetahString, body: Bytes) -> MessageExtBrokerInner {
+        let mut msg = MessageExtBrokerInner::default();
+        msg.set_topic(topic.clone());
+        msg.message_ext_inner.set_queue_id(0);
+        msg.set_body(body);
+        msg
+    }
+
+    fn build_test_batch(topic: &CheetahString, bodies: &[Bytes]) -> MessageExtBatch {
+        let mut batch_body = BytesMut::new();
+        for body in bodies {
+            let record_size = 4 + 4 + 4 + 4 + 4 + body.len() + 2;
+            batch_body.put_i32(record_size as i32);
+            batch_body.put_i32(0);
+            batch_body.put_i32(crc32(body.as_ref()) as i32);
+            batch_body.put_i32(0);
+            batch_body.put_i32(body.len() as i32);
+            batch_body.put_slice(body.as_ref());
+            batch_body.put_i16(0);
+        }
+
+        let mut inner = MessageExtBrokerInner::default();
+        inner.set_topic(topic.clone());
+        inner.message_ext_inner.set_queue_id(0);
+        inner.set_body(batch_body.freeze());
+
+        MessageExtBatch {
+            message_ext_broker_inner: inner,
+            is_inner_batch: false,
+            encoded_buff: None,
+        }
     }
 
     #[test]
@@ -3985,6 +4021,89 @@ mod tests {
         assert_eq!(result.min_offset(), 0);
         assert_eq!(result.max_offset(), 2);
         assert_eq!(result.message_mapped_list().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn store_stats_records_single_put_append_totals() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_async_flush_test_store(&temp_dir);
+        let topic = CheetahString::from_static_str("single-put-store-stats-topic");
+        let stats = store.get_store_stats_service();
+
+        let put_result = store
+            .put_message(build_test_message(&topic, Bytes::from_static(b"single-put-body")))
+            .await;
+
+        assert_eq!(put_result.put_message_status(), PutMessageStatus::PutOk);
+        let append_result = put_result.append_message_result().expect("single put append result");
+        assert_eq!(append_result.msg_num, 1);
+        assert_eq!(stats.get_put_message_times_total(), append_result.msg_num as u64);
+        assert_eq!(stats.get_put_message_size_total(), append_result.wrote_bytes as u64);
+
+        let runtime_info = stats.get_runtime_info();
+        assert_eq!(runtime_info["putMessageTimesTotal"], "1");
+        assert_eq!(
+            runtime_info["putMessageSizeTotal"],
+            append_result.wrote_bytes.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn store_stats_records_batch_put_append_totals() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_async_flush_test_store(&temp_dir);
+        let topic = CheetahString::from_static_str("batch-put-store-stats-topic");
+        let stats = store.get_store_stats_service();
+        let batch = build_test_batch(
+            &topic,
+            &[
+                Bytes::from_static(b"batch-body-1"),
+                Bytes::from_static(b"batch-body-2"),
+                Bytes::from_static(b"batch-body-3"),
+            ],
+        );
+
+        let put_result = store.put_messages(batch).await;
+
+        assert_eq!(put_result.put_message_status(), PutMessageStatus::PutOk);
+        let append_result = put_result.append_message_result().expect("batch put append result");
+        assert_eq!(append_result.msg_num, 3);
+        assert_eq!(stats.get_put_message_times_total(), 3);
+        assert_eq!(stats.get_put_message_size_total(), append_result.wrote_bytes as u64);
+    }
+
+    #[tokio::test]
+    async fn store_stats_records_get_found_miss_and_transferred_counts() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_async_flush_test_store(&temp_dir);
+        let topic = CheetahString::from_static_str("get-store-stats-topic");
+        let group = CheetahString::from_static_str("get-store-stats-group");
+        let stats = store.get_store_stats_service();
+
+        for body in [Bytes::from_static(b"first-body"), Bytes::from_static(b"second-body")] {
+            let put_result = store.put_message(build_test_message(&topic, body)).await;
+            assert_eq!(put_result.put_message_status(), PutMessageStatus::PutOk);
+        }
+        store.reput_once().await;
+
+        let found_result = store
+            .get_message(&group, &topic, 0, 0, 32, None)
+            .await
+            .expect("found get result");
+        assert_eq!(found_result.status(), Some(GetMessageStatus::Found));
+        assert_eq!(found_result.message_count(), 2);
+        assert_eq!(stats.get_message_times_total_found().load(Ordering::Relaxed), 1);
+        assert_eq!(stats.get_message_times_total_miss().load(Ordering::Relaxed), 0);
+        assert_eq!(stats.get_message_transferred_msg_count().load(Ordering::Relaxed), 2);
+
+        let miss_result = store
+            .get_message(&group, &topic, 0, 2, 32, None)
+            .await
+            .expect("miss get result");
+        assert_ne!(miss_result.status(), Some(GetMessageStatus::Found));
+        assert_eq!(stats.get_message_times_total_found().load(Ordering::Relaxed), 1);
+        assert_eq!(stats.get_message_times_total_miss().load(Ordering::Relaxed), 1);
+        assert_eq!(stats.get_message_transferred_msg_count().load(Ordering::Relaxed), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7196

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive benchmarks for store statistics service performance evaluation
  * Expanded unit test coverage for store statistics functionality including sampling behavior, runtime metrics reporting, and message tracking operations

* **Chores**
  * Added benchmark infrastructure for performance monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->