### PR TITLE
[ISSUE #7369]🚀add FileAclConfigStore for managing global white remote addresses with persistence and validation

### DIFF
--- a/rocketmq-auth/src/acl.rs
+++ b/rocketmq-auth/src/acl.rs
@@ -23,5 +23,6 @@ pub use crate::migration::alc::plain_access_config::PlainAccessConfig;
 pub use crate::migration::alc::plain_access_data::PlainAccessData;
 pub use loader::AclConfigFingerprint;
 pub use loader::FileAclConfigLoader;
+pub use loader::FileAclConfigStore;
 pub use validator::validate_acl_config;
 pub use white_list::WhiteList;

--- a/rocketmq-auth/src/acl/loader.rs
+++ b/rocketmq-auth/src/acl/loader.rs
@@ -19,6 +19,7 @@ use std::hash::Hasher;
 use std::path::Path;
 use std::path::PathBuf;
 
+use cheetah_string::CheetahString;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use tokio::fs;
@@ -31,6 +32,11 @@ use crate::migration::alc::plain_access_data::PlainAccessData;
 #[derive(Clone, Debug)]
 pub struct FileAclConfigLoader {
     roots: Vec<PathBuf>,
+}
+
+#[derive(Clone, Debug)]
+pub struct FileAclConfigStore {
+    file: PathBuf,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -72,6 +78,93 @@ impl FileAclConfigLoader {
         tokio::task::spawn_blocking(move || discover_acl_files(&roots))
             .await
             .map_err(|error| RocketMQError::Internal(format!("acl file discovery task failed: {error}")))?
+    }
+}
+
+impl FileAclConfigStore {
+    pub fn new(file: impl Into<PathBuf>) -> Self {
+        Self { file: file.into() }
+    }
+
+    pub async fn update_global_white_remote_addresses<I, S>(&self, addresses: I) -> RocketMQResult<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let addresses: Vec<_> = addresses
+            .into_iter()
+            .map(|address| address.as_ref().trim().to_owned())
+            .filter(|address| !address.is_empty())
+            .map(CheetahString::from)
+            .collect();
+        if addresses.is_empty() {
+            return Err(RocketMQError::illegal_argument("The globalWhiteAddrs is blank"));
+        }
+
+        let mut data = self.load_plain_access_data().await?;
+        data.set_global_white_remote_addresses(addresses);
+        self.write_plain_access_data(&data).await
+    }
+
+    async fn load_plain_access_data(&self) -> RocketMQResult<PlainAccessData> {
+        let bytes = match fs::read(&self.file).await {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(PlainAccessData::default()),
+            Err(error) => {
+                return Err(RocketMQError::StorageReadFailed {
+                    path: self.file.display().to_string(),
+                    reason: error.to_string(),
+                });
+            }
+        };
+
+        if bytes.iter().all(u8::is_ascii_whitespace) {
+            return Ok(PlainAccessData::default());
+        }
+
+        serde_yaml::from_slice(&bytes)
+            .map_err(|error| RocketMQError::deserialization_failed("YAML", format!("{}: {error}", self.file.display())))
+    }
+
+    async fn write_plain_access_data(&self, data: &PlainAccessData) -> RocketMQResult<()> {
+        let content = serde_yaml::to_string(data).map_err(|error| {
+            RocketMQError::Serialization(rocketmq_error::SerializationError::encode_failed(
+                "YAML",
+                error.to_string(),
+            ))
+        })?;
+
+        if let Some(parent) = self.file.parent() {
+            fs::create_dir_all(parent).await.map_err(|error| {
+                RocketMQError::storage_write_failed(parent.display().to_string(), error.to_string())
+            })?;
+        }
+
+        if fs::metadata(&self.file).await.is_ok() {
+            let backup = backup_file_path(&self.file);
+            fs::copy(&self.file, &backup).await.map_err(|error| {
+                RocketMQError::storage_write_failed(backup.display().to_string(), error.to_string())
+            })?;
+        }
+
+        let temp_file = temp_file_path(&self.file);
+        fs::write(&temp_file, content)
+            .await
+            .map_err(|error| RocketMQError::storage_write_failed(temp_file.display().to_string(), error.to_string()))?;
+
+        match fs::rename(&temp_file, &self.file).await {
+            Ok(()) => Ok(()),
+            Err(rename_error) => {
+                fs::copy(&temp_file, &self.file).await.map_err(|error| {
+                    RocketMQError::storage_write_failed(
+                        self.file.display().to_string(),
+                        format!("{error}; rename failed first: {rename_error}"),
+                    )
+                })?;
+                let _ = fs::remove_file(&temp_file).await;
+                Ok(())
+            }
+        }
     }
 }
 
@@ -178,6 +271,24 @@ fn is_acl_yaml(path: &Path) -> bool {
     path.file_name()
         .and_then(|value| value.to_str())
         .is_none_or(|file_name| !file_name.eq_ignore_ascii_case("tools.yml"))
+}
+
+fn backup_file_path(path: &Path) -> PathBuf {
+    let mut backup = path.as_os_str().to_os_string();
+    backup.push(".bak");
+    PathBuf::from(backup)
+}
+
+fn temp_file_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("plain_acl.yml");
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    path.with_file_name(format!(".{file_name}.{}.tmp", nanos))
 }
 
 #[cfg(test)]
@@ -316,5 +427,61 @@ accounts:
 
         assert!(error.to_string().contains("secretKey must not be blank"));
         assert!(!error.to_string().contains("secret="));
+    }
+
+    #[tokio::test]
+    async fn store_updates_global_white_remote_addresses_and_preserves_accounts() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("plain_acl.yml");
+        fs::write(
+            &file,
+            r#"
+globalWhiteRemoteAddresses:
+  - 10.10.*.*
+accounts:
+  - accessKey: ak
+    secretKey: sk
+    defaultTopicPerm: PUB
+"#,
+        )
+        .unwrap();
+
+        FileAclConfigStore::new(&file)
+            .update_global_white_remote_addresses(["172.16.*.*", "192.168.0.*"])
+            .await
+            .unwrap();
+
+        let content = fs::read_to_string(&file).unwrap();
+        let data: PlainAccessData = serde_yaml::from_str(&content).unwrap();
+        assert_eq!(
+            data.global_white_remote_addresses(),
+            &[
+                CheetahString::from_static_str("172.16.*.*"),
+                CheetahString::from_static_str("192.168.0.*")
+            ]
+        );
+        assert_eq!(data.accounts().len(), 1);
+        assert_eq!(data.accounts()[0].access_key().unwrap().as_str(), "ak");
+        assert_eq!(data.accounts()[0].secret_key().unwrap().as_str(), "sk");
+        assert!(content.contains("globalWhiteRemoteAddresses"));
+        assert!(content.contains("accessKey"));
+    }
+
+    #[tokio::test]
+    async fn store_creates_missing_acl_file_for_global_white_remote_addresses() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("conf").join("plain_acl.yml");
+
+        FileAclConfigStore::new(&file)
+            .update_global_white_remote_addresses(["10.10.*.*"])
+            .await
+            .unwrap();
+
+        let data: PlainAccessData = serde_yaml::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+        assert_eq!(
+            data.global_white_remote_addresses(),
+            &[CheetahString::from_static_str("10.10.*.*")]
+        );
+        assert!(data.accounts().is_empty());
     }
 }

--- a/rocketmq-auth/src/runtime.rs
+++ b/rocketmq-auth/src/runtime.rs
@@ -234,6 +234,10 @@ pub struct AuthRuntime {
 }
 
 impl AuthRuntime {
+    pub fn config(&self) -> &AuthConfig {
+        &self.config
+    }
+
     pub fn provider_registry(&self) -> &ProviderRegistry {
         &self.provider_registry
     }

--- a/rocketmq-broker/src/auth/auth_admin_service.rs
+++ b/rocketmq-broker/src/auth/auth_admin_service.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use rocketmq_auth::acl::FileAclConfigStore;
 use rocketmq_auth::authentication::enums::subject_type::SubjectType;
 use rocketmq_auth::authentication::enums::user_type::UserType;
 use rocketmq_auth::authentication::model::subject::Subject;
@@ -24,6 +25,7 @@ use crate::auth::user_converter::UserConverter;
 
 #[derive(Clone)]
 pub struct AuthAdminService {
+    auth_config: AuthConfig,
     provider_registry: ProviderRegistry,
     authentication_provider: Arc<LocalAuthenticationMetadataProvider>,
     authorization_provider: Arc<LocalAuthorizationMetadataProvider>,
@@ -32,11 +34,16 @@ pub struct AuthAdminService {
 impl AuthAdminService {
     pub fn new(auth_config: AuthConfig) -> Result<Self, RocketMQError> {
         let provider_registry = ProviderRegistry::local(&auth_config)?;
-        Ok(Self::with_provider_registry(provider_registry))
+        Ok(Self::with_provider_registry_and_config(provider_registry, auth_config))
     }
 
     pub fn with_provider_registry(provider_registry: ProviderRegistry) -> Self {
+        Self::with_provider_registry_and_config(provider_registry, AuthConfig::default())
+    }
+
+    pub fn with_provider_registry_and_config(provider_registry: ProviderRegistry, auth_config: AuthConfig) -> Self {
         Self {
+            auth_config,
             provider_registry: provider_registry.clone(),
             authentication_provider: provider_registry.authentication_metadata_provider(),
             authorization_provider: provider_registry.authorization_metadata_provider(),
@@ -191,7 +198,7 @@ impl AuthAdminService {
             .is_some_and(|user_type| user_type == UserType::Super))
     }
 
-    pub fn update_global_white_remote_addresses<I, S>(&self, addresses: I) -> RocketMQResult<u64>
+    pub async fn update_global_white_remote_addresses<I, S>(&self, addresses: I) -> RocketMQResult<u64>
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
@@ -203,6 +210,13 @@ impl AuthAdminService {
             .collect();
         if addresses.is_empty() {
             return Err(RocketMQError::illegal_argument("The globalWhiteAddrs is blank"));
+        }
+
+        let acl_file = self.auth_config.acl_file.as_str().trim();
+        if !acl_file.is_empty() {
+            FileAclConfigStore::new(acl_file)
+                .update_global_white_remote_addresses(&addresses)
+                .await?;
         }
 
         self.provider_registry.update_global_white_remote_addresses(addresses)
@@ -375,6 +389,14 @@ mod tests {
         }
     }
 
+    fn temp_test_root(label: &str) -> std::path::PathBuf {
+        let millis = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_millis();
+        std::env::temp_dir().join(format!("rocketmq-rust-auth-admin-service-{label}-{millis}"))
+    }
+
     #[tokio::test]
     async fn create_get_list_update_delete_user_round_trip() {
         let service = AuthAdminService::new(test_auth_config()).unwrap();
@@ -540,6 +562,7 @@ mod tests {
 
         service
             .update_global_white_remote_addresses(["10.10.*.*", "192.168.0.*"])
+            .await
             .unwrap();
 
         assert!(registry.acl_generation() > generation);
@@ -548,12 +571,75 @@ mod tests {
         assert!(!registry.is_acl_white_remote_address(None, Some("172.16.0.7")).unwrap());
     }
 
-    #[test]
-    fn update_global_white_remote_addresses_rejects_empty_values() {
+    #[tokio::test]
+    async fn update_global_white_remote_addresses_rejects_empty_values() {
         let service = AuthAdminService::new(test_auth_config()).unwrap();
 
-        let error = service.update_global_white_remote_addresses([" ", ""]).unwrap_err();
+        let error = service
+            .update_global_white_remote_addresses([" ", ""])
+            .await
+            .unwrap_err();
 
         assert!(matches!(error, RocketMQError::IllegalArgument(_)));
+    }
+
+    #[tokio::test]
+    async fn update_global_white_remote_addresses_persists_configured_acl_file_before_snapshot() {
+        let temp_root = temp_test_root("global-white-persist");
+        std::fs::create_dir_all(&temp_root).unwrap();
+        let acl_file = temp_root.join("plain_acl.yml");
+        std::fs::write(
+            &acl_file,
+            r#"
+globalWhiteRemoteAddresses:
+  - 10.10.*.*
+accounts:
+  - accessKey: alice
+    secretKey: secret
+"#,
+        )
+        .unwrap();
+        let auth_config = AuthConfig {
+            auth_config_path: CheetahString::from_string(temp_root.join("auth.json").to_string_lossy().into_owned()),
+            acl_file: CheetahString::from_string(acl_file.to_string_lossy().into_owned()),
+            ..AuthConfig::default()
+        };
+        let registry = ProviderRegistry::local(&auth_config).unwrap();
+        let service = AuthAdminService::with_provider_registry_and_config(registry.clone(), auth_config);
+
+        service
+            .update_global_white_remote_addresses(["172.16.*.*"])
+            .await
+            .unwrap();
+
+        let content = std::fs::read_to_string(&acl_file).unwrap();
+        assert!(content.contains("globalWhiteRemoteAddresses"));
+        assert!(content.contains("172.16.*.*"));
+        assert!(content.contains("accessKey"));
+        assert!(registry.is_acl_white_remote_address(None, Some("172.16.1.2")).unwrap());
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn update_global_white_remote_addresses_keeps_snapshot_when_acl_file_persist_fails() {
+        let temp_root = temp_test_root("global-white-persist-fails");
+        std::fs::create_dir_all(&temp_root).unwrap();
+        let auth_config = AuthConfig {
+            auth_config_path: CheetahString::from_string(temp_root.join("auth.json").to_string_lossy().into_owned()),
+            acl_file: CheetahString::from_string(temp_root.to_string_lossy().into_owned()),
+            ..AuthConfig::default()
+        };
+        let registry = ProviderRegistry::local(&auth_config).unwrap();
+        let service = AuthAdminService::with_provider_registry_and_config(registry.clone(), auth_config);
+        let generation = registry.acl_generation();
+
+        service
+            .update_global_white_remote_addresses(["172.16.*.*"])
+            .await
+            .expect_err("directory acl_file path should fail persistence");
+
+        assert_eq!(registry.acl_generation(), generation);
+        assert!(!registry.is_acl_white_remote_address(None, Some("172.16.1.2")).unwrap());
+        let _ = std::fs::remove_dir_all(temp_root);
     }
 }

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -889,7 +889,10 @@ impl BrokerRuntime {
             ))),
         );
         let auth_admin_service = Arc::new(match &self.inner.auth_runtime {
-            Some(auth_runtime) => AuthAdminService::with_provider_registry(auth_runtime.provider_registry().clone()),
+            Some(auth_runtime) => AuthAdminService::with_provider_registry_and_config(
+                auth_runtime.provider_registry().clone(),
+                auth_runtime.config().clone(),
+            ),
             None => AuthAdminService::new(build_auth_config(self.inner.broker_config()))
                 .expect("broker auth admin service initialization must succeed"),
         });

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
@@ -73,6 +73,7 @@ impl<MS: MessageStore> UpdateGlobalWhiteAddrsConfigRequestHandler<MS> {
         match self
             .auth_admin_service
             .update_global_white_remote_addresses(global_white_addrs)
+            .await
         {
             Ok(_) => Ok(Some(response.set_code(ResponseCode::Success))),
             Err(error) => Ok(Some(map_error_response(response, error))),


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7369

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file-based persistence for global white remote address configurations in ACL settings.
  * Introduced automatic backup creation and atomic write operations for configuration file updates to ensure data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->