### PR TITLE
[ISSUE #7282]✨add Java-compatible encoding for ConsumeStats and ConsumeStatsList

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
@@ -231,7 +231,7 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
             let new_consume_tps = consume_stats.get_consume_tps() + consume_tps;
             consume_stats.set_consume_tps(new_consume_tps);
         }
-        let body = consume_stats.encode().expect("consume stats encode failed");
+        let body = consume_stats.encode_java_compatible()?;
         response.set_body_mut_ref(body);
         Ok(Some(response))
     }
@@ -288,7 +288,7 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
         Ok(Some(
             RemotingCommand::create_response_command()
                 .set_code(ResponseCode::Success)
-                .set_body(body.encode()?),
+                .set_body(body.encode_java_compatible()?),
         ))
     }
 
@@ -1196,7 +1196,7 @@ mod tests {
             .expect("get broker consume stats should return response");
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
-        let body: ConsumeStatsList = serde_json::from_slice(
+        let body = ConsumeStatsList::decode(
             response
                 .take_body()
                 .expect("broker consume stats should contain body")

--- a/rocketmq-namesrv/tests/route_info_manager_integration.rs
+++ b/rocketmq-namesrv/tests/route_info_manager_integration.rs
@@ -118,7 +118,9 @@ impl NamesrvHarness {
                     last_error = Some(error);
                     let _ = shutdown_tx.send(());
                     client.mut_from_ref().shutdown();
-                    let _ = tokio::time::timeout(Duration::from_secs(1), &mut server_task).await;
+                    if !server_task.is_finished() {
+                        let _ = tokio::time::timeout(Duration::from_secs(1), &mut server_task).await;
+                    }
                 }
             }
         }

--- a/rocketmq-remoting/src/protocol/admin/consume_stats.rs
+++ b/rocketmq-remoting/src/protocol/admin/consume_stats.rs
@@ -87,9 +87,32 @@ impl ConsumeStats {
             }
         }
     }
+
+    pub fn encode_java_compatible(&self) -> rocketmq_error::RocketMQResult<Vec<u8>> {
+        Ok(self.to_java_compatible_json()?.into_bytes())
+    }
+
+    pub fn to_java_compatible_json(&self) -> rocketmq_error::RocketMQResult<String> {
+        let mut body = String::new();
+        body.push_str("{\"offsetTable\":{");
+
+        for (index, (queue, offset)) in self.offset_table.iter().enumerate() {
+            if index > 0 {
+                body.push(',');
+            }
+            append_message_queue_object_key(&mut body, queue)?;
+            body.push(':');
+            body.push_str(&serde_json::to_string(offset)?);
+        }
+
+        body.push_str("},\"consumeTps\":");
+        body.push_str(&serde_json::to_string(&self.consume_tps)?);
+        body.push('}');
+        Ok(body)
+    }
 }
 
-fn normalize_nonstandard_offset_table_keys(input: &str) -> String {
+pub(super) fn normalize_nonstandard_offset_table_keys(input: &str) -> String {
     let chars = input.chars().collect::<Vec<_>>();
     let mut output = String::with_capacity(input.len());
     let mut index = 0;
@@ -135,6 +158,18 @@ fn normalize_nonstandard_offset_table_keys(input: &str) -> String {
         index = next_index;
     }
     output
+}
+
+fn append_message_queue_object_key(output: &mut String, queue: &MessageQueue) -> rocketmq_error::RocketMQResult<()> {
+    output.push('{');
+    output.push_str("\"topic\":");
+    output.push_str(&serde_json::to_string(queue.topic_str())?);
+    output.push_str(",\"brokerName\":");
+    output.push_str(&serde_json::to_string(queue.broker_name().as_str())?);
+    output.push_str(",\"queueId\":");
+    output.push_str(&queue.queue_id().to_string());
+    output.push('}');
+    Ok(())
 }
 
 fn normalize_object_key_map_body(chars: &[char], mut index: usize) -> (String, usize) {
@@ -376,5 +411,24 @@ mod tests {
             normalized,
             r#"{"offsetTable":{"{\"topic\":\"TopicTest\",\"brokerName\":\"broker-a\",\"queueId\":1}":{"brokerOffset":120}},"consumeTps":1.5}"#
         );
+    }
+
+    #[test]
+    fn java_compatible_encode_uses_object_keys_for_offset_table() {
+        let mut stats = ConsumeStats::new();
+        stats
+            .get_offset_table_mut()
+            .insert(create_mq("TopicTest", 1), create_offset_wrapper(120, 20, 80));
+        stats.set_consume_tps(1.5);
+
+        let encoded = String::from_utf8(stats.encode_java_compatible().expect("encode consume stats"))
+            .expect("utf8 consume stats");
+
+        assert!(encoded.contains(r#""offsetTable":{{"topic":"TopicTest","brokerName":"broker_1","queueId":1}:"#));
+        assert!(!encoded.contains(r#""{\"topic\""#));
+
+        let decoded = ConsumeStats::decode(encoded.as_bytes()).expect("decode java-compatible consume stats");
+        assert_eq!(decoded.get_offset_table().len(), 1);
+        assert_eq!(decoded.compute_total_diff(), 100);
     }
 }

--- a/rocketmq-remoting/src/protocol/admin/consume_stats_list.rs
+++ b/rocketmq-remoting/src/protocol/admin/consume_stats_list.rs
@@ -18,7 +18,9 @@ use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::consume_stats::normalize_nonstandard_offset_table_keys;
 use super::consume_stats::ConsumeStats;
+use crate::protocol::RemotingDeserializable;
 
 #[derive(Serialize, Deserialize)]
 pub struct ConsumeStatsList {
@@ -33,6 +35,68 @@ pub struct ConsumeStatsList {
 
     #[serde(rename = "totalInflightDiff")]
     pub total_inflight_diff: i64,
+}
+
+impl ConsumeStatsList {
+    pub fn encode_java_compatible(&self) -> rocketmq_error::RocketMQResult<Vec<u8>> {
+        Ok(self.to_java_compatible_json()?.into_bytes())
+    }
+
+    pub fn to_java_compatible_json(&self) -> rocketmq_error::RocketMQResult<String> {
+        let mut body = String::new();
+        body.push_str("{\"consumeStatsList\":[");
+
+        for (list_index, group_map) in self.consume_stats_list.iter().enumerate() {
+            if list_index > 0 {
+                body.push(',');
+            }
+            body.push('{');
+            for (group_index, (group, stats_list)) in group_map.iter().enumerate() {
+                if group_index > 0 {
+                    body.push(',');
+                }
+                body.push_str(&serde_json::to_string(group)?);
+                body.push(':');
+                body.push('[');
+                for (stats_index, stats) in stats_list.iter().enumerate() {
+                    if stats_index > 0 {
+                        body.push(',');
+                    }
+                    body.push_str(&stats.to_java_compatible_json()?);
+                }
+                body.push(']');
+            }
+            body.push('}');
+        }
+
+        body.push_str("],\"brokerAddr\":");
+        match &self.broker_addr {
+            Some(broker_addr) => body.push_str(&serde_json::to_string(broker_addr)?),
+            None => body.push_str("null"),
+        }
+        body.push_str(",\"totalDiff\":");
+        body.push_str(&self.total_diff.to_string());
+        body.push_str(",\"totalInflightDiff\":");
+        body.push_str(&self.total_inflight_diff.to_string());
+        body.push('}');
+        Ok(body)
+    }
+
+    pub fn decode(body: &[u8]) -> rocketmq_error::RocketMQResult<Self> {
+        match <Self as RemotingDeserializable>::decode(body) {
+            Ok(stats) => Ok(stats),
+            Err(error) => {
+                let Ok(raw_body) = std::str::from_utf8(body) else {
+                    return Err(error);
+                };
+                let normalized_body = normalize_nonstandard_offset_table_keys(raw_body);
+                if normalized_body == raw_body {
+                    return Err(error);
+                }
+                <Self as RemotingDeserializable>::decode_str(&normalized_body)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -65,5 +129,35 @@ mod tests {
             .get(&CheetahString::from("group1"))
             .unwrap();
         assert_eq!(a[0].consume_tps, 1.2);
+    }
+
+    #[test]
+    fn consume_status_list_java_compatible_serialization() {
+        use rocketmq_common::common::message::message_queue::MessageQueue;
+
+        let mut stats = ConsumeStats::new();
+        stats
+            .get_offset_table_mut()
+            .insert(MessageQueue::from_parts("TopicTest", "broker-a", 0), Default::default());
+        let mut map = HashMap::new();
+        map.insert(CheetahString::from("group1"), vec![stats]);
+        let list = ConsumeStatsList {
+            consume_stats_list: vec![map],
+            broker_addr: Some(CheetahString::from("127.0.0.1:10911")),
+            total_diff: 0,
+            total_inflight_diff: 0,
+        };
+
+        let encoded = String::from_utf8(list.encode_java_compatible().expect("encode consume stats list"))
+            .expect("utf8 consume stats list");
+
+        assert!(encoded.contains(r#""consumeStatsList":[{"group1":[{"offsetTable":{{"topic":"TopicTest""#));
+        assert!(!encoded.contains(r#""{\"topic\""#));
+
+        let decoded = ConsumeStatsList::decode(encoded.as_bytes()).expect("decode consume stats list");
+        let group = decoded.consume_stats_list[0]
+            .get(&CheetahString::from("group1"))
+            .expect("group1 stats");
+        assert_eq!(group[0].offset_table.len(), 1);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7282

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Java-compatible serialization methods for consumption statistics, improving interoperability with Java-based systems.

* **Bug Fixes**
  * Enhanced offset table handling during serialization and deserialization of consumption statistics.
  * Improved test infrastructure with conditional task completion checks to avoid unnecessary waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->