### PR TITLE
[ISSUE #7363]♻️refactor error mapping functions to preserve error categories in authorization handling

### DIFF
--- a/rocketmq-auth/src/authorization/provider.rs
+++ b/rocketmq-auth/src/authorization/provider.rs
@@ -19,6 +19,7 @@
 
 use std::sync::Arc;
 
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 
 use crate::authentication::provider::LocalAuthenticationMetadataProvider;
@@ -85,6 +86,28 @@ pub enum AuthorizationError {
     /// Authorization context is invalid or incomplete.
     #[error("Invalid authorization context: {0}")]
     InvalidContext(String),
+}
+
+impl From<AuthorizationError> for RocketMQError {
+    fn from(error: AuthorizationError) -> Self {
+        let message = error.to_string();
+        match error {
+            AuthorizationError::PermissionDenied { .. } => RocketMQError::BrokerPermissionDenied { operation: message },
+            AuthorizationError::SubjectNotFound(_)
+            | AuthorizationError::ResourceNotFound(_)
+            | AuthorizationError::InvalidContext(_) => RocketMQError::illegal_argument(message),
+            AuthorizationError::ConfigurationError(_) | AuthorizationError::NotInitialized(_) => {
+                RocketMQError::ConfigInvalidValue {
+                    key: "auth.authorization",
+                    value: "<redacted>".to_string(),
+                    reason: message,
+                }
+            }
+            AuthorizationError::PolicyEvaluationFailed(_)
+            | AuthorizationError::InternalError(_)
+            | AuthorizationError::MetadataServiceError(_) => RocketMQError::Internal(message),
+        }
+    }
 }
 
 /// Authorization provider trait.
@@ -603,6 +626,31 @@ mod tests {
             let _msg = format!("{}", error);
             let _debug = format!("{:?}", error);
         }
+    }
+
+    #[test]
+    fn test_authorization_error_rocketmq_mapping_categories() {
+        let denied = RocketMQError::from(AuthorizationError::PermissionDenied {
+            subject: "user:alice".to_string(),
+            resource: "topic:test".to_string(),
+            reason: "insufficient permissions".to_string(),
+        });
+        assert!(matches!(denied, RocketMQError::BrokerPermissionDenied { .. }));
+
+        let invalid = RocketMQError::from(AuthorizationError::InvalidContext("missing subject".to_string()));
+        assert!(matches!(invalid, RocketMQError::IllegalArgument(_)));
+
+        let config = RocketMQError::from(AuthorizationError::ConfigurationError("missing config".to_string()));
+        assert!(matches!(
+            config,
+            RocketMQError::ConfigInvalidValue {
+                key: "auth.authorization",
+                ..
+            }
+        ));
+
+        let internal = RocketMQError::from(AuthorizationError::InternalError("unexpected error".to_string()));
+        assert!(matches!(internal, RocketMQError::Internal(_)));
     }
 
     #[tokio::test]

--- a/rocketmq-auth/src/runtime.rs
+++ b/rocketmq-auth/src/runtime.rs
@@ -667,9 +667,7 @@ async fn create_user_if_absent(provider: Arc<LocalAuthenticationMetadataProvider
 }
 
 fn map_authorization_error(error: AuthorizationError) -> RocketMQError {
-    RocketMQError::BrokerPermissionDenied {
-        operation: error.to_string(),
-    }
+    RocketMQError::from(error)
 }
 
 fn access_key_from_command(command: &RemotingCommand) -> Option<&str> {

--- a/rocketmq-broker/src/auth/auth_admin_service.rs
+++ b/rocketmq-broker/src/auth/auth_admin_service.rs
@@ -10,6 +10,7 @@ use rocketmq_auth::authorization::metadata_provider::AuthorizationMetadataProvid
 use rocketmq_auth::authorization::metadata_provider::LocalAuthorizationMetadataProvider;
 use rocketmq_auth::authorization::model::acl::Acl;
 use rocketmq_auth::authorization::model::resource::Resource;
+use rocketmq_auth::authorization::provider::AuthorizationError;
 use rocketmq_auth::config::AuthConfig;
 use rocketmq_auth::ProviderRegistry;
 use rocketmq_common::common::action::Action;
@@ -241,8 +242,8 @@ impl AuthAdminService {
     }
 }
 
-fn map_authz_error(error: rocketmq_auth::authorization::provider::AuthorizationError) -> RocketMQError {
-    RocketMQError::Internal(error.to_string())
+fn map_authz_error(error: AuthorizationError) -> RocketMQError {
+    RocketMQError::from(error)
 }
 
 #[derive(Clone)]
@@ -443,6 +444,31 @@ mod tests {
             .unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].subject, Some(CheetahString::from_static_str("User:alice")));
+    }
+
+    #[test]
+    fn map_authz_error_preserves_admin_error_category() {
+        let denied = map_authz_error(AuthorizationError::PermissionDenied {
+            subject: "User:alice".to_string(),
+            resource: "Topic:test".to_string(),
+            reason: "denied".to_string(),
+        });
+        assert!(matches!(denied, RocketMQError::BrokerPermissionDenied { .. }));
+
+        let invalid = map_authz_error(AuthorizationError::InvalidContext("missing resource".to_string()));
+        assert!(matches!(invalid, RocketMQError::IllegalArgument(_)));
+
+        let config = map_authz_error(AuthorizationError::NotInitialized("provider not ready".to_string()));
+        assert!(matches!(
+            config,
+            RocketMQError::ConfigInvalidValue {
+                key: "auth.authorization",
+                ..
+            }
+        ));
+
+        let internal = map_authz_error(AuthorizationError::MetadataServiceError("storage failed".to_string()));
+        assert!(matches!(internal, RocketMQError::Internal(_)));
     }
 
     #[tokio::test]

--- a/rocketmq-proxy/src/auth.rs
+++ b/rocketmq-proxy/src/auth.rs
@@ -610,9 +610,7 @@ fn metadata_string<T>(request: &Request<T>, key: &'static str) -> Option<String>
 }
 
 fn map_authorization_error(error: AuthorizationError) -> ProxyError {
-    ProxyError::from(RocketMQError::BrokerPermissionDenied {
-        operation: error.to_string(),
-    })
+    ProxyError::from(RocketMQError::from(error))
 }
 
 pub fn is_auth_error(error: &RocketMQError) -> bool {
@@ -663,6 +661,7 @@ fn source_ip_from_channel_context(channel_context: &(dyn std::any::Any + Send + 
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::PathBuf;
 
     use rocketmq_auth::authorization::model::resource::Resource;
     use rocketmq_remoting::code::request_code::RequestCode;
@@ -670,13 +669,48 @@ mod tests {
 
     use super::*;
 
-    fn unique_target_file(prefix: &str) -> String {
-        format!("target/{}-{}.yml", prefix, uuid::Uuid::new_v4())
+    fn unique_test_dir(prefix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("{prefix}-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).expect("test temp directory should be created");
+        dir
+    }
+
+    #[test]
+    fn map_authorization_error_preserves_proxy_error_category() {
+        let denied = map_authorization_error(AuthorizationError::PermissionDenied {
+            subject: "User:alice".to_string(),
+            resource: "Topic:test".to_string(),
+            reason: "denied".to_string(),
+        });
+        assert!(matches!(
+            denied,
+            ProxyError::RocketMQ(RocketMQError::BrokerPermissionDenied { .. })
+        ));
+
+        let invalid = map_authorization_error(AuthorizationError::InvalidContext("missing resource".to_string()));
+        assert!(matches!(
+            invalid,
+            ProxyError::RocketMQ(RocketMQError::IllegalArgument(_))
+        ));
+
+        let config = map_authorization_error(AuthorizationError::ConfigurationError("missing provider".to_string()));
+        assert!(matches!(
+            config,
+            ProxyError::RocketMQ(RocketMQError::ConfigInvalidValue {
+                key: "auth.authorization",
+                ..
+            })
+        ));
+
+        let internal =
+            map_authorization_error(AuthorizationError::PolicyEvaluationFailed("invalid policy".to_string()));
+        assert!(matches!(internal, ProxyError::RocketMQ(RocketMQError::Internal(_))));
     }
 
     #[tokio::test]
     async fn authenticate_remoting_accepts_acl_account_white_remote_address() {
-        let acl_file = unique_target_file("proxy-auth-white-remote-address");
+        let test_dir = unique_test_dir("proxy-auth-white-remote-address");
+        let acl_file = test_dir.join("plain_acl.yml");
         fs::write(
             &acl_file,
             r#"
@@ -690,10 +724,10 @@ accounts:
         .expect("acl file should be written");
 
         let runtime = ProxyAuthRuntime::from_proxy_config(&ProxyAuthConfig {
-            acl_file,
+            acl_file: acl_file.to_string_lossy().into_owned(),
             authentication_enabled: true,
             authorization_enabled: true,
-            auth_config_path: format!("target/proxy-auth-tests-{}", uuid::Uuid::new_v4()),
+            auth_config_path: test_dir.join("auth-store").to_string_lossy().into_owned(),
             ..ProxyAuthConfig::default()
         })
         .await
@@ -717,13 +751,15 @@ accounts:
         assert!(principal.is_white_listed());
 
         runtime.shutdown().await.expect("runtime should shut down");
+        let _ = fs::remove_dir_all(test_dir);
     }
 
     #[tokio::test]
     async fn authorize_request_skips_white_listed_principal() {
+        let test_dir = unique_test_dir("proxy-auth-authorize-white-listed-principal");
         let runtime = ProxyAuthRuntime::from_proxy_config(&ProxyAuthConfig {
             authorization_enabled: true,
-            auth_config_path: format!("target/proxy-auth-tests-{}", uuid::Uuid::new_v4()),
+            auth_config_path: test_dir.join("auth-store").to_string_lossy().into_owned(),
             ..ProxyAuthConfig::default()
         })
         .await
@@ -742,5 +778,6 @@ accounts:
             .expect("white listed principal should bypass authorization metadata lookup");
 
         runtime.shutdown().await.expect("runtime should shut down");
+        let _ = fs::remove_dir_all(test_dir);
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7363

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Authorization error handling now provides more specific and accurate error messages across broker and proxy components, improving troubleshooting for permission-related issues

* **Tests**
  * Expanded test coverage for authorization error scenarios with improved error category verification
  * Enhanced test infrastructure with better isolation practices

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->