### PR TITLE
[ISSUE #7202]✨enh(broker): add tests for fast failure queue handling and Java fast failure key deserialization

### DIFF
--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -731,4 +731,119 @@ mod tests {
 
         assert!(called.load(Ordering::Acquire));
     }
+
+    #[tokio::test]
+    async fn completed_head_is_skipped_and_next_expired_task_is_cleaned() {
+        let fast_failure = BrokerFastFailure::new(config_with_fast_failure_waits(10));
+        let (completed_task, mut completed_rx) =
+            fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Ack, 21, current_millis() - 30);
+        assert!(fast_failure.try_mark_running(FastFailureQueueKind::Ack, &completed_task));
+        fast_failure.complete(FastFailureQueueKind::Ack, &completed_task, None);
+
+        let (_expired_task, expired_rx) =
+            fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Ack, 22, current_millis() - 30);
+
+        fast_failure.clean_expired_request();
+
+        assert!(matches!(completed_rx.try_recv(), Ok(None)));
+        let response = expired_rx.await.expect("expired response").expect("response command");
+        assert_eq!(response.opaque(), 22);
+        assert_eq!(response.code(), ResponseCode::SystemBusy.to_i32());
+        assert!(response
+            .remark()
+            .is_some_and(|remark| remark.starts_with("[TIMEOUT_CLEAN_QUEUE]")));
+    }
+
+    #[tokio::test]
+    async fn page_cache_busy_only_cleans_send_queue() {
+        let fast_failure = BrokerFastFailure::new(config_with_fast_failure_waits(60_000));
+        fast_failure.set_page_cache_busy_checker(|| true);
+        let (_send_task, send_rx) =
+            fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Send, 31, current_millis());
+        let (_pull_task, mut pull_rx) =
+            fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Pull, 32, current_millis());
+
+        fast_failure.clean_expired_request();
+
+        let response = send_rx.await.expect("send response").expect("response command");
+        assert_eq!(response.opaque(), 31);
+        assert!(response
+            .remark()
+            .is_some_and(|remark| remark.starts_with("[PCBUSY_CLEAN_QUEUE]")));
+        assert!(matches!(pull_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn timeout_cleanup_respects_single_scan_batch_limit() {
+        let fast_failure = BrokerFastFailure::new(config_with_fast_failure_waits(0));
+        let now = current_millis();
+        let mut receivers = Vec::with_capacity(DEFAULT_SCAN_BATCH_LIMIT + 1);
+        for opaque in 0..=DEFAULT_SCAN_BATCH_LIMIT {
+            let (_task, rx) =
+                fast_failure.enqueue_with_timestamp(FastFailureQueueKind::AdminBroker, opaque as i32, now);
+            receivers.push(rx);
+        }
+
+        fast_failure.clean_expired_request();
+
+        for (index, rx) in receivers.iter_mut().take(DEFAULT_SCAN_BATCH_LIMIT).enumerate() {
+            let response = rx
+                .try_recv()
+                .expect("expired task should be cleaned in the first batch")
+                .expect("response command");
+            assert_eq!(response.opaque(), index as i32);
+        }
+        assert!(matches!(
+            receivers
+                .get_mut(DEFAULT_SCAN_BATCH_LIMIT)
+                .expect("last receiver")
+                .try_recv(),
+            Err(TryRecvError::Empty)
+        ));
+
+        fast_failure.clean_expired_request();
+        let response = receivers
+            .pop()
+            .expect("last receiver")
+            .await
+            .expect("second batch response")
+            .expect("response command");
+        assert_eq!(response.opaque(), DEFAULT_SCAN_BATCH_LIMIT as i32);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_enqueue_and_timeout_cleanup_returns_each_opaque_once() {
+        let fast_failure = BrokerFastFailure::new(config_with_fast_failure_waits(0));
+        let now = current_millis();
+        let request_count = 512usize;
+        let mut handles = Vec::with_capacity(request_count);
+
+        for opaque in 0..request_count {
+            let fast_failure = fast_failure.clone();
+            handles.push(tokio::spawn(async move {
+                fast_failure.enqueue_with_timestamp(FastFailureQueueKind::Pull, opaque as i32, now)
+            }));
+        }
+
+        let mut receivers = Vec::with_capacity(request_count);
+        for handle in handles {
+            let (_task, rx) = handle.await.expect("enqueue task should finish");
+            receivers.push(rx);
+        }
+
+        for _ in 0..=((request_count / DEFAULT_SCAN_BATCH_LIMIT) + 1) {
+            fast_failure.clean_expired_request();
+        }
+
+        let mut seen = vec![false; request_count];
+        for rx in receivers {
+            let response = rx.await.expect("cleanup response").expect("response command");
+            assert_eq!(response.code(), ResponseCode::SystemBusy.to_i32());
+            let opaque = response.opaque() as usize;
+            assert!(opaque < request_count);
+            assert!(!seen[opaque], "opaque {opaque} should be returned once");
+            seen[opaque] = true;
+        }
+        assert!(seen.into_iter().all(|value| value));
+    }
 }

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -400,3 +400,64 @@ fn system_error_response(opaque: i32, remark: impl Into<String>) -> RemotingComm
     RemotingCommand::create_response_command_with_code_remark(ResponseCode::SystemError, remark.into())
         .set_opaque(opaque)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fast_failure_queue_kind_maps_java_fast_failure_families() {
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::SendMessage as i32, false),
+            Some(FastFailureQueueKind::Send)
+        );
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::SendMessageV2 as i32, false),
+            Some(FastFailureQueueKind::Send)
+        );
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::SendBatchMessage as i32, false),
+            Some(FastFailureQueueKind::Send)
+        );
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::ConsumerSendMsgBack as i32, false),
+            Some(FastFailureQueueKind::Send)
+        );
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::PullMessage as i32, false),
+            Some(FastFailureQueueKind::Pull)
+        );
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::LitePullMessage as i32, false),
+            Some(FastFailureQueueKind::LitePull)
+        );
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::HeartBeat as i32, false),
+            Some(FastFailureQueueKind::Heartbeat)
+        );
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::EndTransaction as i32, false),
+            Some(FastFailureQueueKind::Transaction)
+        );
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::AckMessage as i32, false),
+            Some(FastFailureQueueKind::Ack)
+        );
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::BatchAckMessage as i32, false),
+            Some(FastFailureQueueKind::Ack)
+        );
+    }
+
+    #[test]
+    fn fast_failure_queue_kind_maps_default_processor_to_admin_queue() {
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::UpdateBrokerConfig as i32, true),
+            Some(FastFailureQueueKind::AdminBroker)
+        );
+        assert_eq!(
+            fast_failure_queue_kind(RequestCode::UpdateBrokerConfig as i32, false),
+            None
+        );
+    }
+}

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -1707,4 +1707,30 @@ mod tests {
             Some("5000")
         );
     }
+
+    #[test]
+    fn serde_accepts_java_fast_failure_camel_case_keys() {
+        let config: BrokerConfig = serde_json::from_str(
+            r#"{
+                "brokerFastFailureEnable": false,
+                "waitTimeMillsInSendQueue": 201,
+                "waitTimeMillsInPullQueue": 5001,
+                "waitTimeMillsInLitePullQueue": 5002,
+                "waitTimeMillsInHeartbeatQueue": 31001,
+                "waitTimeMillsInTransactionQueue": 3001,
+                "waitTimeMillsInAckQueue": 3002,
+                "waitTimeMillsInAdminBrokerQueue": 5003
+            }"#,
+        )
+        .expect("broker config should deserialize Java fast failure keys");
+
+        assert!(!config.broker_fast_failure_enable);
+        assert_eq!(config.wait_time_mills_in_send_queue, 201);
+        assert_eq!(config.wait_time_mills_in_pull_queue, 5_001);
+        assert_eq!(config.wait_time_mills_in_lite_pull_queue, 5_002);
+        assert_eq!(config.wait_time_mills_in_heartbeat_queue, 31_001);
+        assert_eq!(config.wait_time_mills_in_transaction_queue, 3_001);
+        assert_eq!(config.wait_time_mills_in_ack_queue, 3_002);
+        assert_eq!(config.wait_time_mills_in_admin_broker_queue, 5_003);
+    }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7202

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for fast-failure queue cleanup behavior under various system conditions, including timeout handling and page-cache busy scenarios.
  * Added tests for broker configuration deserialization to validate settings are correctly parsed from configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->