### PR TITLE
[ISSUE #7367]🚀add global white address configuration support with update handler and validation

### DIFF
--- a/rocketmq-auth/src/acl.rs
+++ b/rocketmq-auth/src/acl.rs
@@ -16,6 +16,7 @@
 
 pub mod loader;
 pub mod validator;
+pub mod white_list;
 
 pub use crate::migration::alc::acl_config::AclConfig;
 pub use crate::migration::alc::plain_access_config::PlainAccessConfig;
@@ -23,3 +24,4 @@ pub use crate::migration::alc::plain_access_data::PlainAccessData;
 pub use loader::AclConfigFingerprint;
 pub use loader::FileAclConfigLoader;
 pub use validator::validate_acl_config;
+pub use white_list::WhiteList;

--- a/rocketmq-auth/src/acl/white_list.rs
+++ b/rocketmq-auth/src/acl/white_list.rs
@@ -1,0 +1,195 @@
+use std::collections::HashMap;
+
+use crate::authorization::model::environment::source_ip_matches;
+use crate::migration::alc::acl_config::AclConfig;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WhiteList {
+    global_patterns: Vec<String>,
+    account_patterns: HashMap<String, Vec<String>>,
+}
+
+impl WhiteList {
+    pub fn from_acl_config(acl_config: &AclConfig) -> Self {
+        let global_patterns = acl_config
+            .global_white_addrs()
+            .unwrap_or_default()
+            .iter()
+            .flat_map(|value| normalize_patterns(value.as_str()))
+            .collect();
+
+        let account_patterns = acl_config
+            .plain_access_configs()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|account| {
+                let access_key = account.access_key()?.as_str().trim();
+                let white_remote_address = account.white_remote_address()?.as_str();
+                if access_key.is_empty() {
+                    return None;
+                }
+
+                let patterns = normalize_patterns(white_remote_address);
+                if patterns.is_empty() {
+                    return None;
+                }
+                Some((access_key.to_owned(), patterns))
+            })
+            .collect();
+
+        Self {
+            global_patterns,
+            account_patterns,
+        }
+    }
+
+    pub fn from_global_patterns<I, S>(patterns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self {
+            global_patterns: patterns
+                .into_iter()
+                .flat_map(|pattern| normalize_patterns(pattern.as_ref()))
+                .collect(),
+            account_patterns: HashMap::new(),
+        }
+    }
+
+    pub fn with_global_patterns<I, S>(&self, patterns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self {
+            global_patterns: patterns
+                .into_iter()
+                .flat_map(|pattern| normalize_patterns(pattern.as_ref()))
+                .collect(),
+            account_patterns: self.account_patterns.clone(),
+        }
+    }
+
+    pub fn matches(&self, access_key: Option<&str>, source_ip: Option<&str>) -> bool {
+        let Some(source_ip) = valid_source_ip(source_ip) else {
+            return false;
+        };
+
+        if self
+            .global_patterns
+            .iter()
+            .any(|pattern| source_ip_matches(pattern, source_ip))
+        {
+            return true;
+        }
+
+        let Some(access_key) = access_key.map(str::trim).filter(|value| !value.is_empty()) else {
+            return false;
+        };
+
+        self.account_patterns
+            .get(access_key)
+            .is_some_and(|patterns| patterns.iter().any(|pattern| source_ip_matches(pattern, source_ip)))
+    }
+}
+
+fn normalize_patterns(value: &str) -> Vec<String> {
+    value
+        .split(';')
+        .map(str::trim)
+        .filter(|pattern| !pattern.is_empty())
+        .flat_map(expand_brace_pattern)
+        .collect()
+}
+
+fn expand_brace_pattern(pattern: &str) -> Vec<String> {
+    let Some(open) = pattern.find('{') else {
+        return vec![pattern.to_owned()];
+    };
+    let Some(close_offset) = pattern[open + 1..].find('}') else {
+        return vec![pattern.to_owned()];
+    };
+    let close = open + 1 + close_offset;
+    let prefix = &pattern[..open];
+    let suffix = &pattern[close + 1..];
+    let choices = &pattern[open + 1..close];
+    let expanded: Vec<String> = choices
+        .split(',')
+        .map(str::trim)
+        .filter(|choice| !choice.is_empty())
+        .map(|choice| format!("{prefix}{choice}{suffix}"))
+        .collect();
+
+    if expanded.is_empty() {
+        vec![pattern.to_owned()]
+    } else {
+        expanded
+    }
+}
+
+fn valid_source_ip(source_ip: Option<&str>) -> Option<&str> {
+    source_ip
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("unknown"))
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+    use crate::migration::alc::acl_config::AclConfig;
+    use crate::migration::alc::plain_access_config::PlainAccessConfig;
+
+    #[test]
+    fn white_list_matches_global_and_account_patterns() {
+        let mut account = PlainAccessConfig::default();
+        account.set_access_key(CheetahString::from_static_str("alice"));
+        account.set_white_remote_address(CheetahString::from_static_str("192.168.0.*;172.16.1.1"));
+
+        let mut config = AclConfig::new();
+        config.set_global_white_addrs(vec![CheetahString::from_static_str("10.10.*.*")]);
+        config.set_plain_access_configs(vec![account]);
+
+        let white_list = WhiteList::from_acl_config(&config);
+
+        assert!(white_list.matches(None, Some("10.10.1.2")));
+        assert!(white_list.matches(Some("alice"), Some("192.168.0.7")));
+        assert!(white_list.matches(Some("alice"), Some("172.16.1.1")));
+        assert!(!white_list.matches(Some("alice"), Some("192.168.1.7")));
+        assert!(!white_list.matches(Some("bob"), Some("192.168.0.7")));
+        assert!(!white_list.matches(Some("alice"), None));
+        assert!(!white_list.matches(Some("alice"), Some("unknown")));
+    }
+
+    #[test]
+    fn white_list_expands_java_brace_address_patterns() {
+        let white_list = WhiteList::from_global_patterns(vec!["1.1.1.{1,2}", "2001:db8::{1,2}"]);
+
+        assert!(white_list.matches(None, Some("1.1.1.1")));
+        assert!(white_list.matches(None, Some("1.1.1.2")));
+        assert!(!white_list.matches(None, Some("1.1.1.3")));
+        assert!(white_list.matches(None, Some("2001:db8::1")));
+        assert!(white_list.matches(None, Some("2001:db8::2")));
+        assert!(!white_list.matches(None, Some("2001:db8::3")));
+    }
+
+    #[test]
+    fn replacing_global_patterns_preserves_account_patterns() {
+        let mut account = PlainAccessConfig::default();
+        account.set_access_key(CheetahString::from_static_str("alice"));
+        account.set_white_remote_address(CheetahString::from_static_str("192.168.0.*"));
+
+        let mut config = AclConfig::new();
+        config.set_global_white_addrs(vec![CheetahString::from_static_str("10.10.*.*")]);
+        config.set_plain_access_configs(vec![account]);
+        let white_list = WhiteList::from_acl_config(&config);
+
+        let white_list = white_list.with_global_patterns(vec!["172.16.*.*"]);
+
+        assert!(!white_list.matches(None, Some("10.10.1.2")));
+        assert!(white_list.matches(None, Some("172.16.1.2")));
+        assert!(white_list.matches(Some("alice"), Some("192.168.0.7")));
+    }
+}

--- a/rocketmq-auth/src/runtime.rs
+++ b/rocketmq-auth/src/runtime.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering as AtomicOrdering;
@@ -23,6 +22,7 @@ use tracing::warn;
 
 use crate::acl::AclConfigFingerprint;
 use crate::acl::FileAclConfigLoader;
+use crate::acl::WhiteList;
 use crate::authentication::builder::default_authentication_context_builder::DefaultAuthenticationContextBuilder;
 use crate::authentication::builder::AuthenticationContextBuilder;
 use crate::authentication::enums::subject_type::SubjectType;
@@ -37,7 +37,6 @@ use crate::authorization::enums::policy_type::PolicyType;
 use crate::authorization::metadata_provider::AuthorizationMetadataProvider;
 use crate::authorization::metadata_provider::LocalAuthorizationMetadataProvider;
 use crate::authorization::model::acl::Acl;
-use crate::authorization::model::environment::source_ip_matches;
 use crate::authorization::model::policy::Policy;
 use crate::authorization::model::policy_entry::PolicyEntry;
 use crate::authorization::model::resource::Resource;
@@ -55,7 +54,7 @@ const ACCESS_KEY: &str = "AccessKey";
 pub struct ProviderRegistry {
     authentication_metadata_provider: Arc<LocalAuthenticationMetadataProvider>,
     authorization_metadata_provider: Arc<LocalAuthorizationMetadataProvider>,
-    acl_white_list_snapshot: Arc<RwLock<AclWhiteListSnapshot>>,
+    acl_white_list_snapshot: Arc<RwLock<WhiteList>>,
     acl_managed_access_keys: Arc<RwLock<HashSet<String>>>,
     acl_generation: Arc<AtomicU64>,
     acl_fingerprint: Arc<RwLock<Option<AclConfigFingerprint>>>,
@@ -72,7 +71,7 @@ impl ProviderRegistry {
         Ok(Self {
             authentication_metadata_provider,
             authorization_metadata_provider: Arc::new(authorization_metadata_provider),
-            acl_white_list_snapshot: Arc::new(RwLock::new(AclWhiteListSnapshot::default())),
+            acl_white_list_snapshot: Arc::new(RwLock::new(WhiteList::default())),
             acl_managed_access_keys: Arc::new(RwLock::new(HashSet::new())),
             acl_generation: Arc::new(AtomicU64::new(0)),
             acl_fingerprint: Arc::new(RwLock::new(None)),
@@ -87,7 +86,7 @@ impl ProviderRegistry {
         self.authorization_metadata_provider.clone()
     }
 
-    fn set_acl_white_list_snapshot(&self, snapshot: AclWhiteListSnapshot) -> RocketMQResult<()> {
+    fn set_acl_white_list_snapshot(&self, snapshot: WhiteList) -> RocketMQResult<()> {
         let mut guard = self
             .acl_white_list_snapshot
             .write()
@@ -153,65 +152,21 @@ impl ProviderRegistry {
             .map_err(|_| RocketMQError::Internal("ACL white list snapshot lock is poisoned".to_owned()))?;
         Ok(guard.matches(access_key, source_ip))
     }
-}
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-struct AclWhiteListSnapshot {
-    global_white_remote_addresses: Vec<String>,
-    account_white_remote_addresses: HashMap<String, String>,
-}
-
-impl AclWhiteListSnapshot {
-    fn from_acl_config(acl_config: &AclConfig) -> Self {
-        let global_white_remote_addresses = acl_config
-            .global_white_addrs()
-            .unwrap_or_default()
-            .iter()
-            .map(|value| value.as_str().trim())
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned)
-            .collect();
-
-        let account_white_remote_addresses = acl_config
-            .plain_access_configs()
-            .unwrap_or_default()
-            .iter()
-            .filter_map(|account| {
-                let access_key = account.access_key()?.as_str().trim();
-                let white_remote_address = account.white_remote_address()?.as_str().trim();
-                if access_key.is_empty() || white_remote_address.is_empty() {
-                    return None;
-                }
-                Some((access_key.to_owned(), white_remote_address.to_owned()))
-            })
-            .collect();
-
-        Self {
-            global_white_remote_addresses,
-            account_white_remote_addresses,
-        }
-    }
-
-    fn matches(&self, access_key: Option<&str>, source_ip: Option<&str>) -> bool {
-        let Some(source_ip) = valid_source_ip(source_ip) else {
-            return false;
+    pub fn update_global_white_remote_addresses<I, S>(&self, addresses: I) -> RocketMQResult<u64>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let updated_snapshot = {
+            let guard = self
+                .acl_white_list_snapshot
+                .read()
+                .map_err(|_| RocketMQError::Internal("ACL white list snapshot lock is poisoned".to_owned()))?;
+            guard.with_global_patterns(addresses)
         };
-
-        if self
-            .global_white_remote_addresses
-            .iter()
-            .any(|pattern| source_ip_matches(pattern, source_ip))
-        {
-            return true;
-        }
-
-        let Some(access_key) = access_key.map(str::trim).filter(|value| !value.is_empty()) else {
-            return false;
-        };
-
-        self.account_white_remote_addresses
-            .get(access_key)
-            .is_some_and(|pattern| source_ip_matches(pattern, source_ip))
+        self.set_acl_white_list_snapshot(updated_snapshot)?;
+        Ok(self.advance_acl_generation())
     }
 }
 
@@ -316,6 +271,14 @@ impl AuthRuntime {
 
     pub fn acl_generation_counter(&self) -> Arc<AtomicU64> {
         self.provider_registry.acl_generation_counter()
+    }
+
+    pub fn update_global_white_remote_addresses<I, S>(&self, addresses: I) -> RocketMQResult<u64>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.provider_registry.update_global_white_remote_addresses(addresses)
     }
 
     pub async fn shutdown(&self) -> RocketMQResult<()> {
@@ -573,7 +536,7 @@ async fn apply_acl_config(provider_registry: &ProviderRegistry, acl_config: &Acl
 }
 
 struct PreparedAclConfig {
-    white_list_snapshot: AclWhiteListSnapshot,
+    white_list_snapshot: WhiteList,
     access_keys: HashSet<String>,
     accounts: Vec<PreparedAclAccount>,
     accounts_len: usize,
@@ -600,7 +563,7 @@ fn prepare_acl_config(acl_config: &AclConfig) -> RocketMQResult<PreparedAclConfi
 
     let accounts_len = accounts.len();
     Ok(PreparedAclConfig {
-        white_list_snapshot: AclWhiteListSnapshot::from_acl_config(acl_config),
+        white_list_snapshot: WhiteList::from_acl_config(acl_config),
         access_keys,
         accounts,
         accounts_len,
@@ -838,12 +801,6 @@ fn channel_id_from_channel_context(channel_context: &(dyn std::any::Any + Send +
     None
 }
 
-fn valid_source_ip(source_ip: Option<&str>) -> Option<&str> {
-    source_ip
-        .map(str::trim)
-        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("unknown"))
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -1034,6 +991,44 @@ accounts:
             .check_remoting_with_source_ip(&(), &account_command, Some("192.168.1.7"), None)
             .await
             .expect_err("non-whitelisted source should still require a valid signature");
+    }
+
+    #[tokio::test]
+    async fn runtime_global_white_remote_address_update_preserves_account_whitelist_and_advances_generation() {
+        let temp = TempDir::new().unwrap();
+        let acl_file = temp.path().join("plain_acl.yml");
+        fs::write(
+            &acl_file,
+            r#"
+globalWhiteRemoteAddresses:
+  - 10.10.*.*
+accounts:
+  - accessKey: alice
+    secretKey: secret
+    whiteRemoteAddress: 192.168.0.*
+"#,
+        )
+        .unwrap();
+
+        let runtime = AuthRuntimeBuilder::new(AuthConfig {
+            acl_file: CheetahString::from(acl_file.to_string_lossy().as_ref()),
+            ..AuthConfig::default()
+        })
+        .build()
+        .await
+        .unwrap();
+        let generation = runtime.acl_generation();
+
+        runtime
+            .update_global_white_remote_addresses(vec!["172.16.*.*"])
+            .unwrap();
+
+        assert!(runtime.acl_generation() > generation);
+        assert!(!runtime.is_acl_white_remote_address(None, Some("10.10.1.2")).unwrap());
+        assert!(runtime.is_acl_white_remote_address(None, Some("172.16.1.2")).unwrap());
+        assert!(runtime
+            .is_acl_white_remote_address(Some("alice"), Some("192.168.0.7"))
+            .unwrap());
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/auth/auth_admin_service.rs
+++ b/rocketmq-broker/src/auth/auth_admin_service.rs
@@ -24,6 +24,7 @@ use crate::auth::user_converter::UserConverter;
 
 #[derive(Clone)]
 pub struct AuthAdminService {
+    provider_registry: ProviderRegistry,
     authentication_provider: Arc<LocalAuthenticationMetadataProvider>,
     authorization_provider: Arc<LocalAuthorizationMetadataProvider>,
 }
@@ -36,6 +37,7 @@ impl AuthAdminService {
 
     pub fn with_provider_registry(provider_registry: ProviderRegistry) -> Self {
         Self {
+            provider_registry: provider_registry.clone(),
             authentication_provider: provider_registry.authentication_metadata_provider(),
             authorization_provider: provider_registry.authorization_metadata_provider(),
         }
@@ -187,6 +189,23 @@ impl AuthAdminService {
             .as_deref()
             .and_then(UserType::get_by_name)
             .is_some_and(|user_type| user_type == UserType::Super))
+    }
+
+    pub fn update_global_white_remote_addresses<I, S>(&self, addresses: I) -> RocketMQResult<u64>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let addresses: Vec<String> = addresses
+            .into_iter()
+            .map(|address| address.as_ref().trim().to_owned())
+            .filter(|address| !address.is_empty())
+            .collect();
+        if addresses.is_empty() {
+            return Err(RocketMQError::illegal_argument("The globalWhiteAddrs is blank"));
+        }
+
+        self.provider_registry.update_global_white_remote_addresses(addresses)
     }
 
     async fn get_existing_user(&self, username: &str) -> RocketMQResult<User> {
@@ -511,5 +530,30 @@ mod tests {
         assert_eq!(policies.len(), 1);
         let entries = policies[0].entries.as_ref().expect("entries should exist");
         assert_eq!(entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_global_white_remote_addresses_updates_shared_provider_registry() {
+        let registry = ProviderRegistry::local(&test_auth_config()).unwrap();
+        let service = AuthAdminService::with_provider_registry(registry.clone());
+        let generation = registry.acl_generation();
+
+        service
+            .update_global_white_remote_addresses(["10.10.*.*", "192.168.0.*"])
+            .unwrap();
+
+        assert!(registry.acl_generation() > generation);
+        assert!(registry.is_acl_white_remote_address(None, Some("10.10.1.2")).unwrap());
+        assert!(registry.is_acl_white_remote_address(None, Some("192.168.0.7")).unwrap());
+        assert!(!registry.is_acl_white_remote_address(None, Some("172.16.0.7")).unwrap());
+    }
+
+    #[test]
+    fn update_global_white_remote_addresses_rejects_empty_values() {
+        let service = AuthAdminService::new(test_auth_config()).unwrap();
+
+        let error = service.update_global_white_remote_addresses([" ", ""]).unwrap_err();
+
+        assert!(matches!(error, RocketMQError::IllegalArgument(_)));
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -39,6 +39,7 @@ use crate::processor::admin_broker_processor::topic_request_handler::TopicReques
 use crate::processor::admin_broker_processor::update_acl_request_handler::UpdateAclRequestHandler;
 use crate::processor::admin_broker_processor::update_broker_ha_handler::UpdateBrokerHaHandler;
 use crate::processor::admin_broker_processor::update_cold_data_flow_ctr_group_config::UpdateColdDataFlowCtrGroupConfigRequestHandler;
+use crate::processor::admin_broker_processor::update_global_white_addrs_config_request_handler::UpdateGlobalWhiteAddrsConfigRequestHandler;
 use crate::processor::admin_broker_processor::update_user_request_handler::UpdateUserRequestHandler;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
@@ -76,6 +77,7 @@ mod topic_request_handler;
 mod update_acl_request_handler;
 mod update_broker_ha_handler;
 mod update_cold_data_flow_ctr_group_config;
+mod update_global_white_addrs_config_request_handler;
 mod update_user_request_handler;
 
 pub struct AdminBrokerProcessor<MS: MessageStore> {
@@ -105,6 +107,7 @@ pub struct AdminBrokerProcessor<MS: MessageStore> {
     get_user_request_handler: GetUserRequestHandler<MS>,
     delete_acl_request_handler: DeleteAclRequestHandler<MS>,
     list_acl_request_handler: ListAclRequestHandler<MS>,
+    update_global_white_addrs_config_request_handler: UpdateGlobalWhiteAddrsConfigRequestHandler<MS>,
     update_cold_data_flow_ctr_group_config_request_handler: UpdateColdDataFlowCtrGroupConfigRequestHandler<MS>,
     get_broker_ha_status_handler: GetBrokerHaStatusHandler<MS>,
     broker_stats_handler: BrokerStatsHandler<MS>,
@@ -167,7 +170,10 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
             GetUserRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
         let delete_acl_request_handler =
             DeleteAclRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
-        let list_acl_request_handler = ListAclRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service);
+        let list_acl_request_handler =
+            ListAclRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service.clone());
+        let update_global_white_addrs_config_request_handler =
+            UpdateGlobalWhiteAddrsConfigRequestHandler::new(broker_runtime_inner.clone(), auth_admin_service);
         let update_cold_data_flow_ctr_group_config_request_handler =
             UpdateColdDataFlowCtrGroupConfigRequestHandler::new(broker_runtime_inner.clone());
         let get_broker_ha_status_handler = GetBrokerHaStatusHandler::new(broker_runtime_inner.clone());
@@ -198,6 +204,7 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
             get_user_request_handler,
             delete_acl_request_handler,
             list_acl_request_handler,
+            update_global_white_addrs_config_request_handler,
             update_cold_data_flow_ctr_group_config_request_handler,
             get_broker_ha_status_handler,
             broker_stats_handler,
@@ -482,10 +489,11 @@ impl<MS: MessageStore> AdminBrokerProcessor<MS> {
                 request_code,
                 "legacy broker ACL cluster info API is deprecated; use AuthListAcl instead",
             )),
-            RequestCode::UpdateGlobalWhiteAddrsConfig => Ok(get_legacy_acl_cmd_response(
-                request_code,
-                "global white address config API is not supported in the current auth runtime",
-            )),
+            RequestCode::UpdateGlobalWhiteAddrsConfig => {
+                self.update_global_white_addrs_config_request_handler
+                    .update_global_white_addrs_config(channel, ctx, request_code, request)
+                    .await
+            }
             RequestCode::ResumeCheckHalfMessage => {
                 self.message_related_handler
                     .resume_check_half_message(channel, ctx, request_code, request)

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
@@ -1,0 +1,219 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::code::response_code::ResponseCode;
+use rocketmq_remoting::net::channel::Channel;
+use rocketmq_remoting::protocol::header::update_global_white_addrs_config_request_header::UpdateGlobalWhiteAddrsConfigRequestHeader;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_store::base::message_store::MessageStore;
+
+use crate::auth::auth_admin_service::AuthAdminService;
+use crate::broker_runtime::BrokerRuntimeInner;
+
+#[derive(Clone)]
+pub struct UpdateGlobalWhiteAddrsConfigRequestHandler<MS: MessageStore> {
+    _broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
+    auth_admin_service: Arc<AuthAdminService>,
+}
+
+impl<MS: MessageStore> UpdateGlobalWhiteAddrsConfigRequestHandler<MS> {
+    pub fn new(
+        broker_runtime_inner: rocketmq_rust::ArcMut<BrokerRuntimeInner<MS>>,
+        auth_admin_service: Arc<AuthAdminService>,
+    ) -> Self {
+        Self {
+            _broker_runtime_inner: broker_runtime_inner,
+            auth_admin_service,
+        }
+    }
+
+    pub async fn update_global_white_addrs_config(
+        &mut self,
+        _channel: Channel,
+        _ctx: rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext,
+        _request_code: RequestCode,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let request_header = request.decode_command_custom_header::<UpdateGlobalWhiteAddrsConfigRequestHeader>()?;
+        let response = RemotingCommand::create_response_command();
+        let global_white_addrs = parse_global_white_addrs(request_header.global_white_addrs.as_str());
+
+        if global_white_addrs.is_empty() {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::InvalidParameter)
+                    .set_remark("The globalWhiteAddrs is blank"),
+            ));
+        }
+
+        if self.is_not_super_user_login(request).await? {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::NoPermission)
+                    .set_remark("Global white addresses can only be updated by super user"),
+            ));
+        }
+
+        match self
+            .auth_admin_service
+            .update_global_white_remote_addresses(global_white_addrs)
+        {
+            Ok(_) => Ok(Some(response.set_code(ResponseCode::Success))),
+            Err(error) => Ok(Some(map_error_response(response, error))),
+        }
+    }
+
+    async fn is_not_super_user_login(&self, request: &RemotingCommand) -> rocketmq_error::RocketMQResult<bool> {
+        let Some(access_key) = request
+            .ext_fields()
+            .and_then(|fields| fields.get(&CheetahString::from_static_str("AccessKey")))
+        else {
+            return Ok(false);
+        };
+
+        Ok(!self.auth_admin_service.is_super_user(access_key.as_str()).await?)
+    }
+}
+
+fn parse_global_white_addrs(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|address| !address.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
+    match error {
+        RocketMQError::IllegalArgument(message) => {
+            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
+        }
+        RocketMQError::BrokerPermissionDenied { operation } => {
+            response.set_code(ResponseCode::NoPermission).set_remark(operation)
+        }
+        other => response
+            .set_code(ResponseCode::SystemError)
+            .set_remark(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::SystemTime;
+
+    use rocketmq_auth::config::AuthConfig;
+    use rocketmq_auth::ProviderRegistry;
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_remoting::base::response_future::ResponseFuture;
+    use rocketmq_remoting::connection::Connection;
+    use rocketmq_remoting::net::channel::ChannelInner;
+    use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
+    use rocketmq_rust::ArcMut;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+
+    use super::*;
+    use crate::broker_runtime::BrokerRuntime;
+
+    fn temp_test_root(label: &str) -> std::path::PathBuf {
+        let millis = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_millis();
+        std::env::temp_dir().join(format!("rocketmq-rust-admin-global-white-{label}-{millis}"))
+    }
+
+    async fn new_test_runtime(label: &str) -> BrokerRuntime {
+        let temp_root = temp_test_root(label);
+        let broker_config = Arc::new(BrokerConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            auth_config_path: temp_root.join("auth.json").to_string_lossy().into_owned().into(),
+            ..BrokerConfig::default()
+        });
+        let message_store_config = Arc::new(MessageStoreConfig {
+            store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
+            ..MessageStoreConfig::default()
+        });
+        let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+        assert!(runtime.initialize().await);
+        runtime
+    }
+
+    async fn create_test_channel() -> Channel {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
+        let local_addr = listener.local_addr().expect("local listener addr");
+        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
+        std_stream.set_nonblocking(true).expect("set nonblocking");
+        drop(listener);
+        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
+        let connection = Connection::new(tcp_stream);
+        let response_table = ArcMut::new(HashMap::<i32, ResponseFuture>::new());
+        let inner = ArcMut::new(ChannelInner::new(connection, response_table));
+        Channel::new(inner, local_addr, local_addr)
+    }
+
+    #[test]
+    fn parse_global_white_addrs_splits_comma_values() {
+        assert_eq!(
+            parse_global_white_addrs("10.10.*.*, 192.168.0.* ,,172.16.1.1"),
+            vec!["10.10.*.*", "192.168.0.*", "172.16.1.1"]
+        );
+    }
+
+    #[tokio::test]
+    async fn update_global_white_addrs_config_updates_runtime_snapshot() {
+        let mut runtime = new_test_runtime("update").await;
+        let inner = runtime.inner_for_test().clone();
+        let provider_registry = ProviderRegistry::local(&AuthConfig {
+            auth_config_path: inner.broker_config().auth_config_path.clone(),
+            ..AuthConfig::default()
+        })
+        .expect("create provider registry");
+        let auth_admin_service = Arc::new(AuthAdminService::with_provider_registry(provider_registry.clone()));
+        let mut handler = UpdateGlobalWhiteAddrsConfigRequestHandler::new(inner.clone(), auth_admin_service);
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::UpdateGlobalWhiteAddrsConfig,
+            UpdateGlobalWhiteAddrsConfigRequestHeader {
+                global_white_addrs: CheetahString::from_static_str("10.10.*.*,192.168.0.*"),
+            },
+        );
+        request.make_custom_header_to_net();
+
+        let response = handler
+            .update_global_white_addrs_config(channel, ctx, RequestCode::UpdateGlobalWhiteAddrsConfig, &mut request)
+            .await
+            .expect("request should be handled")
+            .expect("response should exist");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert!(provider_registry
+            .is_acl_white_remote_address(None, Some("10.10.1.2"))
+            .unwrap());
+        assert!(provider_registry
+            .is_acl_white_remote_address(None, Some("192.168.0.7"))
+            .unwrap());
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+}

--- a/rocketmq-remoting/src/protocol/header.rs
+++ b/rocketmq-remoting/src/protocol/header.rs
@@ -108,6 +108,7 @@ pub mod unlock_batch_mq_request_header;
 pub mod unregister_client_request_header;
 pub mod update_acl_request_header;
 pub mod update_consumer_offset_header;
+pub mod update_global_white_addrs_config_request_header;
 pub mod update_group_forbidden_request_header;
 pub mod update_user_request_header;
 pub mod view_broker_stats_data_request_header;

--- a/rocketmq-remoting/src/protocol/header/update_global_white_addrs_config_request_header.rs
+++ b/rocketmq-remoting/src/protocol/header/update_global_white_addrs_config_request_header.rs
@@ -1,0 +1,47 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV2;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateGlobalWhiteAddrsConfigRequestHeader {
+    pub global_white_addrs: CheetahString,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::protocol::command_custom_header::FromMap;
+
+    #[test]
+    fn update_global_white_addrs_config_request_header_deserializes_from_map() {
+        let mut map = HashMap::new();
+        map.insert(
+            CheetahString::from_static_str("globalWhiteAddrs"),
+            CheetahString::from_static_str("10.10.*.*,192.168.0.*"),
+        );
+
+        let header = <UpdateGlobalWhiteAddrsConfigRequestHeader as FromMap>::from(&map).expect("header from map");
+        assert_eq!(
+            header.global_white_addrs,
+            CheetahString::from_static_str("10.10.*.*,192.168.0.*")
+        );
+    }
+}

--- a/rocketmq-remoting/src/protocol/headers.rs
+++ b/rocketmq-remoting/src/protocol/headers.rs
@@ -147,6 +147,7 @@ pub mod admin {
     pub use super::super::header::get_topic_stats_info_request_header::GetTopicStatsInfoRequestHeader;
     pub use super::super::header::get_topic_stats_request_header::GetTopicStatsRequestHeader;
     pub use super::super::header::remove_broker_request_header::RemoveBrokerRequestHeader;
+    pub use super::super::header::update_global_white_addrs_config_request_header::UpdateGlobalWhiteAddrsConfigRequestHeader;
 }
 
 pub mod transaction {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7367

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IP allowlisting functionality with support for both global and per-account patterns
  * Runtime capability to update global IP allowlist without requiring broker restart
  * New admin API endpoint for managing global white remote addresses dynamically
  * Advanced pattern matching including brace expansion support for IPv4 and IPv6 addresses
  * IP validation that preserves per-account whitelist patterns when updating global settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->