### PR TITLE
[ISSUE #7266]🧪add protocol compatibility tests for Java request and response codes

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -3401,8 +3401,11 @@ mod tests {
     use rocketmq_remoting::protocol::body::kv_table::KVTable;
     use rocketmq_remoting::protocol::body::query_consume_queue_response_body::QueryConsumeQueueResponseBody;
     use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
+    use rocketmq_remoting::protocol::body::user_info::UserInfo;
     use rocketmq_remoting::protocol::header::controller::apply_broker_id_request_header::ApplyBrokerIdRequestHeader;
+    use rocketmq_remoting::protocol::header::create_user_request_header::CreateUserRequestHeader;
     use rocketmq_remoting::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
+    use rocketmq_remoting::protocol::header::delete_user_request_header::DeleteUserRequestHeader;
     use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
     use rocketmq_remoting::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader;
     use rocketmq_remoting::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
@@ -3420,6 +3423,8 @@ mod tests {
     use rocketmq_remoting::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader;
     use rocketmq_remoting::protocol::header::get_topic_config_request_header::GetTopicConfigRequestHeader;
     use rocketmq_remoting::protocol::header::get_topic_stats_request_header::GetTopicStatsRequestHeader;
+    use rocketmq_remoting::protocol::header::get_user_request_headers::GetUserRequestHeader;
+    use rocketmq_remoting::protocol::header::list_users_request_header::ListUsersRequestHeader;
     use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
     use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
     use rocketmq_remoting::protocol::header::namesrv::broker_request::GetBrokerMemberGroupRequestHeader;
@@ -5231,6 +5236,117 @@ mod tests {
             ResponseCode::from(switch_timer_response.code()),
             ResponseCode::InvalidParameter,
             "new_phase3_test_runtime keeps timerWheelEnable disabled"
+        );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn phase7_broker_auth_request_codes_dispatch_to_admin_processor() {
+        let mut runtime = new_phase3_test_runtime("phase7-auth-dispatch").await;
+        let (processor, _) = runtime.init_processor();
+
+        for request_code in [
+            RequestCode::AuthCreateUser,
+            RequestCode::AuthUpdateUser,
+            RequestCode::AuthDeleteUser,
+            RequestCode::AuthGetUser,
+            RequestCode::AuthListUsers,
+            RequestCode::AuthCreateAcl,
+            RequestCode::AuthUpdateAcl,
+            RequestCode::AuthDeleteAcl,
+            RequestCode::AuthGetAcl,
+            RequestCode::AuthListAcl,
+        ] {
+            assert_eq!(
+                processor.dispatch_processor_variant_for_test(request_code),
+                Some("AdminBroker"),
+                "{request_code:?} should fall back to AdminBrokerProcessor"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn phase7_auth_user_admin_lifecycle_returns_decodable_models() {
+        let mut runtime = new_phase3_test_runtime("phase7-auth-user").await;
+        let username = CheetahString::from_static_str("phase7-user");
+        let (mut processor, _) = runtime.init_processor();
+
+        let user_info = UserInfo {
+            username: None,
+            password: Some(CheetahString::from_static_str("secret")),
+            user_type: Some(CheetahString::from_static_str("Normal")),
+            user_status: Some(CheetahString::from_static_str("enable")),
+        };
+        let mut create_request = RemotingCommand::create_request_command(
+            RequestCode::AuthCreateUser,
+            CreateUserRequestHeader {
+                username: username.clone(),
+            },
+        )
+        .set_body(user_info.encode().expect("user info should encode"));
+        create_request.make_custom_header_to_net();
+        let create_response = process_broker_request(&mut processor, &mut create_request).await;
+        assert_eq!(ResponseCode::from(create_response.code()), ResponseCode::Success);
+
+        let mut get_request = RemotingCommand::create_request_command(
+            RequestCode::AuthGetUser,
+            GetUserRequestHeader {
+                username: username.clone(),
+            },
+        );
+        get_request.make_custom_header_to_net();
+        let get_response = process_broker_request(&mut processor, &mut get_request).await;
+        assert_eq!(ResponseCode::from(get_response.code()), ResponseCode::Success);
+        let get_body = get_response.body().expect("AuthGetUser should include a body");
+        let fetched_user = UserInfo::decode(get_body.as_ref()).expect("AuthGetUser body should decode");
+        assert_eq!(fetched_user.username, Some(username.clone()));
+        assert_eq!(fetched_user.user_type.as_deref(), Some("Normal"));
+        assert_eq!(fetched_user.user_status.as_deref(), Some("enable"));
+
+        let mut list_request = RemotingCommand::create_request_command(
+            RequestCode::AuthListUsers,
+            ListUsersRequestHeader {
+                filter: CheetahString::from_static_str("phase7"),
+            },
+        );
+        list_request.make_custom_header_to_net();
+        let list_response = process_broker_request(&mut processor, &mut list_request).await;
+        assert_eq!(ResponseCode::from(list_response.code()), ResponseCode::Success);
+        let listed_users: Vec<UserInfo> = Vec::decode(
+            list_response
+                .body()
+                .expect("AuthListUsers should include a body")
+                .as_ref(),
+        )
+        .expect("AuthListUsers body should decode");
+        assert!(
+            listed_users
+                .iter()
+                .any(|user| user.username.as_ref() == Some(&username)),
+            "AuthListUsers should include the created user"
+        );
+
+        let mut delete_request = RemotingCommand::create_request_command(
+            RequestCode::AuthDeleteUser,
+            DeleteUserRequestHeader {
+                username: username.clone(),
+            },
+        );
+        delete_request.make_custom_header_to_net();
+        let delete_response = process_broker_request(&mut processor, &mut delete_request).await;
+        assert_eq!(ResponseCode::from(delete_response.code()), ResponseCode::Success);
+
+        let mut get_deleted_request =
+            RemotingCommand::create_request_command(RequestCode::AuthGetUser, GetUserRequestHeader { username });
+        get_deleted_request.make_custom_header_to_net();
+        let get_deleted_response = process_broker_request(&mut processor, &mut get_deleted_request).await;
+        assert_eq!(ResponseCode::from(get_deleted_response.code()), ResponseCode::Success);
+        assert!(
+            get_deleted_response.body().is_none(),
+            "AuthGetUser should return success without body after deletion"
         );
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());

--- a/rocketmq-controller/src/metrics/controller_metrics_constant.rs
+++ b/rocketmq-controller/src/metrics/controller_metrics_constant.rs
@@ -187,6 +187,60 @@ mod tests {
     }
 
     #[test]
+    fn phase7_non_dledger_controller_request_set_has_stable_names() {
+        let expected_controller_requests = [
+            (
+                RequestCode::ControllerAlterSyncStateSet,
+                "controller_alter_sync_state_set",
+            ),
+            (RequestCode::ControllerElectMaster, "controller_elect_master"),
+            (RequestCode::ControllerRegisterBroker, "controller_register_broker"),
+            (RequestCode::ControllerGetReplicaInfo, "controller_get_replica_info"),
+            (RequestCode::ControllerGetMetadataInfo, "controller_get_metadata_info"),
+            (
+                RequestCode::ControllerGetSyncStateData,
+                "controller_get_sync_state_data",
+            ),
+            (RequestCode::GetBrokerEpochCache, "controller_get_broker_epoch_cache"),
+            (
+                RequestCode::NotifyBrokerRoleChanged,
+                "controller_notify_broker_role_changed",
+            ),
+            (RequestCode::BrokerHeartbeat, "controller_broker_heartbeat"),
+            (
+                RequestCode::UpdateControllerConfig,
+                "controller_update_controller_config",
+            ),
+            (RequestCode::GetControllerConfig, "controller_get_controller_config"),
+            (RequestCode::CleanBrokerData, "controller_clean_broker_data"),
+            (RequestCode::ControllerGetNextBrokerId, "controller_get_next_broker_id"),
+            (RequestCode::ControllerApplyBrokerId, "controller_apply_broker_id"),
+        ];
+
+        for (request_code, expected_name) in expected_controller_requests {
+            assert_eq!(request_code.get_controller_request_name(), Some(expected_name));
+            assert!(request_code.is_controller_request());
+        }
+    }
+
+    #[test]
+    fn phase7_dledger_request_codes_stay_outside_regular_controller_metrics() {
+        for request_code in [
+            RequestCode::BrokerCloseChannelRequest,
+            RequestCode::CheckNotActiveBrokerRequest,
+            RequestCode::GetBrokerLiveInfoRequest,
+            RequestCode::GetSyncStateDataRequest,
+            RequestCode::RaftBrokerHeartBeatEventRequest,
+        ] {
+            assert_eq!(request_code.get_controller_request_name(), None);
+            assert!(
+                !request_code.is_controller_request(),
+                "{request_code:?} is DLedger/raft-scoped and should not be classified as a regular controller request"
+            );
+        }
+    }
+
+    #[test]
     fn test_request_handle_status() {
         assert_eq!(RequestHandleStatus::Success.get_lower_case_name(), "success");
         assert_eq!(RequestHandleStatus::Failed.get_lower_case_name(), "failed");

--- a/rocketmq-proxy/src/status.rs
+++ b/rocketmq-proxy/src/status.rs
@@ -201,8 +201,10 @@ impl ProxyStatusMapper {
                 ResponseCode::NoPermission => v2::Code::Forbidden,
                 ResponseCode::TopicNotExist => v2::Code::TopicNotFound,
                 ResponseCode::SubscriptionGroupNotExist => v2::Code::ConsumerGroupNotFound,
+                ResponseCode::UserNotExist | ResponseCode::PolicyNotExist => v2::Code::NotFound,
                 ResponseCode::QueryNotFound => v2::Code::OffsetNotFound,
                 ResponseCode::PullOffsetMoved => v2::Code::IllegalOffset,
+                ResponseCode::RequestCodeNotSupported => v2::Code::Unsupported,
                 _ => v2::Code::InternalError,
             },
             RocketMQError::Timeout { .. } => v2::Code::ProxyTimeout,
@@ -215,6 +217,7 @@ impl ProxyStatusMapper {
 #[cfg(test)]
 mod tests {
     use rocketmq_error::RocketMQError;
+    use rocketmq_remoting::code::response_code::ResponseCode;
 
     use super::ProxyStatusMapper;
     use crate::error::ProxyError;
@@ -251,6 +254,43 @@ mod tests {
         assert_eq!(
             ProxyStatusMapper::to_tonic_status(&error).code(),
             tonic::Code::Unavailable
+        );
+    }
+
+    #[test]
+    fn phase7_broker_auth_and_permission_response_codes_map_to_grpc_payload_codes() {
+        for (response_code, expected_grpc_code) in [
+            (ResponseCode::NoPermission, v2::Code::Forbidden),
+            (ResponseCode::UserNotExist, v2::Code::NotFound),
+            (ResponseCode::PolicyNotExist, v2::Code::NotFound),
+        ] {
+            let error = ProxyError::RocketMQ(RocketMQError::broker_operation_failed(
+                "AUTH_ADMIN",
+                response_code.to_i32(),
+                "auth failed",
+            ));
+            let status = ProxyStatusMapper::from_error(&error);
+            assert_eq!(status.code, expected_grpc_code as i32);
+        }
+
+        let authentication_error = ProxyError::RocketMQ(RocketMQError::authentication_failed("bad credentials"));
+        let status = ProxyStatusMapper::from_error(&authentication_error);
+        assert_eq!(status.code, v2::Code::Unauthorized as i32);
+    }
+
+    #[test]
+    fn phase7_request_code_not_supported_maps_to_unsupported_and_unimplemented_transport() {
+        let error = ProxyError::RocketMQ(RocketMQError::broker_operation_failed(
+            "REMOTING",
+            ResponseCode::RequestCodeNotSupported.to_i32(),
+            "request code not supported",
+        ));
+
+        let payload_status = ProxyStatusMapper::from_error(&error);
+        assert_eq!(payload_status.code, v2::Code::Unsupported as i32);
+        assert_eq!(
+            ProxyStatusMapper::to_tonic_status(&error).code(),
+            tonic::Code::Unimplemented
         );
     }
 }

--- a/rocketmq-proxy/tests/remoting_ingress.rs
+++ b/rocketmq-proxy/tests/remoting_ingress.rs
@@ -189,6 +189,69 @@ async fn query_route_over_remoting_integration_injects_transport_context() {
     );
 }
 
+#[tokio::test]
+async fn request_code_not_supported_over_remoting_integration_returns_compatible_response() {
+    let service_manager = Arc::new(ClusterServiceManager::with_services(
+        Arc::new(RecordingRouteService::default()),
+        Arc::new(StaticMetadataService),
+        Arc::new(DefaultAssignmentService),
+        Arc::new(DefaultMessageService),
+        Arc::new(DefaultConsumerService),
+        Arc::new(DefaultTransactionService),
+    ));
+
+    let grpc_addr = free_local_addr();
+    let remoting_addr = free_local_addr();
+    let runtime = ProxyRuntime::builder(ProxyConfig {
+        grpc: GrpcConfig {
+            listen_addr: grpc_addr.to_string(),
+            ..GrpcConfig::default()
+        },
+        remoting: RemotingConfig {
+            enabled: true,
+            listen_addr: remoting_addr.to_string(),
+        },
+        ..ProxyConfig::default()
+    })
+    .with_service_manager(service_manager)
+    .build();
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        runtime
+            .serve_with_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+
+    let mut connection = connect_remoting_with_retry(remoting_addr).await;
+    let request = RemotingCommand::create_remoting_command(RequestCode::AuthCreateUser).set_opaque(88);
+    let opaque = request.opaque();
+    connection
+        .send_command(request)
+        .await
+        .expect("unsupported remoting request should be sent");
+
+    let response = receive_remoting_response(&mut connection).await;
+    assert_eq!(response.code(), ResponseCode::RequestCodeNotSupported as i32);
+    assert_eq!(response.opaque(), opaque);
+    assert!(
+        response
+            .remark()
+            .is_some_and(|remark| remark.contains("does not support request code 3001")),
+        "unsupported response should explain proxy remoting coverage, got {:?}",
+        response.remark()
+    );
+
+    let _ = shutdown_tx.send(());
+    let serve_result = server_task.await.expect("server task should join");
+    assert!(
+        serve_result.is_ok(),
+        "server should shut down cleanly: {serve_result:?}"
+    );
+}
+
 async fn connect_remoting_with_retry(addr: SocketAddr) -> Connection {
     let mut last_error = None;
     for _ in 0..20 {
@@ -202,6 +265,20 @@ async fn connect_remoting_with_retry(addr: SocketAddr) -> Connection {
     }
 
     panic!("remoting client failed to connect to {addr}: {last_error:?}");
+}
+
+async fn receive_remoting_response(connection: &mut Connection) -> RemotingCommand {
+    timeout(Duration::from_secs(3), async {
+        loop {
+            match connection.receive_command().await {
+                Some(Ok(response)) => break response,
+                Some(Err(error)) => panic!("failed to decode remoting response: {error}"),
+                None => continue,
+            }
+        }
+    })
+    .await
+    .expect("remoting response should arrive before timeout")
 }
 
 fn free_local_addr() -> SocketAddr {

--- a/rocketmq-remoting/tests/protocol_compatibility_tests.rs
+++ b/rocketmq-remoting/tests/protocol_compatibility_tests.rs
@@ -406,3 +406,82 @@ fn protocol_compatibility_response_command_codec_round_trip_preserves_wire_field
     assert_eq!(decoded.remark().map(|value| value.as_str()), Some("ok"));
     assert_eq!(decoded.body(), Some(&body));
 }
+
+#[test]
+fn protocol_compatibility_phase8_all_java_request_codes_codec_round_trip() {
+    let mut codec = RemotingCommandCodec::new();
+
+    for (index, (name, value)) in JAVA_REQUEST_CODES.iter().enumerate() {
+        let request_code = RequestCode::from(*value);
+        let body = Bytes::from(format!("phase8-request-body-{name}-{value}"));
+        let expected_remark = format!("phase8 request {name}");
+        let mut buffer = BytesMut::new();
+        let command = RemotingCommand::create_remoting_command(request_code)
+            .set_opaque(10_000 + index as i32)
+            .set_remark_option(Some(expected_remark.clone()))
+            .set_body(body.clone());
+
+        codec
+            .encode(command, &mut buffer)
+            .unwrap_or_else(|error| panic!("Java RequestCode {name}={value} should encode: {error}"));
+        let decoded = codec
+            .decode(&mut buffer)
+            .unwrap_or_else(|error| panic!("Java RequestCode {name}={value} should decode: {error}"))
+            .unwrap_or_else(|| panic!("Java RequestCode {name}={value} should produce a complete command"));
+
+        assert_eq!(
+            decoded.request_code(),
+            request_code,
+            "Java RequestCode {name}={value} request_code drifted after codec round trip"
+        );
+        assert_eq!(
+            decoded.code(),
+            *value,
+            "Java RequestCode {name}={value} numeric code drifted after codec round trip"
+        );
+        assert_eq!(decoded.opaque(), 10_000 + index as i32);
+        assert_eq!(
+            decoded.remark().map(|remark| remark.as_str()),
+            Some(expected_remark.as_str())
+        );
+        assert_eq!(decoded.body(), Some(&body));
+        assert!(buffer.is_empty(), "codec should consume the whole frame for {name}");
+    }
+}
+
+#[test]
+fn protocol_compatibility_phase8_all_java_response_codes_codec_round_trip() {
+    let mut codec = RemotingCommandCodec::new();
+
+    for (index, (name, value)) in JAVA_RESPONSE_CODES.iter().enumerate() {
+        let response_code = ResponseCode::from(*value);
+        let body = Bytes::from(format!("phase8-response-body-{name}-{value}"));
+        let expected_remark = format!("phase8 response {name}");
+        let mut buffer = BytesMut::new();
+        let command = RemotingCommand::create_response_command_with_code_remark(response_code, expected_remark.clone())
+            .set_opaque(20_000 + index as i32)
+            .set_body(body.clone());
+
+        codec
+            .encode(command, &mut buffer)
+            .unwrap_or_else(|error| panic!("Java ResponseCode {name}={value} should encode: {error}"));
+        let decoded = codec
+            .decode(&mut buffer)
+            .unwrap_or_else(|error| panic!("Java ResponseCode {name}={value} should decode: {error}"))
+            .unwrap_or_else(|| panic!("Java ResponseCode {name}={value} should produce a complete command"));
+
+        assert_eq!(
+            decoded.code(),
+            *value,
+            "Java ResponseCode {name}={value} numeric code drifted after codec round trip"
+        );
+        assert!(decoded.is_response_type());
+        assert_eq!(decoded.opaque(), 20_000 + index as i32);
+        assert_eq!(
+            decoded.remark().map(|remark| remark.as_str()),
+            Some(expected_remark.as_str())
+        );
+        assert_eq!(decoded.body(), Some(&body));
+        assert!(buffer.is_empty(), "codec should consume the whole frame for {name}");
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7266

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for authentication operations and user lifecycle management.
  * Improved controller request code classification and metrics testing.
  * Expanded protocol compatibility validation for all request and response codes.
  * Added validation for unsupported request handling in the proxy layer.

* **Bug Fixes**
  * Extended error-to-status mapping to properly handle missing users, missing policies, and unsupported request codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->