### PR TITLE
[ISSUE #7345]✨add tests for signature calculation and request content combination, ensuring compatibility with Java implementations

### DIFF
--- a/rocketmq-auth/src/authentication/builder/default_authentication_context_builder.rs
+++ b/rocketmq-auth/src/authentication/builder/default_authentication_context_builder.rs
@@ -121,9 +121,9 @@ impl DefaultAuthenticationContextBuilder {
     ) -> Vec<u8> {
         let mut content = Vec::new();
 
-        // Add all sorted field values
-        for (key, value) in sorted_fields {
-            content.extend_from_slice(key.as_bytes());
+        // Match Java AclUtils.combineRequestContent: concatenate sorted ext field
+        // values only, then append the request body. Field names are not signed.
+        for value in sorted_fields.values() {
             content.extend_from_slice(value.as_bytes());
         }
 
@@ -282,6 +282,7 @@ impl AuthenticationContextBuilder<DefaultAuthenticationContext> for DefaultAuthe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_hex_to_base64() {
@@ -295,6 +296,18 @@ mod tests {
         let hex = "ZZZZ";
         let result = DefaultAuthenticationContextBuilder::hex_to_base64(hex);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_combine_request_content_matches_java_value_only_order() {
+        let request = RemotingCommand::create_remoting_command(10).set_body(Vec::from("body"));
+        let mut sorted_fields = BTreeMap::new();
+        sorted_fields.insert(CheetahString::from("AccessKey"), CheetahString::from("alice"));
+        sorted_fields.insert(CheetahString::from("topic"), CheetahString::from("topic-a"));
+
+        let content = DefaultAuthenticationContextBuilder::combine_request_content(&request, &sorted_fields);
+
+        assert_eq!(content, b"alicetopic-abody");
     }
 
     #[test]
@@ -318,5 +331,24 @@ mod tests {
 
         assert_eq!(result.base.channel_id(), Some(&CheetahString::from("test-channel")));
         assert!(result.username().is_none());
+    }
+
+    #[test]
+    fn test_build_from_remoting_uses_java_signature_content() {
+        let mut ext_fields = HashMap::new();
+        ext_fields.insert(CheetahString::from("topic"), CheetahString::from("topic-a"));
+        ext_fields.insert(CheetahString::from("AccessKey"), CheetahString::from("alice"));
+        ext_fields.insert(CheetahString::from("Signature"), CheetahString::from("sig"));
+
+        let request = RemotingCommand::create_remoting_command(10)
+            .set_ext_fields(ext_fields)
+            .set_body(Vec::from("body"));
+        let builder = DefaultAuthenticationContextBuilder::new();
+
+        let context = builder.build_from_remoting(&request, Some("test-channel")).unwrap();
+
+        assert_eq!(context.username(), Some(&CheetahString::from("alice")));
+        assert_eq!(context.signature(), Some(&CheetahString::from("sig")));
+        assert_eq!(context.content(), Some(b"alicetopic-abody".as_slice()));
     }
 }

--- a/rocketmq-auth/src/authentication/chain/acl_signer.rs
+++ b/rocketmq-auth/src/authentication/chain/acl_signer.rs
@@ -96,4 +96,11 @@ mod tests {
         let result = cal_signature(content, secret_key);
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_cal_signature_matches_java_hmac_sha1_base64() {
+        let signature = cal_signature(b"alicetopic-a", "secret").unwrap();
+
+        assert_eq!(signature, "3yomro7y0WqWcbV+9tQa4av5w3Q=");
+    }
 }

--- a/rocketmq-auth/src/migration/alc/plain_access_config.rs
+++ b/rocketmq-auth/src/migration/alc/plain_access_config.rs
@@ -19,15 +19,23 @@ use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
 pub struct PlainAccessConfig {
+    #[serde(alias = "access_key")]
     pub access_key: Option<CheetahString>,
+    #[serde(alias = "secret_key")]
     pub secret_key: Option<CheetahString>,
+    #[serde(alias = "white_remote_address")]
     pub white_remote_address: Option<CheetahString>,
     pub admin: bool,
+    #[serde(alias = "default_topic_perm")]
     pub default_topic_perm: Option<CheetahString>,
+    #[serde(alias = "default_group_perm")]
     pub default_group_perm: Option<CheetahString>,
+    #[serde(alias = "topic_perms")]
     pub topic_perms: Option<Vec<CheetahString>>,
+    #[serde(alias = "group_perms")]
     pub group_perms: Option<Vec<CheetahString>>,
 }
 
@@ -123,5 +131,53 @@ impl fmt::Display for PlainAccessConfig {
             self.topic_perms,
             self.group_perms,
         )
+    }
+}
+
+impl fmt::Debug for PlainAccessConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PlainAccessConfig")
+            .field("access_key", &self.access_key)
+            .field("secret_key", &self.secret_key.as_ref().map(|_| "<redacted>"))
+            .field("white_remote_address", &self.white_remote_address)
+            .field("admin", &self.admin)
+            .field("default_topic_perm", &self.default_topic_perm)
+            .field("default_group_perm", &self.default_group_perm)
+            .field("topic_perms", &self.topic_perms)
+            .field("group_perms", &self.group_perms)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_access_config_debug_redacts_secret_key() {
+        let mut config = PlainAccessConfig::new();
+        config.set_access_key(CheetahString::from("ak"));
+        config.set_secret_key(CheetahString::from("top-secret-value"));
+
+        let debug = format!("{config:?}");
+
+        assert!(debug.contains("ak"));
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("top-secret-value"));
+    }
+
+    #[test]
+    fn plain_access_config_deserializes_missing_optional_java_fields() {
+        let yaml = r#"
+accessKey: ak
+secretKey: sk
+"#;
+
+        let config: PlainAccessConfig = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(config.access_key().unwrap().as_str(), "ak");
+        assert_eq!(config.secret_key().unwrap().as_str(), "sk");
+        assert!(!config.is_admin());
+        assert!(config.topic_perms().is_none());
     }
 }

--- a/rocketmq-auth/src/migration/alc/plain_access_data.rs
+++ b/rocketmq-auth/src/migration/alc/plain_access_data.rs
@@ -21,10 +21,12 @@ use serde::Serialize;
 use crate::migration::alc::plain_access_config::PlainAccessConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, rename_all = "camelCase")]
 pub struct PlainAccessData {
+    #[serde(alias = "global_white_remote_addresses")]
     pub global_white_remote_addresses: Vec<CheetahString>,
     pub accounts: Vec<PlainAccessConfig>,
+    #[serde(alias = "data_version")]
     pub data_version: Vec<DataVersion>,
 }
 
@@ -143,5 +145,75 @@ mod tests {
         let json = serde_json::to_string(&data).unwrap();
         let deserialized: PlainAccessData = serde_json::from_str(&json).unwrap();
         assert_eq!(data, deserialized);
+    }
+
+    #[test]
+    fn plain_access_data_deserializes_java_camel_case_yaml() {
+        let yaml = r#"
+globalWhiteRemoteAddresses:
+  - 10.10.*.*
+accounts:
+  - accessKey: RocketMQ
+    secretKey: 12345678
+    whiteRemoteAddress: 192.168.0.*
+    admin: true
+    defaultTopicPerm: PUB|SUB
+    defaultGroupPerm: SUB
+    topicPerms:
+      - TopicA=PUB
+    groupPerms:
+      - GroupA=SUB
+dataVersion:
+  - timestamp: 1
+    counter: 2
+"#;
+
+        let data: PlainAccessData = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(data.global_white_remote_addresses()[0].as_str(), "10.10.*.*");
+        assert_eq!(data.accounts().len(), 1);
+        let account = &data.accounts()[0];
+        assert_eq!(account.access_key().unwrap().as_str(), "RocketMQ");
+        assert_eq!(account.secret_key().unwrap().as_str(), "12345678");
+        assert_eq!(account.white_remote_address().unwrap().as_str(), "192.168.0.*");
+        assert!(account.is_admin());
+        assert_eq!(account.default_topic_perm().unwrap().as_str(), "PUB|SUB");
+        assert_eq!(account.default_group_perm().unwrap().as_str(), "SUB");
+        assert_eq!(account.topic_perms().unwrap()[0].as_str(), "TopicA=PUB");
+        assert_eq!(account.group_perms().unwrap()[0].as_str(), "GroupA=SUB");
+        assert_eq!(
+            data.data_version(),
+            &[DataVersion {
+                timestamp: 1,
+                counter: 2
+            }]
+        );
+    }
+
+    #[test]
+    fn plain_access_data_keeps_snake_case_yaml_compatibility() {
+        let yaml = r#"
+global_white_remote_addresses:
+  - 127.0.0.1
+accounts:
+  - access_key: ak
+    secret_key: sk
+data_version:
+  - timestamp: 3
+    counter: 4
+"#;
+
+        let data: PlainAccessData = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(data.global_white_remote_addresses()[0].as_str(), "127.0.0.1");
+        assert_eq!(data.accounts()[0].access_key().unwrap().as_str(), "ak");
+        assert_eq!(data.accounts()[0].secret_key().unwrap().as_str(), "sk");
+        assert_eq!(
+            data.data_version(),
+            &[DataVersion {
+                timestamp: 3,
+                counter: 4
+            }]
+        );
     }
 }

--- a/rocketmq-auth/src/migration/alc/plain_permission_manager.rs
+++ b/rocketmq-auth/src/migration/alc/plain_permission_manager.rs
@@ -292,4 +292,52 @@ accounts:
             other => panic!("expected serialization error, got {other:?}"),
         }
     }
+
+    #[test]
+    fn test_get_all_acl_config_accepts_java_camel_case_yaml() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        let conf_acl = root.join("conf").join("acl");
+        fs::create_dir_all(&conf_acl).unwrap();
+
+        let acl_file = conf_acl.join("java.yml");
+        fs::write(
+            &acl_file,
+            r#"
+globalWhiteRemoteAddresses:
+  - "10.10.*.*"
+accounts:
+  - accessKey: "ak"
+    secretKey: "sk"
+    whiteRemoteAddress: "192.168.0.*"
+    admin: true
+    defaultTopicPerm: "PUB|SUB"
+    defaultGroupPerm: "SUB"
+    topicPerms: ["TopicA=PUB"]
+    groupPerms: ["GroupA=SUB"]
+"#,
+        )
+        .unwrap();
+
+        let mut mgr = PlainPermissionManager::new();
+        mgr.file_home = root.to_string_lossy().to_string();
+        mgr.default_acl_dir = conf_acl.to_string_lossy().to_string();
+        mgr.file_list = mgr.get_all_acl_files(&mgr.default_acl_dir);
+
+        let acl = mgr.get_all_acl_config().unwrap();
+        let plain = acl.plain_access_configs().unwrap();
+        assert_eq!(plain.len(), 1);
+        assert_eq!(plain[0].access_key().unwrap().as_str(), "ak");
+        assert_eq!(plain[0].secret_key().unwrap().as_str(), "sk");
+        assert_eq!(plain[0].white_remote_address().unwrap().as_str(), "192.168.0.*");
+        assert_eq!(plain[0].default_topic_perm().unwrap().as_str(), "PUB|SUB");
+        assert_eq!(plain[0].default_group_perm().unwrap().as_str(), "SUB");
+        assert_eq!(plain[0].topic_perms().unwrap()[0].as_str(), "TopicA=PUB");
+        assert_eq!(plain[0].group_perms().unwrap()[0].as_str(), "GroupA=SUB");
+
+        let whites = acl.global_white_addrs().unwrap();
+        assert_eq!(whites.len(), 1);
+        assert_eq!(whites[0].as_str(), "10.10.*.*");
+    }
 }

--- a/rocketmq-auth/src/runtime.rs
+++ b/rocketmq-auth/src/runtime.rs
@@ -374,7 +374,7 @@ mod tests {
         );
         authz_provider.create_acl(acl).await.unwrap();
 
-        let signature = acl_signer::cal_signature("AccessKeyalicetopictopic-a".as_bytes(), "secret").unwrap();
+        let signature = acl_signer::cal_signature("alicetopic-a".as_bytes(), "secret").unwrap();
         let command = send_message_command("topic-a", "alice", &signature);
 
         runtime.check_remoting(&(), &command).await.unwrap();

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -1765,8 +1765,7 @@ mod tests {
             .collect::<Vec<_>>();
         fields.sort_by(|left, right| left.0.cmp(&right.0));
         let mut content = Vec::new();
-        for (key, value) in fields {
-            content.extend_from_slice(key.as_bytes());
+        for (_, value) in fields {
             content.extend_from_slice(value.as_bytes());
         }
         if let Some(body) = command.body() {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7345

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ACL configuration now supports Java-style camelCase field names in YAML/JSON inputs while maintaining backward compatibility.
  * Secret keys are now redacted in debug output for improved security.

* **Bug Fixes**
  * Authentication signature calculation corrected to align with Java implementation behavior.

* **Tests**
  * Added comprehensive unit tests verifying Java-compatible signature generation and camelCase configuration deserialization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7346)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->