### PR TITLE
[ISSUE #7335]✨add support for topic and queue deletion in metadata store, enhancing cleanup capabilities

### DIFF
--- a/rocketmq-store/src/tieredstore.rs
+++ b/rocketmq-store/src/tieredstore.rs
@@ -101,6 +101,13 @@ pub fn to_tiered_dispatch_request(dispatch_request: &DispatchRequest, body: Byte
 mod tests {
     use bytes::Bytes;
     use cheetah_string::CheetahString;
+    use rocketmq_error::RocketMQError;
+    use rocketmq_tieredstore::fetcher::TieredGetMessageStatus;
+    use rocketmq_tieredstore::TieredLifecycle;
+    use rocketmq_tieredstore::TieredMessageFetcher;
+    use rocketmq_tieredstore::TieredStorageLevel;
+    use rocketmq_tieredstore::TieredStore;
+    use rocketmq_tieredstore::TieredStoreConfig;
 
     use super::*;
 
@@ -134,5 +141,49 @@ mod tests {
         assert_eq!(tiered_request.uniq_key.as_deref(), Some("uniqA"));
         assert_eq!(tiered_request.offset_id.as_deref(), Some("offsetA"));
         assert_eq!(tiered_request.body, Some(Bytes::from_static(b"test")));
+    }
+
+    #[tokio::test]
+    async fn dispatcher_adapter_writes_commitlog_and_consumequeue_to_tieredstore() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let tiered_store = TieredStore::new(TieredStoreConfig {
+            storage_level: TieredStorageLevel::Force,
+            backend_provider: "memory".to_owned(),
+            store_path_root_dir: temp_dir.path().join("tieredstore"),
+            max_pending_tasks: 8,
+            ..TieredStoreConfig::default()
+        })?;
+        tiered_store.load().await?;
+        tiered_store.start().await?;
+
+        let body = Bytes::from_static(b"adapter-dispatched-body");
+        let resolver_body = body.clone();
+        let adapter = TieredCommitLogDispatcher::new(
+            tiered_store.dispatcher(),
+            Arc::new(move |_| Some(resolver_body.clone())),
+        );
+        let mut dispatch_request = DispatchRequest {
+            topic: CheetahString::from("TopicA"),
+            queue_id: 0,
+            commit_log_offset: 1024,
+            msg_size: body.len() as i32,
+            tags_code: 7,
+            store_timestamp: 100,
+            consume_queue_offset: 0,
+            keys: CheetahString::from("keyA"),
+            success: true,
+            uniq_key: Some(CheetahString::from("uniqA")),
+            offset_id: Some(CheetahString::from("offsetA")),
+            sys_flag: 0,
+            ..DispatchRequest::default()
+        };
+
+        adapter.dispatch(&mut dispatch_request);
+        tiered_store.shutdown().await?;
+
+        let fetched = tiered_store.fetcher().get_message("TopicA".to_owned(), 0, 0, 1).await?;
+        assert_eq!(fetched.status, TieredGetMessageStatus::Found);
+        assert_eq!(fetched.messages, vec![body]);
+        Ok(())
     }
 }

--- a/rocketmq-tieredstore/src/file/flat_file.rs
+++ b/rocketmq-tieredstore/src/file/flat_file.rs
@@ -657,6 +657,7 @@ mod tests {
     use std::time::Duration;
 
     use bytes::Bytes;
+    use bytes::BytesMut;
     use rocketmq_error::RocketMQError;
 
     use super::*;
@@ -674,6 +675,14 @@ mod tests {
             file_reserved_time: Duration::from_millis(1),
             ..TieredStoreConfig::default()
         })
+    }
+
+    fn message_with_store_timestamp(store_timestamp: i64, body: &[u8]) -> Bytes {
+        let mut bytes = BytesMut::zeroed(MESSAGE_STORE_TIMESTAMP_POSITION + std::mem::size_of::<i64>());
+        bytes[MESSAGE_STORE_TIMESTAMP_POSITION..MESSAGE_STORE_TIMESTAMP_POSITION + std::mem::size_of::<i64>()]
+            .copy_from_slice(&store_timestamp.to_be_bytes());
+        bytes.extend_from_slice(body);
+        bytes.freeze()
     }
 
     #[tokio::test]
@@ -715,6 +724,129 @@ mod tests {
             )
             .await;
         assert!(result.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn append_rolls_commit_log_and_consume_queue_segments() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = test_config(temp_dir.path().to_path_buf());
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let provider = MemoryProvider::default();
+        let flat_file = TieredFlatFile::new("TopicA".to_owned(), 0, config, metadata_store, provider.clone());
+
+        for (queue_offset, body, timestamp) in [
+            (0, Bytes::from_static(b"aaaa"), 100),
+            (1, Bytes::from_static(b"bbbb"), 101),
+            (2, Bytes::from_static(b"cccc"), 102),
+        ] {
+            let commit_log_offset = flat_file.append_commit_log(body.clone(), timestamp).await?;
+            flat_file
+                .append_consume_queue(
+                    queue_offset,
+                    ConsumeQueueUnit {
+                        commit_log_offset: commit_log_offset as i64,
+                        size: body.len() as i32,
+                        tags_code: 1,
+                    },
+                    timestamp,
+                )
+                .await?;
+        }
+        flat_file.commit().await?;
+
+        assert_eq!(
+            provider
+                .segment_size(segment_path("TopicA", 0, FileSegmentType::CommitLog, 0))
+                .await?,
+            8
+        );
+        assert_eq!(
+            provider
+                .segment_size(segment_path("TopicA", 0, FileSegmentType::CommitLog, 8))
+                .await?,
+            4
+        );
+        assert_eq!(
+            provider
+                .segment_size(segment_path("TopicA", 0, FileSegmentType::ConsumeQueue, 0))
+                .await?,
+            (CONSUME_QUEUE_UNIT_SIZE * 2) as u64
+        );
+        assert_eq!(
+            provider
+                .segment_size(segment_path("TopicA", 0, FileSegmentType::ConsumeQueue, 40))
+                .await?,
+            CONSUME_QUEUE_UNIT_SIZE as u64
+        );
+        assert_eq!(
+            flat_file.read_message_by_queue_offset(0).await?,
+            Some(Bytes::from_static(b"aaaa"))
+        );
+        assert_eq!(
+            flat_file.read_message_by_queue_offset(2).await?,
+            Some(Bytes::from_static(b"cccc"))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn queue_offset_by_time_respects_lower_and_upper_boundaries() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            commit_log_segment_size: 512,
+            consume_queue_segment_size: CONSUME_QUEUE_UNIT_SIZE as u64 * 4,
+            ..TieredStoreConfig::default()
+        });
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let flat_file = TieredFlatFile::new(
+            "TopicA".to_owned(),
+            0,
+            config,
+            metadata_store,
+            MemoryProvider::default(),
+        );
+
+        for (queue_offset, timestamp) in [(0, 100), (1, 200), (2, 300)] {
+            let body = message_with_store_timestamp(timestamp, format!("body-{queue_offset}").as_bytes());
+            let commit_log_offset = flat_file.append_commit_log(body.clone(), timestamp).await?;
+            flat_file
+                .append_consume_queue(
+                    queue_offset,
+                    ConsumeQueueUnit {
+                        commit_log_offset: commit_log_offset as i64,
+                        size: body.len() as i32,
+                        tags_code: 1,
+                    },
+                    timestamp,
+                )
+                .await?;
+        }
+        flat_file.commit().await?;
+
+        assert_eq!(flat_file.queue_offset_by_time(50).await?, 0);
+        assert_eq!(flat_file.queue_offset_by_time(150).await?, 1);
+        assert_eq!(flat_file.queue_offset_by_time(301).await?, 3);
+        assert_eq!(
+            flat_file
+                .queue_offset_by_time_with_boundary(150, BoundaryType::Upper)
+                .await?,
+            0
+        );
+        assert_eq!(
+            flat_file
+                .queue_offset_by_time_with_boundary(300, BoundaryType::Upper)
+                .await?,
+            2
+        );
+        assert_eq!(
+            flat_file
+                .queue_offset_by_time_with_boundary(301, BoundaryType::Upper)
+                .await?,
+            2
+        );
         Ok(())
     }
 

--- a/rocketmq-tieredstore/src/metadata/metadata_store.rs
+++ b/rocketmq-tieredstore/src/metadata/metadata_store.rs
@@ -39,11 +39,15 @@ pub trait TieredMetadataStore: Send + Sync {
 
     async fn upsert_topic(&self, metadata: TopicMetadata) -> Result<(), RocketMQError>;
 
+    async fn delete_topic(&self, topic: &str) -> Result<(), RocketMQError>;
+
     async fn get_queue(&self, topic: &str, queue_id: i32) -> Result<Option<TopicQueueMetadata>, RocketMQError>;
 
     async fn list_queues(&self) -> Result<Vec<TopicQueueMetadata>, RocketMQError>;
 
     async fn upsert_queue(&self, metadata: TopicQueueMetadata) -> Result<(), RocketMQError>;
+
+    async fn delete_queue(&self, topic: &str, queue_id: i32) -> Result<(), RocketMQError>;
 
     async fn list_file_segments(&self, topic: &str, queue_id: i32) -> Result<Vec<FileSegmentMetadata>, RocketMQError>;
 
@@ -161,6 +165,13 @@ impl TieredMetadataStore for JsonMetadataStore {
         self.persist().await
     }
 
+    async fn delete_topic(&self, topic: &str) -> Result<(), RocketMQError> {
+        {
+            self.state.write().topics.remove(topic);
+        }
+        self.persist().await
+    }
+
     async fn get_queue(&self, topic: &str, queue_id: i32) -> Result<Option<TopicQueueMetadata>, RocketMQError> {
         Ok(self.state.read().queues.get(&Self::queue_key(topic, queue_id)).cloned())
     }
@@ -175,6 +186,13 @@ impl TieredMetadataStore for JsonMetadataStore {
                 .write()
                 .queues
                 .insert(Self::queue_key(&metadata.topic, metadata.queue_id), metadata);
+        }
+        self.persist().await
+    }
+
+    async fn delete_queue(&self, topic: &str, queue_id: i32) -> Result<(), RocketMQError> {
+        {
+            self.state.write().queues.remove(&Self::queue_key(topic, queue_id));
         }
         self.persist().await
     }
@@ -305,13 +323,12 @@ mod tests {
 
         metadata_store.upsert_topic(topic_metadata.clone()).await?;
         metadata_store.upsert_queue(queue_metadata.clone()).await?;
-        metadata_store
-            .upsert_file_segment(FileSegmentMetadata::new(
-                "TopicA/0/commitlog/00000000000000000000".to_owned(),
-                FileSegmentType::CommitLog,
-                0,
-            ))
-            .await?;
+        let segment = FileSegmentMetadata::new(
+            "TopicA/0/commitlog/00000000000000000000".to_owned(),
+            FileSegmentType::CommitLog,
+            0,
+        );
+        metadata_store.upsert_file_segment(segment.clone()).await?;
         let index_entry = TieredIndexEntry {
             topic: "TopicA".to_owned(),
             key: "keyA".to_owned(),
@@ -329,7 +346,58 @@ mod tests {
         assert_eq!(reloaded_store.get_topic("TopicA").await?, Some(topic_metadata));
         assert_eq!(reloaded_store.get_queue("TopicA", 0).await?, Some(queue_metadata));
         assert_eq!(reloaded_store.list_file_segments("TopicA", 0).await?.len(), 1);
+        assert_eq!(reloaded_store.list_all_file_segments().await?, vec![segment]);
         assert_eq!(reloaded_store.list_index_entries().await?, vec![index_entry]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn supports_topic_queue_and_segment_delete_semantics() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            ..TieredStoreConfig::default()
+        });
+        let metadata_store = JsonMetadataStore::new(config.clone());
+        metadata_store
+            .upsert_topic(TopicMetadata {
+                topic_id: 1,
+                topic: "TopicA".to_owned(),
+                reserve_time_millis: 10_000,
+                status: 0,
+                update_timestamp: 100,
+            })
+            .await?;
+        metadata_store
+            .upsert_queue(TopicQueueMetadata {
+                topic: "TopicA".to_owned(),
+                queue_id: 0,
+                min_offset: 0,
+                max_offset: 2,
+                update_timestamp: 101,
+            })
+            .await?;
+        let segment = FileSegmentMetadata::new(
+            "TopicA/0/consumequeue/00000000000000000000".to_owned(),
+            FileSegmentType::ConsumeQueue,
+            0,
+        );
+        metadata_store.upsert_file_segment(segment.clone()).await?;
+
+        metadata_store.delete_topic("TopicA").await?;
+        metadata_store.delete_queue("TopicA", 0).await?;
+        metadata_store
+            .mark_file_segment_deleted(&segment.path, segment.base_offset)
+            .await?;
+
+        let reloaded_store = JsonMetadataStore::new(config);
+        reloaded_store.load().await?;
+
+        assert_eq!(reloaded_store.get_topic("TopicA").await?, None);
+        assert_eq!(reloaded_store.get_queue("TopicA", 0).await?, None);
+        let segments = reloaded_store.list_file_segments("TopicA", 0).await?;
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].status, crate::file::FileSegmentStatus::Deleted);
         Ok(())
     }
 }

--- a/rocketmq-tieredstore/src/provider/posix_file_segment.rs
+++ b/rocketmq-tieredstore/src/provider/posix_file_segment.rs
@@ -132,3 +132,68 @@ impl TieredStoreProvider for PosixProvider {
 fn path_to_string(path: &Path) -> String {
     path.to_string_lossy().into_owned()
 }
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use rocketmq_error::RocketMQError;
+
+    use super::PosixProvider;
+    use crate::file::FileSegment;
+    use crate::file::FileSegmentType;
+    use crate::file::TieredFileSegment;
+    use crate::metadata::FileSegmentMetadata;
+    use crate::provider::TieredStoreProvider;
+
+    #[tokio::test]
+    async fn write_read_size_and_delete() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let provider = PosixProvider::new(temp_dir.path().to_path_buf());
+
+        provider
+            .write("topic/0/commitlog/000".to_owned(), 0, Bytes::from_static(b"abc"))
+            .await?;
+        provider
+            .write("topic/0/commitlog/000".to_owned(), 3, Bytes::from_static(b"def"))
+            .await?;
+
+        assert_eq!(provider.segment_size("topic/0/commitlog/000".to_owned()).await?, 6);
+        assert_eq!(
+            provider.read("topic/0/commitlog/000".to_owned(), 1, 4).await?,
+            Bytes::from_static(b"bcde")
+        );
+
+        provider.delete("topic/0/commitlog/000".to_owned()).await?;
+        assert_eq!(provider.segment_size("topic/0/commitlog/000".to_owned()).await?, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_append_commit_and_recover_segment() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let provider = PosixProvider::new(temp_dir.path().to_path_buf());
+        let path = "topic/0/commitlog/00000000000000000000".to_owned();
+        let segment = provider
+            .create_segment(path.clone(), FileSegmentType::CommitLog, 0, 64)
+            .await?;
+
+        segment.append(Bytes::from_static(b"hello"), 100).await?;
+        segment.append(Bytes::from_static(b"-posix"), 101).await?;
+        assert_eq!(segment.append_position(), 11);
+        assert_eq!(segment.commit_position(), 0);
+
+        segment.commit().await?;
+        assert_eq!(segment.commit_position(), 11);
+        assert_eq!(segment.read(0..11).await?, Bytes::from_static(b"hello-posix"));
+
+        let mut metadata = FileSegmentMetadata::new(path.clone(), FileSegmentType::CommitLog, 0);
+        metadata.size = provider.segment_size(path.clone()).await?;
+        metadata.begin_timestamp = 100;
+        metadata.end_timestamp = 101;
+        let recovered = TieredFileSegment::new(path, FileSegmentType::CommitLog, 0, 64, metadata, provider);
+
+        assert_eq!(recovered.commit_position(), 11);
+        assert_eq!(recovered.read(6..11).await?, Bytes::from_static(b"posix"));
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7335

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added async deletion support for topics and queues in the metadata store

* **Tests**
  * Expanded test coverage for tiered storage functionality, including segment lifecycle management, commit-log and consume-queue operations, message persistence and retrieval, queue offset boundary handling, and POSIX file segment storage behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7336)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->