### PR TITLE
[ISSUE #7301]🚀add dashboard charts and data fetching logic for broker and topic overview

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-common/src/dashboard.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-common/src/dashboard.rs
@@ -1,0 +1,74 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared Dashboard-domain request models for dashboard implementations.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardBrokerOverviewRequest {
+    pub force_refresh: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardBrokerHistoryRequest {
+    pub date: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardTopicHistoryRequest {
+    pub date: String,
+    pub topic_name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DashboardBrokerHistoryRequest;
+    use super::DashboardBrokerOverviewRequest;
+    use super::DashboardTopicHistoryRequest;
+
+    #[test]
+    fn dashboard_broker_overview_request_uses_camel_case_fields() {
+        let request = DashboardBrokerOverviewRequest { force_refresh: true };
+        let json = serde_json::to_string(&request).expect("serialize dashboard broker overview request");
+
+        assert!(json.contains("\"forceRefresh\""));
+    }
+
+    #[test]
+    fn dashboard_topic_history_request_uses_java_dashboard_field_names() {
+        let request = DashboardTopicHistoryRequest {
+            date: "2026-05-04".to_string(),
+            topic_name: "TopicTest".to_string(),
+        };
+        let json = serde_json::to_string(&request).expect("serialize dashboard topic history request");
+
+        assert!(json.contains("\"topicName\""));
+        assert!(json.contains("\"date\""));
+    }
+
+    #[test]
+    fn dashboard_broker_history_request_uses_date_field() {
+        let request = DashboardBrokerHistoryRequest {
+            date: "2026-05-04".to_string(),
+        };
+        let json = serde_json::to_string(&request).expect("serialize dashboard broker history request");
+
+        assert!(json.contains("\"date\""));
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-common/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-common/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod api;
 pub mod cluster;
 pub mod consumer;
+pub mod dashboard;
 pub mod message;
 pub mod models;
 pub mod nameserver;
@@ -30,6 +31,7 @@ pub mod topic;
 pub use api::*;
 pub use cluster::*;
 pub use consumer::*;
+pub use dashboard::*;
 pub use message::*;
 pub use models::*;
 pub use nameserver::*;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/commands.rs
@@ -51,6 +51,17 @@ pub async fn refresh_consumer_group(
 }
 
 #[tauri::command]
+pub async fn refresh_all_consumer_groups(
+    request: ConsumerGroupListRequest,
+    consumer_manager: State<'_, ConsumerManager>,
+) -> Result<ConsumerGroupListResponse, String> {
+    consumer_manager
+        .refresh_all_consumer_groups(request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
 pub async fn query_consumer_connection(
     request: ConsumerConnectionQueryRequest,
     consumer_manager: State<'_, ConsumerManager>,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/consumer/service.rs
@@ -157,6 +157,13 @@ impl ConsumerManager {
         }
     }
 
+    pub(crate) async fn refresh_all_consumer_groups(
+        &self,
+        request: ConsumerGroupListRequest,
+    ) -> ConsumerResult<ConsumerGroupListResponse> {
+        self.query_consumer_groups(request).await
+    }
+
     pub(crate) async fn query_consumer_connection(
         &self,
         request: ConsumerConnectionQueryRequest,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/commands.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/commands.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::cluster::service::ClusterManager;
+use crate::dashboard::service;
+use crate::dashboard::types::DashboardBrokerOverviewResponse;
+use crate::dashboard::types::DashboardTopicCurrentResponse;
+use crate::topic::service::TopicManager;
+use rocketmq_dashboard_common::DashboardBrokerOverviewRequest;
+use tauri::State;
+
+#[tauri::command]
+pub async fn get_dashboard_broker_overview(
+    request: DashboardBrokerOverviewRequest,
+    cluster_manager: State<'_, ClusterManager>,
+) -> Result<DashboardBrokerOverviewResponse, String> {
+    service::get_dashboard_broker_overview(&cluster_manager, request)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn query_dashboard_topic_current(
+    topic_manager: State<'_, TopicManager>,
+) -> Result<DashboardTopicCurrentResponse, String> {
+    service::query_dashboard_topic_current(&topic_manager)
+        .await
+        .map_err(|error| error.to_string())
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/mod.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod commands;
+mod service;
+mod types;

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/service.rs
@@ -1,0 +1,273 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::cluster::service::ClusterManager;
+use crate::cluster::types::ClusterBrokerCardItem;
+use crate::cluster::types::ClusterHomePageResponse;
+use crate::dashboard::types::DashboardBrokerOverviewResponse;
+use crate::dashboard::types::DashboardBrokerSummary;
+use crate::dashboard::types::DashboardBrokerTopItem;
+use crate::dashboard::types::DashboardBrokerTpsItem;
+use crate::dashboard::types::DashboardError;
+use crate::dashboard::types::DashboardResult;
+use crate::dashboard::types::DashboardTopicCategoryItem;
+use crate::dashboard::types::DashboardTopicCurrentResponse;
+use crate::dashboard::types::DashboardTopicQueueItem;
+use crate::topic::service::TopicManager;
+use crate::topic::types::TopicListItem;
+use crate::topic::types::TopicListResponse;
+use rocketmq_dashboard_common::ClusterHomePageRequest;
+use rocketmq_dashboard_common::DashboardBrokerOverviewRequest;
+use rocketmq_dashboard_common::TopicListRequest;
+use std::collections::BTreeMap;
+
+const TOP_LIMIT: usize = 10;
+
+pub(crate) async fn get_dashboard_broker_overview(
+    cluster_manager: &ClusterManager,
+    request: DashboardBrokerOverviewRequest,
+) -> DashboardResult<DashboardBrokerOverviewResponse> {
+    let cluster_response = cluster_manager
+        .get_cluster_home_page(ClusterHomePageRequest {
+            force_refresh: request.force_refresh,
+        })
+        .await
+        .map_err(|error| DashboardError::Cluster(error.to_string()))?;
+
+    Ok(build_broker_overview(cluster_response))
+}
+
+pub(crate) async fn query_dashboard_topic_current(
+    topic_manager: &TopicManager,
+) -> DashboardResult<DashboardTopicCurrentResponse> {
+    let topic_response = topic_manager
+        .get_topic_list(TopicListRequest {
+            skip_sys_process: false,
+            skip_retry_and_dlq: false,
+        })
+        .await
+        .map_err(|error| DashboardError::Topic(error.to_string()))?;
+
+    Ok(build_topic_current(topic_response))
+}
+
+fn build_broker_overview(cluster_response: ClusterHomePageResponse) -> DashboardBrokerOverviewResponse {
+    DashboardBrokerOverviewResponse {
+        current_namesrv: cluster_response.current_namesrv,
+        use_vip_channel: cluster_response.use_vip_channel,
+        use_tls: cluster_response.use_tls,
+        summary: DashboardBrokerSummary {
+            total_clusters: cluster_response.summary.total_clusters,
+            total_brokers: cluster_response.summary.total_brokers,
+            total_masters: cluster_response.summary.total_masters,
+            total_slaves: cluster_response.summary.total_slaves,
+            active_brokers: cluster_response.summary.active_brokers,
+            inactive_brokers: cluster_response.summary.inactive_brokers,
+            brokers_with_status_errors: cluster_response.summary.brokers_with_status_errors,
+        },
+        broker_top: build_broker_top(&cluster_response.items),
+        broker_tps: build_broker_tps(&cluster_response.items),
+    }
+}
+
+fn build_topic_current(topic_response: TopicListResponse) -> DashboardTopicCurrentResponse {
+    DashboardTopicCurrentResponse {
+        current_namesrv: topic_response.current_namesrv,
+        use_vip_channel: topic_response.use_vip_channel,
+        use_tls: topic_response.use_tls,
+        total_topics: topic_response.total,
+        topic_queue_top: build_topic_queue_top(&topic_response.items),
+        topic_category_distribution: build_topic_category_distribution(&topic_response.items),
+    }
+}
+
+fn build_broker_top(items: &[ClusterBrokerCardItem]) -> Vec<DashboardBrokerTopItem> {
+    let mut sorted = items.to_vec();
+    sorted.sort_by(|left, right| {
+        right
+            .today_received_total
+            .cmp(&left.today_received_total)
+            .then(left.broker_name.cmp(&right.broker_name))
+            .then(left.broker_id.cmp(&right.broker_id))
+    });
+
+    sorted
+        .into_iter()
+        .take(TOP_LIMIT)
+        .map(|item| DashboardBrokerTopItem {
+            cluster_name: item.cluster_name,
+            broker_name: item.broker_name,
+            broker_id: item.broker_id,
+            address: item.address,
+            received_total: item.today_received_total,
+        })
+        .collect()
+}
+
+fn build_broker_tps(items: &[ClusterBrokerCardItem]) -> Vec<DashboardBrokerTpsItem> {
+    let mut sorted = items.to_vec();
+    sorted.sort_by(|left, right| {
+        let left_total = left.produce_tps + left.consume_tps;
+        let right_total = right.produce_tps + right.consume_tps;
+        right_total
+            .total_cmp(&left_total)
+            .then(left.broker_name.cmp(&right.broker_name))
+            .then(left.broker_id.cmp(&right.broker_id))
+    });
+
+    sorted
+        .into_iter()
+        .take(TOP_LIMIT)
+        .map(|item| {
+            let total_tps = item.produce_tps + item.consume_tps;
+            DashboardBrokerTpsItem {
+                cluster_name: item.cluster_name,
+                broker_name: item.broker_name,
+                broker_id: item.broker_id,
+                address: item.address,
+                produce_tps: item.produce_tps,
+                consume_tps: item.consume_tps,
+                total_tps,
+            }
+        })
+        .collect()
+}
+
+fn build_topic_queue_top(items: &[TopicListItem]) -> Vec<DashboardTopicQueueItem> {
+    let mut sorted = items.to_vec();
+    sorted.sort_by(|left, right| {
+        let left_total = left.read_queue_count + left.write_queue_count;
+        let right_total = right.read_queue_count + right.write_queue_count;
+        right_total.cmp(&left_total).then(left.topic.cmp(&right.topic))
+    });
+
+    sorted
+        .into_iter()
+        .take(TOP_LIMIT)
+        .map(|item| DashboardTopicQueueItem {
+            topic: item.topic,
+            category: item.category,
+            read_queue_count: item.read_queue_count,
+            write_queue_count: item.write_queue_count,
+            total_queue_count: item.read_queue_count + item.write_queue_count,
+        })
+        .collect()
+}
+
+fn build_topic_category_distribution(items: &[TopicListItem]) -> Vec<DashboardTopicCategoryItem> {
+    let mut counts = BTreeMap::<String, usize>::new();
+    for item in items {
+        *counts.entry(item.category.clone()).or_insert(0) += 1;
+    }
+
+    let mut distribution = counts
+        .into_iter()
+        .map(|(category, count)| DashboardTopicCategoryItem { category, count })
+        .collect::<Vec<_>>();
+    distribution.sort_by(|left, right| right.count.cmp(&left.count).then(left.category.cmp(&right.category)));
+    distribution
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_broker_top;
+    use super::build_broker_tps;
+    use super::build_topic_category_distribution;
+    use super::build_topic_queue_top;
+    use crate::cluster::types::ClusterBrokerCardItem;
+    use crate::topic::types::TopicListItem;
+    use std::collections::BTreeMap;
+
+    fn broker(name: &str, broker_id: u64, received: i64, produce_tps: f64, consume_tps: f64) -> ClusterBrokerCardItem {
+        ClusterBrokerCardItem {
+            cluster_name: "DefaultCluster".into(),
+            broker_name: name.into(),
+            broker_id,
+            role: if broker_id == 0 { "MASTER" } else { "SLAVE" }.into(),
+            address: format!("127.0.0.1:{}", 10911 + broker_id),
+            version: "V5_4_0".into(),
+            produce_tps,
+            consume_tps,
+            today_received_total: received,
+            yesterday_produce: 0,
+            yesterday_consume: 0,
+            today_produce: 0,
+            today_consume: 0,
+            is_active: true,
+            status_load_error: None,
+            raw_status: BTreeMap::new(),
+        }
+    }
+
+    fn topic(name: &str, category: &str, read_queue_count: u32, write_queue_count: u32) -> TopicListItem {
+        TopicListItem {
+            topic: name.into(),
+            category: category.into(),
+            message_type: category.into(),
+            clusters: vec!["DefaultCluster".into()],
+            brokers: vec!["broker-a".into()],
+            read_queue_count,
+            write_queue_count,
+            perm: 6,
+            order: false,
+            system_topic: false,
+        }
+    }
+
+    #[test]
+    fn broker_top_uses_received_total_descending() {
+        let items = vec![broker("broker-b", 0, 20, 1.0, 2.0), broker("broker-a", 0, 50, 1.0, 1.0)];
+
+        let top = build_broker_top(&items);
+
+        assert_eq!(top[0].broker_name, "broker-a");
+        assert_eq!(top[0].received_total, 50);
+    }
+
+    #[test]
+    fn broker_tps_uses_combined_produce_and_consume_tps() {
+        let items = vec![broker("broker-a", 0, 0, 1.0, 1.0), broker("broker-b", 0, 0, 5.0, 2.0)];
+
+        let top = build_broker_tps(&items);
+
+        assert_eq!(top[0].broker_name, "broker-b");
+        assert_eq!(top[0].total_tps, 7.0);
+    }
+
+    #[test]
+    fn topic_queue_top_uses_read_and_write_queue_count() {
+        let items = vec![topic("topic-a", "NORMAL", 2, 2), topic("topic-b", "FIFO", 8, 4)];
+
+        let top = build_topic_queue_top(&items);
+
+        assert_eq!(top[0].topic, "topic-b");
+        assert_eq!(top[0].total_queue_count, 12);
+    }
+
+    #[test]
+    fn topic_category_distribution_counts_and_sorts_categories() {
+        let items = vec![
+            topic("topic-a", "NORMAL", 2, 2),
+            topic("topic-b", "FIFO", 8, 4),
+            topic("topic-c", "NORMAL", 1, 1),
+        ];
+
+        let distribution = build_topic_category_distribution(&items);
+
+        assert_eq!(distribution[0].category, "NORMAL");
+        assert_eq!(distribution[0].count, 2);
+        assert_eq!(distribution[1].category, "FIFO");
+        assert_eq!(distribution[1].count, 1);
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/types.rs
@@ -1,0 +1,109 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt;
+
+pub(crate) type DashboardResult<T> = Result<T, DashboardError>;
+
+#[derive(Debug)]
+pub(crate) enum DashboardError {
+    Cluster(String),
+    Topic(String),
+}
+
+impl fmt::Display for DashboardError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cluster(message) => write!(f, "Cluster error: {message}"),
+            Self::Topic(message) => write!(f, "Topic error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for DashboardError {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DashboardBrokerSummary {
+    pub(crate) total_clusters: usize,
+    pub(crate) total_brokers: usize,
+    pub(crate) total_masters: usize,
+    pub(crate) total_slaves: usize,
+    pub(crate) active_brokers: usize,
+    pub(crate) inactive_brokers: usize,
+    pub(crate) brokers_with_status_errors: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DashboardBrokerTopItem {
+    pub(crate) cluster_name: String,
+    pub(crate) broker_name: String,
+    pub(crate) broker_id: u64,
+    pub(crate) address: String,
+    pub(crate) received_total: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DashboardBrokerTpsItem {
+    pub(crate) cluster_name: String,
+    pub(crate) broker_name: String,
+    pub(crate) broker_id: u64,
+    pub(crate) address: String,
+    pub(crate) produce_tps: f64,
+    pub(crate) consume_tps: f64,
+    pub(crate) total_tps: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DashboardBrokerOverviewResponse {
+    pub(crate) current_namesrv: String,
+    pub(crate) use_vip_channel: bool,
+    pub(crate) use_tls: bool,
+    pub(crate) summary: DashboardBrokerSummary,
+    pub(crate) broker_top: Vec<DashboardBrokerTopItem>,
+    pub(crate) broker_tps: Vec<DashboardBrokerTpsItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DashboardTopicQueueItem {
+    pub(crate) topic: String,
+    pub(crate) category: String,
+    pub(crate) read_queue_count: u32,
+    pub(crate) write_queue_count: u32,
+    pub(crate) total_queue_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DashboardTopicCategoryItem {
+    pub(crate) category: String,
+    pub(crate) count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DashboardTopicCurrentResponse {
+    pub(crate) current_namesrv: String,
+    pub(crate) use_vip_channel: bool,
+    pub(crate) use_tls: bool,
+    pub(crate) total_topics: usize,
+    pub(crate) topic_queue_top: Vec<DashboardTopicQueueItem>,
+    pub(crate) topic_category_distribution: Vec<DashboardTopicCategoryItem>,
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@
 mod auth;
 mod cluster;
 mod consumer;
+mod dashboard;
 mod message;
 mod nameserver;
 mod producer;
@@ -104,11 +105,14 @@ pub fn run() {
             cluster::commands::get_cluster_broker_status,
             consumer::commands::query_consumer_groups,
             consumer::commands::refresh_consumer_group,
+            consumer::commands::refresh_all_consumer_groups,
             consumer::commands::query_consumer_connection,
             consumer::commands::query_consumer_topic_detail,
             consumer::commands::query_consumer_config,
             consumer::commands::create_or_update_consumer_group,
             consumer::commands::delete_consumer_group,
+            dashboard::commands::get_dashboard_broker_overview,
+            dashboard::commands::query_dashboard_topic_current,
             message::commands::query_message_by_topic_key,
             message::commands::query_message_by_id,
             message::commands::query_message_page_by_topic,

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/hooks/useConsumerCatalog.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/consumer/hooks/useConsumerCatalog.ts
@@ -34,10 +34,13 @@ export const useConsumerCatalog = (address?: string) => {
 
         setError('');
         try {
-            const next = await ConsumerService.queryConsumerGroups({
+            const request = {
                 skipSysGroup: false,
                 address: normalizedAddress,
-            });
+            };
+            const next = mode === 'initial'
+                ? await ConsumerService.queryConsumerGroups(request)
+                : await ConsumerService.refreshAllConsumerGroups(request);
             setResponse(next);
             return next;
         } catch (loadError) {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/components/Charts.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/components/Charts.tsx
@@ -1,135 +1,361 @@
-import React from 'react';
-import { 
-  RefreshCw
-} from 'lucide-react';
-import { 
-  AreaChart, 
-  Area, 
-  XAxis, 
-  YAxis, 
-  CartesianGrid, 
-  Tooltip, 
-  ResponsiveContainer,
-  BarChart,
-  Bar,
-  LineChart,
-  Line
+import { useMemo, type ReactNode } from 'react';
+import { RefreshCw } from 'lucide-react';
+import {
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+    BarChart,
+    Bar,
+    LineChart,
+    Line,
 } from 'recharts';
 import { Card } from '../../../components/ui/LegacyCard';
+import { Button } from '../../../components/ui/LegacyButton';
+import { useDashboardCharts } from '../hooks/useDashboardCharts';
 
-// Mock Data for Charts
-const BROKER_DATA = [
-  { name: 'mixsim0', messages: 1200000 },
-  { name: 'broker-a', messages: 950000 },
-  { name: 'broker-b', messages: 850000 },
-  { name: 'broker-c', messages: 600000 },
-  { name: 'broker-d', messages: 450000 },
-];
+const formatNumber = (value: number) =>
+    new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value);
 
-const TOPIC_DATA = [
-  { name: 'OrderPlaced', count: 4500 },
-  { name: 'UserSignup', count: 3200 },
-  { name: 'PaymentProcessed', count: 2800 },
-  { name: 'EmailSent', count: 2100 },
-  { name: 'LogEvent', count: 1800 },
-];
+const compactLabel = (value: string) => {
+    if (value.length <= 18) {
+        return value;
+    }
 
-const TREND_DATA = Array.from({ length: 12 }).map((_, i) => ({
-  time: `${18 + Math.floor(i/6)}:${(i%6)*10 || '00'}`,
-  value: 35 + Math.random() * 10
-}));
+    return `${value.slice(0, 15)}...`;
+};
 
-const TOPIC_TREND_DATA = Array.from({ length: 12 }).map((_, i) => ({
-  time: `${18 + Math.floor(i/6)}:${(i%6)*10 || '00'}`,
-  value: Math.random() * 2
-}));
+const chartTooltipStyle = {
+    borderRadius: '12px',
+    border: 'none',
+    boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+};
+
+const ChartState = ({
+    isLoading,
+    error,
+    isEmpty,
+    children,
+}: {
+    isLoading: boolean;
+    error: string;
+    isEmpty: boolean;
+    children: ReactNode;
+}) => {
+    if (error) {
+        return (
+            <div className="mt-4 rounded-xl border border-red-200 bg-red-50/80 dark:border-red-900/40 dark:bg-red-950/20 px-4 py-3 text-sm text-red-700 dark:text-red-300">
+                {error}
+            </div>
+        );
+    }
+
+    if (isLoading) {
+        return (
+            <div className="mt-4 flex h-[300px] items-center justify-center rounded-xl border border-dashed border-gray-200 text-sm text-gray-500 dark:border-gray-800 dark:text-gray-400">
+                Loading chart data...
+            </div>
+        );
+    }
+
+    if (isEmpty) {
+        return (
+            <div className="mt-4 flex h-[300px] items-center justify-center rounded-xl border border-dashed border-gray-200 text-sm text-gray-500 dark:border-gray-800 dark:text-gray-400">
+                No data available
+            </div>
+        );
+    }
+
+    return <>{children}</>;
+};
+
+interface BrokerTopChartItem {
+    name: string;
+    messages: number;
+    address: string;
+}
+
+const BrokerTopChart = ({ data }: { data: BrokerTopChartItem[] }) => {
+    const maxMessages = Math.max(...data.map((item) => item.messages), 1);
+    const chartWidth = Math.max(data.length * 92, 360);
+    const chartHeight = 292;
+    const plotTop = 30;
+    const plotBottom = 58;
+    const plotLeft = 18;
+    const plotRight = 18;
+    const plotHeight = chartHeight - plotTop - plotBottom;
+    const slotWidth = (chartWidth - plotLeft - plotRight) / data.length;
+    const barWidth = Math.min(48, Math.max(30, slotWidth * 0.56));
+
+    return (
+        <div className="mt-4 min-w-0 w-full overflow-x-auto pb-1">
+            <svg
+                role="img"
+                aria-label="Broker Top 10 received messages chart"
+                viewBox={`0 0 ${chartWidth} ${chartHeight}`}
+                style={{
+                    display: 'block',
+                    width: '100%',
+                    minWidth: `${chartWidth}px`,
+                    height: `${chartHeight}px`,
+                }}
+            >
+                {[0, 1, 2, 3].map((line) => {
+                    const y = plotTop + (plotHeight * line) / 3;
+                    return (
+                        <line
+                            key={line}
+                            x1={plotLeft}
+                            x2={chartWidth - plotRight}
+                            y1={y}
+                            y2={y}
+                            stroke="rgba(148, 163, 184, 0.22)"
+                            strokeDasharray="5 5"
+                        />
+                    );
+                })}
+                {data.map((item, index) => {
+                    const isZero = item.messages <= 0;
+                    const barHeight = isZero ? 5 : Math.max((item.messages / maxMessages) * plotHeight, 12);
+                    const x = plotLeft + index * slotWidth + (slotWidth - barWidth) / 2;
+                    const y = plotTop + plotHeight - barHeight;
+                    const centerX = x + barWidth / 2;
+
+                    return (
+                        <g
+                            key={`${item.name}-${item.address}`}
+                            aria-label={`${item.name} ${formatNumber(item.messages)} messages`}
+                        >
+                            <title>{`${item.name} / ${item.address}: ${formatNumber(item.messages)} messages`}</title>
+                            <rect
+                                x={x}
+                                y={plotTop}
+                                width={barWidth}
+                                height={plotHeight}
+                                rx={10}
+                                fill="rgba(148, 163, 184, 0.16)"
+                            />
+                            <rect
+                                x={x}
+                                y={y}
+                                width={barWidth}
+                                height={barHeight}
+                                rx={10}
+                                fill={isZero ? '#64748b' : index === 0 ? '#60a5fa' : '#3b82f6'}
+                            />
+                            <text
+                                x={centerX}
+                                y={Math.max(y - 10, 12)}
+                                textAnchor="middle"
+                                dominantBaseline="middle"
+                                fill="#f8fafc"
+                                fontSize="12"
+                                fontWeight="700"
+                                fontFamily="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
+                            >
+                                {formatNumber(item.messages)}
+                            </text>
+                            <text
+                                x={centerX}
+                                y={plotTop + plotHeight + 28}
+                                textAnchor="middle"
+                                dominantBaseline="middle"
+                                fill="#94a3b8"
+                                fontSize="12"
+                                fontWeight="700"
+                            >
+                                {compactLabel(item.name)}
+                            </text>
+                        </g>
+                    );
+                })}
+            </svg>
+        </div>
+    );
+};
 
 export const DashboardCharts = () => {
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-      
-      {/* Broker TOP 10 */}
-      <Card title="Broker Top 10" description="Highest message volume by broker">
-        <div className="mt-4 min-w-0 h-[300px] w-full">
-          <ResponsiveContainer width="100%" height="100%" minWidth={0} debounce={200}>
-            <BarChart data={BROKER_DATA} layout="vertical" margin={{ left: 20 }}>
-              <CartesianGrid strokeDasharray="3 3" vertical={true} horizontal={false} stroke="#f0f0f0" />
-              <XAxis type="number" hide />
-              <YAxis dataKey="name" type="category" width={80} tick={{fontSize: 12}} axisLine={false} tickLine={false} />
-              <Tooltip 
-                cursor={{fill: '#f9fafb'}}
-                contentStyle={{borderRadius: '12px', border: 'none', boxShadow: '0 4px 12px rgba(0,0,0,0.1)'}}
-              />
-              <Bar dataKey="messages" fill="#3b82f6" radius={[0, 4, 4, 0]} barSize={20} />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </Card>
+    const {
+        brokerOverview,
+        topicCurrent,
+        isLoading,
+        isRefreshing,
+        brokerError,
+        topicError,
+        refresh,
+    } = useDashboardCharts();
 
-      {/* Broker Trend */}
-      <Card title="Broker 5min Trend" description="Message rate over the last 5 minutes" 
-        headerAction={
-          <div className="flex space-x-2">
-             <button className="p-1.5 hover:bg-gray-100 rounded-md text-gray-400 hover:text-gray-600 transition-colors"><RefreshCw className="w-4 h-4" /></button>
-          </div>
-        }
-      >
-        <div className="mt-4 min-w-0 h-[300px] w-full">
-          <ResponsiveContainer width="100%" height="100%" minWidth={0} debounce={200}>
-            <AreaChart data={TREND_DATA}>
-              <defs>
-                <linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#ef4444" stopOpacity={0.1}/>
-                  <stop offset="95%" stopColor="#ef4444" stopOpacity={0}/>
-                </linearGradient>
-              </defs>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f0f0f0" />
-              <XAxis dataKey="time" tick={{fontSize: 11, fill: '#9ca3af'}} axisLine={false} tickLine={false} />
-              <YAxis tick={{fontSize: 11, fill: '#9ca3af'}} axisLine={false} tickLine={false} />
-              <Tooltip 
-                contentStyle={{borderRadius: '12px', border: 'none', boxShadow: '0 4px 12px rgba(0,0,0,0.1)'}}
-              />
-              <Area type="monotone" dataKey="value" stroke="#ef4444" strokeWidth={2} fillOpacity={1} fill="url(#colorValue)" />
-            </AreaChart>
-          </ResponsiveContainer>
-        </div>
-      </Card>
+    const brokerTopData = useMemo(
+        () =>
+            (brokerOverview?.brokerTop ?? []).map((item) => ({
+                name: `${item.brokerName}-${item.brokerId}`,
+                messages: item.receivedTotal,
+                address: item.address,
+            })),
+        [brokerOverview?.brokerTop]
+    );
 
-      {/* Topic TOP 10 */}
-      <Card title="Topic Top 10" description="Most active topics by message count">
-        <div className="mt-4 min-w-0 h-[300px] w-full">
-          <ResponsiveContainer width="100%" height="100%" minWidth={0} debounce={200}>
-            <BarChart data={TOPIC_DATA}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f0f0f0" />
-              <XAxis dataKey="name" tick={{fontSize: 11, fill: '#9ca3af'}} axisLine={false} tickLine={false} />
-              <YAxis tick={{fontSize: 11, fill: '#9ca3af'}} axisLine={false} tickLine={false} />
-              <Tooltip 
-                 cursor={{fill: '#f9fafb'}}
-                 contentStyle={{borderRadius: '12px', border: 'none', boxShadow: '0 4px 12px rgba(0,0,0,0.1)'}}
-              />
-              <Bar dataKey="count" fill="#6366f1" radius={[4, 4, 0, 0]} barSize={30} />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </Card>
+    const brokerTpsData = useMemo(
+        () =>
+            (brokerOverview?.brokerTps ?? []).map((item) => ({
+                name: `${item.brokerName}-${item.brokerId}`,
+                produceTps: Number(item.produceTps.toFixed(2)),
+                consumeTps: Number(item.consumeTps.toFixed(2)),
+            })),
+        [brokerOverview?.brokerTps]
+    );
 
-      {/* Topic Trend */}
-      <Card title="Topic 5min Trend" description="Topic activity trend analysis">
-        <div className="mt-4 min-w-0 h-[300px] w-full">
-           <ResponsiveContainer width="100%" height="100%" minWidth={0} debounce={200}>
-            <LineChart data={TOPIC_TREND_DATA}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f0f0f0" />
-              <XAxis dataKey="time" tick={{fontSize: 11, fill: '#9ca3af'}} axisLine={false} tickLine={false} />
-              <YAxis tick={{fontSize: 11, fill: '#9ca3af'}} axisLine={false} tickLine={false} />
-              <Tooltip 
-                contentStyle={{borderRadius: '12px', border: 'none', boxShadow: '0 4px 12px rgba(0,0,0,0.1)'}}
-              />
-              <Line type="stepAfter" dataKey="value" stroke="#3b82f6" strokeWidth={2} dot={false} />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-      </Card>
+    const topicQueueData = useMemo(
+        () =>
+            (topicCurrent?.topicQueueTop ?? []).map((item) => ({
+                name: item.topic,
+                queues: item.totalQueueCount,
+                readQueues: item.readQueueCount,
+                writeQueues: item.writeQueueCount,
+            })),
+        [topicCurrent?.topicQueueTop]
+    );
 
-    </div>
-  );
+    const topicCategoryData = useMemo(
+        () =>
+            (topicCurrent?.topicCategoryDistribution ?? []).map((item) => ({
+                name: item.category,
+                count: item.count,
+            })),
+        [topicCurrent?.topicCategoryDistribution]
+    );
+
+    const isBrokerLoading = isLoading && brokerTopData.length === 0;
+    const isTopicLoading = isLoading && topicQueueData.length === 0;
+
+    const handleRefresh = async () => {
+        await refresh();
+    };
+
+    return (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <Card title="Broker Top 10" description="Received messages ranked by broker">
+                <ChartState
+                    isLoading={isBrokerLoading}
+                    error={brokerError}
+                    isEmpty={brokerTopData.length === 0}
+                >
+                    <BrokerTopChart data={brokerTopData} />
+                </ChartState>
+            </Card>
+
+            <Card
+                title="Broker TPS Snapshot"
+                description="Current produce and consume TPS from broker runtime data"
+                headerAction={
+                    <Button variant="ghost" onClick={() => void handleRefresh()} disabled={isRefreshing}>
+                        <RefreshCw className={`w-4 h-4 mr-2 ${isRefreshing ? 'animate-spin' : ''}`} />
+                        Refresh
+                    </Button>
+                }
+            >
+                <ChartState
+                    isLoading={isBrokerLoading}
+                    error={brokerError}
+                    isEmpty={brokerTpsData.length === 0}
+                >
+                    <div className="mt-4 min-w-0 h-[300px] w-full">
+                        <ResponsiveContainer width="100%" height="100%" minWidth={0} debounce={200}>
+                            <LineChart data={brokerTpsData}>
+                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f0f0f0" />
+                                <XAxis
+                                    dataKey="name"
+                                    tick={{ fontSize: 11, fill: '#9ca3af' }}
+                                    tickFormatter={compactLabel}
+                                    axisLine={false}
+                                    tickLine={false}
+                                />
+                                <YAxis tick={{ fontSize: 11, fill: '#9ca3af' }} axisLine={false} tickLine={false} />
+                                <Tooltip
+                                    contentStyle={chartTooltipStyle}
+                                    formatter={(value: number) => [formatNumber(value), 'TPS']}
+                                />
+                                <Line
+                                    type="monotone"
+                                    dataKey="produceTps"
+                                    name="Produce TPS"
+                                    stroke="#ef4444"
+                                    strokeWidth={2}
+                                    dot={false}
+                                />
+                                <Line
+                                    type="monotone"
+                                    dataKey="consumeTps"
+                                    name="Consume TPS"
+                                    stroke="#2563eb"
+                                    strokeWidth={2}
+                                    dot={false}
+                                />
+                            </LineChart>
+                        </ResponsiveContainer>
+                    </div>
+                </ChartState>
+            </Card>
+
+            <Card title="Topic Queue Top 10" description="Largest topics by read and write queue count">
+                <ChartState
+                    isLoading={isTopicLoading}
+                    error={topicError}
+                    isEmpty={topicQueueData.length === 0}
+                >
+                    <div className="mt-4 min-w-0 h-[300px] w-full">
+                        <ResponsiveContainer width="100%" height="100%" minWidth={0} debounce={200}>
+                            <BarChart data={topicQueueData}>
+                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f0f0f0" />
+                                <XAxis
+                                    dataKey="name"
+                                    tick={{ fontSize: 11, fill: '#9ca3af' }}
+                                    tickFormatter={compactLabel}
+                                    axisLine={false}
+                                    tickLine={false}
+                                />
+                                <YAxis tick={{ fontSize: 11, fill: '#9ca3af' }} axisLine={false} tickLine={false} />
+                                <Tooltip
+                                    cursor={{ fill: '#f9fafb' }}
+                                    contentStyle={chartTooltipStyle}
+                                    formatter={(value: number) => [formatNumber(value), 'Queues']}
+                                />
+                                <Bar dataKey="queues" fill="#6366f1" radius={[4, 4, 0, 0]} barSize={30} />
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
+                </ChartState>
+            </Card>
+
+            <Card title="Topic Type Distribution" description="Current topic categories from the Topic catalog">
+                <ChartState
+                    isLoading={isTopicLoading}
+                    error={topicError}
+                    isEmpty={topicCategoryData.length === 0}
+                >
+                    <div className="mt-4 min-w-0 h-[300px] w-full">
+                        <ResponsiveContainer width="100%" height="100%" minWidth={0} debounce={200}>
+                            <BarChart data={topicCategoryData}>
+                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f0f0f0" />
+                                <XAxis
+                                    dataKey="name"
+                                    tick={{ fontSize: 11, fill: '#9ca3af' }}
+                                    axisLine={false}
+                                    tickLine={false}
+                                />
+                                <YAxis allowDecimals={false} tick={{ fontSize: 11, fill: '#9ca3af' }} axisLine={false} tickLine={false} />
+                                <Tooltip
+                                    cursor={{ fill: '#f9fafb' }}
+                                    contentStyle={chartTooltipStyle}
+                                    formatter={(value: number) => [formatNumber(value), 'Topics']}
+                                />
+                                <Bar dataKey="count" fill="#0f766e" radius={[4, 4, 0, 0]} barSize={30} />
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
+                </ChartState>
+            </Card>
+        </div>
+    );
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/hooks/useDashboardCharts.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/hooks/useDashboardCharts.ts
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import { DashboardService } from '../../../services/dashboard.service';
+import type {
+    DashboardBrokerOverviewResponse,
+    DashboardTopicCurrentResponse,
+} from '../types/dashboard.types';
+
+const REFRESH_INDICATOR_DELAY_MS = 180;
+
+const toErrorMessage = (error: unknown, fallback: string) => {
+    if (error instanceof Error) {
+        return error.message;
+    }
+
+    if (typeof error === 'string') {
+        return error;
+    }
+
+    return fallback;
+};
+
+export const useDashboardCharts = () => {
+    const [brokerOverview, setBrokerOverview] = useState<DashboardBrokerOverviewResponse | null>(null);
+    const [topicCurrent, setTopicCurrent] = useState<DashboardTopicCurrentResponse | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [brokerError, setBrokerError] = useState('');
+    const [topicError, setTopicError] = useState('');
+
+    const load = async (mode: 'initial' | 'refresh' = 'refresh') => {
+        let refreshIndicatorTimer: number | null = null;
+        if (mode === 'initial') {
+            setIsLoading(true);
+        } else {
+            refreshIndicatorTimer = window.setTimeout(() => {
+                setIsRefreshing(true);
+            }, REFRESH_INDICATOR_DELAY_MS);
+        }
+
+        setBrokerError('');
+        setTopicError('');
+
+        const [brokerResult, topicResult] = await Promise.allSettled([
+            DashboardService.getBrokerOverview({ forceRefresh: mode === 'refresh' }),
+            DashboardService.queryTopicCurrent(),
+        ]);
+
+        if (brokerResult.status === 'fulfilled') {
+            setBrokerOverview(brokerResult.value);
+        } else {
+            setBrokerError(toErrorMessage(brokerResult.reason, 'Failed to load dashboard broker data'));
+        }
+
+        if (topicResult.status === 'fulfilled') {
+            setTopicCurrent(topicResult.value);
+        } else {
+            setTopicError(toErrorMessage(topicResult.reason, 'Failed to load dashboard topic data'));
+        }
+
+        if (refreshIndicatorTimer !== null) {
+            window.clearTimeout(refreshIndicatorTimer);
+        }
+        setIsLoading(false);
+        setIsRefreshing(false);
+    };
+
+    useEffect(() => {
+        let isMounted = true;
+
+        load('initial')
+            .catch((error) => {
+                if (isMounted) {
+                    const message = toErrorMessage(error, 'Failed to load dashboard charts');
+                    setBrokerError((current) => current || message);
+                    setTopicError((current) => current || message);
+                }
+            })
+            .finally(() => {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            });
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
+
+    return {
+        brokerOverview,
+        topicCurrent,
+        isLoading,
+        isRefreshing,
+        brokerError,
+        topicError,
+        refresh: () => load('refresh'),
+    };
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/types/dashboard.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/types/dashboard.types.ts
@@ -1,0 +1,62 @@
+export interface DashboardBrokerOverviewRequest {
+    forceRefresh: boolean;
+}
+
+export interface DashboardBrokerSummary {
+    totalClusters: number;
+    totalBrokers: number;
+    totalMasters: number;
+    totalSlaves: number;
+    activeBrokers: number;
+    inactiveBrokers: number;
+    brokersWithStatusErrors: number;
+}
+
+export interface DashboardBrokerTopItem {
+    clusterName: string;
+    brokerName: string;
+    brokerId: number;
+    address: string;
+    receivedTotal: number;
+}
+
+export interface DashboardBrokerTpsItem {
+    clusterName: string;
+    brokerName: string;
+    brokerId: number;
+    address: string;
+    produceTps: number;
+    consumeTps: number;
+    totalTps: number;
+}
+
+export interface DashboardBrokerOverviewResponse {
+    currentNamesrv: string;
+    useVipChannel: boolean;
+    useTls: boolean;
+    summary: DashboardBrokerSummary;
+    brokerTop: DashboardBrokerTopItem[];
+    brokerTps: DashboardBrokerTpsItem[];
+}
+
+export interface DashboardTopicQueueItem {
+    topic: string;
+    category: string;
+    readQueueCount: number;
+    writeQueueCount: number;
+    totalQueueCount: number;
+}
+
+export interface DashboardTopicCategoryItem {
+    category: string;
+    count: number;
+}
+
+export interface DashboardTopicCurrentResponse {
+    currentNamesrv: string;
+    useVipChannel: boolean;
+    useTls: boolean;
+    totalTopics: number;
+    topicQueueTop: DashboardTopicQueueItem[];
+    topicCategoryDistribution: DashboardTopicCategoryItem[];
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/consumer.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/consumer.service.ts
@@ -24,6 +24,12 @@ export class ConsumerService {
         return invoke<ConsumerGroupListItem>('refresh_consumer_group', { request });
     }
 
+    static async refreshAllConsumerGroups(
+        request: ConsumerGroupListRequest = {},
+    ): Promise<ConsumerGroupListResponse> {
+        return invoke<ConsumerGroupListResponse>('refresh_all_consumer_groups', { request });
+    }
+
     static async queryConsumerConnection(request: ConsumerConnectionQueryRequest): Promise<ConsumerConnectionView> {
         return invoke<ConsumerConnectionView>('query_consumer_connection', { request });
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/dashboard.service.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/services/dashboard.service.ts
@@ -1,0 +1,18 @@
+import { invoke } from '@tauri-apps/api/core';
+import type {
+    DashboardBrokerOverviewRequest,
+    DashboardBrokerOverviewResponse,
+    DashboardTopicCurrentResponse,
+} from '../features/dashboard/types/dashboard.types';
+
+export class DashboardService {
+    static async getBrokerOverview(
+        request: DashboardBrokerOverviewRequest = { forceRefresh: false }
+    ): Promise<DashboardBrokerOverviewResponse> {
+        return invoke<DashboardBrokerOverviewResponse>('get_dashboard_broker_overview', { request });
+    }
+
+    static async queryTopicCurrent(): Promise<DashboardTopicCurrentResponse> {
+        return invoke<DashboardTopicCurrentResponse>('query_dashboard_topic_current');
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7301

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live dashboard now displays broker overview with summaries, top 10 brokers by message volume, and TPS rankings
  * Added topic metrics visualization showing queue counts and category distribution
  * Consumer groups can now be refreshed to retrieve updated data
  * Enhanced dashboard charts with real-time data fetching and manual refresh controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->