### PR TITLE
[ISSUE #7250]✨enhance(local_file_consume_queue_store, local_file_message_store): add RocksDB compatibility for consume queues and improve queue type handling

### DIFF
--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -3943,6 +3943,7 @@ mod tests {
     use cheetah_string::CheetahString;
     use dashmap::DashMap;
     use rocketmq_common::common::attribute::cleanup_policy::CleanupPolicy;
+    use rocketmq_common::common::attribute::cq_type::CQType;
     use rocketmq_common::common::attribute::Attribute;
     use rocketmq_common::common::boundary_type::BoundaryType;
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
@@ -4315,6 +4316,50 @@ mod tests {
         assert_eq!(store.compaction_store.message_count(&topic, 0), 1);
         assert!(result.message_mapped_list()[0].mapped_file.is_none());
         assert!(result.message_mapped_list()[0].get_bytes_ref().is_some());
+    }
+
+    #[tokio::test]
+    async fn rocksdb_store_type_with_rocksdb_cq_topic_uses_compat_local_queue_path() {
+        let temp_dir = tempdir().unwrap();
+        let topic = CheetahString::from_static_str("rocksdb-compat-topic");
+        let group = CheetahString::from_static_str("rocksdb-compat-group");
+        let mut store = new_configured_test_store(
+            &temp_dir,
+            MessageStoreConfig {
+                store_type: StoreType::RocksDB,
+                flush_disk_type: FlushDiskType::AsyncFlush,
+                ..MessageStoreConfig::default()
+            },
+        );
+        let mut topic_config = TopicConfig::new(topic.clone());
+        topic_config.attributes.insert(
+            TopicAttributes::queue_type_attribute().name().clone(),
+            CQType::RocksDBCQ.to_string().into(),
+        );
+        store
+            .topic_config_table
+            .insert(topic.clone(), ArcMut::new(topic_config));
+
+        store.init().await.expect("init rocksdb compatibility store");
+        assert!(store.load().await, "load rocksdb compatibility store");
+        let put_result = store
+            .put_message(build_test_message(&topic, Bytes::from_static(b"rocksdb-compat-body")))
+            .await;
+        assert_eq!(put_result.put_message_status(), PutMessageStatus::PutOk);
+        store.reput_once().await;
+
+        let queue = store
+            .get_consume_queue(&topic, 0)
+            .expect("compat queue should be present");
+        assert_eq!(queue.get_cq_type(), CQType::SimpleCQ);
+
+        let result = store
+            .get_message(&group, &topic, 0, 0, 32, None)
+            .await
+            .expect("rocksdb compatibility get result");
+        assert_eq!(result.status(), Some(GetMessageStatus::Found));
+        assert_eq!(result.message_count(), 1);
+        assert_eq!(result.next_begin_offset(), 1);
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -745,12 +745,22 @@ impl ConsumeQueueStore {
 
         let topic_config = message_store.get_topic_config(topic);
         let act = QueueTypeUtils::get_cq_type_arc_mut(topic_config.as_ref());
+        if self.is_rocksdb_cq_compat(act, cq_type) {
+            return true;
+        }
         if act != cq_type {
             error!("The queue type of topic: {topic} should be {cq_type:?}, but is {act:?}");
             return false;
         }
 
         true
+    }
+
+    #[inline]
+    fn is_rocksdb_cq_compat(&self, actual: CQType, expected: CQType) -> bool {
+        self.inner.message_store_config.is_enable_rocksdb_store()
+            && actual == CQType::RocksDBCQ
+            && expected == CQType::SimpleCQ
     }
 
     #[inline]
@@ -767,8 +777,7 @@ impl ConsumeQueueStore {
         store_path: CheetahString,
     ) -> ArcMut<Box<dyn ConsumeQueueTrait>> {
         match cq_type {
-            CQType::SimpleCQ => {
-                let ms_ref = self.inner.message_store.as_ref().unwrap();
+            CQType::SimpleCQ | CQType::RocksDBCQ => {
                 let consume_queue = ConsumeQueue::new(
                     topic.clone(),
                     queue_id,
@@ -789,10 +798,6 @@ impl ConsumeQueueStore {
                 );
                 ArcMut::new(Box::new(consume_queue))
             }
-            _ => {
-                error!("Unsupported consume queue type: {cq_type:?}");
-                panic!("Unsupported consume queue type: {cq_type:?}");
-            }
         }
     }
 
@@ -809,12 +814,15 @@ mod tests {
     use bytes::Buf;
     use cheetah_string::CheetahString;
     use dashmap::DashMap;
+    use rocketmq_common::common::attribute::Attribute;
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
     use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_common::TopicAttributes::TopicAttributes;
     use rocketmq_rust::ArcMut;
     use tempfile::tempdir;
 
     use super::*;
+    use crate::base::store_enum::StoreType;
     use crate::queue::batch_consume_queue;
 
     #[test]
@@ -845,6 +853,79 @@ mod tests {
         store.set_message_store(message_store);
 
         assert!(!store.load_consume_queues(&batch_store_path, CQType::BatchCQ));
+    }
+
+    #[test]
+    fn rocksdb_cq_loads_from_simple_cq_path_in_compat_mode() {
+        let root = tempdir().expect("tempdir");
+        let topic = CheetahString::from_static_str("RocksCompatTopic");
+        let message_store_config = Arc::new(MessageStoreConfig {
+            store_path_root_dir: root.path().to_string_lossy().to_string().into(),
+            store_type: StoreType::RocksDB,
+            ..MessageStoreConfig::default()
+        });
+        let broker_config = Arc::new(BrokerConfig::default());
+        let topic_config_table = Arc::new(DashMap::<CheetahString, ArcMut<TopicConfig>>::new());
+        let mut topic_config = TopicConfig::new(topic.clone());
+        topic_config.attributes.insert(
+            TopicAttributes::queue_type_attribute().name().clone(),
+            CQType::RocksDBCQ.to_string().into(),
+        );
+        topic_config_table.insert(topic.clone(), ArcMut::new(topic_config));
+        let mut message_store = ArcMut::new(LocalFileMessageStore::new(
+            message_store_config.clone(),
+            broker_config.clone(),
+            topic_config_table,
+            None,
+            false,
+        ));
+        let message_store_clone = message_store.clone();
+        message_store.set_message_store_arc(message_store_clone);
+
+        let simple_store_path = get_store_path_consume_queue(message_store_config.store_path_root_dir.as_str());
+        fs::create_dir_all(Path::new(&simple_store_path).join(topic.as_str()).join("0"))
+            .expect("simple consume queue directory");
+        let mut store = ConsumeQueueStore::new(message_store_config, broker_config);
+        store.set_message_store(message_store);
+
+        assert!(store.load_consume_queues(&simple_store_path, CQType::SimpleCQ));
+        let queue = store
+            .find_consume_queue(&topic, 0)
+            .expect("rocksdb compatibility queue should load");
+        assert_eq!(queue.get_cq_type(), CQType::SimpleCQ);
+    }
+
+    #[test]
+    fn create_consume_queue_by_type_maps_rocksdb_cq_to_simple_cq() {
+        let root = tempdir().expect("tempdir");
+        let topic = CheetahString::from_static_str("RocksCreateTopic");
+        let message_store_config = Arc::new(MessageStoreConfig {
+            store_path_root_dir: root.path().to_string_lossy().to_string().into(),
+            store_type: StoreType::RocksDB,
+            ..MessageStoreConfig::default()
+        });
+        let broker_config = Arc::new(BrokerConfig::default());
+        let topic_config_table = Arc::new(DashMap::<CheetahString, ArcMut<TopicConfig>>::new());
+        let mut message_store = ArcMut::new(LocalFileMessageStore::new(
+            message_store_config.clone(),
+            broker_config.clone(),
+            topic_config_table,
+            None,
+            false,
+        ));
+        let message_store_clone = message_store.clone();
+        message_store.set_message_store_arc(message_store_clone);
+        let mut store = ConsumeQueueStore::new(message_store_config, broker_config);
+        store.set_message_store(message_store);
+
+        let queue = store.create_consume_queue_by_type(
+            &topic,
+            0,
+            CQType::RocksDBCQ,
+            CheetahString::from_string(root.path().join("compat-cq").to_string_lossy().to_string()),
+        );
+
+        assert_eq!(queue.get_cq_type(), CQType::SimpleCQ);
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7250

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests validating RocksDB message store behavior and queue type compatibility scenarios.

* **Improvements**
  * Implemented RocksDB compatibility mode enabling automatic queue type mapping between RocksDB and local queue formats. Enhanced error handling to prevent queue type mismatch failures during store initialization and topic loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->