### PR TITLE
[ISSUE #7312]🚀implement tiered storage features for RocketMQ, including segment management, metadata handling, and message retrieval enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3971,6 +3971,7 @@ dependencies = [
  "rocketmq-error",
  "rocketmq-remoting",
  "rocketmq-rust",
+ "rocketmq-tieredstore",
  "serde",
  "serde_json",
  "sysinfo",

--- a/rocketmq-store/Cargo.toml
+++ b/rocketmq-store/Cargo.toml
@@ -44,6 +44,7 @@ io_uring = ["dep:tokio-uring"]
 fast-load = []
 # Safe sequential loading fallback (disables fast-load)
 safe-load = []
+tieredstore = ["dep:rocketmq-tieredstore"]
 
 
 [dependencies]
@@ -51,6 +52,7 @@ rocketmq-common   = { workspace = true }
 rocketmq-rust     = { workspace = true }
 rocketmq-remoting = { workspace = true }
 rocketmq-error    = { workspace = true }
+rocketmq-tieredstore = { path = "../rocketmq-tieredstore", optional = true }
 
 #tools
 dirs.workspace = true

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -33,5 +33,7 @@ pub mod stats;
 pub mod store;
 pub mod store_error;
 pub mod store_path_config_helper;
+#[cfg(feature = "tieredstore")]
+pub mod tieredstore;
 pub mod timer;
 pub mod utils;

--- a/rocketmq-store/src/tieredstore.rs
+++ b/rocketmq-store/src/tieredstore.rs
@@ -1,0 +1,138 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use rocketmq_tieredstore::dispatcher::DefaultTieredDispatcher;
+use rocketmq_tieredstore::dispatcher::TieredDispatchRequest;
+use rocketmq_tieredstore::provider::ProviderKind;
+use rocketmq_tieredstore::provider::TieredStoreProvider;
+use tracing::debug;
+use tracing::warn;
+
+use crate::base::commit_log_dispatcher::CommitLogDispatcher;
+use crate::base::dispatch_request::DispatchRequest;
+
+pub type DispatchBodyResolver = dyn Fn(&DispatchRequest) -> Option<Bytes> + Send + Sync;
+
+pub struct TieredCommitLogDispatcher<P = ProviderKind>
+where
+    P: TieredStoreProvider,
+{
+    dispatcher: Arc<DefaultTieredDispatcher<P>>,
+    body_resolver: Arc<DispatchBodyResolver>,
+}
+
+impl<P> TieredCommitLogDispatcher<P>
+where
+    P: TieredStoreProvider,
+{
+    pub fn new(dispatcher: Arc<DefaultTieredDispatcher<P>>, body_resolver: Arc<DispatchBodyResolver>) -> Self {
+        Self {
+            dispatcher,
+            body_resolver,
+        }
+    }
+}
+
+impl<P> CommitLogDispatcher for TieredCommitLogDispatcher<P>
+where
+    P: TieredStoreProvider,
+{
+    fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
+        if !dispatch_request.success {
+            return;
+        }
+
+        let Some(body) = (self.body_resolver)(dispatch_request) else {
+            debug!(
+                topic = %dispatch_request.topic,
+                queue_id = dispatch_request.queue_id,
+                queue_offset = dispatch_request.consume_queue_offset,
+                "skip tieredstore dispatch because commitlog body is unavailable"
+            );
+            return;
+        };
+
+        let request = to_tiered_dispatch_request(dispatch_request, body);
+        if let Err(error) = self.dispatcher.try_dispatch(request) {
+            warn!(
+                topic = %dispatch_request.topic,
+                queue_id = dispatch_request.queue_id,
+                queue_offset = dispatch_request.consume_queue_offset,
+                error = %error,
+                "failed to enqueue tieredstore dispatch request"
+            );
+        }
+    }
+}
+
+pub fn to_tiered_dispatch_request(dispatch_request: &DispatchRequest, body: Bytes) -> TieredDispatchRequest {
+    let keys = dispatch_request.keys.to_string();
+    TieredDispatchRequest {
+        topic: dispatch_request.topic.to_string(),
+        queue_id: dispatch_request.queue_id,
+        queue_offset: dispatch_request.consume_queue_offset,
+        commit_log_offset: dispatch_request.commit_log_offset,
+        message_size: dispatch_request.msg_size,
+        tags_code: dispatch_request.tags_code,
+        store_timestamp: dispatch_request.store_timestamp,
+        keys: (!keys.is_empty()).then_some(keys),
+        uniq_key: dispatch_request.uniq_key.as_ref().map(ToString::to_string),
+        offset_id: dispatch_request.offset_id.as_ref().map(ToString::to_string),
+        sys_flag: dispatch_request.sys_flag,
+        body: Some(body),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    #[test]
+    fn converts_store_dispatch_request_to_tiered_request() {
+        let dispatch_request = DispatchRequest {
+            topic: CheetahString::from("TopicA"),
+            queue_id: 1,
+            commit_log_offset: 1024,
+            msg_size: 4,
+            tags_code: 7,
+            store_timestamp: 100,
+            consume_queue_offset: 9,
+            keys: CheetahString::from("keyA"),
+            success: true,
+            uniq_key: Some(CheetahString::from("uniqA")),
+            offset_id: Some(CheetahString::from("offsetA")),
+            ..DispatchRequest::default()
+        };
+
+        let tiered_request = to_tiered_dispatch_request(&dispatch_request, Bytes::from_static(b"test"));
+
+        assert_eq!(tiered_request.topic, "TopicA");
+        assert_eq!(tiered_request.queue_id, 1);
+        assert_eq!(tiered_request.queue_offset, 9);
+        assert_eq!(tiered_request.commit_log_offset, 1024);
+        assert_eq!(tiered_request.message_size, 4);
+        assert_eq!(tiered_request.tags_code, 7);
+        assert_eq!(tiered_request.store_timestamp, 100);
+        assert_eq!(tiered_request.keys.as_deref(), Some("keyA"));
+        assert_eq!(tiered_request.uniq_key.as_deref(), Some("uniqA"));
+        assert_eq!(tiered_request.offset_id.as_deref(), Some("offsetA"));
+        assert_eq!(tiered_request.body, Some(Bytes::from_static(b"test")));
+    }
+}

--- a/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs
+++ b/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs
@@ -103,6 +103,7 @@ where
                         .append_commit_log(message, request.store_timestamp)
                         .await?;
                     file.append_consume_queue(
+                        request.queue_offset,
                         ConsumeQueueUnit {
                             commit_log_offset: tiered_offset as i64,
                             size: request.message_size,

--- a/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
+++ b/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
@@ -112,19 +112,92 @@ where
         queue_offset: i64,
         max_msg_nums: i32,
     ) -> Result<TieredGetMessageResult, RocketMQError> {
-        let Some(_flat_file) = self.flat_file_store.get(&topic, queue_id) else {
+        let Some(flat_file) = self.flat_file_store.get(&topic, queue_id) else {
             return Ok(TieredGetMessageResult {
                 status: TieredGetMessageStatus::NoMatchedLogicQueue,
                 ..TieredGetMessageResult::default()
             });
         };
 
-        let _ = queue_offset;
-        let _ = max_msg_nums;
+        let min_offset = flat_file.consume_queue_min_offset();
+        let max_offset = flat_file.consume_queue_commit_offset();
+        if max_offset <= min_offset {
+            return Ok(TieredGetMessageResult {
+                status: TieredGetMessageStatus::NoMatchedMessage,
+                min_offset,
+                max_offset,
+                next_begin_offset: max_offset,
+                ..TieredGetMessageResult::default()
+            });
+        }
+        if queue_offset < min_offset {
+            return Ok(TieredGetMessageResult {
+                status: TieredGetMessageStatus::OffsetTooSmall,
+                min_offset,
+                max_offset,
+                next_begin_offset: min_offset,
+                ..TieredGetMessageResult::default()
+            });
+        }
+        if queue_offset == max_offset {
+            return Ok(TieredGetMessageResult {
+                status: TieredGetMessageStatus::OffsetOverflowOne,
+                min_offset,
+                max_offset,
+                next_begin_offset: max_offset,
+                ..TieredGetMessageResult::default()
+            });
+        }
+        if queue_offset > max_offset {
+            return Ok(TieredGetMessageResult {
+                status: TieredGetMessageStatus::OffsetOverflowBadly,
+                min_offset,
+                max_offset,
+                next_begin_offset: max_offset,
+                ..TieredGetMessageResult::default()
+            });
+        }
+
+        let max_msg_nums = (max_msg_nums.max(1) as usize).min(self.config.read_ahead_message_count.max(1));
+        let mut messages = Vec::with_capacity(max_msg_nums.min(16));
+        let mut next_begin_offset = queue_offset;
+        for offset in queue_offset..max_offset {
+            if messages.len() >= max_msg_nums {
+                break;
+            }
+            match flat_file.read_message_by_queue_offset(offset).await? {
+                Some(message) => {
+                    messages.push(message);
+                    next_begin_offset = offset.saturating_add(1);
+                }
+                None => {
+                    return Ok(TieredGetMessageResult {
+                        status: TieredGetMessageStatus::OffsetFoundNull,
+                        messages,
+                        min_offset,
+                        max_offset,
+                        next_begin_offset: offset,
+                    });
+                }
+            }
+        }
+
         let _ = &self.config;
+        if messages.is_empty() {
+            return Ok(TieredGetMessageResult {
+                status: TieredGetMessageStatus::NoMatchedMessage,
+                min_offset,
+                max_offset,
+                next_begin_offset,
+                ..TieredGetMessageResult::default()
+            });
+        }
         Ok(TieredGetMessageResult {
-            status: TieredGetMessageStatus::NoMatchedMessage,
-            ..TieredGetMessageResult::default()
+            status: TieredGetMessageStatus::Found,
+            messages,
+            min_offset,
+            max_offset,
+            next_begin_offset,
         })
     }
 
@@ -134,10 +207,16 @@ where
         queue_id: i32,
         queue_offset: i64,
     ) -> Result<i64, RocketMQError> {
-        let _ = topic;
-        let _ = queue_id;
-        let _ = queue_offset;
-        Ok(-1)
+        let Some(flat_file) = self.flat_file_store.get(&topic, queue_id) else {
+            return Ok(-1);
+        };
+        if queue_offset.saturating_add(1) == flat_file.consume_queue_commit_offset() {
+            return Ok(flat_file.max_store_timestamp());
+        }
+        Ok(flat_file
+            .read_message_store_timestamp(queue_offset)
+            .await?
+            .unwrap_or(-1))
     }
 
     async fn get_offset_by_time(
@@ -146,10 +225,10 @@ where
         queue_id: i32,
         timestamp_millis: i64,
     ) -> Result<i64, RocketMQError> {
-        let _ = topic;
-        let _ = queue_id;
-        let _ = timestamp_millis;
-        Ok(-1)
+        let Some(flat_file) = self.flat_file_store.get(&topic, queue_id) else {
+            return Ok(-1);
+        };
+        flat_file.queue_offset_by_time(timestamp_millis).await
     }
 
     async fn query_message(
@@ -166,5 +245,169 @@ where
         let _ = begin;
         let _ = end;
         Ok(TieredQueryResult::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use bytes::BytesMut;
+    use rocketmq_error::RocketMQError;
+
+    use super::*;
+    use crate::config::TieredStoreConfig;
+    use crate::file::ConsumeQueueUnit;
+    use crate::file::TieredFlatFileStore;
+    use crate::metadata::JsonMetadataStore;
+    use crate::provider::MemoryProvider;
+
+    async fn build_fetcher() -> Result<DefaultTieredMessageFetcher<MemoryProvider>, RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            ..TieredStoreConfig::default()
+        });
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let provider = MemoryProvider::default();
+        let flat_file_store = Arc::new(TieredFlatFileStore::new(config.clone(), metadata_store, provider));
+        let flat_file = flat_file_store.get_or_create("TopicA".to_owned(), 0)?;
+
+        let first_offset = flat_file.append_commit_log(Bytes::from_static(b"msg-a"), 100).await?;
+        flat_file
+            .append_consume_queue(
+                3,
+                ConsumeQueueUnit {
+                    commit_log_offset: first_offset as i64,
+                    size: 5,
+                    tags_code: 1,
+                },
+                100,
+            )
+            .await?;
+
+        let second_offset = flat_file.append_commit_log(Bytes::from_static(b"msg-b"), 101).await?;
+        flat_file
+            .append_consume_queue(
+                4,
+                ConsumeQueueUnit {
+                    commit_log_offset: second_offset as i64,
+                    size: 5,
+                    tags_code: 1,
+                },
+                101,
+            )
+            .await?;
+        flat_file.commit().await?;
+
+        Ok(DefaultTieredMessageFetcher::new(config, flat_file_store))
+    }
+
+    async fn build_timestamp_fetcher() -> Result<DefaultTieredMessageFetcher<MemoryProvider>, RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            ..TieredStoreConfig::default()
+        });
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let provider = MemoryProvider::default();
+        let flat_file_store = Arc::new(TieredFlatFileStore::new(config.clone(), metadata_store, provider));
+        let flat_file = flat_file_store.get_or_create("TopicA".to_owned(), 0)?;
+
+        for (queue_offset, timestamp) in [(3, 100), (4, 200), (5, 300)] {
+            let message = message_with_store_timestamp(timestamp);
+            let commit_log_offset = flat_file.append_commit_log(message, timestamp).await?;
+            flat_file
+                .append_consume_queue(
+                    queue_offset,
+                    ConsumeQueueUnit {
+                        commit_log_offset: commit_log_offset as i64,
+                        size: 64,
+                        tags_code: 1,
+                    },
+                    timestamp,
+                )
+                .await?;
+        }
+        flat_file.commit().await?;
+
+        Ok(DefaultTieredMessageFetcher::new(config, flat_file_store))
+    }
+
+    fn message_with_store_timestamp(timestamp: i64) -> Bytes {
+        let mut bytes = BytesMut::zeroed(64);
+        bytes[56..64].copy_from_slice(&timestamp.to_be_bytes());
+        bytes.freeze()
+    }
+
+    #[tokio::test]
+    async fn fetches_messages_by_queue_offset() -> Result<(), RocketMQError> {
+        let fetcher = build_fetcher().await?;
+
+        let result = fetcher.get_message("TopicA".to_owned(), 0, 3, 2).await?;
+
+        assert_eq!(result.status, TieredGetMessageStatus::Found);
+        assert_eq!(result.min_offset, 3);
+        assert_eq!(result.max_offset, 5);
+        assert_eq!(result.next_begin_offset, 5);
+        assert_eq!(
+            result.messages,
+            vec![Bytes::from_static(b"msg-a"), Bytes::from_static(b"msg-b")]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn returns_java_aligned_offset_boundaries() -> Result<(), RocketMQError> {
+        let fetcher = build_fetcher().await?;
+
+        let too_small = fetcher.get_message("TopicA".to_owned(), 0, 2, 1).await?;
+        assert_eq!(too_small.status, TieredGetMessageStatus::OffsetTooSmall);
+        assert_eq!(too_small.next_begin_offset, 3);
+
+        let overflow_one = fetcher.get_message("TopicA".to_owned(), 0, 5, 1).await?;
+        assert_eq!(overflow_one.status, TieredGetMessageStatus::OffsetOverflowOne);
+
+        let overflow_badly = fetcher.get_message("TopicA".to_owned(), 0, 6, 1).await?;
+        assert_eq!(overflow_badly.status, TieredGetMessageStatus::OffsetOverflowBadly);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn missing_flat_file_returns_no_matched_logic_queue() -> Result<(), RocketMQError> {
+        let fetcher = build_fetcher().await?;
+
+        let result = fetcher.get_message("MissingTopic".to_owned(), 0, 0, 1).await?;
+
+        assert_eq!(result.status, TieredGetMessageStatus::NoMatchedLogicQueue);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reads_message_store_timestamp_from_commit_log() -> Result<(), RocketMQError> {
+        let fetcher = build_timestamp_fetcher().await?;
+
+        assert_eq!(fetcher.get_message_timestamp("TopicA".to_owned(), 0, 4).await?, 200);
+        assert_eq!(
+            fetcher.get_message_timestamp("MissingTopic".to_owned(), 0, 4).await?,
+            -1
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn finds_lower_bound_offset_by_store_timestamp() -> Result<(), RocketMQError> {
+        let fetcher = build_timestamp_fetcher().await?;
+
+        assert_eq!(fetcher.get_offset_by_time("TopicA".to_owned(), 0, 50).await?, 3);
+        assert_eq!(fetcher.get_offset_by_time("TopicA".to_owned(), 0, 100).await?, 3);
+        assert_eq!(fetcher.get_offset_by_time("TopicA".to_owned(), 0, 150).await?, 4);
+        assert_eq!(fetcher.get_offset_by_time("TopicA".to_owned(), 0, 300).await?, 5);
+        assert_eq!(fetcher.get_offset_by_time("TopicA".to_owned(), 0, 301).await?, 6);
+        assert_eq!(fetcher.get_offset_by_time("MissingTopic".to_owned(), 0, 100).await?, -1);
+        Ok(())
     }
 }

--- a/rocketmq-tieredstore/src/file/file_segment.rs
+++ b/rocketmq-tieredstore/src/file/file_segment.rs
@@ -102,6 +102,55 @@ impl<P> TieredFileSegment<P> {
     fn current_status(&self) -> FileSegmentStatus {
         self.metadata.lock().status
     }
+
+    pub fn max_size(&self) -> u64 {
+        self.max_size
+    }
+
+    pub fn next_absolute_offset(&self) -> u64 {
+        self.base_offset
+            .saturating_add(self.append_position.load(Ordering::Acquire))
+    }
+
+    pub fn committed_absolute_end(&self) -> u64 {
+        self.base_offset
+            .saturating_add(self.commit_position.load(Ordering::Acquire))
+    }
+
+    pub fn min_timestamp(&self) -> i64 {
+        self.metadata.lock().begin_timestamp
+    }
+
+    pub fn max_timestamp(&self) -> i64 {
+        self.metadata.lock().end_timestamp
+    }
+
+    pub fn can_hold(&self, absolute_offset: u64, len: usize) -> bool {
+        if self.current_status() != FileSegmentStatus::New {
+            return false;
+        }
+        let relative_offset = absolute_offset.saturating_sub(self.base_offset);
+        absolute_offset >= self.base_offset && relative_offset.saturating_add(len as u64) <= self.max_size
+    }
+
+    pub fn contains_committed_range(&self, absolute_offset: u64, len: usize) -> bool {
+        if self.current_status() == FileSegmentStatus::Deleted {
+            return false;
+        }
+        absolute_offset >= self.base_offset
+            && absolute_offset.saturating_add(len as u64) <= self.committed_absolute_end()
+    }
+
+    pub fn is_expired_sealed(&self, expire_before_millis: i64) -> bool {
+        let metadata = self.metadata.lock();
+        metadata.status == FileSegmentStatus::Sealed
+            && metadata.end_timestamp != i64::MIN
+            && metadata.end_timestamp < expire_before_millis
+    }
+
+    pub fn mark_deleted(&self) {
+        self.metadata.lock().status = FileSegmentStatus::Deleted;
+    }
 }
 
 impl<P> FileSegment for TieredFileSegment<P>

--- a/rocketmq-tieredstore/src/file/flat_file.rs
+++ b/rocketmq-tieredstore/src/file/flat_file.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -23,11 +24,16 @@ use rocketmq_error::RocketMQError;
 use crate::config::TieredStoreConfig;
 use crate::error;
 use crate::file::FileSegment;
+use crate::file::FileSegmentStatus;
 use crate::file::FileSegmentType;
 use crate::file::TieredFileSegment;
+use crate::metadata::JsonMetadataStore;
+use crate::metadata::TieredMetadataStore;
+use crate::metadata::TopicQueueMetadata;
 use crate::provider::TieredStoreProvider;
 
 pub const CONSUME_QUEUE_UNIT_SIZE: usize = 20;
+pub const MESSAGE_STORE_TIMESTAMP_POSITION: usize = 56;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConsumeQueueUnit {
@@ -44,6 +50,20 @@ impl ConsumeQueueUnit {
         bytes.put_i64(self.tags_code);
         bytes.freeze()
     }
+
+    pub fn decode(mut bytes: Bytes) -> Result<Self, RocketMQError> {
+        if bytes.len() != CONSUME_QUEUE_UNIT_SIZE {
+            return Err(error::illegal_argument(format!(
+                "tiered consume queue unit must be {CONSUME_QUEUE_UNIT_SIZE} bytes, got {}",
+                bytes.len()
+            )));
+        }
+        Ok(Self {
+            commit_log_offset: bytes.get_i64(),
+            size: bytes.get_i32(),
+            tags_code: bytes.get_i64(),
+        })
+    }
 }
 
 pub struct TieredFlatFile<P>
@@ -53,6 +73,7 @@ where
     topic: String,
     queue_id: i32,
     config: Arc<TieredStoreConfig>,
+    metadata_store: Arc<JsonMetadataStore>,
     provider: P,
     commit_log_segments: Mutex<Vec<Arc<TieredFileSegment<P>>>>,
     consume_queue_segments: Mutex<Vec<Arc<TieredFileSegment<P>>>>,
@@ -62,11 +83,18 @@ impl<P> TieredFlatFile<P>
 where
     P: TieredStoreProvider,
 {
-    pub fn new(topic: String, queue_id: i32, config: Arc<TieredStoreConfig>, provider: P) -> Self {
+    pub fn new(
+        topic: String,
+        queue_id: i32,
+        config: Arc<TieredStoreConfig>,
+        metadata_store: Arc<JsonMetadataStore>,
+        provider: P,
+    ) -> Self {
         Self {
             topic,
             queue_id,
             config,
+            metadata_store,
             provider,
             commit_log_segments: Mutex::new(Vec::new()),
             consume_queue_segments: Mutex::new(Vec::new()),
@@ -82,21 +110,46 @@ where
     }
 
     pub async fn append_commit_log(&self, message: Bytes, store_timestamp: i64) -> Result<u64, RocketMQError> {
+        let append_len = message.len();
+        let absolute_offset = self.commit_log_append_offset();
         let segment = self
-            .ensure_segment(FileSegmentType::CommitLog, self.config.commit_log_segment_size)
+            .ensure_writable_segment(
+                FileSegmentType::CommitLog,
+                self.config.commit_log_segment_size,
+                absolute_offset,
+                append_len,
+            )
             .await?;
-        let offset = segment.base_offset().saturating_add(segment.append_position());
+        let offset = segment.next_absolute_offset();
         segment.append(message, store_timestamp).await?;
         Ok(offset)
     }
 
     pub async fn append_consume_queue(
         &self,
+        queue_offset: i64,
         unit: ConsumeQueueUnit,
         store_timestamp: i64,
     ) -> Result<(), RocketMQError> {
+        if queue_offset < 0 {
+            return Err(error::illegal_argument(
+                "tiered consume queue offset must not be negative",
+            ));
+        }
+        let absolute_offset = (queue_offset as u64).saturating_mul(CONSUME_QUEUE_UNIT_SIZE as u64);
+        let expected_offset = self.consume_queue_append_byte_offset();
+        if !self.consume_queue_segments.lock().is_empty() && absolute_offset != expected_offset {
+            return Err(error::illegal_argument(format!(
+                "tiered consume queue offset gap, expected byte offset {expected_offset}, got {absolute_offset}"
+            )));
+        }
         let segment = self
-            .ensure_segment(FileSegmentType::ConsumeQueue, self.config.consume_queue_segment_size)
+            .ensure_writable_segment(
+                FileSegmentType::ConsumeQueue,
+                self.config.consume_queue_segment_size,
+                absolute_offset,
+                CONSUME_QUEUE_UNIT_SIZE,
+            )
             .await?;
         segment.append(unit.encode(), store_timestamp).await?;
         Ok(())
@@ -106,23 +159,215 @@ where
         let commit_log_segments = { self.commit_log_segments.lock().clone() };
         for segment in commit_log_segments {
             segment.commit().await?;
+            self.metadata_store.upsert_file_segment(segment.metadata()).await?;
         }
 
         let consume_queue_segments = { self.consume_queue_segments.lock().clone() };
         for segment in consume_queue_segments {
             segment.commit().await?;
+            self.metadata_store.upsert_file_segment(segment.metadata()).await?;
+        }
+        if !self.consume_queue_segments.lock().is_empty() {
+            self.metadata_store
+                .upsert_queue(TopicQueueMetadata {
+                    topic: self.topic.clone(),
+                    queue_id: self.queue_id,
+                    min_offset: self.consume_queue_min_offset(),
+                    max_offset: self.consume_queue_commit_offset(),
+                    update_timestamp: current_time_millis(),
+                })
+                .await?;
         }
         Ok(())
     }
 
     pub async fn recover(&self) -> Result<(), RocketMQError> {
+        let mut commit_log_segments = Vec::new();
+        let mut consume_queue_segments = Vec::new();
+
+        for mut metadata in self
+            .metadata_store
+            .list_file_segments(&self.topic, self.queue_id)
+            .await?
+        {
+            if metadata.status == FileSegmentStatus::Deleted {
+                continue;
+            }
+            let max_size = self.max_segment_size(metadata.segment_type)?;
+            let real_size = self.provider.segment_size(metadata.path.clone()).await?;
+            if metadata.size != real_size {
+                metadata.size = real_size.min(max_size);
+                self.metadata_store.upsert_file_segment(metadata.clone()).await?;
+            }
+            let segment = Arc::new(TieredFileSegment::new(
+                metadata.path.clone(),
+                metadata.segment_type,
+                metadata.base_offset,
+                max_size,
+                metadata,
+                self.provider.clone(),
+            ));
+            match segment.segment_type() {
+                FileSegmentType::CommitLog => commit_log_segments.push(segment),
+                FileSegmentType::ConsumeQueue => consume_queue_segments.push(segment),
+                FileSegmentType::Index => {}
+            }
+        }
+
+        commit_log_segments.sort_by_key(|segment| segment.base_offset());
+        consume_queue_segments.sort_by_key(|segment| segment.base_offset());
+        *self.commit_log_segments.lock() = commit_log_segments;
+        *self.consume_queue_segments.lock() = consume_queue_segments;
         Ok(())
     }
 
-    async fn ensure_segment(
+    pub fn commit_log_append_offset(&self) -> u64 {
+        self.commit_log_segments
+            .lock()
+            .last()
+            .map(|segment| segment.next_absolute_offset())
+            .unwrap_or(0)
+    }
+
+    pub fn consume_queue_min_offset(&self) -> i64 {
+        self.consume_queue_segments
+            .lock()
+            .first()
+            .map(|segment| (segment.base_offset() / CONSUME_QUEUE_UNIT_SIZE as u64) as i64)
+            .unwrap_or(0)
+    }
+
+    pub fn consume_queue_append_offset(&self) -> i64 {
+        (self.consume_queue_append_byte_offset() / CONSUME_QUEUE_UNIT_SIZE as u64) as i64
+    }
+
+    pub fn consume_queue_commit_offset(&self) -> i64 {
+        self.consume_queue_segments
+            .lock()
+            .last()
+            .map(|segment| {
+                ((segment.base_offset().saturating_add(segment.commit_position())) / CONSUME_QUEUE_UNIT_SIZE as u64)
+                    as i64
+            })
+            .unwrap_or(0)
+    }
+
+    pub async fn cleanup_expired(&self, now_millis: i64) -> Result<(), RocketMQError> {
+        let reserved_millis = self.config.file_reserved_time.as_millis() as i64;
+        let expire_before_millis = now_millis.saturating_sub(reserved_millis);
+
+        let mut expired = Vec::new();
+        expired.extend(self.expired_segments(FileSegmentType::CommitLog, expire_before_millis));
+        expired.extend(self.expired_segments(FileSegmentType::ConsumeQueue, expire_before_millis));
+
+        for segment in expired {
+            let metadata = segment.metadata();
+            self.provider.delete(metadata.path.clone()).await?;
+            segment.mark_deleted();
+            self.metadata_store
+                .mark_file_segment_deleted(&metadata.path, metadata.base_offset)
+                .await?;
+            self.remove_segment(metadata.segment_type, metadata.base_offset, &metadata.path);
+        }
+        Ok(())
+    }
+
+    pub async fn read_consume_queue_unit(&self, queue_offset: i64) -> Result<Option<ConsumeQueueUnit>, RocketMQError> {
+        if queue_offset < 0 {
+            return Err(error::illegal_argument(
+                "tiered consume queue offset must not be negative",
+            ));
+        }
+        let byte_offset = (queue_offset as u64).saturating_mul(CONSUME_QUEUE_UNIT_SIZE as u64);
+        let Some(bytes) = self
+            .read_from_segments(FileSegmentType::ConsumeQueue, byte_offset, CONSUME_QUEUE_UNIT_SIZE)
+            .await?
+        else {
+            return Ok(None);
+        };
+        ConsumeQueueUnit::decode(bytes).map(Some)
+    }
+
+    pub async fn read_message_by_queue_offset(&self, queue_offset: i64) -> Result<Option<Bytes>, RocketMQError> {
+        let Some(unit) = self.read_consume_queue_unit(queue_offset).await? else {
+            return Ok(None);
+        };
+        if unit.commit_log_offset < 0 || unit.size <= 0 {
+            return Ok(None);
+        }
+        self.read_commit_log(unit.commit_log_offset as u64, unit.size as usize)
+            .await
+    }
+
+    pub async fn read_message_store_timestamp(&self, queue_offset: i64) -> Result<Option<i64>, RocketMQError> {
+        let Some(message) = self.read_message_by_queue_offset(queue_offset).await? else {
+            return Ok(None);
+        };
+        Ok(decode_message_store_timestamp(&message))
+    }
+
+    pub async fn read_commit_log(&self, offset: u64, length: usize) -> Result<Option<Bytes>, RocketMQError> {
+        self.read_from_segments(FileSegmentType::CommitLog, offset, length)
+            .await
+    }
+
+    pub async fn queue_offset_by_time(&self, timestamp_millis: i64) -> Result<i64, RocketMQError> {
+        let cq_min = self.consume_queue_min_offset();
+        let cq_max = self.consume_queue_commit_offset().saturating_sub(1);
+        if cq_max == -1 || cq_max < cq_min {
+            return Ok(cq_min);
+        }
+
+        let Some(max_store_time) = self.read_message_store_timestamp(cq_max).await? else {
+            return Ok(cq_min);
+        };
+        if max_store_time < timestamp_millis {
+            return Ok(cq_max.saturating_add(1));
+        }
+
+        let Some(min_store_time) = self.read_message_store_timestamp(cq_min).await? else {
+            return Ok(cq_min);
+        };
+        if min_store_time > timestamp_millis {
+            return Ok(cq_min);
+        }
+
+        let (mut low, mut high) = self.timestamp_search_range(timestamp_millis, cq_min, cq_max);
+        while low < high {
+            let middle = low.saturating_add((high - low) / 2);
+            let Some(store_time) = self.read_message_store_timestamp(middle).await? else {
+                return Ok(low);
+            };
+            if store_time < timestamp_millis {
+                low = middle.saturating_add(1);
+            } else {
+                high = middle;
+            }
+        }
+        Ok(low)
+    }
+
+    pub fn min_store_timestamp(&self) -> i64 {
+        let mut min_store_time = -1;
+        if let Some(timestamp) = segment_min_timestamp(&self.commit_log_segments.lock()) {
+            min_store_time = min_store_time.max(timestamp);
+        }
+        if let Some(timestamp) = segment_min_timestamp(&self.consume_queue_segments.lock()) {
+            min_store_time = min_store_time.max(timestamp);
+        }
+        min_store_time
+    }
+
+    pub fn max_store_timestamp(&self) -> i64 {
+        segment_max_timestamp(&self.commit_log_segments.lock()).unwrap_or(-1)
+    }
+
+    async fn ensure_writable_segment(
         &self,
         segment_type: FileSegmentType,
         max_size: u64,
+        absolute_offset: u64,
+        append_len: usize,
     ) -> Result<Arc<TieredFileSegment<P>>, RocketMQError> {
         let existing = match segment_type {
             FileSegmentType::CommitLog => self.commit_log_segments.lock().last().cloned(),
@@ -130,22 +375,40 @@ where
             FileSegmentType::Index => return Err(error::internal("index segment is managed by tiered index service")),
         };
         if let Some(segment) = existing {
-            return Ok(segment);
+            if segment.can_hold(absolute_offset, append_len) {
+                return Ok(segment);
+            }
+            segment.commit().await?;
+            segment.seal().await?;
+            self.metadata_store.upsert_file_segment(segment.metadata()).await?;
         }
 
-        let path = segment_path(&self.topic, self.queue_id, segment_type, 0);
-        let segment = Arc::new(self.provider.create_segment(path, segment_type, 0, max_size).await?);
+        let path = segment_path(&self.topic, self.queue_id, segment_type, absolute_offset);
+        let segment = Arc::new(
+            self.provider
+                .create_segment(path, segment_type, absolute_offset, max_size)
+                .await?,
+        );
+        self.metadata_store.upsert_file_segment(segment.metadata()).await?;
         match segment_type {
             FileSegmentType::CommitLog => {
                 let mut segments = self.commit_log_segments.lock();
-                if let Some(existing) = segments.last().cloned() {
+                if let Some(existing) = segments
+                    .last()
+                    .filter(|segment| segment.can_hold(absolute_offset, append_len))
+                    .cloned()
+                {
                     return Ok(existing);
                 }
                 segments.push(segment.clone());
             }
             FileSegmentType::ConsumeQueue => {
                 let mut segments = self.consume_queue_segments.lock();
-                if let Some(existing) = segments.last().cloned() {
+                if let Some(existing) = segments
+                    .last()
+                    .filter(|segment| segment.can_hold(absolute_offset, append_len))
+                    .cloned()
+                {
                     return Ok(existing);
                 }
                 segments.push(segment.clone());
@@ -153,6 +416,89 @@ where
             FileSegmentType::Index => {}
         }
         Ok(segment)
+    }
+
+    fn consume_queue_append_byte_offset(&self) -> u64 {
+        self.consume_queue_segments
+            .lock()
+            .last()
+            .map(|segment| segment.next_absolute_offset())
+            .unwrap_or(0)
+    }
+
+    fn max_segment_size(&self, segment_type: FileSegmentType) -> Result<u64, RocketMQError> {
+        match segment_type {
+            FileSegmentType::CommitLog => Ok(self.config.commit_log_segment_size),
+            FileSegmentType::ConsumeQueue => Ok(self.config.consume_queue_segment_size),
+            FileSegmentType::Index => Err(error::internal("index segment is managed by tiered index service")),
+        }
+    }
+
+    fn expired_segments(
+        &self,
+        segment_type: FileSegmentType,
+        expire_before_millis: i64,
+    ) -> Vec<Arc<TieredFileSegment<P>>> {
+        let segments = match segment_type {
+            FileSegmentType::CommitLog => self.commit_log_segments.lock().clone(),
+            FileSegmentType::ConsumeQueue => self.consume_queue_segments.lock().clone(),
+            FileSegmentType::Index => Vec::new(),
+        };
+        segments
+            .into_iter()
+            .filter(|segment| segment.is_expired_sealed(expire_before_millis))
+            .collect()
+    }
+
+    fn remove_segment(&self, segment_type: FileSegmentType, base_offset: u64, path: &str) {
+        let mut segments = match segment_type {
+            FileSegmentType::CommitLog => self.commit_log_segments.lock(),
+            FileSegmentType::ConsumeQueue => self.consume_queue_segments.lock(),
+            FileSegmentType::Index => return,
+        };
+        segments.retain(|segment| segment.base_offset() != base_offset || segment.path() != path);
+    }
+
+    fn timestamp_search_range(&self, timestamp_millis: i64, cq_min: i64, cq_max: i64) -> (i64, i64) {
+        let segments = self.consume_queue_segments.lock().clone();
+        for segment in segments {
+            let min_timestamp = segment.min_timestamp();
+            let max_timestamp = segment.max_timestamp();
+            if min_timestamp <= timestamp_millis && timestamp_millis <= max_timestamp {
+                let min_offset = (segment.base_offset() / CONSUME_QUEUE_UNIT_SIZE as u64) as i64;
+                let max_offset =
+                    (segment.committed_absolute_end() / CONSUME_QUEUE_UNIT_SIZE as u64).saturating_sub(1) as i64;
+                return (min_offset.max(cq_min), max_offset.min(cq_max));
+            }
+        }
+        (cq_min, cq_max)
+    }
+
+    async fn read_from_segments(
+        &self,
+        segment_type: FileSegmentType,
+        absolute_offset: u64,
+        length: usize,
+    ) -> Result<Option<Bytes>, RocketMQError> {
+        if length == 0 {
+            return Ok(Some(Bytes::new()));
+        }
+        let segments = match segment_type {
+            FileSegmentType::CommitLog => self.commit_log_segments.lock().clone(),
+            FileSegmentType::ConsumeQueue => self.consume_queue_segments.lock().clone(),
+            FileSegmentType::Index => return Ok(None),
+        };
+        let Some(segment) = segments
+            .into_iter()
+            .find(|segment| segment.contains_committed_range(absolute_offset, length))
+        else {
+            return Ok(None);
+        };
+        let relative_offset = absolute_offset.saturating_sub(segment.base_offset());
+        let bytes = segment
+            .read(relative_offset..relative_offset.saturating_add(length as u64))
+            .await?;
+        Ok(Some(bytes))
     }
 }
 
@@ -163,4 +509,164 @@ fn segment_path(topic: &str, queue_id: i32, segment_type: FileSegmentType, base_
         FileSegmentType::Index => "index",
     };
     format!("{topic}/{queue_id}/{segment_name}/{base_offset:020}")
+}
+
+fn current_time_millis() -> i64 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis() as i64,
+        Err(_) => 0,
+    }
+}
+
+fn decode_message_store_timestamp(message: &Bytes) -> Option<i64> {
+    let end = MESSAGE_STORE_TIMESTAMP_POSITION.saturating_add(std::mem::size_of::<i64>());
+    if message.len() < end {
+        return None;
+    }
+    let mut bytes = [0; std::mem::size_of::<i64>()];
+    bytes.copy_from_slice(&message[MESSAGE_STORE_TIMESTAMP_POSITION..end]);
+    Some(i64::from_be_bytes(bytes))
+}
+
+fn segment_min_timestamp<P>(segments: &[Arc<TieredFileSegment<P>>]) -> Option<i64> {
+    segments
+        .iter()
+        .map(|segment| segment.min_timestamp())
+        .filter(|timestamp| *timestamp != i64::MAX)
+        .min()
+}
+
+fn segment_max_timestamp<P>(segments: &[Arc<TieredFileSegment<P>>]) -> Option<i64> {
+    segments
+        .iter()
+        .map(|segment| segment.max_timestamp())
+        .filter(|timestamp| *timestamp != i64::MIN)
+        .max()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use rocketmq_error::RocketMQError;
+
+    use super::*;
+    use crate::metadata::JsonMetadataStore;
+    use crate::provider::MemoryProvider;
+    use crate::provider::TieredStoreProvider;
+
+    fn test_config(root: std::path::PathBuf) -> Arc<TieredStoreConfig> {
+        Arc::new(TieredStoreConfig {
+            store_path_root_dir: root,
+            backend_provider: "memory".to_owned(),
+            commit_log_segment_size: 8,
+            consume_queue_segment_size: CONSUME_QUEUE_UNIT_SIZE as u64 * 2,
+            file_reserved_time: Duration::from_millis(1),
+            ..TieredStoreConfig::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn consume_queue_offsets_are_contiguous() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = test_config(temp_dir.path().to_path_buf());
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let flat_file = TieredFlatFile::new(
+            "TopicA".to_owned(),
+            0,
+            config,
+            metadata_store,
+            MemoryProvider::default(),
+        );
+
+        flat_file
+            .append_consume_queue(
+                10,
+                ConsumeQueueUnit {
+                    commit_log_offset: 0,
+                    size: 4,
+                    tags_code: 1,
+                },
+                100,
+            )
+            .await?;
+        assert_eq!(flat_file.consume_queue_min_offset(), 10);
+        assert_eq!(flat_file.consume_queue_append_offset(), 11);
+
+        let result = flat_file
+            .append_consume_queue(
+                12,
+                ConsumeQueueUnit {
+                    commit_log_offset: 4,
+                    size: 4,
+                    tags_code: 1,
+                },
+                101,
+            )
+            .await;
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn recovers_segments_from_metadata_and_provider_size() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = test_config(temp_dir.path().to_path_buf());
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let provider = MemoryProvider::default();
+        let flat_file = TieredFlatFile::new(
+            "TopicA".to_owned(),
+            0,
+            config.clone(),
+            metadata_store.clone(),
+            provider.clone(),
+        );
+
+        flat_file.append_commit_log(Bytes::from_static(b"abcd"), 100).await?;
+        flat_file
+            .append_consume_queue(
+                0,
+                ConsumeQueueUnit {
+                    commit_log_offset: 0,
+                    size: 4,
+                    tags_code: 1,
+                },
+                100,
+            )
+            .await?;
+        flat_file.commit().await?;
+
+        let recovered = TieredFlatFile::new("TopicA".to_owned(), 0, config, metadata_store, provider);
+        recovered.recover().await?;
+
+        assert_eq!(recovered.commit_log_append_offset(), 4);
+        assert_eq!(recovered.consume_queue_min_offset(), 0);
+        assert_eq!(recovered.consume_queue_commit_offset(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cleanup_deletes_expired_sealed_segments() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = test_config(temp_dir.path().to_path_buf());
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let provider = MemoryProvider::default();
+        let flat_file = TieredFlatFile::new("TopicA".to_owned(), 0, config, metadata_store, provider.clone());
+
+        flat_file.append_commit_log(Bytes::from_static(b"abcd"), 10).await?;
+        flat_file.append_commit_log(Bytes::from_static(b"efgh"), 11).await?;
+        flat_file.append_commit_log(Bytes::from_static(b"ijkl"), 1_000).await?;
+        flat_file.commit().await?;
+
+        let first_path = segment_path("TopicA", 0, FileSegmentType::CommitLog, 0);
+        assert_eq!(provider.segment_size(first_path.clone()).await?, 8);
+
+        flat_file.cleanup_expired(2_000).await?;
+
+        assert_eq!(provider.segment_size(first_path).await?, 0);
+        assert_eq!(flat_file.commit_log_append_offset(), 12);
+        Ok(())
+    }
 }

--- a/rocketmq-tieredstore/src/file/flat_file_store.rs
+++ b/rocketmq-tieredstore/src/file/flat_file_store.rs
@@ -55,7 +55,8 @@ where
     pub async fn load(&self) -> Result<(), RocketMQError> {
         let queues = self.metadata_store.list_queues().await?;
         for queue in queues {
-            self.get_or_create(queue.topic, queue.queue_id)?;
+            let flat_file = self.get_or_create(queue.topic, queue.queue_id)?;
+            flat_file.recover().await?;
         }
         Ok(())
     }
@@ -78,6 +79,7 @@ where
                 topic,
                 queue_id,
                 self.config.clone(),
+                self.metadata_store.clone(),
                 self.provider.clone(),
             ))
         });
@@ -85,7 +87,10 @@ where
     }
 
     pub async fn cleanup_expired(&self, now_millis: i64) -> Result<(), RocketMQError> {
-        let _ = now_millis;
+        let flat_files = self.files.iter().map(|entry| entry.value().clone()).collect::<Vec<_>>();
+        for flat_file in flat_files {
+            flat_file.cleanup_expired(now_millis).await?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7312

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tiered storage support with configurable feature flag to enable optional tiered storage functionality.
  * Implemented real message fetching logic for tiered storage, including offset boundary handling and timestamp-based queries.
  * Added metadata persistence to track message offsets and timestamps in tiered storage.
  * Implemented segment cleanup for expired messages in tiered storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->