### PR TITLE
[ISSUE #7310]🚀add initial implementation of tiered storage for RocketMQ in Rust, including core traits, metadata models, and file segment management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3998,6 +3998,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocketmq-tieredstore"
+version = "0.8.0"
+dependencies = [
+ "bytes",
+ "dashmap",
+ "parking_lot",
+ "rocketmq-common",
+ "rocketmq-error",
+ "rocketmq-runtime",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "trait-variant",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "rocketmq-proxy",
   "rocketmq-remoting",
   "rocketmq-runtime",
+  "rocketmq-tieredstore",
   "rocketmq-store",
   "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli",
   "rocketmq-tools/rocketmq-admin/rocketmq-admin-core",

--- a/rocketmq-tieredstore/Cargo.toml
+++ b/rocketmq-tieredstore/Cargo.toml
@@ -1,0 +1,57 @@
+# Copyright 2023 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "rocketmq-tieredstore"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords = [
+  "apache-rocketmq",
+  "rocketmq-rust",
+  "rocketmq-tieredstore",
+  "rust",
+  "storage",
+]
+readme = "README.md"
+description = "Tiered storage layer for Apache RocketMQ in Rust."
+rust-version.workspace = true
+
+[features]
+default = ["posix-provider", "memory-provider", "serde"]
+posix-provider = []
+memory-provider = []
+serde = ["dep:serde", "dep:serde_json"]
+rocketmq-store-integration = []
+
+[dependencies]
+rocketmq-common = { workspace = true }
+rocketmq-error = { workspace = true }
+rocketmq-runtime = { workspace = true }
+
+bytes = { workspace = true }
+dashmap = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+trait-variant = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/rocketmq-tieredstore/README.md
+++ b/rocketmq-tieredstore/README.md
@@ -1,0 +1,5 @@
+# rocketmq-tieredstore
+
+Tiered storage crate for `rocketmq-rust`.
+
+This crate is being migrated from Apache RocketMQ Java tieredstore semantics in staged steps. The first stage provides the independent crate boundary, core traits, metadata model, provider abstraction, and basic memory/POSIX segment IO.

--- a/rocketmq-tieredstore/src/config.rs
+++ b/rocketmq-tieredstore/src/config.rs
@@ -1,0 +1,138 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TieredStorageLevel {
+    Disable = 0,
+    NotInDisk = 1,
+    NotInMem = 2,
+    Force = 3,
+}
+
+impl TieredStorageLevel {
+    #[inline]
+    pub fn enabled(self) -> bool {
+        !matches!(self, Self::Disable)
+    }
+
+    #[inline]
+    pub fn check(self, target: Self) -> bool {
+        self as u8 >= target as u8
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TieredStoreConfig {
+    pub storage_level: TieredStorageLevel,
+    pub store_path_root_dir: PathBuf,
+    pub commit_log_segment_size: u64,
+    pub consume_queue_segment_size: u64,
+    pub index_file_max_hash_slot_num: u32,
+    pub index_file_max_index_num: u32,
+    pub message_index_enable: bool,
+    pub backend_provider: String,
+    pub metadata_provider: String,
+    pub delete_file_enable: bool,
+    pub file_reserved_time: Duration,
+    pub delete_file_interval: Duration,
+    pub commit_log_rolling_interval: Duration,
+    pub commit_log_rolling_min_size: u64,
+    pub group_commit: bool,
+    pub group_commit_timeout: Duration,
+    pub group_commit_count: usize,
+    pub group_commit_size: usize,
+    pub max_group_commit_count: usize,
+    pub max_pending_tasks: usize,
+    pub read_ahead_cache_enable: bool,
+    pub read_ahead_message_count: usize,
+    pub read_ahead_message_size: usize,
+    pub read_ahead_cache_expire: Duration,
+    pub crc_check_enable: bool,
+}
+
+impl Default for TieredStoreConfig {
+    fn default() -> Self {
+        Self {
+            storage_level: TieredStorageLevel::NotInDisk,
+            store_path_root_dir: default_store_root(),
+            commit_log_segment_size: 1024 * 1024 * 1024,
+            consume_queue_segment_size: 100 * 1024 * 1024,
+            index_file_max_hash_slot_num: 5_000_000,
+            index_file_max_index_num: 20_000_000,
+            message_index_enable: true,
+            backend_provider: "posix".to_owned(),
+            metadata_provider: "json".to_owned(),
+            delete_file_enable: true,
+            file_reserved_time: Duration::from_secs(72 * 60 * 60),
+            delete_file_interval: Duration::from_secs(60 * 60),
+            commit_log_rolling_interval: Duration::from_secs(24 * 60 * 60),
+            commit_log_rolling_min_size: 16 * 1024 * 1024,
+            group_commit: true,
+            group_commit_timeout: Duration::from_secs(30),
+            group_commit_count: 4096,
+            group_commit_size: 4 * 1024 * 1024,
+            max_group_commit_count: 10_000,
+            max_pending_tasks: 10_000,
+            read_ahead_cache_enable: true,
+            read_ahead_message_count: 4096,
+            read_ahead_message_size: 16 * 1024 * 1024,
+            read_ahead_cache_expire: Duration::from_secs(15),
+            crc_check_enable: false,
+        }
+    }
+}
+
+fn default_store_root() -> PathBuf {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("store")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_matches_java_tieredstore_defaults() {
+        let config = TieredStoreConfig::default();
+
+        assert_eq!(config.storage_level, TieredStorageLevel::NotInDisk);
+        assert_eq!(config.commit_log_segment_size, 1024 * 1024 * 1024);
+        assert_eq!(config.consume_queue_segment_size, 100 * 1024 * 1024);
+        assert_eq!(config.index_file_max_hash_slot_num, 5_000_000);
+        assert_eq!(config.index_file_max_index_num, 20_000_000);
+        assert!(config.message_index_enable);
+        assert!(config.delete_file_enable);
+        assert_eq!(config.file_reserved_time, Duration::from_secs(72 * 60 * 60));
+        assert_eq!(config.delete_file_interval, Duration::from_secs(60 * 60));
+        assert_eq!(config.commit_log_rolling_interval, Duration::from_secs(24 * 60 * 60));
+        assert_eq!(config.commit_log_rolling_min_size, 16 * 1024 * 1024);
+        assert!(config.group_commit);
+        assert_eq!(config.group_commit_timeout, Duration::from_secs(30));
+        assert_eq!(config.group_commit_count, 4096);
+        assert_eq!(config.group_commit_size, 4 * 1024 * 1024);
+        assert_eq!(config.max_group_commit_count, 10_000);
+        assert_eq!(config.max_pending_tasks, 10_000);
+        assert!(config.read_ahead_cache_enable);
+        assert_eq!(config.read_ahead_message_count, 4096);
+        assert_eq!(config.read_ahead_message_size, 16 * 1024 * 1024);
+        assert_eq!(config.read_ahead_cache_expire, Duration::from_secs(15));
+        assert!(!config.crc_check_enable);
+    }
+}

--- a/rocketmq-tieredstore/src/dispatcher.rs
+++ b/rocketmq-tieredstore/src/dispatcher.rs
@@ -1,0 +1,20 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod dispatch_request;
+pub mod tiered_dispatcher;
+
+pub use dispatch_request::TieredDispatchRequest;
+pub use tiered_dispatcher::DefaultTieredDispatcher;
+pub use tiered_dispatcher::TieredDispatcher;

--- a/rocketmq-tieredstore/src/dispatcher/dispatch_request.rs
+++ b/rocketmq-tieredstore/src/dispatcher/dispatch_request.rs
@@ -1,0 +1,37 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+
+#[derive(Debug, Clone)]
+pub struct TieredDispatchRequest {
+    pub topic: String,
+    pub queue_id: i32,
+    pub queue_offset: i64,
+    pub commit_log_offset: i64,
+    pub message_size: i32,
+    pub tags_code: i64,
+    pub store_timestamp: i64,
+    pub keys: Option<String>,
+    pub uniq_key: Option<String>,
+    pub offset_id: Option<String>,
+    pub sys_flag: i32,
+    pub body: Option<Bytes>,
+}
+
+impl TieredDispatchRequest {
+    pub fn is_valid(&self) -> bool {
+        !self.topic.is_empty() && self.queue_id >= 0 && self.queue_offset >= 0 && self.message_size > 0
+    }
+}

--- a/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs
+++ b/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs
@@ -1,0 +1,159 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use rocketmq_error::RocketMQError;
+use tokio::sync::mpsc;
+use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::TieredStoreConfig;
+use crate::dispatcher::TieredDispatchRequest;
+use crate::file::ConsumeQueueUnit;
+use crate::file::TieredFlatFileStore;
+use crate::provider::TieredStoreProvider;
+
+#[allow(async_fn_in_trait)]
+pub trait TieredDispatcher: Send + Sync {
+    async fn dispatch(&self, request: TieredDispatchRequest) -> Result<(), RocketMQError>;
+
+    async fn start(&self) -> Result<(), RocketMQError>;
+
+    async fn shutdown(&self) -> Result<(), RocketMQError>;
+}
+
+pub struct DefaultTieredDispatcher<P>
+where
+    P: TieredStoreProvider,
+{
+    config: Arc<TieredStoreConfig>,
+    flat_file_store: Arc<TieredFlatFileStore<P>>,
+    sender: mpsc::Sender<TieredDispatchRequest>,
+    receiver: tokio::sync::Mutex<Option<mpsc::Receiver<TieredDispatchRequest>>>,
+    permits: Arc<Semaphore>,
+    shutdown: CancellationToken,
+    handle: tokio::sync::Mutex<Option<JoinHandle<Result<(), RocketMQError>>>>,
+}
+
+impl<P> DefaultTieredDispatcher<P>
+where
+    P: TieredStoreProvider,
+{
+    pub fn new(
+        config: Arc<TieredStoreConfig>,
+        flat_file_store: Arc<TieredFlatFileStore<P>>,
+        shutdown: CancellationToken,
+    ) -> Self {
+        let (sender, receiver) = mpsc::channel(config.max_pending_tasks);
+        let permits = Arc::new(Semaphore::new((config.max_pending_tasks / 4).max(1)));
+        Self {
+            config,
+            flat_file_store,
+            sender,
+            receiver: tokio::sync::Mutex::new(Some(receiver)),
+            permits,
+            shutdown,
+            handle: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    pub fn try_dispatch(&self, request: TieredDispatchRequest) -> Result<(), RocketMQError> {
+        if !self.config.storage_level.enabled() || !request.is_valid() {
+            return Ok(());
+        }
+        self.sender
+            .try_send(request)
+            .map_err(|err| RocketMQError::storage_write_failed("tiered_dispatch_queue", err.to_string()))
+    }
+
+    async fn run(
+        flat_file_store: Arc<TieredFlatFileStore<P>>,
+        mut receiver: mpsc::Receiver<TieredDispatchRequest>,
+        permits: Arc<Semaphore>,
+        shutdown: CancellationToken,
+    ) -> Result<(), RocketMQError> {
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => {
+                    break;
+                }
+                maybe_request = receiver.recv() => {
+                    let Some(request) = maybe_request else {
+                        break;
+                    };
+                    let permit = permits.clone().acquire_owned().await.map_err(|err| {
+                        RocketMQError::Internal(err.to_string())
+                    })?;
+                    let file = flat_file_store.get_or_create(request.topic.clone(), request.queue_id)?;
+                    let message = request.body.unwrap_or_default();
+                    let tiered_offset = file
+                        .append_commit_log(message, request.store_timestamp)
+                        .await?;
+                    file.append_consume_queue(
+                        ConsumeQueueUnit {
+                            commit_log_offset: tiered_offset as i64,
+                            size: request.message_size,
+                            tags_code: request.tags_code,
+                        },
+                        request.store_timestamp,
+                    )
+                    .await?;
+                    file.commit().await?;
+                    drop(permit);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<P> TieredDispatcher for DefaultTieredDispatcher<P>
+where
+    P: TieredStoreProvider,
+{
+    async fn dispatch(&self, request: TieredDispatchRequest) -> Result<(), RocketMQError> {
+        if !self.config.storage_level.enabled() || !request.is_valid() {
+            return Ok(());
+        }
+        self.sender
+            .send(request)
+            .await
+            .map_err(|err| RocketMQError::storage_write_failed("tiered_dispatch_queue", err.to_string()))
+    }
+
+    async fn start(&self) -> Result<(), RocketMQError> {
+        let mut receiver_guard = self.receiver.lock().await;
+        let Some(receiver) = receiver_guard.take() else {
+            return Ok(());
+        };
+        let handle = tokio::spawn(Self::run(
+            self.flat_file_store.clone(),
+            receiver,
+            self.permits.clone(),
+            self.shutdown.clone(),
+        ));
+        *self.handle.lock().await = Some(handle);
+        Ok(())
+    }
+
+    async fn shutdown(&self) -> Result<(), RocketMQError> {
+        self.shutdown.cancel();
+        if let Some(handle) = self.handle.lock().await.take() {
+            handle.await.map_err(|err| RocketMQError::Internal(err.to_string()))??;
+        }
+        Ok(())
+    }
+}

--- a/rocketmq-tieredstore/src/error.rs
+++ b/rocketmq-tieredstore/src/error.rs
@@ -1,0 +1,62 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::RocketMQError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TieredStoreErrorKind {
+    IllegalOffset,
+    SegmentFull,
+    SegmentClosed,
+    SegmentDeleted,
+    MetadataCorrupted,
+    ProviderReadFailed,
+    ProviderWriteFailed,
+    Internal,
+}
+
+#[inline]
+pub fn illegal_argument(message: impl Into<String>) -> RocketMQError {
+    RocketMQError::illegal_argument(message)
+}
+
+#[inline]
+pub fn storage_read_failed(path: impl Into<String>, reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::storage_read_failed(path, reason)
+}
+
+#[inline]
+pub fn storage_write_failed(path: impl Into<String>, reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::storage_write_failed(path, reason)
+}
+
+#[inline]
+pub fn internal(message: impl Into<String>) -> RocketMQError {
+    RocketMQError::Internal(message.into())
+}
+
+pub fn from_kind(kind: TieredStoreErrorKind, path: impl Into<String>, message: impl Into<String>) -> RocketMQError {
+    let path = path.into();
+    let message = message.into();
+    match kind {
+        TieredStoreErrorKind::IllegalOffset => illegal_argument(message),
+        TieredStoreErrorKind::ProviderReadFailed => storage_read_failed(path, message),
+        TieredStoreErrorKind::ProviderWriteFailed => storage_write_failed(path, message),
+        TieredStoreErrorKind::SegmentFull
+        | TieredStoreErrorKind::SegmentClosed
+        | TieredStoreErrorKind::SegmentDeleted
+        | TieredStoreErrorKind::MetadataCorrupted
+        | TieredStoreErrorKind::Internal => internal(message),
+    }
+}

--- a/rocketmq-tieredstore/src/fetcher.rs
+++ b/rocketmq-tieredstore/src/fetcher.rs
@@ -1,0 +1,21 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod tiered_message_fetcher;
+
+pub use tiered_message_fetcher::DefaultTieredMessageFetcher;
+pub use tiered_message_fetcher::TieredGetMessageResult;
+pub use tiered_message_fetcher::TieredGetMessageStatus;
+pub use tiered_message_fetcher::TieredMessageFetcher;
+pub use tiered_message_fetcher::TieredQueryResult;

--- a/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
+++ b/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
@@ -1,0 +1,170 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use rocketmq_error::RocketMQError;
+
+use crate::config::TieredStoreConfig;
+use crate::file::TieredFlatFileStore;
+use crate::provider::TieredStoreProvider;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TieredGetMessageStatus {
+    Found,
+    NoMatchedMessage,
+    OffsetFoundNull,
+    OffsetOverflowBadly,
+    OffsetOverflowOne,
+    OffsetTooSmall,
+    #[default]
+    NoMatchedLogicQueue,
+}
+
+#[derive(Debug, Default)]
+pub struct TieredGetMessageResult {
+    pub status: TieredGetMessageStatus,
+    pub messages: Vec<Bytes>,
+    pub min_offset: i64,
+    pub max_offset: i64,
+    pub next_begin_offset: i64,
+}
+
+#[derive(Debug, Default)]
+pub struct TieredQueryResult<T> {
+    pub values: Vec<T>,
+}
+
+#[allow(async_fn_in_trait)]
+pub trait TieredMessageFetcher: Send + Sync {
+    async fn get_message(
+        &self,
+        topic: String,
+        queue_id: i32,
+        queue_offset: i64,
+        max_msg_nums: i32,
+    ) -> Result<TieredGetMessageResult, RocketMQError>;
+
+    async fn get_message_timestamp(
+        &self,
+        topic: String,
+        queue_id: i32,
+        queue_offset: i64,
+    ) -> Result<i64, RocketMQError>;
+
+    async fn get_offset_by_time(
+        &self,
+        topic: String,
+        queue_id: i32,
+        timestamp_millis: i64,
+    ) -> Result<i64, RocketMQError>;
+
+    async fn query_message(
+        &self,
+        topic: String,
+        key: String,
+        max_num: i32,
+        begin: i64,
+        end: i64,
+    ) -> Result<TieredQueryResult<Bytes>, RocketMQError>;
+}
+
+pub struct DefaultTieredMessageFetcher<P>
+where
+    P: TieredStoreProvider,
+{
+    config: Arc<TieredStoreConfig>,
+    flat_file_store: Arc<TieredFlatFileStore<P>>,
+}
+
+impl<P> DefaultTieredMessageFetcher<P>
+where
+    P: TieredStoreProvider,
+{
+    pub fn new(config: Arc<TieredStoreConfig>, flat_file_store: Arc<TieredFlatFileStore<P>>) -> Self {
+        Self {
+            config,
+            flat_file_store,
+        }
+    }
+}
+
+impl<P> TieredMessageFetcher for DefaultTieredMessageFetcher<P>
+where
+    P: TieredStoreProvider,
+{
+    async fn get_message(
+        &self,
+        topic: String,
+        queue_id: i32,
+        queue_offset: i64,
+        max_msg_nums: i32,
+    ) -> Result<TieredGetMessageResult, RocketMQError> {
+        let Some(_flat_file) = self.flat_file_store.get(&topic, queue_id) else {
+            return Ok(TieredGetMessageResult {
+                status: TieredGetMessageStatus::NoMatchedLogicQueue,
+                ..TieredGetMessageResult::default()
+            });
+        };
+
+        let _ = queue_offset;
+        let _ = max_msg_nums;
+        let _ = &self.config;
+        Ok(TieredGetMessageResult {
+            status: TieredGetMessageStatus::NoMatchedMessage,
+            ..TieredGetMessageResult::default()
+        })
+    }
+
+    async fn get_message_timestamp(
+        &self,
+        topic: String,
+        queue_id: i32,
+        queue_offset: i64,
+    ) -> Result<i64, RocketMQError> {
+        let _ = topic;
+        let _ = queue_id;
+        let _ = queue_offset;
+        Ok(-1)
+    }
+
+    async fn get_offset_by_time(
+        &self,
+        topic: String,
+        queue_id: i32,
+        timestamp_millis: i64,
+    ) -> Result<i64, RocketMQError> {
+        let _ = topic;
+        let _ = queue_id;
+        let _ = timestamp_millis;
+        Ok(-1)
+    }
+
+    async fn query_message(
+        &self,
+        topic: String,
+        key: String,
+        max_num: i32,
+        begin: i64,
+        end: i64,
+    ) -> Result<TieredQueryResult<Bytes>, RocketMQError> {
+        let _ = topic;
+        let _ = key;
+        let _ = max_num;
+        let _ = begin;
+        let _ = end;
+        Ok(TieredQueryResult::default())
+    }
+}

--- a/rocketmq-tieredstore/src/file.rs
+++ b/rocketmq-tieredstore/src/file.rs
@@ -1,0 +1,32 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod commit_log_segment;
+pub mod consume_queue_segment;
+pub mod file_segment;
+pub mod flat_file;
+pub mod flat_file_store;
+pub mod index_file_segment;
+
+pub use commit_log_segment::CommitLogSegment;
+pub use consume_queue_segment::ConsumeQueueSegment;
+pub use file_segment::FileSegment;
+pub use file_segment::FileSegmentStatus;
+pub use file_segment::FileSegmentType;
+pub use file_segment::TieredFileSegment;
+pub use flat_file::ConsumeQueueUnit;
+pub use flat_file::TieredFlatFile;
+pub use flat_file::CONSUME_QUEUE_UNIT_SIZE;
+pub use flat_file_store::TieredFlatFileStore;
+pub use index_file_segment::IndexFileSegment;

--- a/rocketmq-tieredstore/src/file/commit_log_segment.rs
+++ b/rocketmq-tieredstore/src/file/commit_log_segment.rs
@@ -1,0 +1,19 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug, Clone)]
+pub struct CommitLogSegment {
+    pub path: String,
+    pub base_offset: u64,
+}

--- a/rocketmq-tieredstore/src/file/consume_queue_segment.rs
+++ b/rocketmq-tieredstore/src/file/consume_queue_segment.rs
@@ -1,0 +1,19 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug, Clone)]
+pub struct ConsumeQueueSegment {
+    pub path: String,
+    pub base_offset: u64,
+}

--- a/rocketmq-tieredstore/src/file/file_segment.rs
+++ b/rocketmq-tieredstore/src/file/file_segment.rs
@@ -1,0 +1,253 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Range;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use bytes::Bytes;
+use parking_lot::Mutex;
+use rocketmq_error::RocketMQError;
+
+use crate::error::TieredStoreErrorKind;
+use crate::error::{self};
+use crate::metadata::FileSegmentMetadata;
+use crate::provider::TieredStoreProvider;
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum FileSegmentType {
+    CommitLog,
+    ConsumeQueue,
+    Index,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileSegmentStatus {
+    New,
+    Sealed,
+    Deleted,
+}
+
+#[trait_variant::make(FileSegment: Send)]
+pub trait FileSegmentInner: Sync {
+    fn path(&self) -> &str;
+
+    fn segment_type(&self) -> FileSegmentType;
+
+    fn base_offset(&self) -> u64;
+
+    fn append_position(&self) -> u64;
+
+    fn commit_position(&self) -> u64;
+
+    fn metadata(&self) -> FileSegmentMetadata;
+
+    async fn append(&self, data: Bytes, timestamp_millis: i64) -> Result<usize, RocketMQError>;
+
+    async fn read(&self, range: Range<u64>) -> Result<Bytes, RocketMQError>;
+
+    async fn commit(&self) -> Result<(), RocketMQError>;
+
+    async fn seal(&self) -> Result<(), RocketMQError>;
+}
+
+pub struct TieredFileSegment<P> {
+    path: String,
+    segment_type: FileSegmentType,
+    base_offset: u64,
+    max_size: u64,
+    append_position: AtomicU64,
+    commit_position: AtomicU64,
+    metadata: Mutex<FileSegmentMetadata>,
+    pending: Mutex<Vec<Bytes>>,
+    provider: P,
+}
+
+impl<P> TieredFileSegment<P> {
+    pub fn new(
+        path: String,
+        segment_type: FileSegmentType,
+        base_offset: u64,
+        max_size: u64,
+        metadata: FileSegmentMetadata,
+        provider: P,
+    ) -> Self {
+        let size = metadata.size;
+        Self {
+            path,
+            segment_type,
+            base_offset,
+            max_size,
+            append_position: AtomicU64::new(size),
+            commit_position: AtomicU64::new(size),
+            metadata: Mutex::new(metadata),
+            pending: Mutex::new(Vec::new()),
+            provider,
+        }
+    }
+
+    fn current_status(&self) -> FileSegmentStatus {
+        self.metadata.lock().status
+    }
+}
+
+impl<P> FileSegment for TieredFileSegment<P>
+where
+    P: TieredStoreProvider,
+{
+    fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn segment_type(&self) -> FileSegmentType {
+        self.segment_type
+    }
+
+    fn base_offset(&self) -> u64 {
+        self.base_offset
+    }
+
+    fn append_position(&self) -> u64 {
+        self.append_position.load(Ordering::Acquire)
+    }
+
+    fn commit_position(&self) -> u64 {
+        self.commit_position.load(Ordering::Acquire)
+    }
+
+    fn metadata(&self) -> FileSegmentMetadata {
+        self.metadata.lock().clone()
+    }
+
+    async fn append(&self, data: Bytes, timestamp_millis: i64) -> Result<usize, RocketMQError> {
+        if self.current_status() != FileSegmentStatus::New {
+            return Err(error::from_kind(
+                TieredStoreErrorKind::SegmentClosed,
+                self.path.clone(),
+                "tiered file segment is not appendable",
+            ));
+        }
+
+        let len = data.len();
+        let mut pending = self.pending.lock();
+        let position = self.append_position.load(Ordering::Acquire);
+        let next = position.saturating_add(len as u64);
+        if next > self.max_size {
+            return Err(error::from_kind(
+                TieredStoreErrorKind::SegmentFull,
+                self.path.clone(),
+                "tiered file segment is full",
+            ));
+        }
+
+        {
+            let mut metadata = self.metadata.lock();
+            metadata.begin_timestamp = metadata.begin_timestamp.min(timestamp_millis);
+            metadata.end_timestamp = metadata.end_timestamp.max(timestamp_millis);
+        }
+        pending.push(data);
+        self.append_position.store(next, Ordering::Release);
+        Ok(len)
+    }
+
+    async fn read(&self, range: Range<u64>) -> Result<Bytes, RocketMQError> {
+        let commit_position = self.commit_position.load(Ordering::Acquire);
+        if range.start >= commit_position || range.end <= range.start {
+            return Err(error::from_kind(
+                TieredStoreErrorKind::IllegalOffset,
+                self.path.clone(),
+                "invalid tiered segment read range",
+            ));
+        }
+        let end = range.end.min(commit_position);
+        self.provider
+            .read(self.path.clone(), range.start, (end - range.start) as usize)
+            .await
+    }
+
+    async fn commit(&self) -> Result<(), RocketMQError> {
+        let buffers = {
+            let mut pending = self.pending.lock();
+            if pending.is_empty() {
+                return Ok(());
+            }
+            std::mem::take(&mut *pending)
+        };
+
+        let mut position = self.commit_position.load(Ordering::Acquire);
+        for (index, buffer) in buffers.iter().cloned().enumerate() {
+            match self.provider.write(self.path.clone(), position, buffer).await {
+                Ok(written) => {
+                    position = position.saturating_add(written as u64);
+                    self.commit_position.store(position, Ordering::Release);
+                }
+                Err(error) => {
+                    let mut pending = self.pending.lock();
+                    pending.extend(buffers[index..].iter().cloned());
+                    return Err(error);
+                }
+            }
+        }
+
+        {
+            let mut metadata = self.metadata.lock();
+            metadata.size = position;
+        }
+        Ok(())
+    }
+
+    async fn seal(&self) -> Result<(), RocketMQError> {
+        let mut metadata = self.metadata.lock();
+        metadata.status = FileSegmentStatus::Sealed;
+        metadata.seal_timestamp = current_time_millis();
+        Ok(())
+    }
+}
+
+fn current_time_millis() -> i64 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis() as i64,
+        Err(_) => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use rocketmq_error::RocketMQError;
+
+    use crate::file::FileSegment;
+    use crate::file::FileSegmentType;
+    use crate::provider::MemoryProvider;
+    use crate::provider::TieredStoreProvider;
+
+    #[tokio::test]
+    async fn append_commit_and_read_segment() -> Result<(), RocketMQError> {
+        let provider = MemoryProvider::default();
+        let segment = provider
+            .create_segment("topic/0/commitlog/000".to_owned(), FileSegmentType::CommitLog, 0, 64)
+            .await?;
+
+        segment.append(Bytes::from_static(b"hello"), 100).await?;
+        assert_eq!(segment.append_position(), 5);
+        assert_eq!(segment.commit_position(), 0);
+
+        segment.commit().await?;
+        assert_eq!(segment.commit_position(), 5);
+        assert_eq!(segment.read(0..5).await?, Bytes::from_static(b"hello"));
+        Ok(())
+    }
+}

--- a/rocketmq-tieredstore/src/file/flat_file.rs
+++ b/rocketmq-tieredstore/src/file/flat_file.rs
@@ -1,0 +1,166 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use parking_lot::Mutex;
+use rocketmq_error::RocketMQError;
+
+use crate::config::TieredStoreConfig;
+use crate::error;
+use crate::file::FileSegment;
+use crate::file::FileSegmentType;
+use crate::file::TieredFileSegment;
+use crate::provider::TieredStoreProvider;
+
+pub const CONSUME_QUEUE_UNIT_SIZE: usize = 20;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConsumeQueueUnit {
+    pub commit_log_offset: i64,
+    pub size: i32,
+    pub tags_code: i64,
+}
+
+impl ConsumeQueueUnit {
+    pub fn encode(self) -> Bytes {
+        let mut bytes = BytesMut::with_capacity(CONSUME_QUEUE_UNIT_SIZE);
+        bytes.put_i64(self.commit_log_offset);
+        bytes.put_i32(self.size);
+        bytes.put_i64(self.tags_code);
+        bytes.freeze()
+    }
+}
+
+pub struct TieredFlatFile<P>
+where
+    P: TieredStoreProvider,
+{
+    topic: String,
+    queue_id: i32,
+    config: Arc<TieredStoreConfig>,
+    provider: P,
+    commit_log_segments: Mutex<Vec<Arc<TieredFileSegment<P>>>>,
+    consume_queue_segments: Mutex<Vec<Arc<TieredFileSegment<P>>>>,
+}
+
+impl<P> TieredFlatFile<P>
+where
+    P: TieredStoreProvider,
+{
+    pub fn new(topic: String, queue_id: i32, config: Arc<TieredStoreConfig>, provider: P) -> Self {
+        Self {
+            topic,
+            queue_id,
+            config,
+            provider,
+            commit_log_segments: Mutex::new(Vec::new()),
+            consume_queue_segments: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn topic(&self) -> &str {
+        &self.topic
+    }
+
+    pub fn queue_id(&self) -> i32 {
+        self.queue_id
+    }
+
+    pub async fn append_commit_log(&self, message: Bytes, store_timestamp: i64) -> Result<u64, RocketMQError> {
+        let segment = self
+            .ensure_segment(FileSegmentType::CommitLog, self.config.commit_log_segment_size)
+            .await?;
+        let offset = segment.base_offset().saturating_add(segment.append_position());
+        segment.append(message, store_timestamp).await?;
+        Ok(offset)
+    }
+
+    pub async fn append_consume_queue(
+        &self,
+        unit: ConsumeQueueUnit,
+        store_timestamp: i64,
+    ) -> Result<(), RocketMQError> {
+        let segment = self
+            .ensure_segment(FileSegmentType::ConsumeQueue, self.config.consume_queue_segment_size)
+            .await?;
+        segment.append(unit.encode(), store_timestamp).await?;
+        Ok(())
+    }
+
+    pub async fn commit(&self) -> Result<(), RocketMQError> {
+        let commit_log_segments = { self.commit_log_segments.lock().clone() };
+        for segment in commit_log_segments {
+            segment.commit().await?;
+        }
+
+        let consume_queue_segments = { self.consume_queue_segments.lock().clone() };
+        for segment in consume_queue_segments {
+            segment.commit().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn recover(&self) -> Result<(), RocketMQError> {
+        Ok(())
+    }
+
+    async fn ensure_segment(
+        &self,
+        segment_type: FileSegmentType,
+        max_size: u64,
+    ) -> Result<Arc<TieredFileSegment<P>>, RocketMQError> {
+        let existing = match segment_type {
+            FileSegmentType::CommitLog => self.commit_log_segments.lock().last().cloned(),
+            FileSegmentType::ConsumeQueue => self.consume_queue_segments.lock().last().cloned(),
+            FileSegmentType::Index => return Err(error::internal("index segment is managed by tiered index service")),
+        };
+        if let Some(segment) = existing {
+            return Ok(segment);
+        }
+
+        let path = segment_path(&self.topic, self.queue_id, segment_type, 0);
+        let segment = Arc::new(self.provider.create_segment(path, segment_type, 0, max_size).await?);
+        match segment_type {
+            FileSegmentType::CommitLog => {
+                let mut segments = self.commit_log_segments.lock();
+                if let Some(existing) = segments.last().cloned() {
+                    return Ok(existing);
+                }
+                segments.push(segment.clone());
+            }
+            FileSegmentType::ConsumeQueue => {
+                let mut segments = self.consume_queue_segments.lock();
+                if let Some(existing) = segments.last().cloned() {
+                    return Ok(existing);
+                }
+                segments.push(segment.clone());
+            }
+            FileSegmentType::Index => {}
+        }
+        Ok(segment)
+    }
+}
+
+fn segment_path(topic: &str, queue_id: i32, segment_type: FileSegmentType, base_offset: u64) -> String {
+    let segment_name = match segment_type {
+        FileSegmentType::CommitLog => "commitlog",
+        FileSegmentType::ConsumeQueue => "consumequeue",
+        FileSegmentType::Index => "index",
+    };
+    format!("{topic}/{queue_id}/{segment_name}/{base_offset:020}")
+}

--- a/rocketmq-tieredstore/src/file/flat_file_store.rs
+++ b/rocketmq-tieredstore/src/file/flat_file_store.rs
@@ -1,0 +1,100 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use rocketmq_error::RocketMQError;
+
+use crate::config::TieredStoreConfig;
+use crate::file::TieredFlatFile;
+use crate::metadata::JsonMetadataStore;
+use crate::metadata::TieredMetadataStore;
+use crate::provider::TieredStoreProvider;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FlatFileKey {
+    topic: String,
+    queue_id: i32,
+}
+
+pub struct TieredFlatFileStore<P>
+where
+    P: TieredStoreProvider,
+{
+    config: Arc<TieredStoreConfig>,
+    metadata_store: Arc<JsonMetadataStore>,
+    provider: P,
+    files: DashMap<FlatFileKey, Arc<TieredFlatFile<P>>>,
+}
+
+impl<P> TieredFlatFileStore<P>
+where
+    P: TieredStoreProvider,
+{
+    pub fn new(config: Arc<TieredStoreConfig>, metadata_store: Arc<JsonMetadataStore>, provider: P) -> Self {
+        Self {
+            config,
+            metadata_store,
+            provider,
+            files: DashMap::new(),
+        }
+    }
+
+    pub async fn load(&self) -> Result<(), RocketMQError> {
+        let queues = self.metadata_store.list_queues().await?;
+        for queue in queues {
+            self.get_or_create(queue.topic, queue.queue_id)?;
+        }
+        Ok(())
+    }
+
+    pub fn get(&self, topic: &str, queue_id: i32) -> Option<Arc<TieredFlatFile<P>>> {
+        let key = FlatFileKey {
+            topic: topic.to_owned(),
+            queue_id,
+        };
+        self.files.get(&key).map(|entry| entry.value().clone())
+    }
+
+    pub fn get_or_create(&self, topic: String, queue_id: i32) -> Result<Arc<TieredFlatFile<P>>, RocketMQError> {
+        let key = FlatFileKey {
+            topic: topic.clone(),
+            queue_id,
+        };
+        let entry = self.files.entry(key).or_insert_with(|| {
+            Arc::new(TieredFlatFile::new(
+                topic,
+                queue_id,
+                self.config.clone(),
+                self.provider.clone(),
+            ))
+        });
+        Ok(entry.value().clone())
+    }
+
+    pub async fn cleanup_expired(&self, now_millis: i64) -> Result<(), RocketMQError> {
+        let _ = now_millis;
+        Ok(())
+    }
+
+    pub async fn shutdown(&self) -> Result<(), RocketMQError> {
+        Ok(())
+    }
+
+    pub async fn destroy(&self) -> Result<(), RocketMQError> {
+        self.files.clear();
+        Ok(())
+    }
+}

--- a/rocketmq-tieredstore/src/file/index_file_segment.rs
+++ b/rocketmq-tieredstore/src/file/index_file_segment.rs
@@ -1,0 +1,19 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug, Clone)]
+pub struct IndexFileSegment {
+    pub path: String,
+    pub base_offset: u64,
+}

--- a/rocketmq-tieredstore/src/lib.rs
+++ b/rocketmq-tieredstore/src/lib.rs
@@ -1,0 +1,53 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod config;
+pub mod dispatcher;
+pub mod error;
+pub mod fetcher;
+pub mod file;
+pub mod lifecycle;
+pub mod metadata;
+pub mod metrics;
+pub mod provider;
+pub mod service;
+pub mod store;
+
+pub use config::TieredStorageLevel;
+pub use config::TieredStoreConfig;
+pub use dispatcher::DefaultTieredDispatcher;
+pub use dispatcher::TieredDispatchRequest;
+pub use dispatcher::TieredDispatcher;
+pub use fetcher::DefaultTieredMessageFetcher;
+pub use fetcher::TieredMessageFetcher;
+pub use file::CommitLogSegment;
+pub use file::ConsumeQueueSegment;
+pub use file::FileSegment;
+pub use file::FileSegmentStatus;
+pub use file::FileSegmentType;
+pub use file::IndexFileSegment;
+pub use file::TieredFileSegment;
+pub use file::TieredFlatFile;
+pub use file::TieredFlatFileStore;
+pub use lifecycle::TieredLifecycle;
+pub use metadata::FileSegmentMetadata;
+pub use metadata::JsonMetadataStore;
+pub use metadata::TieredMetadataStore;
+pub use metadata::TopicMetadata;
+pub use metadata::TopicQueueMetadata;
+pub use provider::MemoryProvider;
+pub use provider::PosixProvider;
+pub use provider::ProviderKind;
+pub use provider::TieredStoreProvider;
+pub use store::TieredStore;

--- a/rocketmq-tieredstore/src/lifecycle.rs
+++ b/rocketmq-tieredstore/src/lifecycle.rs
@@ -1,0 +1,26 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::RocketMQError;
+
+#[allow(async_fn_in_trait)]
+pub trait TieredLifecycle: Send + Sync {
+    async fn load(&self) -> Result<(), RocketMQError>;
+
+    async fn start(&self) -> Result<(), RocketMQError>;
+
+    async fn shutdown(&self) -> Result<(), RocketMQError>;
+
+    async fn destroy(&self) -> Result<(), RocketMQError>;
+}

--- a/rocketmq-tieredstore/src/metadata.rs
+++ b/rocketmq-tieredstore/src/metadata.rs
@@ -1,0 +1,23 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod file_segment_metadata;
+pub mod metadata_store;
+pub mod topic_queue_metadata;
+
+pub use file_segment_metadata::FileSegmentMetadata;
+pub use metadata_store::JsonMetadataStore;
+pub use metadata_store::TieredMetadataStore;
+pub use topic_queue_metadata::TopicMetadata;
+pub use topic_queue_metadata::TopicQueueMetadata;

--- a/rocketmq-tieredstore/src/metadata/file_segment_metadata.rs
+++ b/rocketmq-tieredstore/src/metadata/file_segment_metadata.rs
@@ -1,0 +1,53 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::file::FileSegmentStatus;
+use crate::file::FileSegmentType;
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileSegmentMetadata {
+    pub path: String,
+    pub segment_type: FileSegmentType,
+    pub base_offset: u64,
+    pub status: FileSegmentStatus,
+    pub size: u64,
+    pub create_timestamp: i64,
+    pub begin_timestamp: i64,
+    pub end_timestamp: i64,
+    pub seal_timestamp: i64,
+}
+
+impl FileSegmentMetadata {
+    pub fn new(path: String, segment_type: FileSegmentType, base_offset: u64) -> Self {
+        Self {
+            path,
+            segment_type,
+            base_offset,
+            status: FileSegmentStatus::New,
+            size: 0,
+            create_timestamp: current_time_millis(),
+            begin_timestamp: i64::MAX,
+            end_timestamp: i64::MIN,
+            seal_timestamp: 0,
+        }
+    }
+}
+
+fn current_time_millis() -> i64 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis() as i64,
+        Err(_) => 0,
+    }
+}

--- a/rocketmq-tieredstore/src/metadata/metadata_store.rs
+++ b/rocketmq-tieredstore/src/metadata/metadata_store.rs
@@ -1,0 +1,266 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use rocketmq_error::RocketMQError;
+use tokio::fs;
+
+use crate::config::TieredStoreConfig;
+use crate::error;
+use crate::metadata::FileSegmentMetadata;
+use crate::metadata::TopicMetadata;
+use crate::metadata::TopicQueueMetadata;
+
+#[allow(async_fn_in_trait)]
+pub trait TieredMetadataStore: Send + Sync {
+    async fn load(&self) -> Result<(), RocketMQError>;
+
+    async fn persist(&self) -> Result<(), RocketMQError>;
+
+    async fn destroy(&self) -> Result<(), RocketMQError>;
+
+    async fn get_topic(&self, topic: &str) -> Result<Option<TopicMetadata>, RocketMQError>;
+
+    async fn upsert_topic(&self, metadata: TopicMetadata) -> Result<(), RocketMQError>;
+
+    async fn get_queue(&self, topic: &str, queue_id: i32) -> Result<Option<TopicQueueMetadata>, RocketMQError>;
+
+    async fn list_queues(&self) -> Result<Vec<TopicQueueMetadata>, RocketMQError>;
+
+    async fn upsert_queue(&self, metadata: TopicQueueMetadata) -> Result<(), RocketMQError>;
+
+    async fn list_file_segments(&self, topic: &str, queue_id: i32) -> Result<Vec<FileSegmentMetadata>, RocketMQError>;
+
+    async fn upsert_file_segment(&self, metadata: FileSegmentMetadata) -> Result<(), RocketMQError>;
+
+    async fn mark_file_segment_deleted(&self, path: &str, base_offset: u64) -> Result<(), RocketMQError>;
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Clone, Default)]
+struct MetadataState {
+    topics: HashMap<String, TopicMetadata>,
+    queues: HashMap<String, TopicQueueMetadata>,
+    segments: HashMap<String, FileSegmentMetadata>,
+}
+
+pub struct JsonMetadataStore {
+    path: PathBuf,
+    state: RwLock<MetadataState>,
+}
+
+impl JsonMetadataStore {
+    pub fn new(config: Arc<TieredStoreConfig>) -> Self {
+        Self {
+            path: config
+                .store_path_root_dir
+                .join("config")
+                .join("tieredStoreMetadata.json"),
+            state: RwLock::new(MetadataState::default()),
+        }
+    }
+
+    fn queue_key(topic: &str, queue_id: i32) -> String {
+        format!("{topic}@{queue_id}")
+    }
+
+    fn segment_key(path: &str, base_offset: u64) -> String {
+        format!("{path}@{base_offset:020}")
+    }
+}
+
+impl TieredMetadataStore for JsonMetadataStore {
+    async fn load(&self) -> Result<(), RocketMQError> {
+        if fs::metadata(&self.path).await.is_err() {
+            return Ok(());
+        }
+
+        #[cfg(feature = "serde")]
+        {
+            let data = fs::read(&self.path)
+                .await
+                .map_err(|err| error::storage_read_failed(path_to_string(&self.path), err.to_string()))?;
+            let state =
+                serde_json::from_slice::<MetadataState>(&data).map_err(|err| error::internal(err.to_string()))?;
+            *self.state.write() = state;
+        }
+
+        Ok(())
+    }
+
+    async fn persist(&self) -> Result<(), RocketMQError> {
+        let Some(parent) = self.path.parent() else {
+            return Err(error::storage_write_failed(
+                path_to_string(&self.path),
+                "metadata path has no parent",
+            ));
+        };
+        fs::create_dir_all(parent)
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(parent), err.to_string()))?;
+
+        #[cfg(feature = "serde")]
+        {
+            let snapshot = self.state.read().clone();
+            let data = serde_json::to_vec_pretty(&snapshot).map_err(|err| error::internal(err.to_string()))?;
+            let tmp_path = self.path.with_extension("json.tmp");
+            fs::write(&tmp_path, data)
+                .await
+                .map_err(|err| error::storage_write_failed(path_to_string(&tmp_path), err.to_string()))?;
+            fs::rename(&tmp_path, &self.path)
+                .await
+                .map_err(|err| error::storage_write_failed(path_to_string(&self.path), err.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    async fn destroy(&self) -> Result<(), RocketMQError> {
+        *self.state.write() = MetadataState::default();
+        Ok(())
+    }
+
+    async fn get_topic(&self, topic: &str) -> Result<Option<TopicMetadata>, RocketMQError> {
+        Ok(self.state.read().topics.get(topic).cloned())
+    }
+
+    async fn upsert_topic(&self, metadata: TopicMetadata) -> Result<(), RocketMQError> {
+        {
+            self.state.write().topics.insert(metadata.topic.clone(), metadata);
+        }
+        self.persist().await
+    }
+
+    async fn get_queue(&self, topic: &str, queue_id: i32) -> Result<Option<TopicQueueMetadata>, RocketMQError> {
+        Ok(self.state.read().queues.get(&Self::queue_key(topic, queue_id)).cloned())
+    }
+
+    async fn list_queues(&self) -> Result<Vec<TopicQueueMetadata>, RocketMQError> {
+        Ok(self.state.read().queues.values().cloned().collect())
+    }
+
+    async fn upsert_queue(&self, metadata: TopicQueueMetadata) -> Result<(), RocketMQError> {
+        {
+            self.state
+                .write()
+                .queues
+                .insert(Self::queue_key(&metadata.topic, metadata.queue_id), metadata);
+        }
+        self.persist().await
+    }
+
+    async fn list_file_segments(&self, topic: &str, queue_id: i32) -> Result<Vec<FileSegmentMetadata>, RocketMQError> {
+        let queue_prefix = format!("{topic}/{queue_id}/");
+        let mut segments = self
+            .state
+            .read()
+            .segments
+            .values()
+            .filter(|segment| segment.path.starts_with(&queue_prefix))
+            .cloned()
+            .collect::<Vec<_>>();
+        segments.sort_by_key(|segment| (segment.segment_type, segment.base_offset));
+        Ok(segments)
+    }
+
+    async fn upsert_file_segment(&self, metadata: FileSegmentMetadata) -> Result<(), RocketMQError> {
+        {
+            self.state
+                .write()
+                .segments
+                .insert(Self::segment_key(&metadata.path, metadata.base_offset), metadata);
+        }
+        self.persist().await
+    }
+
+    async fn mark_file_segment_deleted(&self, path: &str, base_offset: u64) -> Result<(), RocketMQError> {
+        {
+            if let Some(segment) = self
+                .state
+                .write()
+                .segments
+                .get_mut(&Self::segment_key(path, base_offset))
+            {
+                segment.status = crate::file::FileSegmentStatus::Deleted;
+            }
+        }
+        self.persist().await
+    }
+}
+
+fn path_to_string(path: &std::path::Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rocketmq_error::RocketMQError;
+
+    use crate::config::TieredStoreConfig;
+    use crate::file::FileSegmentType;
+    use crate::metadata::FileSegmentMetadata;
+    use crate::metadata::JsonMetadataStore;
+    use crate::metadata::TieredMetadataStore;
+    use crate::metadata::TopicMetadata;
+    use crate::metadata::TopicQueueMetadata;
+
+    #[tokio::test]
+    async fn persists_and_loads_metadata() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            ..TieredStoreConfig::default()
+        });
+
+        let metadata_store = JsonMetadataStore::new(config.clone());
+        let topic_metadata = TopicMetadata {
+            topic_id: 1,
+            topic: "TopicA".to_owned(),
+            reserve_time_millis: 72 * 60 * 60 * 1000,
+            status: 0,
+            update_timestamp: 100,
+        };
+        let queue_metadata = TopicQueueMetadata {
+            topic: "TopicA".to_owned(),
+            queue_id: 0,
+            min_offset: 10,
+            max_offset: 20,
+            update_timestamp: 101,
+        };
+
+        metadata_store.upsert_topic(topic_metadata.clone()).await?;
+        metadata_store.upsert_queue(queue_metadata.clone()).await?;
+        metadata_store
+            .upsert_file_segment(FileSegmentMetadata::new(
+                "TopicA/0/commitlog/00000000000000000000".to_owned(),
+                FileSegmentType::CommitLog,
+                0,
+            ))
+            .await?;
+
+        let reloaded_store = JsonMetadataStore::new(config);
+        reloaded_store.load().await?;
+
+        assert_eq!(reloaded_store.get_topic("TopicA").await?, Some(topic_metadata));
+        assert_eq!(reloaded_store.get_queue("TopicA", 0).await?, Some(queue_metadata));
+        assert_eq!(reloaded_store.list_file_segments("TopicA", 0).await?.len(), 1);
+        Ok(())
+    }
+}

--- a/rocketmq-tieredstore/src/metadata/topic_queue_metadata.rs
+++ b/rocketmq-tieredstore/src/metadata/topic_queue_metadata.rs
@@ -1,0 +1,40 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TopicMetadata {
+    pub topic_id: i32,
+    pub topic: String,
+    pub reserve_time_millis: i64,
+    pub status: i32,
+    pub update_timestamp: i64,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TopicQueueMetadata {
+    pub topic: String,
+    pub queue_id: i32,
+    pub min_offset: i64,
+    pub max_offset: i64,
+    pub update_timestamp: i64,
+}
+
+impl TopicQueueMetadata {
+    pub fn update_max_offset(&mut self, max_offset: i64, update_timestamp: i64) {
+        self.max_offset = self.max_offset.max(max_offset);
+        self.update_timestamp = update_timestamp;
+    }
+}

--- a/rocketmq-tieredstore/src/metrics.rs
+++ b/rocketmq-tieredstore/src/metrics.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+#[derive(Default)]
+pub struct TieredStoreMetrics {
+    dispatch_requests: AtomicU64,
+    commit_failures: AtomicU64,
+    fetch_requests: AtomicU64,
+}
+
+impl TieredStoreMetrics {
+    pub fn record_dispatch_request(&self) {
+        self.dispatch_requests.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_commit_failure(&self) {
+        self.commit_failures.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_fetch_request(&self) {
+        self.fetch_requests.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn dispatch_requests(&self) -> u64 {
+        self.dispatch_requests.load(Ordering::Relaxed)
+    }
+}

--- a/rocketmq-tieredstore/src/provider.rs
+++ b/rocketmq-tieredstore/src/provider.rs
@@ -1,0 +1,48 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod memory_file_segment;
+pub mod posix_file_segment;
+pub mod provider_impl;
+
+use bytes::Bytes;
+use rocketmq_error::RocketMQError;
+
+use crate::file::FileSegmentType;
+use crate::file::TieredFileSegment;
+
+pub use memory_file_segment::MemoryProvider;
+pub use posix_file_segment::PosixProvider;
+pub use provider_impl::ProviderKind;
+
+#[trait_variant::make(TieredStoreProvider: Send)]
+pub trait TieredStoreProviderInner: Sync + Clone + 'static {
+    async fn create_segment(
+        &self,
+        path: String,
+        segment_type: FileSegmentType,
+        base_offset: u64,
+        max_size: u64,
+    ) -> Result<TieredFileSegment<Self>, RocketMQError>
+    where
+        Self: Sized;
+
+    async fn segment_size(&self, path: String) -> Result<u64, RocketMQError>;
+
+    async fn read(&self, path: String, position: u64, length: usize) -> Result<Bytes, RocketMQError>;
+
+    async fn write(&self, path: String, position: u64, data: Bytes) -> Result<usize, RocketMQError>;
+
+    async fn delete(&self, path: String) -> Result<(), RocketMQError>;
+}

--- a/rocketmq-tieredstore/src/provider/memory_file_segment.rs
+++ b/rocketmq-tieredstore/src/provider/memory_file_segment.rs
@@ -1,0 +1,122 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use bytes::BytesMut;
+use parking_lot::RwLock;
+use rocketmq_error::RocketMQError;
+
+use crate::file::FileSegmentType;
+use crate::file::TieredFileSegment;
+use crate::metadata::FileSegmentMetadata;
+use crate::provider::TieredStoreProvider;
+
+#[derive(Clone, Default)]
+pub struct MemoryProvider {
+    files: Arc<RwLock<HashMap<String, BytesMut>>>,
+}
+
+impl TieredStoreProvider for MemoryProvider {
+    async fn create_segment(
+        &self,
+        path: String,
+        segment_type: FileSegmentType,
+        base_offset: u64,
+        max_size: u64,
+    ) -> Result<TieredFileSegment<Self>, RocketMQError>
+    where
+        Self: Sized,
+    {
+        let metadata = FileSegmentMetadata::new(path.clone(), segment_type, base_offset);
+        Ok(TieredFileSegment::new(
+            path,
+            segment_type,
+            base_offset,
+            max_size,
+            metadata,
+            self.clone(),
+        ))
+    }
+
+    async fn segment_size(&self, path: String) -> Result<u64, RocketMQError> {
+        let files = self.files.read();
+        Ok(files.get(&path).map(|bytes| bytes.len() as u64).unwrap_or(0))
+    }
+
+    async fn read(&self, path: String, position: u64, length: usize) -> Result<Bytes, RocketMQError> {
+        let files = self.files.read();
+        let Some(bytes) = files.get(&path) else {
+            return Ok(Bytes::new());
+        };
+        let start = position as usize;
+        if start >= bytes.len() {
+            return Ok(Bytes::new());
+        }
+        let end = start.saturating_add(length).min(bytes.len());
+        Ok(Bytes::copy_from_slice(&bytes[start..end]))
+    }
+
+    async fn write(&self, path: String, position: u64, data: Bytes) -> Result<usize, RocketMQError> {
+        let mut files = self.files.write();
+        let bytes = files.entry(path).or_default();
+        let start = position as usize;
+        if bytes.len() < start {
+            bytes.resize(start, 0);
+        }
+        let end = start.saturating_add(data.len());
+        if bytes.len() < end {
+            bytes.resize(end, 0);
+        }
+        bytes[start..end].copy_from_slice(&data);
+        Ok(data.len())
+    }
+
+    async fn delete(&self, path: String) -> Result<(), RocketMQError> {
+        self.files.write().remove(&path);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use rocketmq_error::RocketMQError;
+
+    use crate::provider::MemoryProvider;
+    use crate::provider::TieredStoreProvider;
+
+    #[tokio::test]
+    async fn write_read_size_and_delete() -> Result<(), RocketMQError> {
+        let provider = MemoryProvider::default();
+        provider
+            .write("segment".to_owned(), 0, Bytes::from_static(b"abc"))
+            .await?;
+        provider
+            .write("segment".to_owned(), 3, Bytes::from_static(b"def"))
+            .await?;
+
+        assert_eq!(provider.segment_size("segment".to_owned()).await?, 6);
+        assert_eq!(
+            provider.read("segment".to_owned(), 1, 4).await?,
+            Bytes::from_static(b"bcde")
+        );
+
+        provider.delete("segment".to_owned()).await?;
+        assert_eq!(provider.segment_size("segment".to_owned()).await?, 0);
+        Ok(())
+    }
+}

--- a/rocketmq-tieredstore/src/provider/posix_file_segment.rs
+++ b/rocketmq-tieredstore/src/provider/posix_file_segment.rs
@@ -1,0 +1,134 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::SeekFrom;
+use std::path::Path;
+use std::path::PathBuf;
+
+use bytes::Bytes;
+use rocketmq_error::RocketMQError;
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncSeekExt;
+use tokio::io::AsyncWriteExt;
+
+use crate::error;
+use crate::file::FileSegmentType;
+use crate::file::TieredFileSegment;
+use crate::metadata::FileSegmentMetadata;
+use crate::provider::TieredStoreProvider;
+
+#[derive(Debug, Clone)]
+pub struct PosixProvider {
+    root: PathBuf,
+}
+
+impl PosixProvider {
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    fn resolve(&self, path: &str) -> PathBuf {
+        self.root.join(path)
+    }
+}
+
+impl TieredStoreProvider for PosixProvider {
+    async fn create_segment(
+        &self,
+        path: String,
+        segment_type: FileSegmentType,
+        base_offset: u64,
+        max_size: u64,
+    ) -> Result<TieredFileSegment<Self>, RocketMQError>
+    where
+        Self: Sized,
+    {
+        let metadata = FileSegmentMetadata::new(path.clone(), segment_type, base_offset);
+        Ok(TieredFileSegment::new(
+            path,
+            segment_type,
+            base_offset,
+            max_size,
+            metadata,
+            self.clone(),
+        ))
+    }
+
+    async fn segment_size(&self, path: String) -> Result<u64, RocketMQError> {
+        match tokio::fs::metadata(self.resolve(&path)).await {
+            Ok(metadata) => Ok(metadata.len()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(0),
+            Err(err) => Err(error::storage_read_failed(path, err.to_string())),
+        }
+    }
+
+    async fn read(&self, path: String, position: u64, length: usize) -> Result<Bytes, RocketMQError> {
+        let full_path = self.resolve(&path);
+        let mut file = OpenOptions::new()
+            .read(true)
+            .open(&full_path)
+            .await
+            .map_err(|err| error::storage_read_failed(path_to_string(&full_path), err.to_string()))?;
+        file.seek(SeekFrom::Start(position))
+            .await
+            .map_err(|err| error::storage_read_failed(path_to_string(&full_path), err.to_string()))?;
+        let mut buffer = vec![0_u8; length];
+        let read = file
+            .read(&mut buffer)
+            .await
+            .map_err(|err| error::storage_read_failed(path_to_string(&full_path), err.to_string()))?;
+        buffer.truncate(read);
+        Ok(Bytes::from(buffer))
+    }
+
+    async fn write(&self, path: String, position: u64, data: Bytes) -> Result<usize, RocketMQError> {
+        let full_path = self.resolve(&path);
+        if let Some(parent) = full_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|err| error::storage_write_failed(path_to_string(parent), err.to_string()))?;
+        }
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&full_path)
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&full_path), err.to_string()))?;
+        file.seek(SeekFrom::Start(position))
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&full_path), err.to_string()))?;
+        file.write_all(&data)
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&full_path), err.to_string()))?;
+        file.flush()
+            .await
+            .map_err(|err| error::storage_write_failed(path_to_string(&full_path), err.to_string()))?;
+        Ok(data.len())
+    }
+
+    async fn delete(&self, path: String) -> Result<(), RocketMQError> {
+        let full_path = self.resolve(&path);
+        match tokio::fs::remove_file(&full_path).await {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(error::storage_write_failed(path_to_string(&full_path), err.to_string())),
+        }
+    }
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}

--- a/rocketmq-tieredstore/src/provider/provider_impl.rs
+++ b/rocketmq-tieredstore/src/provider/provider_impl.rs
@@ -1,0 +1,92 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use rocketmq_error::RocketMQError;
+
+use crate::config::TieredStoreConfig;
+use crate::file::FileSegmentType;
+use crate::file::TieredFileSegment;
+use crate::provider::MemoryProvider;
+use crate::provider::PosixProvider;
+use crate::provider::TieredStoreProvider;
+
+#[derive(Clone)]
+pub enum ProviderKind {
+    Posix(PosixProvider),
+    Memory(MemoryProvider),
+}
+
+impl ProviderKind {
+    pub fn from_config(config: &TieredStoreConfig) -> Result<Self, RocketMQError> {
+        match config.backend_provider.as_str() {
+            "posix" => Ok(Self::Posix(PosixProvider::new(config.store_path_root_dir.clone()))),
+            "memory" => Ok(Self::Memory(MemoryProvider::default())),
+            provider => Err(RocketMQError::illegal_argument(format!(
+                "unsupported tiered backend provider: {provider}"
+            ))),
+        }
+    }
+}
+
+impl TieredStoreProvider for ProviderKind {
+    async fn create_segment(
+        &self,
+        path: String,
+        segment_type: FileSegmentType,
+        base_offset: u64,
+        max_size: u64,
+    ) -> Result<TieredFileSegment<Self>, RocketMQError>
+    where
+        Self: Sized,
+    {
+        let metadata = crate::metadata::FileSegmentMetadata::new(path.clone(), segment_type, base_offset);
+        Ok(TieredFileSegment::new(
+            path,
+            segment_type,
+            base_offset,
+            max_size,
+            metadata,
+            self.clone(),
+        ))
+    }
+
+    async fn segment_size(&self, path: String) -> Result<u64, RocketMQError> {
+        match self {
+            Self::Posix(provider) => provider.segment_size(path).await,
+            Self::Memory(provider) => provider.segment_size(path).await,
+        }
+    }
+
+    async fn read(&self, path: String, position: u64, length: usize) -> Result<Bytes, RocketMQError> {
+        match self {
+            Self::Posix(provider) => provider.read(path, position, length).await,
+            Self::Memory(provider) => provider.read(path, position, length).await,
+        }
+    }
+
+    async fn write(&self, path: String, position: u64, data: Bytes) -> Result<usize, RocketMQError> {
+        match self {
+            Self::Posix(provider) => provider.write(path, position, data).await,
+            Self::Memory(provider) => provider.write(path, position, data).await,
+        }
+    }
+
+    async fn delete(&self, path: String) -> Result<(), RocketMQError> {
+        match self {
+            Self::Posix(provider) => provider.delete(path).await,
+            Self::Memory(provider) => provider.delete(path).await,
+        }
+    }
+}

--- a/rocketmq-tieredstore/src/service.rs
+++ b/rocketmq-tieredstore/src/service.rs
@@ -1,0 +1,76 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod cleanup_service;
+
+use std::sync::Arc;
+
+use rocketmq_error::RocketMQError;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::TieredStoreConfig;
+use crate::file::TieredFlatFileStore;
+use crate::provider::TieredStoreProvider;
+use crate::service::cleanup_service::CleanupService;
+
+pub struct TieredServiceSet<P>
+where
+    P: TieredStoreProvider,
+{
+    cleanup_handle: tokio::sync::Mutex<Option<JoinHandle<Result<(), RocketMQError>>>>,
+    _marker: std::marker::PhantomData<P>,
+}
+
+impl<P> TieredServiceSet<P>
+where
+    P: TieredStoreProvider,
+{
+    pub fn new() -> Self {
+        Self {
+            cleanup_handle: tokio::sync::Mutex::new(None),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub async fn start_cleanup(
+        &self,
+        config: Arc<TieredStoreConfig>,
+        flat_file_store: Arc<TieredFlatFileStore<P>>,
+        shutdown: CancellationToken,
+    ) -> Result<(), RocketMQError> {
+        if !config.delete_file_enable {
+            return Ok(());
+        }
+        let service = CleanupService::new(config, flat_file_store, shutdown);
+        *self.cleanup_handle.lock().await = Some(tokio::spawn(service.run()));
+        Ok(())
+    }
+
+    pub async fn shutdown(&self) -> Result<(), RocketMQError> {
+        if let Some(handle) = self.cleanup_handle.lock().await.take() {
+            handle.await.map_err(|err| RocketMQError::Internal(err.to_string()))??;
+        }
+        Ok(())
+    }
+}
+
+impl<P> Default for TieredServiceSet<P>
+where
+    P: TieredStoreProvider,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rocketmq-tieredstore/src/service/cleanup_service.rs
+++ b/rocketmq-tieredstore/src/service/cleanup_service.rs
@@ -1,0 +1,74 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use rocketmq_error::RocketMQError;
+use tokio::time::interval;
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::TieredStoreConfig;
+use crate::file::TieredFlatFileStore;
+use crate::provider::TieredStoreProvider;
+
+pub struct CleanupService<P>
+where
+    P: TieredStoreProvider,
+{
+    config: Arc<TieredStoreConfig>,
+    flat_file_store: Arc<TieredFlatFileStore<P>>,
+    shutdown: CancellationToken,
+}
+
+impl<P> CleanupService<P>
+where
+    P: TieredStoreProvider,
+{
+    pub fn new(
+        config: Arc<TieredStoreConfig>,
+        flat_file_store: Arc<TieredFlatFileStore<P>>,
+        shutdown: CancellationToken,
+    ) -> Self {
+        Self {
+            config,
+            flat_file_store,
+            shutdown,
+        }
+    }
+
+    pub async fn run(self) -> Result<(), RocketMQError> {
+        let mut ticker = interval(self.config.delete_file_interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                _ = self.shutdown.cancelled() => {
+                    break;
+                }
+                _ = ticker.tick() => {
+                    self.flat_file_store.cleanup_expired(current_time_millis()).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn current_time_millis() -> i64 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis() as i64,
+        Err(_) => 0,
+    }
+}

--- a/rocketmq-tieredstore/src/store.rs
+++ b/rocketmq-tieredstore/src/store.rs
@@ -1,0 +1,130 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use rocketmq_error::RocketMQError;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::TieredStoreConfig;
+use crate::dispatcher::DefaultTieredDispatcher;
+use crate::dispatcher::TieredDispatcher;
+use crate::fetcher::DefaultTieredMessageFetcher;
+use crate::file::TieredFlatFileStore;
+use crate::lifecycle::TieredLifecycle;
+use crate::metadata::JsonMetadataStore;
+use crate::metadata::TieredMetadataStore;
+use crate::provider::ProviderKind;
+use crate::provider::TieredStoreProvider;
+use crate::service::TieredServiceSet;
+
+pub struct TieredStore<P = ProviderKind>
+where
+    P: TieredStoreProvider,
+{
+    config: Arc<TieredStoreConfig>,
+    metadata_store: Arc<JsonMetadataStore>,
+    flat_file_store: Arc<TieredFlatFileStore<P>>,
+    dispatcher: Arc<DefaultTieredDispatcher<P>>,
+    fetcher: Arc<DefaultTieredMessageFetcher<P>>,
+    services: TieredServiceSet<P>,
+    shutdown: CancellationToken,
+}
+
+impl TieredStore<ProviderKind> {
+    pub fn new(config: TieredStoreConfig) -> Result<Self, RocketMQError> {
+        let provider = ProviderKind::from_config(&config)?;
+        Self::with_provider(config, provider)
+    }
+}
+
+impl<P> TieredStore<P>
+where
+    P: TieredStoreProvider,
+{
+    pub fn with_provider(config: TieredStoreConfig, provider: P) -> Result<Self, RocketMQError> {
+        let config = Arc::new(config);
+        let shutdown = CancellationToken::new();
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let flat_file_store = Arc::new(TieredFlatFileStore::new(
+            config.clone(),
+            metadata_store.clone(),
+            provider,
+        ));
+        let dispatcher = Arc::new(DefaultTieredDispatcher::new(
+            config.clone(),
+            flat_file_store.clone(),
+            shutdown.child_token(),
+        ));
+        let fetcher = Arc::new(DefaultTieredMessageFetcher::new(
+            config.clone(),
+            flat_file_store.clone(),
+        ));
+
+        Ok(Self {
+            config,
+            metadata_store,
+            flat_file_store,
+            dispatcher,
+            fetcher,
+            services: TieredServiceSet::new(),
+            shutdown,
+        })
+    }
+
+    pub fn config(&self) -> &TieredStoreConfig {
+        self.config.as_ref()
+    }
+
+    pub fn dispatcher(&self) -> Arc<DefaultTieredDispatcher<P>> {
+        self.dispatcher.clone()
+    }
+
+    pub fn fetcher(&self) -> Arc<DefaultTieredMessageFetcher<P>> {
+        self.fetcher.clone()
+    }
+}
+
+impl<P> TieredLifecycle for TieredStore<P>
+where
+    P: TieredStoreProvider,
+{
+    async fn load(&self) -> Result<(), RocketMQError> {
+        self.metadata_store.load().await?;
+        self.flat_file_store.load().await
+    }
+
+    async fn start(&self) -> Result<(), RocketMQError> {
+        self.dispatcher.start().await?;
+        self.services
+            .start_cleanup(
+                self.config.clone(),
+                self.flat_file_store.clone(),
+                self.shutdown.child_token(),
+            )
+            .await
+    }
+
+    async fn shutdown(&self) -> Result<(), RocketMQError> {
+        self.shutdown.cancel();
+        self.dispatcher.shutdown().await?;
+        self.services.shutdown().await?;
+        self.flat_file_store.shutdown().await
+    }
+
+    async fn destroy(&self) -> Result<(), RocketMQError> {
+        self.flat_file_store.destroy().await?;
+        self.metadata_store.destroy().await
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7310

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tiered storage support enabling messages to be managed across different storage tiers based on configurable levels and policies.
  * Introduced message dispatching to tiered storage with async request handling and queue management.
  * Added message retrieval capabilities from tiered storage with configurable fetching behavior.
  * Implemented support for multiple storage backends: POSIX filesystem and in-memory providers.

* **Chores**
  * Added `rocketmq-tieredstore` crate to the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->