### PR TITLE
[ISSUE #7292]✨add support for Java-compatible numeric keys in topic queue mapping and enhance timer properties handling

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -50,6 +50,70 @@ use tracing::info;
 
 use crate::broker_runtime::BrokerRuntimeInner;
 
+fn decode_topic_queue_mapping_detail(body: &[u8]) -> Result<TopicQueueMappingDetail, String> {
+    match serde_json::from_slice::<TopicQueueMappingDetail>(body) {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            let text = std::str::from_utf8(body).map_err(|utf8_error| {
+                format!("decode TopicQueueMappingDetail failed: {error}; body is not utf8: {utf8_error}")
+            })?;
+            let normalized = quote_unquoted_numeric_json_keys(text);
+            serde_json::from_str::<TopicQueueMappingDetail>(&normalized).map_err(|normalized_error| {
+                format!("{error}; normalized Java numeric map keys failed: {normalized_error}")
+            })
+        }
+    }
+}
+
+fn quote_unquoted_numeric_json_keys(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut output = String::with_capacity(input.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        output.push(byte as char);
+        index += 1;
+
+        if byte != b'{' && byte != b',' {
+            continue;
+        }
+
+        let whitespace_start = index;
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+
+        let key_start = index;
+        if index < bytes.len() && bytes[index] == b'-' {
+            index += 1;
+        }
+        let digit_start = index;
+        while index < bytes.len() && bytes[index].is_ascii_digit() {
+            index += 1;
+        }
+        let key_end = index;
+
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+
+        if key_end > digit_start && index < bytes.len() && bytes[index] == b':' {
+            output.push_str(&input[whitespace_start..key_start]);
+            output.push('"');
+            output.push_str(&input[key_start..key_end]);
+            output.push('"');
+            output.push_str(&input[key_end..index]);
+            output.push(':');
+            index += 1;
+        } else {
+            output.push_str(&input[whitespace_start..index]);
+        }
+    }
+
+    output
+}
+
 #[derive(Clone)]
 pub(super) struct TopicRequestHandler<MS: MessageStore> {
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
@@ -198,7 +262,7 @@ impl<MS: MessageStore> TopicRequestHandler<MS> {
                     .set_remark("topic queue mapping detail is missing"),
             ));
         };
-        let mut topic_queue_mapping_detail = match serde_json::from_slice::<TopicQueueMappingDetail>(body.as_ref()) {
+        let mut topic_queue_mapping_detail = match decode_topic_queue_mapping_detail(body.as_ref()) {
             Ok(value) => value,
             Err(error) => {
                 return Ok(Some(
@@ -756,6 +820,32 @@ mod tests {
         let response_table = ArcMut::new(HashMap::<i32, ResponseFuture>::new());
         let inner = ArcMut::new(ChannelInner::new(connection, response_table));
         Channel::new(inner, local_addr, local_addr)
+    }
+
+    #[test]
+    fn decode_topic_queue_mapping_detail_accepts_java_fastjson_numeric_keys() {
+        let body = br#"{"topic":"static-topic","scope":"__global__","totalQueues":2,"bname":"interopBroker","epoch":1,"dirty":false,"currIdMap":{0:0,1:1},"hostedQueues":{0:[{"gen":0,"queueId":0,"bname":"interopBroker","logicOffset":0,"startOffset":0,"endOffset":-1,"timeOfStart":-1,"timeOfEnd":-1}],1:[{"gen":0,"queueId":1,"bname":"interopBroker","logicOffset":0,"startOffset":0,"endOffset":-1,"timeOfStart":-1,"timeOfEnd":-1}]}}"#;
+
+        let detail = decode_topic_queue_mapping_detail(body).expect("Java FastJSON body should decode");
+
+        assert_eq!(detail.topic_queue_mapping_info.topic.as_deref(), Some("static-topic"));
+        assert_eq!(
+            detail
+                .topic_queue_mapping_info
+                .curr_id_map
+                .as_ref()
+                .and_then(|curr_id_map| curr_id_map.get(&1)),
+            Some(&1)
+        );
+        assert_eq!(
+            detail
+                .hosted_queues
+                .as_ref()
+                .and_then(|hosted_queues| hosted_queues.get(&1))
+                .and_then(|items| items.first())
+                .map(|item| item.queue_id),
+            Some(1)
+        );
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/processor/recall_message_processor.rs
+++ b/rocketmq-broker/src/processor/recall_message_processor.rs
@@ -224,6 +224,7 @@ where
             &mut response,
             begin_time_millis,
             CheetahString::from_string(handle_topic.to_string()),
+            CheetahString::from_string(handle_message_id.to_string()),
         )?;
 
         Ok(response)
@@ -322,6 +323,7 @@ where
         response: &mut RemotingCommand,
         begin_time_millis: u64,
         topic: CheetahString,
+        message_id: CheetahString,
     ) -> rocketmq_error::RocketMQResult<()> {
         let append_result = match put_message_result.append_message_result() {
             Some(result) => result,
@@ -359,9 +361,7 @@ where
                         .read_custom_header_mut::<RecallMessageResponseHeader>()
                         .ok_or_else(|| RocketMQError::Internal("Response header missing".to_string()))?;
 
-                    if let Some(msg_id) = &append_result.msg_id {
-                        response_header.set_msg_id(msg_id.as_str());
-                    }
+                    response_header.set_msg_id(message_id.as_str());
                 }
 
                 response.set_code_mut(ResponseCode::Success);
@@ -374,9 +374,7 @@ where
                         .read_custom_header_mut::<RecallMessageResponseHeader>()
                         .ok_or_else(|| RocketMQError::Internal("Response header missing".to_string()))?;
 
-                    if let Some(msg_id) = &append_result.msg_id {
-                        response_header.set_msg_id(msg_id.as_str());
-                    }
+                    response_header.set_msg_id(message_id.as_str());
                 }
 
                 response.set_code_mut(ResponseCode::Success);

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -69,8 +69,10 @@ use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::config::message_store_config::MessageStoreConfig;
 use rocketmq_store::stats::broker_stats_manager::BrokerStatsManager;
 use rocketmq_store::stats::stats_type::StatsType;
+use rocketmq_store::timer::timer_message_store::TIMER_TOPIC;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -471,8 +473,7 @@ where
         message_ext.message_ext_inner.message.set_body(request.body().cloned());
         message_ext.message_ext_inner.message.set_flag(request_header.flag);
 
-        let uniq_key = ori_props.get(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX);
-        if !uniq_key.is_some_and(|uniq_key_inner| uniq_key_inner.is_empty()) {
+        if should_create_uniq_key(&ori_props) {
             ori_props.insert(
                 CheetahString::from_static_str(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX),
                 CheetahString::from_string(MessageClientIDSetter::create_uniq_id()),
@@ -910,20 +911,13 @@ where
     }
 
     fn build_recall_handle(&self, message: &MessageExtBrokerInner) -> Option<CheetahString> {
-        let timestamp_str = message
-            .message_ext_inner
-            .message
-            .property(&CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_OUT_MS))?;
-        let real_topic = message
-            .message_ext_inner
-            .message
-            .property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))?;
+        let (real_topic, timestamp) =
+            recall_handle_topic_and_timestamp(message, self.inner.broker_runtime_inner.message_store_config())?;
         if real_topic.starts_with(RETRY_GROUP_TOPIC_PREFIX) {
             return None;
         }
 
         let uniq_id = MessageClientIDSetter::get_uniq_id(&message.message_ext_inner.message)?;
-        let timestamp = timestamp_str.parse::<i64>().ok()?.checked_add(1)?;
         let broker_name = self
             .inner
             .broker_runtime_inner
@@ -1564,6 +1558,55 @@ where
     }
 }
 
+fn recall_handle_topic_and_timestamp(
+    message: &MessageExtBrokerInner,
+    message_store_config: &MessageStoreConfig,
+) -> Option<(CheetahString, i64)> {
+    if let (Some(timestamp_str), Some(real_topic)) = (
+        message.property(MessageConst::PROPERTY_TIMER_OUT_MS),
+        message.property(MessageConst::PROPERTY_REAL_TOPIC),
+    ) {
+        let timestamp = timestamp_str.parse::<i64>().ok()?.checked_add(1)?;
+        return Some((real_topic, timestamp));
+    }
+
+    if message.message_ext_inner.message.delay_time_level() > 0 || message.topic().as_str() == TIMER_TOPIC {
+        return None;
+    }
+
+    let deliver_ms = message
+        .property(MessageConst::PROPERTY_TIMER_DELIVER_MS)?
+        .parse::<u64>()
+        .ok()?;
+    let now = TimeUtils::current_millis();
+    if deliver_ms <= now {
+        return None;
+    }
+
+    let max_delay_ms = message_store_config.timer_max_delay_sec.checked_mul(1000)?;
+    if deliver_ms.saturating_sub(now) > max_delay_ms {
+        return None;
+    }
+
+    let precision_ms = message_store_config.timer_precision_ms;
+    let timer_out_ms = if precision_ms == 0 {
+        deliver_ms
+    } else if deliver_ms % precision_ms == 0 {
+        deliver_ms.saturating_sub(precision_ms)
+    } else {
+        (deliver_ms / precision_ms) * precision_ms
+    };
+    let timestamp = i64::try_from(timer_out_ms).ok()?.checked_add(1)?;
+    Some((message.topic().clone(), timestamp))
+}
+
+fn should_create_uniq_key(properties: &HashMap<CheetahString, CheetahString>) -> bool {
+    properties
+        .get(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX)
+        .map(|uniq_key| uniq_key.is_empty())
+        .unwrap_or(true)
+}
+
 fn rewrite_response_for_static_topic(
     response_header: &mut SendMessageResponseHeader,
     mapping_context: &TopicQueueMappingContext,
@@ -1589,4 +1632,72 @@ fn rewrite_response_for_static_topic(
     response_header.set_queue_id(mapping_context.global_id.unwrap());
     response_header.set_queue_offset(static_logic_offset);
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message_with_topic(topic: &str) -> MessageExtBrokerInner {
+        let mut message = MessageExtBrokerInner::default();
+        message
+            .message_ext_inner
+            .message
+            .set_topic(CheetahString::from_string(topic.to_string()));
+        message
+    }
+
+    #[test]
+    fn recall_handle_timestamp_uses_transformed_timer_properties() {
+        let mut message = message_with_topic(TIMER_TOPIC);
+        message.message_ext_inner.message.properties_mut().as_map_mut().insert(
+            CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_OUT_MS),
+            CheetahString::from_static_str("123000"),
+        );
+        message.message_ext_inner.message.properties_mut().as_map_mut().insert(
+            CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC),
+            CheetahString::from_static_str("RecallTopic"),
+        );
+
+        let (topic, timestamp) =
+            recall_handle_topic_and_timestamp(&message, &MessageStoreConfig::default()).expect("recall data");
+
+        assert_eq!(topic, "RecallTopic");
+        assert_eq!(timestamp, 123001);
+    }
+
+    #[test]
+    fn recall_handle_timestamp_uses_absolute_deliver_time_before_store_transform() {
+        let now = TimeUtils::current_millis();
+        let deliver_ms = ((now + 60_000) / 1000) * 1000;
+        let mut message = message_with_topic("RecallTopic");
+        message.message_ext_inner.message.properties_mut().as_map_mut().insert(
+            CheetahString::from_static_str(MessageConst::PROPERTY_TIMER_DELIVER_MS),
+            CheetahString::from_string(deliver_ms.to_string()),
+        );
+
+        let (topic, timestamp) =
+            recall_handle_topic_and_timestamp(&message, &MessageStoreConfig::default()).expect("recall data");
+
+        assert_eq!(topic, "RecallTopic");
+        assert_eq!(timestamp, i64::try_from(deliver_ms - 1000).unwrap() + 1);
+    }
+
+    #[test]
+    fn should_create_uniq_key_only_when_missing_or_empty() {
+        let mut properties = HashMap::new();
+        assert!(should_create_uniq_key(&properties));
+
+        properties.insert(
+            CheetahString::from_static_str(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX),
+            CheetahString::new(),
+        );
+        assert!(should_create_uniq_key(&properties));
+
+        properties.insert(
+            CheetahString::from_static_str(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX),
+            CheetahString::from_static_str("java-uniq-id"),
+        );
+        assert!(!should_create_uniq_key(&properties));
+    }
 }

--- a/rocketmq-remoting/src/protocol/static_topic.rs
+++ b/rocketmq-remoting/src/protocol/static_topic.rs
@@ -14,6 +14,7 @@
 
 pub mod logic_queue_mapping_item;
 
+pub(crate) mod i32_key_map_serde;
 pub mod topic_config_and_queue_mapping;
 pub mod topic_queue_mapping_context;
 pub mod topic_queue_mapping_detail;

--- a/rocketmq-remoting/src/protocol/static_topic/i32_key_map_serde.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/i32_key_map_serde.rs
@@ -1,0 +1,24 @@
+use serde::de;
+use serde::Deserialize;
+use serde::Deserializer;
+use std::collections::HashMap;
+
+pub(crate) fn deserialize_optional_i32_key_map<'de, D, V>(deserializer: D) -> Result<Option<HashMap<i32, V>>, D::Error>
+where
+    D: Deserializer<'de>,
+    V: Deserialize<'de>,
+{
+    let raw = Option::<HashMap<String, V>>::deserialize(deserializer)?;
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+
+    let mut parsed = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let key = key
+            .parse::<i32>()
+            .map_err(|error| de::Error::custom(format!("invalid i32 map key `{key}`: {error}")))?;
+        parsed.insert(key, value);
+    }
+    Ok(Some(parsed))
+}

--- a/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_detail.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_detail.rs
@@ -18,6 +18,7 @@ use rocketmq_rust::ArcMut;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::protocol::static_topic::i32_key_map_serde;
 use crate::protocol::static_topic::logic_queue_mapping_item::LogicQueueMappingItem;
 use crate::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo;
 
@@ -27,6 +28,7 @@ pub struct TopicQueueMappingDetail {
     pub topic_queue_mapping_info: TopicQueueMappingInfo,
 
     #[serde(rename = "hostedQueues")]
+    #[serde(default, deserialize_with = "i32_key_map_serde::deserialize_optional_i32_key_map")]
     pub hosted_queues: Option<HashMap<i32 /* global id */, Vec<LogicQueueMappingItem>>>,
 }
 

--- a/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_info.rs
+++ b/rocketmq-remoting/src/protocol/static_topic/topic_queue_mapping_info.rs
@@ -19,6 +19,8 @@ use rocketmq_common::common::mix_all::METADATA_SCOPE_GLOBAL;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::protocol::static_topic::i32_key_map_serde;
+
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct TopicQueueMappingInfo {
     pub topic: Option<CheetahString>,
@@ -29,6 +31,7 @@ pub struct TopicQueueMappingInfo {
     pub epoch: i64,
     pub dirty: bool,
     #[serde(rename = "currIdMap")]
+    #[serde(default, deserialize_with = "i32_key_map_serde::deserialize_optional_i32_key_map")]
     pub curr_id_map: Option<HashMap<i32, i32>>,
 }
 

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -110,6 +110,10 @@ mod defaults {
         true
     }
 
+    pub fn timer_max_delay_sec() -> u64 {
+        3600 * 24 * 3
+    }
+
     pub fn timer_wheel_enable() -> bool {
         true
     }
@@ -419,7 +423,7 @@ pub struct MessageStoreConfig {
     #[serde(default)]
     pub timer_intercept_delay_level: bool,
 
-    #[serde(default)]
+    #[serde(default = "defaults::timer_max_delay_sec")]
     pub timer_max_delay_sec: u64,
 
     #[serde(default = "defaults::timer_wheel_enable")]
@@ -1739,5 +1743,12 @@ mod tests {
         assert_eq!(properties["timerRocksDBRollRangeHours"], "2");
         assert_eq!(properties["timerRecallToTimeWheelEnable"], "true");
         assert_eq!(properties["timerRecallToTimelineEnable"], "true");
+    }
+
+    #[test]
+    fn serde_defaults_keep_timer_max_delay_sec_java_default() -> Result<(), serde_json::Error> {
+        let config: MessageStoreConfig = serde_json::from_str("{}")?;
+        assert_eq!(config.timer_max_delay_sec, 3600 * 24 * 3);
+        Ok(())
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7292

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved JSON deserialization robustness for topic queue mappings with numeric keys
  * Fixed message ID assignment in recall message responses
  * Enhanced message sending with improved timer and recall handle processing

* **New Features**
  * Added `timer_max_delay_sec` configuration parameter for message store to control maximum timer delay duration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->