### PR TITLE
[ISSUE #7200]🚀feat(broker): add fast failure configuration and implement request handling for broker queues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3659,6 +3659,7 @@ dependencies = [
  "sysinfo",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "trait-variant",
 ]

--- a/rocketmq-broker/Cargo.toml
+++ b/rocketmq-broker/Cargo.toml
@@ -46,6 +46,7 @@ rocketmq-auth        = { workspace = true }
 anyhow.workspace = true
 
 tokio.workspace = true
+tokio-util.workspace = true
 
 tracing.workspace = true
 

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -251,7 +251,7 @@ impl BrokerRuntime {
             escape_bridge: None,
             pop_inflight_message_counter,
             replicas_manager: None,
-            broker_fast_failure: BrokerFastFailure,
+            broker_fast_failure: BrokerFastFailure::new(broker_config.clone()),
             cold_data_pull_request_hold_service: Some(ColdDataPullRequestHoldService::default()),
             cold_data_cg_ctr_service: Some(ColdDataCgCtrService::new(
                 message_store_config.cold_data_flow_control_enable,
@@ -525,6 +525,10 @@ impl BrokerRuntime {
             self.inner.timer_message_store = message_store.get_timer_message_store().cloned();
             self.inner.broker_stats = Some(BrokerStats::new(message_store.clone()));
             self.inner.message_store = Some(message_store.clone());
+            let message_store_for_fast_failure = message_store.clone();
+            self.inner
+                .broker_fast_failure
+                .set_page_cache_busy_checker(move || message_store_for_fast_failure.is_os_page_cache_busy());
             self.inner
                 .consumer_offset_manager
                 .set_message_store(Some(message_store));
@@ -668,6 +672,7 @@ impl BrokerRuntime {
         if let Some(auth_runtime) = &self.inner.auth_runtime {
             broker_request_processor.set_auth_runtime(auth_runtime.clone());
         }
+        broker_request_processor.set_broker_fast_failure(self.inner.broker_fast_failure.clone());
         let send_message_processor = ArcMut::new(send_message_processor);
 
         broker_request_processor.register_processor(

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -12,16 +12,723 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::VecDeque;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use tokio::sync::oneshot;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
 use tracing::warn;
 
-pub struct BrokerFastFailure;
+const TASK_STATE_PENDING: u8 = 0;
+const TASK_STATE_RUNNING: u8 = 1;
+const TASK_STATE_COMPLETED: u8 = 2;
+const TASK_STATE_CANCELED: u8 = 3;
 
-impl BrokerFastFailure {
-    pub fn start(&mut self) {
-        warn!("BrokerFastFailure started not implemented");
+const INITIAL_DELAY: Duration = Duration::from_millis(1_000);
+const SCAN_INTERVAL: Duration = Duration::from_millis(10);
+const DEFAULT_SCAN_BATCH_LIMIT: usize = 256;
+const JSTACK_LOG_INTERVAL_MILLIS: i64 = 15_000;
+
+const ALL_QUEUE_KINDS: [FastFailureQueueKind; 7] = [
+    FastFailureQueueKind::Send,
+    FastFailureQueueKind::Pull,
+    FastFailureQueueKind::LitePull,
+    FastFailureQueueKind::Heartbeat,
+    FastFailureQueueKind::Transaction,
+    FastFailureQueueKind::Ack,
+    FastFailureQueueKind::AdminBroker,
+];
+
+type PageCacheBusyChecker = Arc<dyn Fn() -> bool + Send + Sync + 'static>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum FastFailureQueueKind {
+    Send,
+    Pull,
+    LitePull,
+    Heartbeat,
+    Transaction,
+    Ack,
+    AdminBroker,
+}
+
+impl FastFailureQueueKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Send => "send",
+            Self::Pull => "pull",
+            Self::LitePull => "litePull",
+            Self::Heartbeat => "heartbeat",
+            Self::Transaction => "transaction",
+            Self::Ack => "ack",
+            Self::AdminBroker => "adminBroker",
+        }
+    }
+}
+
+pub(crate) struct FastFailureTask {
+    id: u64,
+    created_timestamp_millis: u64,
+    opaque: i32,
+    state: AtomicU8,
+    response_tx: Mutex<Option<oneshot::Sender<Option<RemotingCommand>>>>,
+}
+
+impl FastFailureTask {
+    fn new(
+        id: u64,
+        opaque: i32,
+        created_timestamp_millis: u64,
+        response_tx: oneshot::Sender<Option<RemotingCommand>>,
+    ) -> Self {
+        Self {
+            id,
+            created_timestamp_millis,
+            opaque,
+            state: AtomicU8::new(TASK_STATE_PENDING),
+            response_tx: Mutex::new(Some(response_tx)),
+        }
     }
 
-    pub fn shutdown(&mut self) {
-        warn!("BrokerFastFailure shutdown not implemented");
+    #[inline]
+    pub(crate) fn created_timestamp_millis(&self) -> u64 {
+        self.created_timestamp_millis
+    }
+
+    #[inline]
+    fn state(&self) -> u8 {
+        self.state.load(Ordering::Acquire)
+    }
+
+    fn mark_running(&self) -> bool {
+        self.state
+            .compare_exchange(
+                TASK_STATE_PENDING,
+                TASK_STATE_RUNNING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn complete(&self, response: Option<RemotingCommand>) -> bool {
+        if self
+            .state
+            .compare_exchange(
+                TASK_STATE_RUNNING,
+                TASK_STATE_COMPLETED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            self.send_response(response);
+            return true;
+        }
+
+        false
+    }
+
+    fn cancel(&self, response: RemotingCommand) -> bool {
+        if self
+            .state
+            .compare_exchange(
+                TASK_STATE_PENDING,
+                TASK_STATE_CANCELED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            self.send_response(Some(response));
+            return true;
+        }
+
+        false
+    }
+
+    fn send_response(&self, response: Option<RemotingCommand>) {
+        if let Some(response_tx) = self.response_tx.lock().take() {
+            let _ = response_tx.send(response);
+        }
+    }
+}
+
+struct FastFailureQueue {
+    kind: FastFailureQueueKind,
+    tasks: Mutex<VecDeque<Arc<FastFailureTask>>>,
+    pending_count: AtomicUsize,
+    running_count: AtomicUsize,
+    semaphore: Arc<Semaphore>,
+}
+
+impl FastFailureQueue {
+    fn new(kind: FastFailureQueueKind, permits: usize) -> Self {
+        Self {
+            kind,
+            tasks: Mutex::new(VecDeque::new()),
+            pending_count: AtomicUsize::new(0),
+            running_count: AtomicUsize::new(0),
+            semaphore: Arc::new(Semaphore::new(permits.max(1))),
+        }
+    }
+
+    fn enqueue(&self, task: Arc<FastFailureTask>) {
+        self.tasks.lock().push_back(task);
+        self.pending_count.fetch_add(1, Ordering::AcqRel);
+    }
+
+    async fn acquire_permit(&self) -> Option<OwnedSemaphorePermit> {
+        self.semaphore.clone().acquire_owned().await.ok()
+    }
+
+    fn try_mark_running(&self, task: &FastFailureTask) -> bool {
+        if task.mark_running() {
+            self.pending_count.fetch_sub(1, Ordering::AcqRel);
+            self.running_count.fetch_add(1, Ordering::AcqRel);
+            return true;
+        }
+
+        false
+    }
+
+    fn complete(&self, task: &FastFailureTask, response: Option<RemotingCommand>) {
+        if task.complete(response) {
+            self.running_count.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
+    fn cancel_pending(&self, task: &FastFailureTask, response: RemotingCommand) -> bool {
+        if task.cancel(response) {
+            self.pending_count.fetch_sub(1, Ordering::AcqRel);
+            return true;
+        }
+
+        false
+    }
+
+    #[inline]
+    fn pending_count(&self) -> usize {
+        self.pending_count.load(Ordering::Acquire)
+    }
+
+    fn clean_expired(&self, now_millis: u64, max_wait_millis: u64, batch_limit: usize) -> usize {
+        self.clean_pending(now_millis, Some(max_wait_millis), batch_limit, "[TIMEOUT_CLEAN_QUEUE]")
+    }
+
+    fn clean_page_cache_busy(&self, now_millis: u64, batch_limit: usize) -> usize {
+        self.clean_pending(now_millis, None, batch_limit, "[PCBUSY_CLEAN_QUEUE]")
+    }
+
+    fn clean_pending(
+        &self,
+        now_millis: u64,
+        max_wait_millis: Option<u64>,
+        batch_limit: usize,
+        remark_prefix: &'static str,
+    ) -> usize {
+        let mut cleaned = 0;
+
+        while cleaned < batch_limit {
+            let Some(task) = self.take_cleanable_head(now_millis, max_wait_millis) else {
+                break;
+            };
+            let behind = now_millis.saturating_sub(task.created_timestamp_millis());
+            let response = system_busy_response(task.opaque, remark_prefix, behind, self.pending_count());
+
+            if self.cancel_pending(&task, response) {
+                cleaned += 1;
+            }
+        }
+
+        cleaned
+    }
+
+    fn take_cleanable_head(&self, now_millis: u64, max_wait_millis: Option<u64>) -> Option<Arc<FastFailureTask>> {
+        loop {
+            let mut tasks = self.tasks.lock();
+            let front = tasks.front().cloned()?;
+
+            match front.state() {
+                TASK_STATE_RUNNING | TASK_STATE_COMPLETED | TASK_STATE_CANCELED => {
+                    tasks.pop_front();
+                }
+                TASK_STATE_PENDING => {
+                    let expired = max_wait_millis.is_none_or(|max_wait_millis| {
+                        now_millis.saturating_sub(front.created_timestamp_millis()) >= max_wait_millis
+                    });
+                    if !expired {
+                        return None;
+                    }
+                    tasks.pop_front();
+                    return Some(front);
+                }
+                _ => {
+                    warn!(
+                        "unknown fast failure task state: queue={}, task_id={}, state={}",
+                        self.kind.name(),
+                        front.id,
+                        front.state()
+                    );
+                    tasks.pop_front();
+                }
+            }
+        }
+    }
+}
+
+struct FastFailureQueues {
+    send: Arc<FastFailureQueue>,
+    pull: Arc<FastFailureQueue>,
+    lite_pull: Arc<FastFailureQueue>,
+    heartbeat: Arc<FastFailureQueue>,
+    transaction: Arc<FastFailureQueue>,
+    ack: Arc<FastFailureQueue>,
+    admin_broker: Arc<FastFailureQueue>,
+}
+
+impl FastFailureQueues {
+    fn new() -> Self {
+        Self {
+            send: Arc::new(FastFailureQueue::new(
+                FastFailureQueueKind::Send,
+                permits_for(FastFailureQueueKind::Send),
+            )),
+            pull: Arc::new(FastFailureQueue::new(
+                FastFailureQueueKind::Pull,
+                permits_for(FastFailureQueueKind::Pull),
+            )),
+            lite_pull: Arc::new(FastFailureQueue::new(
+                FastFailureQueueKind::LitePull,
+                permits_for(FastFailureQueueKind::LitePull),
+            )),
+            heartbeat: Arc::new(FastFailureQueue::new(
+                FastFailureQueueKind::Heartbeat,
+                permits_for(FastFailureQueueKind::Heartbeat),
+            )),
+            transaction: Arc::new(FastFailureQueue::new(
+                FastFailureQueueKind::Transaction,
+                permits_for(FastFailureQueueKind::Transaction),
+            )),
+            ack: Arc::new(FastFailureQueue::new(
+                FastFailureQueueKind::Ack,
+                permits_for(FastFailureQueueKind::Ack),
+            )),
+            admin_broker: Arc::new(FastFailureQueue::new(
+                FastFailureQueueKind::AdminBroker,
+                permits_for(FastFailureQueueKind::AdminBroker),
+            )),
+        }
+    }
+
+    fn get(&self, kind: FastFailureQueueKind) -> &Arc<FastFailureQueue> {
+        match kind {
+            FastFailureQueueKind::Send => &self.send,
+            FastFailureQueueKind::Pull => &self.pull,
+            FastFailureQueueKind::LitePull => &self.lite_pull,
+            FastFailureQueueKind::Heartbeat => &self.heartbeat,
+            FastFailureQueueKind::Transaction => &self.transaction,
+            FastFailureQueueKind::Ack => &self.ack,
+            FastFailureQueueKind::AdminBroker => &self.admin_broker,
+        }
+    }
+}
+
+#[derive(Default)]
+struct FastFailureLifecycle {
+    cancel: Option<CancellationToken>,
+    handle: Option<JoinHandle<()>>,
+}
+
+struct BrokerFastFailureInner {
+    broker_config: Arc<BrokerConfig>,
+    queues: FastFailureQueues,
+    next_task_id: AtomicU64,
+    running: AtomicBool,
+    lifecycle: Mutex<FastFailureLifecycle>,
+    page_cache_busy_checker: Mutex<Option<PageCacheBusyChecker>>,
+    jstack_time_millis: AtomicI64,
+    scan_batch_limit: usize,
+}
+
+#[derive(Clone)]
+pub(crate) struct BrokerFastFailure {
+    inner: Arc<BrokerFastFailureInner>,
+}
+
+impl BrokerFastFailure {
+    pub(crate) fn new(broker_config: Arc<BrokerConfig>) -> Self {
+        Self {
+            inner: Arc::new(BrokerFastFailureInner {
+                broker_config,
+                queues: FastFailureQueues::new(),
+                next_task_id: AtomicU64::new(0),
+                running: AtomicBool::new(false),
+                lifecycle: Mutex::new(FastFailureLifecycle::default()),
+                page_cache_busy_checker: Mutex::new(None),
+                jstack_time_millis: AtomicI64::new(current_millis() as i64),
+                scan_batch_limit: DEFAULT_SCAN_BATCH_LIMIT,
+            }),
+        }
+    }
+
+    pub(crate) fn set_page_cache_busy_checker<F>(&self, checker: F)
+    where
+        F: Fn() -> bool + Send + Sync + 'static,
+    {
+        *self.inner.page_cache_busy_checker.lock() = Some(Arc::new(checker));
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.inner.broker_config.broker_fast_failure_enable
+    }
+
+    pub(crate) fn is_running(&self) -> bool {
+        self.inner.running.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn start(&self) {
+        if self
+            .inner
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let cancel = CancellationToken::new();
+        let cancel_for_task = cancel.clone();
+        let this = self.clone();
+        let handle = tokio::spawn(async move {
+            tokio::select! {
+                _ = cancel_for_task.cancelled() => {
+                    this.inner.running.store(false, Ordering::Release);
+                    return;
+                }
+                _ = tokio::time::sleep(INITIAL_DELAY) => {}
+            }
+
+            let mut interval = tokio::time::interval(SCAN_INTERVAL);
+            interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+            loop {
+                tokio::select! {
+                    _ = cancel_for_task.cancelled() => {
+                        this.inner.running.store(false, Ordering::Release);
+                        return;
+                    }
+                    _ = interval.tick() => {
+                        if this.is_enabled() {
+                            this.clean_expired_request();
+                        }
+                    }
+                }
+            }
+        });
+
+        let mut lifecycle = self.inner.lifecycle.lock();
+        lifecycle.cancel = Some(cancel);
+        lifecycle.handle = Some(handle);
+        info!("BrokerFastFailure started");
+    }
+
+    pub(crate) fn shutdown(&self) {
+        self.inner.running.store(false, Ordering::Release);
+        let mut lifecycle = self.inner.lifecycle.lock();
+        if let Some(cancel) = lifecycle.cancel.take() {
+            cancel.cancel();
+        }
+        if let Some(handle) = lifecycle.handle.take() {
+            handle.abort();
+        }
+        info!("BrokerFastFailure shutdown");
+    }
+
+    pub(crate) fn enqueue(
+        &self,
+        kind: FastFailureQueueKind,
+        opaque: i32,
+    ) -> (Arc<FastFailureTask>, oneshot::Receiver<Option<RemotingCommand>>) {
+        self.enqueue_with_timestamp(kind, opaque, current_millis())
+    }
+
+    fn enqueue_with_timestamp(
+        &self,
+        kind: FastFailureQueueKind,
+        opaque: i32,
+        created_timestamp_millis: u64,
+    ) -> (Arc<FastFailureTask>, oneshot::Receiver<Option<RemotingCommand>>) {
+        let (response_tx, response_rx) = oneshot::channel();
+        let task_id = self.inner.next_task_id.fetch_add(1, Ordering::AcqRel);
+        let task = Arc::new(FastFailureTask::new(
+            task_id,
+            opaque,
+            created_timestamp_millis,
+            response_tx,
+        ));
+        self.inner.queues.get(kind).enqueue(task.clone());
+        (task, response_rx)
+    }
+
+    pub(crate) async fn acquire_permit(&self, kind: FastFailureQueueKind) -> Option<OwnedSemaphorePermit> {
+        self.inner.queues.get(kind).acquire_permit().await
+    }
+
+    pub(crate) fn try_mark_running(&self, kind: FastFailureQueueKind, task: &FastFailureTask) -> bool {
+        self.inner.queues.get(kind).try_mark_running(task)
+    }
+
+    pub(crate) fn complete(
+        &self,
+        kind: FastFailureQueueKind,
+        task: &FastFailureTask,
+        response: Option<RemotingCommand>,
+    ) {
+        self.inner.queues.get(kind).complete(task, response);
+    }
+
+    fn clean_expired_request(&self) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        let now_millis = current_millis();
+
+        if self.is_os_page_cache_busy() {
+            let cleaned = self
+                .inner
+                .queues
+                .send
+                .clean_page_cache_busy(now_millis, self.inner.scan_batch_limit);
+            if cleaned >= self.inner.scan_batch_limit {
+                warn!(
+                    "BrokerFastFailure page-cache cleanup reached batch limit: cleaned={}",
+                    cleaned
+                );
+            }
+        }
+
+        for kind in ALL_QUEUE_KINDS {
+            let cleaned = self.inner.queues.get(kind).clean_expired(
+                now_millis,
+                self.wait_time_millis(kind),
+                self.inner.scan_batch_limit,
+            );
+            if cleaned > 0 && self.should_log_jstack(now_millis as i64) {
+                warn!(
+                    "BrokerFastFailure cleaned expired requests: queue={}, cleaned={}",
+                    kind.name(),
+                    cleaned
+                );
+            }
+        }
+    }
+
+    fn wait_time_millis(&self, kind: FastFailureQueueKind) -> u64 {
+        match kind {
+            FastFailureQueueKind::Send => self.inner.broker_config.wait_time_mills_in_send_queue,
+            FastFailureQueueKind::Pull => self.inner.broker_config.wait_time_mills_in_pull_queue,
+            FastFailureQueueKind::LitePull => self.inner.broker_config.wait_time_mills_in_lite_pull_queue,
+            FastFailureQueueKind::Heartbeat => self.inner.broker_config.wait_time_mills_in_heartbeat_queue,
+            FastFailureQueueKind::Transaction => self.inner.broker_config.wait_time_mills_in_transaction_queue,
+            FastFailureQueueKind::Ack => self.inner.broker_config.wait_time_mills_in_ack_queue,
+            FastFailureQueueKind::AdminBroker => self.inner.broker_config.wait_time_mills_in_admin_broker_queue,
+        }
+    }
+
+    fn is_os_page_cache_busy(&self) -> bool {
+        let checker = self.inner.page_cache_busy_checker.lock().clone();
+        checker.is_some_and(|checker| checker())
+    }
+
+    fn should_log_jstack(&self, now_millis: i64) -> bool {
+        let last = self.inner.jstack_time_millis.load(Ordering::Acquire);
+        if now_millis.saturating_sub(last) <= JSTACK_LOG_INTERVAL_MILLIS {
+            return false;
+        }
+
+        self.inner
+            .jstack_time_millis
+            .compare_exchange(last, now_millis, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+}
+
+fn permits_for(kind: FastFailureQueueKind) -> usize {
+    let cpus = num_cpus::get().max(1);
+    match kind {
+        FastFailureQueueKind::Send => cpus.clamp(1, 8),
+        FastFailureQueueKind::Pull | FastFailureQueueKind::LitePull => (cpus * 2).clamp(4, 32),
+        FastFailureQueueKind::Heartbeat => cpus.clamp(2, 16),
+        FastFailureQueueKind::Transaction | FastFailureQueueKind::Ack => (cpus * 2).clamp(4, 16),
+        FastFailureQueueKind::AdminBroker => cpus.clamp(2, 8),
+    }
+}
+
+fn system_busy_response(
+    opaque: i32,
+    remark_prefix: &'static str,
+    period_in_queue_millis: u64,
+    queue_size: usize,
+) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code_remark(
+        ResponseCode::SystemBusy,
+        format!(
+            "{remark_prefix}broker busy, start flow control for a while, period in queue: {period_in_queue_millis}ms, \
+             size of queue: {queue_size}"
+        ),
+    )
+    .set_opaque(opaque)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use tokio::sync::oneshot::error::TryRecvError;
+
+    use super::*;
+
+    fn config_with_fast_failure_waits(wait_millis: u64) -> Arc<BrokerConfig> {
+        Arc::new(BrokerConfig {
+            wait_time_mills_in_send_queue: wait_millis,
+            wait_time_mills_in_pull_queue: wait_millis,
+            wait_time_mills_in_lite_pull_queue: wait_millis,
+            wait_time_mills_in_heartbeat_queue: wait_millis,
+            wait_time_mills_in_transaction_queue: wait_millis,
+            wait_time_mills_in_ack_queue: wait_millis,
+            wait_time_mills_in_admin_broker_queue: wait_millis,
+            ..BrokerConfig::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn head_not_expired_stops_timeout_cleanup() {
+        let fast_failure = BrokerFastFailure::new(config_with_fast_failure_waits(1_000));
+        let now = current_millis();
+        let (_head_task, mut head_rx) = fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Send, 1, now);
+        let (_tail_task, mut tail_rx) = fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Send, 2, now - 2_000);
+
+        fast_failure.clean_expired_request();
+
+        assert!(matches!(head_rx.try_recv(), Err(TryRecvError::Empty)));
+        assert!(matches!(tail_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn head_expired_is_canceled_with_timeout_response() {
+        let fast_failure = BrokerFastFailure::new(config_with_fast_failure_waits(10));
+        let (_task, response_rx) =
+            fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Send, 7, current_millis() - 20);
+
+        fast_failure.clean_expired_request();
+
+        let response = response_rx.await.expect("timeout response").expect("response command");
+        assert_eq!(response.code(), ResponseCode::SystemBusy.to_i32());
+        assert_eq!(response.opaque(), 7);
+        assert!(response
+            .remark()
+            .is_some_and(|remark| remark.starts_with("[TIMEOUT_CLEAN_QUEUE]")));
+    }
+
+    #[tokio::test]
+    async fn running_task_is_not_canceled_by_cleanup() {
+        let fast_failure = BrokerFastFailure::new(config_with_fast_failure_waits(10));
+        let (task, mut response_rx) =
+            fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Pull, 9, current_millis() - 20);
+
+        assert!(fast_failure.try_mark_running(FastFailureQueueKind::Pull, &task));
+        fast_failure.clean_expired_request();
+        assert!(matches!(response_rx.try_recv(), Err(TryRecvError::Empty)));
+
+        let response = system_busy_response(9, "[TEST]", 0, 0);
+        fast_failure.complete(FastFailureQueueKind::Pull, &task, Some(response));
+        let response = response_rx.await.expect("worker response").expect("response command");
+        assert_eq!(response.opaque(), 9);
+    }
+
+    #[tokio::test]
+    async fn page_cache_busy_cleans_send_queue_without_waiting() {
+        let fast_failure = BrokerFastFailure::new(config_with_fast_failure_waits(60_000));
+        fast_failure.set_page_cache_busy_checker(|| true);
+        let (_task, response_rx) =
+            fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Send, 11, current_millis());
+
+        fast_failure.clean_expired_request();
+
+        let response = response_rx
+            .await
+            .expect("page cache response")
+            .expect("response command");
+        assert_eq!(response.code(), ResponseCode::SystemBusy.to_i32());
+        assert_eq!(response.opaque(), 11);
+        assert!(response
+            .remark()
+            .is_some_and(|remark| remark.starts_with("[PCBUSY_CLEAN_QUEUE]")));
+    }
+
+    #[tokio::test]
+    async fn start_is_idempotent_and_shutdown_stops_running_flag() {
+        let fast_failure = BrokerFastFailure::new(config_with_fast_failure_waits(1_000));
+
+        fast_failure.start();
+        fast_failure.start();
+        assert!(fast_failure.is_running());
+
+        fast_failure.shutdown();
+        assert!(!fast_failure.is_running());
+    }
+
+    #[tokio::test]
+    async fn disabled_config_starts_scanner_but_does_not_clean() {
+        let fast_failure = BrokerFastFailure::new(Arc::new(BrokerConfig {
+            broker_fast_failure_enable: false,
+            ..BrokerConfig::default()
+        }));
+        let (_task, mut response_rx) =
+            fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Send, 15, current_millis() - 60_000);
+
+        fast_failure.start();
+        assert!(fast_failure.is_running());
+
+        fast_failure.clean_expired_request();
+
+        assert!(matches!(response_rx.try_recv(), Err(TryRecvError::Empty)));
+        fast_failure.shutdown();
+
+        assert!(!fast_failure.is_running());
+    }
+
+    #[tokio::test]
+    async fn page_cache_checker_is_called_when_configured() {
+        let fast_failure = BrokerFastFailure::new(config_with_fast_failure_waits(1_000));
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+        fast_failure.set_page_cache_busy_checker(move || {
+            called_clone.store(true, Ordering::Release);
+            false
+        });
+
+        fast_failure.clean_expired_request();
+
+        assert!(called.load(Ordering::Acquire));
     }
 }

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use rocketmq_auth::AuthRuntime;
+use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
@@ -24,8 +25,11 @@ use rocketmq_remoting::runtime::processor::RejectRequestResponse;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
+use tracing::warn;
 
 use self::client_manage_processor::ClientManageProcessor;
+use crate::latency::broker_fast_failure::BrokerFastFailure;
+use crate::latency::broker_fast_failure::FastFailureQueueKind;
 use crate::processor::ack_message_processor::AckMessageProcessor;
 use crate::processor::admin_broker_processor::AdminBrokerProcessor;
 use crate::processor::change_invisible_time_processor::ChangeInvisibleTimeProcessor;
@@ -90,6 +94,35 @@ pub enum BrokerProcessorType<MS: MessageStore, TS> {
     LiteSubscriptionCtl(ArcMut<LiteSubscriptionCtlProcessor<MS>>),
     EndTransaction(ArcMut<EndTransactionProcessor<TS, MS>>),
     AdminBroker(ArcMut<AdminBrokerProcessor<MS>>),
+}
+
+impl<MS, TS> Clone for BrokerProcessorType<MS, TS>
+where
+    MS: MessageStore,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Send(processor) => Self::Send(processor.clone()),
+            Self::Pull(processor) => Self::Pull(processor.clone()),
+            Self::Peek(processor) => Self::Peek(processor.clone()),
+            Self::Pop(processor) => Self::Pop(processor.clone()),
+            Self::PopLite(processor) => Self::PopLite(processor.clone()),
+            Self::Ack(processor) => Self::Ack(processor.clone()),
+            Self::ChangeInvisible(processor) => Self::ChangeInvisible(processor.clone()),
+            Self::Notification(processor) => Self::Notification(processor.clone()),
+            Self::PollingInfo(processor) => Self::PollingInfo(processor.clone()),
+            Self::Reply(processor) => Self::Reply(processor.clone()),
+            Self::Recall(processor) => Self::Recall(processor.clone()),
+            Self::QueryMessage(processor) => Self::QueryMessage(processor.clone()),
+            Self::ClientManage(processor) => Self::ClientManage(processor.clone()),
+            Self::ConsumerManage(processor) => Self::ConsumerManage(processor.clone()),
+            Self::QueryAssignment(processor) => Self::QueryAssignment(processor.clone()),
+            Self::LiteManager(processor) => Self::LiteManager(processor.clone()),
+            Self::LiteSubscriptionCtl(processor) => Self::LiteSubscriptionCtl(processor.clone()),
+            Self::EndTransaction(processor) => Self::EndTransaction(processor.clone()),
+            Self::AdminBroker(processor) => Self::AdminBroker(processor.clone()),
+        }
+    }
 }
 
 impl<MS, TS> RequestProcessor for BrokerProcessorType<MS, TS>
@@ -159,6 +192,7 @@ pub struct BrokerRequestProcessor<MS: MessageStore, TS> {
     process_table: ArcMut<HashMap<RequestCodeType, BrokerProcessorType<MS, TS>>>,
     default_request_processor: Option<ArcMut<BrokerProcessorType<MS, TS>>>,
     auth_runtime: Option<Arc<AuthRuntime>>,
+    broker_fast_failure: Option<BrokerFastFailure>,
 }
 
 impl<MS, TS> BrokerRequestProcessor<MS, TS>
@@ -171,6 +205,7 @@ where
             process_table: ArcMut::new(HashMap::new()),
             default_request_processor: None,
             auth_runtime: None,
+            broker_fast_failure: None,
         }
     }
 
@@ -185,6 +220,10 @@ where
     pub fn set_auth_runtime(&mut self, auth_runtime: Arc<AuthRuntime>) {
         self.auth_runtime = Some(auth_runtime);
     }
+
+    pub fn set_broker_fast_failure(&mut self, broker_fast_failure: BrokerFastFailure) {
+        self.broker_fast_failure = Some(broker_fast_failure);
+    }
 }
 
 impl<MS: MessageStore, TS> Clone for BrokerRequestProcessor<MS, TS> {
@@ -193,6 +232,7 @@ impl<MS: MessageStore, TS> Clone for BrokerRequestProcessor<MS, TS> {
             process_table: self.process_table.clone(),
             default_request_processor: self.default_request_processor.clone(),
             auth_runtime: self.auth_runtime.clone(),
+            broker_fast_failure: self.broker_fast_failure.clone(),
         }
     }
 }
@@ -200,7 +240,7 @@ impl<MS: MessageStore, TS> Clone for BrokerRequestProcessor<MS, TS> {
 impl<MS, TS> RequestProcessor for BrokerRequestProcessor<MS, TS>
 where
     MS: MessageStore + Send + Sync + 'static,
-    TS: TransactionalMessageService,
+    TS: TransactionalMessageService + Send + Sync + 'static,
 {
     async fn process_request(
         &mut self,
@@ -219,10 +259,30 @@ where
             }
         }
 
-        match self.process_table.get_mut(request.code_ref()) {
-            Some(processor) => processor.process_request(channel, ctx, request).await,
-            None => match self.default_request_processor.as_mut() {
-                Some(default_processor) => default_processor.process_request(channel, ctx, request).await,
+        let request_code = *request.code_ref();
+
+        match self.process_table.get(&request_code).cloned() {
+            Some(processor) => {
+                self.process_with_optional_fast_failure(
+                    fast_failure_queue_kind(request_code, false),
+                    processor,
+                    channel,
+                    ctx,
+                    request,
+                )
+                .await
+            }
+            None => match self.default_request_processor.as_ref() {
+                Some(default_processor) => {
+                    self.process_with_optional_fast_failure(
+                        fast_failure_queue_kind(request_code, true),
+                        default_processor.as_ref().clone(),
+                        channel,
+                        ctx,
+                        request,
+                    )
+                    .await
+                }
                 None => {
                     let response_command = RemotingCommand::create_response_command_with_code_remark(
                         rocketmq_remoting::code::response_code::ResponseCode::RequestCodeNotSupported,
@@ -250,4 +310,93 @@ where
             }
         }
     }
+}
+
+impl<MS, TS> BrokerRequestProcessor<MS, TS>
+where
+    MS: MessageStore + Send + Sync + 'static,
+    TS: TransactionalMessageService + Send + Sync + 'static,
+{
+    async fn process_with_optional_fast_failure(
+        &self,
+        queue_kind: Option<FastFailureQueueKind>,
+        mut processor: BrokerProcessorType<MS, TS>,
+        channel: Channel,
+        ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let Some(queue_kind) = queue_kind else {
+            return processor.process_request(channel, ctx, request).await;
+        };
+        let Some(broker_fast_failure) = &self.broker_fast_failure else {
+            return processor.process_request(channel, ctx, request).await;
+        };
+        if !broker_fast_failure.is_enabled() {
+            return processor.process_request(channel, ctx, request).await;
+        }
+
+        let opaque = request.opaque();
+        let mut queued_request = request.clone();
+        let (task, response_rx) = broker_fast_failure.enqueue(queue_kind, opaque);
+        let broker_fast_failure = broker_fast_failure.clone();
+
+        tokio::spawn(async move {
+            let Some(_permit) = broker_fast_failure.acquire_permit(queue_kind).await else {
+                warn!("fast failure queue permit acquisition failed: queue={queue_kind:?}");
+                if broker_fast_failure.try_mark_running(queue_kind, &task) {
+                    broker_fast_failure.complete(
+                        queue_kind,
+                        &task,
+                        Some(system_error_response(
+                            opaque,
+                            "fast failure queue permit acquisition failed",
+                        )),
+                    );
+                }
+                return;
+            };
+
+            if !broker_fast_failure.try_mark_running(queue_kind, &task) {
+                return;
+            }
+
+            let response = match processor.process_request(channel, ctx, &mut queued_request).await {
+                Ok(response) => response,
+                Err(error) => Some(system_error_response(opaque, error.to_string())),
+            };
+            broker_fast_failure.complete(queue_kind, &task, response);
+        });
+
+        match response_rx.await {
+            Ok(response) => Ok(response),
+            Err(_error) => Ok(Some(system_error_response(
+                opaque,
+                "fast failure response channel closed before request completed",
+            ))),
+        }
+    }
+}
+
+fn fast_failure_queue_kind(request_code: i32, default_processor: bool) -> Option<FastFailureQueueKind> {
+    if default_processor {
+        return Some(FastFailureQueueKind::AdminBroker);
+    }
+
+    match RequestCode::from(request_code) {
+        RequestCode::SendMessage
+        | RequestCode::SendMessageV2
+        | RequestCode::SendBatchMessage
+        | RequestCode::ConsumerSendMsgBack => Some(FastFailureQueueKind::Send),
+        RequestCode::PullMessage => Some(FastFailureQueueKind::Pull),
+        RequestCode::LitePullMessage => Some(FastFailureQueueKind::LitePull),
+        RequestCode::HeartBeat => Some(FastFailureQueueKind::Heartbeat),
+        RequestCode::EndTransaction => Some(FastFailureQueueKind::Transaction),
+        RequestCode::AckMessage | RequestCode::BatchAckMessage => Some(FastFailureQueueKind::Ack),
+        _ => None,
+    }
+}
+
+fn system_error_response(opaque: i32, remark: impl Into<String>) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code_remark(ResponseCode::SystemError, remark.into())
+        .set_opaque(opaque)
 }

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -470,6 +470,38 @@ mod defaults {
         1000
     }
 
+    pub const fn broker_fast_failure_enable() -> bool {
+        true
+    }
+
+    pub const fn wait_time_mills_in_send_queue() -> u64 {
+        200
+    }
+
+    pub const fn wait_time_mills_in_pull_queue() -> u64 {
+        5_000
+    }
+
+    pub const fn wait_time_mills_in_lite_pull_queue() -> u64 {
+        5_000
+    }
+
+    pub const fn wait_time_mills_in_heartbeat_queue() -> u64 {
+        31_000
+    }
+
+    pub const fn wait_time_mills_in_transaction_queue() -> u64 {
+        3_000
+    }
+
+    pub const fn wait_time_mills_in_ack_queue() -> u64 {
+        3_000
+    }
+
+    pub const fn wait_time_mills_in_admin_broker_queue() -> u64 {
+        5_000
+    }
+
     pub const fn controller_heartbeat_timeout_mills() -> i64 {
         10 * 1000
     }
@@ -690,6 +722,30 @@ pub struct BrokerConfig {
 
     #[serde(default = "defaults::send_heartbeat_timeout_millis")]
     pub send_heartbeat_timeout_millis: u64,
+
+    #[serde(default = "defaults::broker_fast_failure_enable")]
+    pub broker_fast_failure_enable: bool,
+
+    #[serde(default = "defaults::wait_time_mills_in_send_queue")]
+    pub wait_time_mills_in_send_queue: u64,
+
+    #[serde(default = "defaults::wait_time_mills_in_pull_queue")]
+    pub wait_time_mills_in_pull_queue: u64,
+
+    #[serde(default = "defaults::wait_time_mills_in_lite_pull_queue")]
+    pub wait_time_mills_in_lite_pull_queue: u64,
+
+    #[serde(default = "defaults::wait_time_mills_in_heartbeat_queue")]
+    pub wait_time_mills_in_heartbeat_queue: u64,
+
+    #[serde(default = "defaults::wait_time_mills_in_transaction_queue")]
+    pub wait_time_mills_in_transaction_queue: u64,
+
+    #[serde(default = "defaults::wait_time_mills_in_ack_queue")]
+    pub wait_time_mills_in_ack_queue: u64,
+
+    #[serde(default = "defaults::wait_time_mills_in_admin_broker_queue")]
+    pub wait_time_mills_in_admin_broker_queue: u64,
 
     #[serde(default)]
     pub skip_pre_online: bool,
@@ -1029,6 +1085,14 @@ impl Default for BrokerConfig {
             force_register: true,
             register_name_server_period: 1000 * 30,
             send_heartbeat_timeout_millis: 1000,
+            broker_fast_failure_enable: defaults::broker_fast_failure_enable(),
+            wait_time_mills_in_send_queue: defaults::wait_time_mills_in_send_queue(),
+            wait_time_mills_in_pull_queue: defaults::wait_time_mills_in_pull_queue(),
+            wait_time_mills_in_lite_pull_queue: defaults::wait_time_mills_in_lite_pull_queue(),
+            wait_time_mills_in_heartbeat_queue: defaults::wait_time_mills_in_heartbeat_queue(),
+            wait_time_mills_in_transaction_queue: defaults::wait_time_mills_in_transaction_queue(),
+            wait_time_mills_in_ack_queue: defaults::wait_time_mills_in_ack_queue(),
+            wait_time_mills_in_admin_broker_queue: defaults::wait_time_mills_in_admin_broker_queue(),
             skip_pre_online: false,
             namesrv_addr: NAMESRV_ADDR.clone().map(|addr| addr.into()),
             fetch_name_srv_addr_by_dns_lookup: false,
@@ -1281,6 +1345,38 @@ impl BrokerConfig {
             "sendHeartbeatTimeoutMillis".into(),
             self.send_heartbeat_timeout_millis.to_string().into(),
         );
+        properties.insert(
+            "brokerFastFailureEnable".into(),
+            self.broker_fast_failure_enable.to_string().into(),
+        );
+        properties.insert(
+            "waitTimeMillsInSendQueue".into(),
+            self.wait_time_mills_in_send_queue.to_string().into(),
+        );
+        properties.insert(
+            "waitTimeMillsInPullQueue".into(),
+            self.wait_time_mills_in_pull_queue.to_string().into(),
+        );
+        properties.insert(
+            "waitTimeMillsInLitePullQueue".into(),
+            self.wait_time_mills_in_lite_pull_queue.to_string().into(),
+        );
+        properties.insert(
+            "waitTimeMillsInHeartbeatQueue".into(),
+            self.wait_time_mills_in_heartbeat_queue.to_string().into(),
+        );
+        properties.insert(
+            "waitTimeMillsInTransactionQueue".into(),
+            self.wait_time_mills_in_transaction_queue.to_string().into(),
+        );
+        properties.insert(
+            "waitTimeMillsInAckQueue".into(),
+            self.wait_time_mills_in_ack_queue.to_string().into(),
+        );
+        properties.insert(
+            "waitTimeMillsInAdminBrokerQueue".into(),
+            self.wait_time_mills_in_admin_broker_queue.to_string().into(),
+        );
         properties.insert("skipPreOnline".into(), self.skip_pre_online.to_string().into());
         properties.insert("namesrvAddr".into(), self.namesrv_addr.clone().unwrap_or_default());
         properties.insert(
@@ -1479,6 +1575,20 @@ mod tests {
     }
 
     #[test]
+    fn default_broker_config_uses_java_fast_failure_defaults() {
+        let config = BrokerConfig::default();
+
+        assert!(config.broker_fast_failure_enable);
+        assert_eq!(config.wait_time_mills_in_send_queue, 200);
+        assert_eq!(config.wait_time_mills_in_pull_queue, 5_000);
+        assert_eq!(config.wait_time_mills_in_lite_pull_queue, 5_000);
+        assert_eq!(config.wait_time_mills_in_heartbeat_queue, 31_000);
+        assert_eq!(config.wait_time_mills_in_transaction_queue, 3_000);
+        assert_eq!(config.wait_time_mills_in_ack_queue, 3_000);
+        assert_eq!(config.wait_time_mills_in_admin_broker_queue, 5_000);
+    }
+
+    #[test]
     fn get_properties_contains_java_lite_keys() {
         let config = BrokerConfig::default();
         let properties = config.get_properties();
@@ -1548,6 +1658,53 @@ mod tests {
         assert_eq!(
             properties.get("liteLagLatencyTopK").map(|value| value.as_str()),
             Some("50")
+        );
+    }
+
+    #[test]
+    fn get_properties_contains_java_fast_failure_keys() {
+        let config = BrokerConfig::default();
+        let properties = config.get_properties();
+
+        assert_eq!(
+            properties.get("brokerFastFailureEnable").map(|value| value.as_str()),
+            Some("true")
+        );
+        assert_eq!(
+            properties.get("waitTimeMillsInSendQueue").map(|value| value.as_str()),
+            Some("200")
+        );
+        assert_eq!(
+            properties.get("waitTimeMillsInPullQueue").map(|value| value.as_str()),
+            Some("5000")
+        );
+        assert_eq!(
+            properties
+                .get("waitTimeMillsInLitePullQueue")
+                .map(|value| value.as_str()),
+            Some("5000")
+        );
+        assert_eq!(
+            properties
+                .get("waitTimeMillsInHeartbeatQueue")
+                .map(|value| value.as_str()),
+            Some("31000")
+        );
+        assert_eq!(
+            properties
+                .get("waitTimeMillsInTransactionQueue")
+                .map(|value| value.as_str()),
+            Some("3000")
+        );
+        assert_eq!(
+            properties.get("waitTimeMillsInAckQueue").map(|value| value.as_str()),
+            Some("3000")
+        );
+        assert_eq!(
+            properties
+                .get("waitTimeMillsInAdminBrokerQueue")
+                .map(|value| value.as_str()),
+            Some("5000")
         );
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7200

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broker fast-failure mechanism to improve resilience under high system load.
  * Introduced configurable queue-specific wait times for various broker operations (send, pull, heartbeat, transaction, ack, admin).
  * Added broker configuration option to enable or disable fast-failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->