### PR TITLE
[ISSUE #7290]♻️refactor consume stats encoding to use Java-compatible keys and improve deserialization logic

### DIFF
--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+use std::time::Duration;
+
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_common::EnvUtils::EnvUtils;
 use rocketmq_controller::parse_command_line;
+use rocketmq_controller::typ::Node;
 use rocketmq_controller::ControllerManager;
+use rocketmq_error::ControllerError;
 use rocketmq_error::Result;
 use rocketmq_remoting::protocol::remoting_command;
 use rocketmq_rust::ArcMut;
@@ -94,6 +99,7 @@ pub async fn main() -> Result<()> {
     }
 
     ControllerManager::start(ArcMut::clone(&controller_manager)).await?;
+    initialize_single_node_cluster_if_configured(&controller_manager).await?;
 
     info!("Controller started successfully!");
     info!("  Node ID: {}", controller_manager.controller_config().node_id);
@@ -118,4 +124,41 @@ pub async fn main() -> Result<()> {
 
     info!("Controller shutdown completed.");
     Ok(())
+}
+
+async fn initialize_single_node_cluster_if_configured(controller_manager: &ArcMut<ControllerManager>) -> Result<()> {
+    let config = controller_manager.controller_config();
+    if config.raft_peers.len() != 1 {
+        return Ok(());
+    }
+
+    let peer = config.raft_peers[0].clone();
+    if peer.id != config.node_id {
+        return Ok(());
+    }
+    if controller_manager.controller().has_committed_log()? {
+        info!("Single-node controller cluster already has committed logs; skip bootstrap");
+        return Ok(());
+    }
+
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        peer.id,
+        Node {
+            node_id: peer.id,
+            rpc_addr: peer.addr.to_string(),
+        },
+    );
+    info!("Bootstrapping single-node controller cluster with node {}", peer.id);
+    controller_manager.controller().initialize_cluster(nodes).await?;
+
+    for _ in 0..30 {
+        if controller_manager.is_leader() {
+            info!("Single-node controller cluster elected local node as leader");
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    Err(ControllerError::Internal("single-node controller did not become leader after bootstrap".to_string()).into())
 }

--- a/rocketmq-remoting/src/protocol/admin/consume_stats.rs
+++ b/rocketmq-remoting/src/protocol/admin/consume_stats.rs
@@ -112,7 +112,7 @@ impl ConsumeStats {
     }
 }
 
-pub(super) fn normalize_nonstandard_offset_table_keys(input: &str) -> String {
+pub(crate) fn normalize_nonstandard_offset_table_keys(input: &str) -> String {
     let chars = input.chars().collect::<Vec<_>>();
     let mut output = String::with_capacity(input.len());
     let mut index = 0;
@@ -160,7 +160,10 @@ pub(super) fn normalize_nonstandard_offset_table_keys(input: &str) -> String {
     output
 }
 
-fn append_message_queue_object_key(output: &mut String, queue: &MessageQueue) -> rocketmq_error::RocketMQResult<()> {
+pub(crate) fn append_message_queue_object_key(
+    output: &mut String,
+    queue: &MessageQueue,
+) -> rocketmq_error::RocketMQResult<()> {
     output.push('{');
     output.push_str("\"topic\":");
     output.push_str(&serde_json::to_string(queue.topic_str())?);

--- a/rocketmq-remoting/src/protocol/body/response/get_consumer_status_body.rs
+++ b/rocketmq-remoting/src/protocol/body/response/get_consumer_status_body.rs
@@ -20,6 +20,10 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json_any_key::*;
 
+use crate::protocol::admin::consume_stats::append_message_queue_object_key;
+use crate::protocol::admin::consume_stats::normalize_nonstandard_offset_table_keys;
+use crate::protocol::RemotingDeserializable;
+
 /// Response body for get consumer status operation.
 /// Maps client ID to their message queue offset table.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
@@ -43,13 +47,75 @@ impl GetConsumerStatusBody {
     }
 
     pub fn encode(&self) -> Vec<u8> {
-        serde_json::to_vec(self).unwrap_or_default()
+        self.encode_java_compatible().unwrap_or_default()
+    }
+
+    pub fn encode_java_compatible(&self) -> rocketmq_error::RocketMQResult<Vec<u8>> {
+        Ok(self.to_java_compatible_json()?.into_bytes())
+    }
+
+    pub fn to_java_compatible_json(&self) -> rocketmq_error::RocketMQResult<String> {
+        let mut body = String::new();
+        body.push_str("{\"messageQueueTable\":{");
+        append_offset_map(&mut body, &self.message_queue_table)?;
+        body.push_str("},\"consumerTable\":{");
+
+        for (index, (client_id, offsets)) in self.consumer_table.iter().enumerate() {
+            if index > 0 {
+                body.push(',');
+            }
+            body.push_str(&serde_json::to_string(client_id.as_str())?);
+            body.push_str(":{");
+            append_offset_map(&mut body, offsets)?;
+            body.push('}');
+        }
+
+        body.push_str("}}");
+        Ok(body)
     }
 
     pub fn decode(body: &[u8]) -> Option<Self> {
-        serde_json::from_slice(body).ok()
+        match <Self as RemotingDeserializable>::decode(body) {
+            Ok(decoded) => Some(decoded),
+            Err(_) => {
+                let raw = std::str::from_utf8(body).ok()?;
+                let normalized = normalize_nonstandard_message_queue_table_keys(raw);
+                if normalized == raw {
+                    return None;
+                }
+                <Self as RemotingDeserializable>::decode_str(&normalized).ok()
+            }
+        }
     }
 }
+
+fn append_offset_map(output: &mut String, offsets: &HashMap<MessageQueue, i64>) -> rocketmq_error::RocketMQResult<()> {
+    for (index, (queue, offset)) in offsets.iter().enumerate() {
+        if index > 0 {
+            output.push(',');
+        }
+        append_message_queue_object_key(output, queue)?;
+        output.push(':');
+        output.push_str(&offset.to_string());
+    }
+    Ok(())
+}
+
+fn normalize_nonstandard_message_queue_table_keys(input: &str) -> String {
+    let marker = "\"messageQueueTable\"";
+    if !input.contains(marker) {
+        return input.to_string();
+    }
+
+    let offset_marker = "\"offsetTable\"";
+    let rewritten = input.replacen(marker, offset_marker, 1);
+    let normalized = normalize_nonstandard_offset_table_keys(&rewritten);
+    if normalized == rewritten {
+        return input.to_string();
+    }
+    normalized.replacen(offset_marker, marker, 1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -89,6 +155,34 @@ mod tests {
         assert!(json.contains("consumerTable"));
         let deserialized: GetConsumerStatusBody = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.message_queue_table.get(&mq), Some(&123));
+    }
+
+    #[test]
+    fn get_consumer_status_body_encode_uses_java_object_keys() {
+        let mut body = GetConsumerStatusBody::new();
+        let mq = MessageQueue::from_parts(CheetahString::from("topic"), CheetahString::from("broker"), 1);
+        body.message_queue_table.insert(mq.clone(), 123);
+        let mut consumer_offsets = HashMap::new();
+        consumer_offsets.insert(mq, 456);
+        body.consumer_table
+            .insert(CheetahString::from("client-a"), consumer_offsets);
+
+        let encoded = String::from_utf8(body.encode()).expect("get consumer status body should be utf8");
+
+        assert!(encoded.contains(r#""messageQueueTable":{{"topic":"topic","brokerName":"broker","queueId":1}:123}"#));
+        assert!(encoded.contains(r#""client-a":{{"topic":"topic","brokerName":"broker","queueId":1}:456}"#));
+        assert!(!encoded.contains(r#""{\"topic\""#));
+    }
+
+    #[test]
+    fn get_consumer_status_body_decode_accepts_java_message_queue_table_keys() {
+        let body =
+            r#"{"messageQueueTable":{{"topic":"topic","brokerName":"broker","queueId":1}:123},"consumerTable":{}}"#;
+
+        let decoded = GetConsumerStatusBody::decode(body.as_bytes()).expect("decode get consumer status body");
+
+        let mq = MessageQueue::from_parts(CheetahString::from("topic"), CheetahString::from("broker"), 1);
+        assert_eq!(decoded.message_queue_table.get(&mq), Some(&123));
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/body/response/reset_offset_body.rs
+++ b/rocketmq-remoting/src/protocol/body/response/reset_offset_body.rs
@@ -20,6 +20,10 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json_any_key::*;
 
+use crate::protocol::admin::consume_stats::append_message_queue_object_key;
+use crate::protocol::admin::consume_stats::normalize_nonstandard_offset_table_keys;
+use crate::protocol::RemotingDeserializable;
+
 /// Response body for reset consumer offset operation.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -36,11 +40,42 @@ impl ResetOffsetBody {
     }
 
     pub fn encode(&self) -> Vec<u8> {
-        serde_json::to_vec(self).unwrap_or_default()
+        self.encode_java_compatible().unwrap_or_default()
+    }
+
+    pub fn encode_java_compatible(&self) -> rocketmq_error::RocketMQResult<Vec<u8>> {
+        Ok(self.to_java_compatible_json()?.into_bytes())
+    }
+
+    pub fn to_java_compatible_json(&self) -> rocketmq_error::RocketMQResult<String> {
+        let mut body = String::new();
+        body.push_str("{\"offsetTable\":{");
+
+        for (index, (queue, offset)) in self.offset_table.iter().enumerate() {
+            if index > 0 {
+                body.push(',');
+            }
+            append_message_queue_object_key(&mut body, queue)?;
+            body.push(':');
+            body.push_str(&offset.to_string());
+        }
+
+        body.push_str("}}");
+        Ok(body)
     }
 
     pub fn decode(body: &[u8]) -> Option<Self> {
-        serde_json::from_slice(body).ok()
+        match <Self as RemotingDeserializable>::decode(body) {
+            Ok(decoded) => Some(decoded),
+            Err(_) => {
+                let raw = std::str::from_utf8(body).ok()?;
+                let normalized = normalize_nonstandard_offset_table_keys(raw);
+                if normalized == raw {
+                    return None;
+                }
+                <Self as RemotingDeserializable>::decode_str(&normalized).ok()
+            }
+        }
     }
 }
 
@@ -104,6 +139,28 @@ mod tests {
         // Test that encoding produces valid JSON
         let json_str = String::from_utf8(encoded).unwrap();
         assert!(json_str.contains("offsetTable"));
+    }
+
+    #[test]
+    fn reset_offset_body_encode_uses_java_object_keys() {
+        let mut body = ResetOffsetBody::new();
+        body.offset_table
+            .insert(MessageQueue::from_parts("test_topic", "broker-a", 1), 100);
+
+        let encoded = String::from_utf8(body.encode()).expect("reset offset body should be utf8");
+
+        assert!(encoded.contains(r#""offsetTable":{{"topic":"test_topic","brokerName":"broker-a","queueId":1}:100}"#));
+        assert!(!encoded.contains(r#""{\"topic\""#));
+    }
+
+    #[test]
+    fn reset_offset_body_decode_accepts_java_object_keys() {
+        let body = r#"{"offsetTable":{{"topic":"test_topic","brokerName":"broker-a","queueId":1}:100}}"#;
+
+        let decoded = ResetOffsetBody::decode(body.as_bytes()).expect("decode reset offset body");
+
+        let queue = MessageQueue::from_parts("test_topic", "broker-a", 1);
+        assert_eq!(decoded.offset_table.get(&queue), Some(&100));
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7290

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Java-compatible serialization format for consumer status and offset information to enable seamless interoperability.

* **Improvements**
  * Strengthened protocol deserialization with automatic fallback mechanisms that handle non-standard offset table key formats gracefully.
  * Enhanced single-node cluster bootstrap process with built-in leadership verification and configurable timeout safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->