### PR TITLE
[ISSUE #7333]🚀implement asynchronous offset retrieval by timestamp with boundary support for tiered storage

### DIFF
--- a/rocketmq-broker/src/client/net/broker_to_client.rs
+++ b/rocketmq-broker/src/client/net/broker_to_client.rs
@@ -246,9 +246,22 @@ impl Broker2Client {
                     .map(|store| store.get_max_offset_in_queue(topic, queue_id))
                     .unwrap_or(0)
             } else {
-                message_store
-                    .map(|store| store.get_offset_in_queue_by_time(topic, queue_id, timestamp))
-                    .unwrap_or(0)
+                match message_store {
+                    Some(store) => match store
+                        .get_offset_in_queue_by_time_async(topic, queue_id, timestamp)
+                        .await
+                    {
+                        Ok(offset) => offset,
+                        Err(error) => {
+                            warn!(
+                                "reset offset by timestamp failed. topic={}, queueId={}, timestamp={}, error={}",
+                                topic, queue_id, timestamp, error
+                            );
+                            0
+                        }
+                    },
+                    None => 0,
+                }
             };
 
             let timestamp_offset = if timestamp_offset < 0 {

--- a/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
@@ -582,6 +582,7 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
                 request_header.timestamp,
                 request_header.offset,
             )
+            .await
         } else {
             let broker_to_client = Broker2Client;
             if request.language() == LanguageCode::CPP {
@@ -878,7 +879,7 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
         }
     }
 
-    fn reset_offset_inner(
+    async fn reset_offset_inner(
         &mut self,
         topic: &cheetah_string::CheetahString,
         group: &cheetah_string::CheetahString,
@@ -916,7 +917,7 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
 
         let mut queue_offset_map = std::collections::HashMap::new();
         if queue_id >= 0 {
-            match self.resolve_reset_offset(topic, queue_id, timestamp, offset) {
+            match self.resolve_reset_offset(topic, queue_id, timestamp, offset).await {
                 Ok(target_offset) => {
                     queue_offset_map.insert(queue_id, target_offset);
                 }
@@ -924,7 +925,10 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
             }
         } else {
             for queue_index in 0..topic_config.read_queue_nums {
-                match self.resolve_reset_offset(topic, queue_index as i32, timestamp, None) {
+                match self
+                    .resolve_reset_offset(topic, queue_index as i32, timestamp, None)
+                    .await
+                {
                     Ok(target_offset) => {
                         queue_offset_map.insert(queue_index as i32, target_offset);
                     }
@@ -964,7 +968,7 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
         response
     }
 
-    fn resolve_reset_offset(
+    async fn resolve_reset_offset(
         &self,
         topic: &cheetah_string::CheetahString,
         queue_id: i32,
@@ -993,7 +997,18 @@ impl<MS: MessageStore> ConsumerRequestHandler<MS> {
         let target_offset = if timestamp < 0 {
             message_store.get_max_offset_in_queue(topic, queue_id)
         } else {
-            message_store.get_offset_in_queue_by_time(topic, queue_id, timestamp)
+            match message_store
+                .get_offset_in_queue_by_time_async(topic, queue_id, timestamp)
+                .await
+            {
+                Ok(offset) => offset,
+                Err(error) => {
+                    response = response
+                        .set_code(ResponseCode::SystemError)
+                        .set_remark(format!("Resolve offset by timestamp failed: {error}"));
+                    return Err(response);
+                }
+            }
         };
         Ok(target_offset)
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
@@ -93,12 +93,24 @@ where
                 ));
             }
         };
-        let offset = message_store.get_offset_in_queue_by_time_with_boundary(
-            &search_offset_request_header.topic,
-            search_offset_request_header.queue_id,
-            search_offset_request_header.timestamp,
-            search_offset_request_header.boundary_type,
-        );
+        let offset = match message_store
+            .get_offset_in_queue_by_time_with_boundary_async(
+                &search_offset_request_header.topic,
+                search_offset_request_header.queue_id,
+                search_offset_request_header.timestamp,
+                search_offset_request_header.boundary_type,
+            )
+            .await
+        {
+            Ok(offset) => offset,
+            Err(error) => {
+                return Ok(Some(
+                    response
+                        .set_code(ResponseCode::SystemError)
+                        .set_remark(format!("search offset by timestamp failed: {error}")),
+                ));
+            }
+        };
         let response_header = SearchOffsetResponseHeader { offset };
 
         Ok(Some(response.set_command_custom_header(response_header)))
@@ -352,12 +364,23 @@ where
             if mapping_detail.topic_queue_mapping_info.bname == item.bname {
                 // Local broker - query directly from message store
                 if let Some(message_store) = self.broker_runtime_inner.message_store() {
-                    let local_offset = message_store.get_offset_in_queue_by_time_with_boundary(
-                        &mapping_context.topic,
-                        item.queue_id,
-                        timestamp,
-                        request_header.boundary_type,
-                    );
+                    let local_offset = match message_store
+                        .get_offset_in_queue_by_time_with_boundary_async(
+                            &mapping_context.topic,
+                            item.queue_id,
+                            timestamp,
+                            request_header.boundary_type,
+                        )
+                        .await
+                    {
+                        Ok(offset) => offset,
+                        Err(error) => {
+                            return Ok(Some(
+                                RemotingCommand::create_response_command_with_code(ResponseCode::SystemError)
+                                    .set_remark(format!("search offset by timestamp failed: {error}")),
+                            ));
+                        }
+                    };
                     if local_offset > 0 {
                         offset = item.compute_static_queue_offset_strictly(local_offset);
                         break;

--- a/rocketmq-store/src/base/message_store.rs
+++ b/rocketmq-store/src/base/message_store.rs
@@ -208,6 +208,24 @@ pub trait MessageStoreInner: Sync + 'static {
         boundary_type: BoundaryType,
     ) -> i64;
 
+    /// Look up the logical offset by timestamp, allowing asynchronous tiered-store fallback.
+    async fn get_offset_in_queue_by_time_async(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        timestamp: i64,
+    ) -> Result<i64, StoreError>;
+
+    /// Look up the logical offset by timestamp with boundary type, allowing asynchronous
+    /// tiered-store fallback.
+    async fn get_offset_in_queue_by_time_with_boundary_async(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        timestamp: i64,
+        boundary_type: BoundaryType,
+    ) -> Result<i64, StoreError>;
+
     /// Look up the message by given commit log offset.
     fn look_message_by_offset(&self, commit_log_offset: i64) -> Option<MessageExt>;
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -666,6 +666,20 @@ impl LocalFileMessageStore {
     }
 
     #[cfg(feature = "tieredstore")]
+    fn should_try_tiered_offset_by_time(&self, topic: &CheetahString, queue_id: i32, timestamp: i64) -> bool {
+        let Some(logic_queue) = self.get_consume_queue(topic, queue_id) else {
+            return true;
+        };
+        if logic_queue.get_message_total_in_queue() <= 0 {
+            return true;
+        }
+        logic_queue
+            .get_earliest_unit_and_store_time()
+            .map(|(_, earliest_store_time)| timestamp < earliest_store_time)
+            .unwrap_or(true)
+    }
+
+    #[cfg(feature = "tieredstore")]
     fn to_store_get_message_result(
         fetched: TieredGetMessageResult,
         requested_offset: i64,
@@ -2280,6 +2294,45 @@ impl MessageStore for LocalFileMessageStore {
     ) -> i64 {
         self.consume_queue_store
             .get_offset_in_queue_by_time(topic, queue_id, timestamp, boundary_type)
+    }
+
+    async fn get_offset_in_queue_by_time_async(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        timestamp: i64,
+    ) -> Result<i64, StoreError> {
+        self.get_offset_in_queue_by_time_with_boundary_async(topic, queue_id, timestamp, BoundaryType::Lower)
+            .await
+    }
+
+    async fn get_offset_in_queue_by_time_with_boundary_async(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        timestamp: i64,
+        boundary_type: BoundaryType,
+    ) -> Result<i64, StoreError> {
+        #[cfg(feature = "tieredstore")]
+        if self.should_try_tiered_offset_by_time(topic, queue_id, timestamp) {
+            if let Some(tiered_store) = self.tiered_store.as_ref() {
+                match tiered_store
+                    .fetcher()
+                    .get_offset_by_time_with_boundary(topic.to_string(), queue_id, timestamp, boundary_type)
+                    .await
+                {
+                    Ok(offset) if offset >= 0 => return Ok(offset),
+                    Ok(_) => {}
+                    Err(error) => {
+                        return Err(StoreError::General(format!(
+                            "tieredstore offset by time lookup failed: {error}"
+                        )));
+                    }
+                }
+            }
+        }
+
+        Ok(self.get_offset_in_queue_by_time_with_boundary(topic, queue_id, timestamp, boundary_type))
     }
 
     fn look_message_by_offset(&self, commit_log_offset: i64) -> Option<MessageExt> {
@@ -4803,6 +4856,28 @@ mod tests {
             .await
             .expect("tieredstore timestamp fallback");
         assert_eq!(timestamp, store_timestamp);
+
+        assert_eq!(
+            store
+                .get_offset_in_queue_by_time_async(&topic, 0, store_timestamp - 1)
+                .await
+                .expect("tieredstore offset lower fallback"),
+            queue_offset
+        );
+        assert_eq!(
+            store
+                .get_offset_in_queue_by_time_with_boundary_async(&topic, 0, store_timestamp, BoundaryType::Upper)
+                .await
+                .expect("tieredstore offset upper fallback"),
+            queue_offset
+        );
+        assert_eq!(
+            store
+                .get_offset_in_queue_by_time_async(&topic, 0, store_timestamp + 1)
+                .await
+                .expect("tieredstore offset overflow fallback"),
+            queue_offset + 1
+        );
 
         let query_result = store
             .query_message(&topic, &key, 10, 0, i64::MAX)

--- a/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
+++ b/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use rocketmq_common::common::boundary_type::BoundaryType;
 use rocketmq_error::RocketMQError;
 
 use crate::config::TieredStoreConfig;
@@ -69,6 +70,14 @@ pub trait TieredMessageFetcher: Send + Sync {
         topic: String,
         queue_id: i32,
         timestamp_millis: i64,
+    ) -> Result<i64, RocketMQError>;
+
+    async fn get_offset_by_time_with_boundary(
+        &self,
+        topic: String,
+        queue_id: i32,
+        timestamp_millis: i64,
+        boundary_type: BoundaryType,
     ) -> Result<i64, RocketMQError>;
 
     async fn query_message(
@@ -225,10 +234,23 @@ where
         queue_id: i32,
         timestamp_millis: i64,
     ) -> Result<i64, RocketMQError> {
+        self.get_offset_by_time_with_boundary(topic, queue_id, timestamp_millis, BoundaryType::Lower)
+            .await
+    }
+
+    async fn get_offset_by_time_with_boundary(
+        &self,
+        topic: String,
+        queue_id: i32,
+        timestamp_millis: i64,
+        boundary_type: BoundaryType,
+    ) -> Result<i64, RocketMQError> {
         let Some(flat_file) = self.flat_file_store.get(&topic, queue_id) else {
             return Ok(-1);
         };
-        flat_file.queue_offset_by_time(timestamp_millis).await
+        flat_file
+            .queue_offset_by_time_with_boundary(timestamp_millis, boundary_type)
+            .await
     }
 
     async fn query_message(
@@ -487,6 +509,49 @@ mod tests {
         assert_eq!(fetcher.get_offset_by_time("TopicA".to_owned(), 0, 300).await?, 5);
         assert_eq!(fetcher.get_offset_by_time("TopicA".to_owned(), 0, 301).await?, 6);
         assert_eq!(fetcher.get_offset_by_time("MissingTopic".to_owned(), 0, 100).await?, -1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn finds_upper_bound_offset_by_store_timestamp() -> Result<(), RocketMQError> {
+        let fetcher = build_timestamp_fetcher().await?;
+
+        assert_eq!(
+            fetcher
+                .get_offset_by_time_with_boundary("TopicA".to_owned(), 0, 50, BoundaryType::Upper)
+                .await?,
+            3
+        );
+        assert_eq!(
+            fetcher
+                .get_offset_by_time_with_boundary("TopicA".to_owned(), 0, 100, BoundaryType::Upper)
+                .await?,
+            3
+        );
+        assert_eq!(
+            fetcher
+                .get_offset_by_time_with_boundary("TopicA".to_owned(), 0, 150, BoundaryType::Upper)
+                .await?,
+            3
+        );
+        assert_eq!(
+            fetcher
+                .get_offset_by_time_with_boundary("TopicA".to_owned(), 0, 300, BoundaryType::Upper)
+                .await?,
+            5
+        );
+        assert_eq!(
+            fetcher
+                .get_offset_by_time_with_boundary("TopicA".to_owned(), 0, 301, BoundaryType::Upper)
+                .await?,
+            5
+        );
+        assert_eq!(
+            fetcher
+                .get_offset_by_time_with_boundary("MissingTopic".to_owned(), 0, 100, BoundaryType::Upper)
+                .await?,
+            -1
+        );
         Ok(())
     }
 

--- a/rocketmq-tieredstore/src/file/flat_file.rs
+++ b/rocketmq-tieredstore/src/file/flat_file.rs
@@ -19,6 +19,7 @@ use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
 use parking_lot::Mutex;
+use rocketmq_common::common::boundary_type::BoundaryType;
 use rocketmq_error::RocketMQError;
 
 use crate::config::TieredStoreConfig;
@@ -218,6 +219,17 @@ where
         consume_queue_segments.sort_by_key(|segment| segment.base_offset());
         *self.commit_log_segments.lock() = commit_log_segments;
         *self.consume_queue_segments.lock() = consume_queue_segments;
+        if !self.consume_queue_segments.lock().is_empty() {
+            self.metadata_store
+                .upsert_queue(TopicQueueMetadata {
+                    topic: self.topic.clone(),
+                    queue_id: self.queue_id,
+                    min_offset: self.consume_queue_min_offset(),
+                    max_offset: self.consume_queue_commit_offset(),
+                    update_timestamp: current_time_millis(),
+                })
+                .await?;
+        }
         Ok(())
     }
 
@@ -315,8 +327,18 @@ where
     }
 
     pub async fn queue_offset_by_time(&self, timestamp_millis: i64) -> Result<i64, RocketMQError> {
+        self.queue_offset_by_time_with_boundary(timestamp_millis, BoundaryType::Lower)
+            .await
+    }
+
+    pub async fn queue_offset_by_time_with_boundary(
+        &self,
+        timestamp_millis: i64,
+        boundary_type: BoundaryType,
+    ) -> Result<i64, RocketMQError> {
         let cq_min = self.consume_queue_min_offset();
-        let cq_max = self.consume_queue_commit_offset().saturating_sub(1);
+        let cq_commit = self.consume_queue_commit_offset();
+        let cq_max = cq_commit.saturating_sub(1);
         if cq_max == -1 || cq_max < cq_min {
             return Ok(cq_min);
         }
@@ -325,7 +347,10 @@ where
             return Ok(cq_min);
         };
         if max_store_time < timestamp_millis {
-            return Ok(cq_max.saturating_add(1));
+            return Ok(match boundary_type {
+                BoundaryType::Lower => cq_commit,
+                BoundaryType::Upper => cq_max,
+            });
         }
 
         let Some(min_store_time) = self.read_message_store_timestamp(cq_min).await? else {
@@ -336,18 +361,40 @@ where
         }
 
         let (mut low, mut high) = self.timestamp_search_range(timestamp_millis, cq_min, cq_max);
-        while low < high {
-            let middle = low.saturating_add((high - low) / 2);
-            let Some(store_time) = self.read_message_store_timestamp(middle).await? else {
-                return Ok(low);
-            };
-            if store_time < timestamp_millis {
-                low = middle.saturating_add(1);
-            } else {
-                high = middle;
+        match boundary_type {
+            BoundaryType::Lower => {
+                while low < high {
+                    let middle = low.saturating_add((high - low) / 2);
+                    let Some(store_time) = self.read_message_store_timestamp(middle).await? else {
+                        return Ok(low);
+                    };
+                    if store_time < timestamp_millis {
+                        low = middle.saturating_add(1);
+                    } else {
+                        high = middle;
+                    }
+                }
+                Ok(low)
+            }
+            BoundaryType::Upper => {
+                let mut result = cq_min;
+                while low <= high {
+                    let middle = low.saturating_add((high - low) / 2);
+                    let Some(store_time) = self.read_message_store_timestamp(middle).await? else {
+                        return Ok(result);
+                    };
+                    if store_time <= timestamp_millis {
+                        result = middle;
+                        low = middle.saturating_add(1);
+                    } else if middle == 0 {
+                        break;
+                    } else {
+                        high = middle.saturating_sub(1);
+                    }
+                }
+                Ok(result)
             }
         }
-        Ok(low)
     }
 
     pub fn min_store_timestamp(&self) -> i64 {

--- a/rocketmq-tieredstore/src/file/flat_file_store.rs
+++ b/rocketmq-tieredstore/src/file/flat_file_store.rs
@@ -19,6 +19,8 @@ use rocketmq_error::RocketMQError;
 
 use crate::config::TieredStoreConfig;
 use crate::dispatcher::TieredDispatchRequest;
+use crate::file::FileSegmentStatus;
+use crate::file::FileSegmentType;
 use crate::file::IndexFileSegment;
 use crate::file::TieredFlatFile;
 use crate::file::TieredIndexEntry;
@@ -64,9 +66,9 @@ where
     }
 
     pub async fn load(&self) -> Result<(), RocketMQError> {
-        let queues = self.metadata_store.list_queues().await?;
-        for queue in queues {
-            let flat_file = self.get_or_create(queue.topic, queue.queue_id)?;
+        let keys = self.recoverable_flat_file_keys().await?;
+        for key in keys {
+            let flat_file = self.get_or_create(key.topic, key.queue_id)?;
             flat_file.recover().await?;
         }
         self.recover_index_file().await?;
@@ -201,6 +203,53 @@ where
         entries.dedup();
         Ok(entries)
     }
+
+    async fn recoverable_flat_file_keys(&self) -> Result<Vec<FlatFileKey>, RocketMQError> {
+        let mut keys = self
+            .metadata_store
+            .list_queues()
+            .await?
+            .into_iter()
+            .map(|queue| FlatFileKey {
+                topic: queue.topic,
+                queue_id: queue.queue_id,
+            })
+            .collect::<Vec<_>>();
+
+        for segment in self.metadata_store.list_all_file_segments().await? {
+            if segment.status == FileSegmentStatus::Deleted || segment.segment_type == FileSegmentType::Index {
+                continue;
+            }
+            let Some(key) = flat_file_key_from_segment_path(&segment.path) else {
+                continue;
+            };
+            if !keys.contains(&key) {
+                keys.push(key);
+            }
+        }
+
+        keys.sort_by(|left, right| left.topic.cmp(&right.topic).then(left.queue_id.cmp(&right.queue_id)));
+        keys.dedup();
+        Ok(keys)
+    }
+}
+
+fn flat_file_key_from_segment_path(path: &str) -> Option<FlatFileKey> {
+    let mut parts = path.rsplitn(4, '/');
+    let _base_offset = parts.next()?;
+    let segment_name = parts.next()?;
+    let queue_id = parts.next()?.parse::<i32>().ok()?;
+    let topic = parts.next()?;
+    if topic.is_empty() {
+        return None;
+    }
+    match segment_name {
+        "commitlog" | "consumequeue" => Some(FlatFileKey {
+            topic: topic.to_owned(),
+            queue_id,
+        }),
+        _ => None,
+    }
 }
 
 fn build_index_entries(request: &TieredDispatchRequest, tiered_commit_log_offset: u64) -> Vec<TieredIndexEntry> {
@@ -246,11 +295,15 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use bytes::Bytes;
     use rocketmq_error::RocketMQError;
 
     use super::*;
+    use crate::file::ConsumeQueueUnit;
+    use crate::file::FileSegment;
     use crate::metadata::JsonMetadataStore;
     use crate::provider::MemoryProvider;
+    use crate::provider::TieredStoreProvider;
 
     fn test_request(timestamp: i64, keys: &str) -> TieredDispatchRequest {
         TieredDispatchRequest {
@@ -407,5 +460,90 @@ mod tests {
 
         assert_eq!(entries, vec![entry]);
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn load_recovers_queue_from_segment_metadata_when_queue_metadata_is_missing() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            commit_log_segment_size: 8,
+            consume_queue_segment_size: crate::file::CONSUME_QUEUE_UNIT_SIZE as u64,
+            ..TieredStoreConfig::default()
+        });
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let provider = MemoryProvider::default();
+
+        let commit_log_segment = provider
+            .create_segment(
+                "TopicA/0/commitlog/00000000000000000000".to_owned(),
+                FileSegmentType::CommitLog,
+                0,
+                config.commit_log_segment_size,
+            )
+            .await?;
+        commit_log_segment.append(Bytes::from_static(b"body"), 100).await?;
+        commit_log_segment.commit().await?;
+        metadata_store
+            .upsert_file_segment(commit_log_segment.metadata())
+            .await?;
+
+        let consume_queue_segment = provider
+            .create_segment(
+                "TopicA/0/consumequeue/00000000000000000000".to_owned(),
+                FileSegmentType::ConsumeQueue,
+                0,
+                config.consume_queue_segment_size,
+            )
+            .await?;
+        consume_queue_segment
+            .append(
+                ConsumeQueueUnit {
+                    commit_log_offset: 0,
+                    size: 4,
+                    tags_code: 1,
+                }
+                .encode(),
+                100,
+            )
+            .await?;
+        consume_queue_segment.commit().await?;
+        metadata_store
+            .upsert_file_segment(consume_queue_segment.metadata())
+            .await?;
+
+        let reloaded_metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        reloaded_metadata_store.load().await?;
+        let store = TieredFlatFileStore::new(config, reloaded_metadata_store.clone(), provider);
+        store.load().await?;
+
+        let flat_file = store
+            .get("TopicA", 0)
+            .ok_or_else(|| RocketMQError::Internal("missing recovered flat file".to_owned()))?;
+        assert_eq!(
+            flat_file.read_message_by_queue_offset(0).await?,
+            Some(Bytes::from_static(b"body"))
+        );
+        let queue_metadata = reloaded_metadata_store
+            .get_queue("TopicA", 0)
+            .await?
+            .ok_or_else(|| RocketMQError::Internal("missing recovered queue metadata".to_owned()))?;
+        assert_eq!(queue_metadata.min_offset, 0);
+        assert_eq!(queue_metadata.max_offset, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn parses_flat_file_key_from_segment_path() {
+        assert_eq!(
+            flat_file_key_from_segment_path("TopicA/3/commitlog/00000000000000000000"),
+            Some(FlatFileKey {
+                topic: "TopicA".to_owned(),
+                queue_id: 3,
+            })
+        );
+        assert_eq!(flat_file_key_from_segment_path("TopicA/3/index/000"), None);
+        assert_eq!(flat_file_key_from_segment_path("bad-path"), None);
     }
 }

--- a/rocketmq-tieredstore/src/metadata/metadata_store.rs
+++ b/rocketmq-tieredstore/src/metadata/metadata_store.rs
@@ -47,6 +47,8 @@ pub trait TieredMetadataStore: Send + Sync {
 
     async fn list_file_segments(&self, topic: &str, queue_id: i32) -> Result<Vec<FileSegmentMetadata>, RocketMQError>;
 
+    async fn list_all_file_segments(&self) -> Result<Vec<FileSegmentMetadata>, RocketMQError>;
+
     async fn upsert_file_segment(&self, metadata: FileSegmentMetadata) -> Result<(), RocketMQError>;
 
     async fn mark_file_segment_deleted(&self, path: &str, base_offset: u64) -> Result<(), RocketMQError>;
@@ -188,6 +190,12 @@ impl TieredMetadataStore for JsonMetadataStore {
             .cloned()
             .collect::<Vec<_>>();
         segments.sort_by_key(|segment| (segment.segment_type, segment.base_offset));
+        Ok(segments)
+    }
+
+    async fn list_all_file_segments(&self) -> Result<Vec<FileSegmentMetadata>, RocketMQError> {
+        let mut segments = self.state.read().segments.values().cloned().collect::<Vec<_>>();
+        segments.sort_by_key(|segment| (segment.path.clone(), segment.segment_type, segment.base_offset));
         Ok(segments)
     }
 

--- a/rocketmq-tieredstore/tests/posix_persistence_tests.rs
+++ b/rocketmq-tieredstore/tests/posix_persistence_tests.rs
@@ -1,0 +1,123 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use bytes::BytesMut;
+use rocketmq_common::common::boundary_type::BoundaryType;
+use rocketmq_error::RocketMQError;
+use rocketmq_tieredstore::fetcher::TieredGetMessageStatus;
+use rocketmq_tieredstore::TieredDispatchRequest;
+use rocketmq_tieredstore::TieredDispatcher;
+use rocketmq_tieredstore::TieredLifecycle;
+use rocketmq_tieredstore::TieredMessageFetcher;
+use rocketmq_tieredstore::TieredStorageLevel;
+use rocketmq_tieredstore::TieredStore;
+use rocketmq_tieredstore::TieredStoreConfig;
+
+const MESSAGE_STORE_TIMESTAMP_POSITION: usize = 56;
+
+#[tokio::test]
+async fn posix_store_recovers_dispatched_messages_and_index_after_restart() -> Result<(), RocketMQError> {
+    let temp_dir = tempfile::tempdir().map_err(|error| RocketMQError::Internal(error.to_string()))?;
+    let config = TieredStoreConfig {
+        storage_level: TieredStorageLevel::Force,
+        backend_provider: "posix".to_owned(),
+        store_path_root_dir: temp_dir.path().join("tieredstore"),
+        commit_log_segment_size: 128,
+        consume_queue_segment_size: 80,
+        index_file_max_hash_slot_num: 16,
+        index_file_max_index_num: 64,
+        max_pending_tasks: 8,
+        ..TieredStoreConfig::default()
+    };
+    let topic = "TopicA".to_owned();
+    let queue_id = 0;
+    let queue_offset = 0;
+    let store_timestamp = 1_700_000_i64;
+    let message = encoded_message(store_timestamp, b"persisted-posix-message");
+
+    let store = TieredStore::new(config.clone())?;
+    store.load().await?;
+    store.start().await?;
+    store
+        .dispatcher()
+        .dispatch(TieredDispatchRequest {
+            topic: topic.clone(),
+            queue_id,
+            queue_offset,
+            commit_log_offset: 0,
+            message_size: message.len() as i32,
+            tags_code: 0,
+            store_timestamp,
+            keys: Some("keyA".to_owned()),
+            uniq_key: Some("uniqA".to_owned()),
+            offset_id: None,
+            sys_flag: 0,
+            body: Some(message.clone()),
+        })
+        .await?;
+    store.shutdown().await?;
+
+    let reloaded = TieredStore::new(config)?;
+    reloaded.load().await?;
+
+    let fetched = reloaded
+        .fetcher()
+        .get_message(topic.clone(), queue_id, queue_offset, 1)
+        .await?;
+    assert_eq!(fetched.status, TieredGetMessageStatus::Found);
+    assert_eq!(fetched.messages, vec![message.clone()]);
+    assert_eq!(
+        reloaded
+            .fetcher()
+            .get_message_timestamp(topic.clone(), queue_id, queue_offset)
+            .await?,
+        store_timestamp
+    );
+    assert_eq!(
+        reloaded
+            .fetcher()
+            .get_offset_by_time(topic.clone(), queue_id, store_timestamp - 1)
+            .await?,
+        queue_offset
+    );
+    assert_eq!(
+        reloaded
+            .fetcher()
+            .get_offset_by_time_with_boundary(topic.clone(), queue_id, store_timestamp + 1, BoundaryType::Upper)
+            .await?,
+        queue_offset
+    );
+
+    let query_result = reloaded
+        .fetcher()
+        .query_message(topic.clone(), "keyA".to_owned(), 10, 0, i64::MAX)
+        .await?;
+    assert_eq!(query_result.values, vec![message.clone()]);
+    let uniq_query_result = reloaded
+        .fetcher()
+        .query_message(topic, "uniqA".to_owned(), 10, 0, i64::MAX)
+        .await?;
+    assert_eq!(uniq_query_result.values, vec![message]);
+
+    Ok(())
+}
+
+fn encoded_message(store_timestamp: i64, body: &[u8]) -> Bytes {
+    let mut bytes = BytesMut::zeroed(MESSAGE_STORE_TIMESTAMP_POSITION + std::mem::size_of::<i64>());
+    bytes[MESSAGE_STORE_TIMESTAMP_POSITION..MESSAGE_STORE_TIMESTAMP_POSITION + std::mem::size_of::<i64>()]
+        .copy_from_slice(&store_timestamp.to_be_bytes());
+    bytes.extend_from_slice(body);
+    bytes.freeze()
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7333

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boundary-aware timestamp-based offset lookup (lower/upper bounds) for message queues.
  * Improved tiered storage recovery mechanism to handle missing queue metadata using segment information.

* **Bug Fixes**
  * Enhanced error handling for timestamp-based offset queries with better logging and fallback behavior.

* **Refactor**
  * Converted offset-by-timestamp operations to asynchronous processing for improved broker responsiveness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7334)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->