### PR TITLE
[ISSUE #7308]🚀add topic statistics retrieval and display in dashboard, including new data structures and UI components for topic metrics

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -2714,20 +2714,24 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
             .replicas_manager()
             .map(|replicas_manager| replicas_manager.heartbeat_targets())
             .unwrap_or_default();
+        let mut first_reachable = None;
         for address in targets {
             match this.broker_outer_api.get_controller_metadata(&address).await {
                 Ok(metadata) => {
                     if let Some(controller_leader_address) = metadata.controller_leader_address {
                         return Some(controller_leader_address);
                     }
-                    return Some(address);
+                    if metadata.is_leader == Some(true) {
+                        return Some(address);
+                    }
+                    first_reachable.get_or_insert(address);
                 }
                 Err(error) => {
                     warn!("Discover controller leader failed via {}: {}", address, error);
                 }
             }
         }
-        None
+        first_reachable
     }
 
     async fn refresh_controller_leader(mut this: ArcMut<Self>) -> Option<CheetahString> {

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -185,6 +185,7 @@ impl BrokerRuntime {
         let broker_address = format!("{}:{}", broker_config.broker_ip1, broker_config.listen_port);
         let store_host = broker_address.parse::<SocketAddr>().expect("parse store_host failed");
         let runtime = RocketMQRuntime::new_multi(10, "broker-thread");
+        let scheduled_task_manager = ScheduledTaskManager::default();
         let broker_outer_api = BrokerOuterAPI::new(Arc::new(TokioClientConfig::default()));
 
         let topic_queue_mapping_manager = TopicQueueMappingManager::new(broker_config.clone());
@@ -273,7 +274,10 @@ impl BrokerRuntime {
             min_broker_addr_in_group: Default::default(),
             lock: Default::default(),
         });
-        let mut stats_manager = BrokerStatsManager::new(inner.broker_config.clone());
+        let mut stats_manager = BrokerStatsManager::new_with_scheduler(
+            inner.broker_config.clone(),
+            Some(Arc::new(scheduled_task_manager.clone())),
+        );
         stats_manager.set_producer_state_getter(Arc::new(ProducerStateGetter {
             broker_runtime_inner: inner.clone(),
         }));
@@ -302,7 +306,7 @@ impl BrokerRuntime {
             shutdown_hook: None,
             proxy_request_processor: None,
             consumer_ids_change_listener,
-            scheduled_task_manager: Default::default(),
+            scheduled_task_manager,
         }
     }
 

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -969,6 +969,19 @@ where
             }
             Some(result_inner) => {
                 if !result_inner.message_mapped_list().is_empty() {
+                    let broker_stats = self.broker_runtime_inner.broker_stats_manager();
+                    broker_stats.inc_broker_get_nums(request_header.topic.as_str(), result_inner.message_count());
+                    broker_stats.inc_group_get_nums(
+                        request_header.consumer_group.as_str(),
+                        topic.as_str(),
+                        result_inner.message_count(),
+                    );
+                    broker_stats.inc_group_get_size(
+                        request_header.consumer_group.as_str(),
+                        topic.as_str(),
+                        result_inner.buffer_total_size(),
+                    );
+
                     if is_order {
                         self.broker_runtime_inner.consumer_order_info_manager().update(
                             request_header.attempt_id.clone().unwrap_or_default(),

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/service.rs
@@ -24,13 +24,16 @@ use crate::dashboard::types::DashboardResult;
 use crate::dashboard::types::DashboardTopicCategoryItem;
 use crate::dashboard::types::DashboardTopicCurrentResponse;
 use crate::dashboard::types::DashboardTopicQueueItem;
+use crate::dashboard::types::DashboardTopicTopItem;
 use crate::topic::service::TopicManager;
+use crate::topic::types::TopicCurrentStatsItem;
 use crate::topic::types::TopicListItem;
 use crate::topic::types::TopicListResponse;
 use rocketmq_dashboard_common::ClusterHomePageRequest;
 use rocketmq_dashboard_common::DashboardBrokerOverviewRequest;
 use rocketmq_dashboard_common::TopicListRequest;
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 
 const TOP_LIMIT: usize = 10;
 
@@ -58,8 +61,20 @@ pub(crate) async fn query_dashboard_topic_current(
         })
         .await
         .map_err(|error| DashboardError::Topic(error.to_string()))?;
+    let stats_response = topic_manager
+        .get_topic_current_stats()
+        .await
+        .map_err(|error| DashboardError::Topic(error.to_string()))?;
 
-    Ok(build_topic_current(topic_response))
+    for failure in &stats_response.failures {
+        log::warn!(
+            "Failed to collect dashboard topic current stats for `{}`: {}",
+            failure.topic,
+            failure.error
+        );
+    }
+
+    Ok(build_topic_current(topic_response, stats_response.items))
 }
 
 fn build_broker_overview(cluster_response: ClusterHomePageResponse) -> DashboardBrokerOverviewResponse {
@@ -81,12 +96,16 @@ fn build_broker_overview(cluster_response: ClusterHomePageResponse) -> Dashboard
     }
 }
 
-fn build_topic_current(topic_response: TopicListResponse) -> DashboardTopicCurrentResponse {
+fn build_topic_current(
+    topic_response: TopicListResponse,
+    topic_stats: Vec<TopicCurrentStatsItem>,
+) -> DashboardTopicCurrentResponse {
     DashboardTopicCurrentResponse {
         current_namesrv: topic_response.current_namesrv,
         use_vip_channel: topic_response.use_vip_channel,
         use_tls: topic_response.use_tls,
         total_topics: topic_response.total,
+        topic_top: build_topic_top(topic_stats, &topic_response.items),
         topic_queue_top: build_topic_queue_top(&topic_response.items),
         topic_category_distribution: build_topic_category_distribution(&topic_response.items),
     }
@@ -165,6 +184,31 @@ fn build_topic_queue_top(items: &[TopicListItem]) -> Vec<DashboardTopicQueueItem
         .collect()
 }
 
+fn build_topic_top(items: Vec<TopicCurrentStatsItem>, topic_items: &[TopicListItem]) -> Vec<DashboardTopicTopItem> {
+    let java_collectable_topics = topic_items
+        .iter()
+        .filter(|item| !item.system_topic && !matches!(item.category.as_str(), "RETRY" | "DLQ"))
+        .map(|item| item.topic.as_str())
+        .collect::<HashSet<_>>();
+    let mut sorted = items;
+    sorted.retain(|item| java_collectable_topics.contains(item.topic.as_str()));
+    sorted.sort_by(|left, right| right.total_msg.cmp(&left.total_msg).then(left.topic.cmp(&right.topic)));
+
+    sorted
+        .into_iter()
+        .take(TOP_LIMIT)
+        .map(|item| DashboardTopicTopItem {
+            topic: item.topic,
+            total_msg: item.total_msg,
+            produced_msg_count_24h: item.produced_msg_count_24h,
+            consumed_msg_count_24h: item.consumed_msg_count_24h,
+            in_tps: item.in_tps,
+            out_tps: item.out_tps,
+            consumer_group_count: item.consumer_group_count,
+        })
+        .collect()
+}
+
 fn build_topic_category_distribution(items: &[TopicListItem]) -> Vec<DashboardTopicCategoryItem> {
     let mut counts = BTreeMap::<String, usize>::new();
     for item in items {
@@ -185,7 +229,9 @@ mod tests {
     use super::build_broker_tps;
     use super::build_topic_category_distribution;
     use super::build_topic_queue_top;
+    use super::build_topic_top;
     use crate::cluster::types::ClusterBrokerCardItem;
+    use crate::topic::types::TopicCurrentStatsItem;
     use crate::topic::types::TopicListItem;
     use std::collections::BTreeMap;
 
@@ -211,6 +257,20 @@ mod tests {
     }
 
     fn topic(name: &str, category: &str, read_queue_count: u32, write_queue_count: u32) -> TopicListItem {
+        topic_with_system_flag(name, category, read_queue_count, write_queue_count, false)
+    }
+
+    fn system_topic(name: &str) -> TopicListItem {
+        topic_with_system_flag(name, "SYSTEM", 1, 1, true)
+    }
+
+    fn topic_with_system_flag(
+        name: &str,
+        category: &str,
+        read_queue_count: u32,
+        write_queue_count: u32,
+        system_topic: bool,
+    ) -> TopicListItem {
         TopicListItem {
             topic: name.into(),
             category: category.into(),
@@ -221,7 +281,19 @@ mod tests {
             write_queue_count,
             perm: 6,
             order: false,
-            system_topic: false,
+            system_topic,
+        }
+    }
+
+    fn topic_stats(topic: &str, total_msg: u64) -> TopicCurrentStatsItem {
+        TopicCurrentStatsItem {
+            topic: topic.into(),
+            total_msg,
+            produced_msg_count_24h: total_msg + 10,
+            consumed_msg_count_24h: total_msg,
+            in_tps: 1.0,
+            out_tps: 2.0,
+            consumer_group_count: 1,
         }
     }
 
@@ -253,6 +325,39 @@ mod tests {
 
         assert_eq!(top[0].topic, "topic-b");
         assert_eq!(top[0].total_queue_count, 12);
+    }
+
+    #[test]
+    fn topic_top_uses_java_total_msg_descending() {
+        let items = vec![topic_stats("topic-a", 20), topic_stats("topic-b", 50)];
+        let topic_items = vec![topic("topic-a", "NORMAL", 2, 2), topic("topic-b", "NORMAL", 2, 2)];
+
+        let top = build_topic_top(items, &topic_items);
+
+        assert_eq!(top[0].topic, "topic-b");
+        assert_eq!(top[0].total_msg, 50);
+    }
+
+    #[test]
+    fn topic_top_filters_java_dashboard_non_collectable_topics() {
+        let items = vec![
+            topic_stats("TopicTest1111", 7),
+            topic_stats("SCHEDULE_TOPIC_XXXX", 90),
+            topic_stats("%RETRY%group-a", 80),
+            topic_stats("%DLQ%group-a", 70),
+        ];
+        let topic_items = vec![
+            topic("TopicTest1111", "NORMAL", 2, 2),
+            system_topic("SCHEDULE_TOPIC_XXXX"),
+            topic("%RETRY%group-a", "RETRY", 1, 1),
+            topic("%DLQ%group-a", "DLQ", 1, 1),
+        ];
+
+        let top = build_topic_top(items, &topic_items);
+
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].topic, "TopicTest1111");
+        assert_eq!(top[0].total_msg, 7);
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/dashboard/types.rs
@@ -90,6 +90,18 @@ pub(crate) struct DashboardTopicQueueItem {
     pub(crate) total_queue_count: u32,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DashboardTopicTopItem {
+    pub(crate) topic: String,
+    pub(crate) total_msg: u64,
+    pub(crate) produced_msg_count_24h: u64,
+    pub(crate) consumed_msg_count_24h: u64,
+    pub(crate) in_tps: f64,
+    pub(crate) out_tps: f64,
+    pub(crate) consumer_group_count: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DashboardTopicCategoryItem {
@@ -97,13 +109,14 @@ pub(crate) struct DashboardTopicCategoryItem {
     pub(crate) count: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DashboardTopicCurrentResponse {
     pub(crate) current_namesrv: String,
     pub(crate) use_vip_channel: bool,
     pub(crate) use_tls: bool,
     pub(crate) total_topics: usize,
+    pub(crate) topic_top: Vec<DashboardTopicTopItem>,
     pub(crate) topic_queue_top: Vec<DashboardTopicQueueItem>,
     pub(crate) topic_category_distribution: Vec<DashboardTopicCategoryItem>,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -19,6 +19,9 @@ use crate::topic::types::TopicConfigView;
 use crate::topic::types::TopicConsumerGroupListResponse;
 use crate::topic::types::TopicConsumerInfoResponse;
 use crate::topic::types::TopicConsumerInfoView;
+use crate::topic::types::TopicCurrentStatsFailure;
+use crate::topic::types::TopicCurrentStatsItem;
+use crate::topic::types::TopicCurrentStatsResponse;
 use crate::topic::types::TopicError;
 use crate::topic::types::TopicListItem;
 use crate::topic::types::TopicListResponse;
@@ -33,6 +36,9 @@ use crate::topic::types::TopicStatusView;
 use crate::topic::types::TopicTargetOption;
 use cheetah_string::CheetahString;
 use rocketmq_admin_core::admin::default_mq_admin_ext::DefaultMQAdminExt;
+use rocketmq_admin_core::core::stats::StatsAllQueryRequest;
+use rocketmq_admin_core::core::stats::StatsAllRow;
+use rocketmq_admin_core::core::stats::StatsService;
 use rocketmq_client_rust::admin::mq_admin_ext_async::MQAdminExt;
 use rocketmq_client_rust::base::client_config::ClientConfig;
 use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
@@ -63,6 +69,7 @@ use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use std::any::Any;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -137,6 +144,42 @@ impl TopicManager {
                 Ok(response) => return Ok(response),
                 Err(error) if should_reset && attempt < 2 => {
                     log::warn!("Retrying `get_topic_list` after reconnect: {}", error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    pub(crate) async fn get_topic_current_stats(&self) -> TopicResult<TopicCurrentStatsResponse> {
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let mut session_guard = self.admin_session.lock().await;
+            self.ensure_admin_session(&mut session_guard).await?;
+
+            let snapshot = session_guard
+                .as_ref()
+                .expect("topic admin session should be initialized before use")
+                .snapshot
+                .clone();
+            let result = {
+                let session = session_guard
+                    .as_ref()
+                    .expect("topic admin session should be initialized before use");
+                self.get_topic_current_stats_with_admin(&session.admin, &snapshot).await
+            };
+
+            let should_reset = Self::should_reset_session(&result);
+            if should_reset {
+                self.reset_admin_session(&mut session_guard, "get_topic_current_stats failed")
+                    .await;
+            }
+            drop(session_guard);
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) if should_reset && attempt < 2 => {
+                    log::warn!("Retrying `get_topic_current_stats` after reconnect: {}", error);
                 }
                 Err(error) => return Err(error),
             }
@@ -525,6 +568,32 @@ impl TopicManager {
     ) -> TopicResult<TopicRouteView> {
         let route = require_topic_route(admin, &request.topic).await?;
         Ok(map_route_view(&request.topic, &route))
+    }
+
+    async fn get_topic_current_stats_with_admin(
+        &self,
+        admin: &DefaultMQAdminExt,
+        snapshot: &NameServerConfigSnapshot,
+    ) -> TopicResult<TopicCurrentStatsResponse> {
+        let request = StatsAllQueryRequest::new(false, None::<String>);
+        let stats_result = StatsService::query_stats_all_with_admin(admin, &request)
+            .await
+            .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+
+        Ok(TopicCurrentStatsResponse {
+            items: build_topic_current_stats_items(stats_result.rows),
+            failures: stats_result
+                .failures
+                .into_iter()
+                .map(|failure| TopicCurrentStatsFailure {
+                    topic: failure.topic.to_string(),
+                    error: failure.error,
+                })
+                .collect(),
+            current_namesrv: snapshot.current_namesrv.clone().unwrap_or_default(),
+            use_vip_channel: snapshot.use_vip_channel,
+            use_tls: snapshot.use_tls,
+        })
     }
 
     async fn get_topic_stats_with_admin(
@@ -998,6 +1067,49 @@ impl TopicManager {
 
         Ok(map_send_result(request.topic, send_result))
     }
+}
+
+#[derive(Default)]
+struct TopicCurrentStatsAccumulator {
+    produced_msg_count_24h: u64,
+    consumed_msg_count_24h: u64,
+    in_tps: f64,
+    out_tps: f64,
+    consumer_group_count: usize,
+}
+
+fn build_topic_current_stats_items(rows: Vec<StatsAllRow>) -> Vec<TopicCurrentStatsItem> {
+    let mut by_topic = BTreeMap::<String, TopicCurrentStatsAccumulator>::new();
+
+    for row in rows {
+        let topic = row.topic.to_string();
+        let entry = by_topic.entry(topic).or_default();
+        entry.produced_msg_count_24h = entry.produced_msg_count_24h.max(row.in_msg_count_24h);
+        entry.in_tps = entry.in_tps.max(row.in_tps);
+
+        if let Some(out_msg_count_24h) = row.out_msg_count_24h {
+            entry.consumed_msg_count_24h += out_msg_count_24h;
+        }
+        if let Some(out_tps) = row.out_tps {
+            entry.out_tps += out_tps;
+        }
+        if row.consumer_group.is_some() {
+            entry.consumer_group_count += 1;
+        }
+    }
+
+    by_topic
+        .into_iter()
+        .map(|(topic, stats)| TopicCurrentStatsItem {
+            topic,
+            total_msg: stats.consumed_msg_count_24h,
+            produced_msg_count_24h: stats.produced_msg_count_24h,
+            consumed_msg_count_24h: stats.consumed_msg_count_24h,
+            in_tps: stats.in_tps,
+            out_tps: stats.out_tps,
+            consumer_group_count: stats.consumer_group_count,
+        })
+        .collect()
 }
 
 async fn send_transaction_message_with_runtime(
@@ -1712,6 +1824,7 @@ fn quote_numeric_object_keys(input: &str) -> String {
 mod tests {
     use super::TopicBrokerConfigSnapshot;
     use super::build_send_message;
+    use super::build_topic_current_stats_items;
     use super::classify_topic;
     use super::cluster_targets_from_cluster_info;
     use super::find_master_addr_by_broker_name;
@@ -1723,6 +1836,7 @@ mod tests {
     use super::normalize_topic_message_body;
     use super::quote_numeric_object_keys;
     use cheetah_string::CheetahString;
+    use rocketmq_admin_core::core::stats::StatsAllRow;
     use rocketmq_client_rust::producer::local_transaction_state::LocalTransactionState;
     use rocketmq_client_rust::producer::send_result::SendResult;
     use rocketmq_client_rust::producer::send_status::SendStatus;
@@ -1763,6 +1877,58 @@ mod tests {
         assert_eq!(category, "FIFO");
         assert_eq!(message_type, "FIFO");
         assert!(!system_topic);
+    }
+
+    #[test]
+    fn build_topic_current_stats_items_aggregates_java_topic_current_rows() {
+        let rows = vec![
+            StatsAllRow {
+                topic: CheetahString::from_static_str("TopicA"),
+                consumer_group: Some(CheetahString::from_static_str("GroupA")),
+                accumulation: 0,
+                in_tps: 12.0,
+                out_tps: Some(3.0),
+                in_msg_count_24h: 100,
+                out_msg_count_24h: Some(20),
+            },
+            StatsAllRow {
+                topic: CheetahString::from_static_str("TopicA"),
+                consumer_group: Some(CheetahString::from_static_str("GroupB")),
+                accumulation: 0,
+                in_tps: 12.0,
+                out_tps: Some(5.0),
+                in_msg_count_24h: 100,
+                out_msg_count_24h: Some(30),
+            },
+            StatsAllRow {
+                topic: CheetahString::from_static_str("TopicB"),
+                consumer_group: None,
+                accumulation: 0,
+                in_tps: 2.0,
+                out_tps: None,
+                in_msg_count_24h: 7,
+                out_msg_count_24h: None,
+            },
+        ];
+
+        let items = build_topic_current_stats_items(rows);
+        let topic_a = items
+            .iter()
+            .find(|item| item.topic == "TopicA")
+            .expect("TopicA should be present");
+        let topic_b = items
+            .iter()
+            .find(|item| item.topic == "TopicB")
+            .expect("TopicB should be present");
+
+        assert_eq!(topic_a.total_msg, 50);
+        assert_eq!(topic_a.produced_msg_count_24h, 100);
+        assert_eq!(topic_a.consumed_msg_count_24h, 50);
+        assert_eq!(topic_a.out_tps, 8.0);
+        assert_eq!(topic_a.consumer_group_count, 2);
+        assert_eq!(topic_b.total_msg, 0);
+        assert_eq!(topic_b.produced_msg_count_24h, 7);
+        assert_eq!(topic_b.consumer_group_count, 0);
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/types.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/types.rs
@@ -71,6 +71,35 @@ pub(crate) struct TopicListResponse {
     pub(crate) use_tls: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicCurrentStatsItem {
+    pub(crate) topic: String,
+    pub(crate) total_msg: u64,
+    pub(crate) produced_msg_count_24h: u64,
+    pub(crate) consumed_msg_count_24h: u64,
+    pub(crate) in_tps: f64,
+    pub(crate) out_tps: f64,
+    pub(crate) consumer_group_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicCurrentStatsFailure {
+    pub(crate) topic: String,
+    pub(crate) error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TopicCurrentStatsResponse {
+    pub(crate) items: Vec<TopicCurrentStatsItem>,
+    pub(crate) failures: Vec<TopicCurrentStatsFailure>,
+    pub(crate) current_namesrv: String,
+    pub(crate) use_vip_channel: bool,
+    pub(crate) use_tls: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TopicBrokerAddressView {

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/components/Charts.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/components/Charts.tsx
@@ -8,6 +8,7 @@ import {
     ResponsiveContainer,
     BarChart,
     Bar,
+    LabelList,
 } from 'recharts';
 import { Card } from '../../../components/ui/LegacyCard';
 import { Button } from '../../../components/ui/LegacyButton';
@@ -25,9 +26,11 @@ const compactLabel = (value: string) => {
 };
 
 const chartTooltipStyle = {
-    borderRadius: '12px',
-    border: 'none',
-    boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+    borderRadius: '10px',
+    border: '1px solid rgba(71, 85, 105, 0.8)',
+    backgroundColor: '#0f172a',
+    color: '#e2e8f0',
+    boxShadow: '0 16px 32px rgba(0,0,0,0.28)',
 };
 
 const ChartState = ({
@@ -79,6 +82,14 @@ interface BrokerTpsChartItem {
     address: string;
     produceTps: number;
     consumeTps: number;
+}
+
+interface TopicTopChartItem {
+    topic: string;
+    totalMsg: number;
+    producedMsgCount24h: number;
+    consumedMsgCount24h: number;
+    consumerGroupCount: number;
 }
 
 const BrokerTopChart = ({ data }: { data: BrokerTopChartItem[] }) => {
@@ -268,6 +279,76 @@ const BrokerTpsCompactCards = ({ data }: { data: BrokerTpsChartItem[] }) => {
     );
 };
 
+const TopicTopBarChart = ({ data }: { data: TopicTopChartItem[] }) => {
+    const chartHeight = Math.max(300, data.length * 34 + 56);
+
+    return (
+        <div className="mt-4">
+            <div className="mb-3 flex items-center justify-between gap-3 text-xs">
+                <div className="flex items-center gap-2 font-semibold text-slate-300">
+                    <span className="h-2.5 w-2.5 rounded-sm bg-indigo-400" />
+                    TotalMsg
+                </div>
+                <div className="text-slate-500">
+                    24h consumed messages
+                </div>
+            </div>
+
+            <div className="min-w-0 w-full" style={{ height: `${chartHeight}px` }}>
+                <ResponsiveContainer width="100%" height="100%" minWidth={0} debounce={200}>
+                    <BarChart
+                        data={data}
+                        layout="vertical"
+                        margin={{ top: 8, right: 92, bottom: 8, left: 8 }}
+                        barCategoryGap={8}
+                    >
+                        <CartesianGrid horizontal={false} stroke="rgba(148, 163, 184, 0.18)" />
+                        <XAxis
+                            type="number"
+                            tick={{ fontSize: 11, fill: '#94a3b8' }}
+                            axisLine={false}
+                            tickLine={false}
+                            tickFormatter={(value) => formatNumber(Number(value))}
+                        />
+                        <YAxis
+                            type="category"
+                            dataKey="topic"
+                            width={142}
+                            tick={{ fontSize: 11, fill: '#cbd5e1', fontWeight: 600 }}
+                            tickFormatter={compactLabel}
+                            axisLine={false}
+                            tickLine={false}
+                        />
+                        <Tooltip
+                            cursor={{ fill: 'rgba(30, 41, 59, 0.45)' }}
+                            contentStyle={chartTooltipStyle}
+                            labelFormatter={(topic) => `Topic: ${topic}`}
+                            formatter={(value: number, name: string, item) => {
+                                if (name === 'totalMsg') {
+                                    return [formatNumber(value), 'TotalMsg'];
+                                }
+
+                                return [formatNumber(value), item.name];
+                            }}
+                        />
+                        <Bar dataKey="totalMsg" name="TotalMsg" fill="#818cf8" radius={[0, 6, 6, 0]} barSize={18}>
+                            <LabelList
+                                dataKey="totalMsg"
+                                position="right"
+                                formatter={(value: number) => formatNumber(value)}
+                                fill="#e0e7ff"
+                                fontSize={11}
+                                fontWeight={700}
+                                fontFamily="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
+                            />
+                        </Bar>
+                    </BarChart>
+                </ResponsiveContainer>
+            </div>
+        </div>
+    );
+};
+
 export const DashboardCharts = () => {
     const {
         brokerOverview,
@@ -300,6 +381,18 @@ export const DashboardCharts = () => {
         [brokerOverview?.brokerTps]
     );
 
+    const topicTopData = useMemo(
+        () =>
+            (topicCurrent?.topicTop ?? []).map((item) => ({
+                topic: item.topic,
+                totalMsg: item.totalMsg,
+                producedMsgCount24h: item.producedMsgCount24h,
+                consumedMsgCount24h: item.consumedMsgCount24h,
+                consumerGroupCount: item.consumerGroupCount,
+            })),
+        [topicCurrent?.topicTop]
+    );
+
     const topicQueueData = useMemo(
         () =>
             (topicCurrent?.topicQueueTop ?? []).map((item) => ({
@@ -321,7 +414,8 @@ export const DashboardCharts = () => {
     );
 
     const isBrokerLoading = isLoading && brokerTopData.length === 0;
-    const isTopicLoading = isLoading && topicQueueData.length === 0;
+    const isTopicLoading =
+        isLoading && topicTopData.length === 0 && topicQueueData.length === 0 && topicCategoryData.length === 0;
 
     const handleRefresh = async () => {
         await refresh();
@@ -358,6 +452,16 @@ export const DashboardCharts = () => {
                 </ChartState>
             </Card>
 
+            <Card title="Topic TOP 10" description="TotalMsg ranked by topic">
+                <ChartState
+                    isLoading={isTopicLoading}
+                    error={topicError}
+                    isEmpty={topicTopData.length === 0}
+                >
+                    <TopicTopBarChart data={topicTopData} />
+                </ChartState>
+            </Card>
+
             <Card title="Topic Queue Top 10" description="Largest topics by read and write queue count">
                 <ChartState
                     isLoading={isTopicLoading}
@@ -367,7 +471,7 @@ export const DashboardCharts = () => {
                     <div className="mt-4 min-w-0 h-[300px] w-full">
                         <ResponsiveContainer width="100%" height="100%" minWidth={0} debounce={200}>
                             <BarChart data={topicQueueData}>
-                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f0f0f0" />
+                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(148, 163, 184, 0.22)" />
                                 <XAxis
                                     dataKey="name"
                                     tick={{ fontSize: 11, fill: '#9ca3af' }}
@@ -377,7 +481,7 @@ export const DashboardCharts = () => {
                                 />
                                 <YAxis tick={{ fontSize: 11, fill: '#9ca3af' }} axisLine={false} tickLine={false} />
                                 <Tooltip
-                                    cursor={{ fill: '#f9fafb' }}
+                                    cursor={{ fill: 'rgba(30, 41, 59, 0.45)' }}
                                     contentStyle={chartTooltipStyle}
                                     formatter={(value: number) => [formatNumber(value), 'Queues']}
                                 />
@@ -397,7 +501,7 @@ export const DashboardCharts = () => {
                     <div className="mt-4 min-w-0 h-[300px] w-full">
                         <ResponsiveContainer width="100%" height="100%" minWidth={0} debounce={200}>
                             <BarChart data={topicCategoryData}>
-                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f0f0f0" />
+                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(148, 163, 184, 0.22)" />
                                 <XAxis
                                     dataKey="name"
                                     tick={{ fontSize: 11, fill: '#9ca3af' }}
@@ -406,11 +510,11 @@ export const DashboardCharts = () => {
                                 />
                                 <YAxis allowDecimals={false} tick={{ fontSize: 11, fill: '#9ca3af' }} axisLine={false} tickLine={false} />
                                 <Tooltip
-                                    cursor={{ fill: '#f9fafb' }}
+                                    cursor={{ fill: 'rgba(30, 41, 59, 0.45)' }}
                                     contentStyle={chartTooltipStyle}
                                     formatter={(value: number) => [formatNumber(value), 'Topics']}
                                 />
-                                <Bar dataKey="count" fill="#0f766e" radius={[4, 4, 0, 0]} barSize={30} />
+                                <Bar dataKey="count" fill="#2dd4bf" radius={[4, 4, 0, 0]} barSize={30} />
                             </BarChart>
                         </ResponsiveContainer>
                     </div>

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/types/dashboard.types.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src/features/dashboard/types/dashboard.types.ts
@@ -47,6 +47,16 @@ export interface DashboardTopicQueueItem {
     totalQueueCount: number;
 }
 
+export interface DashboardTopicTopItem {
+    topic: string;
+    totalMsg: number;
+    producedMsgCount24h: number;
+    consumedMsgCount24h: number;
+    inTps: number;
+    outTps: number;
+    consumerGroupCount: number;
+}
+
 export interface DashboardTopicCategoryItem {
     category: string;
     count: number;
@@ -57,6 +67,7 @@ export interface DashboardTopicCurrentResponse {
     useVipChannel: boolean;
     useTls: boolean;
     totalTopics: number;
+    topicTop: DashboardTopicTopItem[];
     topicQueueTop: DashboardTopicQueueItem[];
     topicCategoryDistribution: DashboardTopicCategoryItem[];
 }

--- a/rocketmq-store/src/stats/broker_stats_manager.rs
+++ b/rocketmq-store/src/stats/broker_stats_manager.rs
@@ -31,7 +31,6 @@ use rocketmq_common::common::stats::stats_item::StatsItem;
 use rocketmq_common::common::stats::stats_item_set::StatsItemSet;
 use rocketmq_common::common::stats::Stats;
 use rocketmq_common::common::topic::TopicValidator;
-use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::schedule::simple_scheduler::ScheduledTaskManager;
 use tokio::time::Duration;
 use tracing::info;
@@ -118,33 +117,38 @@ impl BrokerStatsManager {
     fn start_sampling_tasks(&self, scheduler: &Arc<ScheduledTaskManager>) {
         // Task 1: Sample every 10 seconds for minute-level statistics
         let stats_table = Arc::clone(&self.stats_table);
-        let task_id = scheduler.add_fixed_rate_task(Duration::from_secs(10), Duration::from_secs(10), move |_cancel| {
+        let task_id = scheduler.add_fixed_rate_task(Duration::ZERO, Duration::from_secs(10), move |_cancel| {
             let stats_table = Arc::clone(&stats_table);
             async move {
-                for entry in stats_table.iter() {
-                    entry.value().sampling_in_minutes();
-                }
+                Self::sample_stats_table_in_seconds(&stats_table);
                 Ok(())
             }
         });
         self.task_ids.lock().push(task_id);
 
-        // Task 2: Sample every minute (aligned to minute boundary)
+        // Task 2: Sample every 10 minutes for hour-level statistics
         let stats_table = Arc::clone(&self.stats_table);
-        let initial_delay = Self::compute_initial_delay_to_next_minute();
-        let task_id = scheduler.add_fixed_rate_task(initial_delay, Duration::from_secs(60), move |_cancel| {
+        let task_id = scheduler.add_fixed_rate_task(Duration::ZERO, Duration::from_secs(600), move |_cancel| {
             let stats_table = Arc::clone(&stats_table);
             async move {
-                info!("Executing minute-level sampling for all stats");
-                for entry in stats_table.iter() {
-                    entry.value().sampling_in_minutes();
-                }
+                Self::sample_stats_table_in_minutes(&stats_table);
                 Ok(())
             }
         });
         self.task_ids.lock().push(task_id);
 
-        // Task 3: Clean up expired stats every 10 minutes
+        // Task 3: Sample every hour for day-level statistics
+        let stats_table = Arc::clone(&self.stats_table);
+        let task_id = scheduler.add_fixed_rate_task(Duration::ZERO, Duration::from_secs(3600), move |_cancel| {
+            let stats_table = Arc::clone(&stats_table);
+            async move {
+                Self::sample_stats_table_in_hours(&stats_table);
+                Ok(())
+            }
+        });
+        self.task_ids.lock().push(task_id);
+
+        // Task 4: Clean up expired stats every 10 minutes
         let stats_table = Arc::clone(&self.stats_table);
         let task_id =
             scheduler.add_fixed_rate_task(Duration::from_secs(600), Duration::from_secs(600), move |_cancel| {
@@ -163,14 +167,22 @@ impl BrokerStatsManager {
         );
     }
 
-    /// Compute delay to next minute boundary
-    fn compute_initial_delay_to_next_minute() -> Duration {
-        let now = current_millis();
+    fn sample_stats_table_in_seconds(stats_table: &DashMap<String, StatsItemSet>) {
+        for entry in stats_table.iter() {
+            entry.value().sampling_in_seconds();
+        }
+    }
 
-        let next_minute = ((now / 60000) + 1) * 60000;
-        let delay_ms = next_minute - now;
+    fn sample_stats_table_in_minutes(stats_table: &DashMap<String, StatsItemSet>) {
+        for entry in stats_table.iter() {
+            entry.value().sampling_in_minutes();
+        }
+    }
 
-        Duration::from_millis(delay_ms)
+    fn sample_stats_table_in_hours(stats_table: &DashMap<String, StatsItemSet>) {
+        for entry in stats_table.iter() {
+            entry.value().sampling_in_hours();
+        }
     }
 
     #[inline]
@@ -1117,6 +1129,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sampling_helpers_populate_java_compatible_stats_windows() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let manager = BrokerStatsManager::new(broker_config);
+
+        manager.inc_topic_put_nums("TestTopic", 100, 1);
+        manager.inc_group_get_nums("TestGroup", "TestTopic", 40);
+
+        BrokerStatsManager::sample_stats_table_in_seconds(&manager.stats_table);
+        BrokerStatsManager::sample_stats_table_in_minutes(&manager.stats_table);
+        BrokerStatsManager::sample_stats_table_in_hours(&manager.stats_table);
+
+        let stats = manager
+            .stats_table
+            .get(Stats::TOPIC_PUT_NUMS)
+            .expect("topic stats should exist");
+        let item = stats
+            .get_stats_item("TestTopic")
+            .expect("topic stats item should exist");
+
+        assert_eq!(stats.get_stats_data_in_minute("TestTopic").get_sum(), 100);
+        assert_eq!(stats.get_stats_data_in_hour("TestTopic").get_sum(), 100);
+        assert_eq!(item.get_stats_data_in_day().get_sum(), 100);
+
+        let group_stats_key = build_stats_key(Some("TestTopic"), Some("TestGroup"));
+        let group_stats = manager
+            .stats_table
+            .get(Stats::GROUP_GET_NUMS)
+            .expect("group get stats should exist");
+        let group_item = group_stats
+            .get_stats_item(&group_stats_key)
+            .expect("group get stats item should exist");
+
+        assert_eq!(group_stats.get_stats_data_in_minute(&group_stats_key).get_sum(), 40);
+        assert_eq!(group_stats.get_stats_data_in_hour(&group_stats_key).get_sum(), 40);
+        assert_eq!(group_item.get_stats_data_in_day().get_sum(), 40);
+    }
+
+    #[tokio::test]
     async fn test_inc_topic_put_nums() {
         let broker_config = Arc::new(BrokerConfig::default());
         let manager = BrokerStatsManager::new(broker_config);
@@ -1376,7 +1426,7 @@ mod tests {
 
         manager.start();
 
-        assert_eq!(manager.task_ids.lock().len(), 3);
+        assert_eq!(manager.task_ids.lock().len(), 4);
     }
 
     #[tokio::test]
@@ -1387,7 +1437,7 @@ mod tests {
 
         manager.start();
         let task_count_before = manager.task_ids.lock().len();
-        assert_eq!(task_count_before, 3);
+        assert_eq!(task_count_before, 4);
 
         manager.shutdown();
         let task_count_after = manager.task_ids.lock().len();


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7308

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard: added "Topic TOP 10" chart and topic-top data to dashboard responses, showing per-topic totals, 24h in/out counts, TPS and consumer-group counts.
  * Dashboard API: returns per-topic current stats to populate dashboard views.

* **Refactor**
  * Broker: sampling/scheduling for statistics collection reorganized and scheduler initialization improved.

* **Bug Fixes**
  * Improved leader discovery logic and expanded broker-side stat accounting on message pop.

* **Tests**
  * Extended unit tests for topic stats aggregation, top sorting/filtering, and sampling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->