### PR TITLE
[ISSUE #7272]🚀add reset consumer client offset and get consumer status request handling

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -1544,6 +1544,34 @@ impl MQConsumerInner for DefaultLitePullConsumerImpl {
         self.client_config.unit_mode
     }
 
+    async fn reset_offsets(&self, topic: &CheetahString, offsets: HashMap<MessageQueue, i64>) {
+        let Some(offset_store) = self.offset_store.as_ref() else {
+            warn!(
+                "lite pull reset offset ignored because offset store is not initialized. group={}, topic={}",
+                self.consumer_config.consumer_group, topic
+            );
+            return;
+        };
+
+        for (mq, offset) in offsets {
+            if mq.topic() == topic {
+                offset_store.update_and_freeze_offset(&mq, offset).await;
+            }
+        }
+    }
+
+    async fn consumer_status(&self, topic: &CheetahString) -> HashMap<MessageQueue, i64> {
+        let Some(offset_store) = self.offset_store.as_ref() else {
+            warn!(
+                "lite pull consumer status is empty because offset store is not initialized. group={}, topic={}",
+                self.consumer_config.consumer_group, topic
+            );
+            return HashMap::new();
+        };
+
+        offset_store.clone_offset_table(topic).await
+    }
+
     fn consumer_running_info(&self) -> rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInfo {
         rocketmq_remoting::protocol::body::consumer_running_info::ConsumerRunningInfo::default()
     }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
 use std::sync::atomic::AtomicBool;
@@ -1507,6 +1508,34 @@ impl MQConsumerInner for DefaultMQPushConsumerImpl {
 
     fn is_unit_mode(&self) -> bool {
         self.consumer_config.unit_mode
+    }
+
+    async fn reset_offsets(&self, topic: &CheetahString, offsets: HashMap<MessageQueue, i64>) {
+        let Some(offset_store) = self.offset_store.as_ref() else {
+            warn!(
+                "reset offset ignored because offset store is not initialized. group={}, topic={}",
+                self.consumer_config.consumer_group, topic
+            );
+            return;
+        };
+
+        for (mq, offset) in offsets {
+            if mq.topic() == topic {
+                offset_store.update_and_freeze_offset(&mq, offset).await;
+            }
+        }
+    }
+
+    async fn consumer_status(&self, topic: &CheetahString) -> HashMap<MessageQueue, i64> {
+        let Some(offset_store) = self.offset_store.as_ref() else {
+            warn!(
+                "consumer status is empty because offset store is not initialized. group={}, topic={}",
+                self.consumer_config.consumer_group, topic
+            );
+            return HashMap::new();
+        };
+
+        offset_store.clone_offset_table(topic).await
     }
 
     fn consumer_running_info(&self) -> ConsumerRunningInfo {

--- a/rocketmq-client/src/consumer/mq_consumer_inner.rs
+++ b/rocketmq-client/src/consumer/mq_consumer_inner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 use cheetah_string::CheetahString;
@@ -81,6 +82,12 @@ pub trait MQConsumerInnerLocal: MQConsumerInnerAny + Sync + 'static {
 
     /// Returns whether the consumer is in unit mode.
     fn is_unit_mode(&self) -> bool;
+
+    /// Replaces the in-memory offsets for queues belonging to the given topic.
+    async fn reset_offsets(&self, topic: &CheetahString, offsets: HashMap<MessageQueue, i64>);
+
+    /// Returns a snapshot of the consumer offsets for the given topic.
+    async fn consumer_status(&self, topic: &CheetahString) -> HashMap<MessageQueue, i64>;
 
     /// Returns the running information of the consumer.
     fn consumer_running_info(&self) -> ConsumerRunningInfo;
@@ -182,6 +189,16 @@ impl MQConsumerInner for MQConsumerInnerImpl {
     #[inline]
     fn is_unit_mode(&self) -> bool {
         MQConsumerInner::is_unit_mode(self.default_mqpush_consumer_impl.as_ref())
+    }
+
+    #[inline]
+    async fn reset_offsets(&self, topic: &CheetahString, offsets: HashMap<MessageQueue, i64>) {
+        MQConsumerInner::reset_offsets(self.default_mqpush_consumer_impl.as_ref(), topic, offsets).await
+    }
+
+    #[inline]
+    async fn consumer_status(&self, topic: &CheetahString) -> HashMap<MessageQueue, i64> {
+        MQConsumerInner::consumer_status(self.default_mqpush_consumer_impl.as_ref(), topic).await
     }
 
     #[inline]

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -1576,6 +1576,34 @@ impl MQClientInstance {
         self.consumer_table.get(group).map(|entry| entry.value().clone())
     }
 
+    pub async fn reset_offset(
+        &self,
+        topic: &CheetahString,
+        group: &CheetahString,
+        offset_table: HashMap<MessageQueue, i64>,
+    ) -> bool {
+        let Some(consumer) = self.select_consumer(group).await else {
+            warn!("reset offset failed because consumer group does not exist. group={group}, topic={topic}");
+            return false;
+        };
+
+        consumer.reset_offsets(topic, offset_table).await;
+        true
+    }
+
+    pub async fn get_consumer_status(
+        &self,
+        topic: &CheetahString,
+        group: &CheetahString,
+    ) -> Option<HashMap<MessageQueue, i64>> {
+        let Some(consumer) = self.select_consumer(group).await else {
+            warn!("get consumer status failed because consumer group does not exist. group={group}, topic={topic}");
+            return None;
+        };
+
+        Some(consumer.consumer_status(topic).await)
+    }
+
     pub async fn select_producer(&self, group: &str) -> Option<MQProducerInnerImpl> {
         self.producer_table.get(group).map(|entry| entry.value().clone())
     }

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -27,11 +27,15 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::body::response::get_consumer_status_body::GetConsumerStatusBody;
+use rocketmq_remoting::protocol::body::response::reset_offset_body::ResetOffsetBody;
 use rocketmq_remoting::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_remoting::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
+use rocketmq_remoting::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
 use rocketmq_remoting::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
 use rocketmq_remoting::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader;
 use rocketmq_remoting::protocol::header::reply_message_request_header::ReplyMessageRequestHeader;
+use rocketmq_remoting::protocol::header::reset_offset_request_header::ResetOffsetRequestHeader;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingSerializable;
@@ -67,9 +71,9 @@ impl RequestProcessor for ClientRemotingProcessor {
         info!("process_request: {:?}", request_code);
         match request_code {
             RequestCode::CheckTransactionState => self.check_transaction_state(channel, ctx, request).await,
-            RequestCode::ResetConsumerClientOffset
-            | RequestCode::GetConsumerStatusFromClient
-            | RequestCode::GetConsumerRunningInfo => Ok(Some(Self::unsupported_client_callback_response(request_code))),
+            RequestCode::ResetConsumerClientOffset => self.reset_consumer_client_offset(channel, request).await,
+            RequestCode::GetConsumerStatusFromClient => self.get_consumer_status_from_client(request).await,
+            RequestCode::GetConsumerRunningInfo => Ok(Some(Self::unsupported_client_callback_response(request_code))),
             RequestCode::ConsumeMessageDirectly => self.consume_message_directly(channel, ctx, request).await,
             //RPC message handle code
             RequestCode::PushReplyMessageToClient => self.receive_reply_message(ctx, request).await,
@@ -260,6 +264,79 @@ impl ClientRemotingProcessor {
         Ok(None)
     }
 
+    async fn reset_consumer_client_offset(
+        &mut self,
+        channel: Channel,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_header = match request.decode_command_custom_header::<ResetOffsetRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => {
+                warn!(
+                    "ignore malformed ResetConsumerClientOffset callback from {}: {}",
+                    channel.remote_address(),
+                    error
+                );
+                return Ok(None);
+            }
+        };
+        let Some(body) = request.get_body() else {
+            warn!(
+                "ignore ResetConsumerClientOffset callback with missing body from {}; topic={}, group={}",
+                channel.remote_address(),
+                request_header.topic,
+                request_header.group
+            );
+            return Ok(None);
+        };
+        let Some(reset_body) = ResetOffsetBody::decode(body) else {
+            warn!(
+                "ignore ResetConsumerClientOffset callback with malformed body from {}; topic={}, group={}",
+                channel.remote_address(),
+                request_header.topic,
+                request_header.group
+            );
+            return Ok(None);
+        };
+
+        self.client_instance
+            .reset_offset(&request_header.topic, &request_header.group, reset_body.offset_table)
+            .await;
+        Ok(None)
+    }
+
+    async fn get_consumer_status_from_client(
+        &mut self,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let response = RemotingCommand::create_response_command().set_opaque(request.opaque());
+        let request_header = match request.decode_command_custom_header::<GetConsumerStatusRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => {
+                warn!("decode GetConsumerStatusFromClient request header failed: {}", error);
+                return Ok(Some(response.set_code(ResponseCode::SystemError).set_remark(format!(
+                    "decode GetConsumerStatusFromClient request header failed: {error}"
+                ))));
+            }
+        };
+
+        match self
+            .client_instance
+            .get_consumer_status(&request_header.topic, &request_header.group)
+            .await
+        {
+            Some(message_queue_table) => {
+                let mut body = GetConsumerStatusBody::new();
+                body.message_queue_table = message_queue_table;
+                Ok(Some(response.set_body(body.encode())))
+            }
+            None => Ok(Some(response.set_code(ResponseCode::SystemError).set_remark(format!(
+                "The Consumer Group <{}> not exist in this consumer",
+                request_header.group
+            )))),
+        }
+    }
+
     async fn check_transaction_state(
         &mut self,
         channel: Channel,
@@ -365,11 +442,54 @@ mod tests {
     use std::collections::HashMap;
 
     use bytes::Bytes;
+    use rocketmq_common::common::message::message_queue::MessageQueue;
     use rocketmq_remoting::local::LocalRequestHarness;
 
     use super::*;
     use crate::base::client_config::ClientConfig;
+    use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
+    use crate::consumer::default_mq_push_consumer::ConsumerConfig;
+    use crate::consumer::mq_consumer_inner::MQConsumerInnerImpl;
+    use crate::consumer::store::offset_store::OffsetStore;
+    use crate::consumer::store::read_offset_type::ReadOffsetType;
+    use crate::consumer::store::remote_broker_offset_store::RemoteBrokerOffsetStore;
     use crate::producer::request_response_future::RequestResponseFuture;
+
+    async fn client_with_push_consumer(
+        group: CheetahString,
+        client_id: &str,
+    ) -> (ArcMut<MQClientInstance>, ArcMut<DefaultMQPushConsumerImpl>) {
+        let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, client_id, None);
+        let consumer_config = ConsumerConfig {
+            consumer_group: group.clone(),
+            ..Default::default()
+        };
+        let consumer_config = ArcMut::new(consumer_config);
+        let mut consumer_impl = ArcMut::new(DefaultMQPushConsumerImpl::new(
+            ClientConfig::default(),
+            consumer_config,
+            None,
+        ));
+        let wrapper = consumer_impl.clone();
+        consumer_impl.set_default_mqpush_consumer_impl(wrapper);
+        consumer_impl.offset_store = Some(ArcMut::new(OffsetStore::new_with_remote(RemoteBrokerOffsetStore::new(
+            client_instance.clone(),
+            group.clone(),
+        ))));
+
+        let registered = client_instance
+            .mut_from_ref()
+            .register_consumer(
+                &group,
+                MQConsumerInnerImpl {
+                    default_mqpush_consumer_impl: consumer_impl.clone(),
+                },
+            )
+            .await;
+        assert!(registered, "test consumer should register");
+
+        (client_instance, consumer_impl)
+    }
 
     fn valid_reply_message_header(correlation_id: Option<CheetahString>, sys_flag: i32) -> ReplyMessageRequestHeader {
         let properties = correlation_id.map(|correlation_id| {
@@ -398,6 +518,154 @@ mod tests {
             store_timestamp: current_millis() as i64,
             topic_request: None,
         }
+    }
+
+    #[tokio::test]
+    async fn reset_consumer_client_offset_updates_matching_consumer_offsets() {
+        let topic = CheetahString::from_static_str("reset-topic");
+        let group = CheetahString::from_static_str("reset-group");
+        let (client_instance, consumer_impl) =
+            client_with_push_consumer(group.clone(), "reset-consumer-offset-test").await;
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mq = MessageQueue::from_parts(topic.clone(), "broker-a", 0);
+        let mut reset_body = ResetOffsetBody::new();
+        reset_body.offset_table.insert(mq.clone(), 123);
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::ResetConsumerClientOffset,
+            ResetOffsetRequestHeader {
+                topic: topic.clone(),
+                group: group.clone(),
+                queue_id: -1,
+                offset: None,
+                timestamp: current_millis() as i64,
+                is_force: true,
+                topic_request_header: None,
+            },
+        )
+        .set_body(reset_body.encode());
+        request.make_custom_header_to_net();
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("reset offset callback should not fail");
+
+        assert!(
+            response.is_none(),
+            "ResetConsumerClientOffset is a one-way broker callback"
+        );
+        let stored_offset = consumer_impl
+            .offset_store
+            .as_ref()
+            .expect("test consumer should have offset store")
+            .read_offset(&mq, ReadOffsetType::ReadFromMemory)
+            .await;
+        assert_eq!(stored_offset, 123);
+    }
+
+    #[tokio::test]
+    async fn reset_consumer_client_offset_with_missing_body_is_oneway_noop() {
+        let topic = CheetahString::from_static_str("reset-missing-body-topic");
+        let group = CheetahString::from_static_str("reset-missing-body-group");
+        let (client_instance, _) = client_with_push_consumer(group.clone(), "reset-missing-body-test").await;
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::ResetConsumerClientOffset,
+            ResetOffsetRequestHeader {
+                topic,
+                group,
+                queue_id: -1,
+                offset: None,
+                timestamp: current_millis() as i64,
+                is_force: true,
+                topic_request_header: None,
+            },
+        );
+        request.make_custom_header_to_net();
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("missing-body reset offset callback should not fail");
+
+        assert!(response.is_none(), "missing reset body should be a one-way noop");
+    }
+
+    #[tokio::test]
+    async fn get_consumer_status_from_client_returns_offset_table_body() {
+        let topic = CheetahString::from_static_str("status-topic");
+        let group = CheetahString::from_static_str("status-group");
+        let (client_instance, consumer_impl) = client_with_push_consumer(group.clone(), "consumer-status-test").await;
+        let mq = MessageQueue::from_parts(topic.clone(), "broker-a", 1);
+        consumer_impl
+            .offset_store
+            .as_ref()
+            .expect("test consumer should have offset store")
+            .update_offset(&mq, 456, false)
+            .await;
+
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::GetConsumerStatusFromClient,
+            GetConsumerStatusRequestHeader {
+                topic,
+                group,
+                client_addr: None,
+                rpc_request_header: None,
+            },
+        );
+        request.make_custom_header_to_net();
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("consumer status callback should not fail")
+            .expect("consumer status callback should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let body = response.body().expect("consumer status response should have body");
+        let body = GetConsumerStatusBody::decode(body).expect("consumer status body should decode");
+        assert_eq!(body.message_queue_table.get(&mq), Some(&456));
+    }
+
+    #[tokio::test]
+    async fn get_consumer_status_from_client_missing_group_returns_system_error() {
+        let client_instance =
+            MQClientInstance::new_arc(ClientConfig::default(), 0, "consumer-status-missing-test", None);
+        let mut processor = ClientRemotingProcessor::new(client_instance);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::GetConsumerStatusFromClient,
+            GetConsumerStatusRequestHeader {
+                topic: CheetahString::from_static_str("missing-status-topic"),
+                group: CheetahString::from_static_str("missing-status-group"),
+                client_addr: None,
+                rpc_request_header: None,
+            },
+        );
+        request.make_custom_header_to_net();
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("missing-group consumer status callback should not fail")
+            .expect("missing-group consumer status callback should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+        assert!(response
+            .remark()
+            .is_some_and(|remark| remark.contains("not exist in this consumer")));
     }
 
     #[tokio::test]
@@ -629,11 +897,7 @@ mod tests {
         let client_instance = MQClientInstance::new_arc(ClientConfig::default(), 0, "client-callback-test", None);
         let mut processor = ClientRemotingProcessor::new(client_instance);
 
-        for request_code in [
-            RequestCode::ResetConsumerClientOffset,
-            RequestCode::GetConsumerStatusFromClient,
-            RequestCode::GetConsumerRunningInfo,
-        ] {
+        for request_code in [RequestCode::GetConsumerRunningInfo] {
             let harness = LocalRequestHarness::new()
                 .await
                 .expect("local remoting harness should start");

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -174,6 +174,7 @@ where
                 return Ok(Some(auth_error_response(request.opaque(), error)));
             }
         }
+        self.dispatcher.bind_remoting_channel_if_heartbeat(&channel, request);
         Ok(Some(self.dispatcher.dispatch(&context, request).await))
     }
 
@@ -269,6 +270,22 @@ where
                     request.code()
                 ),
             ),
+        }
+    }
+
+    fn bind_remoting_channel_if_heartbeat(&self, channel: &Channel, request: &RemotingCommand) {
+        if RequestCode::from(request.code()) != RequestCode::HeartBeat {
+            return;
+        }
+        let Some(body) = request.body() else {
+            return;
+        };
+        let Ok(heartbeat) = SerdeJsonUtils::from_json_bytes::<HeartbeatData>(body.as_ref()) else {
+            return;
+        };
+        if !heartbeat.client_id.is_empty() {
+            self.sessions
+                .bind_remoting_channel(heartbeat.client_id.as_str(), channel.clone());
         }
     }
 
@@ -468,6 +485,30 @@ where
                 format!(
                     "no matching lite consumer for group {}, clientId {}",
                     header.consumer_group, header.client_id
+                ),
+            );
+        }
+        let Some(mut client_channel) = self.sessions.remoting_channel(header.client_id.as_str()) else {
+            return response_with_code(
+                request.opaque(),
+                ResponseCode::ConsumerNotOnline,
+                format!(
+                    "no remoting channel for lite consumer group {}, clientId {}",
+                    header.consumer_group, header.client_id
+                ),
+            );
+        };
+        if let Err(error) = client_channel
+            .channel_inner_mut()
+            .send_oneway(request.clone(), 100)
+            .await
+        {
+            return response_with_code(
+                request.opaque(),
+                ResponseCode::SystemError,
+                format!(
+                    "forward notifyUnsubscribeLite failed for group {}, clientId {}: {}",
+                    header.consumer_group, header.client_id, error
                 ),
             );
         }
@@ -1529,6 +1570,7 @@ mod tests {
     use rocketmq_error::RocketMQError;
     use rocketmq_remoting::code::request_code::RequestCode;
     use rocketmq_remoting::code::response_code::ResponseCode;
+    use rocketmq_remoting::local::LocalRequestHarness;
     use rocketmq_remoting::prelude::RemotingDeserializable;
     use rocketmq_remoting::prelude::RemotingSerializable;
     use rocketmq_remoting::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
@@ -1564,9 +1606,12 @@ mod tests {
     use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
     use rocketmq_remoting::protocol::route::route_data_view::QueueData;
     use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+    use rocketmq_remoting::runtime::processor::RequestProcessor;
+    use tokio::time::timeout;
 
     use super::ProxyRemotingBackend;
     use super::ProxyRemotingDispatcher;
+    use super::ProxyRemotingRequestProcessor;
     use crate::auth::ProxyAuthRuntime;
     use crate::config::ProxyAuthConfig;
     use crate::config::ProxyConfig;
@@ -1955,6 +2000,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn process_request_heartbeat_binds_remoting_channel() {
+        let sessions = ClientSessionRegistry::default();
+        let processor = Arc::new(DefaultMessagingProcessor::new(Arc::new(
+            LocalServiceManager::with_services(
+                Arc::new(StaticRouteService::default()),
+                Arc::new(StaticMetadataService::default()),
+                Arc::new(DefaultAssignmentService),
+                Arc::new(TestMessageService),
+                Arc::new(TestConsumerService),
+                Arc::new(DefaultTransactionService),
+            ),
+        )));
+        let mut request_processor = ProxyRemotingRequestProcessor::new(
+            Arc::new(ProxyConfig {
+                mode: ProxyMode::Local,
+                ..ProxyConfig::default()
+            }),
+            processor,
+            sessions.clone(),
+            None,
+            None,
+        );
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        let heartbeat = HeartbeatData {
+            client_id: CheetahString::from_static_str("client-a"),
+            producer_data_set: HashSet::new(),
+            consumer_data_set: HashSet::from([ConsumerData {
+                group_name: CheetahString::from_static_str("GroupA"),
+                ..ConsumerData::default()
+            }]),
+            heartbeat_fingerprint: 0,
+            is_without_sub: false,
+        };
+        let mut heartbeat_request =
+            RemotingCommand::create_request_command(RequestCode::HeartBeat, HeartbeatRequestHeader::default())
+                .set_body(heartbeat.encode().expect("heartbeat should encode"));
+        heartbeat_request.make_custom_header_to_net();
+
+        let response = request_processor
+            .process_request(harness.channel(), harness.context(), &mut heartbeat_request)
+            .await
+            .expect("heartbeat should process")
+            .expect("heartbeat should return a response");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert_eq!(sessions.consumer_client_ids("GroupA"), vec!["client-a".to_owned()]);
+        assert!(sessions.remoting_channel("client-a").is_some());
+    }
+
+    #[tokio::test]
     async fn dispatch_unregister_client_removes_membership() {
         let sessions = ClientSessionRegistry::default();
         let processor = Arc::new(DefaultMessagingProcessor::new(Arc::new(
@@ -2199,6 +2296,10 @@ mod tests {
         heartbeat_request.make_custom_header_to_net();
         let heartbeat_response = dispatcher.dispatch(&test_context(), &heartbeat_request).await;
         assert_eq!(ResponseCode::from(heartbeat_response.code()), ResponseCode::Success);
+        let mut harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        sessions.bind_remoting_channel("client-a", harness.channel());
 
         let mut request = RemotingCommand::create_request_command(
             RequestCode::NotifyUnsubscribeLite,
@@ -2214,6 +2315,18 @@ mod tests {
         let response = dispatcher.dispatch(&test_context(), &request).await;
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let forwarded = timeout(std::time::Duration::from_secs(3), harness.receive_response())
+            .await
+            .expect("forwarded notify unsubscribe lite should arrive before timeout")
+            .expect("forwarded notify unsubscribe lite should decode")
+            .expect("forwarded notify unsubscribe lite should be present");
+        assert_eq!(RequestCode::from(forwarded.code()), RequestCode::NotifyUnsubscribeLite);
+        assert!(forwarded.is_oneway_rpc());
+        let forwarded_header = forwarded
+            .decode_command_custom_header::<NotifyUnsubscribeLiteRequestHeader>()
+            .expect("forwarded notify header should decode");
+        assert_eq!(forwarded_header.consumer_group, "GroupA");
+        assert_eq!(forwarded_header.client_id, "client-a");
     }
 
     #[tokio::test]

--- a/rocketmq-proxy/src/session.rs
+++ b/rocketmq-proxy/src/session.rs
@@ -20,6 +20,7 @@ use std::time::SystemTime;
 use dashmap::DashMap;
 use rocketmq_common::get_parent_and_lite_topic;
 use rocketmq_common::to_lmq_name;
+use rocketmq_remoting::net::channel::Channel;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -334,6 +335,7 @@ pub struct ClientSessionRegistry {
     lite_subscriptions: Arc<DashMap<LiteSubscriptionKey, LiteSubscriptionSnapshot>>,
     prepared_transactions: Arc<DashMap<PreparedTransactionKey, PreparedTransactionHandle>>,
     telemetry_links: Arc<DashMap<String, TelemetryLink>>,
+    remoting_channels: Arc<DashMap<String, Channel>>,
     pending_telemetry_commands: Arc<DashMap<TelemetryCommandKey, PendingTelemetryCommand>>,
     thread_stack_traces: Arc<DashMap<ThreadStackTraceKey, ThreadStackTraceReport>>,
     verify_message_reports: Arc<DashMap<TelemetryCommandKey, VerifyMessageReport>>,
@@ -656,6 +658,14 @@ impl ClientSessionRegistry {
 
     pub fn has_telemetry_link(&self, client_id: &str) -> bool {
         self.telemetry_links.contains_key(client_id)
+    }
+
+    pub fn bind_remoting_channel(&self, client_id: impl Into<String>, channel: Channel) {
+        self.remoting_channels.insert(client_id.into(), channel);
+    }
+
+    pub fn remoting_channel(&self, client_id: &str) -> Option<Channel> {
+        self.remoting_channels.get(client_id).map(|entry| entry.clone())
     }
 
     pub fn register_pending_telemetry_command(&self, client_id: &str, kind: TelemetryCommandKind, nonce: &str) -> bool {
@@ -1013,6 +1023,7 @@ impl ClientSessionRegistry {
             let _ = self.prepared_transactions.remove(&key);
         }
         self.telemetry_links.remove(client_id);
+        self.remoting_channels.remove(client_id);
         let pending_telemetry_keys = self
             .pending_telemetry_commands
             .iter()
@@ -1082,6 +1093,10 @@ impl ClientSessionRegistry {
 
     pub fn telemetry_link_count(&self) -> usize {
         self.telemetry_links.len()
+    }
+
+    pub fn remoting_channel_count(&self) -> usize {
+        self.remoting_channels.len()
     }
 
     pub fn pending_telemetry_command_count(&self) -> usize {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7272

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consumer offset management capabilities: reset offsets for a specific topic and retrieve consumer status (current offset state).
  * Enhanced client request handling to support remote offset reset and status queries.
  * Improved proxy session management to track and forward consumer-related client requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->