### PR TITLE
[ISSUE #7268]🚀add support for NotifyUnsubscribeLite request handling and validation

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -4739,6 +4739,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn java_definition_only_g8_request_codes_return_explicit_unsupported() {
+        let mut runtime = new_phase3_test_runtime("g8-definition-only-unsupported").await;
+        let (mut processor, _) = runtime.init_processor();
+
+        for request_code in [
+            RequestCode::QueryBrokerOffset,
+            RequestCode::GetTopicConfigList,
+            RequestCode::GetTopicNameList,
+            RequestCode::TriggerDeleteFiles,
+            RequestCode::GetClientConfig,
+            RequestCode::AckLiteMessage,
+            RequestCode::SuspendConsumer,
+            RequestCode::ResumeConsumer,
+            RequestCode::ResetConsumerOffsetInConsumer,
+            RequestCode::ResetConsumerOffsetInBroker,
+            RequestCode::AdjustConsumerThreadPool,
+            RequestCode::WhoConsumeTheMessage,
+            RequestCode::RegisterFilterServer,
+            RequestCode::RegisterMessageFilterClass,
+        ] {
+            let mut request = RemotingCommand::create_remoting_command(request_code);
+            let response = process_broker_request(&mut processor, &mut request).await;
+            assert_eq!(
+                ResponseCode::from(response.code()),
+                ResponseCode::RequestCodeNotSupported,
+                "{request_code:?} should keep an explicit unsupported contract"
+            );
+            assert!(
+                response
+                    .remark()
+                    .is_some_and(|remark| remark.contains(&request_code.to_i32().to_string())),
+                "{request_code:?} unsupported response should mention the request code"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
     async fn phase5_broker_admin_request_codes_dispatch_to_admin_processor() {
         let mut runtime = new_phase3_test_runtime("phase5-dispatch").await;
         let (processor, _) = runtime.init_processor();

--- a/rocketmq-broker/src/client/net/broker_to_client.rs
+++ b/rocketmq-broker/src/client/net/broker_to_client.rs
@@ -28,6 +28,7 @@ use rocketmq_remoting::protocol::body::response::reset_offset_body::ResetOffsetB
 use rocketmq_remoting::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_remoting::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
 use rocketmq_remoting::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
+use rocketmq_remoting::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader;
 use rocketmq_remoting::protocol::header::reset_offset_request_header::ResetOffsetRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_store::base::message_store::MessageStore;
@@ -124,6 +125,27 @@ impl Broker2Client {
             warn!(
                 "notifyConsumerIdsChanged exception. group={}, error={:?}",
                 consumer_group, e
+            );
+        }
+    }
+
+    /// Notify Lite clients that a Lite subscription has been removed.
+    ///
+    /// Java sends this as a one-way broker-to-client callback with a short timeout.
+    pub async fn notify_unsubscribe_lite(
+        &self,
+        channel: &mut Channel,
+        request_header: NotifyUnsubscribeLiteRequestHeader,
+    ) {
+        let lite_topic = request_header.lite_topic.clone();
+        let consumer_group = request_header.consumer_group.clone();
+        let client_id = request_header.client_id.clone();
+        let request = RemotingCommand::create_request_command(RequestCode::NotifyUnsubscribeLite, request_header);
+
+        if let Err(e) = channel.channel_inner_mut().send_oneway(request, 100).await {
+            error!(
+                "notifyUnsubscribeLite failed. liteTopic={}, group={}, clientId={}, error={:?}",
+                lite_topic, consumer_group, client_id, e
             );
         }
     }

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -30,6 +30,7 @@ use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_remoting::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
 use rocketmq_remoting::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
+use rocketmq_remoting::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader;
 use rocketmq_remoting::protocol::header::reply_message_request_header::ReplyMessageRequestHeader;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
@@ -66,18 +67,13 @@ impl RequestProcessor for ClientRemotingProcessor {
         info!("process_request: {:?}", request_code);
         match request_code {
             RequestCode::CheckTransactionState => self.check_transaction_state(channel, ctx, request).await,
-            RequestCode::ResetConsumerClientOffset => {
-                unimplemented!("ResetConsumerClientOffset")
-            }
-            RequestCode::GetConsumerStatusFromClient => {
-                unimplemented!("GetConsumerStatusFromClient")
-            }
-            RequestCode::GetConsumerRunningInfo => {
-                unimplemented!("GetConsumerRunningInfo")
-            }
+            RequestCode::ResetConsumerClientOffset
+            | RequestCode::GetConsumerStatusFromClient
+            | RequestCode::GetConsumerRunningInfo => Ok(Some(Self::unsupported_client_callback_response(request_code))),
             RequestCode::ConsumeMessageDirectly => self.consume_message_directly(channel, ctx, request).await,
             //RPC message handle code
             RequestCode::PushReplyMessageToClient => self.receive_reply_message(ctx, request).await,
+            RequestCode::NotifyUnsubscribeLite => self.notify_unsubscribe_lite(channel, request),
             RequestCode::NotifyConsumerIdsChanged => self.notify_consumer_ids_changed(channel, ctx, request),
 
             _ => {
@@ -89,16 +85,61 @@ impl RequestProcessor for ClientRemotingProcessor {
 }
 
 impl ClientRemotingProcessor {
+    fn unsupported_client_callback_response(request_code: RequestCode) -> RemotingCommand {
+        RemotingCommand::create_response_command_with_code_remark(
+            ResponseCode::RequestCodeNotSupported,
+            format!(
+                "client callback request {:?}-{} is not implemented",
+                request_code,
+                request_code.to_i32()
+            ),
+        )
+    }
+
+    fn notify_unsubscribe_lite(
+        &mut self,
+        channel: Channel,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        match request.decode_command_custom_header::<NotifyUnsubscribeLiteRequestHeader>() {
+            Ok(header) => {
+                info!(
+                    "receive broker's notify unsubscribe lite callback from {}; liteTopic={}, group={}, clientId={}",
+                    channel.remote_address(),
+                    header.lite_topic,
+                    header.consumer_group,
+                    header.client_id
+                );
+            }
+            Err(error) => {
+                warn!(
+                    "decode notify unsubscribe lite callback header failed from {}; error={:?}",
+                    channel.remote_address(),
+                    error
+                );
+            }
+        }
+        Ok(None)
+    }
+
     async fn receive_reply_message(
         &mut self,
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let receive_time = current_millis();
-        let response = RemotingCommand::create_response_command();
-        let request_header = request
-            .decode_command_custom_header::<ReplyMessageRequestHeader>()
-            .unwrap();
+        let response = RemotingCommand::create_response_command().set_opaque(request.opaque());
+        let request_header = match request.decode_command_custom_header::<ReplyMessageRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => {
+                warn!("decode reply message request header failed: {:?}", error);
+                return Ok(Some(
+                    response
+                        .set_code(ResponseCode::SystemError)
+                        .set_remark(format!("decode reply message request header failed: {error}")),
+                ));
+            }
+        };
 
         let mut msg = MessageExt::default();
         msg.message.set_topic(request_header.topic.clone());
@@ -134,14 +175,24 @@ impl ClientRemotingProcessor {
         let sys_flag = request_header.sys_flag;
 
         if (sys_flag & MessageSysFlag::COMPRESSED_FLAG) == MessageSysFlag::COMPRESSED_FLAG {
-            let de_result = CompressorFactory::get_compressor(MessageSysFlag::get_compression_type(sys_flag))
-                .decompress(body.unwrap());
+            let Some(body) = body else {
+                warn!("compressed reply message body is missing");
+                return Ok(Some(
+                    response
+                        .set_code(ResponseCode::SystemError)
+                        .set_remark("compressed reply message body is missing"),
+                ));
+            };
+            let de_result =
+                CompressorFactory::get_compressor(MessageSysFlag::get_compression_type(sys_flag)).decompress(body);
             if let Ok(decompressed) = de_result {
                 msg.message.set_body(Some(decompressed));
             } else {
                 warn!("err when uncompress constant");
-                msg.message.set_body(body.cloned());
+                msg.message.set_body(Some(body.clone()));
             }
+        } else {
+            msg.message.set_body(body.cloned());
         }
         msg.message.set_flag(request_header.flag);
         MessageAccessor::set_properties(
@@ -168,6 +219,7 @@ impl ClientRemotingProcessor {
             .unwrap_or_default();
         if let Some(request_response_future) = REQUEST_FUTURE_HOLDER.get_request(correlation_id.as_str()).await {
             request_response_future.put_response_message(Some(Box::new(reply_msg)));
+            REQUEST_FUTURE_HOLDER.remove_request(correlation_id.as_str()).await;
             if request_response_future.get_request_callback().is_some() {
                 request_response_future.on_success();
             }
@@ -185,9 +237,17 @@ impl ClientRemotingProcessor {
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let request_header = request
-            .decode_command_custom_header::<NotifyConsumerIdsChangedRequestHeader>()
-            .unwrap();
+        let request_header = match request.decode_command_custom_header::<NotifyConsumerIdsChangedRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => {
+                warn!(
+                    "ignore malformed NotifyConsumerIdsChanged callback from {}: {}",
+                    channel.remote_address(),
+                    error
+                );
+                return Ok(None);
+            }
+        };
 
         info!(
             "receive broker's notification[{}], the consumer group: {} changed, rebalance immediately",
@@ -206,10 +266,25 @@ impl ClientRemotingProcessor {
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let request_header = request
-            .decode_command_custom_header::<CheckTransactionStateRequestHeader>()
-            .unwrap();
-        let message_ext = MessageDecoder::decode(request.get_body_mut().unwrap(), true, true, false, false, false);
+        let request_header = match request.decode_command_custom_header::<CheckTransactionStateRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => {
+                warn!(
+                    "ignore malformed CheckTransactionState callback from {}: {}",
+                    channel.remote_address(),
+                    error
+                );
+                return Ok(None);
+            }
+        };
+        let Some(body) = request.get_body_mut() else {
+            warn!(
+                "ignore CheckTransactionState callback with missing body from {}",
+                channel.remote_address()
+            );
+            return Ok(None);
+        };
+        let message_ext = MessageDecoder::decode(body, true, true, false, false, false);
         if let Some(mut message_ext) = message_ext {
             if let Some(ref namespace) = self.client_instance.client_config.get_namespace() {
                 let topic = NamespaceUtil::without_namespace_with_namespace(
@@ -281,6 +356,306 @@ impl ClientRemotingProcessor {
                     request_header.consumer_group
                 )),
             ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use bytes::Bytes;
+    use rocketmq_remoting::local::LocalRequestHarness;
+
+    use super::*;
+    use crate::base::client_config::ClientConfig;
+    use crate::producer::request_response_future::RequestResponseFuture;
+
+    fn valid_reply_message_header(correlation_id: Option<CheetahString>, sys_flag: i32) -> ReplyMessageRequestHeader {
+        let properties = correlation_id.map(|correlation_id| {
+            let mut properties = HashMap::new();
+            properties.insert(
+                CheetahString::from_static_str(MessageConst::PROPERTY_CORRELATION_ID),
+                correlation_id,
+            );
+            message_decoder::message_properties_to_string(&properties)
+        });
+
+        ReplyMessageRequestHeader {
+            producer_group: CheetahString::from_static_str("reply-producer"),
+            topic: CheetahString::from_static_str("reply-topic"),
+            default_topic: CheetahString::from_static_str("TBW102"),
+            default_topic_queue_nums: 1,
+            queue_id: 0,
+            sys_flag,
+            born_timestamp: current_millis() as i64,
+            flag: 0,
+            properties,
+            reconsume_times: None,
+            unit_mode: Some(false),
+            born_host: CheetahString::from_static_str("127.0.0.1:10000"),
+            store_host: CheetahString::from_static_str("127.0.0.1:10911"),
+            store_timestamp: current_millis() as i64,
+            topic_request: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn reply_message_processing_removes_completed_future() {
+        let correlation_id = CheetahString::from_string(format!("reply-cleanup-{}", current_millis()));
+        let request_future = std::sync::Arc::new(RequestResponseFuture::new(correlation_id.clone(), 30_000, None));
+        REQUEST_FUTURE_HOLDER
+            .put_request(correlation_id.to_string(), request_future)
+            .await;
+
+        let mut reply_msg = MessageExt::default();
+        MessageAccessor::put_property(
+            &mut reply_msg.message,
+            CheetahString::from_static_str(MessageConst::PROPERTY_CORRELATION_ID),
+            correlation_id.clone(),
+        );
+
+        ClientRemotingProcessor::process_reply_message(reply_msg).await;
+
+        assert!(
+            REQUEST_FUTURE_HOLDER
+                .get_request(correlation_id.as_str())
+                .await
+                .is_none(),
+            "completed reply future should be removed from the holder"
+        );
+    }
+
+    #[tokio::test]
+    async fn push_reply_message_with_malformed_header_returns_system_error() {
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "reply-malformed-test", None);
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_remoting_command(RequestCode::PushReplyMessageToClient);
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("malformed reply callback should not fail")
+            .expect("malformed reply callback should return an error response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+        assert!(response
+            .remark()
+            .is_some_and(|remark| remark.contains("decode reply message request header failed")));
+    }
+
+    #[tokio::test]
+    async fn push_reply_message_with_compressed_missing_body_returns_system_error() {
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "reply-missing-body-test", None);
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::PushReplyMessageToClient,
+            valid_reply_message_header(None, MessageSysFlag::COMPRESSED_FLAG),
+        );
+        request.make_custom_header_to_net();
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("missing body reply callback should not fail")
+            .expect("missing body reply callback should return an error response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+        assert!(response
+            .remark()
+            .is_some_and(|remark| remark.contains("compressed reply message body is missing")));
+    }
+
+    #[tokio::test]
+    async fn push_reply_message_stores_response_and_removes_future() {
+        let correlation_id = CheetahString::from_string(format!("reply-roundtrip-{}", current_millis()));
+        let request_future = std::sync::Arc::new(RequestResponseFuture::new(correlation_id.clone(), 30_000, None));
+        REQUEST_FUTURE_HOLDER
+            .put_request(correlation_id.to_string(), request_future.clone())
+            .await;
+
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "reply-roundtrip-test", None);
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::PushReplyMessageToClient,
+            valid_reply_message_header(Some(correlation_id.clone()), 0),
+        )
+        .set_body(Bytes::from_static(b"reply-body"));
+        request.make_custom_header_to_net();
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("reply callback should not fail")
+            .expect("reply callback should return success response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert!(request_future.get_response_msg().is_some());
+        assert!(
+            REQUEST_FUTURE_HOLDER
+                .get_request(correlation_id.as_str())
+                .await
+                .is_none(),
+            "completed reply future should be removed from the holder"
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_unsubscribe_lite_callback_is_explicit_oneway_noop() {
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "notify-lite-test", None);
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_remoting_command(RequestCode::NotifyUnsubscribeLite);
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("notify unsubscribe lite callback should not fail");
+
+        assert!(response.is_none(), "NotifyUnsubscribeLite is a one-way broker callback");
+    }
+
+    #[tokio::test]
+    async fn notify_unsubscribe_lite_callback_with_valid_header_is_oneway_noop() {
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "notify-lite-valid-test", None);
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::NotifyUnsubscribeLite,
+            NotifyUnsubscribeLiteRequestHeader {
+                lite_topic: CheetahString::from_static_str("lite-topic"),
+                consumer_group: CheetahString::from_static_str("consumer-group"),
+                client_id: CheetahString::from_static_str("client-id"),
+                rpc_request_header: None,
+            },
+        );
+        request.make_custom_header_to_net();
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("notify unsubscribe lite callback should not fail");
+
+        assert!(response.is_none(), "NotifyUnsubscribeLite is a one-way broker callback");
+    }
+
+    #[tokio::test]
+    async fn notify_consumer_ids_changed_with_malformed_header_is_oneway_noop() {
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "notify-consumer-test", None);
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_remoting_command(RequestCode::NotifyConsumerIdsChanged);
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("malformed notify callback should not fail");
+
+        assert!(
+            response.is_none(),
+            "NotifyConsumerIdsChanged is a one-way broker callback"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_transaction_state_with_malformed_header_is_oneway_noop() {
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "tx-malformed-test", None);
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_remoting_command(RequestCode::CheckTransactionState);
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("malformed transaction callback should not fail");
+
+        assert!(
+            response.is_none(),
+            "CheckTransactionState malformed broker callback should be one-way noop"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_transaction_state_with_missing_body_is_oneway_noop() {
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "tx-missing-body-test", None);
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::CheckTransactionState,
+            CheckTransactionStateRequestHeader {
+                topic: Some(CheetahString::from_static_str("tx-topic")),
+                tran_state_table_offset: 0,
+                commit_log_offset: 0,
+                msg_id: Some(CheetahString::from_static_str("msg-id")),
+                transaction_id: Some(CheetahString::from_static_str("tx-id")),
+                offset_msg_id: None,
+                rpc_request_header: None,
+            },
+        );
+        request.make_custom_header_to_net();
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("missing body transaction callback should not fail");
+
+        assert!(
+            response.is_none(),
+            "CheckTransactionState missing-body broker callback should be one-way noop"
+        );
+    }
+
+    #[tokio::test]
+    async fn client_callback_unimplemented_request_codes_return_unsupported() {
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "client-callback-test", None);
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+
+        for request_code in [
+            RequestCode::ResetConsumerClientOffset,
+            RequestCode::GetConsumerStatusFromClient,
+            RequestCode::GetConsumerRunningInfo,
+        ] {
+            let harness = LocalRequestHarness::new()
+                .await
+                .expect("local remoting harness should start");
+            let mut request = RemotingCommand::create_remoting_command(request_code);
+
+            let response = processor
+                .process_request(harness.channel(), harness.context(), &mut request)
+                .await
+                .expect("client callback processor should not fail")
+                .expect("unsupported callback should return an explicit response");
+
+            assert_eq!(
+                ResponseCode::from(response.code()),
+                ResponseCode::RequestCodeNotSupported
+            );
+            assert!(
+                response
+                    .remark()
+                    .expect("unsupported callback should include a remark")
+                    .contains(&request_code.to_i32().to_string()),
+                "{request_code:?} unsupported response should name the request code"
+            );
         }
     }
 }

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -64,6 +64,7 @@ use rocketmq_remoting::protocol::header::message_operation_header::send_message_
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
 use rocketmq_remoting::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use rocketmq_remoting::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
+use rocketmq_remoting::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader;
 use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_remoting::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_remoting::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
@@ -245,6 +246,7 @@ where
             RequestCode::UnregisterClient => self.dispatch_unregister_client(request).await,
             RequestCode::GetConsumerListByGroup => self.dispatch_get_consumer_list_by_group(request).await,
             RequestCode::NotifyConsumerIdsChanged => self.dispatch_notify_consumer_ids_changed(request).await,
+            RequestCode::NotifyUnsubscribeLite => self.dispatch_notify_unsubscribe_lite(request).await,
             RequestCode::LockBatchMq => self.dispatch_lock_batch_mq(request).await,
             RequestCode::UnlockBatchMq => self.dispatch_unlock_batch_mq(request).await,
             RequestCode::CheckClientConfig => self.dispatch_check_client_config(request).await,
@@ -442,6 +444,31 @@ where
                 request.opaque(),
                 ResponseCode::ConsumerNotOnline,
                 format!("no consumer for this group, {}", header.consumer_group),
+            );
+        }
+        RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_opaque(request.opaque())
+    }
+
+    async fn dispatch_notify_unsubscribe_lite(&self, request: &RemotingCommand) -> RemotingCommand {
+        let header = match request.decode_command_custom_header::<NotifyUnsubscribeLiteRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => {
+                return decode_error_response(request.opaque(), "decode notifyUnsubscribeLite header", error);
+            }
+        };
+        if !self
+            .sessions
+            .consumer_client_ids(header.consumer_group.as_str())
+            .iter()
+            .any(|client_id| client_id.as_str() == header.client_id.as_str())
+        {
+            return response_with_code(
+                request.opaque(),
+                ResponseCode::ConsumerNotOnline,
+                format!(
+                    "no matching lite consumer for group {}, clientId {}",
+                    header.consumer_group, header.client_id
+                ),
             );
         }
         RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_opaque(request.opaque())
@@ -1000,6 +1027,7 @@ fn remoting_rpc_name(code: i32) -> &'static str {
         RequestCode::UnregisterClient => "RemotingUnregisterClient",
         RequestCode::GetConsumerListByGroup => "RemotingGetConsumerListByGroup",
         RequestCode::NotifyConsumerIdsChanged => "RemotingNotifyConsumerIdsChanged",
+        RequestCode::NotifyUnsubscribeLite => "RemotingNotifyUnsubscribeLite",
         RequestCode::LockBatchMq => "RemotingLockBatchMq",
         RequestCode::UnlockBatchMq => "RemotingUnlockBatchMq",
         RequestCode::CheckClientConfig => "RemotingCheckClientConfig",
@@ -1519,6 +1547,7 @@ mod tests {
     use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
     use rocketmq_remoting::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
     use rocketmq_remoting::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
+    use rocketmq_remoting::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader;
     use rocketmq_remoting::protocol::header::pull_message_request_header::PullMessageRequestHeader;
     use rocketmq_remoting::protocol::header::pull_message_response_header::PullMessageResponseHeader;
     use rocketmq_remoting::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
@@ -2113,6 +2142,78 @@ mod tests {
         let response = dispatcher.dispatch(&test_context(), &request).await;
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::ConsumerNotOnline);
+    }
+
+    #[tokio::test]
+    async fn dispatch_notify_unsubscribe_lite_validates_matching_session() {
+        let sessions = ClientSessionRegistry::default();
+        let processor = Arc::new(DefaultMessagingProcessor::new(Arc::new(
+            LocalServiceManager::with_services(
+                Arc::new(StaticRouteService::default()),
+                Arc::new(StaticMetadataService::default()),
+                Arc::new(DefaultAssignmentService),
+                Arc::new(TestMessageService),
+                Arc::new(TestConsumerService),
+                Arc::new(DefaultTransactionService),
+            ),
+        )));
+        let dispatcher = ProxyRemotingDispatcher::new(
+            Arc::new(ProxyConfig {
+                mode: ProxyMode::Local,
+                ..ProxyConfig::default()
+            }),
+            processor,
+            sessions.clone(),
+            None,
+        );
+
+        let mut missing_request = RemotingCommand::create_request_command(
+            RequestCode::NotifyUnsubscribeLite,
+            NotifyUnsubscribeLiteRequestHeader {
+                lite_topic: CheetahString::from_static_str("LiteTopic"),
+                consumer_group: CheetahString::from_static_str("GroupA"),
+                client_id: CheetahString::from_static_str("client-a"),
+                rpc_request_header: None,
+            },
+        );
+        missing_request.make_custom_header_to_net();
+        let missing_response = dispatcher.dispatch(&test_context(), &missing_request).await;
+        assert_eq!(
+            ResponseCode::from(missing_response.code()),
+            ResponseCode::ConsumerNotOnline
+        );
+
+        let heartbeat = HeartbeatData {
+            client_id: CheetahString::from_static_str("client-a"),
+            producer_data_set: HashSet::new(),
+            consumer_data_set: HashSet::from([ConsumerData {
+                group_name: CheetahString::from_static_str("GroupA"),
+                ..ConsumerData::default()
+            }]),
+            heartbeat_fingerprint: 0,
+            is_without_sub: false,
+        };
+        let mut heartbeat_request =
+            RemotingCommand::create_request_command(RequestCode::HeartBeat, HeartbeatRequestHeader::default())
+                .set_body(heartbeat.encode().expect("heartbeat should encode"));
+        heartbeat_request.make_custom_header_to_net();
+        let heartbeat_response = dispatcher.dispatch(&test_context(), &heartbeat_request).await;
+        assert_eq!(ResponseCode::from(heartbeat_response.code()), ResponseCode::Success);
+
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::NotifyUnsubscribeLite,
+            NotifyUnsubscribeLiteRequestHeader {
+                lite_topic: CheetahString::from_static_str("LiteTopic"),
+                consumer_group: CheetahString::from_static_str("GroupA"),
+                client_id: CheetahString::from_static_str("client-a"),
+                rpc_request_header: None,
+            },
+        );
+        request.make_custom_header_to_net();
+
+        let response = dispatcher.dispatch(&test_context(), &request).await;
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
     }
 
     #[tokio::test]

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -74,6 +74,7 @@ pub mod notification_request_header;
 pub mod notification_response_header;
 pub mod notify_broker_role_change_request_header;
 pub mod notify_consumer_ids_changed_request_header;
+pub mod notify_unsubscribe_lite_request_header;
 pub mod peek_message_request_header;
 pub mod polling_info_request_header;
 pub mod polling_info_response_header;

--- a/rocketmq-remoting/src/protocol/header/notify_unsubscribe_lite_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/notify_unsubscribe_lite_request_header.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::rpc::rpc_request_header::RpcRequestHeader;
+
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct NotifyUnsubscribeLiteRequestHeader {
+    #[required]
+    pub lite_topic: CheetahString,
+
+    #[required]
+    pub consumer_group: CheetahString,
+
+    #[required]
+    pub client_id: CheetahString,
+
+    #[serde(flatten)]
+    pub rpc_request_header: Option<RpcRequestHeader>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::CommandCustomHeader;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn notify_unsubscribe_lite_request_header_round_trips_ext_fields() {
+        let header = NotifyUnsubscribeLiteRequestHeader {
+            lite_topic: CheetahString::from_static_str("lite-topic"),
+            consumer_group: CheetahString::from_static_str("consumer-group"),
+            client_id: CheetahString::from_static_str("client-id"),
+            rpc_request_header: None,
+        };
+
+        let map = header.to_map().expect("header should encode to ext fields");
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("liteTopic")),
+            Some(&CheetahString::from_static_str("lite-topic"))
+        );
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("consumerGroup")),
+            Some(&CheetahString::from_static_str("consumer-group"))
+        );
+        assert_eq!(
+            map.get(&CheetahString::from_static_str("clientId")),
+            Some(&CheetahString::from_static_str("client-id"))
+        );
+
+        let decoded =
+            <NotifyUnsubscribeLiteRequestHeader as FromMap>::from(&map).expect("header should decode from ext fields");
+        assert_eq!(decoded.lite_topic, "lite-topic");
+        assert_eq!(decoded.consumer_group, "consumer-group");
+        assert_eq!(decoded.client_id, "client-id");
+    }
+
+    #[test]
+    fn notify_unsubscribe_lite_request_header_requires_java_fields() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("liteTopic"),
+            CheetahString::from_static_str("lite-topic"),
+        );
+        map.insert(
+            CheetahString::from_static_str("consumerGroup"),
+            CheetahString::from_static_str("consumer-group"),
+        );
+
+        assert!(
+            <NotifyUnsubscribeLiteRequestHeader as FromMap>::from(&map).is_err(),
+            "clientId is required by the Java header contract"
+        );
+    }
+}

--- a/rocketmq-remoting/src/protocol/headers.rs
+++ b/rocketmq-remoting/src/protocol/headers.rs
@@ -86,6 +86,7 @@ pub mod client {
     pub use super::super::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader;
     pub use super::super::header::heartbeat_request_header::HeartbeatRequestHeader;
     pub use super::super::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
+    pub use super::super::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader;
     pub use super::super::header::unregister_client_request_header::UnregisterClientRequestHeader;
 }
 

--- a/rocketmq-remoting/tests/protocol_compatibility_tests.rs
+++ b/rocketmq-remoting/tests/protocol_compatibility_tests.rs
@@ -267,6 +267,23 @@ const RUST_LEGACY_REQUEST_CODE_EXTRAS: &[(&str, i32, RequestCode)] = &[
     ),
 ];
 
+const JAVA_DEFINITION_ONLY_SERVICE_UNSUPPORTED_REQUEST_CODES: &[(&str, i32)] = &[
+    ("QUERY_BROKER_OFFSET", 13),
+    ("GET_TOPIC_CONFIG_LIST", 22),
+    ("GET_TOPIC_NAME_LIST", 23),
+    ("TRIGGER_DELETE_FILES", 27),
+    ("GET_CLIENT_CONFIG", 47),
+    ("ACK_LITE_MESSAGE", 200072),
+    ("SUSPEND_CONSUMER", 209),
+    ("RESUME_CONSUMER", 210),
+    ("RESET_CONSUMER_OFFSET_IN_CONSUMER", 211),
+    ("RESET_CONSUMER_OFFSET_IN_BROKER", 212),
+    ("ADJUST_CONSUMER_THREAD_POOL", 213),
+    ("WHO_CONSUME_THE_MESSAGE", 214),
+    ("REGISTER_FILTER_SERVER", 301),
+    ("REGISTER_MESSAGE_FILTER_CLASS", 302),
+];
+
 #[test]
 fn protocol_compatibility_java_request_codes_are_defined() {
     assert_eq!(JAVA_REQUEST_CODES.len(), 169);
@@ -281,6 +298,23 @@ fn protocol_compatibility_java_request_codes_are_defined() {
             request_code.to_i32(),
             *value,
             "RequestCode round trip failed for {name}"
+        );
+    }
+}
+
+#[test]
+fn protocol_compatibility_java_definition_only_codes_stay_protocol_defined() {
+    for (name, value) in JAVA_DEFINITION_ONLY_SERVICE_UNSUPPORTED_REQUEST_CODES {
+        assert!(
+            JAVA_REQUEST_CODES
+                .iter()
+                .any(|(java_name, java_value)| java_name == name && java_value == value),
+            "{name}={value} should remain in the Java protocol baseline"
+        );
+        assert_ne!(
+            RequestCode::from(*value),
+            RequestCode::Unknown,
+            "{name}={value} must stay protocol-defined even when the service layer returns unsupported"
         );
     }
 }


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7268

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lite consumer unsubscribe notification support between brokers and clients.
  * Enhanced broker-to-client callback communication mechanisms.

* **Bug Fixes**
  * Improved error handling for unsupported client callbacks; now returns explicit error responses instead of panicking.
  * Enhanced robustness of reply message processing and malformed callback handling with fallback mechanisms.

* **Chores**
  * Expanded protocol compatibility test coverage for definition-only request codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->