### PR TITLE
[ISSUE #7240]✨enhance(flush_manager, commit_log): implement graceful shutdown logic for improved resource management

### DIFF
--- a/rocketmq-store/src/base/store_stats_service.rs
+++ b/rocketmq-store/src/base/store_stats_service.rs
@@ -29,8 +29,10 @@ use parking_lot::Mutex;
 use rocketmq_common::common::broker::broker_config::BrokerIdentity;
 use rocketmq_common::common::system_clock::SystemClock;
 use rocketmq_common::TimeUtils::current_millis;
+use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tracing::info;
+use tracing::warn;
 
 const FREQUENCY_OF_SAMPLING: u64 = 1000;
 const MAX_RECORDS_OF_SAMPLING: usize = 60 * 10;
@@ -100,6 +102,7 @@ pub struct StoreStatsService {
     sampling_lock: Mutex<()>,
     last_print_timestamp: AtomicU64,
     stopped: AtomicBool,
+    shutdown_notify: Notify,
     worker_handle: Mutex<Option<JoinHandle<()>>>,
     broker_identity: Option<BrokerIdentity>,
 }
@@ -130,6 +133,7 @@ impl StoreStatsService {
             sampling_lock: Mutex::new(()),
             last_print_timestamp: AtomicU64::new(current_millis()),
             stopped: AtomicBool::new(true),
+            shutdown_notify: Notify::new(),
             worker_handle: Mutex::new(None),
             broker_identity,
         }
@@ -149,13 +153,17 @@ impl StoreStatsService {
             let mut interval = tokio::time::interval(Duration::from_millis(FREQUENCY_OF_SAMPLING));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-            while !service.stopped.load(Ordering::Acquire) {
-                interval.tick().await;
-                if service.stopped.load(Ordering::Acquire) {
-                    break;
+            loop {
+                tokio::select! {
+                    _ = service.shutdown_notify.notified() => break,
+                    _ = interval.tick() => {
+                        if service.stopped.load(Ordering::Acquire) {
+                            break;
+                        }
+                        service.sampling();
+                        service.print_tps();
+                    }
                 }
-                service.sampling();
-                service.print_tps();
             }
 
             info!("{} service end", service.get_service_name());
@@ -165,9 +173,28 @@ impl StoreStatsService {
 
     pub fn shutdown(&self) {
         self.stopped.store(true, Ordering::Release);
+        self.shutdown_notify.notify_waiters();
         if let Some(handle) = self.worker_handle.lock().take() {
             handle.abort();
         }
+    }
+
+    pub async fn shutdown_gracefully(&self) {
+        self.stopped.store(true, Ordering::Release);
+        self.shutdown_notify.notify_waiters();
+        let handle = self.worker_handle.lock().take();
+        if let Some(handle) = handle {
+            if let Err(error) = handle.await {
+                if !error.is_cancelled() {
+                    warn!("StoreStatsService task failed during shutdown: {error}");
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_worker_handle(&self) -> bool {
+        self.worker_handle.lock().is_some()
     }
 
     #[inline]
@@ -884,13 +911,13 @@ mod call_snapshot_tests {
         assert!(!stats.stopped.load(Ordering::Acquire));
 
         task::yield_now().await;
-        stats.shutdown();
-        stats.shutdown();
+        stats.shutdown_gracefully().await;
+        stats.shutdown_gracefully().await;
         assert!(stats.worker_handle.lock().is_none());
         assert!(stats.stopped.load(Ordering::Acquire));
 
         stats.start();
         assert!(stats.worker_handle.lock().is_some());
-        stats.shutdown();
+        stats.shutdown_gracefully().await;
     }
 }

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -347,20 +347,21 @@ impl CommitLog {
         let mut flush_manager = self.flush_manager.clone();
         let flush_manager_weak = ArcMut::downgrade(&flush_manager);
 
-        tokio::spawn(async move {
-            // Acquire lock only for initialization
-            {
-                if let Some(service) = flush_manager.commit_real_time_service_mut() {
-                    service.set_flush_manager(flush_manager_weak);
-                }
-                flush_manager.start();
-            }
-        });
+        if let Some(service) = flush_manager.commit_real_time_service_mut() {
+            service.set_flush_manager(flush_manager_weak);
+        }
+        flush_manager.start();
     }
 
     pub fn shutdown(&mut self) {
         self.flush();
         self.flush_manager.shutdown();
+    }
+
+    pub async fn shutdown_gracefully(&mut self) {
+        self.flush();
+        let mut flush_manager = self.flush_manager.clone();
+        flush_manager.shutdown_gracefully().await;
     }
 
     pub fn destroy(&mut self) {
@@ -2426,7 +2427,7 @@ mod tests {
         assert_eq!(store.get_commit_log().get_flushed_where(), 0);
         assert_eq!(store.get_commit_log().get_max_offset(), 4);
 
-        store.get_commit_log_mut().shutdown();
+        store.get_commit_log_mut().shutdown_gracefully().await;
 
         assert_eq!(store.get_commit_log().get_flushed_where(), 4);
         assert_eq!(

--- a/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
@@ -22,6 +22,7 @@ use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio::time;
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
 use crate::base::flush_manager::FlushManager;
 use crate::base::message_result::AppendMessageResult;
@@ -99,6 +100,29 @@ impl DefaultFlushManager {
     pub(crate) fn commit_real_time_service_mut(&mut self) -> Option<&mut CommitRealTimeService> {
         self.commit_real_time_service.as_mut()
     }
+
+    pub(crate) async fn shutdown_gracefully(&mut self) {
+        self.flush_before_shutdown();
+
+        if let Some(ref mut group_commit_service) = self.group_commit_service {
+            group_commit_service.shutdown_gracefully().await;
+        }
+        if let Some(ref mut flush_real_time_service) = self.flush_real_time_service {
+            flush_real_time_service.shutdown_gracefully().await;
+        }
+        if let Some(ref mut commit_real_time_service) = self.commit_real_time_service {
+            commit_real_time_service.shutdown_gracefully().await;
+        }
+    }
+
+    fn flush_before_shutdown(&self) {
+        if let Some(mapped_file_queue) = self.mapped_file_queue.as_ref() {
+            if self.message_store_config.transient_store_pool_enable {
+                mapped_file_queue.commit(0);
+            }
+            mapped_file_queue.flush(0);
+        }
+    }
 }
 
 impl FlushManager for DefaultFlushManager {
@@ -118,12 +142,7 @@ impl FlushManager for DefaultFlushManager {
     }
 
     fn shutdown(&mut self) {
-        if let Some(mapped_file_queue) = self.mapped_file_queue.as_ref() {
-            if self.message_store_config.transient_store_pool_enable {
-                mapped_file_queue.commit(0);
-            }
-            mapped_file_queue.flush(0);
-        }
+        self.flush_before_shutdown();
 
         if let Some(ref mut group_commit_service) = self.group_commit_service {
             group_commit_service.shutdown();
@@ -285,7 +304,17 @@ impl GroupCommitService {
     pub fn shutdown(&mut self) {
         self.shutdown_token.cancel();
         self.tx_in.take();
-        drop(self.worker_handle.take());
+        if let Some(handle) = self.worker_handle.take() {
+            handle.abort();
+        }
+    }
+
+    pub async fn shutdown_gracefully(&mut self) {
+        self.shutdown_token.cancel();
+        self.tx_in.take();
+        if let Some(handle) = self.worker_handle.take() {
+            await_worker("GroupCommitService", handle).await;
+        }
     }
 }
 
@@ -378,7 +407,17 @@ impl FlushRealTimeService {
     pub fn shutdown(&mut self) {
         self.shutdown_token.cancel();
         self.notified.notify_waiters();
-        drop(self.worker_handle.take());
+        if let Some(handle) = self.worker_handle.take() {
+            handle.abort();
+        }
+    }
+
+    pub async fn shutdown_gracefully(&mut self) {
+        self.shutdown_token.cancel();
+        self.notified.notify_waiters();
+        if let Some(handle) = self.worker_handle.take() {
+            await_worker("FlushRealTimeService", handle).await;
+        }
     }
 }
 
@@ -457,11 +496,29 @@ impl CommitRealTimeService {
     pub fn shutdown(&mut self) {
         self.shutdown_token.cancel();
         self.notified.notify_waiters();
-        drop(self.worker_handle.take());
+        if let Some(handle) = self.worker_handle.take() {
+            handle.abort();
+        }
+    }
+
+    pub async fn shutdown_gracefully(&mut self) {
+        self.shutdown_token.cancel();
+        self.notified.notify_waiters();
+        if let Some(handle) = self.worker_handle.take() {
+            await_worker("CommitRealTimeService", handle).await;
+        }
     }
 
     pub fn set_flush_manager(&mut self, flush_manager: WeakArcMut<DefaultFlushManager>) {
         self.flush_manager = Some(flush_manager);
+    }
+}
+
+async fn await_worker(service_name: &str, handle: JoinHandle<()>) {
+    if let Err(error) = handle.await {
+        if !error.is_cancelled() {
+            warn!("{service_name} task failed during shutdown: {error}");
+        }
     }
 }
 
@@ -575,12 +632,37 @@ mod tests {
 
         let (request, response) = GroupCommitRequest::new(1, 0);
         assert!(service.put_request(request).await);
-        service.shutdown();
+        service.shutdown_gracefully().await;
+        assert!(service.worker_handle.is_none());
 
         let status = time::timeout(time::Duration::from_secs(1), response)
             .await
             .expect("shutdown should complete pending group commit request")
             .expect("group commit worker should send a completion status");
         assert_eq!(status, PutMessageStatus::FlushDiskTimeout);
+    }
+
+    #[tokio::test]
+    async fn flush_real_time_shutdown_gracefully_waits_for_worker() {
+        let temp_dir = tempdir().unwrap();
+        let store_checkpoint = Arc::new(StoreCheckpoint::new(temp_dir.path().join("checkpoint")).unwrap());
+        let mapped_file_queue = ArcMut::new(MappedFileQueue::default());
+        let mut service = FlushRealTimeService {
+            message_store_config: Arc::new(MessageStoreConfig {
+                flush_interval_commit_log: 60_000,
+                ..MessageStoreConfig::default()
+            }),
+            store_checkpoint,
+            notified: Arc::new(Notify::new()),
+            shutdown_token: CancellationToken::new(),
+            worker_handle: None,
+        };
+
+        service.start(mapped_file_queue);
+        assert!(service.worker_handle.is_some());
+
+        service.shutdown_gracefully().await;
+
+        assert!(service.worker_handle.is_none());
     }
 }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1330,8 +1330,8 @@ impl MessageStore for LocalFileMessageStore {
             }
 
             self.shutdown_schedule_tasks().await;
-            self.store_stats_service.shutdown();
-            self.commit_log.shutdown();
+            self.store_stats_service.shutdown_gracefully().await;
+            self.commit_log.shutdown_gracefully().await;
 
             self.reput_message_service.shutdown().await;
             self.consume_queue_store.shutdown();
@@ -1347,7 +1347,7 @@ impl MessageStore for LocalFileMessageStore {
                 // this.rocksDBMessageStore.consumeQueueStore.shutdown();
             }
             if let Some(timer_message_store) = self.timer_message_store.as_ref() {
-                timer_message_store.shutdown();
+                timer_message_store.shutdown_gracefully().await;
             }
             self.flush_consume_queue_service.shutdown();
             self.allocate_mapped_file_service.shutdown().await;
@@ -4130,6 +4130,38 @@ mod tests {
 
         second.start().await.expect("lock should be reusable after shutdown");
         second.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_stats_and_timer_background_tasks() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_configured_test_store(
+            &temp_dir,
+            MessageStoreConfig {
+                duplication_enable: true,
+                timer_wheel_enable: true,
+                ..MessageStoreConfig::default()
+            },
+        );
+
+        store.init().await.expect("init store");
+        store.start().await.expect("start store");
+
+        assert!(store.store_stats_service.has_worker_handle());
+        assert!(store
+            .timer_message_store
+            .as_ref()
+            .expect("timer store should be initialized")
+            .has_scheduler_handle());
+
+        store.shutdown().await;
+
+        assert!(!store.store_stats_service.has_worker_handle());
+        assert!(!store
+            .timer_message_store
+            .as_ref()
+            .expect("timer store should be initialized")
+            .has_scheduler_handle());
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -36,9 +36,9 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::is_it_time_to_do;
 use rocketmq_rust::ArcMut;
 use tokio::sync::Mutex as AsyncMutex;
-use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
 use tracing::error;
 use tracing::warn;
 
@@ -251,7 +251,7 @@ pub struct TimerMessageStore {
     should_running_dequeue: AtomicBool,
     enqueue_suspended: AtomicBool,
     process_lock: AsyncMutex<()>,
-    scheduler_shutdown: Notify,
+    scheduler_shutdown: Mutex<CancellationToken>,
     scheduler_handle: Mutex<Option<JoinHandle<()>>>,
     enqueue_tps_counter: TpsCounter,
     dequeue_tps_counter: TpsCounter,
@@ -317,6 +317,8 @@ impl TimerMessageStore {
             return;
         }
 
+        let shutdown_token = CancellationToken::new();
+        *self.scheduler_shutdown.lock() = shutdown_token.clone();
         let scheduler = self.clone();
         let interval_ms = scheduler
             .message_store_config
@@ -327,7 +329,7 @@ impl TimerMessageStore {
             interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
             loop {
                 tokio::select! {
-                    _ = scheduler.scheduler_shutdown.notified() => break,
+                    _ = shutdown_token.cancelled() => break,
                     _ = interval.tick() => {
                         let _ = scheduler.process_once().await;
                     }
@@ -470,7 +472,7 @@ impl TimerMessageStore {
             should_running_dequeue: AtomicBool::new(false),
             enqueue_suspended: AtomicBool::new(false),
             process_lock: AsyncMutex::new(()),
-            scheduler_shutdown: Notify::new(),
+            scheduler_shutdown: Mutex::new(CancellationToken::new()),
             scheduler_handle: Mutex::new(None),
             enqueue_tps_counter: TpsCounter::default(),
             dequeue_tps_counter: TpsCounter::default(),
@@ -492,10 +494,32 @@ impl TimerMessageStore {
     }
 
     pub fn shutdown(&self) {
-        self.scheduler_shutdown.notify_waiters();
+        self.scheduler_shutdown.lock().cancel();
         if let Some(handle) = self.scheduler_handle.lock().take() {
             handle.abort();
         }
+        self.shutdown_storage();
+    }
+
+    pub async fn shutdown_gracefully(&self) {
+        self.scheduler_shutdown.lock().cancel();
+        let handle = self.scheduler_handle.lock().take();
+        if let Some(handle) = handle {
+            if let Err(error) = handle.await {
+                if !error.is_cancelled() {
+                    warn!("TimerMessageStore scheduler failed during shutdown: {error}");
+                }
+            }
+        }
+        self.shutdown_storage();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_scheduler_handle(&self) -> bool {
+        self.scheduler_handle.lock().is_some()
+    }
+
+    fn shutdown_storage(&self) {
         self.sync_last_read_time_ms();
         self.timer_metrics.persist();
         if let Some(timer_log) = self.timer_log.lock().take() {
@@ -1584,6 +1608,22 @@ mod tests {
         assert!(reloaded_store.load());
         assert_eq!(reloaded_store.curr_read_time_ms.load(Ordering::Relaxed), read_time_ms);
         assert_eq!(reloaded_store.curr_queue_offset.load(Ordering::Relaxed), 9);
+    }
+
+    #[tokio::test]
+    async fn scheduler_shutdown_gracefully_waits_for_task() {
+        let temp_dir = tempdir().unwrap();
+        let root_dir = temp_dir.path().to_string_lossy().to_string();
+        let config = config_with_root(root_dir.as_str());
+        let timer_message_store = Arc::new(TimerMessageStore::new_with_config(None, config));
+
+        assert!(timer_message_store.load());
+        timer_message_store.start();
+        assert!(timer_message_store.scheduler_handle.lock().is_some());
+
+        timer_message_store.shutdown_gracefully().await;
+
+        assert!(timer_message_store.scheduler_handle.lock().is_none());
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7240

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Services now implement graceful shutdown with proper awaiting of background tasks to completion.
  * Commit log, statistics monitoring, and timer scheduler reliably flush pending data before shutdown.
  * Enhanced reliability of service termination across all storage components.
  * Background workers and schedulers properly complete operations before shutdown rather than abrupt termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->