### PR TITLE
[ISSUE #7248]🚀feat(compaction_service, compaction_store, local_file_message_store): implement compaction service and dispatcher for improved message management

### DIFF
--- a/rocketmq-store/src/kv.rs
+++ b/rocketmq-store/src/kv.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) mod compaction_dispatch;
 pub(crate) mod compaction_service;
 pub(crate) mod compaction_store;

--- a/rocketmq-store/src/kv/compaction_dispatch.rs
+++ b/rocketmq-store/src/kv/compaction_dispatch.rs
@@ -1,0 +1,85 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use dashmap::DashMap;
+use rocketmq_common::common::attribute::cleanup_policy::CleanupPolicy;
+use rocketmq_common::common::config::TopicConfig;
+use rocketmq_common::CleanupPolicyUtils::get_delete_policy_arc_mut;
+use rocketmq_rust::ArcMut;
+
+use crate::base::commit_log_dispatcher::CommitLogDispatcher;
+use crate::base::dispatch_request::DispatchRequest;
+use crate::config::message_store_config::MessageStoreConfig;
+use crate::kv::compaction_store::CompactionStore;
+use crate::log_file::commit_log::CommitLog;
+
+pub struct CommitLogDispatcherCompaction {
+    compaction_store: Arc<CompactionStore>,
+    commit_log: ArcMut<CommitLog>,
+    message_store_config: Arc<MessageStoreConfig>,
+    topic_config_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>>,
+}
+
+impl CommitLogDispatcherCompaction {
+    pub fn new(
+        compaction_store: Arc<CompactionStore>,
+        commit_log: ArcMut<CommitLog>,
+        message_store_config: Arc<MessageStoreConfig>,
+        topic_config_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>>,
+    ) -> Self {
+        Self {
+            compaction_store,
+            commit_log,
+            message_store_config,
+            topic_config_table,
+        }
+    }
+
+    fn is_compaction_topic(&self, topic: &CheetahString) -> bool {
+        if !self.message_store_config.enable_compaction {
+            return false;
+        }
+
+        let topic_config = self.topic_config_table.get(topic).map(|entry| entry.value().clone());
+        get_delete_policy_arc_mut(topic_config.as_ref()) == CleanupPolicy::COMPACTION
+    }
+}
+
+impl CommitLogDispatcher for CommitLogDispatcherCompaction {
+    fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
+        if !dispatch_request.success
+            || dispatch_request.msg_size <= 0
+            || dispatch_request.commit_log_offset < 0
+            || dispatch_request.consume_queue_offset < 0
+            || !self.is_compaction_topic(&dispatch_request.topic)
+        {
+            return;
+        }
+
+        let Some(select_result) = self
+            .commit_log
+            .get_message(dispatch_request.commit_log_offset, dispatch_request.msg_size)
+        else {
+            return;
+        };
+        let Some(payload) = select_result.get_bytes() else {
+            return;
+        };
+
+        self.compaction_store.put_dispatch_message(dispatch_request, payload);
+    }
+}

--- a/rocketmq-store/src/kv/compaction_service.rs
+++ b/rocketmq-store/src/kv/compaction_service.rs
@@ -12,16 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
+use tracing::error;
 use tracing::info;
 
-#[derive(Default, Clone)]
+use crate::kv::compaction_store::CompactionStore;
+
 pub struct CompactionService {
+    compaction_store: Arc<CompactionStore>,
+    schedule_interval: Duration,
+    shutdown_token: CancellationToken,
+    worker_handle: Option<JoinHandle<()>>,
     loaded: bool,
 }
 
 impl CompactionService {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(compaction_store: Arc<CompactionStore>, schedule_interval_ms: usize) -> Self {
+        Self {
+            compaction_store,
+            schedule_interval: Duration::from_millis(schedule_interval_ms.max(1) as u64),
+            shutdown_token: CancellationToken::new(),
+            worker_handle: None,
+            loaded: false,
+        }
     }
 
     pub fn load(&mut self, exit_ok: bool) -> bool {
@@ -30,11 +48,92 @@ impl CompactionService {
         true
     }
 
-    pub fn shutdown(&self) {
+    pub fn start(&mut self) {
+        if self.worker_handle.is_some() {
+            return;
+        }
+
+        self.shutdown_token = CancellationToken::new();
+        let shutdown = self.shutdown_token.clone();
+        let compaction_store = self.compaction_store.clone();
+        let schedule_interval = self.schedule_interval;
+
+        self.worker_handle = Some(tokio::spawn(async move {
+            let mut interval = tokio::time::interval(schedule_interval);
+            interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            interval.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = shutdown.cancelled() => {
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        let removed = compaction_store.compact_once();
+                        if removed > 0 {
+                            info!("compaction service removed {} obsolete messages", removed);
+                        }
+                    }
+                }
+            }
+        }));
+    }
+
+    pub async fn shutdown_gracefully(&mut self) {
+        self.shutdown_token.cancel();
+        if let Some(worker_handle) = self.worker_handle.take() {
+            if let Err(error) = worker_handle.await {
+                error!("compaction service task failed during shutdown: {error}");
+            }
+        }
+        self.loaded = false;
         info!("shutdown compaction service");
     }
 
     pub fn is_loaded(&self) -> bool {
         self.loaded
+    }
+
+    pub fn has_worker_handle(&self) -> bool {
+        self.worker_handle.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use cheetah_string::CheetahString;
+
+    use super::CompactionService;
+    use crate::kv::compaction_store::CompactionStore;
+
+    #[tokio::test]
+    async fn start_compacts_and_shutdown_clears_worker_handle() {
+        let compaction_store = Arc::new(CompactionStore::new());
+        let topic = CheetahString::from_static_str("compaction-service-topic");
+        let key = CheetahString::from_static_str("same-key");
+        compaction_store.put_message_with_key(&topic, 0, 0, 1, Some(key.clone()), Bytes::from_static(b"old-message"));
+        compaction_store.put_message_with_key(&topic, 0, 1, 1, Some(key), Bytes::from_static(b"latest-message"));
+
+        let mut service = CompactionService::new(compaction_store.clone(), 1);
+        assert!(service.load(true));
+        service.start();
+        assert!(service.has_worker_handle());
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+        while compaction_store.message_count(&topic, 0) != 1 {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "compaction service did not compact duplicate keys in time"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        service.shutdown_gracefully().await;
+        assert!(!service.has_worker_handle());
+        assert!(!service.is_loaded());
     }
 }

--- a/rocketmq-store/src/kv/compaction_store.rs
+++ b/rocketmq-store/src/kv/compaction_store.rs
@@ -12,29 +12,342 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use cheetah_string::CheetahString;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
 
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use dashmap::DashMap;
+
+use crate::base::dispatch_request::DispatchRequest;
 use crate::base::get_message_result::GetMessageResult;
+use crate::base::message_status_enum::GetMessageStatus;
+use crate::base::select_result::SelectMappedBufferResult;
+use crate::log_file::mapped_file::MappedFile;
 
 #[derive(Default)]
-pub struct CompactionStore;
+pub struct CompactionStore {
+    queues: DashMap<CompactionQueueKey, BTreeMap<i64, CompactionMessage>>,
+}
 
-impl CompactionStore {
-    pub fn new() -> Self {
-        Self
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct CompactionQueueKey {
+    topic: CheetahString,
+    queue_id: i32,
+}
+
+impl CompactionQueueKey {
+    fn new(topic: &CheetahString, queue_id: i32) -> Self {
+        Self {
+            topic: topic.clone(),
+            queue_id,
+        }
     }
 }
 
+#[derive(Clone, Debug)]
+struct CompactionMessage {
+    queue_offset: i64,
+    batch_num: i32,
+    key: Option<CheetahString>,
+    payload: Bytes,
+}
+
 impl CompactionStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn put_message(&self, topic: &CheetahString, queue_id: i32, queue_offset: i64, batch_num: i32, payload: Bytes) {
+        self.put_message_with_key(topic, queue_id, queue_offset, batch_num, None, payload);
+    }
+
+    pub(crate) fn put_dispatch_message(&self, dispatch_request: &DispatchRequest, payload: Bytes) {
+        let key = (!dispatch_request.keys.is_empty()).then(|| dispatch_request.keys.clone());
+        self.put_message_with_key(
+            &dispatch_request.topic,
+            dispatch_request.queue_id,
+            dispatch_request.consume_queue_offset,
+            dispatch_request.batch_size as i32,
+            key,
+            payload,
+        );
+    }
+
+    pub(crate) fn put_message_with_key(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        queue_offset: i64,
+        batch_num: i32,
+        message_key: Option<CheetahString>,
+        payload: Bytes,
+    ) {
+        if queue_offset < 0 || payload.is_empty() {
+            return;
+        }
+
+        let key = CompactionQueueKey::new(topic, queue_id);
+        let mut queue = self.queues.entry(key).or_default();
+        queue.insert(
+            queue_offset,
+            CompactionMessage {
+                queue_offset,
+                batch_num: batch_num.max(1),
+                key: message_key,
+                payload,
+            },
+        );
+    }
+
+    pub fn dispatch_from_commit_log<MF: MappedFile>(
+        &self,
+        dispatch_request: &DispatchRequest,
+        commit_log_file: &MF,
+    ) -> bool {
+        if !dispatch_request.success
+            || dispatch_request.msg_size <= 0
+            || dispatch_request.commit_log_offset < 0
+            || dispatch_request.consume_queue_offset < 0
+        {
+            return false;
+        }
+
+        let file_from_offset = commit_log_file.get_file_from_offset() as i64;
+        if dispatch_request.commit_log_offset < file_from_offset {
+            return false;
+        }
+
+        let pos = (dispatch_request.commit_log_offset - file_from_offset) as usize;
+        let size = dispatch_request.msg_size as usize;
+        let Some(payload) = commit_log_file.get_data(pos, size) else {
+            return false;
+        };
+
+        self.put_dispatch_message(dispatch_request, payload);
+        true
+    }
+
+    pub fn compact_once(&self) -> usize {
+        let mut removed = 0;
+
+        for mut queue in self.queues.iter_mut() {
+            let mut latest_offset_by_key = HashMap::<CheetahString, i64>::new();
+            for (&queue_offset, message) in queue.iter() {
+                let Some(key) = message.key.as_ref() else {
+                    continue;
+                };
+                latest_offset_by_key
+                    .entry(key.clone())
+                    .and_modify(|latest_offset| *latest_offset = (*latest_offset).max(queue_offset))
+                    .or_insert(queue_offset);
+            }
+
+            if latest_offset_by_key.is_empty() {
+                continue;
+            }
+
+            let before = queue.len();
+            queue.retain(|queue_offset, message| {
+                let Some(key) = message.key.as_ref() else {
+                    return true;
+                };
+                match latest_offset_by_key.get(key) {
+                    Some(latest_offset) => *latest_offset == *queue_offset,
+                    None => true,
+                }
+            });
+            removed += before.saturating_sub(queue.len());
+        }
+
+        removed
+    }
+
     pub fn get_message(
         &self,
         _group: &CheetahString,
-        _topic: &CheetahString,
-        _queue_id: i32,
-        _offset: i64,
-        _max_msg_nums: i32,
-        _max_total_msg_size: i32,
+        topic: &CheetahString,
+        queue_id: i32,
+        offset: i64,
+        max_msg_nums: i32,
+        max_total_msg_size: i32,
     ) -> Option<GetMessageResult> {
-        None
+        let key = CompactionQueueKey::new(topic, queue_id);
+        let Some(queue) = self.queues.get(&key) else {
+            return Some(status_result(GetMessageStatus::NoMatchedLogicQueue, 0, 0, 0));
+        };
+        if queue.is_empty() {
+            return Some(status_result(GetMessageStatus::NoMessageInQueue, 0, 0, 0));
+        }
+
+        let min_offset = *queue.keys().next().unwrap_or(&0);
+        let max_offset = queue
+            .values()
+            .map(|message| message.queue_offset + message.batch_num as i64)
+            .max()
+            .unwrap_or(min_offset);
+
+        if offset < min_offset {
+            return Some(status_result(
+                GetMessageStatus::OffsetTooSmall,
+                min_offset,
+                min_offset,
+                max_offset,
+            ));
+        }
+        if offset == max_offset {
+            return Some(status_result(
+                GetMessageStatus::OffsetOverflowOne,
+                offset,
+                min_offset,
+                max_offset,
+            ));
+        }
+        if offset > max_offset {
+            return Some(status_result(
+                GetMessageStatus::OffsetOverflowBadly,
+                max_offset,
+                min_offset,
+                max_offset,
+            ));
+        }
+
+        let mut result = GetMessageResult::new_result_size(max_msg_nums.max(1) as usize);
+        let max_msg_nums = max_msg_nums.max(1);
+        let max_total_msg_size = max_total_msg_size.max(1);
+        let mut next_begin_offset = offset;
+
+        for (&queue_offset, message) in queue.range(offset..) {
+            if result.message_count() >= max_msg_nums {
+                break;
+            }
+
+            let payload_size = message.payload.len() as i32;
+            if result.buffer_total_size() > 0 && result.buffer_total_size() + payload_size > max_total_msg_size {
+                break;
+            }
+
+            result.add_message(
+                SelectMappedBufferResult {
+                    start_offset: 0,
+                    bytes: Some(message.payload.clone()),
+                    size: payload_size,
+                    mapped_file: None,
+                    is_in_cache: true,
+                },
+                queue_offset as u64,
+                message.batch_num,
+            );
+            next_begin_offset = message.queue_offset + message.batch_num as i64;
+        }
+
+        if result.message_count() == 0 {
+            return Some(status_result(
+                GetMessageStatus::NoMatchedMessage,
+                offset,
+                min_offset,
+                max_offset,
+            ));
+        }
+
+        result.set_status(Some(GetMessageStatus::Found));
+        result.set_next_begin_offset(next_begin_offset);
+        result.set_min_offset(min_offset);
+        result.set_max_offset(max_offset);
+        Some(result)
+    }
+
+    pub fn message_count(&self, topic: &CheetahString, queue_id: i32) -> usize {
+        self.queues
+            .get(&CompactionQueueKey::new(topic, queue_id))
+            .map(|queue| queue.len())
+            .unwrap_or_default()
+    }
+}
+
+fn status_result(
+    status: GetMessageStatus,
+    next_begin_offset: i64,
+    min_offset: i64,
+    max_offset: i64,
+) -> GetMessageResult {
+    let mut result = GetMessageResult::new_result_size(0);
+    result.set_status(Some(status));
+    result.set_next_begin_offset(next_begin_offset);
+    result.set_min_offset(min_offset);
+    result.set_max_offset(max_offset);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use cheetah_string::CheetahString;
+
+    use super::CompactionStore;
+    use crate::base::message_status_enum::GetMessageStatus;
+
+    #[test]
+    fn get_message_returns_java_style_status_for_missing_queue() {
+        let store = CompactionStore::new();
+        let topic = CheetahString::from_static_str("compaction-missing-topic");
+        let group = CheetahString::from_static_str("compaction-missing-group");
+
+        let result = store
+            .get_message(&group, &topic, 0, 0, 32, 1024)
+            .expect("compaction store should return a status result");
+
+        assert_eq!(result.status(), Some(GetMessageStatus::NoMatchedLogicQueue));
+        assert_eq!(result.message_count(), 0);
+    }
+
+    #[test]
+    fn put_and_get_message_round_trips_in_compaction_store() {
+        let store = CompactionStore::new();
+        let topic = CheetahString::from_static_str("compaction-topic");
+        let group = CheetahString::from_static_str("compaction-group");
+
+        store.put_message(&topic, 0, 7, 1, Bytes::from_static(b"compacted-message"));
+
+        let result = store
+            .get_message(&group, &topic, 0, 7, 32, 1024)
+            .expect("compaction result");
+
+        assert_eq!(result.status(), Some(GetMessageStatus::Found));
+        assert_eq!(result.message_count(), 1);
+        assert_eq!(result.next_begin_offset(), 8);
+        assert_eq!(
+            result.message_mapped_list()[0].get_bytes_ref().unwrap().as_ref(),
+            b"compacted-message"
+        );
+    }
+
+    #[test]
+    fn compact_once_keeps_latest_message_for_same_key() {
+        let store = CompactionStore::new();
+        let topic = CheetahString::from_static_str("compaction-topic");
+        let group = CheetahString::from_static_str("compaction-group");
+        let key = CheetahString::from_static_str("same-key");
+
+        store.put_message_with_key(&topic, 0, 0, 1, Some(key.clone()), Bytes::from_static(b"old-message"));
+        store.put_message_with_key(&topic, 0, 1, 1, Some(key), Bytes::from_static(b"latest-message"));
+
+        assert_eq!(store.message_count(&topic, 0), 2);
+        assert_eq!(store.compact_once(), 1);
+        assert_eq!(store.message_count(&topic, 0), 1);
+
+        let old_result = store
+            .get_message(&group, &topic, 0, 0, 32, 1024)
+            .expect("old offset should return a boundary status");
+        assert_eq!(old_result.status(), Some(GetMessageStatus::OffsetTooSmall));
+
+        let latest_result = store
+            .get_message(&group, &topic, 0, 1, 32, 1024)
+            .expect("latest result");
+        assert_eq!(latest_result.status(), Some(GetMessageStatus::Found));
+        assert_eq!(
+            latest_result.message_mapped_list()[0].get_bytes_ref().unwrap(),
+            &Bytes::from_static(b"latest-message")
+        );
     }
 }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -118,6 +118,7 @@ use crate::hook::put_message_hook::PutMessageHook;
 use crate::hook::send_message_back_hook::SendMessageBackHook;
 use crate::index::index_dispatch::CommitLogDispatcherBuildIndex;
 use crate::index::index_service::IndexService;
+use crate::kv::compaction_dispatch::CommitLogDispatcherCompaction;
 use crate::kv::compaction_service::CompactionService;
 use crate::kv::compaction_store::CompactionStore;
 use crate::log_file::commit_log;
@@ -445,7 +446,7 @@ impl LocalFileMessageStore {
         let build_consume_queue: Arc<dyn CommitLogDispatcher> =
             Arc::new(CommitLogDispatcherBuildConsumeQueue::new(consume_queue_store.clone()));
 
-        let dispatcher = ArcMut::new(CommitLogDispatcherDefault {
+        let mut dispatcher = ArcMut::new(CommitLogDispatcherDefault {
             dispatcher_vec: vec![build_consume_queue, build_index],
         });
 
@@ -457,6 +458,15 @@ impl LocalFileMessageStore {
             topic_config_table.clone(),
             consume_queue_store.clone(),
         ));
+        let compaction_store = Arc::new(CompactionStore::new());
+        if message_store_config.enable_compaction {
+            dispatcher.add_dispatcher(Arc::new(CommitLogDispatcherCompaction::new(
+                compaction_store.clone(),
+                commit_log.clone(),
+                message_store_config.clone(),
+                topic_config_table.clone(),
+            )));
+        }
 
         ensure_dir_ok(message_store_config.store_path_root_dir.as_str());
         ensure_dir_ok(Self::get_store_path_physic(&message_store_config).as_str());
@@ -467,7 +477,12 @@ impl LocalFileMessageStore {
             message_store_config.transient_store_pool_size,
             message_store_config.mapped_file_size_commit_log,
         );
-        let compaction_service = message_store_config.enable_compaction.then(CompactionService::new);
+        let compaction_service = message_store_config.enable_compaction.then(|| {
+            CompactionService::new(
+                compaction_store.clone(),
+                message_store_config.compaction_schedule_internal,
+            )
+        });
         Ok(Self {
             message_store_config: message_store_config.clone(),
             broker_config,
@@ -518,7 +533,7 @@ impl LocalFileMessageStore {
             message_arriving_listener: None,
             notify_message_arrive_in_batch,
             store_stats_service: Arc::new(StoreStatsService::new(Some(identity))),
-            compaction_store: Arc::new(CompactionStore::new()),
+            compaction_store,
             timer_message_store: None,
             transient_store_pool,
             message_store_arc: None,
@@ -1406,6 +1421,9 @@ impl MessageStore for LocalFileMessageStore {
             self.commit_log.start();
             self.consume_queue_store.start();
             self.store_stats_service.start();
+            if let Some(compaction_service) = self.compaction_service.as_mut() {
+                compaction_service.start();
+            }
             if let Some(timer_message_store) = self.timer_message_store.as_ref() {
                 timer_message_store.start();
             }
@@ -1516,8 +1534,8 @@ impl MessageStore for LocalFileMessageStore {
             // dispatch-related services must be shut down after reputMessageService
             self.index_service.shutdown();
 
-            if let Some(compaction_service) = self.compaction_service.as_ref() {
-                compaction_service.shutdown();
+            if let Some(compaction_service) = self.compaction_service.as_mut() {
+                compaction_service.shutdown_gracefully().await;
             }
 
             if self.message_store_config.rocksdb_cq_double_write_enable {
@@ -3962,6 +3980,7 @@ mod tests {
     use crate::filter::MessageFilter;
     use crate::hook::put_message_hook::PutMessageHook;
     use crate::hook::send_message_back_hook::SendMessageBackHook;
+    use crate::kv::compaction_service::CompactionService;
     use crate::message_encoder::message_ext_encoder::MessageExtEncoder;
     use crate::queue::consume_queue::ConsumeQueueTrait;
     use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
@@ -4254,10 +4273,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compaction_topic_loads_and_reads_from_commitlog_until_compaction_backend_has_data() {
+    async fn compaction_topic_dispatches_and_reads_from_compaction_store() {
         let temp_dir = tempdir().unwrap();
-        let topic = CheetahString::from_static_str("compaction-fallback-topic");
-        let group = CheetahString::from_static_str("compaction-fallback-group");
+        let topic = CheetahString::from_static_str("compaction-dispatch-topic");
+        let group = CheetahString::from_static_str("compaction-dispatch-group");
         let mut store = new_configured_test_store(
             &temp_dir,
             MessageStoreConfig {
@@ -4290,9 +4309,12 @@ mod tests {
         let result = store
             .get_message(&group, &topic, 0, 0, 32, None)
             .await
-            .expect("compaction topic should fall back to commitlog read");
+            .expect("compaction topic should read from compaction store");
         assert_eq!(result.status(), Some(GetMessageStatus::Found));
         assert_eq!(result.message_count(), 1);
+        assert_eq!(store.compaction_store.message_count(&topic, 0), 1);
+        assert!(result.message_mapped_list()[0].mapped_file.is_none());
+        assert!(result.message_mapped_list()[0].get_bytes_ref().is_some());
     }
 
     #[tokio::test]
@@ -4352,6 +4374,7 @@ mod tests {
             &temp_dir,
             MessageStoreConfig {
                 duplication_enable: true,
+                enable_compaction: true,
                 timer_wheel_enable: true,
                 ..MessageStoreConfig::default()
             },
@@ -4361,6 +4384,10 @@ mod tests {
         store.start().await.expect("start store");
 
         assert!(store.store_stats_service.has_worker_handle());
+        assert!(store
+            .compaction_service
+            .as_ref()
+            .is_some_and(CompactionService::has_worker_handle));
         assert!(store.reput_message_service.reader_handle.is_some());
         assert!(store.reput_message_service.dispatcher_handle.is_some());
         assert!(store
@@ -4372,6 +4399,10 @@ mod tests {
         store.shutdown().await;
 
         assert!(!store.store_stats_service.has_worker_handle());
+        assert!(store
+            .compaction_service
+            .as_ref()
+            .is_some_and(|service| !service.has_worker_handle()));
         assert!(store.reput_message_service.reader_handle.is_none());
         assert!(store.reput_message_service.dispatcher_handle.is_none());
         assert!(!store


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7248

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented message compaction functionality that deduplicates and removes obsolete messages based on message keys and topic queue offsets.
  * Added configurable periodic compaction service that runs automatically during message store operation when compaction is enabled.
  * Compaction is now fully integrated into the commit-log dispatch pipeline to automatically process eligible messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->