### PR TITLE
[ISSUE #7204]🚀feat(broker): implement topic stats and config retrieval from broker

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -165,7 +165,6 @@ pub(crate) struct BrokerRuntime {
     shutdown_hook: Option<BrokerShutdownHook>,
     proxy_request_processor: Option<DefaultServerProcessor>,
     consumer_ids_change_listener: Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static>,
-    topic_queue_mapping_clean_service: TopicQueueMappingCleanService,
     scheduled_task_manager: ScheduledTaskManager,
 }
 
@@ -296,13 +295,13 @@ impl BrokerRuntime {
         inner.client_housekeeping_service = Some(Arc::new(ClientHousekeepingService::new(inner.clone())));
         inner.slave_synchronize = Some(SlaveSynchronize::new(inner.clone()));
         inner.broker_pre_online_service = Some(BrokerPreOnlineService::new(inner.clone()));
+        inner.topic_queue_mapping_clean_service = Some(TopicQueueMappingCleanService::new(inner.clone()));
         Self {
             inner,
             broker_runtime: Some(runtime),
             shutdown_hook: None,
             proxy_request_processor: None,
             consumer_ids_change_listener,
-            topic_queue_mapping_clean_service: TopicQueueMappingCleanService,
             scheduled_task_manager: Default::default(),
         }
     }
@@ -400,7 +399,9 @@ impl BrokerRuntime {
             notification_processor.shutdown();
         }
         self.consumer_ids_change_listener.shutdown();
-        self.topic_queue_mapping_clean_service.shutdown();
+        if let Some(topic_queue_mapping_clean_service) = self.inner.topic_queue_mapping_clean_service.as_ref() {
+            topic_queue_mapping_clean_service.shutdown();
+        }
 
         self.inner.broadcast_offset_manager.shutdown();
 
@@ -619,7 +620,9 @@ impl BrokerRuntime {
     }
 
     fn initialize_resources(&mut self) {
-        self.inner.topic_queue_mapping_clean_service = Some(TopicQueueMappingCleanService);
+        if self.inner.topic_queue_mapping_clean_service.is_none() {
+            self.inner.topic_queue_mapping_clean_service = Some(TopicQueueMappingCleanService::new(self.inner.clone()));
+        }
     }
 
     fn init_processor(&mut self) -> (DefaultServerProcessor, FasterServerProcessor) {
@@ -1561,7 +1564,7 @@ pub(crate) struct BrokerRuntimeInner<MS: MessageStore> {
     consumer_manager: ConsumerManager,
     broadcast_offset_manager: BroadcastOffsetManager,
     broker_stats_manager: Option<Arc<BrokerStatsManager>>,
-    topic_queue_mapping_clean_service: Option<TopicQueueMappingCleanService>,
+    topic_queue_mapping_clean_service: Option<TopicQueueMappingCleanService<MS>>,
     update_master_haserver_addr_periodically: bool,
     should_start_time: Arc<AtomicU64>,
     is_isolated: Arc<AtomicBool>,
@@ -1705,7 +1708,7 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
-    pub fn topic_queue_mapping_clean_service_mut(&mut self) -> Option<&mut TopicQueueMappingCleanService> {
+    pub fn topic_queue_mapping_clean_service_mut(&mut self) -> Option<&mut TopicQueueMappingCleanService<MS>> {
         self.topic_queue_mapping_clean_service.as_mut()
     }
 
@@ -1973,12 +1976,12 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     }
 
     #[inline]
-    pub fn topic_queue_mapping_clean_service(&self) -> &Option<TopicQueueMappingCleanService> {
+    pub fn topic_queue_mapping_clean_service(&self) -> &Option<TopicQueueMappingCleanService<MS>> {
         &self.topic_queue_mapping_clean_service
     }
 
     #[inline]
-    pub fn topic_queue_mapping_clean_service_unchecked(&self) -> &TopicQueueMappingCleanService {
+    pub fn topic_queue_mapping_clean_service_unchecked(&self) -> &TopicQueueMappingCleanService<MS> {
         unsafe { self.topic_queue_mapping_clean_service.as_ref().unwrap_unchecked() }
     }
 
@@ -2177,7 +2180,7 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     #[inline]
     pub fn set_topic_queue_mapping_clean_service(
         &mut self,
-        topic_queue_mapping_clean_service: TopicQueueMappingCleanService,
+        topic_queue_mapping_clean_service: TopicQueueMappingCleanService<MS>,
     ) {
         self.topic_queue_mapping_clean_service = Some(topic_queue_mapping_clean_service);
     }

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::broker_runtime::BrokerRuntimeInner;
+use bytes::Bytes;
 use cheetah_string::CheetahString;
 use dns_lookup::lookup_host;
 use rocketmq_client_rust::consumer::pull_result::PullResult;
@@ -44,6 +45,7 @@ use rocketmq_remoting::clients::rocketmq_tokio_client::RocketmqDefaultClient;
 use rocketmq_remoting::clients::RemotingClient;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::GetBrokerMemberGroupResponseBody;
 use rocketmq_remoting::protocol::body::broker_body::register_broker_body::RegisterBrokerBody;
@@ -75,6 +77,8 @@ use rocketmq_remoting::protocol::header::get_max_offset_response_header::GetMaxO
 use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
 use rocketmq_remoting::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader;
 use rocketmq_remoting::protocol::header::get_min_offset_response_header::GetMinOffsetResponseHeader;
+use rocketmq_remoting::protocol::header::get_topic_config_request_header::GetTopicConfigRequestHeader;
+use rocketmq_remoting::protocol::header::get_topic_stats_info_request_header::GetTopicStatsInfoRequestHeader;
 use rocketmq_remoting::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
@@ -96,14 +100,18 @@ use rocketmq_remoting::protocol::namesrv::RegisterBrokerResult;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::route::route_data_view::QueueData;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use rocketmq_remoting::protocol::static_topic::topic_config_and_queue_mapping::TopicConfigAndQueueMapping;
 use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::remoting::RemotingService;
 use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
 use rocketmq_remoting::rpc::client_metadata::ClientMetadata;
+use rocketmq_remoting::rpc::rpc_client::RpcClient;
 use rocketmq_remoting::rpc::rpc_client_impl::RpcClientImpl;
+use rocketmq_remoting::rpc::rpc_request::RpcRequest;
 use rocketmq_remoting::rpc::rpc_request_header::RpcRequestHeader;
+use rocketmq_remoting::rpc::topic_request_header::TopicRequestHeader as RpcTopicRequestHeader;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_remoting::runtime::RPCHook;
 use rocketmq_rust::ArcMut;
@@ -743,7 +751,9 @@ impl BrokerOuterAPI {
             ResponseCode::TopicNotExist => {}
             ResponseCode::Success => {
                 if let Some(body) = response.body() {
-                    let topic_route_data = TopicRouteData::decode(body).unwrap();
+                    let topic_route_data = TopicRouteData::decode(body)?;
+                    self.client_metadata
+                        .fresh_topic_route(topic, Some(topic_route_data.clone()));
                     return Ok(topic_route_data);
                 }
             }
@@ -755,6 +765,77 @@ impl BrokerOuterAPI {
             message: response.remark().cloned().unwrap_or(CheetahString::empty()).to_string(),
             broker_addr: Some("".to_string()),
         })
+    }
+
+    pub(crate) async fn get_topic_stats_info_from_broker(
+        &self,
+        broker_name: &CheetahString,
+        topic: &CheetahString,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<TopicStatsTable> {
+        let header = GetTopicStatsInfoRequestHeader {
+            topic: topic.clone(),
+            topic_request_header: Some(TopicRequestHeader {
+                lo: Some(false),
+                rpc: Some(RpcRequestHeader {
+                    broker_name: Some(broker_name.clone()),
+                    ..Default::default()
+                }),
+            }),
+        };
+        let request = RpcRequest::new(RequestCode::GetTopicStatsInfo as i32, header, None);
+        let response = self.rpc_client.invoke(request, timeout_millis).await?;
+        let body = Self::rpc_response_body_as_bytes(response, "get_topic_stats_info")?;
+        TopicStatsTable::decode(body.as_ref())
+    }
+
+    pub(crate) async fn get_topic_config_from_broker(
+        &self,
+        broker_name: &CheetahString,
+        topic: &CheetahString,
+        lo: bool,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<TopicConfigAndQueueMapping> {
+        let header = GetTopicConfigRequestHeader {
+            topic: topic.clone(),
+            topic_request_header: Some(RpcTopicRequestHeader {
+                lo: Some(lo),
+                rpc_request_header: Some(RpcRequestHeader {
+                    broker_name: Some(broker_name.clone()),
+                    ..Default::default()
+                }),
+            }),
+        };
+        let request = RpcRequest::new(RequestCode::GetTopicConfig as i32, header, None);
+        let response = self.rpc_client.invoke(request, timeout_millis).await?;
+        let body = Self::rpc_response_body_as_bytes(response, "get_topic_config")?;
+        TopicConfigAndQueueMapping::decode(body.as_ref())
+    }
+
+    fn rpc_response_body_as_bytes(
+        response: rocketmq_remoting::rpc::rpc_response::RpcResponse,
+        operation: &'static str,
+    ) -> rocketmq_error::RocketMQResult<Bytes> {
+        if let Some(exception) = response.exception {
+            return Err(RocketMQError::ResponseProcessFailed {
+                operation,
+                reason: exception.to_string(),
+            });
+        }
+
+        let Some(body) = response.body else {
+            return Err(RocketMQError::ResponseProcessFailed {
+                operation,
+                reason: "missing response body".to_string(),
+            });
+        };
+
+        body.downcast::<Bytes>()
+            .map(|bytes| *bytes)
+            .map_err(|_| RocketMQError::ResponseProcessFailed {
+                operation,
+                reason: "response body is not bytes".to_string(),
+            })
     }
 
     pub async fn send_message_to_specific_broker(

--- a/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config_manager::ConfigManager;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_queue_wrapper::TopicQueueMappingSerializeWrapper;
 use rocketmq_remoting::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::static_topic::logic_queue_mapping_item::LogicQueueMappingItem;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_context::TopicQueueMappingContext;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
 use rocketmq_remoting::protocol::DataVersion;
@@ -199,6 +203,129 @@ impl TopicQueueMappingManager {
         self.persist();
     }
 
+    pub(crate) fn snapshot_topic_queue_mapping_table(&self) -> Vec<(CheetahString, TopicQueueMappingDetail)> {
+        self.topic_queue_mapping_table
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().as_ref().clone()))
+            .collect()
+    }
+
+    pub(crate) fn replace_cleaned_queue_items(
+        &self,
+        topic: &CheetahString,
+        expected_epoch: i64,
+        expected_bname: &CheetahString,
+        replacements: &HashMap<i32, (Vec<LogicQueueMappingItem>, Vec<LogicQueueMappingItem>)>,
+    ) -> bool {
+        if replacements.is_empty() {
+            return false;
+        }
+
+        let Some(current_ref) = self.topic_queue_mapping_table.get(topic) else {
+            return false;
+        };
+        let current = current_ref.as_ref();
+        if current.topic_queue_mapping_info.epoch != expected_epoch
+            || current.topic_queue_mapping_info.bname.as_ref() != Some(expected_bname)
+        {
+            return false;
+        }
+
+        let Some(current_hosted_queues) = current.hosted_queues.as_ref() else {
+            return false;
+        };
+
+        let mut new_detail = current.clone();
+        let mut changed = false;
+        {
+            let new_hosted_queues = new_detail.hosted_queues.get_or_insert_with(HashMap::new);
+            for (qid, (expected_items, new_items)) in replacements {
+                if new_items.is_empty() {
+                    continue;
+                }
+                let Some(current_items) = current_hosted_queues.get(qid) else {
+                    continue;
+                };
+                if current_items != expected_items || current_items == new_items {
+                    continue;
+                }
+                new_hosted_queues.insert(*qid, new_items.clone());
+                changed = true;
+            }
+        }
+        drop(current_ref);
+
+        if changed {
+            self.topic_queue_mapping_table
+                .insert(topic.clone(), ArcMut::new(new_detail));
+        }
+        changed
+    }
+
+    pub(crate) fn remove_cleaned_hosted_queues(
+        &self,
+        topic: &CheetahString,
+        expected_epoch: i64,
+        expected_bname: &CheetahString,
+        expected_items_by_qid: &HashMap<i32, Vec<LogicQueueMappingItem>>,
+    ) -> bool {
+        if expected_items_by_qid.is_empty() {
+            return false;
+        }
+
+        let Some(current_ref) = self.topic_queue_mapping_table.get(topic) else {
+            return false;
+        };
+        let current = current_ref.as_ref();
+        if current.topic_queue_mapping_info.epoch != expected_epoch
+            || current.topic_queue_mapping_info.bname.as_ref() != Some(expected_bname)
+        {
+            return false;
+        }
+
+        let Some(current_hosted_queues) = current.hosted_queues.as_ref() else {
+            return false;
+        };
+
+        let mut new_detail = current.clone();
+        let mut changed = false;
+        if let Some(new_hosted_queues) = new_detail.hosted_queues.as_mut() {
+            for (qid, expected_items) in expected_items_by_qid {
+                let Some(current_items) = current_hosted_queues.get(qid) else {
+                    continue;
+                };
+                if current_items != expected_items {
+                    continue;
+                }
+                if new_hosted_queues.remove(qid).is_some() {
+                    changed = true;
+                }
+            }
+        }
+        drop(current_ref);
+
+        if changed {
+            self.topic_queue_mapping_table
+                .insert(topic.clone(), ArcMut::new(new_detail));
+        }
+        changed
+    }
+
+    pub(crate) async fn persist_clean_result(&self) -> RocketMQResult<()> {
+        self.data_version.lock().next_version();
+        let json = self.encode_pretty(true);
+        if json.is_empty() {
+            return Ok(());
+        }
+
+        let file_name = self.config_file_path();
+        tokio::task::spawn_blocking(move || {
+            rocketmq_common::FileUtils::string_to_file(json.as_str(), file_name.as_str())
+        })
+        .await
+        .map_err(|err| RocketMQError::Internal(format!("persist topic queue mapping clean result failed: {err}")))?
+    }
+
     pub fn delete(&self, topic: &CheetahString) {
         let old = self.topic_queue_mapping_table.remove(topic);
         match old {
@@ -318,5 +445,96 @@ mod tests {
             Some(broker_config.broker_name().as_str())
         );
         assert!(mapping.hosted_queues.is_some());
+    }
+
+    #[test]
+    fn replace_cleaned_queue_items_rechecks_expected_items() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let broker_name = broker_config.broker_name().clone();
+        let manager = TopicQueueMappingManager::new(broker_config);
+        let topic = CheetahString::from_static_str("static-topic");
+        let item0 = LogicQueueMappingItem {
+            gen: 0,
+            queue_id: 0,
+            bname: Some(broker_name.clone()),
+            end_offset: 10,
+            ..Default::default()
+        };
+        let item1 = LogicQueueMappingItem {
+            gen: 1,
+            queue_id: 1,
+            bname: Some(broker_name.clone()),
+            logic_offset: 10,
+            ..Default::default()
+        };
+        let mut hosted_queues = HashMap::new();
+        hosted_queues.insert(0, vec![item0.clone(), item1.clone()]);
+        manager.topic_queue_mapping_table.insert(
+            topic.clone(),
+            ArcMut::new(TopicQueueMappingDetail {
+                topic_queue_mapping_info:
+                    rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo {
+                        topic: Some(topic.clone()),
+                        bname: Some(broker_name.clone()),
+                        epoch: 1,
+                        ..Default::default()
+                    },
+                hosted_queues: Some(hosted_queues),
+            }),
+        );
+        let mut replacements = HashMap::new();
+        replacements.insert(0, (vec![item0, item1.clone()], vec![item1.clone()]));
+
+        assert!(manager.replace_cleaned_queue_items(&topic, 1, &broker_name, &replacements));
+
+        let mapping = manager.get_topic_queue_mapping(topic.as_str()).unwrap();
+        assert_eq!(mapping.hosted_queues.as_ref().unwrap().get(&0).unwrap(), &vec![item1]);
+        assert_eq!(manager.data_version.lock().get_state_version(), 0);
+    }
+
+    #[test]
+    fn remove_cleaned_hosted_queues_skips_when_current_items_changed() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let broker_name = broker_config.broker_name().clone();
+        let manager = TopicQueueMappingManager::new(broker_config);
+        let topic = CheetahString::from_static_str("static-topic");
+        let old_item = LogicQueueMappingItem {
+            gen: 0,
+            queue_id: 0,
+            bname: Some(CheetahString::from_static_str("old-broker")),
+            ..Default::default()
+        };
+        let current_item = LogicQueueMappingItem {
+            gen: 1,
+            queue_id: 1,
+            bname: Some(broker_name.clone()),
+            ..Default::default()
+        };
+        let mut hosted_queues = HashMap::new();
+        hosted_queues.insert(0, vec![current_item]);
+        manager.topic_queue_mapping_table.insert(
+            topic.clone(),
+            ArcMut::new(TopicQueueMappingDetail {
+                topic_queue_mapping_info:
+                    rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo {
+                        topic: Some(topic.clone()),
+                        bname: Some(broker_name.clone()),
+                        epoch: 1,
+                        ..Default::default()
+                    },
+                hosted_queues: Some(hosted_queues),
+            }),
+        );
+        let mut expected_items = HashMap::new();
+        expected_items.insert(0, vec![old_item]);
+
+        assert!(!manager.remove_cleaned_hosted_queues(&topic, 1, &broker_name, &expected_items));
+        assert!(manager
+            .get_topic_queue_mapping(topic.as_str())
+            .unwrap()
+            .hosted_queues
+            .as_ref()
+            .unwrap()
+            .contains_key(&0));
     }
 }

--- a/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
+++ b/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
@@ -12,16 +12,498 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_common::common::message::message_queue::MessageQueue;
+use rocketmq_common::common::mix_all::LOGICAL_QUEUE_MOCK_BROKER_PREFIX;
+use rocketmq_common::common::mix_all::METADATA_SCOPE_GLOBAL;
+use rocketmq_common::UtilAll::is_it_time_to_do;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::admin::topic_offset::TopicOffset;
+use rocketmq_remoting::protocol::static_topic::logic_queue_mapping_item::LogicQueueMappingItem;
+use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
+use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_utils::TopicQueueMappingUtils;
+use rocketmq_remoting::rpc::client_metadata::ClientMetadata;
+use rocketmq_rust::ArcMut;
+use rocketmq_store::base::message_store::MessageStore;
+use tokio::task::JoinHandle;
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
 use tracing::warn;
 
-pub struct TopicQueueMappingCleanService;
+use crate::broker_runtime::BrokerRuntimeInner;
 
-impl TopicQueueMappingCleanService {
-    pub fn start(&mut self) {
-        warn!("TopicQueueMappingCleanService started not implemented");
+const INITIAL_DELAY: Duration = Duration::from_secs(5 * 60);
+const CLEAN_INTERVAL: Duration = Duration::from_secs(5 * 60);
+const TOPIC_SCAN_YIELD_DELAY: Duration = Duration::from_millis(10);
+
+#[derive(Default)]
+struct CleanServiceLifecycle {
+    cancel: Option<CancellationToken>,
+    handle: Option<JoinHandle<()>>,
+}
+
+struct TopicQueueMappingCleanServiceInner<MS: MessageStore> {
+    broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+    running: AtomicBool,
+    lifecycle: Mutex<CleanServiceLifecycle>,
+}
+
+#[derive(Clone)]
+pub struct TopicQueueMappingCleanService<MS: MessageStore> {
+    inner: Arc<TopicQueueMappingCleanServiceInner<MS>>,
+}
+
+impl<MS: MessageStore> TopicQueueMappingCleanService<MS> {
+    pub fn new(broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        Self {
+            inner: Arc::new(TopicQueueMappingCleanServiceInner {
+                broker_runtime_inner,
+                running: AtomicBool::new(false),
+                lifecycle: Mutex::new(CleanServiceLifecycle::default()),
+            }),
+        }
     }
 
-    pub fn shutdown(&mut self) {
-        warn!("TopicQueueMappingCleanService shutdown not implemented");
+    pub fn start(&self) {
+        if self
+            .inner
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let cancel = CancellationToken::new();
+        let cancel_for_task = cancel.clone();
+        let this = Self {
+            inner: Arc::clone(&self.inner),
+        };
+        let handle = tokio::spawn(async move {
+            tokio::select! {
+                _ = cancel_for_task.cancelled() => {
+                    this.inner.running.store(false, Ordering::Release);
+                    return;
+                }
+                _ = tokio::time::sleep(INITIAL_DELAY) => {}
+            }
+
+            let mut interval = tokio::time::interval(CLEAN_INTERVAL);
+            interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+            loop {
+                tokio::select! {
+                    _ = cancel_for_task.cancelled() => {
+                        this.inner.running.store(false, Ordering::Release);
+                        return;
+                    }
+                    _ = interval.tick() => {
+                        if let Err(err) = this.run_once().await {
+                            warn!("TopicQueueMappingCleanService scan failed: {}", err);
+                        }
+                    }
+                }
+            }
+        });
+
+        let mut lifecycle = self.inner.lifecycle.lock();
+        lifecycle.cancel = Some(cancel);
+        lifecycle.handle = Some(handle);
+        info!("TopicQueueMappingCleanService started");
+    }
+
+    pub fn shutdown(&self) {
+        self.inner.running.store(false, Ordering::Release);
+        let mut lifecycle = self.inner.lifecycle.lock();
+        if let Some(cancel) = lifecycle.cancel.take() {
+            cancel.cancel();
+        }
+        if let Some(handle) = lifecycle.handle.take() {
+            handle.abort();
+        }
+        info!("TopicQueueMappingCleanService shutdown");
+    }
+
+    pub(crate) fn is_running(&self) -> bool {
+        self.inner.running.load(Ordering::Acquire)
+    }
+
+    pub(crate) async fn run_once(&self) -> RocketMQResult<bool> {
+        let expired_changed = self.clean_item_expired_once().await?;
+        let old_generation_changed = self.clean_item_list_more_than_second_gen_once().await?;
+        Ok(expired_changed || old_generation_changed)
+    }
+
+    pub(crate) async fn clean_item_expired_once(&self) -> RocketMQResult<bool> {
+        if !self.is_time_to_clean() {
+            return Ok(false);
+        }
+
+        let start = Instant::now();
+        let broker_runtime_inner = &self.inner.broker_runtime_inner;
+        let current_broker = broker_runtime_inner.broker_config().broker_name().clone();
+        let timeout_millis = broker_runtime_inner.broker_config().forward_timeout;
+        let snapshot = broker_runtime_inner
+            .topic_queue_mapping_manager()
+            .snapshot_topic_queue_mapping_table();
+        let mut changed = false;
+
+        for (topic, mapping_detail) in snapshot {
+            if !Self::is_current_broker_mapping(&mapping_detail, &current_broker) {
+                warn!(
+                    "TopicQueueMappingDetail for topic {} should not exist in broker {}: {:?}",
+                    topic, current_broker, mapping_detail
+                );
+                continue;
+            }
+
+            let Some(hosted_queues) = mapping_detail.hosted_queues.as_ref() else {
+                continue;
+            };
+            if hosted_queues.is_empty() {
+                continue;
+            }
+
+            let mut brokers = HashSet::new();
+            for items in hosted_queues.values() {
+                if items.len() <= 1 || !TopicQueueMappingUtils::check_if_leader(items, &mapping_detail) {
+                    continue;
+                }
+                if let Some(broker_name) = items.first().and_then(|item| item.bname.clone()) {
+                    brokers.insert(broker_name);
+                }
+            }
+            if brokers.is_empty() {
+                continue;
+            }
+
+            if let Err(err) = broker_runtime_inner
+                .broker_outer_api()
+                .get_topic_route_info_from_name_server(&topic, timeout_millis, true)
+                .await
+            {
+                warn!(
+                    "Refresh route before cleaning expired mapping item failed for topic {}: {}",
+                    topic, err
+                );
+            }
+
+            let mut stats_table = HashMap::new();
+            for broker_name in brokers {
+                match broker_runtime_inner
+                    .broker_outer_api()
+                    .get_topic_stats_info_from_broker(&broker_name, &topic, timeout_millis)
+                    .await
+                {
+                    Ok(stats) => {
+                        stats_table.insert(broker_name, stats);
+                    }
+                    Err(err) => {
+                        warn!(
+                            "Get remote topic {} stats failed from broker {}: {}",
+                            topic, broker_name, err
+                        );
+                    }
+                }
+            }
+
+            let mut replacements: HashMap<i32, (Vec<LogicQueueMappingItem>, Vec<LogicQueueMappingItem>)> =
+                HashMap::new();
+            for (qid, items) in hosted_queues {
+                if items.len() <= 1 || !TopicQueueMappingUtils::check_if_leader(items, &mapping_detail) {
+                    continue;
+                }
+                let Some(earliest_item) = items.first() else {
+                    continue;
+                };
+                let Some(earliest_broker) = earliest_item.bname.as_ref() else {
+                    continue;
+                };
+                let Some(topic_stats) = stats_table.get(earliest_broker) else {
+                    continue;
+                };
+
+                let message_queue =
+                    MessageQueue::from_parts(topic.clone(), earliest_broker.clone(), earliest_item.queue_id);
+                let Some(topic_offset) = topic_stats.get_offset_table().get(&message_queue) else {
+                    warn!(
+                        "TopicQueueMappingCleanService got null TopicOffset for topic {} item {:?}",
+                        topic, earliest_item
+                    );
+                    continue;
+                };
+                if Self::should_remove_earliest_item(topic_offset) {
+                    let mut new_items = items.clone();
+                    new_items.remove(0);
+                    replacements.insert(*qid, (items.clone(), new_items));
+                    info!(
+                        "Remove expired logic queue item topic={} item={:?} because offset={}",
+                        topic, earliest_item, topic_offset
+                    );
+                }
+            }
+
+            if !replacements.is_empty() {
+                let expected_epoch = mapping_detail.topic_queue_mapping_info.epoch;
+                let Some(expected_bname) = mapping_detail.topic_queue_mapping_info.bname.as_ref() else {
+                    continue;
+                };
+                if broker_runtime_inner
+                    .topic_queue_mapping_manager()
+                    .replace_cleaned_queue_items(&topic, expected_epoch, expected_bname, &replacements)
+                {
+                    changed = true;
+                }
+            }
+
+            tokio::time::sleep(TOPIC_SCAN_YIELD_DELAY).await;
+        }
+
+        if changed {
+            broker_runtime_inner
+                .topic_queue_mapping_manager()
+                .persist_clean_result()
+                .await?;
+            info!("cleanItemExpired changed");
+        }
+        info!("cleanItemExpired cost {} ms", start.elapsed().as_millis());
+        Ok(changed)
+    }
+
+    pub(crate) async fn clean_item_list_more_than_second_gen_once(&self) -> RocketMQResult<bool> {
+        if !self.is_time_to_clean() {
+            return Ok(false);
+        }
+
+        let start = Instant::now();
+        let broker_runtime_inner = &self.inner.broker_runtime_inner;
+        let current_broker = broker_runtime_inner.broker_config().broker_name().clone();
+        let timeout_millis = broker_runtime_inner.broker_config().forward_timeout;
+        let snapshot = broker_runtime_inner
+            .topic_queue_mapping_manager()
+            .snapshot_topic_queue_mapping_table();
+        let client_metadata = ClientMetadata::new();
+        let mut changed = false;
+
+        for (topic, mapping_detail) in snapshot {
+            if !Self::is_current_broker_mapping(&mapping_detail, &current_broker) {
+                warn!(
+                    "TopicQueueMappingDetail for topic {} should not exist in broker {}: {:?}",
+                    topic, current_broker, mapping_detail
+                );
+                continue;
+            }
+
+            let Some(hosted_queues) = mapping_detail.hosted_queues.as_ref() else {
+                continue;
+            };
+            if hosted_queues.is_empty() {
+                continue;
+            }
+
+            let Some(expected_bname) = mapping_detail.topic_queue_mapping_info.bname.as_ref() else {
+                continue;
+            };
+            let mut qid_to_current_leader = HashMap::new();
+            let mut local_expected_items = HashMap::new();
+            for (qid, items) in hosted_queues {
+                let Some(leader_item) = items.last() else {
+                    continue;
+                };
+                let Some(leader_broker) = leader_item.bname.as_ref() else {
+                    continue;
+                };
+                if leader_broker != expected_bname {
+                    qid_to_current_leader.insert(*qid, leader_broker.clone());
+                    local_expected_items.insert(*qid, items.clone());
+                }
+            }
+            if qid_to_current_leader.is_empty() {
+                continue;
+            }
+
+            let topic_route_data = match broker_runtime_inner
+                .broker_outer_api()
+                .get_topic_route_info_from_name_server(&topic, timeout_millis, true)
+                .await
+            {
+                Ok(topic_route_data) => topic_route_data,
+                Err(err) => {
+                    warn!(
+                        "Get topic route failed before cleaning old mapping list for topic {}: {}",
+                        topic, err
+                    );
+                    continue;
+                }
+            };
+            client_metadata.fresh_topic_route(&topic, Some(topic_route_data));
+
+            let scope = mapping_detail
+                .topic_queue_mapping_info
+                .scope
+                .as_ref()
+                .map(CheetahString::as_str)
+                .unwrap_or(METADATA_SCOPE_GLOBAL);
+            let mock_broker_name = TopicQueueMappingUtils::get_mock_broker_name(scope);
+            let mut qid_to_real_leader = HashMap::new();
+            for qid in qid_to_current_leader.keys() {
+                let message_queue = MessageQueue::from_parts(topic.clone(), mock_broker_name.clone(), *qid);
+                if let Some(real_leader) = client_metadata.get_broker_name_from_message_queue(&message_queue) {
+                    qid_to_real_leader.insert(*qid, real_leader);
+                }
+            }
+
+            let mut brokers_to_fetch = HashSet::new();
+            for broker_name in qid_to_real_leader.values() {
+                if !broker_name.as_str().starts_with(LOGICAL_QUEUE_MOCK_BROKER_PREFIX) {
+                    brokers_to_fetch.insert(broker_name.clone());
+                }
+            }
+
+            let mut mapping_detail_by_broker = HashMap::new();
+            for broker_name in brokers_to_fetch {
+                match broker_runtime_inner
+                    .broker_outer_api()
+                    .get_topic_config_from_broker(&broker_name, &topic, true, timeout_millis)
+                    .await
+                {
+                    Ok(topic_config_mapping) => {
+                        if let Some(remote_detail) = topic_config_mapping.topic_queue_mapping_detail {
+                            if remote_detail.topic_queue_mapping_info.bname.as_ref() == Some(&broker_name) {
+                                mapping_detail_by_broker.insert(broker_name, remote_detail.as_ref().clone());
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        warn!(
+                            "Get remote topic {} config failed from broker {}: {}",
+                            topic, broker_name, err
+                        );
+                    }
+                }
+            }
+
+            let mut expected_items_to_delete = HashMap::new();
+            for (qid, current_leader) in &qid_to_current_leader {
+                let Some(real_leader) = qid_to_real_leader.get(qid) else {
+                    continue;
+                };
+                let Some(remote_mapping_detail) = mapping_detail_by_broker.get(real_leader) else {
+                    continue;
+                };
+                if remote_mapping_detail.topic_queue_mapping_info.total_queues
+                    != mapping_detail.topic_queue_mapping_info.total_queues
+                    || remote_mapping_detail.topic_queue_mapping_info.epoch
+                        != mapping_detail.topic_queue_mapping_info.epoch
+                {
+                    continue;
+                }
+                let Some(remote_items) = remote_mapping_detail
+                    .hosted_queues
+                    .as_ref()
+                    .and_then(|queues| queues.get(qid))
+                else {
+                    continue;
+                };
+                let Some(remote_leader_item) = remote_items.last() else {
+                    continue;
+                };
+                if remote_leader_item.bname.as_ref() != Some(real_leader) {
+                    continue;
+                }
+                if real_leader != current_leader {
+                    if let Some(expected_items) = local_expected_items.get(qid) {
+                        expected_items_to_delete.insert(*qid, expected_items.clone());
+                    }
+                }
+            }
+
+            if !expected_items_to_delete.is_empty() {
+                let expected_epoch = mapping_detail.topic_queue_mapping_info.epoch;
+                if broker_runtime_inner
+                    .topic_queue_mapping_manager()
+                    .remove_cleaned_hosted_queues(&topic, expected_epoch, expected_bname, &expected_items_to_delete)
+                {
+                    changed = true;
+                    for (qid, items) in expected_items_to_delete {
+                        info!(
+                            "Remove old generation mapping list topic={} qid={} items={:?}",
+                            topic, qid, items
+                        );
+                    }
+                }
+            }
+
+            tokio::time::sleep(TOPIC_SCAN_YIELD_DELAY).await;
+        }
+
+        if changed {
+            broker_runtime_inner
+                .topic_queue_mapping_manager()
+                .persist_clean_result()
+                .await?;
+        }
+        info!("cleanItemListMoreThanSecondGen cost {} ms", start.elapsed().as_millis());
+        Ok(changed)
+    }
+
+    fn is_time_to_clean(&self) -> bool {
+        is_it_time_to_do(&self.inner.broker_runtime_inner.message_store_config().delete_when)
+    }
+
+    fn is_current_broker_mapping(mapping_detail: &TopicQueueMappingDetail, broker_name: &CheetahString) -> bool {
+        mapping_detail.topic_queue_mapping_info.bname.as_ref() == Some(broker_name)
+    }
+
+    pub(crate) fn should_remove_earliest_item(topic_offset: &TopicOffset) -> bool {
+        topic_offset.get_max_offset() == topic_offset.get_min_offset() || topic_offset.get_max_offset() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_remove_earliest_item_when_queue_is_empty() {
+        let mut offset = TopicOffset::new();
+        offset.set_min_offset(10);
+        offset.set_max_offset(10);
+
+        assert!(TopicQueueMappingCleanService::<
+            rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore,
+        >::should_remove_earliest_item(&offset));
+    }
+
+    #[test]
+    fn should_remove_earliest_item_when_max_offset_is_zero() {
+        let mut offset = TopicOffset::new();
+        offset.set_min_offset(-1);
+        offset.set_max_offset(0);
+
+        assert!(TopicQueueMappingCleanService::<
+            rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore,
+        >::should_remove_earliest_item(&offset));
+    }
+
+    #[test]
+    fn should_keep_earliest_item_when_queue_has_messages() {
+        let mut offset = TopicOffset::new();
+        offset.set_min_offset(10);
+        offset.set_max_offset(20);
+
+        assert!(!TopicQueueMappingCleanService::<
+            rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore,
+        >::should_remove_earliest_item(&offset));
     }
 }

--- a/rocketmq-remoting/src/protocol/header/get_topic_config_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_topic_config_request_header.rs
@@ -17,6 +17,8 @@ use rocketmq_macros::RequestHeaderCodecV2;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
+use crate::rpc::rpc_request_header::RpcRequestHeader;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
 #[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2)]
@@ -36,6 +38,92 @@ impl GetTopicConfigRequestHeader {
     pub fn set_topic(&mut self, topic: CheetahString) {
         self.topic = topic;
     }
+}
+
+impl TopicRequestHeaderTrait for GetTopicConfigRequestHeader {
+    fn set_lo(&mut self, lo: Option<bool>) {
+        self.topic_request_header
+            .get_or_insert_with(TopicRequestHeader::default)
+            .lo = lo;
+    }
+
+    fn lo(&self) -> Option<bool> {
+        self.topic_request_header.as_ref().and_then(|header| header.lo)
+    }
+
+    fn set_topic(&mut self, topic: CheetahString) {
+        self.topic = topic;
+    }
+
+    fn topic(&self) -> &CheetahString {
+        &self.topic
+    }
+
+    fn broker_name(&self) -> Option<&CheetahString> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|header| header.rpc_request_header.as_ref())
+            .and_then(|rpc| rpc.broker_name.as_ref())
+    }
+
+    fn set_broker_name(&mut self, broker_name: CheetahString) {
+        self.topic_request_header
+            .get_or_insert_with(TopicRequestHeader::default)
+            .rpc_request_header
+            .get_or_insert_with(RpcRequestHeader::default)
+            .broker_name = Some(broker_name);
+    }
+
+    fn namespace(&self) -> Option<&str> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|header| header.rpc_request_header.as_ref())
+            .and_then(|rpc| rpc.namespace.as_deref())
+    }
+
+    fn set_namespace(&mut self, namespace: CheetahString) {
+        self.topic_request_header
+            .get_or_insert_with(TopicRequestHeader::default)
+            .rpc_request_header
+            .get_or_insert_with(RpcRequestHeader::default)
+            .namespace = Some(namespace);
+    }
+
+    fn namespaced(&self) -> Option<bool> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|header| header.rpc_request_header.as_ref())
+            .and_then(|rpc| rpc.namespaced)
+    }
+
+    fn set_namespaced(&mut self, namespaced: bool) {
+        self.topic_request_header
+            .get_or_insert_with(TopicRequestHeader::default)
+            .rpc_request_header
+            .get_or_insert_with(RpcRequestHeader::default)
+            .namespaced = Some(namespaced);
+    }
+
+    fn oneway(&self) -> Option<bool> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|header| header.rpc_request_header.as_ref())
+            .and_then(|rpc| rpc.oneway)
+    }
+
+    fn set_oneway(&mut self, oneway: bool) {
+        self.topic_request_header
+            .get_or_insert_with(TopicRequestHeader::default)
+            .rpc_request_header
+            .get_or_insert_with(RpcRequestHeader::default)
+            .oneway = Some(oneway);
+    }
+
+    fn queue_id(&self) -> i32 {
+        -1
+    }
+
+    fn set_queue_id(&mut self, _queue_id: i32) {}
 }
 
 #[cfg(test)]

--- a/rocketmq-remoting/src/protocol/header/get_topic_stats_info_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/get_topic_stats_info_request_header.rs
@@ -17,7 +17,9 @@ use rocketmq_macros::RequestHeaderCodecV2;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
+use crate::rpc::rpc_request_header::RpcRequestHeader;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
 #[serde(rename_all = "camelCase")]
@@ -27,6 +29,92 @@ pub struct GetTopicStatsInfoRequestHeader {
 
     #[serde(flatten)]
     pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+impl TopicRequestHeaderTrait for GetTopicStatsInfoRequestHeader {
+    fn set_lo(&mut self, lo: Option<bool>) {
+        self.topic_request_header
+            .get_or_insert_with(TopicRequestHeader::default)
+            .lo = lo;
+    }
+
+    fn lo(&self) -> Option<bool> {
+        self.topic_request_header.as_ref().and_then(|header| header.lo)
+    }
+
+    fn set_topic(&mut self, topic: CheetahString) {
+        self.topic = topic;
+    }
+
+    fn topic(&self) -> &CheetahString {
+        &self.topic
+    }
+
+    fn broker_name(&self) -> Option<&CheetahString> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|header| header.rpc.as_ref())
+            .and_then(|rpc| rpc.broker_name.as_ref())
+    }
+
+    fn set_broker_name(&mut self, broker_name: CheetahString) {
+        self.topic_request_header
+            .get_or_insert_with(TopicRequestHeader::default)
+            .rpc
+            .get_or_insert_with(RpcRequestHeader::default)
+            .broker_name = Some(broker_name);
+    }
+
+    fn namespace(&self) -> Option<&str> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|header| header.rpc.as_ref())
+            .and_then(|rpc| rpc.namespace.as_deref())
+    }
+
+    fn set_namespace(&mut self, namespace: CheetahString) {
+        self.topic_request_header
+            .get_or_insert_with(TopicRequestHeader::default)
+            .rpc
+            .get_or_insert_with(RpcRequestHeader::default)
+            .namespace = Some(namespace);
+    }
+
+    fn namespaced(&self) -> Option<bool> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|header| header.rpc.as_ref())
+            .and_then(|rpc| rpc.namespaced)
+    }
+
+    fn set_namespaced(&mut self, namespaced: bool) {
+        self.topic_request_header
+            .get_or_insert_with(TopicRequestHeader::default)
+            .rpc
+            .get_or_insert_with(RpcRequestHeader::default)
+            .namespaced = Some(namespaced);
+    }
+
+    fn oneway(&self) -> Option<bool> {
+        self.topic_request_header
+            .as_ref()
+            .and_then(|header| header.rpc.as_ref())
+            .and_then(|rpc| rpc.oneway)
+    }
+
+    fn set_oneway(&mut self, oneway: bool) {
+        self.topic_request_header
+            .get_or_insert_with(TopicRequestHeader::default)
+            .rpc
+            .get_or_insert_with(RpcRequestHeader::default)
+            .oneway = Some(oneway);
+    }
+
+    fn queue_id(&self) -> i32 {
+        -1
+    }
+
+    fn set_queue_id(&mut self, _queue_id: i32) {}
 }
 
 #[cfg(test)]

--- a/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_detail.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_detail.rs
@@ -54,13 +54,30 @@ impl TopicQueueMappingDetail {
 
 //impl static methods(Like java static method)
 impl TopicQueueMappingDetail {
+    pub fn build_id_map(mapping_detail: &TopicQueueMappingDetail) -> HashMap<i32, i32> {
+        let mut curr_id_map = HashMap::new();
+        let broker_name = mapping_detail.topic_queue_mapping_info.bname.as_ref();
+        if let (Some(hosted_queues), Some(broker_name)) = (&mapping_detail.hosted_queues, broker_name) {
+            for (global_id, items) in hosted_queues {
+                if let Some(last_item) = items.last() {
+                    if last_item.bname.as_ref() == Some(broker_name) {
+                        curr_id_map.insert(*global_id, last_item.queue_id);
+                    }
+                }
+            }
+        }
+        curr_id_map
+    }
+
     pub fn clone_as_mapping_info(mapping_detail: &TopicQueueMappingDetail) -> TopicQueueMappingInfo {
         TopicQueueMappingInfo {
             topic: mapping_detail.topic_queue_mapping_info.topic.clone(),
+            scope: mapping_detail.topic_queue_mapping_info.scope.clone(),
             total_queues: mapping_detail.topic_queue_mapping_info.total_queues,
             bname: mapping_detail.topic_queue_mapping_info.bname.clone(),
             epoch: mapping_detail.topic_queue_mapping_info.epoch,
-            ..TopicQueueMappingInfo::default()
+            dirty: mapping_detail.topic_queue_mapping_info.dirty,
+            curr_id_map: Some(Self::build_id_map(mapping_detail)),
         }
     }
     pub fn put_mapping_info(
@@ -167,6 +184,45 @@ mod tests {
         assert_eq!(info.total_queues, detail.topic_queue_mapping_info.total_queues);
         assert_eq!(info.bname, detail.topic_queue_mapping_info.bname);
         assert_eq!(info.epoch, detail.topic_queue_mapping_info.epoch);
+    }
+
+    #[test]
+    fn clone_as_mapping_info_builds_current_id_map_for_leader_items() {
+        let broker_a = cheetah_string::CheetahString::from_static_str("broker_a");
+        let broker_b = cheetah_string::CheetahString::from_static_str("broker_b");
+        let mut hosted_queues = HashMap::new();
+        hosted_queues.insert(
+            0,
+            vec![LogicQueueMappingItem {
+                queue_id: 3,
+                bname: Some(broker_a.clone()),
+                ..Default::default()
+            }],
+        );
+        hosted_queues.insert(
+            1,
+            vec![LogicQueueMappingItem {
+                queue_id: 7,
+                bname: Some(broker_b),
+                ..Default::default()
+            }],
+        );
+        let detail = TopicQueueMappingDetail {
+            topic_queue_mapping_info: TopicQueueMappingInfo {
+                topic: Some("test_topic".into()),
+                total_queues: 2,
+                bname: Some(broker_a),
+                epoch: 10,
+                ..TopicQueueMappingInfo::default()
+            },
+            hosted_queues: Some(hosted_queues),
+        };
+
+        let info = TopicQueueMappingDetail::clone_as_mapping_info(&detail);
+
+        let curr_id_map = info.curr_id_map.unwrap();
+        assert_eq!(curr_id_map.get(&0), Some(&3));
+        assert!(!curr_id_map.contains_key(&1));
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_utils.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_utils.rs
@@ -204,14 +204,11 @@ impl TopicQueueMappingUtils {
         ))
     }
     pub fn check_if_reuse_physical_queue(mapping_ones: &Vec<TopicQueueMappingOne>) -> RocketMQResult<()> {
-        let mut physical_queue_id_map = HashMap::new();
+        let mut physical_queue_id_map: HashMap<String, TopicQueueMappingOne> = HashMap::new();
         for mapping_one in mapping_ones {
             for item in mapping_one.items() {
                 if let Some(bname) = &item.bname {
                     let physical_queue_id = format!("{} - {}", bname, item.queue_id);
-                    physical_queue_id_map
-                        .entry(physical_queue_id.clone())
-                        .or_insert(mapping_one.clone());
                     if let Some(id) = physical_queue_id_map.get(&physical_queue_id) {
                         return Err(RocketMQError::Internal(format!(
                             "Topic {} global queue id {} and {} shared the same physical queue {}",
@@ -221,6 +218,7 @@ impl TopicQueueMappingUtils {
                             physical_queue_id
                         )));
                     }
+                    physical_queue_id_map.insert(physical_queue_id, mapping_one.clone());
                 }
             }
         }
@@ -229,13 +227,11 @@ impl TopicQueueMappingUtils {
 
     pub fn check_logic_queue_mapping_item_offset(items: &[LogicQueueMappingItem]) -> RocketMQResult<()> {
         if items.is_empty() {
-            return Err(RocketMQError::Internal(
-                "check_logic_queue_mapping_item_offset input items is empty".to_string(),
-            ));
+            return Ok(());
         }
         let mut last_gen = -1;
         let mut last_offset = -1;
-        for i in items.len() - 1..=0 {
+        for i in (0..items.len()).rev() {
             let item = &items[i];
             if item.start_offset < 0 || item.gen < 0 || item.queue_id < 0 {
                 return Err(RocketMQError::Internal(
@@ -276,6 +272,14 @@ impl TopicQueueMappingUtils {
         }
         Ok(())
     }
+
+    pub fn check_if_leader(items: &[LogicQueueMappingItem], mapping_detail: &TopicQueueMappingDetail) -> bool {
+        let Some(item) = items.last() else {
+            return false;
+        };
+        item.bname.as_ref() == mapping_detail.topic_queue_mapping_info.bname.as_ref()
+    }
+
     pub fn get_leader_item(items: &[LogicQueueMappingItem]) -> RocketMQResult<LogicQueueMappingItem> {
         if items.is_empty() {
             return Err(RocketMQError::Internal(
@@ -892,5 +896,57 @@ impl TopicQueueMappingUtils {
             brokers_to_map_in,
             brokers_to_map_out,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_logic_queue_mapping_item_offset_accepts_monotonic_items() {
+        let items = vec![
+            LogicQueueMappingItem {
+                gen: 0,
+                logic_offset: 0,
+                start_offset: 0,
+                end_offset: 9,
+                ..Default::default()
+            },
+            LogicQueueMappingItem {
+                gen: 1,
+                logic_offset: 10,
+                start_offset: 0,
+                end_offset: -1,
+                ..Default::default()
+            },
+        ];
+
+        assert!(TopicQueueMappingUtils::check_logic_queue_mapping_item_offset(&items).is_ok());
+    }
+
+    #[test]
+    fn check_if_leader_requires_last_item_broker_to_match_detail_broker() {
+        let broker_a = CheetahString::from_static_str("broker-a");
+        let broker_b = CheetahString::from_static_str("broker-b");
+        let detail = TopicQueueMappingDetail {
+            topic_queue_mapping_info: TopicQueueMappingInfo {
+                bname: Some(broker_a.clone()),
+                ..Default::default()
+            },
+            hosted_queues: None,
+        };
+        let leader_items = vec![LogicQueueMappingItem {
+            bname: Some(broker_a),
+            ..Default::default()
+        }];
+        let follower_items = vec![LogicQueueMappingItem {
+            bname: Some(broker_b),
+            ..Default::default()
+        }];
+
+        assert!(TopicQueueMappingUtils::check_if_leader(&leader_items, &detail));
+        assert!(!TopicQueueMappingUtils::check_if_leader(&follower_items, &detail));
+        assert!(!TopicQueueMappingUtils::check_if_leader(&[], &detail));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7204

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented topic queue mapping cleanup service with periodic maintenance to remove expired items and outdated queue generations.
  * Added broker-to-broker RPC methods for fetching topic statistics and configuration data.

* **Refactor**
  * Generified topic queue mapping service over message store type for improved type safety.
  * Enhanced topic queue mapping utilities and validation logic with improved offset checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->