### PR TITLE
[ISSUE #7274]✨add transaction end header building and validation for consumer requests

### DIFF
--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -2197,6 +2197,36 @@ impl DefaultMQProducerImpl {
         }
     }
 
+    fn build_end_transaction_header_for_check(
+        producer_group: CheetahString,
+        check_request_header: &CheckTransactionStateRequestHeader,
+        msg_id: CheetahString,
+        transaction_state: LocalTransactionState,
+    ) -> EndTransactionRequestHeader {
+        EndTransactionRequestHeader {
+            topic: check_request_header.topic.clone().unwrap_or_default(),
+            producer_group,
+            tran_state_table_offset: check_request_header.tran_state_table_offset as u64,
+            commit_log_offset: check_request_header.commit_log_offset as u64,
+            commit_or_rollback: match transaction_state {
+                LocalTransactionState::CommitMessage => MessageSysFlag::TRANSACTION_COMMIT_TYPE,
+                LocalTransactionState::RollbackMessage => MessageSysFlag::TRANSACTION_ROLLBACK_TYPE,
+                LocalTransactionState::Unknown => MessageSysFlag::TRANSACTION_NOT_TYPE,
+            },
+            from_transaction_check: true,
+            msg_id,
+            transaction_id: check_request_header.transaction_id.clone(),
+            rpc_request_header: RpcRequestHeader {
+                broker_name: check_request_header
+                    .rpc_request_header
+                    .clone()
+                    .unwrap_or_default()
+                    .broker_name,
+                ..Default::default()
+            },
+        }
+    }
+
     pub fn set_default_mqproducer_impl_inner(
         &mut self,
         default_mqproducer_impl_inner: WeakArcMut<DefaultMQProducerImpl>,
@@ -2252,12 +2282,11 @@ impl MQProducerInner for DefaultMQProducerImpl {
         // Use spawn_blocking to avoid blocking Tokio worker threads (matches Java's ExecutorService
         // behavior)
         tokio::task::spawn_blocking(move || {
-            let mut unique_key = msg.property(&CheetahString::from_static_str(
-                MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
-            ));
-            if unique_key.is_none() {
-                unique_key = Some(msg.msg_id.clone());
-            }
+            let unique_key = msg
+                .property(&CheetahString::from_static_str(
+                    MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+                ))
+                .unwrap_or_else(|| msg.msg_id.clone());
 
             // Check local transaction state with exception handling (synchronous execution)
             let transaction_state = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -2277,43 +2306,31 @@ impl MQProducerInner for DefaultMQProducerImpl {
             // Switch back to async context for network I/O
             let handle = tokio::runtime::Handle::current();
             handle.spawn(async move {
-                let request_header = EndTransactionRequestHeader {
-                    topic: check_request_header.topic.clone().unwrap_or_default(),
-                    producer_group: CheetahString::from_string(
-                        producer_impl_inner.producer_config.producer_group().to_string(),
-                    ),
-                    tran_state_table_offset: check_request_header.commit_log_offset as u64,
-                    commit_log_offset: check_request_header.commit_log_offset as u64,
-                    commit_or_rollback: match transaction_state {
-                        LocalTransactionState::CommitMessage => MessageSysFlag::TRANSACTION_COMMIT_TYPE,
-                        LocalTransactionState::RollbackMessage => MessageSysFlag::TRANSACTION_ROLLBACK_TYPE,
-                        LocalTransactionState::Unknown => MessageSysFlag::TRANSACTION_NOT_TYPE,
-                    },
-                    from_transaction_check: true,
-                    msg_id: unique_key.clone().unwrap_or_default(),
-                    transaction_id: check_request_header.transaction_id.clone(),
-                    rpc_request_header: RpcRequestHeader {
-                        broker_name: check_request_header.rpc_request_header.unwrap_or_default().broker_name,
-                        ..Default::default()
-                    },
-                };
+                let request_header = Self::build_end_transaction_header_for_check(
+                    producer_impl_inner.producer_config.producer_group().clone(),
+                    &check_request_header,
+                    unique_key.clone(),
+                    transaction_state,
+                );
                 // Execute end transaction hook
                 producer_impl_inner.do_execute_end_transaction_hook(
                     &msg.message,
-                    unique_key.as_ref().unwrap(),
+                    &unique_key,
                     &broker_addr,
                     transaction_state,
                     true,
                 );
 
                 // Send end transaction request with error handling
-                if let Err(e) = producer_impl_inner
-                    .client_instance
-                    .as_mut()
-                    .unwrap()
-                    .mq_client_api_impl
-                    .as_mut()
-                    .unwrap()
+                let Some(client_instance) = producer_impl_inner.client_instance.as_mut() else {
+                    tracing::warn!("endTransactionOneway skipped: client instance is not available");
+                    return;
+                };
+                let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.as_mut() else {
+                    tracing::warn!("endTransactionOneway skipped: MQClientAPIImpl is not available");
+                    return;
+                };
+                if let Err(e) = mq_client_api_impl
                     .end_transaction_oneway(&broker_addr, request_header, CheetahString::from_static_str(""), 3000)
                     .await
                 {
@@ -2805,5 +2822,75 @@ pub(crate) struct DefaultResolver {
 impl Resolver for DefaultResolver {
     async fn resolve(&self, name: &CheetahString) -> Option<CheetahString> {
         self.client_instance.find_broker_address_in_publish(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transaction_check_end_header_preserves_java_offsets() {
+        let check_header = CheckTransactionStateRequestHeader {
+            topic: Some(CheetahString::from_static_str("TopicA")),
+            tran_state_table_offset: 123,
+            commit_log_offset: 456,
+            msg_id: Some(CheetahString::from_static_str("msg-id")),
+            transaction_id: Some(CheetahString::from_static_str("tx-id")),
+            offset_msg_id: Some(CheetahString::from_static_str("offset-msg-id")),
+            rpc_request_header: Some(RpcRequestHeader {
+                broker_name: Some(CheetahString::from_static_str("broker-a")),
+                ..Default::default()
+            }),
+        };
+
+        let end_header = DefaultMQProducerImpl::build_end_transaction_header_for_check(
+            CheetahString::from_static_str("ProducerA"),
+            &check_header,
+            CheetahString::from_static_str("unique-msg-id"),
+            LocalTransactionState::CommitMessage,
+        );
+
+        assert_eq!(end_header.topic, "TopicA");
+        assert_eq!(end_header.producer_group, "ProducerA");
+        assert_eq!(end_header.tran_state_table_offset, 123);
+        assert_eq!(end_header.commit_log_offset, 456);
+        assert_eq!(end_header.commit_or_rollback, MessageSysFlag::TRANSACTION_COMMIT_TYPE);
+        assert!(end_header.from_transaction_check);
+        assert_eq!(end_header.msg_id, "unique-msg-id");
+        assert_eq!(end_header.transaction_id.as_deref(), Some("tx-id"));
+        assert_eq!(end_header.rpc_request_header.broker_name.as_deref(), Some("broker-a"));
+    }
+
+    #[test]
+    fn transaction_check_end_header_maps_local_transaction_state() {
+        let check_header = CheckTransactionStateRequestHeader {
+            tran_state_table_offset: 1,
+            commit_log_offset: 2,
+            ..Default::default()
+        };
+
+        let cases = [
+            (
+                LocalTransactionState::CommitMessage,
+                MessageSysFlag::TRANSACTION_COMMIT_TYPE,
+            ),
+            (
+                LocalTransactionState::RollbackMessage,
+                MessageSysFlag::TRANSACTION_ROLLBACK_TYPE,
+            ),
+            (LocalTransactionState::Unknown, MessageSysFlag::TRANSACTION_NOT_TYPE),
+        ];
+
+        for (state, expected_flag) in cases {
+            let end_header = DefaultMQProducerImpl::build_end_transaction_header_for_check(
+                CheetahString::from_static_str("ProducerA"),
+                &check_header,
+                CheetahString::from_static_str("msg-id"),
+                state,
+            );
+
+            assert_eq!(end_header.commit_or_rollback, expected_flag);
+        }
     }
 }

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -452,15 +452,43 @@ where
                 return decode_error_response(request.opaque(), "decode notifyConsumerIdsChanged header", error);
             }
         };
-        if self
-            .sessions
-            .consumer_client_ids(header.consumer_group.as_str())
-            .is_empty()
-        {
+        let client_ids = self.sessions.consumer_client_ids(header.consumer_group.as_str());
+        if client_ids.is_empty() {
             return response_with_code(
                 request.opaque(),
                 ResponseCode::ConsumerNotOnline,
                 format!("no consumer for this group, {}", header.consumer_group),
+            );
+        }
+        let mut forwarded = 0usize;
+        for client_id in client_ids {
+            let Some(mut client_channel) = self.sessions.remoting_channel(client_id.as_str()) else {
+                continue;
+            };
+            if let Err(error) = client_channel
+                .channel_inner_mut()
+                .send_oneway(request.clone(), 10)
+                .await
+            {
+                return response_with_code(
+                    request.opaque(),
+                    ResponseCode::SystemError,
+                    format!(
+                        "forward notifyConsumerIdsChanged failed for group {}, clientId {}: {}",
+                        header.consumer_group, client_id, error
+                    ),
+                );
+            }
+            forwarded += 1;
+        }
+        if forwarded == 0 {
+            return response_with_code(
+                request.opaque(),
+                ResponseCode::ConsumerNotOnline,
+                format!(
+                    "no remoting channel for consumer group {}, clients are online",
+                    header.consumer_group
+                ),
             );
         }
         RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_opaque(request.opaque())
@@ -2239,6 +2267,93 @@ mod tests {
         let response = dispatcher.dispatch(&test_context(), &request).await;
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::ConsumerNotOnline);
+    }
+
+    #[tokio::test]
+    async fn dispatch_notify_consumer_ids_changed_forwards_to_remoting_consumers() {
+        let sessions = ClientSessionRegistry::default();
+        let processor = Arc::new(DefaultMessagingProcessor::new(Arc::new(
+            LocalServiceManager::with_services(
+                Arc::new(StaticRouteService::default()),
+                Arc::new(StaticMetadataService::default()),
+                Arc::new(DefaultAssignmentService),
+                Arc::new(TestMessageService),
+                Arc::new(TestConsumerService),
+                Arc::new(DefaultTransactionService),
+            ),
+        )));
+        let dispatcher = ProxyRemotingDispatcher::new(
+            Arc::new(ProxyConfig {
+                mode: ProxyMode::Local,
+                ..ProxyConfig::default()
+            }),
+            processor,
+            sessions.clone(),
+            None,
+        );
+
+        let heartbeat = HeartbeatData {
+            client_id: CheetahString::from_static_str("client-a"),
+            producer_data_set: HashSet::new(),
+            consumer_data_set: HashSet::from([ConsumerData {
+                group_name: CheetahString::from_static_str("GroupA"),
+                ..ConsumerData::default()
+            }]),
+            heartbeat_fingerprint: 0,
+            is_without_sub: false,
+        };
+        let mut heartbeat_request =
+            RemotingCommand::create_request_command(RequestCode::HeartBeat, HeartbeatRequestHeader::default())
+                .set_body(heartbeat.encode().expect("heartbeat should encode"));
+        heartbeat_request.make_custom_header_to_net();
+        let heartbeat_response = dispatcher.dispatch(&test_context(), &heartbeat_request).await;
+        assert_eq!(ResponseCode::from(heartbeat_response.code()), ResponseCode::Success);
+
+        let mut missing_channel_request = RemotingCommand::create_request_command(
+            RequestCode::NotifyConsumerIdsChanged,
+            NotifyConsumerIdsChangedRequestHeader {
+                consumer_group: CheetahString::from_static_str("GroupA"),
+                rpc_request_header: None,
+            },
+        );
+        missing_channel_request.make_custom_header_to_net();
+        let missing_channel_response = dispatcher.dispatch(&test_context(), &missing_channel_request).await;
+        assert_eq!(
+            ResponseCode::from(missing_channel_response.code()),
+            ResponseCode::ConsumerNotOnline
+        );
+
+        let mut harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+        sessions.bind_remoting_channel("client-a", harness.channel());
+
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::NotifyConsumerIdsChanged,
+            NotifyConsumerIdsChangedRequestHeader {
+                consumer_group: CheetahString::from_static_str("GroupA"),
+                rpc_request_header: None,
+            },
+        );
+        request.make_custom_header_to_net();
+
+        let response = dispatcher.dispatch(&test_context(), &request).await;
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        let forwarded = timeout(std::time::Duration::from_secs(3), harness.receive_response())
+            .await
+            .expect("forwarded notify consumer ids changed should arrive before timeout")
+            .expect("forwarded notify consumer ids changed should decode")
+            .expect("forwarded notify consumer ids changed should be present");
+        assert_eq!(
+            RequestCode::from(forwarded.code()),
+            RequestCode::NotifyConsumerIdsChanged
+        );
+        assert!(forwarded.is_oneway_rpc());
+        let forwarded_header = forwarded
+            .decode_command_custom_header::<NotifyConsumerIdsChangedRequestHeader>()
+            .expect("forwarded notify header should decode");
+        assert_eq!(forwarded_header.consumer_group, "GroupA");
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7274

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Consumer group member change notifications now forward to all registered consumers in the group.

* **Improvements**
  * Transaction state checking is more robust with guarded checks and warning logs for unavailable client instances, preventing unconditional failures.

* **Tests**
  * Added tests validating transaction header construction and consumer notification forwarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->