### PR TITLE
[ISSUE #7337]✨add commit log recovery service and enhance dispatch request validation

### DIFF
--- a/rocketmq-tieredstore/src/dispatcher/dispatch_request.rs
+++ b/rocketmq-tieredstore/src/dispatcher/dispatch_request.rs
@@ -32,6 +32,45 @@ pub struct TieredDispatchRequest {
 
 impl TieredDispatchRequest {
     pub fn is_valid(&self) -> bool {
-        !self.topic.is_empty() && self.queue_id >= 0 && self.queue_offset >= 0 && self.message_size > 0
+        let Some(body) = self.body.as_ref() else {
+            return false;
+        };
+        !self.topic.is_empty()
+            && self.queue_id >= 0
+            && self.queue_offset >= 0
+            && self.message_size > 0
+            && body.len() == self.message_size as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::TieredDispatchRequest;
+
+    fn request(body: Option<Bytes>, message_size: i32) -> TieredDispatchRequest {
+        TieredDispatchRequest {
+            topic: "TopicA".to_owned(),
+            queue_id: 0,
+            queue_offset: 0,
+            commit_log_offset: 0,
+            message_size,
+            tags_code: 0,
+            store_timestamp: 100,
+            keys: None,
+            uniq_key: None,
+            offset_id: None,
+            sys_flag: 0,
+            body,
+        }
+    }
+
+    #[test]
+    fn valid_dispatch_requires_body_matching_message_size() {
+        assert!(request(Some(Bytes::from_static(b"body")), 4).is_valid());
+        assert!(!request(None, 4).is_valid());
+        assert!(!request(Some(Bytes::from_static(b"body")), 5).is_valid());
+        assert!(!request(Some(Bytes::new()), 0).is_valid());
     }
 }

--- a/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs
+++ b/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs
@@ -182,3 +182,71 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use rocketmq_error::RocketMQError;
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::config::TieredStoreConfig;
+    use crate::file::TieredFlatFileStore;
+    use crate::metadata::JsonMetadataStore;
+    use crate::provider::MemoryProvider;
+
+    #[tokio::test]
+    async fn dispatch_writes_commit_log_and_consume_queue_unit() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            max_pending_tasks: 4,
+            ..TieredStoreConfig::default()
+        });
+        let flat_file_store = Arc::new(TieredFlatFileStore::new(
+            config.clone(),
+            Arc::new(JsonMetadataStore::new(config.clone())),
+            MemoryProvider::default(),
+        ));
+        let dispatcher = DefaultTieredDispatcher::new(config, flat_file_store.clone(), CancellationToken::new());
+
+        dispatcher.start().await?;
+        dispatcher
+            .dispatch(TieredDispatchRequest {
+                topic: "TopicA".to_owned(),
+                queue_id: 0,
+                queue_offset: 3,
+                commit_log_offset: 1024,
+                message_size: 4,
+                tags_code: 7,
+                store_timestamp: 100,
+                keys: None,
+                uniq_key: None,
+                offset_id: None,
+                sys_flag: 0,
+                body: Some(Bytes::from_static(b"body")),
+            })
+            .await?;
+        dispatcher.shutdown().await?;
+
+        let flat_file = flat_file_store
+            .get("TopicA", 0)
+            .ok_or_else(|| RocketMQError::Internal("missing dispatched flat file".to_owned()))?;
+        let cq_unit = flat_file
+            .read_consume_queue_unit(3)
+            .await?
+            .ok_or_else(|| RocketMQError::Internal("missing dispatched consume queue unit".to_owned()))?;
+
+        assert_eq!(cq_unit.commit_log_offset, 0);
+        assert_eq!(cq_unit.size, 4);
+        assert_eq!(cq_unit.tags_code, 7);
+        assert_eq!(
+            flat_file.read_message_by_queue_offset(3).await?,
+            Some(Bytes::from_static(b"body"))
+        );
+        Ok(())
+    }
+}

--- a/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
+++ b/rocketmq-tieredstore/src/fetcher/tiered_message_fetcher.rs
@@ -169,13 +169,41 @@ where
 
         let max_msg_nums = (max_msg_nums.max(1) as usize).min(self.config.read_ahead_message_count.max(1));
         let mut messages = Vec::with_capacity(max_msg_nums.min(16));
+        let max_total_msg_size = self.config.read_ahead_message_size.max(1);
+        let mut total_msg_size = 0_usize;
         let mut next_begin_offset = queue_offset;
         for offset in queue_offset..max_offset {
             if messages.len() >= max_msg_nums {
                 break;
             }
-            match flat_file.read_message_by_queue_offset(offset).await? {
+            let Some(unit) = flat_file.read_consume_queue_unit(offset).await? else {
+                return Ok(TieredGetMessageResult {
+                    status: TieredGetMessageStatus::OffsetFoundNull,
+                    messages,
+                    min_offset,
+                    max_offset,
+                    next_begin_offset: offset,
+                });
+            };
+            if unit.commit_log_offset < 0 || unit.size <= 0 {
+                return Ok(TieredGetMessageResult {
+                    status: TieredGetMessageStatus::OffsetFoundNull,
+                    messages,
+                    min_offset,
+                    max_offset,
+                    next_begin_offset: offset,
+                });
+            }
+            let message_size = unit.size as usize;
+            if !messages.is_empty() && total_msg_size.saturating_add(message_size) > max_total_msg_size {
+                break;
+            }
+            match flat_file
+                .read_commit_log(unit.commit_log_offset as u64, message_size)
+                .await?
+            {
                 Some(message) => {
+                    total_msg_size = total_msg_size.saturating_add(message.len());
                     messages.push(message);
                     next_begin_offset = offset.saturating_add(1);
                 }
@@ -458,6 +486,46 @@ mod tests {
             result.messages,
             vec![Bytes::from_static(b"msg-a"), Bytes::from_static(b"msg-b")]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetch_respects_read_ahead_message_size_after_first_message() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            read_ahead_message_count: 10,
+            read_ahead_message_size: 6,
+            ..TieredStoreConfig::default()
+        });
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let provider = MemoryProvider::default();
+        let flat_file_store = Arc::new(TieredFlatFileStore::new(config.clone(), metadata_store, provider));
+        let flat_file = flat_file_store.get_or_create("TopicA".to_owned(), 0)?;
+
+        for (queue_offset, body) in [(0, Bytes::from_static(b"first")), (1, Bytes::from_static(b"second"))] {
+            let commit_log_offset = flat_file.append_commit_log(body.clone(), 100 + queue_offset).await?;
+            flat_file
+                .append_consume_queue(
+                    queue_offset,
+                    ConsumeQueueUnit {
+                        commit_log_offset: commit_log_offset as i64,
+                        size: body.len() as i32,
+                        tags_code: 1,
+                    },
+                    100 + queue_offset,
+                )
+                .await?;
+        }
+        flat_file.commit().await?;
+        let fetcher = DefaultTieredMessageFetcher::new(config, flat_file_store);
+
+        let result = fetcher.get_message("TopicA".to_owned(), 0, 0, 10).await?;
+
+        assert_eq!(result.status, TieredGetMessageStatus::Found);
+        assert_eq!(result.messages, vec![Bytes::from_static(b"first")]);
+        assert_eq!(result.next_begin_offset, 1);
         Ok(())
     }
 

--- a/rocketmq-tieredstore/src/file/flat_file_store.rs
+++ b/rocketmq-tieredstore/src/file/flat_file_store.rs
@@ -83,6 +83,14 @@ where
         self.files.get(&key).map(|entry| entry.value().clone())
     }
 
+    pub fn flat_file_count(&self) -> usize {
+        self.files.len()
+    }
+
+    pub async fn index_segment_count(&self) -> Result<usize, RocketMQError> {
+        self.index_file.segment_count().await
+    }
+
     pub fn get_or_create(&self, topic: String, queue_id: i32) -> Result<Arc<TieredFlatFile<P>>, RocketMQError> {
         let key = FlatFileKey {
             topic: topic.clone(),

--- a/rocketmq-tieredstore/src/lib.rs
+++ b/rocketmq-tieredstore/src/lib.rs
@@ -51,4 +51,6 @@ pub use provider::MemoryProvider;
 pub use provider::PosixProvider;
 pub use provider::ProviderKind;
 pub use provider::TieredStoreProvider;
+pub use service::CommitLogRecoverService;
+pub use service::TieredRecoverResult;
 pub use store::TieredStore;

--- a/rocketmq-tieredstore/src/service.rs
+++ b/rocketmq-tieredstore/src/service.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod cleanup_service;
+pub mod commit_log_recover_service;
 
 use std::sync::Arc;
 
@@ -24,6 +25,8 @@ use crate::config::TieredStoreConfig;
 use crate::file::TieredFlatFileStore;
 use crate::provider::TieredStoreProvider;
 use crate::service::cleanup_service::CleanupService;
+pub use crate::service::commit_log_recover_service::CommitLogRecoverService;
+pub use crate::service::commit_log_recover_service::TieredRecoverResult;
 
 pub struct TieredServiceSet<P>
 where

--- a/rocketmq-tieredstore/src/service/commit_log_recover_service.rs
+++ b/rocketmq-tieredstore/src/service/commit_log_recover_service.rs
@@ -1,0 +1,160 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use rocketmq_error::RocketMQError;
+
+use crate::file::TieredFlatFileStore;
+use crate::metadata::JsonMetadataStore;
+use crate::metadata::TieredMetadataStore;
+use crate::provider::TieredStoreProvider;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TieredRecoverResult {
+    pub flat_file_count: usize,
+    pub index_segment_count: usize,
+}
+
+pub struct CommitLogRecoverService<P>
+where
+    P: TieredStoreProvider,
+{
+    metadata_store: Arc<JsonMetadataStore>,
+    flat_file_store: Arc<TieredFlatFileStore<P>>,
+}
+
+impl<P> CommitLogRecoverService<P>
+where
+    P: TieredStoreProvider,
+{
+    pub fn new(metadata_store: Arc<JsonMetadataStore>, flat_file_store: Arc<TieredFlatFileStore<P>>) -> Self {
+        Self {
+            metadata_store,
+            flat_file_store,
+        }
+    }
+
+    pub async fn recover(&self) -> Result<TieredRecoverResult, RocketMQError> {
+        self.metadata_store.load().await?;
+        self.flat_file_store.load().await?;
+        Ok(TieredRecoverResult {
+            flat_file_count: self.flat_file_store.flat_file_count(),
+            index_segment_count: self.flat_file_store.index_segment_count().await?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use rocketmq_error::RocketMQError;
+
+    use super::CommitLogRecoverService;
+    use crate::config::TieredStoreConfig;
+    use crate::file::ConsumeQueueUnit;
+    use crate::file::FileSegment;
+    use crate::file::FileSegmentType;
+    use crate::file::TieredFlatFileStore;
+    use crate::metadata::JsonMetadataStore;
+    use crate::metadata::TieredMetadataStore;
+    use crate::provider::MemoryProvider;
+    use crate::provider::TieredStoreProvider;
+
+    #[tokio::test]
+    async fn recover_corrects_half_committed_segment_metadata_size() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            commit_log_segment_size: 64,
+            consume_queue_segment_size: crate::file::CONSUME_QUEUE_UNIT_SIZE as u64,
+            ..TieredStoreConfig::default()
+        });
+        let metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let provider = MemoryProvider::default();
+
+        let commit_log_segment = provider
+            .create_segment(
+                "TopicA/0/commitlog/00000000000000000000".to_owned(),
+                FileSegmentType::CommitLog,
+                0,
+                config.commit_log_segment_size,
+            )
+            .await?;
+        commit_log_segment.append(Bytes::from_static(b"body"), 100).await?;
+        commit_log_segment.commit().await?;
+        let mut commit_log_metadata = commit_log_segment.metadata();
+        commit_log_metadata.size = 12;
+        metadata_store.upsert_file_segment(commit_log_metadata.clone()).await?;
+
+        let consume_queue_segment = provider
+            .create_segment(
+                "TopicA/0/consumequeue/00000000000000000000".to_owned(),
+                FileSegmentType::ConsumeQueue,
+                0,
+                config.consume_queue_segment_size,
+            )
+            .await?;
+        consume_queue_segment
+            .append(
+                ConsumeQueueUnit {
+                    commit_log_offset: 0,
+                    size: 4,
+                    tags_code: 7,
+                }
+                .encode(),
+                100,
+            )
+            .await?;
+        consume_queue_segment.commit().await?;
+        let mut consume_queue_metadata = consume_queue_segment.metadata();
+        consume_queue_metadata.size = crate::file::CONSUME_QUEUE_UNIT_SIZE as u64 * 2;
+        metadata_store
+            .upsert_file_segment(consume_queue_metadata.clone())
+            .await?;
+
+        let reloaded_metadata_store = Arc::new(JsonMetadataStore::new(config.clone()));
+        let flat_file_store = Arc::new(TieredFlatFileStore::new(
+            config,
+            reloaded_metadata_store.clone(),
+            provider,
+        ));
+        let service = CommitLogRecoverService::new(reloaded_metadata_store.clone(), flat_file_store.clone());
+        let result = service.recover().await?;
+
+        assert_eq!(result.flat_file_count, 1);
+        let flat_file = flat_file_store
+            .get("TopicA", 0)
+            .ok_or_else(|| RocketMQError::Internal("missing recovered flat file".to_owned()))?;
+        assert_eq!(
+            flat_file.read_message_by_queue_offset(0).await?,
+            Some(Bytes::from_static(b"body"))
+        );
+        let segments = reloaded_metadata_store.list_file_segments("TopicA", 0).await?;
+        assert!(segments.iter().any(|segment| {
+            segment.segment_type == FileSegmentType::CommitLog
+                && segment.path == commit_log_metadata.path
+                && segment.size == 4
+        }));
+        assert!(segments.iter().any(|segment| {
+            segment.segment_type == FileSegmentType::ConsumeQueue
+                && segment.path == consume_queue_metadata.path
+                && segment.size == crate::file::CONSUME_QUEUE_UNIT_SIZE as u64
+        }));
+        Ok(())
+    }
+}

--- a/rocketmq-tieredstore/src/store.rs
+++ b/rocketmq-tieredstore/src/store.rs
@@ -27,6 +27,7 @@ use crate::metadata::JsonMetadataStore;
 use crate::metadata::TieredMetadataStore;
 use crate::provider::ProviderKind;
 use crate::provider::TieredStoreProvider;
+use crate::service::CommitLogRecoverService;
 use crate::service::TieredServiceSet;
 
 pub struct TieredStore<P = ProviderKind>
@@ -101,8 +102,8 @@ where
     P: TieredStoreProvider,
 {
     async fn load(&self) -> Result<(), RocketMQError> {
-        self.metadata_store.load().await?;
-        self.flat_file_store.load().await
+        let recover_service = CommitLogRecoverService::new(self.metadata_store.clone(), self.flat_file_store.clone());
+        recover_service.recover().await.map(|_| ())
     }
 
     async fn start(&self) -> Result<(), RocketMQError> {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7337

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery service to correct commit-log segment metadata during initialization.

* **Improvements**
  * Strengthened message validation to reject incomplete or size-mismatched payloads.
  * Message retrieval now enforces size limits alongside message count limits.
  * Added monitoring helpers to track storage segment counts.

* **Tests**
  * Expanded test coverage for validation and recovery scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7338)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->