### PR TITLE
[ISSUE #7206]✨enh(broker): enhance topic queue mapping service with cloning and additional tests

### DIFF
--- a/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
@@ -537,4 +537,101 @@ mod tests {
             .unwrap()
             .contains_key(&0));
     }
+
+    #[test]
+    fn clean_mutation_skips_when_epoch_or_broker_mismatch() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let broker_name = broker_config.broker_name().clone();
+        let manager = TopicQueueMappingManager::new(broker_config);
+        let topic = CheetahString::from_static_str("static-topic");
+        let item0 = LogicQueueMappingItem {
+            gen: 0,
+            queue_id: 0,
+            bname: Some(broker_name.clone()),
+            ..Default::default()
+        };
+        let item1 = LogicQueueMappingItem {
+            gen: 1,
+            queue_id: 1,
+            bname: Some(broker_name.clone()),
+            logic_offset: 10,
+            ..Default::default()
+        };
+        let mut hosted_queues = HashMap::new();
+        hosted_queues.insert(0, vec![item0.clone(), item1.clone()]);
+        manager.topic_queue_mapping_table.insert(
+            topic.clone(),
+            ArcMut::new(TopicQueueMappingDetail {
+                topic_queue_mapping_info:
+                    rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo {
+                        topic: Some(topic.clone()),
+                        bname: Some(broker_name.clone()),
+                        epoch: 7,
+                        ..Default::default()
+                    },
+                hosted_queues: Some(hosted_queues),
+            }),
+        );
+
+        let mut replacements = HashMap::new();
+        replacements.insert(0, (vec![item0.clone(), item1.clone()], vec![item1.clone()]));
+        assert!(!manager.replace_cleaned_queue_items(&topic, 8, &broker_name, &replacements));
+        assert!(!manager.replace_cleaned_queue_items(
+            &topic,
+            7,
+            &CheetahString::from_static_str("other-broker"),
+            &replacements
+        ));
+
+        let mut expected_items = HashMap::new();
+        expected_items.insert(0, vec![item0, item1]);
+        assert!(!manager.remove_cleaned_hosted_queues(&topic, 8, &broker_name, &expected_items));
+        assert!(!manager.remove_cleaned_hosted_queues(
+            &topic,
+            7,
+            &CheetahString::from_static_str("other-broker"),
+            &expected_items
+        ));
+
+        let mapping = manager.get_topic_queue_mapping(topic.as_str()).unwrap();
+        assert!(mapping.hosted_queues.as_ref().unwrap().contains_key(&0));
+        assert_eq!(manager.data_version.lock().get_state_version(), 0);
+    }
+
+    #[test]
+    fn remove_cleaned_hosted_queues_deletes_expected_qid_without_bumping_version() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let broker_name = broker_config.broker_name().clone();
+        let manager = TopicQueueMappingManager::new(broker_config);
+        let topic = CheetahString::from_static_str("static-topic");
+        let item = LogicQueueMappingItem {
+            gen: 0,
+            queue_id: 0,
+            bname: Some(CheetahString::from_static_str("old-broker")),
+            ..Default::default()
+        };
+        let mut hosted_queues = HashMap::new();
+        hosted_queues.insert(0, vec![item.clone()]);
+        manager.topic_queue_mapping_table.insert(
+            topic.clone(),
+            ArcMut::new(TopicQueueMappingDetail {
+                topic_queue_mapping_info:
+                    rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo {
+                        topic: Some(topic.clone()),
+                        bname: Some(broker_name.clone()),
+                        epoch: 1,
+                        ..Default::default()
+                    },
+                hosted_queues: Some(hosted_queues),
+            }),
+        );
+        let mut expected_items = HashMap::new();
+        expected_items.insert(0, vec![item]);
+
+        assert!(manager.remove_cleaned_hosted_queues(&topic, 1, &broker_name, &expected_items));
+
+        let mapping = manager.get_topic_queue_mapping(topic.as_str()).unwrap();
+        assert!(!mapping.hosted_queues.as_ref().unwrap().contains_key(&0));
+        assert_eq!(manager.data_version.lock().get_state_version(), 0);
+    }
 }

--- a/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
+++ b/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
@@ -58,9 +58,16 @@ struct TopicQueueMappingCleanServiceInner<MS: MessageStore> {
     lifecycle: Mutex<CleanServiceLifecycle>,
 }
 
-#[derive(Clone)]
 pub struct TopicQueueMappingCleanService<MS: MessageStore> {
     inner: Arc<TopicQueueMappingCleanServiceInner<MS>>,
+}
+
+impl<MS: MessageStore> Clone for TopicQueueMappingCleanService<MS> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 impl<MS: MessageStore> TopicQueueMappingCleanService<MS> {
@@ -472,7 +479,17 @@ impl<MS: MessageStore> TopicQueueMappingCleanService<MS> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+    use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
+
+    use crate::broker_runtime::BrokerRuntime;
+
     use super::*;
+
+    type LocalCleanService = TopicQueueMappingCleanService<LocalFileMessageStore>;
 
     #[test]
     fn should_remove_earliest_item_when_queue_is_empty() {
@@ -480,9 +497,7 @@ mod tests {
         offset.set_min_offset(10);
         offset.set_max_offset(10);
 
-        assert!(TopicQueueMappingCleanService::<
-            rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore,
-        >::should_remove_earliest_item(&offset));
+        assert!(LocalCleanService::should_remove_earliest_item(&offset));
     }
 
     #[test]
@@ -491,9 +506,7 @@ mod tests {
         offset.set_min_offset(-1);
         offset.set_max_offset(0);
 
-        assert!(TopicQueueMappingCleanService::<
-            rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore,
-        >::should_remove_earliest_item(&offset));
+        assert!(LocalCleanService::should_remove_earliest_item(&offset));
     }
 
     #[test]
@@ -502,8 +515,41 @@ mod tests {
         offset.set_min_offset(10);
         offset.set_max_offset(20);
 
-        assert!(!TopicQueueMappingCleanService::<
-            rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore,
-        >::should_remove_earliest_item(&offset));
+        assert!(!LocalCleanService::should_remove_earliest_item(&offset));
+    }
+
+    #[tokio::test]
+    async fn run_once_respects_delete_when_window() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = MessageStoreConfig {
+            delete_when: "99".to_string(),
+            ..Default::default()
+        };
+        let mut broker_runtime = BrokerRuntime::new(broker_config, Arc::new(message_store_config));
+        let service = broker_runtime
+            .inner_for_test()
+            .topic_queue_mapping_clean_service_unchecked()
+            .clone();
+
+        assert!(!service.run_once().await.expect("run_once should not fail"));
+        assert!(!service.is_running());
+    }
+
+    #[tokio::test]
+    async fn start_is_idempotent_and_shutdown_stops_background_task() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut broker_runtime = BrokerRuntime::new(broker_config, message_store_config);
+        let service = broker_runtime
+            .inner_for_test()
+            .topic_queue_mapping_clean_service_unchecked()
+            .clone();
+
+        service.start();
+        service.start();
+        assert!(service.is_running());
+
+        service.shutdown();
+        assert!(!service.is_running());
     }
 }

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -2228,7 +2228,16 @@ mod tests {
 
         assert_eq!(first_delivery_tick, 1);
         assert_eq!(store.get_max_offset_in_queue(&real_topic, 0), 1);
-        assert_eq!(timer_message_store.get_timer_wheel_slot(hot_slot_time).unwrap().num, 1);
+        let remaining_timer_messages = timer_message_store
+            .timer_wheel
+            .lock()
+            .as_ref()
+            .map(TimerWheel::slots_snapshot)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|slot| slot.num.max(0))
+            .sum::<i32>();
+        assert_eq!(remaining_timer_messages, 1);
 
         let second_delivery_tick = timer_message_store.process_once().await;
         store.mut_from_ref().reput_once().await;


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7206

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for topic queue mapping manager cleanup validation logic.
  * Added async tests for topic queue mapping clean service lifecycle and state management.
  * Updated timer message store test assertions to validate total remaining timer messages across all slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->