### PR TITLE
[ISSUE #7254]✨Add timer RocksDB configuration and improve request handling

### DIFF
--- a/rocketmq-store/src/base/allocate_mapped_file_service.rs
+++ b/rocketmq-store/src/base/allocate_mapped_file_service.rs
@@ -203,6 +203,11 @@ impl AllocateMappedFileService {
         self.warm_mapped_file_config.should_warm(file_size)
     }
 
+    #[cfg(test)]
+    pub(crate) fn has_request(&self, file_path: &str) -> bool {
+        self.request_table.read().contains_key(file_path)
+    }
+
     /// Start the background worker thread
     /// Corresponds to Java's ServiceThread.start()
     pub fn start(&self) {

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -82,6 +82,34 @@ mod defaults {
         3
     }
 
+    pub fn timer_rocksdb_precision_ms() -> u64 {
+        1000
+    }
+
+    pub fn timer_rocksdb_roll_max_tps() -> f64 {
+        8000.0
+    }
+
+    pub fn timer_rocksdb_time_expired_max_tps() -> f64 {
+        200000.0
+    }
+
+    pub fn timer_rocksdb_roll_interval_hours() -> usize {
+        1
+    }
+
+    pub fn timer_rocksdb_roll_range_hours() -> usize {
+        2
+    }
+
+    pub fn timer_recall_to_time_wheel_enable() -> bool {
+        true
+    }
+
+    pub fn timer_recall_to_timeline_enable() -> bool {
+        true
+    }
+
     pub fn timer_wheel_enable() -> bool {
         true
     }
@@ -353,6 +381,33 @@ pub struct MessageStoreConfig {
 
     #[serde(default)]
     pub timer_enable_disruptor: bool,
+
+    #[serde(default)]
+    pub timer_rocksdb_enable: bool,
+
+    #[serde(default)]
+    pub timer_rocksdb_stop_scan: bool,
+
+    #[serde(default = "defaults::timer_rocksdb_precision_ms")]
+    pub timer_rocksdb_precision_ms: u64,
+
+    #[serde(default = "defaults::timer_rocksdb_roll_max_tps")]
+    pub timer_rocksdb_roll_max_tps: f64,
+
+    #[serde(default = "defaults::timer_rocksdb_time_expired_max_tps")]
+    pub timer_rocksdb_time_expired_max_tps: f64,
+
+    #[serde(default = "defaults::timer_rocksdb_roll_interval_hours")]
+    pub timer_rocksdb_roll_interval_hours: usize,
+
+    #[serde(default = "defaults::timer_rocksdb_roll_range_hours")]
+    pub timer_rocksdb_roll_range_hours: usize,
+
+    #[serde(default = "defaults::timer_recall_to_time_wheel_enable")]
+    pub timer_recall_to_time_wheel_enable: bool,
+
+    #[serde(default = "defaults::timer_recall_to_timeline_enable")]
+    pub timer_recall_to_timeline_enable: bool,
 
     #[serde(default)]
     pub timer_enable_check_metrics: bool,
@@ -851,6 +906,15 @@ impl Default for MessageStoreConfig {
             timer_get_message_thread_num: 3,
             timer_put_message_thread_num: 3,
             timer_enable_disruptor: false,
+            timer_rocksdb_enable: false,
+            timer_rocksdb_stop_scan: false,
+            timer_rocksdb_precision_ms: 1000,
+            timer_rocksdb_roll_max_tps: 8000.0,
+            timer_rocksdb_time_expired_max_tps: 200000.0,
+            timer_rocksdb_roll_interval_hours: 1,
+            timer_rocksdb_roll_range_hours: 2,
+            timer_recall_to_time_wheel_enable: true,
+            timer_recall_to_timeline_enable: true,
             timer_enable_check_metrics: false,
             timer_intercept_delay_level: false,
             timer_max_delay_sec: 3600 * 24 * 3,
@@ -1112,6 +1176,39 @@ impl MessageStoreConfig {
         properties.insert(
             "timerEnableDisruptor".to_string(),
             self.timer_enable_disruptor.to_string(),
+        );
+        properties.insert("timerRocksDBEnable".to_string(), self.timer_rocksdb_enable.to_string());
+        properties.insert(
+            "timerRocksDBStopScan".to_string(),
+            self.timer_rocksdb_stop_scan.to_string(),
+        );
+        properties.insert(
+            "timerRocksDBPrecisionMs".to_string(),
+            self.timer_rocksdb_precision_ms.to_string(),
+        );
+        properties.insert(
+            "timerRocksDBRollMaxTps".to_string(),
+            self.timer_rocksdb_roll_max_tps.to_string(),
+        );
+        properties.insert(
+            "timerRocksDBTimeExpiredMaxTps".to_string(),
+            self.timer_rocksdb_time_expired_max_tps.to_string(),
+        );
+        properties.insert(
+            "timerRocksDBRollIntervalHours".to_string(),
+            self.timer_rocksdb_roll_interval_hours.to_string(),
+        );
+        properties.insert(
+            "timerRocksDBRollRangeHours".to_string(),
+            self.timer_rocksdb_roll_range_hours.to_string(),
+        );
+        properties.insert(
+            "timerRecallToTimeWheelEnable".to_string(),
+            self.timer_recall_to_time_wheel_enable.to_string(),
+        );
+        properties.insert(
+            "timerRecallToTimelineEnable".to_string(),
+            self.timer_recall_to_timeline_enable.to_string(),
         );
         properties.insert(
             "timerEnableCheckMetrics".to_string(),
@@ -1605,5 +1702,30 @@ mod tests {
         assert_eq!(config.disk_space_warning_level_ratio, 90);
         assert_eq!(config.disk_space_clean_forcibly_ratio, 85);
         assert!(config.clean_file_forcibly_enable);
+    }
+
+    #[test]
+    fn default_timer_rocksdb_config_matches_java_defaults() {
+        let config = MessageStoreConfig::default();
+        assert!(!config.timer_rocksdb_enable);
+        assert!(!config.timer_rocksdb_stop_scan);
+        assert_eq!(config.timer_rocksdb_precision_ms, 1000);
+        assert_eq!(config.timer_rocksdb_roll_max_tps, 8000.0);
+        assert_eq!(config.timer_rocksdb_time_expired_max_tps, 200000.0);
+        assert_eq!(config.timer_rocksdb_roll_interval_hours, 1);
+        assert_eq!(config.timer_rocksdb_roll_range_hours, 2);
+        assert!(config.timer_recall_to_time_wheel_enable);
+        assert!(config.timer_recall_to_timeline_enable);
+
+        let properties = config.get_properties();
+        assert_eq!(properties["timerRocksDBEnable"], "false");
+        assert_eq!(properties["timerRocksDBStopScan"], "false");
+        assert_eq!(properties["timerRocksDBPrecisionMs"], "1000");
+        assert_eq!(properties["timerRocksDBRollMaxTps"], "8000");
+        assert_eq!(properties["timerRocksDBTimeExpiredMaxTps"], "200000");
+        assert_eq!(properties["timerRocksDBRollIntervalHours"], "1");
+        assert_eq!(properties["timerRocksDBRollRangeHours"], "2");
+        assert_eq!(properties["timerRecallToTimeWheelEnable"], "true");
+        assert_eq!(properties["timerRecallToTimelineEnable"], "true");
     }
 }

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -262,9 +262,7 @@ impl MappedFileQueue {
 
             let next_file_path = PathBuf::from(self.store_path.clone()).join(offset_to_file_name(next_offset));
 
-            // Submit async request (non-blocking)
-            let _drop = service.submit_request(next_file_path.to_string_lossy().to_string(), self.mapped_file_size);
-            std::mem::drop(_drop);
+            service.submit_request_in_background(next_file_path.to_string_lossy().to_string(), self.mapped_file_size);
         }
     }
 
@@ -1310,5 +1308,36 @@ mod tests {
         };
         assert!(queue.load());
         assert_eq!(queue.mapped_files.load().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn trigger_pre_allocation_submits_background_request() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mapped_file_size = 1024;
+        let first_file_path = temp_dir.path().join(offset_to_file_name(0));
+        let next_file_path = temp_dir.path().join(offset_to_file_name(mapped_file_size));
+        let first_file = Arc::new(
+            DefaultMappedFile::try_new(
+                CheetahString::from_string(first_file_path.to_string_lossy().to_string()),
+                mapped_file_size,
+            )
+            .expect("first mapped file"),
+        );
+        first_file.set_wrote_position(820);
+
+        let service = AllocateMappedFileService::new();
+        service.start();
+        let mut queue = MappedFileQueue::new(
+            temp_dir.path().to_string_lossy().to_string(),
+            mapped_file_size,
+            Some(service.clone()),
+        );
+        queue.mapped_files.store(Arc::new(vec![first_file]));
+
+        assert!(!service.has_request(next_file_path.to_string_lossy().as_ref()));
+        assert!(queue.get_last_mapped_file_mut_start_offset(0, true).is_some());
+        assert!(service.has_request(next_file_path.to_string_lossy().as_ref()));
+
+        service.shutdown().await;
     }
 }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -637,6 +637,12 @@ impl LocalFileMessageStore {
                 "DLedger commit log is Java-specific and is intentionally unsupported in rocketmq-rust".to_string(),
             ));
         }
+        if self.message_store_config.timer_rocksdb_enable {
+            return Err(StoreError::General(
+                "Timer RocksDB backend is not implemented in rocketmq-rust; keep timer_rocksdb_enable=false"
+                    .to_string(),
+            ));
+        }
 
         let enabled_rocksdb_options = Self::enabled_rocksdb_specific_options(self.message_store_config.as_ref());
         if !self.message_store_config.is_enable_rocksdb_store() && !enabled_rocksdb_options.is_empty() {
@@ -2099,6 +2105,23 @@ impl MessageStore for LocalFileMessageStore {
         result.insert(
             RunningStats::CommitLogMaxOffset.as_str().to_string(),
             self.get_max_phy_offset().to_string(),
+        );
+        result.insert(
+            "storeType".to_string(),
+            self.message_store_config.store_type.get_store_type().to_string(),
+        );
+        result.insert(
+            "rocksdbCqDoubleWriteEnable".to_string(),
+            self.message_store_config.rocksdb_cq_double_write_enable.to_string(),
+        );
+        result.insert(
+            "rocksdbCompatibilityMode".to_string(),
+            if self.message_store_config.is_enable_rocksdb_store() {
+                "local_file_compat"
+            } else {
+                "disabled"
+            }
+            .to_string(),
         );
 
         if let Some(timer_message_store) = self.timer_message_store.as_ref() {
@@ -4293,6 +4316,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn init_rejects_timer_rocksdb_backend_until_native_store_exists() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = new_configured_test_store(
+            &temp_dir,
+            MessageStoreConfig {
+                timer_rocksdb_enable: true,
+                ..MessageStoreConfig::default()
+            },
+        );
+
+        let error = store
+            .init()
+            .await
+            .expect_err("timer rocksdb backend is not implemented");
+        assert!(matches!(
+            error,
+            StoreError::General(message)
+                if message.contains("Timer RocksDB backend")
+                    && message.contains("timer_rocksdb_enable=false")
+        ));
+    }
+
+    #[tokio::test]
     async fn compaction_topic_dispatches_and_reads_from_compaction_store() {
         let temp_dir = tempdir().unwrap();
         let topic = CheetahString::from_static_str("compaction-dispatch-topic");
@@ -4346,6 +4392,7 @@ mod tests {
             &temp_dir,
             MessageStoreConfig {
                 store_type: StoreType::RocksDB,
+                rocksdb_cq_double_write_enable: true,
                 flush_disk_type: FlushDiskType::AsyncFlush,
                 ..MessageStoreConfig::default()
             },
@@ -4379,6 +4426,11 @@ mod tests {
         assert_eq!(result.status(), Some(GetMessageStatus::Found));
         assert_eq!(result.message_count(), 1);
         assert_eq!(result.next_begin_offset(), 1);
+
+        let runtime_info = store.get_runtime_info();
+        assert_eq!(runtime_info["storeType"], "RocksDB");
+        assert_eq!(runtime_info["rocksdbCqDoubleWriteEnable"], "true");
+        assert_eq!(runtime_info["rocksdbCompatibilityMode"], "local_file_compat");
     }
 
     #[tokio::test]
@@ -5203,6 +5255,9 @@ mod tests {
         assert!(runtime_info.contains_key("putMessageTimesTotal"));
         assert!(runtime_info.contains_key(RunningStats::CommitLogMinOffset.as_str()));
         assert!(runtime_info.contains_key(RunningStats::CommitLogMaxOffset.as_str()));
+        assert_eq!(runtime_info["storeType"], "LocalFile");
+        assert_eq!(runtime_info["rocksdbCqDoubleWriteEnable"], "false");
+        assert_eq!(runtime_info["rocksdbCompatibilityMode"], "disabled");
         assert_eq!(runtime_info["timerReadBehind"], "0");
         assert_eq!(runtime_info["timerOffsetBehind"], "0");
         assert_eq!(runtime_info["timerCongestNum"], "0");


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7254

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RocksDB timer configuration options including precision, throughput limits, and rollover settings.
  * Expanded runtime metadata reporting with additional store configuration details.

* **Bug Fixes**
  * Configuration validation now properly rejects incompatible timer RocksDB settings with clear guidance.

* **Tests**
  * Added unit tests for pre-allocation and configuration validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->