### PR TITLE
[ISSUE #7210]♻️refactor(mapped_file): replace panic handling with Result for mapped file creation and improve error reporting

### DIFF
--- a/rocketmq-store/src/base/allocate_mapped_file_service.rs
+++ b/rocketmq-store/src/base/allocate_mapped_file_service.rs
@@ -16,8 +16,6 @@ use std::collections::BinaryHeap;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fmt::Formatter;
-use std::panic::catch_unwind;
-use std::panic::AssertUnwindSafe;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -314,22 +312,20 @@ impl AllocateMappedFileService {
         let file_size = req.file_size as u64;
         let transient_pool = transient_store_pool.clone();
 
-        let mapped_file = catch_unwind(AssertUnwindSafe(move || -> DefaultMappedFile {
-            if let Some(pool) = transient_pool {
-                // With TransientStorePool (zero-copy)
-                DefaultMappedFile::new_with_transient_store_pool(
-                    CheetahString::from_string(file_path.clone()),
-                    file_size,
-                    (*pool).clone(),
-                )
-            } else {
-                // Standard mmap
-                DefaultMappedFile::new(CheetahString::from_string(file_path.clone()), file_size)
-            }
-        }))
-        .map_err(|payload| RocketMQError::StorageWriteFailed {
+        let mapped_file = if let Some(pool) = transient_pool {
+            // With TransientStorePool (zero-copy)
+            DefaultMappedFile::try_new_with_transient_store_pool(
+                CheetahString::from_string(file_path.clone()),
+                file_size,
+                (*pool).clone(),
+            )
+        } else {
+            // Standard mmap
+            DefaultMappedFile::try_new(CheetahString::from_string(file_path.clone()), file_size)
+        }
+        .map_err(|error| RocketMQError::StorageWriteFailed {
             path: req.file_path.clone(),
-            reason: panic_payload_to_string(payload),
+            reason: error.to_string(),
         })?;
 
         let elapsed = start.elapsed();
@@ -779,16 +775,6 @@ impl Ord for AllocateRequest {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // Reverse ordering: smaller offsets come out first (min-heap behavior)
         other.file_offset().cmp(&self.file_offset())
-    }
-}
-
-fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
-    if let Some(message) = payload.downcast_ref::<&str>() {
-        (*message).to_string()
-    } else if let Some(message) = payload.downcast_ref::<String>() {
-        message.clone()
-    } else {
-        "mapped file allocation panicked".to_string()
     }
 }
 

--- a/rocketmq-store/src/base/store_checkpoint.rs
+++ b/rocketmq-store/src/base/store_checkpoint.rs
@@ -14,6 +14,7 @@
 
 use std::fs::File;
 use std::fs::OpenOptions;
+use std::io;
 use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
@@ -37,24 +38,31 @@ pub struct StoreCheckpoint {
 impl StoreCheckpoint {
     #[inline]
     pub fn new<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
-        ensure_dir_ok(path.as_ref().parent().unwrap().to_str().unwrap());
+        let checkpoint_path = path.as_ref();
+        let checkpoint_dir = checkpoint_path
+            .parent()
+            .and_then(|parent| parent.to_str())
+            .ok_or_else(|| {
+                invalid_checkpoint_error(format!("checkpoint path is invalid: {}", checkpoint_path.display()))
+            })?;
+        ensure_dir_ok(checkpoint_dir);
+
         let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
-            .open(path.as_ref())?;
-        let _ = file.set_len(OS_PAGE_SIZE);
+            .open(checkpoint_path)?;
+        file.set_len(OS_PAGE_SIZE)?;
         let mmap = unsafe { MmapMut::map_mut(&file)? };
         if file.metadata()?.len() > 0 {
-            let buffer = &mmap[..8];
-            let physic_msg_timestamp = u64::from_be_bytes(buffer.try_into().unwrap());
-            let logics_msg_timestamp = u64::from_be_bytes(mmap[8..16].try_into().unwrap());
-            let index_msg_timestamp = u64::from_be_bytes(mmap[16..24].try_into().unwrap());
-            let master_flushed_offset = u64::from_be_bytes(mmap[24..32].try_into().unwrap());
-            let confirm_phy_offset = u64::from_be_bytes(mmap[32..40].try_into().unwrap());
+            let physic_msg_timestamp = read_checkpoint_u64(&mmap, 0, "physicMsgTimestamp")?;
+            let logics_msg_timestamp = read_checkpoint_u64(&mmap, 8, "logicsMsgTimestamp")?;
+            let index_msg_timestamp = read_checkpoint_u64(&mmap, 16, "indexMsgTimestamp")?;
+            let master_flushed_offset = read_checkpoint_u64(&mmap, 24, "masterFlushedOffset")?;
+            let confirm_phy_offset = read_checkpoint_u64(&mmap, 32, "confirmPhyOffset")?;
 
-            info!("store checkpoint file exists, {}", path.as_ref().display());
+            info!("store checkpoint file exists, {}", checkpoint_path.display());
             info!("physicMsgTimestamp: {}", physic_msg_timestamp);
             info!("logicsMsgTimestamp: {}", logics_msg_timestamp);
             info!("indexMsgTimestamp: {}", index_msg_timestamp);
@@ -167,4 +175,19 @@ impl StoreCheckpoint {
         self.get_min_timestamp()
             .min(self.index_msg_timestamp.load(Ordering::Relaxed))
     }
+}
+
+fn read_checkpoint_u64(mmap: &[u8], offset: usize, field_name: &str) -> io::Result<u64> {
+    let bytes = mmap.get(offset..offset + 8).ok_or_else(|| {
+        invalid_checkpoint_error(format!(
+            "checkpoint file is too small to read {field_name} at offset {offset}"
+        ))
+    })?;
+    let mut value = [0; 8];
+    value.copy_from_slice(bytes);
+    Ok(u64::from_be_bytes(value))
+}
+
+fn invalid_checkpoint_error(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
 }

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -185,10 +185,16 @@ impl MappedFileQueue {
                 return false;
             }
 
-            let mapped_file = DefaultMappedFile::new(
+            let mapped_file = match DefaultMappedFile::try_new(
                 CheetahString::from_string(file.to_string_lossy().to_string()),
                 self.mapped_file_size,
-            );
+            ) {
+                Ok(mapped_file) => mapped_file,
+                Err(error) => {
+                    error!("Failed to load mapped file {}: {}", file.display(), error);
+                    return false;
+                }
+            };
             // Set wrote, flushed, committed positions for mapped_file
             mapped_file.set_wrote_position(self.mapped_file_size as i32);
             mapped_file.set_flushed_position(self.mapped_file_size as i32);
@@ -325,10 +331,13 @@ impl MappedFileQueue {
         }
 
         // Fallback: synchronous creation
-        Some(Arc::new(DefaultMappedFile::new(
-            CheetahString::from_string(file_path_str),
-            self.mapped_file_size,
-        )))
+        match DefaultMappedFile::try_new(CheetahString::from_string(file_path_str.clone()), self.mapped_file_size) {
+            Ok(mapped_file) => Some(Arc::new(mapped_file)),
+            Err(error) => {
+                error!("Failed to create mapped file {}: {}", file_path_str, error);
+                None
+            }
+        }
     }
 
     #[inline]

--- a/rocketmq-store/src/index/index_file.rs
+++ b/rocketmq-store/src/index/index_file.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
 use std::mem;
 use std::sync::Arc;
 
@@ -110,11 +111,22 @@ impl IndexFile {
         end_phy_offset: i64,
         end_timestamp: i64,
     ) -> IndexFile {
+        Self::try_new(file_name, hash_slot_num, index_num, end_phy_offset, end_timestamp)
+            .expect("Create index file failed")
+    }
+
+    pub fn try_new(
+        file_name: &str,
+        hash_slot_num: usize,
+        index_num: usize,
+        end_phy_offset: i64,
+        end_timestamp: i64,
+    ) -> io::Result<IndexFile> {
         let file_total_size = INDEX_HEADER_SIZE + (hash_slot_num * HASH_SLOT_SIZE) + (index_num * INDEX_SIZE);
-        let mapped_file = Arc::new(DefaultMappedFile::new(
+        let mapped_file = Arc::new(DefaultMappedFile::try_new(
             CheetahString::from_slice(file_name),
             file_total_size as u64,
-        ));
+        )?);
 
         let index_header = IndexHeader::new(mapped_file.clone());
         let index_file = IndexFile {
@@ -134,7 +146,7 @@ impl IndexFile {
             index_file.index_header.set_begin_timestamp(end_timestamp);
             index_file.index_header.set_end_timestamp(end_timestamp);
         }
-        index_file
+        Ok(index_file)
     }
 
     #[inline]

--- a/rocketmq-store/src/index/index_service.rs
+++ b/rocketmq-store/src/index/index_service.rs
@@ -99,7 +99,14 @@ impl IndexService {
                 continue;
             };
 
-            let index_file = IndexFile::new(file_path, self.hash_slot_num as usize, self.index_num as usize, 0, 0);
+            let index_file =
+                match IndexFile::try_new(file_path, self.hash_slot_num as usize, self.index_num as usize, 0, 0) {
+                    Ok(index_file) => index_file,
+                    Err(error) => {
+                        error!("load index file {} failed: {}", file_path, error);
+                        return false;
+                    }
+                };
             index_file.load();
 
             if !last_exit_ok && index_file.get_end_timestamp() > checkpoint_timestamp {
@@ -405,13 +412,20 @@ impl IndexService {
                 time_millis_to_human_string(current_millis() as i64)
             );
 
-            let new_index_file = Arc::new(IndexFile::new(
+            let new_index_file = match IndexFile::try_new(
                 file_name.as_str(),
                 self.hash_slot_num as usize,
                 self.index_num as usize,
                 last_update_end_phy_offset,
                 last_update_index_timestamp,
-            ));
+            ) {
+                Ok(index_file) => Arc::new(index_file),
+                Err(error) => {
+                    error!("create index file {} failed: {}", file_name, error);
+                    self.running_flags.make_index_file_error();
+                    return None;
+                }
+            };
 
             {
                 let mut write = self.index_file_list.write();

--- a/rocketmq-store/src/log_file/commit_log_loader.rs
+++ b/rocketmq-store/src/log_file/commit_log_loader.rs
@@ -251,10 +251,10 @@ impl CommitLogLoader {
         let results: Result<Vec<_>, io::Error> = metadata
             .par_iter()
             .map(|meta| {
-                let mapped_file = DefaultMappedFile::new(
+                let mapped_file = DefaultMappedFile::try_new(
                     CheetahString::from_string(meta.path.to_string_lossy().to_string()),
                     self.mapped_file_size,
-                );
+                )?;
 
                 // Apply memory hints for sequential access
                 self.apply_memory_hints(&mapped_file);
@@ -277,10 +277,10 @@ impl CommitLogLoader {
         let mut mapped_files = Vec::with_capacity(metadata.len());
 
         for meta in metadata {
-            let mapped_file = DefaultMappedFile::new(
+            let mapped_file = DefaultMappedFile::try_new(
                 CheetahString::from_string(meta.path.to_string_lossy().to_string()),
                 self.mapped_file_size,
-            );
+            )?;
 
             self.apply_memory_hints(&mapped_file);
 

--- a/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
@@ -50,7 +50,6 @@ impl DefaultFlushManager {
             FlushDiskType::SyncFlush => (
                 Some(GroupCommitService {
                     store_checkpoint: store_checkpoint.clone(),
-                    rx_out: None,
                     tx_in: None,
                     shutdown_token: CancellationToken::new(),
                     worker_handle: None,
@@ -160,21 +159,25 @@ impl FlushManager for DefaultFlushManager {
         match self.message_store_config.flush_disk_type {
             FlushDiskType::SyncFlush => {
                 if message_ext.is_wait_store_msg_ok() {
-                    let commit_request = GroupCommitRequest::new(
+                    let (commit_request, flush_ok_receiver) = GroupCommitRequest::new(
                         result.wrote_offset + result.wrote_bytes as i64,
                         self.message_store_config.sync_flush_timeout,
                     );
 
                     time::timeout(
                         time::Duration::from_millis(self.message_store_config.sync_flush_timeout),
-                        self.group_commit_service.as_mut().unwrap().put_request(commit_request),
+                        async {
+                            let Some(group_commit_service) = self.group_commit_service.as_mut() else {
+                                return PutMessageStatus::FlushDiskTimeout;
+                            };
+                            if !group_commit_service.put_request(commit_request).await {
+                                return PutMessageStatus::FlushDiskTimeout;
+                            }
+                            flush_ok_receiver.await.unwrap_or(PutMessageStatus::FlushDiskTimeout)
+                        },
                     )
                     .await
-                    .map_or(PutMessageStatus::FlushDiskTimeout, |request| {
-                        request.map_or(PutMessageStatus::FlushDiskTimeout, |request| {
-                            request.flush_ok.unwrap_or(PutMessageStatus::FlushDiskTimeout)
-                        })
-                    })
+                    .unwrap_or(PutMessageStatus::FlushDiskTimeout)
                 } else {
                     self.group_commit_service.as_ref().unwrap().wakeup();
                     PutMessageStatus::PutOk
@@ -194,31 +197,23 @@ impl FlushManager for DefaultFlushManager {
 
 struct GroupCommitService {
     store_checkpoint: Arc<StoreCheckpoint>,
-    rx_out: Option<tokio::sync::mpsc::Receiver<GroupCommitRequest>>,
     tx_in: Option<tokio::sync::mpsc::Sender<GroupCommitRequest>>,
     shutdown_token: CancellationToken,
     worker_handle: Option<JoinHandle<()>>,
 }
 
 impl GroupCommitService {
-    pub async fn put_request(&mut self, request: GroupCommitRequest) -> Option<GroupCommitRequest> {
+    pub async fn put_request(&mut self, request: GroupCommitRequest) -> bool {
         if self.shutdown_token.is_cancelled() {
-            return None;
+            return false;
         }
 
-        let tx_in = self.tx_in.as_ref()?;
-        if tx_in.send(request).await.is_err() {
-            return None;
-        }
-
-        match self.rx_out {
-            None => None,
-            Some(ref mut rx_out) => {
-                tokio::select! {
-                    request = rx_out.recv() => request,
-                    _ = self.shutdown_token.cancelled() => None,
-                }
-            }
+        let Some(tx_in) = self.tx_in.as_ref() else {
+            return false;
+        };
+        tokio::select! {
+            result = tx_in.send(request) => result.is_ok(),
+            _ = self.shutdown_token.cancelled() => false,
         }
     }
 
@@ -230,8 +225,6 @@ impl GroupCommitService {
         self.shutdown_token = CancellationToken::new();
         let (tx_in, mut rx_in) = tokio::sync::mpsc::channel::<GroupCommitRequest>(1024);
         self.tx_in = Some(tx_in);
-        let (tx_out, rx_out) = tokio::sync::mpsc::channel::<GroupCommitRequest>(1024);
-        self.rx_out = Some(rx_out);
         let shutdown_token = self.shutdown_token.clone();
         let store_checkpoint = self.store_checkpoint.clone();
         self.worker_handle = Some(tokio::spawn(async move {
@@ -244,10 +237,7 @@ impl GroupCommitService {
                         }
                         if !remaining.is_empty() {
                             mapped_file_queue.flush(0);
-                            complete_group_commit_batch(&mut remaining, mapped_file_queue.get_flushed_where());
-                            for request in remaining {
-                                let _ = tx_out.send(request).await;
-                            }
+                            complete_group_commit_batch(remaining, mapped_file_queue.get_flushed_where());
                         }
                         break;
                     }
@@ -278,11 +268,7 @@ impl GroupCommitService {
                         if store_timestamp > 0 {
                             store_checkpoint.set_physic_msg_timestamp(store_timestamp);
                         }
-                        complete_group_commit_batch(&mut requests, flushed_where);
-
-                        for request in requests {
-                            let _ = tx_out.send(request).await;
-                        }
+                        complete_group_commit_batch(requests, flushed_where);
                     }
                     }
                 }
@@ -295,20 +281,20 @@ impl GroupCommitService {
     pub fn shutdown(&mut self) {
         self.shutdown_token.cancel();
         self.tx_in.take();
-        self.rx_out.take();
         if let Some(handle) = self.worker_handle.take() {
             handle.abort();
         }
     }
 }
 
-fn complete_group_commit_batch(requests: &mut [GroupCommitRequest], flushed_where: i64) {
+fn complete_group_commit_batch(requests: Vec<GroupCommitRequest>, flushed_where: i64) {
     for request in requests {
-        request.flush_ok = Some(if flushed_where >= request.next_offset {
+        let status = if flushed_where >= request.next_offset {
             PutMessageStatus::PutOk
         } else {
             PutMessageStatus::FlushDiskTimeout
-        });
+        };
+        request.complete(status);
     }
 }
 
@@ -477,11 +463,13 @@ mod tests {
 
     #[test]
     fn complete_group_commit_batch_marks_each_request_by_final_flushed_offset() {
-        let mut requests = vec![GroupCommitRequest::new(64, 5_000), GroupCommitRequest::new(96, 5_000)];
+        let (request_64, mut response_64) = GroupCommitRequest::new(64, 5_000);
+        let (request_96, mut response_96) = GroupCommitRequest::new(96, 5_000);
+        let requests = vec![request_64, request_96];
 
-        complete_group_commit_batch(&mut requests, 80);
+        complete_group_commit_batch(requests, 80);
 
-        assert_eq!(requests[0].flush_ok, Some(PutMessageStatus::PutOk));
-        assert_eq!(requests[1].flush_ok, Some(PutMessageStatus::FlushDiskTimeout));
+        assert_eq!(response_64.try_recv(), Ok(PutMessageStatus::PutOk));
+        assert_eq!(response_96.try_recv(), Ok(PutMessageStatus::FlushDiskTimeout));
     }
 }

--- a/rocketmq-store/src/log_file/flush_manager_impl/group_commit_request.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/group_commit_request.rs
@@ -12,38 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::AtomicI32;
-
 use rocketmq_common::TimeUtils::current_nano;
+use tokio::sync::oneshot;
 
 use crate::base::message_status_enum::PutMessageStatus;
 
 #[derive(Debug)]
 pub(crate) struct GroupCommitRequest {
     pub(crate) next_offset: i64,
-    pub(crate) flush_ok: Option<PutMessageStatus>,
-    pub(crate) ack_nums: AtomicI32,
+    flush_ok_sender: Option<oneshot::Sender<PutMessageStatus>>,
     pub(crate) dead_line: u64,
 }
 
-impl Default for GroupCommitRequest {
-    fn default() -> Self {
-        Self {
-            next_offset: 0,
-            flush_ok: None,
-            ack_nums: AtomicI32::new(1),
-            dead_line: 0,
-        }
-    }
-}
-
 impl GroupCommitRequest {
-    pub(crate) fn new(next_offset: i64, timeout_millis: u64) -> Self {
+    pub(crate) fn new(next_offset: i64, timeout_millis: u64) -> (Self, oneshot::Receiver<PutMessageStatus>) {
         let dead_line = current_nano() + timeout_millis * 1_000_000;
-        Self {
-            next_offset,
-            dead_line,
-            ..Self::default()
+        let (flush_ok_sender, flush_ok_receiver) = oneshot::channel();
+        (
+            Self {
+                next_offset,
+                flush_ok_sender: Some(flush_ok_sender),
+                dead_line,
+            },
+            flush_ok_receiver,
+        )
+    }
+
+    pub(crate) fn complete(mut self, status: PutMessageStatus) {
+        if let Some(sender) = self.flush_ok_sender.take() {
+            let _ = sender.send(status);
         }
     }
 }

--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -15,6 +15,7 @@
 use std::fs;
 use std::fs::File;
 use std::fs::OpenOptions;
+use std::io;
 use std::io::Write;
 use std::ops::Deref;
 use std::path::Path;
@@ -62,6 +63,10 @@ pub const OS_PAGE_SIZE: u64 = 1024 * 4;
 
 static TOTAL_MAPPED_VIRTUAL_MEMORY: AtomicI64 = AtomicI64::new(0);
 static TOTAL_MAPPED_FILES: AtomicI32 = AtomicI32::new(0);
+
+fn invalid_input_error(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message)
+}
 
 pub struct DefaultMappedFile {
     reference_resource: ReferenceResourceCounter,
@@ -117,27 +122,36 @@ impl Default for DefaultMappedFile {
 impl DefaultMappedFile {
     #[inline]
     pub fn new(file_name: CheetahString, file_size: u64) -> Self {
+        Self::try_new(file_name, file_size).expect("Create mapped file failed")
+    }
+
+    pub fn try_new(file_name: CheetahString, file_size: u64) -> io::Result<Self> {
+        Self::try_new_inner(file_name, file_size, None)
+    }
+
+    fn try_new_inner(
+        file_name: CheetahString,
+        file_size: u64,
+        transient_store_pool: Option<TransientStorePool>,
+    ) -> io::Result<Self> {
         let path_buf = PathBuf::from(file_name.as_str());
-        if path_buf.parent().is_none() {
-            panic!("file path is invalid: {file_name}");
-        }
-        let dir = path_buf.parent().unwrap().to_str();
-        if dir.is_none() {
-            panic!("file path is invalid: {file_name}");
-        }
-        ensure_dir_ok(dir.unwrap());
-        let file_from_offset = Self::parse_file_from_offset(&path_buf);
+        let dir = path_buf
+            .parent()
+            .and_then(|path| path.to_str())
+            .ok_or_else(|| invalid_input_error(format!("file path is invalid: {file_name}")))?;
+        ensure_dir_ok(dir);
+
+        let file_from_offset = Self::try_parse_file_from_offset(&path_buf)?;
         let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
-            .open(path_buf)
-            .expect("Create file failed");
-        file.set_len(file_size).unwrap();
+            .open(&path_buf)?;
+        file.set_len(file_size)?;
 
-        let mmap = unsafe { MmapMut::map_mut(&file).unwrap() };
-        Self {
+        let mmap = unsafe { MmapMut::map_mut(&file)? };
+        Ok(Self {
             reference_resource: ReferenceResourceCounter::new(),
             file,
             mmapped_file: ArcMut::new(mmap),
@@ -154,11 +168,11 @@ impl DefaultMappedFile {
             swap_map_time: AtomicU64::new(current_millis()),
             mapped_byte_buffer_access_count_since_last_swap: Default::default(),
             start_timestamp: AtomicI64::new(-1),
-            transient_store_pool: None,
+            transient_store_pool,
             stop_timestamp: AtomicI64::new(-1),
             metrics: Some(MappedFileMetrics::new()),
             flush_strategy: FlushStrategy::Async,
-        }
+        })
     }
 
     /// Extracts the file offset from the given file name.
@@ -179,11 +193,18 @@ impl DefaultMappedFile {
     /// This function will panic if the file name cannot be parsed to a valid `u64` offset.
     #[inline]
     pub fn parse_file_from_offset(file_name: &Path) -> u64 {
+        Self::try_parse_file_from_offset(file_name).expect("File name parse to offset is invalid")
+    }
+
+    #[inline]
+    pub fn try_parse_file_from_offset(file_name: &Path) -> io::Result<u64> {
         file_name
             .file_name()
             .and_then(|name| name.to_str())
             .and_then(|s| s.parse::<u64>().ok())
-            .expect("File name parse to offset is invalid")
+            .ok_or_else(|| {
+                invalid_input_error(format!("file name parse to offset is invalid: {}", file_name.display()))
+            })
     }
 
     /// Creates and initializes a new file with the specified name and size.
@@ -224,40 +245,16 @@ impl DefaultMappedFile {
         file_size: u64,
         transient_store_pool: TransientStorePool,
     ) -> Self {
-        let path_buf = PathBuf::from(file_name.as_str());
-        let file_from_offset = Self::parse_file_from_offset(&path_buf);
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(path_buf)
-            .expect("Open file failed");
-        file.set_len(file_size).expect("Set file size failed");
+        Self::try_new_with_transient_store_pool(file_name, file_size, transient_store_pool)
+            .expect("Create mapped file with transient store pool failed")
+    }
 
-        let mmap = unsafe { MmapMut::map_mut(&file).unwrap() };
-        Self {
-            reference_resource: ReferenceResourceCounter::new(),
-            file,
-            file_name,
-            file_from_offset,
-            mapped_byte_buffer: None,
-            wrote_position: Default::default(),
-            committed_position: Default::default(),
-            flushed_position: Default::default(),
-            file_size,
-            store_timestamp: Default::default(),
-            first_create_in_queue: false,
-            last_flush_time: AtomicU64::new(0),
-            swap_map_time: AtomicU64::new(current_millis()),
-            mapped_byte_buffer_access_count_since_last_swap: Default::default(),
-            start_timestamp: AtomicI64::new(-1),
-            transient_store_pool: Some(transient_store_pool),
-            stop_timestamp: AtomicI64::new(-1),
-            mmapped_file: ArcMut::new(mmap),
-            metrics: Some(MappedFileMetrics::new()),
-            flush_strategy: FlushStrategy::Async,
-        }
+    pub fn try_new_with_transient_store_pool(
+        file_name: CheetahString,
+        file_size: u64,
+        transient_store_pool: TransientStorePool,
+    ) -> io::Result<Self> {
+        Self::try_new_inner(file_name, file_size, Some(transient_store_pool))
     }
 }
 

--- a/rocketmq-store/src/log_file/mapped_file/factory.rs
+++ b/rocketmq-store/src/log_file/mapped_file/factory.rs
@@ -110,7 +110,7 @@ impl MappedFileFactory {
     ) -> io::Result<MappedFileImpl> {
         match _config.file_type {
             MappedFileType::Default => {
-                let mapped_file = DefaultMappedFile::new(file_name, file_size);
+                let mapped_file = DefaultMappedFile::try_new(file_name, file_size)?;
                 Ok(MappedFileImpl::Default(mapped_file))
             }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7210

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage reliability by replacing panic-prone file operations with graceful error handling across mapped-file allocation, checkpoint creation, and index file operations.
  * Enhanced error recovery in flush and commit log operations to prevent system crashes during file creation failures.

* **Refactor**
  * Modernized internal error propagation mechanisms to provide better diagnostic logging and clearer failure states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->