### PR TITLE
[ISSUE #7270]♻️refactor RocksDB config export handling to return unsupported backend response

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -3402,6 +3402,7 @@ mod tests {
     use rocketmq_remoting::protocol::body::query_consume_queue_response_body::QueryConsumeQueueResponseBody;
     use rocketmq_remoting::protocol::body::topic_info_wrapper::topic_config_wrapper::TopicConfigAndMappingSerializeWrapper;
     use rocketmq_remoting::protocol::body::user_info::UserInfo;
+    use rocketmq_remoting::protocol::header::add_broker_request_header::AddBrokerRequestHeader;
     use rocketmq_remoting::protocol::header::controller::apply_broker_id_request_header::ApplyBrokerIdRequestHeader;
     use rocketmq_remoting::protocol::header::create_user_request_header::CreateUserRequestHeader;
     use rocketmq_remoting::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
@@ -3433,6 +3434,7 @@ mod tests {
     use rocketmq_remoting::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
     use rocketmq_remoting::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
     use rocketmq_remoting::protocol::header::query_consumer_offset_response_header::QueryConsumerOffsetResponseHeader;
+    use rocketmq_remoting::protocol::header::remove_broker_request_header::RemoveBrokerRequestHeader;
     use rocketmq_remoting::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
     use rocketmq_remoting::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
     use rocketmq_remoting::protocol::header::trigger_lite_dispatch_request_header::TriggerLiteDispatchRequestHeader;
@@ -4773,6 +4775,48 @@ mod tests {
                 "{request_code:?} unsupported response should mention the request code"
             );
         }
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn add_remove_broker_without_container_returns_request_code_not_supported() {
+        let mut runtime = new_phase3_test_runtime("container-add-remove-unsupported").await;
+        let (mut processor, _) = runtime.init_processor();
+
+        let mut add_request = RemotingCommand::create_request_command(
+            RequestCode::AddBroker,
+            AddBrokerRequestHeader {
+                config_path: Some(CheetahString::from_static_str("broker.conf")),
+            },
+        );
+        add_request.make_custom_header_to_net();
+        let add_response = process_broker_request(&mut processor, &mut add_request).await;
+        assert_eq!(
+            ResponseCode::from(add_response.code()),
+            ResponseCode::RequestCodeNotSupported
+        );
+        assert!(add_response
+            .remark()
+            .is_some_and(|remark| remark.contains(&RequestCode::AddBroker.to_i32().to_string())));
+
+        let mut remove_request = RemotingCommand::create_request_command(
+            RequestCode::RemoveBroker,
+            RemoveBrokerRequestHeader {
+                broker_name: CheetahString::from_static_str("broker-a"),
+                broker_cluster_name: CheetahString::from_static_str("DefaultCluster"),
+                broker_id: 1,
+            },
+        );
+        remove_request.make_custom_header_to_net();
+        let remove_response = process_broker_request(&mut processor, &mut remove_request).await;
+        assert_eq!(
+            ResponseCode::from(remove_response.code()),
+            ResponseCode::RequestCodeNotSupported
+        );
+        assert!(remove_response
+            .remark()
+            .is_some_and(|remark| remark.contains(&RequestCode::RemoveBroker.to_i32().to_string())));
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
-use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::common::constant::file_readahead_mode::READ_AHEAD_MODE;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::mix_all;
@@ -26,7 +25,6 @@ use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
 use rocketmq_remoting::protocol::body::kv_table::KVTable;
 use rocketmq_remoting::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigToJsonRequestHeader;
-use rocketmq_remoting::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigType;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_rust::ArcMut;
@@ -224,31 +222,17 @@ impl<MS: MessageStore> BrokerConfigRequestHandler<MS> {
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let response = RemotingCommand::create_response_command();
         let request_header = request.decode_command_custom_header::<ExportRocksdbConfigToJsonRequestHeader>()?;
-        let config_types = match request_header.fetch_config_type() {
-            Ok(config_types) => config_types,
-            Err(error) => {
-                return Ok(Some(
-                    response.set_code(ResponseCode::InvalidParameter).set_remark(error),
-                ));
-            }
-        };
-
-        for config_type in config_types {
-            match config_type {
-                ExportRocksdbConfigType::Topics => {
-                    self.broker_runtime_inner.topic_config_manager().persist();
-                }
-                ExportRocksdbConfigType::SubscriptionGroups => {
-                    self.broker_runtime_inner.subscription_group_manager().persist();
-                }
-                ExportRocksdbConfigType::ConsumerOffsets => {
-                    self.broker_runtime_inner.consumer_offset_manager().persist();
-                }
-            }
+        if let Err(error) = request_header.fetch_config_type() {
+            return Ok(Some(
+                response.set_code(ResponseCode::InvalidParameter).set_remark(error),
+            ));
         }
 
         Ok(Some(
-            response.set_code(ResponseCode::Success).set_remark("export done."),
+            response.set_code(ResponseCode::RequestCodeNotSupported).set_remark(
+                "EXPORT_ROCKSDB_CONFIG_TO_JSON requires a real RocksDB config backend; current Rust broker uses \
+                 file-backed config managers",
+            ),
         ))
     }
 
@@ -670,8 +654,6 @@ mod tests {
 
     use cheetah_string::CheetahString;
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
-    use rocketmq_common::common::config::TopicConfig;
-    use rocketmq_common::common::config_manager::ConfigManager;
     use rocketmq_common::common::constant::file_readahead_mode::READ_AHEAD_MODE;
     use rocketmq_common::common::message::MessageConst;
     use rocketmq_common::TimeUtils::current_millis;
@@ -683,7 +665,6 @@ mod tests {
     use rocketmq_remoting::net::channel::ChannelInner;
     use rocketmq_remoting::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigToJsonRequestHeader;
     use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
-    use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
     use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
     use rocketmq_rust::ArcMut;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
@@ -907,27 +888,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn export_rocksdb_config_to_json_persists_requested_managers() {
+    async fn export_rocksdb_config_without_rocksdb_returns_not_supported() {
         let mut runtime = new_test_runtime("export-config", false).await;
-        let mut inner = runtime.inner_for_test().clone();
-        inner
-            .topic_config_manager_mut()
-            .update_topic_config(ArcMut::new(TopicConfig::with_queues("export-topic", 1, 1)));
-
-        let mut subscription_group_config = SubscriptionGroupConfig::default();
-        subscription_group_config.set_group_name(CheetahString::from_static_str("export-group"));
-        inner
-            .subscription_group_manager_mut()
-            .update_subscription_group_config(&mut subscription_group_config);
-        inner.consumer_offset_manager().commit_offset(
-            CheetahString::from_static_str("client"),
-            &CheetahString::from_static_str("export-group"),
-            &CheetahString::from_static_str("export-topic"),
-            0,
-            7,
-        );
-
-        let mut handler = BrokerConfigRequestHandler::new(inner.clone());
+        let inner = runtime.inner_for_test().clone();
+        let mut handler = BrokerConfigRequestHandler::new(inner);
         let channel = create_test_channel().await;
         let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let mut request = RemotingCommand::create_request_command(
@@ -944,16 +908,17 @@ mod tests {
             .expect("export config should succeed")
             .expect("export config should return response");
 
-        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
-        let topic_json =
-            fs::read_to_string(inner.topic_config_manager().config_file_path()).expect("topic config file");
-        let group_json =
-            fs::read_to_string(inner.subscription_group_manager().config_file_path()).expect("group config file");
-        let offset_json =
-            fs::read_to_string(inner.consumer_offset_manager().config_file_path()).expect("offset config file");
-        assert!(topic_json.contains("export-topic"));
-        assert!(group_json.contains("export-group"));
-        assert!(offset_json.contains("export-topic@export-group"));
+        assert_eq!(
+            ResponseCode::from(response.code()),
+            ResponseCode::RequestCodeNotSupported
+        );
+        assert_eq!(
+            response
+                .remark()
+                .expect("export rocksdb config should explain unsupported backend"),
+            "EXPORT_ROCKSDB_CONFIG_TO_JSON requires a real RocksDB config backend; current Rust broker uses \
+             file-backed config managers"
+        );
 
         let _ = fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
@@ -16,8 +16,6 @@ use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
-use rocketmq_remoting::protocol::body::check_rocksdb_cqwrite_progress_response_body::CheckRocksdbCqWriteResult;
-use rocketmq_remoting::protocol::body::check_rocksdb_cqwrite_progress_response_body::CheckStatus;
 use rocketmq_remoting::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader;
 use rocketmq_remoting::protocol::header::get_earliest_msg_storetime_request_header::GetEarliestMsgStoretimeRequestHeader;
 use rocketmq_remoting::protocol::header::get_earliest_msg_storetime_response_header::GetEarliestMsgStoretimeResponseHeader;
@@ -29,7 +27,6 @@ use rocketmq_remoting::protocol::header::message_operation_header::TopicRequestH
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_context::TopicQueueMappingContext;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_utils::TopicQueueMappingUtils;
-use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::rpc::rpc_client::RpcClient;
 use rocketmq_remoting::rpc::rpc_request::RpcRequest;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
@@ -347,16 +344,11 @@ impl<MS: MessageStore> OffsetRequestHandler<MS> {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let _request_header = request.decode_command_custom_header::<CheckRocksdbCqWriteProgressRequestHeader>()?;
-        let body = CheckRocksdbCqWriteResult {
-            check_result: Some("It is not CombineConsumeQueueStore, no need check".into()),
-            check_status: CheckStatus::CheckOk as i32,
-        };
-
-        Ok(Some(
-            RemotingCommand::create_response_command()
-                .set_code(ResponseCode::Success)
-                .set_body(body.encode()?),
-        ))
+        Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            ResponseCode::RequestCodeNotSupported,
+            "CHECK_ROCKSDB_CQ_WRITE_PROGRESS requires a real RocksDB consume queue backend; current Rust broker uses \
+             file-backed consume queues",
+        )))
     }
 
     pub async fn get_all_subscription_group_config(
@@ -479,14 +471,11 @@ mod tests {
     use rocketmq_remoting::connection::Connection;
     use rocketmq_remoting::net::channel::Channel;
     use rocketmq_remoting::net::channel::ChannelInner;
-    use rocketmq_remoting::protocol::body::check_rocksdb_cqwrite_progress_response_body::CheckRocksdbCqWriteResult;
-    use rocketmq_remoting::protocol::body::check_rocksdb_cqwrite_progress_response_body::CheckStatus;
     use rocketmq_remoting::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader;
     use rocketmq_remoting::protocol::header::empty_header::EmptyHeader;
     use rocketmq_remoting::protocol::header::get_earliest_msg_storetime_request_header::GetEarliestMsgStoretimeRequestHeader;
     use rocketmq_remoting::protocol::header::get_earliest_msg_storetime_response_header::GetEarliestMsgStoretimeResponseHeader;
     use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
-    use rocketmq_remoting::protocol::RemotingDeserializable;
     use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
     use rocketmq_rust::ArcMut;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
@@ -597,7 +586,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn check_rocksdb_cq_write_progress_returns_no_need_check_for_local_file_store() {
+    async fn check_rocksdb_cq_write_progress_without_rocksdb_returns_not_supported() {
         let mut runtime = new_test_runtime("check-rocksdb-progress").await;
         let inner = runtime.inner_for_test().clone();
         let mut handler = OffsetRequestHandler::new(inner);
@@ -613,24 +602,22 @@ mod tests {
         let channel = create_test_channel().await;
         let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
 
-        let mut response = handler
+        let response = handler
             .check_rocksdb_cq_write_progress(channel, ctx, RequestCode::CheckRocksdbCqWriteProgress, &mut request)
             .await
             .expect("check rocksdb cq write progress should succeed")
             .expect("check rocksdb cq write progress should return response");
 
-        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
-        let body = CheckRocksdbCqWriteResult::decode(
-            response
-                .take_body()
-                .expect("check rocksdb cq write progress should contain body")
-                .as_ref(),
-        )
-        .expect("decode check rocksdb cq write progress body");
-        assert_eq!(body.get_check_status(), CheckStatus::CheckOk);
         assert_eq!(
-            body.check_result.as_deref(),
-            Some("It is not CombineConsumeQueueStore, no need check")
+            ResponseCode::from(response.code()),
+            ResponseCode::RequestCodeNotSupported
+        );
+        assert_eq!(
+            response
+                .remark()
+                .expect("check rocksdb cq write progress should explain unsupported backend"),
+            "CHECK_ROCKSDB_CQ_WRITE_PROGRESS requires a real RocksDB consume queue backend; current Rust broker uses \
+             file-backed consume queues"
         );
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());

--- a/rocketmq-controller/tests/controller_request_processor_contract_test.rs
+++ b/rocketmq-controller/tests/controller_request_processor_contract_test.rs
@@ -611,6 +611,37 @@ async fn controller_request_contract_get_sync_state_data() {
 }
 
 #[tokio::test]
+async fn dledger_only_request_codes_return_request_code_not_supported() {
+    let mut harness = ProcessorHarness::new().await;
+
+    for request_code in [
+        RequestCode::BrokerCloseChannelRequest,
+        RequestCode::CheckNotActiveBrokerRequest,
+        RequestCode::GetBrokerLiveInfoRequest,
+        RequestCode::GetSyncStateDataRequest,
+        RequestCode::RaftBrokerHeartBeatEventRequest,
+    ] {
+        let response = harness
+            .send(RemotingCommand::create_remoting_command(request_code))
+            .await;
+
+        assert_eq!(
+            ResponseCode::from(response.code()),
+            ResponseCode::RequestCodeNotSupported,
+            "{request_code:?} should stay outside the non-DLedger controller contract"
+        );
+        assert!(
+            response
+                .remark()
+                .is_some_and(|remark| remark.contains(&request_code.to_i32().to_string())),
+            "{request_code:?} unsupported response should mention the request code"
+        );
+    }
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
 async fn controller_request_contract_update_controller_config() {
     let mut harness = ProcessorHarness::new().await;
     let response = harness


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7270

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Broker now properly rejects unsupported broker configuration requests with appropriate error responses.
  * Broker now properly rejects unsupported RocksDB operations with appropriate error responses.
  * Controller now properly rejects non-DLedger request codes with appropriate error responses.

* **Tests**
  * Added tests to verify proper handling and rejection of unsupported operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->