### PR TITLE
[ISSUE #7252]✨enhance(allocate_mapped_file_service, commit_log, local_file_message_store): integrate warm mapped file configuration and improve file allocation logic

### DIFF
--- a/rocketmq-store/src/base/allocate_mapped_file_service.rs
+++ b/rocketmq-store/src/base/allocate_mapped_file_service.rs
@@ -33,11 +33,45 @@ use tracing::info;
 use tracing::warn;
 
 use crate::base::transient_store_pool::TransientStorePool;
+use crate::config::flush_disk_type::FlushDiskType;
+use crate::config::message_store_config::MessageStoreConfig;
 use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::MappedFile;
 
 /// Timeout for waiting on file allocation (matches Java: 5 seconds)
 const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy)]
+struct WarmMappedFileConfig {
+    enabled: bool,
+    flush_disk_type: FlushDiskType,
+    mapped_file_size_commit_log: usize,
+    flush_least_pages_when_warm_mapped_file: usize,
+}
+
+impl WarmMappedFileConfig {
+    fn disabled() -> Self {
+        Self {
+            enabled: false,
+            flush_disk_type: FlushDiskType::AsyncFlush,
+            mapped_file_size_commit_log: usize::MAX,
+            flush_least_pages_when_warm_mapped_file: 0,
+        }
+    }
+
+    fn from_message_store_config(message_store_config: &MessageStoreConfig) -> Self {
+        Self {
+            enabled: message_store_config.warm_mapped_file_enable,
+            flush_disk_type: message_store_config.flush_disk_type,
+            mapped_file_size_commit_log: message_store_config.mapped_file_size_commit_log,
+            flush_least_pages_when_warm_mapped_file: message_store_config.flush_least_pages_when_warm_mapped_file,
+        }
+    }
+
+    fn should_warm(self, file_size: u64) -> bool {
+        self.enabled && file_size as usize >= self.mapped_file_size_commit_log
+    }
+}
 
 /// Background service for asynchronous MappedFile pre-allocation
 ///
@@ -76,6 +110,9 @@ pub struct AllocateMappedFileService {
 
     /// Whether to fast fail when no buffer available in pool
     fast_fail_if_no_buffer: bool,
+
+    /// CommitLog warm-up behavior copied from MessageStoreConfig.
+    warm_mapped_file_config: WarmMappedFileConfig,
 }
 
 impl Clone for AllocateMappedFileService {
@@ -91,6 +128,7 @@ impl Clone for AllocateMappedFileService {
             transient_store_pool: self.transient_store_pool.clone(),
             transient_store_pool_enable: self.transient_store_pool_enable,
             fast_fail_if_no_buffer: self.fast_fail_if_no_buffer,
+            warm_mapped_file_config: self.warm_mapped_file_config,
         }
     }
 }
@@ -131,13 +169,38 @@ impl AllocateMappedFileService {
             transient_store_pool,
             transient_store_pool_enable,
             fast_fail_if_no_buffer,
+            warm_mapped_file_config: WarmMappedFileConfig::disabled(),
         }
+    }
+
+    pub fn new_with_message_store_config(
+        transient_store_pool: Option<Arc<TransientStorePool>>,
+        transient_store_pool_enable: bool,
+        fast_fail_if_no_buffer: bool,
+        message_store_config: &MessageStoreConfig,
+    ) -> Self {
+        let mut service = Self::new_with_config(
+            transient_store_pool,
+            transient_store_pool_enable,
+            fast_fail_if_no_buffer,
+        );
+        service.warm_mapped_file_config = WarmMappedFileConfig::from_message_store_config(message_store_config);
+        service
     }
 
     /// Create a new AllocateMappedFileService with default configuration
     /// (no TransientStorePool)
     pub fn new() -> Self {
         Self::new_with_config(None, false, false)
+    }
+
+    pub fn is_started(&self) -> bool {
+        self.worker_handle.lock().is_some() && !self.stopped.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn should_warm_mapped_file(&self, file_size: u64) -> bool {
+        self.warm_mapped_file_config.should_warm(file_size)
     }
 
     /// Start the background worker thread
@@ -158,6 +221,7 @@ impl AllocateMappedFileService {
         let stopped = self.stopped.clone();
         let transient_store_pool = self.transient_store_pool.clone();
         let worker_wakeup = self.worker_wakeup.clone();
+        let warm_mapped_file_config = self.warm_mapped_file_config;
 
         match thread::Builder::new()
             .name("allocate-mapped-file-service".to_string())
@@ -169,6 +233,7 @@ impl AllocateMappedFileService {
                     stopped,
                     transient_store_pool,
                     worker_wakeup,
+                    warm_mapped_file_config,
                 );
             }) {
             Ok(handle) => {
@@ -190,14 +255,20 @@ impl AllocateMappedFileService {
         stopped: Arc<AtomicBool>,
         transient_store_pool: Option<Arc<TransientStorePool>>,
         worker_wakeup: Arc<(StdMutex<()>, Condvar)>,
+        warm_mapped_file_config: WarmMappedFileConfig,
     ) {
         info!("AllocateMappedFileService: service started");
 
         while !stopped.load(Ordering::Relaxed) {
             while !stopped.load(Ordering::Relaxed)
-                && Self::mmap_operation(&request_table, &request_queue, &has_exception, &transient_store_pool)
-            {
-            }
+                && Self::mmap_operation(
+                    &request_table,
+                    &request_queue,
+                    &has_exception,
+                    &transient_store_pool,
+                    warm_mapped_file_config,
+                )
+            {}
 
             if stopped.load(Ordering::Relaxed) {
                 break;
@@ -226,6 +297,7 @@ impl AllocateMappedFileService {
         request_queue: &Arc<RwLock<BinaryHeap<Arc<AllocateRequest>>>>,
         has_exception: &Arc<AtomicBool>,
         transient_store_pool: &Option<Arc<TransientStorePool>>,
+        warm_mapped_file_config: WarmMappedFileConfig,
     ) -> bool {
         // Pop request from priority queue
         let req = {
@@ -270,7 +342,7 @@ impl AllocateMappedFileService {
         }
 
         // Perform actual file allocation
-        let result = Self::create_mapped_file(&req, transient_store_pool);
+        let result = Self::create_mapped_file(&req, transient_store_pool, warm_mapped_file_config);
 
         match result {
             Ok(mapped_file) => {
@@ -306,6 +378,7 @@ impl AllocateMappedFileService {
     fn create_mapped_file(
         req: &AllocateRequest,
         transient_store_pool: &Option<Arc<TransientStorePool>>,
+        warm_mapped_file_config: WarmMappedFileConfig,
     ) -> Result<Arc<DefaultMappedFile>, RocketMQError> {
         let start = std::time::Instant::now();
         let file_path = req.file_path.clone();
@@ -328,6 +401,13 @@ impl AllocateMappedFileService {
             reason: error.to_string(),
         })?;
 
+        if warm_mapped_file_config.should_warm(file_size) {
+            mapped_file.warm_mapped_file(
+                warm_mapped_file_config.flush_disk_type,
+                warm_mapped_file_config.flush_least_pages_when_warm_mapped_file,
+            );
+        }
+
         let elapsed = start.elapsed();
         if elapsed.as_millis() > 10 {
             let queue_size = 0; // TODO: pass queue size if needed
@@ -339,11 +419,6 @@ impl AllocateMappedFileService {
                 req.file_size
             );
         }
-
-        // TODO: Pre-warm mapped file if configured
-        // if file_size >= commitlog_size && warm_mapped_file_enable {
-        //     mapped_file.warm_mapped_file(...);
-        // }
 
         Ok(Arc::new(mapped_file))
     }
@@ -783,13 +858,16 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::config::message_store_config::MessageStoreConfig;
 
     #[tokio::test]
     async fn allocate_mapped_file_blocking_works_inside_runtime() {
         let temp_dir = tempdir().expect("temp dir");
         let file_path = temp_dir.path().join("00000000000000000000");
         let service = AllocateMappedFileService::new();
+        assert!(!service.is_started());
         service.start();
+        assert!(service.is_started());
 
         let mapped_file = service
             .allocate_mapped_file_blocking(file_path.to_string_lossy().to_string(), 1024)
@@ -799,5 +877,20 @@ mod tests {
         assert!(file_path.exists(), "mapped file should be created on disk");
 
         service.shutdown().await;
+        assert!(!service.is_started());
+    }
+
+    #[test]
+    fn warm_mapped_file_config_follows_commitlog_file_size_threshold() {
+        let config = MessageStoreConfig {
+            warm_mapped_file_enable: true,
+            mapped_file_size_commit_log: 1024,
+            flush_least_pages_when_warm_mapped_file: 1,
+            ..MessageStoreConfig::default()
+        };
+        let service = AllocateMappedFileService::new_with_message_store_config(None, false, false, &config);
+
+        assert!(!service.should_warm_mapped_file(1023));
+        assert!(service.should_warm_mapped_file(1024));
     }
 }

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -256,6 +256,10 @@ impl MappedFileQueue {
     #[inline]
     fn trigger_pre_allocation(&self, next_offset: u64) {
         if let Some(ref service) = self.allocate_mapped_file_service {
+            if !service.is_started() {
+                return;
+            }
+
             let next_file_path = PathBuf::from(self.store_path.clone()).join(offset_to_file_name(next_offset));
 
             // Submit async request (non-blocking)
@@ -314,18 +318,20 @@ impl MappedFileQueue {
 
         // Try async allocation if service available
         if let Some(ref service) = self.allocate_mapped_file_service {
-            match service.allocate_mapped_file_blocking(file_path_str.clone(), self.mapped_file_size) {
-                Ok(pre_allocated) => {
-                    // Trigger pre-allocation of N+2 file
-                    service.submit_request_in_background(
-                        next_file_path.to_string_lossy().to_string(),
-                        self.mapped_file_size,
-                    );
-                    // Return Arc directly
-                    return Some(pre_allocated);
-                }
-                Err(e) => {
-                    warn!("Pre-allocation failed: {}, using sync creation", e);
+            if service.is_started() {
+                match service.allocate_mapped_file_blocking(file_path_str.clone(), self.mapped_file_size) {
+                    Ok(pre_allocated) => {
+                        // Trigger pre-allocation of N+2 file
+                        service.submit_request_in_background(
+                            next_file_path.to_string_lossy().to_string(),
+                            self.mapped_file_size,
+                        );
+                        // Return Arc directly
+                        return Some(pre_allocated);
+                    }
+                    Err(e) => {
+                        warn!("Pre-allocation failed: {}, using sync creation", e);
+                    }
                 }
             }
         }

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -54,6 +54,7 @@ use tracing::error;
 use tracing::info;
 use tracing::warn;
 
+use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
 use crate::base::append_message_callback::DefaultAppendMessageCallback;
 use crate::base::commit_log_dispatcher::CommitLogDispatcher;
 use crate::base::dispatch_request::DispatchRequest;
@@ -195,11 +196,16 @@ impl CommitLog {
         store_checkpoint: Arc<StoreCheckpoint>,
         topic_config_table: Arc<DashMap<CheetahString, ArcMut<TopicConfig>>>,
         consume_queue_store: ConsumeQueueStore,
+        allocate_mapped_file_service: AllocateMappedFileService,
     ) -> Self {
         let enabled_append_prop_crc = message_store_config.enabled_append_prop_crc;
         let store_path = message_store_config.get_store_path_commit_log();
         let mapped_file_size = message_store_config.mapped_file_size_commit_log;
-        let mapped_file_queue = ArcMut::new(MappedFileQueue::new(store_path, mapped_file_size as u64, None));
+        let mapped_file_queue = ArcMut::new(MappedFileQueue::new(
+            store_path,
+            mapped_file_size as u64,
+            Some(allocate_mapped_file_service),
+        ));
         Self {
             mapped_file_queue: mapped_file_queue.clone(),
             message_store_config: message_store_config.clone(),
@@ -225,6 +231,11 @@ impl CommitLog {
             begin_time_in_lock: Arc::new(AtomicU64::new(0)),
             cold_data_check_service: Arc::new(Default::default()),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_allocate_mapped_file_service(&self) -> bool {
+        self.mapped_file_queue.allocate_mapped_file_service.is_some()
     }
 }
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -450,6 +450,20 @@ impl LocalFileMessageStore {
             dispatcher_vec: vec![build_consume_queue, build_index],
         });
 
+        let transient_store_pool = TransientStorePool::new(
+            message_store_config.transient_store_pool_size,
+            message_store_config.mapped_file_size_commit_log,
+        );
+        let transient_store_pool_enable = message_store_config.transient_store_pool_enable
+            && (broker_config.enable_controller_mode || message_store_config.broker_role != BrokerRole::Slave);
+        let allocate_transient_store_pool = transient_store_pool_enable.then(|| Arc::new(transient_store_pool.clone()));
+        let allocate_mapped_file_service = Arc::new(AllocateMappedFileService::new_with_message_store_config(
+            allocate_transient_store_pool,
+            transient_store_pool_enable,
+            message_store_config.fast_fail_if_no_buffer_in_store_pool,
+            message_store_config.as_ref(),
+        ));
+
         let commit_log = ArcMut::new(CommitLog::new(
             message_store_config.clone(),
             broker_config.clone(),
@@ -457,6 +471,7 @@ impl LocalFileMessageStore {
             store_checkpoint.clone(),
             topic_config_table.clone(),
             consume_queue_store.clone(),
+            (*allocate_mapped_file_service).clone(),
         ));
         let compaction_store = Arc::new(CompactionStore::new());
         if message_store_config.enable_compaction {
@@ -473,10 +488,6 @@ impl LocalFileMessageStore {
         ensure_dir_ok(Self::get_store_path_logic(&message_store_config).as_str());
 
         let identity = broker_config.broker_identity.clone();
-        let transient_store_pool = TransientStorePool::new(
-            message_store_config.transient_store_pool_size,
-            message_store_config.mapped_file_size_commit_log,
-        );
         let compaction_service = message_store_config.enable_compaction.then(|| {
             CompactionService::new(
                 compaction_store.clone(),
@@ -495,7 +506,7 @@ impl LocalFileMessageStore {
             master_flushed_offset: Arc::new(AtomicI64::new(-1)),
             alive_replica_num_in_group: Arc::new(AtomicI32::new(1)),
             index_service: index_service.clone(),
-            allocate_mapped_file_service: Arc::new(AllocateMappedFileService::new()),
+            allocate_mapped_file_service,
             consume_queue_store: consume_queue_store.clone(),
             dispatcher,
             broker_init_max_offset: Arc::new(AtomicI64::new(-1)),
@@ -4026,6 +4037,14 @@ mod tests {
         let store_clone = store.clone();
         store.set_message_store_arc(store_clone);
         store
+    }
+
+    #[test]
+    fn commitlog_uses_allocate_mapped_file_service_for_file_creation() {
+        let temp_dir = tempdir().unwrap();
+        let store = new_configured_test_store(&temp_dir, MessageStoreConfig::default());
+
+        assert!(store.commit_log.has_allocate_mapped_file_service());
     }
 
     fn new_unwired_test_store(temp_dir: &tempfile::TempDir) -> ArcMut<LocalFileMessageStore> {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7252

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commit-log memory warm-up support to improve file allocation performance.
  * Enhanced file allocation service initialization with configuration and status introspection.

* **Bug Fixes**
  * Prevented invalid async allocation requests when the file allocation service is not ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->