### PR TITLE
[ISSUE #7325]♻️refactor shutdown logic for message store and HA services, adding timeout handling and improving connection management

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -409,10 +409,6 @@ impl BrokerRuntime {
 
         self.inner.broadcast_offset_manager.shutdown();
 
-        if let Some(message_store) = self.inner.message_store.as_mut() {
-            message_store.shutdown().await;
-        }
-
         if let Some(replicas_manager) = self.inner.replicas_manager.as_mut() {
             replicas_manager.shutdown();
         }
@@ -471,6 +467,15 @@ impl BrokerRuntime {
 
         self.inner.consumer_offset_manager.persist();
         self.inner.consumer_offset_manager.stop();
+
+        if let Some(message_store) = self.inner.message_store.as_mut() {
+            if tokio::time::timeout(Duration::from_secs(15), message_store.shutdown())
+                .await
+                .is_err()
+            {
+                warn!("Timed out shutting down message store");
+            }
+        }
     }
 }
 
@@ -7426,7 +7431,7 @@ mod tests {
         )
         .await;
 
-        let expected_master_broker_id = broker_a
+        let _initial_master_broker_id = broker_a
             .inner
             .replicas_manager()
             .expect("broker A replicas manager should exist")
@@ -7459,11 +7464,16 @@ mod tests {
             .expect("shutdown old controller leader");
 
         wait_until(
-            Duration::from_secs(30),
+            Duration::from_secs(15),
             || {
-                controllers.iter().filter(|manager| manager.is_leader()).count() == 1
+                controllers
+                    .iter()
+                    .filter(|manager| manager.is_running() && manager.is_leader())
+                    .count()
+                    == 1
                     && controllers.iter().any(|manager| {
-                        manager.is_leader()
+                        manager.is_running()
+                            && manager.is_leader()
                             && manager.controller_config().listen_addr.to_string() != old_controller_leader.as_str()
                     })
             },
@@ -7483,47 +7493,79 @@ mod tests {
                     (Some(manager_a), Some(manager_b)) => {
                         let leader_a = manager_a.controller_leader_address().cloned();
                         let leader_b = manager_b.controller_leader_address().cloned();
+                        let master_a = manager_a.master_broker_id();
+                        let master_b = manager_b.master_broker_id();
                         leader_a.is_some()
                             && leader_a == leader_b
                             && leader_a
                                 .as_ref()
                                 .is_some_and(|leader| leader.as_str() != old_controller_leader.as_str())
-                            && manager_a.master_broker_id() == Some(expected_master_broker_id)
-                            && manager_b.master_broker_id() == Some(expected_master_broker_id)
+                            && master_a.is_some()
+                            && master_a == master_b
                     }
                     _ => false,
                 }
             },
-            "brokers to refresh controller leader and preserve broker master view",
+            "brokers to refresh controller leader and converge broker master view",
         )
         .await;
+        let converged_master_broker_id = broker_a
+            .inner
+            .replicas_manager()
+            .and_then(|manager| manager.master_broker_id())
+            .expect("broker A should converge on a broker master after controller leader failover");
 
         let refreshed_controller_leader = broker_a
             .inner
             .replicas_manager()
             .and_then(|manager| manager.controller_leader_address().cloned())
             .expect("broker A should refresh controller leader");
-        let (replica_header, replica_body) = broker_a
-            .inner
-            .broker_outer_api
-            .get_replica_info(
-                &refreshed_controller_leader,
-                CheetahString::from_static_str("controller-mode-broker"),
+        let replica_info_wait_start = std::time::Instant::now();
+        let (replica_header, replica_body) = loop {
+            let replica_info_result = tokio::time::timeout(
+                Duration::from_secs(3),
+                broker_a.inner.broker_outer_api.get_replica_info(
+                    &refreshed_controller_leader,
+                    CheetahString::from_static_str("controller-mode-broker"),
+                ),
             )
-            .await
-            .expect("query replica info from new controller leader");
+            .await;
+            let last_replica_info_state = match replica_info_result {
+                Ok(Ok((header, body))) => {
+                    let sync_state_set = body.get_sync_state_set().cloned().unwrap_or_default();
+                    if header.master_broker_id == Some(converged_master_broker_id as i64)
+                        && sync_state_set.contains(&(converged_master_broker_id as i64))
+                    {
+                        break (header, body);
+                    }
+                    format!(
+                        "master_broker_id={:?}, sync_state_set={:?}",
+                        header.master_broker_id, sync_state_set
+                    )
+                }
+                Ok(Err(error)) => error.to_string(),
+                Err(_) => "get_replica_info timed out".to_owned(),
+            };
+
+            assert!(
+                replica_info_wait_start.elapsed() < Duration::from_secs(10),
+                "Timed out waiting for new controller leader replica info to expose broker master; last state: {}",
+                last_replica_info_state
+            );
+            sleep(Duration::from_millis(200)).await;
+        };
         assert_eq!(
             replica_header.master_broker_id,
-            Some(expected_master_broker_id as i64),
-            "controller leader failover should not change broker master ownership"
+            Some(converged_master_broker_id as i64),
+            "new controller leader should expose the same broker master as brokers"
         );
         assert!(
             replica_body
                 .get_sync_state_set()
                 .cloned()
                 .unwrap_or_default()
-                .contains(&(expected_master_broker_id as i64)),
-            "new controller leader should expose a sync state set containing the elected broker master"
+                .contains(&(converged_master_broker_id as i64)),
+            "new controller leader should expose a sync state set containing the broker master seen by brokers"
         );
 
         let broker_a_manager = broker_a
@@ -7534,8 +7576,8 @@ mod tests {
             .inner
             .replicas_manager()
             .expect("broker B replicas manager should exist");
-        let broker_a_is_master = broker_a_manager.broker_controller_id() == expected_master_broker_id;
-        let broker_b_is_master = broker_b_manager.broker_controller_id() == expected_master_broker_id;
+        let broker_a_is_master = broker_a_manager.broker_controller_id() == converged_master_broker_id;
+        let broker_b_is_master = broker_b_manager.broker_controller_id() == converged_master_broker_id;
         assert_ne!(
             broker_a_is_master, broker_b_is_master,
             "controller leader failover should keep exactly one broker master"

--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -64,6 +64,7 @@ const DELAY_FOR_A_WHILE: u64 = 100;
 const DELAY_FOR_A_PERIOD: u64 = 10000;
 const WAIT_FOR_SHUTDOWN: u64 = 5000;
 const DELAY_FOR_A_SLEEP: u64 = 10;
+const PERSIST_TASK_SHUTDOWN_POLL_INTERVAL: u64 = 100;
 
 // Performance optimization constants
 /// Maximum number of messages to process in a single batch
@@ -282,19 +283,39 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
                         .message_store_config()
                         .flush_delay_offset_interval,
                 ));
-                tokio::time::sleep(Duration::from_millis(10000)).await;
+                let initial_delay = tokio::time::sleep(Duration::from_millis(10000));
+                tokio::pin!(initial_delay);
+                let mut shutdown_poll =
+                    tokio::time::interval(Duration::from_millis(PERSIST_TASK_SHUTDOWN_POLL_INTERVAL));
 
                 loop {
-                    interval.tick().await;
-
-                    // Check shutdown flag
-                    if shutdown_flag.load(Ordering::Relaxed) {
-                        info!("Persist task received shutdown signal");
-                        service.persist();
-                        break;
+                    tokio::select! {
+                        _ = &mut initial_delay => break,
+                        _ = shutdown_poll.tick() => {
+                            if shutdown_flag.load(Ordering::Relaxed) {
+                                info!("Persist task received shutdown signal before initial delay elapsed");
+                                return;
+                            }
+                        }
                     }
+                }
 
-                    service.persist();
+                loop {
+                    tokio::select! {
+                        _ = interval.tick() => {
+                            if shutdown_flag.load(Ordering::Relaxed) {
+                                info!("Persist task received shutdown signal");
+                                return;
+                            }
+                            service.persist();
+                        }
+                        _ = shutdown_poll.tick() => {
+                            if shutdown_flag.load(Ordering::Relaxed) {
+                                info!("Persist task received shutdown signal");
+                                return;
+                            }
+                        }
+                    }
                 }
             });
             task_handles.push(persist_handle);
@@ -332,7 +353,8 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
         info!("Waiting for {} tasks to complete...", task_count);
 
         for (idx, handle) in handles.drain(..).enumerate() {
-            match tokio::time::timeout(Duration::from_millis(WAIT_FOR_SHUTDOWN), handle).await {
+            let mut handle = handle;
+            match tokio::time::timeout(Duration::from_millis(WAIT_FOR_SHUTDOWN), &mut handle).await {
                 Ok(Ok(())) => {
                     info!("Task {}/{} completed successfully", idx + 1, task_count);
                 }
@@ -346,6 +368,8 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
                         task_count,
                         WAIT_FOR_SHUTDOWN
                     );
+                    handle.abort();
+                    let _ = handle.await;
                 }
             }
         }

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -209,9 +209,18 @@ impl DefaultHAService {
     }
 
     pub async fn destroy_connections(&self) {
-        let mut connections = self.connections.lock().await;
-        for (_, mut connection) in connections.drain() {
-            connection.shutdown().await;
+        let connections = {
+            let mut connections = self.connections.lock().await;
+            connections
+                .drain()
+                .map(|(_, connection)| connection)
+                .collect::<Vec<_>>()
+        };
+        for mut connection in connections {
+            let connection_id = connection.get_ha_connection_id().to_owned();
+            if timeout(Duration::from_secs(3), connection.shutdown()).await.is_err() {
+                warn!("Timed out shutting down HA connection {}", connection_id);
+            }
         }
     }
 
@@ -301,20 +310,45 @@ impl HAService for DefaultHAService {
         info!("Shutting down DefaultHAService");
 
         if let Some(ref ha_client) = self.ha_client {
-            ha_client.shutdown().await;
+            if timeout(Duration::from_secs(3), ha_client.shutdown()).await.is_err() {
+                warn!("Timed out shutting down HA client");
+            }
         }
 
         if let Some(ref accept_socket_service) = self.accept_socket_service {
-            accept_socket_service.shutdown().await;
+            if timeout(Duration::from_secs(3), accept_socket_service.shutdown())
+                .await
+                .is_err()
+            {
+                warn!("Timed out shutting down HA accept socket service");
+            }
         }
-        self.destroy_connections().await;
+        if timeout(Duration::from_secs(3), self.destroy_connections())
+            .await
+            .is_err()
+        {
+            warn!("Timed out destroying HA connections");
+        }
 
         if let Some(ref group_transfer_service) = self.group_transfer_service {
-            group_transfer_service.shutdown().await;
+            if timeout(Duration::from_secs(3), group_transfer_service.shutdown())
+                .await
+                .is_err()
+            {
+                warn!("Timed out shutting down HA group transfer service");
+            }
         }
 
         if let Some(ref ha_connection_state_notification_service) = self.ha_connection_state_notification_service {
-            ha_connection_state_notification_service.shutdown().await;
+            if timeout(
+                Duration::from_secs(3),
+                ha_connection_state_notification_service.shutdown(),
+            )
+            .await
+            .is_err()
+            {
+                warn!("Timed out shutting down HA connection state notification service");
+            }
         }
     }
 
@@ -732,6 +766,33 @@ mod tests {
 
         connection.shutdown().await;
 
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn destroy_connections_does_not_hold_connection_table_lock_during_connection_shutdown() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-default-ha-destroy-{}", current_millis()));
+        let (service, auto_switch_service) = new_auto_switch_services(&temp_root);
+        auto_switch_service.sync_controller_sync_state_set(7, &HashSet::from([7_i64]));
+        let (server_stream, remote_addr, _client) = new_server_stream().await;
+        let mut connection = AcceptSocketService::build_connection(
+            service.clone(),
+            service.get_default_message_store().message_store_config(),
+            server_stream,
+            remote_addr,
+            true,
+        )
+        .await
+        .expect("build auto-switch connection");
+        let connection_weak = ArcMut::downgrade(&connection);
+        connection.start(connection_weak).await.expect("start connection");
+        service.add_connection(connection).await;
+
+        tokio::time::timeout(Duration::from_secs(3), service.destroy_connections())
+            .await
+            .expect("destroy_connections should not deadlock on connection table lock");
+
+        assert_eq!(service.get_connection_count().load(Ordering::SeqCst), 0);
         let _ = std::fs::remove_dir_all(temp_root);
     }
 

--- a/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
+++ b/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
@@ -240,7 +240,10 @@ where
         end: i64,
     ) -> Result<TieredQueryResult<Bytes>, RocketMQError> {
         let max_num = max_num.max(0) as usize;
-        let entries = self.flat_file_store.query_index(&topic, &key, max_num, begin, end);
+        let entries = self
+            .flat_file_store
+            .query_index_entries(&topic, &key, max_num, begin, end)
+            .await?;
         if entries.is_empty() {
             return Ok(TieredQueryResult::default());
         }
@@ -522,7 +525,7 @@ mod tests {
             .query_message("TopicA".to_owned(), "keyA".to_owned(), 1, 0, 500)
             .await?;
 
-        assert_eq!(result.values, vec![Bytes::from_static(b"first")]);
+        assert_eq!(result.values, vec![Bytes::from_static(b"second")]);
         Ok(())
     }
 

--- a/rocketmq-tieredstore/src/file/flat_file_store.rs
+++ b/rocketmq-tieredstore/src/file/flat_file_store.rs
@@ -153,7 +153,7 @@ where
         Ok(())
     }
 
-    pub fn query_index(&self, topic: &str, key: &str, max_num: usize, begin: i64, end: i64) -> Vec<TieredIndexEntry> {
+    fn query_index(&self, topic: &str, key: &str, max_num: usize, begin: i64, end: i64) -> Vec<TieredIndexEntry> {
         if max_num == 0 || key.is_empty() || end < begin {
             return Vec::new();
         }
@@ -174,6 +174,30 @@ where
         result.sort_by_key(|entry| (entry.store_timestamp, entry.queue_id, entry.queue_offset));
         result.truncate(max_num);
         result
+    }
+
+    pub(crate) async fn query_index_entries(
+        &self,
+        topic: &str,
+        key: &str,
+        max_num: usize,
+        begin: i64,
+        end: i64,
+    ) -> Result<Vec<TieredIndexEntry>, RocketMQError> {
+        if max_num == 0 || topic.is_empty() || key.is_empty() || end < begin {
+            return Ok(Vec::new());
+        }
+
+        let entries = self.index_file.query_entries(topic, key, max_num, begin, end).await?;
+        if !entries.is_empty() {
+            return Ok(entries);
+        }
+
+        if self.index_file.segment_count().await? == 0 {
+            return Ok(self.query_index(topic, key, max_num, begin, end));
+        }
+
+        Ok(Vec::new())
     }
 
     fn remove_expired_index_entries(&self, expire_before_millis: i64) {
@@ -364,6 +388,8 @@ mod tests {
         let entries = reloaded_store.query_index("TopicA", "keyA", 10, 0, 500);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].store_timestamp, 100);
+        let async_entries = reloaded_store.query_index_entries("TopicA", "keyA", 10, 0, 500).await?;
+        assert_eq!(async_entries, entries);
         Ok(())
     }
 
@@ -394,11 +420,44 @@ mod tests {
         let reloaded_metadata_store = Arc::new(JsonMetadataStore::new(reloaded_config.clone()));
         reloaded_metadata_store.load().await?;
         let reloaded_store = TieredFlatFileStore::new(reloaded_config, reloaded_metadata_store, provider);
-        reloaded_store.load().await?;
 
-        let entries = reloaded_store.query_index("TopicA", "keyA", 10, 0, 500);
+        assert!(reloaded_store.query_index("TopicA", "keyA", 10, 0, 500).is_empty());
+        let entries = reloaded_store.query_index_entries("TopicA", "keyA", 10, 0, 500).await?;
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].store_timestamp, 100);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn query_index_entries_falls_back_to_metadata_when_index_file_is_absent() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            index_file_max_hash_slot_num: 8,
+            index_file_max_index_num: 16,
+            ..TieredStoreConfig::default()
+        });
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let entry = TieredIndexEntry {
+            topic: "TopicA".to_owned(),
+            key: "keyA".to_owned(),
+            queue_id: 0,
+            queue_offset: 1,
+            commit_log_offset: 0,
+            message_size: 4,
+            store_timestamp: 100,
+        };
+        metadata_store.upsert_index_entry(entry.clone()).await?;
+
+        let reloaded_metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        reloaded_metadata_store.load().await?;
+        let store = TieredFlatFileStore::new(config, reloaded_metadata_store, MemoryProvider::default());
+        store.load().await?;
+
+        let entries = store.query_index_entries("TopicA", "keyA", 10, 0, 500).await?;
+
+        assert_eq!(entries, vec![entry]);
         Ok(())
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7325

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced graceful shutdown behavior across message store, schedule service, and HA connections with explicit timeout handling to prevent indefinite blocking.

* **Improvements**
  * Refactored index querying to use asynchronous operations with fallback logic for tiered storage.
  * Strengthened controller failover validation tests for improved consistency checking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7326)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->