### PR TITLE
[ISSUE #7373]🚀add data version management for global white remote addresses and refactor error response handling

### DIFF
--- a/rocketmq-auth/src/acl/loader.rs
+++ b/rocketmq-auth/src/acl/loader.rs
@@ -27,6 +27,7 @@ use tokio::fs;
 use crate::acl::validator::validate_acl_config;
 use crate::migration::alc::acl_config::AclConfig;
 use crate::migration::alc::plain_access_config::PlainAccessConfig;
+use crate::migration::alc::plain_access_data::DataVersion;
 use crate::migration::alc::plain_access_data::PlainAccessData;
 
 #[derive(Clone, Debug)]
@@ -103,6 +104,7 @@ impl FileAclConfigStore {
 
         let mut data = self.load_plain_access_data().await?;
         data.set_global_white_remote_addresses(addresses);
+        bump_data_version(&mut data);
         self.write_plain_access_data(&data).await
     }
 
@@ -289,6 +291,22 @@ fn temp_file_path(path: &Path) -> PathBuf {
         .map(|duration| duration.as_nanos())
         .unwrap_or_default();
     path.with_file_name(format!(".{file_name}.{}.tmp", nanos))
+}
+
+fn bump_data_version(data: &mut PlainAccessData) {
+    let counter = data
+        .latest_version()
+        .map_or(1, |version| version.counter.saturating_add(1));
+    data.set_data_version(vec![DataVersion {
+        timestamp: current_time_millis(),
+        counter,
+    }]);
+}
+
+fn current_time_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
 }
 
 #[cfg(test)]
@@ -483,5 +501,51 @@ accounts:
             &[CheetahString::from_static_str("10.10.*.*")]
         );
         assert!(data.accounts().is_empty());
+    }
+
+    #[tokio::test]
+    async fn store_bumps_data_version_when_global_white_remote_addresses_change() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("plain_acl.yml");
+        fs::write(
+            &file,
+            r#"
+globalWhiteRemoteAddresses:
+  - 10.10.*.*
+dataVersion:
+  - timestamp: 100
+    counter: 7
+accounts:
+  - accessKey: ak
+    secretKey: sk
+"#,
+        )
+        .unwrap();
+
+        FileAclConfigStore::new(&file)
+            .update_global_white_remote_addresses(["172.16.*.*"])
+            .await
+            .unwrap();
+
+        let data: PlainAccessData = serde_yaml::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+        let version = data.latest_version().unwrap();
+        assert_eq!(version.counter, 8);
+        assert!(version.timestamp > 100);
+    }
+
+    #[tokio::test]
+    async fn store_creates_data_version_when_missing() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("plain_acl.yml");
+
+        FileAclConfigStore::new(&file)
+            .update_global_white_remote_addresses(["10.10.*.*"])
+            .await
+            .unwrap();
+
+        let data: PlainAccessData = serde_yaml::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+        let version = data.latest_version().unwrap();
+        assert_eq!(version.counter, 1);
+        assert!(version.timestamp > 0);
     }
 }

--- a/rocketmq-auth/src/authentication/provider/local_authentication_metadata_provider.rs
+++ b/rocketmq-auth/src/authentication/provider/local_authentication_metadata_provider.rs
@@ -17,34 +17,27 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::future::Future;
+use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_error::SerializationError;
+use tokio::fs;
 
 use crate::authentication::model::user::User;
 use crate::config::AuthConfig;
 
 use super::authentication_metadata_provider::AuthenticationMetadataProvider;
 
-/// Column family name for authentication metadata in RocksDB.
-const AUTH_METADATA_COLUMN_FAMILY: &str = "default";
-
-/// Empty user marker (sentinel value for cache).
-const EMPTY_USER_MARKER: &str = "__EMPTY_USER__";
-
-/// Local authentication metadata provider using in-memory storage.
-///
-/// Note: This is a simplified implementation using HashMap instead of RocksDB.
-/// For production use, consider implementing RocksDB storage.
+/// Local authentication metadata provider backed by an in-memory snapshot and an
+/// optional JSON snapshot file.
 pub struct LocalAuthenticationMetadataProvider {
-    /// In-memory user storage (simplified implementation).
     storage: Arc<tokio::sync::RwLock<HashMap<String, User>>>,
-
-    /// Storage path (for future RocksDB implementation).
     storage_path: Option<PathBuf>,
+    write_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl LocalAuthenticationMetadataProvider {
@@ -53,13 +46,44 @@ impl LocalAuthenticationMetadataProvider {
         Self {
             storage: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             storage_path: None,
+            write_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
-    /// Get user from storage.
-    async fn get_user_from_storage(&self, username: &str) -> RocketMQResult<Option<User>> {
-        let storage = self.storage.read().await;
-        Ok(storage.get(username).cloned())
+    pub fn with_config(config: &AuthConfig) -> RocketMQResult<Self> {
+        let storage_path = auth_metadata_snapshot_path(config, "users.json");
+        let users = match &storage_path {
+            Some(path) => read_users_snapshot_blocking(path)?,
+            None => HashMap::new(),
+        };
+        Ok(Self {
+            storage: Arc::new(tokio::sync::RwLock::new(users)),
+            storage_path,
+            write_lock: Arc::new(tokio::sync::Mutex::new(())),
+        })
+    }
+
+    async fn persist_users(&self, users: &HashMap<String, User>) -> RocketMQResult<()> {
+        let Some(path) = &self.storage_path else {
+            return Ok(());
+        };
+        write_users_snapshot(path, users).await
+    }
+
+    async fn mutate_users<F>(&self, mutation: F) -> RocketMQResult<()>
+    where
+        F: FnOnce(&mut HashMap<String, User>) -> RocketMQResult<()>,
+    {
+        let _write_guard = self.write_lock.lock().await;
+        let mut snapshot = {
+            let storage = self.storage.read().await;
+            storage.clone()
+        };
+        mutation(&mut snapshot)?;
+        self.persist_users(&snapshot).await?;
+        let mut storage = self.storage.write().await;
+        *storage = snapshot;
+        Ok(())
     }
 }
 
@@ -77,15 +101,18 @@ impl AuthenticationMetadataProvider for LocalAuthenticationMetadataProvider {
         _metadata_service: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Pin<Box<dyn Future<Output = RocketMQResult<()>> + Send + 'a>> {
         Box::pin(async move {
-            // Build storage path
-            let mut storage_path = PathBuf::from(config.auth_config_path.to_string());
-            storage_path.push("users");
-            self.storage_path = Some(storage_path.clone());
-
-            tracing::info!(
-                "LocalAuthenticationMetadataProvider initialized (in-memory mode) at {:?}",
-                storage_path
-            );
+            let storage_path = auth_metadata_snapshot_path(&config, "users.json");
+            let users = if let Some(path) = storage_path.clone() {
+                let users = read_users_snapshot(&path).await?;
+                tracing::info!("LocalAuthenticationMetadataProvider initialized at {:?}", path);
+                users
+            } else {
+                tracing::info!("LocalAuthenticationMetadataProvider initialized in memory-only mode");
+                HashMap::new()
+            };
+            let mut storage = self.storage.write().await;
+            *storage = users;
+            self.storage_path = storage_path;
             Ok(())
         })
     }
@@ -104,8 +131,16 @@ impl AuthenticationMetadataProvider for LocalAuthenticationMetadataProvider {
     fn create_user<'a>(&'a self, user: User) -> Pin<Box<dyn Future<Output = RocketMQResult<()>> + Send + 'a>> {
         Box::pin(async move {
             let username = user.username().to_string();
-            let mut storage = self.storage.write().await;
-            storage.insert(username.clone(), user);
+            self.mutate_users(|storage| {
+                if storage.contains_key(&username) {
+                    return Err(RocketMQError::authentication_failed(format!(
+                        "The user already exists: {username}"
+                    )));
+                }
+                storage.insert(username.clone(), user);
+                Ok(())
+            })
+            .await?;
 
             tracing::info!("User '{}' created successfully", username);
             Ok(())
@@ -115,8 +150,11 @@ impl AuthenticationMetadataProvider for LocalAuthenticationMetadataProvider {
     /// Delete a user.
     fn delete_user<'a>(&'a self, username: &'a str) -> Pin<Box<dyn Future<Output = RocketMQResult<()>> + Send + 'a>> {
         Box::pin(async move {
-            let mut storage = self.storage.write().await;
-            storage.remove(username);
+            self.mutate_users(|storage| {
+                storage.remove(username);
+                Ok(())
+            })
+            .await?;
 
             tracing::info!("User '{}' deleted successfully", username);
             Ok(())
@@ -127,8 +165,11 @@ impl AuthenticationMetadataProvider for LocalAuthenticationMetadataProvider {
     fn update_user<'a>(&'a self, user: User) -> Pin<Box<dyn Future<Output = RocketMQResult<()>> + Send + 'a>> {
         Box::pin(async move {
             let username = user.username().to_string();
-            let mut storage = self.storage.write().await;
-            storage.insert(username.clone(), user);
+            self.mutate_users(|storage| {
+                storage.insert(username.clone(), user);
+                Ok(())
+            })
+            .await?;
 
             tracing::info!("User '{}' updated successfully", username);
             Ok(())
@@ -173,9 +214,105 @@ impl AuthenticationMetadataProvider for LocalAuthenticationMetadataProvider {
     }
 }
 
+fn auth_metadata_snapshot_path(config: &AuthConfig, file_name: &str) -> Option<PathBuf> {
+    let raw_path = config.auth_config_path.as_str().trim();
+    if raw_path.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw_path);
+    let root = if path.extension().is_some() {
+        path.with_extension("")
+    } else {
+        path
+    };
+    Some(root.join(file_name))
+}
+
+async fn read_users_snapshot(path: &Path) -> RocketMQResult<HashMap<String, User>> {
+    let bytes = match fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
+        Err(error) => {
+            return Err(RocketMQError::storage_read_failed(
+                path.display().to_string(),
+                error.to_string(),
+            ))
+        }
+    };
+    decode_users_snapshot(path, &bytes)
+}
+
+fn read_users_snapshot_blocking(path: &Path) -> RocketMQResult<HashMap<String, User>> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
+        Err(error) => {
+            return Err(RocketMQError::storage_read_failed(
+                path.display().to_string(),
+                error.to_string(),
+            ))
+        }
+    };
+    decode_users_snapshot(path, &bytes)
+}
+
+fn decode_users_snapshot(path: &Path, bytes: &[u8]) -> RocketMQResult<HashMap<String, User>> {
+    if bytes.iter().all(u8::is_ascii_whitespace) {
+        return Ok(HashMap::new());
+    }
+    serde_json::from_slice(bytes)
+        .map_err(|error| RocketMQError::deserialization_failed("JSON", format!("{}: {error}", path.display())))
+}
+
+async fn write_users_snapshot(path: &Path, users: &HashMap<String, User>) -> RocketMQResult<()> {
+    let content = serde_json::to_vec_pretty(users)
+        .map_err(|error| RocketMQError::Serialization(SerializationError::encode_failed("JSON", error.to_string())))?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .map_err(|error| RocketMQError::storage_write_failed(parent.display().to_string(), error.to_string()))?;
+    }
+
+    let temp_file = temp_snapshot_path(path);
+    fs::write(&temp_file, content)
+        .await
+        .map_err(|error| RocketMQError::storage_write_failed(temp_file.display().to_string(), error.to_string()))?;
+
+    match fs::rename(&temp_file, path).await {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            fs::copy(&temp_file, path).await.map_err(|error| {
+                RocketMQError::storage_write_failed(
+                    path.display().to_string(),
+                    format!("{error}; rename failed first: {rename_error}"),
+                )
+            })?;
+            let _ = fs::remove_file(&temp_file).await;
+            Ok(())
+        }
+    }
+}
+
+fn temp_snapshot_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("users.json");
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    path.with_file_name(format!(".{file_name}.{nanos}.tmp"))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use cheetah_string::CheetahString;
+    use tempfile::TempDir;
+
     use super::*;
+    use crate::authentication::enums::user_status::UserStatus;
 
     #[tokio::test]
     async fn test_local_provider_initialization() {
@@ -195,6 +332,26 @@ mod tests {
 
         let retrieved = provider.get_user("testuser").await.unwrap();
         assert_eq!(retrieved.username().to_string(), "testuser");
+    }
+
+    #[tokio::test]
+    async fn create_user_rejects_duplicate_without_overwriting_existing_secret() {
+        let mut provider = LocalAuthenticationMetadataProvider::new();
+        provider.initialize(AuthConfig::default(), None).await.unwrap();
+
+        provider
+            .create_user(User::of_with_password("duplicate", "first"))
+            .await
+            .unwrap();
+
+        let error = provider
+            .create_user(User::of_with_password("duplicate", "second"))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("already exists"));
+
+        let user = provider.get_user("duplicate").await.unwrap();
+        assert_eq!(user.password().map(|value| value.as_str()), Some("first"));
     }
 
     #[tokio::test]
@@ -239,5 +396,96 @@ mod tests {
 
         let filtered_users = provider.list_user(Some("user")).await.unwrap();
         assert_eq!(filtered_users.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn local_provider_persists_users_across_reinitialization() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from_string(temp.path().join("auth.json").to_string_lossy().into_owned()),
+            ..AuthConfig::default()
+        };
+
+        let mut provider = LocalAuthenticationMetadataProvider::new();
+        provider.initialize(config.clone(), None).await.unwrap();
+        let mut user = User::of_with_password("persisted", "secret");
+        user.set_user_status(UserStatus::Enable);
+        provider.create_user(user).await.unwrap();
+
+        let mut restarted = LocalAuthenticationMetadataProvider::new();
+        restarted.initialize(config, None).await.unwrap();
+        let restored = restarted.get_user("persisted").await.unwrap();
+
+        assert_eq!(restored.username().as_str(), "persisted");
+        assert_eq!(restored.password().map(|value| value.as_str()), Some("secret"));
+        assert_eq!(restored.user_status(), Some(UserStatus::Enable));
+    }
+
+    #[tokio::test]
+    async fn local_provider_persists_user_update_and_delete_across_reinitialization() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from_string(temp.path().join("auth.json").to_string_lossy().into_owned()),
+            ..AuthConfig::default()
+        };
+
+        let mut provider = LocalAuthenticationMetadataProvider::new();
+        provider.initialize(config.clone(), None).await.unwrap();
+        provider
+            .create_user(User::of_with_password("persisted", "first"))
+            .await
+            .unwrap();
+        provider
+            .update_user(User::of_with_password("persisted", "second"))
+            .await
+            .unwrap();
+
+        let mut restarted = LocalAuthenticationMetadataProvider::new();
+        restarted.initialize(config.clone(), None).await.unwrap();
+        let restored = restarted.get_user("persisted").await.unwrap();
+        assert_eq!(restored.password().map(|value| value.as_str()), Some("second"));
+
+        restarted.delete_user("persisted").await.unwrap();
+
+        let mut deleted_restart = LocalAuthenticationMetadataProvider::new();
+        deleted_restart.initialize(config, None).await.unwrap();
+        assert!(deleted_restart.get_user("persisted").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn local_provider_rejects_corrupted_user_snapshot() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from_string(temp.path().join("auth.json").to_string_lossy().into_owned()),
+            ..AuthConfig::default()
+        };
+        let snapshot = temp.path().join("auth").join("users.json");
+        fs::create_dir_all(snapshot.parent().unwrap()).unwrap();
+        fs::write(&snapshot, b"{not valid json").unwrap();
+
+        let mut provider = LocalAuthenticationMetadataProvider::new();
+        let error = provider.initialize(config, None).await.unwrap_err();
+
+        assert!(error.to_string().contains("users.json"));
+    }
+
+    #[tokio::test]
+    async fn initialize_without_storage_path_clears_previous_snapshot() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from_string(temp.path().join("auth.json").to_string_lossy().into_owned()),
+            ..AuthConfig::default()
+        };
+
+        let mut provider = LocalAuthenticationMetadataProvider::new();
+        provider.initialize(config, None).await.unwrap();
+        provider
+            .create_user(User::of_with_password("stale", "secret"))
+            .await
+            .unwrap();
+
+        provider.initialize(AuthConfig::default(), None).await.unwrap();
+
+        assert!(provider.get_user("stale").await.is_err());
     }
 }

--- a/rocketmq-auth/src/authorization/metadata_provider/local.rs
+++ b/rocketmq-auth/src/authorization/metadata_provider/local.rs
@@ -14,30 +14,44 @@
 
 //! Local authorization metadata provider implementation.
 //!
-//! This module provides a RocksDB-based implementation of the `AuthorizationMetadataProvider`
-//! trait for storing and retrieving ACL (Access Control List) metadata locally.
+//! This module provides a local implementation of the `AuthorizationMetadataProvider`
+//! trait for storing and retrieving ACL (Access Control List) metadata.
 
 use std::any::Any;
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::sync::RwLockReadGuard;
+use std::sync::RwLockWriteGuard;
 use std::time::Duration;
 
+use rocketmq_common::common::action::Action;
+use serde::Deserialize;
+use serde::Serialize;
 use tracing::debug;
 use tracing::warn;
 
+use crate::authentication::enums::subject_type::SubjectType;
 use crate::authentication::model::subject::Subject;
+use crate::authorization::enums::decision::Decision;
+use crate::authorization::enums::policy_type::PolicyType;
 use crate::authorization::metadata_provider::AuthorizationMetadataProvider;
 use crate::authorization::metadata_provider::MetadataResult;
 use crate::authorization::model::acl::Acl;
+use crate::authorization::model::environment::Environment;
+use crate::authorization::model::policy::Policy;
+use crate::authorization::model::policy_entry::PolicyEntry;
+use crate::authorization::model::resource::Resource;
 use crate::authorization::provider::AuthorizationError;
 use crate::config::AuthConfig;
 
-/// Local authorization metadata provider using RocksDB for persistent storage.
+/// Local authorization metadata provider backed by an in-memory snapshot and an optional JSON
+/// snapshot file.
 ///
 /// This provider implements ACL metadata storage with the following features:
-/// - Persistent storage using RocksDB
+/// - Persistent local snapshot storage when `auth_config_path` is configured
 /// - In-memory caching for performance
 /// - Thread-safe operations
 /// - Automatic cache invalidation on updates
@@ -46,16 +60,15 @@ use crate::config::AuthConfig;
 ///
 /// ```text
 /// LocalAuthorizationMetadataProvider
-/// ├── RocksDB Storage (persistent)
-/// │   └── Column Family: acls
-/// │       └── Key: subject_key → Value: ACL (JSON)
-/// └── Cache (in-memory)
-///     └── LRU cache with TTL
+/// |- JSON snapshot file (persistent, optional)
+/// |  `- acls.json
+/// `- Cache (in-memory)
+///    `- subject_key -> ACL
 /// ```
 ///
 /// # Storage Format
 ///
-/// ACLs are stored in RocksDB with the following layout:
+/// ACLs are stored in a JSON snapshot with the following layout:
 /// - **Key**: Subject key (e.g., "User:alice", "Role:admin")
 /// - **Value**: JSON-serialized ACL object
 ///
@@ -79,8 +92,9 @@ use crate::config::AuthConfig;
 /// provider.initialize(config, None)?;
 /// ```
 pub struct LocalAuthorizationMetadataProvider {
-    /// Path to RocksDB storage directory
+    /// Path to the JSON snapshot file.
     storage_path: Option<PathBuf>,
+    storage: Arc<RwLock<HashMap<String, Acl>>>,
 
     /// In-memory ACL cache (subject_key -> ACL)
     /// Using RwLock for thread-safe access
@@ -91,6 +105,7 @@ pub struct LocalAuthorizationMetadataProvider {
 
     /// Initialization state
     initialized: Arc<RwLock<bool>>,
+    write_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 /// Cached ACL entry with expiration
@@ -143,130 +158,65 @@ impl Default for CacheConfig {
     }
 }
 
+impl CacheConfig {
+    fn from_auth_config(config: &AuthConfig) -> Self {
+        Self {
+            max_size: config.acl_cache_max_num as usize,
+            ttl: Duration::from_secs(config.acl_cache_expired_second as u64),
+            refresh_interval: Duration::from_secs(config.acl_cache_refresh_second as u64),
+        }
+    }
+}
+
 impl LocalAuthorizationMetadataProvider {
     /// Create a new local authorization metadata provider.
     pub fn new() -> Self {
         Self {
             storage_path: None,
+            storage: Arc::new(RwLock::new(HashMap::new())),
             cache: Arc::new(RwLock::new(HashMap::new())),
             cache_config: CacheConfig::default(),
             initialized: Arc::new(RwLock::new(false)),
+            write_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
-    /// Load ACL from RocksDB storage.
-    ///
-    /// This is a placeholder for actual RocksDB integration.
-    /// In production, this would use `rust-rocksdb` crate.
     fn load_from_storage(&self, subject_key: &str) -> MetadataResult<Option<Acl>> {
-        // Placeholder implementation
-        // TODO: Integrate with RocksDB
-        // let db_path = self.storage_path.as_ref().ok_or_else(|| {
-        //     AuthorizationError::NotInitialized("Storage not initialized".to_string())
-        // })?;
-        //
-        // let db = rocksdb::DB::open_default(db_path)
-        //     .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //
-        // let key_bytes = subject_key.as_bytes();
-        // let value_bytes = db.get(key_bytes)
-        //     .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //
-        // match value_bytes {
-        //     Some(bytes) => {
-        //         let acl: Acl = serde_json::from_slice(&bytes)
-        //             .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //         Ok(Some(acl))
-        //     }
-        //     None => Ok(None),
-        // }
-
-        debug!("load_from_storage called for subject: {}", subject_key);
-        Ok(None)
+        let storage = self.storage_read()?;
+        Ok(storage.get(subject_key).cloned())
     }
 
-    /// Save ACL to RocksDB storage.
-    fn save_to_storage(&self, acl: &Acl) -> MetadataResult<()> {
-        // Placeholder implementation
-        // TODO: Integrate with RocksDB
-        // let db_path = self.storage_path.as_ref().ok_or_else(|| {
-        //     AuthorizationError::NotInitialized("Storage not initialized".to_string())
-        // })?;
-        //
-        // let db = rocksdb::DB::open_default(db_path)
-        //     .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //
-        // let key_bytes = acl.subject_key().as_bytes();
-        // let value_bytes = serde_json::to_vec(acl)
-        //     .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //
-        // db.put(key_bytes, value_bytes)
-        //     .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //
-        // db.flush()
-        //     .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
+    async fn persist_storage_snapshot(&self, snapshot: &HashMap<String, Acl>) -> MetadataResult<()> {
+        let Some(path) = &self.storage_path else {
+            return Ok(());
+        };
+        let path = path.clone();
+        let snapshot = snapshot.clone();
+        tokio::task::spawn_blocking(move || write_acl_snapshot(&path, &snapshot))
+            .await
+            .map_err(|error| AuthorizationError::MetadataServiceError(format!("ACL snapshot task failed: {error}")))?
+    }
 
-        debug!("save_to_storage called for subject: {}", acl.subject_key());
+    fn replace_storage(&self, snapshot: HashMap<String, Acl>) -> MetadataResult<()> {
+        let mut storage = self.storage_write()?;
+        *storage = snapshot;
         Ok(())
     }
 
-    /// Delete ACL from RocksDB storage.
-    fn delete_from_storage(&self, subject_key: &str) -> MetadataResult<()> {
-        // Placeholder implementation
-        // TODO: Integrate with RocksDB
-        // let db_path = self.storage_path.as_ref().ok_or_else(|| {
-        //     AuthorizationError::NotInitialized("Storage not initialized".to_string())
-        // })?;
-        //
-        // let db = rocksdb::DB::open_default(db_path)
-        //     .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //
-        // let key_bytes = subject_key.as_bytes();
-        // db.delete(key_bytes)
-        //     .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //
-        // db.flush()
-        //     .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-
-        debug!("delete_from_storage called for subject: {}", subject_key);
-        Ok(())
-    }
-
-    /// List all ACLs from RocksDB storage.
     fn list_from_storage(&self) -> MetadataResult<Vec<Acl>> {
-        // Placeholder implementation
-        // TODO: Integrate with RocksDB
-        // let db_path = self.storage_path.as_ref().ok_or_else(|| {
-        //     AuthorizationError::NotInitialized("Storage not initialized".to_string())
-        // })?;
-        //
-        // let db = rocksdb::DB::open_default(db_path)
-        //     .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //
-        // let mut acls = Vec::new();
-        // let iter = db.iterator(rocksdb::IteratorMode::Start);
-        //
-        // for item in iter {
-        //     let (_, value) = item
-        //         .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //
-        //     let acl: Acl = serde_json::from_slice(&value)
-        //         .map_err(|e| AuthorizationError::MetadataServiceError(e.to_string()))?;
-        //
-        //     acls.push(acl);
-        // }
-        //
-        // Ok(acls)
-
-        debug!("list_from_storage called");
-        Ok(Vec::new())
+        let storage = self.storage_read()?;
+        Ok(storage.values().cloned().collect())
     }
 
     /// Get ACL from cache, loading from storage if necessary.
     async fn get_cached(&self, subject_key: &str) -> MetadataResult<Option<Acl>> {
+        if self.cache_config.max_size == 0 {
+            return self.load_from_storage(subject_key);
+        }
+
         // Check cache first
         {
-            let mut cache = self.cache.write().unwrap();
+            let mut cache = self.cache_write()?;
             if let Some(cached) = cache.get_mut(subject_key) {
                 // Check if expired
                 if !cached.is_expired(self.cache_config.ttl) {
@@ -287,7 +237,7 @@ impl LocalAuthorizationMetadataProvider {
 
         // Update cache
         {
-            let mut cache = self.cache.write().unwrap();
+            let mut cache = self.cache_write()?;
 
             // Evict oldest entry if cache is full
             if cache.len() >= self.cache_config.max_size {
@@ -313,11 +263,71 @@ impl LocalAuthorizationMetadataProvider {
     }
 
     /// Invalidate cache entry for a subject.
-    fn invalidate_cache(&self, subject_key: &str) {
-        let mut cache = self.cache.write().unwrap();
+    fn invalidate_cache(&self, subject_key: &str) -> MetadataResult<()> {
+        let mut cache = self.cache_write()?;
         if cache.remove(subject_key).is_some() {
             debug!("Invalidated cache for subject: {}", subject_key);
         }
+        Ok(())
+    }
+
+    fn store_cache_entry(&self, subject_key: &str, acl: Option<Acl>) -> MetadataResult<()> {
+        if self.cache_config.max_size == 0 {
+            return Ok(());
+        }
+
+        let mut cache = self.cache_write()?;
+        if !cache.contains_key(subject_key) && cache.len() >= self.cache_config.max_size {
+            self.evict_oldest(&mut cache);
+        }
+        cache.insert(subject_key.to_string(), CachedAcl::new(acl));
+        Ok(())
+    }
+
+    fn ensure_initialized(&self) -> MetadataResult<()> {
+        if *self.initialized_read()? {
+            Ok(())
+        } else {
+            Err(AuthorizationError::NotInitialized(
+                "Provider not initialized".to_string(),
+            ))
+        }
+    }
+
+    fn initialized_read(&self) -> MetadataResult<RwLockReadGuard<'_, bool>> {
+        self.initialized
+            .read()
+            .map_err(|_| AuthorizationError::MetadataServiceError("ACL initialized lock is poisoned".to_string()))
+    }
+
+    fn initialized_write(&self) -> MetadataResult<RwLockWriteGuard<'_, bool>> {
+        self.initialized
+            .write()
+            .map_err(|_| AuthorizationError::MetadataServiceError("ACL initialized lock is poisoned".to_string()))
+    }
+
+    fn storage_read(&self) -> MetadataResult<RwLockReadGuard<'_, HashMap<String, Acl>>> {
+        self.storage
+            .read()
+            .map_err(|_| AuthorizationError::MetadataServiceError("ACL storage lock is poisoned".to_string()))
+    }
+
+    fn storage_write(&self) -> MetadataResult<RwLockWriteGuard<'_, HashMap<String, Acl>>> {
+        self.storage
+            .write()
+            .map_err(|_| AuthorizationError::MetadataServiceError("ACL storage lock is poisoned".to_string()))
+    }
+
+    fn cache_write(&self) -> MetadataResult<RwLockWriteGuard<'_, HashMap<String, CachedAcl>>> {
+        self.cache
+            .write()
+            .map_err(|_| AuthorizationError::MetadataServiceError("ACL cache lock is poisoned".to_string()))
+    }
+
+    fn cache_read(&self) -> MetadataResult<RwLockReadGuard<'_, HashMap<String, CachedAcl>>> {
+        self.cache
+            .read()
+            .map_err(|_| AuthorizationError::MetadataServiceError("ACL cache lock is poisoned".to_string()))
     }
 
     /// Filter ACLs by subject and resource patterns.
@@ -357,6 +367,182 @@ impl LocalAuthorizationMetadataProvider {
     }
 }
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredAclSnapshot {
+    acls: Vec<StoredAclRecord>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredAclRecord {
+    subject: String,
+    policies: Vec<StoredPolicyRecord>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredPolicyRecord {
+    policy_type: String,
+    entries: Vec<StoredPolicyEntryRecord>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredPolicyEntryRecord {
+    resource: String,
+    actions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    source_ips: Vec<String>,
+    decision: String,
+}
+
+fn auth_metadata_snapshot_path(config: &AuthConfig, file_name: &str) -> Option<PathBuf> {
+    let raw_path = config.auth_config_path.as_str().trim();
+    if raw_path.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw_path);
+    let root = if path.extension().is_some() {
+        path.with_extension("")
+    } else {
+        path
+    };
+    Some(root.join(file_name))
+}
+
+fn read_acl_snapshot(path: &Path) -> MetadataResult<HashMap<String, Acl>> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
+        Err(error) => return Err(storage_error(path, error)),
+    };
+    if bytes.iter().all(u8::is_ascii_whitespace) {
+        return Ok(HashMap::new());
+    }
+    let snapshot: StoredAclSnapshot = serde_json::from_slice(&bytes)
+        .map_err(|error| AuthorizationError::MetadataServiceError(format!("{}: {error}", path.display())))?;
+    let mut acls = HashMap::new();
+    for record in snapshot.acls {
+        let acl = acl_from_record(record)?;
+        acls.insert(acl.subject_key().to_string(), acl);
+    }
+    Ok(acls)
+}
+
+fn write_acl_snapshot(path: &Path, acls: &HashMap<String, Acl>) -> MetadataResult<()> {
+    let mut records = acls.values().map(acl_to_record).collect::<Vec<_>>();
+    records.sort_by(|left, right| left.subject.cmp(&right.subject));
+    let snapshot = StoredAclSnapshot { acls: records };
+    let content = serde_json::to_vec_pretty(&snapshot)
+        .map_err(|error| AuthorizationError::MetadataServiceError(error.to_string()))?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| storage_error(parent, error))?;
+    }
+
+    let temp_file = temp_snapshot_path(path);
+    std::fs::write(&temp_file, content).map_err(|error| storage_error(&temp_file, error))?;
+    match std::fs::rename(&temp_file, path) {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            std::fs::copy(&temp_file, path).map_err(|error| {
+                AuthorizationError::MetadataServiceError(format!(
+                    "{}: {error}; rename failed first: {rename_error}",
+                    path.display()
+                ))
+            })?;
+            let _ = std::fs::remove_file(&temp_file);
+            Ok(())
+        }
+    }
+}
+
+fn acl_to_record(acl: &Acl) -> StoredAclRecord {
+    StoredAclRecord {
+        subject: acl.subject_key().to_string(),
+        policies: acl
+            .policies()
+            .iter()
+            .map(|policy| StoredPolicyRecord {
+                policy_type: policy.policy_type().name().to_string(),
+                entries: policy.entries().iter().filter_map(policy_entry_to_record).collect(),
+            })
+            .collect(),
+    }
+}
+
+fn policy_entry_to_record(entry: &PolicyEntry) -> Option<StoredPolicyEntryRecord> {
+    Some(StoredPolicyEntryRecord {
+        resource: entry.resource().resource_key()?,
+        actions: entry.actions().iter().map(|action| action.name().to_string()).collect(),
+        source_ips: entry
+            .environment()
+            .map(|environment| environment.source_ips().clone())
+            .unwrap_or_default(),
+        decision: entry.decision().name().to_string(),
+    })
+}
+
+fn acl_from_record(record: StoredAclRecord) -> MetadataResult<Acl> {
+    let subject_type = subject_type_from_key(&record.subject)?;
+    let policies = record
+        .policies
+        .into_iter()
+        .map(policy_from_record)
+        .collect::<MetadataResult<Vec<_>>>()?;
+    Ok(Acl::of_with_policies(record.subject, subject_type, policies))
+}
+
+fn policy_from_record(record: StoredPolicyRecord) -> MetadataResult<Policy> {
+    let policy_type = PolicyType::get_by_name(&record.policy_type).ok_or_else(|| {
+        AuthorizationError::MetadataServiceError(format!("Invalid policy type '{}'", record.policy_type))
+    })?;
+    let entries = record
+        .entries
+        .into_iter()
+        .map(policy_entry_from_record)
+        .collect::<MetadataResult<Vec<_>>>()?;
+    Ok(Policy::of_entries(policy_type, entries))
+}
+
+fn policy_entry_from_record(record: StoredPolicyEntryRecord) -> MetadataResult<PolicyEntry> {
+    let resource = Resource::of_str(&record.resource)
+        .ok_or_else(|| AuthorizationError::MetadataServiceError(format!("Invalid resource '{}'", record.resource)))?;
+    let actions = record
+        .actions
+        .iter()
+        .map(|action| {
+            Action::get_by_name(action)
+                .ok_or_else(|| AuthorizationError::MetadataServiceError(format!("Invalid action '{action}'")))
+        })
+        .collect::<MetadataResult<Vec<_>>>()?;
+    let decision = Decision::get_by_name(&record.decision)
+        .ok_or_else(|| AuthorizationError::MetadataServiceError(format!("Invalid decision '{}'", record.decision)))?;
+    let environment = Environment::of_list(record.source_ips);
+    Ok(PolicyEntry::of(resource, actions, environment, decision))
+}
+
+fn subject_type_from_key(subject_key: &str) -> MetadataResult<SubjectType> {
+    let Some((subject_type, _)) = subject_key.split_once(':') else {
+        return Ok(SubjectType::User);
+    };
+    SubjectType::get_by_name(subject_type)
+        .ok_or_else(|| AuthorizationError::MetadataServiceError(format!("Invalid subject type '{subject_type}'")))
+}
+
+fn storage_error(path: &Path, error: std::io::Error) -> AuthorizationError {
+    AuthorizationError::MetadataServiceError(format!("{}: {error}", path.display()))
+}
+
+fn temp_snapshot_path(path: &Path) -> PathBuf {
+    let file_name = path.file_name().and_then(|value| value.to_str()).unwrap_or("acls.json");
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    path.with_file_name(format!(".{file_name}.{nanos}.tmp"))
+}
+
 impl Default for LocalAuthorizationMetadataProvider {
     fn default() -> Self {
         Self::new()
@@ -370,125 +556,117 @@ impl AuthorizationMetadataProvider for LocalAuthorizationMetadataProvider {
         config: AuthConfig,
         _metadata_service: Option<Box<dyn Any + Send + Sync>>,
     ) -> MetadataResult<()> {
-        let mut initialized = self.initialized.write().unwrap();
-        if *initialized {
-            warn!("LocalAuthorizationMetadataProvider already initialized");
-            return Ok(());
+        {
+            let initialized = self.initialized_read()?;
+            if *initialized {
+                warn!("LocalAuthorizationMetadataProvider already initialized");
+                return Ok(());
+            }
         }
 
-        // Set up storage path
-        let base_path = config.auth_config_path.to_string();
-        let storage_path = PathBuf::from(base_path).join("acls");
-        self.storage_path = Some(storage_path.clone());
+        self.cache_config = CacheConfig::from_auth_config(&config);
+        let storage_path = auth_metadata_snapshot_path(&config, "acls.json");
+        self.storage_path = storage_path.clone();
 
         debug!("Initializing LocalAuthorizationMetadataProvider at: {:?}", storage_path);
 
-        // Create storage directory if it doesn't exist
-        if let Some(parent) = storage_path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| AuthorizationError::ConfigurationError(e.to_string()))?;
+        if let Some(path) = storage_path {
+            let snapshot = read_acl_snapshot(&path)?;
+            self.replace_storage(snapshot)?;
         }
 
-        // TODO: Initialize RocksDB
-        // let db = rocksdb::DB::open_default(&storage_path)
-        //     .map_err(|e| AuthorizationError::ConfigurationError(e.to_string()))?;
-
+        let mut initialized = self.initialized_write()?;
         *initialized = true;
         debug!("LocalAuthorizationMetadataProvider initialized successfully");
         Ok(())
     }
 
     fn shutdown(&mut self) {
-        let mut initialized = self.initialized.write().unwrap();
+        let Ok(mut initialized) = self.initialized.write() else {
+            warn!("LocalAuthorizationMetadataProvider initialized lock is poisoned during shutdown");
+            return;
+        };
         if !*initialized {
             return;
         }
 
         debug!("Shutting down LocalAuthorizationMetadataProvider");
 
-        // Clear cache
-        self.cache.write().unwrap().clear();
-
-        // TODO: Close RocksDB
-        // if let Some(db) = self.db.take() {
-        //     drop(db);
-        // }
+        match self.cache.write() {
+            Ok(mut cache) => cache.clear(),
+            Err(_) => warn!("LocalAuthorizationMetadataProvider cache lock is poisoned during shutdown"),
+        }
+        match self.storage.write() {
+            Ok(mut storage) => storage.clear(),
+            Err(_) => warn!("LocalAuthorizationMetadataProvider storage lock is poisoned during shutdown"),
+        }
 
         *initialized = false;
         debug!("LocalAuthorizationMetadataProvider shut down");
     }
 
     async fn create_acl(&self, acl: Acl) -> MetadataResult<()> {
-        if !*self.initialized.read().unwrap() {
-            return Err(AuthorizationError::NotInitialized(
-                "Provider not initialized".to_string(),
-            ));
-        }
+        self.ensure_initialized()?;
 
         let subject_key = acl.subject_key().to_string();
         debug!("Creating ACL for subject: {}", subject_key);
 
-        // Check if ACL already exists (check cache first for testing)
-        {
-            let cache = self.cache.read().unwrap();
-            if cache.contains_key(&subject_key) {
-                return Err(AuthorizationError::InternalError(format!(
-                    "ACL already exists for subject: {}",
-                    subject_key
-                )));
-            }
+        let _write_guard = self.write_lock.lock().await;
+        let mut snapshot = {
+            let storage = self.storage_read()?;
+            storage.clone()
+        };
+        if snapshot.contains_key(&subject_key) {
+            return Err(AuthorizationError::InternalError(format!(
+                "ACL already exists for subject: {}",
+                subject_key
+            )));
         }
+        snapshot.insert(subject_key.clone(), acl.clone());
 
-        // Save to storage (TODO: actual RocksDB implementation)
-        self.save_to_storage(&acl)?;
-
-        // Update cache directly (for testing since storage is TODO)
-        {
-            let mut cache = self.cache.write().unwrap();
-            cache.insert(subject_key.to_string(), CachedAcl::new(Some(acl)));
-        }
+        self.persist_storage_snapshot(&snapshot).await?;
+        self.replace_storage(snapshot)?;
+        self.store_cache_entry(&subject_key, Some(acl))?;
 
         debug!("ACL created successfully for subject: {}", subject_key);
         Ok(())
     }
 
     async fn delete_acl<S: Subject + Send + Sync>(&self, subject: &S) -> MetadataResult<()> {
-        if !*self.initialized.read().unwrap() {
-            return Err(AuthorizationError::NotInitialized(
-                "Provider not initialized".to_string(),
-            ));
-        }
+        self.ensure_initialized()?;
 
         let subject_key = subject.subject_key();
         debug!("Deleting ACL for subject: {}", subject_key);
 
-        // Delete from storage
-        self.delete_from_storage(subject_key)?;
-
-        // Invalidate cache
-        self.invalidate_cache(subject_key);
+        let _write_guard = self.write_lock.lock().await;
+        let mut snapshot = {
+            let storage = self.storage_read()?;
+            storage.clone()
+        };
+        snapshot.remove(subject_key);
+        self.persist_storage_snapshot(&snapshot).await?;
+        self.replace_storage(snapshot)?;
+        self.invalidate_cache(subject_key)?;
 
         debug!("ACL deleted successfully for subject: {}", subject_key);
         Ok(())
     }
 
     async fn update_acl(&self, acl: Acl) -> MetadataResult<()> {
-        if !*self.initialized.read().unwrap() {
-            return Err(AuthorizationError::NotInitialized(
-                "Provider not initialized".to_string(),
-            ));
-        }
+        self.ensure_initialized()?;
 
         let subject_key = acl.subject_key().to_string();
         debug!("Updating ACL for subject: {}", subject_key);
 
-        // Save to storage (overwrite existing - TODO: actual RocksDB implementation)
-        self.save_to_storage(&acl)?;
-
-        // Update cache directly (for testing since storage is TODO)
-        {
-            let mut cache = self.cache.write().unwrap();
-            cache.insert(subject_key.to_string(), CachedAcl::new(Some(acl)));
-        }
+        let _write_guard = self.write_lock.lock().await;
+        let mut snapshot = {
+            let storage = self.storage_read()?;
+            storage.clone()
+        };
+        snapshot.insert(subject_key.clone(), acl.clone());
+        self.persist_storage_snapshot(&snapshot).await?;
+        self.replace_storage(snapshot)?;
+        self.store_cache_entry(&subject_key, Some(acl))?;
 
         debug!("ACL updated successfully for subject: {}", subject_key);
         Ok(())
@@ -498,31 +676,20 @@ impl AuthorizationMetadataProvider for LocalAuthorizationMetadataProvider {
         &self,
         subject: &S,
     ) -> impl std::future::Future<Output = MetadataResult<Option<Acl>>> + Send {
-        let initialized = *self.initialized.read().unwrap();
+        let initialized = self.ensure_initialized();
         let subject_key = subject.subject_key().to_string();
-        let cache = self.cache.clone();
+        let provider = self;
 
         async move {
-            if !initialized {
-                return Err(AuthorizationError::NotInitialized(
-                    "Provider not initialized".to_string(),
-                ));
-            }
+            initialized?;
 
             debug!("Getting ACL for subject: {}", subject_key);
-
-            // Get from cache
-            let cache_read = cache.read().unwrap();
-            Ok(cache_read.get(&subject_key).and_then(|cached| cached.acl.clone()))
+            provider.get_cached(&subject_key).await
         }
     }
 
     async fn list_acl(&self, subject_filter: Option<&str>, resource_filter: Option<&str>) -> MetadataResult<Vec<Acl>> {
-        if !*self.initialized.read().unwrap() {
-            return Err(AuthorizationError::NotInitialized(
-                "Provider not initialized".to_string(),
-            ));
-        }
+        self.ensure_initialized()?;
 
         debug!(
             "Listing ACLs with subject_filter={:?}, resource_filter={:?}",
@@ -532,9 +699,7 @@ impl AuthorizationMetadataProvider for LocalAuthorizationMetadataProvider {
         // Load all ACLs from storage, then overlay live cache entries.
         let mut acls = self.list_from_storage()?;
         let cache_snapshot: Vec<Acl> = self
-            .cache
-            .read()
-            .unwrap()
+            .cache_read()?
             .values()
             .filter_map(|cached| cached.acl.clone())
             .collect();
@@ -559,7 +724,11 @@ impl AuthorizationMetadataProvider for LocalAuthorizationMetadataProvider {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use cheetah_string::CheetahString;
     use rocketmq_common::common::action::Action;
+    use tempfile::TempDir;
 
     use super::*;
     use crate::authentication::enums::subject_type::SubjectType;
@@ -601,7 +770,6 @@ mod tests {
         let acl = Acl::of("user:test", SubjectType::User, policy);
 
         let result = provider.create_acl(acl).await;
-        // Result will be Ok() in placeholder implementation
         assert!(result.is_ok());
     }
 
@@ -614,7 +782,6 @@ mod tests {
         let result = provider.get_acl(&user).await;
 
         assert!(result.is_ok());
-        // In placeholder implementation, should return None
         assert!(result.unwrap().is_none());
     }
 
@@ -679,6 +846,56 @@ mod tests {
     }
 
     #[test]
+    fn initialize_applies_acl_cache_config() {
+        let mut provider = LocalAuthorizationMetadataProvider::new();
+        provider
+            .initialize(
+                AuthConfig {
+                    acl_cache_max_num: 2,
+                    acl_cache_expired_second: 3,
+                    acl_cache_refresh_second: 4,
+                    ..AuthConfig::default()
+                },
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(provider.cache_config.max_size, 2);
+        assert_eq!(provider.cache_config.ttl, Duration::from_secs(3));
+        assert_eq!(provider.cache_config.refresh_interval, Duration::from_secs(4));
+    }
+
+    #[tokio::test]
+    async fn zero_acl_cache_max_num_disables_cache_entries() {
+        let mut provider = LocalAuthorizationMetadataProvider::new();
+        provider
+            .initialize(
+                AuthConfig {
+                    acl_cache_max_num: 0,
+                    ..AuthConfig::default()
+                },
+                None,
+            )
+            .unwrap();
+
+        let acl = Acl::of(
+            "cache-disabled",
+            SubjectType::User,
+            Policy::of(
+                vec![Resource::of_topic("topic-a")],
+                vec![Action::Pub],
+                None,
+                Decision::Allow,
+            ),
+        );
+        provider.create_acl(acl).await.unwrap();
+
+        let user = User::of("cache-disabled");
+        assert!(provider.get_acl(&user).await.unwrap().is_some());
+        assert!(provider.cache.read().unwrap().is_empty());
+    }
+
+    #[test]
     fn test_cached_acl_expiration() {
         let cached = CachedAcl::new(None);
         // Check that it's not expired with a 1 second TTL
@@ -687,5 +904,111 @@ mod tests {
         // Wait for 100ms and check with 50ms TTL - should be expired
         std::thread::sleep(Duration::from_millis(100));
         assert!(cached.is_expired(Duration::from_millis(50)));
+    }
+
+    #[tokio::test]
+    async fn local_provider_persists_acls_across_reinitialization() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from_string(temp.path().join("auth.json").to_string_lossy().into_owned()),
+            ..AuthConfig::default()
+        };
+
+        let mut provider = LocalAuthorizationMetadataProvider::new();
+        provider.initialize(config.clone(), None).unwrap();
+        let acl = Acl::of(
+            "alice",
+            SubjectType::User,
+            Policy::of(
+                vec![Resource::of_topic("topic-a")],
+                vec![Action::Pub],
+                Environment::of("192.168.0.1"),
+                Decision::Allow,
+            ),
+        );
+        provider.create_acl(acl).await.unwrap();
+
+        let mut restarted = LocalAuthorizationMetadataProvider::new();
+        restarted.initialize(config, None).unwrap();
+        let user = User::of("alice");
+        let restored = restarted.get_acl(&user).await.unwrap().unwrap();
+
+        assert_eq!(restored.subject_key(), "User:alice");
+        assert_eq!(restored.policies().len(), 1);
+        assert_eq!(restored.policies()[0].entries().len(), 1);
+        assert_eq!(
+            restored.policies()[0].entries()[0].resource().resource_key().as_deref(),
+            Some("Topic:topic-a")
+        );
+    }
+
+    #[tokio::test]
+    async fn local_provider_persists_acl_update_and_delete_across_reinitialization() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from_string(temp.path().join("auth.json").to_string_lossy().into_owned()),
+            ..AuthConfig::default()
+        };
+
+        let mut provider = LocalAuthorizationMetadataProvider::new();
+        provider.initialize(config.clone(), None).unwrap();
+        provider
+            .create_acl(Acl::of(
+                "alice",
+                SubjectType::User,
+                Policy::of(
+                    vec![Resource::of_topic("topic-a")],
+                    vec![Action::Pub],
+                    None,
+                    Decision::Allow,
+                ),
+            ))
+            .await
+            .unwrap();
+        provider
+            .update_acl(Acl::of(
+                "alice",
+                SubjectType::User,
+                Policy::of(
+                    vec![Resource::of_topic("topic-b")],
+                    vec![Action::Sub],
+                    None,
+                    Decision::Deny,
+                ),
+            ))
+            .await
+            .unwrap();
+
+        let mut restarted = LocalAuthorizationMetadataProvider::new();
+        restarted.initialize(config.clone(), None).unwrap();
+        let user = User::of("alice");
+        let restored = restarted.get_acl(&user).await.unwrap().unwrap();
+        let entry = &restored.policies()[0].entries()[0];
+        assert_eq!(entry.resource().resource_key().as_deref(), Some("Topic:topic-b"));
+        assert_eq!(entry.actions(), &vec![Action::Sub]);
+        assert_eq!(entry.decision(), Decision::Deny);
+
+        restarted.delete_acl(&user).await.unwrap();
+
+        let mut deleted_restart = LocalAuthorizationMetadataProvider::new();
+        deleted_restart.initialize(config, None).unwrap();
+        assert!(deleted_restart.get_acl(&user).await.unwrap().is_none());
+    }
+
+    #[test]
+    fn local_provider_rejects_corrupted_acl_snapshot() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from_string(temp.path().join("auth.json").to_string_lossy().into_owned()),
+            ..AuthConfig::default()
+        };
+        let snapshot = temp.path().join("auth").join("acls.json");
+        fs::create_dir_all(snapshot.parent().unwrap()).unwrap();
+        fs::write(&snapshot, b"{not valid json").unwrap();
+
+        let mut provider = LocalAuthorizationMetadataProvider::new();
+        let error = provider.initialize(config, None).unwrap_err();
+
+        assert!(error.to_string().contains("acls.json"));
     }
 }

--- a/rocketmq-auth/src/runtime.rs
+++ b/rocketmq-auth/src/runtime.rs
@@ -62,7 +62,7 @@ pub struct ProviderRegistry {
 
 impl ProviderRegistry {
     pub fn local(config: &AuthConfig) -> RocketMQResult<Self> {
-        let authentication_metadata_provider = Arc::new(LocalAuthenticationMetadataProvider::new());
+        let authentication_metadata_provider = Arc::new(LocalAuthenticationMetadataProvider::with_config(config)?);
         let mut authorization_metadata_provider = LocalAuthorizationMetadataProvider::new();
         authorization_metadata_provider
             .initialize(config.clone(), None)
@@ -1036,6 +1036,111 @@ accounts:
     }
 
     #[tokio::test]
+    async fn provider_registry_local_loads_persisted_authentication_users() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from(temp.path().join("auth.json").to_string_lossy().as_ref()),
+            ..AuthConfig::default()
+        };
+
+        let mut provider = LocalAuthenticationMetadataProvider::new();
+        provider.initialize(config.clone(), None).await.unwrap();
+        provider
+            .create_user(User::of_with_password("persisted", "secret"))
+            .await
+            .unwrap();
+
+        let registry = ProviderRegistry::local(&config).unwrap();
+        let restored = registry
+            .authentication_metadata_provider()
+            .get_user("persisted")
+            .await
+            .unwrap();
+
+        assert_eq!(restored.password().map(|value| value.as_str()), Some("secret"));
+    }
+
+    #[tokio::test]
+    async fn auth_runtime_restores_persisted_metadata_after_restart() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from(temp.path().join("auth.json").to_string_lossy().as_ref()),
+            authentication_enabled: true,
+            authorization_enabled: true,
+            ..AuthConfig::default()
+        };
+
+        let runtime = AuthRuntimeBuilder::new(config.clone()).build().await.unwrap();
+        let authn_provider = runtime.provider_registry().authentication_metadata_provider();
+        let mut user = User::of_with_type("alice", "secret", UserType::Normal);
+        user.set_user_status(UserStatus::Enable);
+        authn_provider.create_user(user).await.unwrap();
+
+        let authz_provider = runtime.provider_registry().authorization_metadata_provider();
+        authz_provider
+            .create_acl(Acl::of(
+                "alice",
+                SubjectType::User,
+                Policy::of(
+                    vec![Resource::of_topic("topic-a")],
+                    vec![Action::Pub],
+                    None,
+                    Decision::Allow,
+                ),
+            ))
+            .await
+            .unwrap();
+        runtime.shutdown().await.unwrap();
+
+        let restarted = AuthRuntimeBuilder::new(config).build().await.unwrap();
+        let signature = acl_signer::cal_signature("alicetopic-a".as_bytes(), "secret").unwrap();
+        let command = send_message_command("topic-a", "alice", &signature);
+
+        restarted.check_remoting(&(), &command).await.unwrap();
+        restarted.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn auth_runtime_rejects_corrupted_persisted_users_snapshot() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from(temp.path().join("auth.json").to_string_lossy().as_ref()),
+            authentication_enabled: true,
+            ..AuthConfig::default()
+        };
+        let snapshot = temp.path().join("auth").join("users.json");
+        fs::create_dir_all(snapshot.parent().unwrap()).unwrap();
+        fs::write(&snapshot, b"{not valid json").unwrap();
+
+        let error = match AuthRuntimeBuilder::new(config).build().await {
+            Ok(_) => panic!("runtime must reject corrupted users snapshot"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("users.json"));
+    }
+
+    #[tokio::test]
+    async fn auth_runtime_rejects_corrupted_persisted_acls_snapshot() {
+        let temp = TempDir::new().unwrap();
+        let config = AuthConfig {
+            auth_config_path: CheetahString::from(temp.path().join("auth.json").to_string_lossy().as_ref()),
+            authorization_enabled: true,
+            ..AuthConfig::default()
+        };
+        let snapshot = temp.path().join("auth").join("acls.json");
+        fs::create_dir_all(snapshot.parent().unwrap()).unwrap();
+        fs::write(&snapshot, b"{not valid json").unwrap();
+
+        let error = match AuthRuntimeBuilder::new(config).build().await {
+            Ok(_) => panic!("runtime must reject corrupted ACL snapshot"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("acls.json"));
+    }
+
+    #[tokio::test]
     async fn acl_file_watcher_reloads_changed_user_secret() {
         let temp = TempDir::new().unwrap();
         let acl_file = temp.path().join("plain_acl.yml");
@@ -1122,6 +1227,134 @@ accounts:
             "watcher must not advance generation when ACL file content is unchanged"
         );
 
+        runtime.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn manual_acl_reload_failure_preserves_previous_snapshot_and_generation() {
+        let temp = TempDir::new().unwrap();
+        let acl_file = temp.path().join("plain_acl.yml");
+        fs::write(
+            &acl_file,
+            r#"
+globalWhiteRemoteAddresses:
+  - 10.10.*.*
+accounts:
+  - accessKey: alice
+    secretKey: first
+"#,
+        )
+        .unwrap();
+
+        let runtime = AuthRuntimeBuilder::new(AuthConfig {
+            acl_file: CheetahString::from(acl_file.to_string_lossy().as_ref()),
+            ..AuthConfig::default()
+        })
+        .build()
+        .await
+        .unwrap();
+        let authn_provider = runtime.provider_registry().authentication_metadata_provider();
+        let generation = runtime.acl_generation();
+        assert!(runtime.is_acl_white_remote_address(None, Some("10.10.1.2")).unwrap());
+        let user = authn_provider.get_user("alice").await.unwrap();
+        assert_eq!(user.password().map(|value| value.as_str()), Some("first"));
+
+        fs::write(
+            &acl_file,
+            r#"
+globalWhiteRemoteAddresses:
+  - 172.16.*.*
+accounts:
+  - accessKey: alice
+"#,
+        )
+        .unwrap();
+
+        let error = runtime.reload_acl_file().await.unwrap_err();
+        assert!(error.to_string().contains("secretKey must not be blank"));
+        assert_eq!(runtime.acl_generation(), generation);
+
+        let user = authn_provider.get_user("alice").await.unwrap();
+        assert_eq!(user.password().map(|value| value.as_str()), Some("first"));
+        assert!(runtime.is_acl_white_remote_address(None, Some("10.10.1.2")).unwrap());
+        assert!(!runtime.is_acl_white_remote_address(None, Some("172.16.1.2")).unwrap());
+    }
+
+    #[tokio::test]
+    async fn acl_file_watcher_failure_preserves_snapshot_and_recovers_after_fix() {
+        let temp = TempDir::new().unwrap();
+        let acl_file = temp.path().join("plain_acl.yml");
+        fs::write(
+            &acl_file,
+            r#"
+globalWhiteRemoteAddresses:
+  - 10.10.*.*
+accounts:
+  - accessKey: alice
+    secretKey: first
+"#,
+        )
+        .unwrap();
+
+        let runtime = AuthRuntimeBuilder::new(AuthConfig {
+            acl_file: CheetahString::from(acl_file.to_string_lossy().as_ref()),
+            acl_file_watch_enabled: true,
+            acl_file_watch_interval_millis: 25,
+            ..AuthConfig::default()
+        })
+        .build()
+        .await
+        .unwrap();
+        let authn_provider = runtime.provider_registry().authentication_metadata_provider();
+        let generation = runtime.acl_generation();
+
+        fs::write(
+            &acl_file,
+            r#"
+globalWhiteRemoteAddresses:
+  - 172.16.*.*
+accounts:
+  - accessKey: alice
+"#,
+        )
+        .unwrap();
+
+        sleep(Duration::from_millis(150)).await;
+
+        assert_eq!(runtime.acl_generation(), generation);
+        let user = authn_provider.get_user("alice").await.unwrap();
+        assert_eq!(user.password().map(|value| value.as_str()), Some("first"));
+        assert!(runtime.is_acl_white_remote_address(None, Some("10.10.1.2")).unwrap());
+        assert!(!runtime.is_acl_white_remote_address(None, Some("172.16.1.2")).unwrap());
+
+        fs::write(
+            &acl_file,
+            r#"
+globalWhiteRemoteAddresses:
+  - 172.16.*.*
+accounts:
+  - accessKey: alice
+    secretKey: second
+"#,
+        )
+        .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let user = authn_provider.get_user("alice").await.unwrap();
+            if user.password().map(|value| value.as_str()) == Some("second")
+                && runtime.is_acl_white_remote_address(None, Some("172.16.1.2")).unwrap()
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "ACL file watcher did not recover after a failed reload"
+            );
+            sleep(Duration::from_millis(25)).await;
+        }
+
+        assert!(runtime.acl_generation() > generation);
         runtime.shutdown().await.unwrap();
     }
 

--- a/rocketmq-broker/src/auth/auth_admin_service.rs
+++ b/rocketmq-broker/src/auth/auth_admin_service.rs
@@ -616,6 +616,8 @@ accounts:
         assert!(content.contains("globalWhiteRemoteAddresses"));
         assert!(content.contains("172.16.*.*"));
         assert!(content.contains("accessKey"));
+        assert!(content.contains("dataVersion"));
+        assert!(content.contains("counter: 1"));
         assert!(registry.is_acl_white_remote_address(None, Some("172.16.1.2")).unwrap());
         let _ = std::fs::remove_dir_all(temp_root);
     }

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -451,6 +451,15 @@ fn system_error_response(opaque: i32, remark: impl Into<String>) -> RemotingComm
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rocketmq_auth::config::AuthConfig;
+    use rocketmq_auth::AuthRuntimeBuilder;
+    use rocketmq_remoting::local::LocalRequestHarness;
+    use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
+
+    use crate::transaction::queue::default_transactional_message_service::DefaultTransactionalMessageService;
+
+    type TestBrokerRequestProcessor =
+        BrokerRequestProcessor<LocalFileMessageStore, DefaultTransactionalMessageService<LocalFileMessageStore>>;
 
     #[test]
     fn fast_failure_queue_kind_maps_java_fast_failure_families() {
@@ -505,6 +514,39 @@ mod tests {
         assert_eq!(
             fast_failure_queue_kind(RequestCode::UpdateBrokerConfig as i32, false),
             None
+        );
+    }
+
+    #[tokio::test]
+    async fn broker_request_processor_checks_auth_before_dispatch() {
+        let auth_runtime = AuthRuntimeBuilder::new(AuthConfig {
+            authentication_enabled: true,
+            ..AuthConfig::default()
+        })
+        .build()
+        .await
+        .expect("auth runtime should initialize");
+        let mut processor = TestBrokerRequestProcessor::new();
+        processor.set_auth_runtime(Arc::new(auth_runtime));
+
+        let mut request = RemotingCommand::create_remoting_command(RequestCode::SendMessage.to_i32()).set_opaque(7);
+        let harness = LocalRequestHarness::new()
+            .await
+            .expect("local remoting harness should start");
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("broker processor should return auth response")
+            .expect("auth failure should be encoded as a response command");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
+        assert_eq!(response.opaque(), 7);
+        assert!(
+            response
+                .remark()
+                .is_some_and(|remark| remark.as_str().contains("username cannot be null")),
+            "missing AccessKey should be reported as an authentication failure"
         );
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -41,6 +41,8 @@ use crate::processor::admin_broker_processor::update_broker_ha_handler::UpdateBr
 use crate::processor::admin_broker_processor::update_cold_data_flow_ctr_group_config::UpdateColdDataFlowCtrGroupConfigRequestHandler;
 use crate::processor::admin_broker_processor::update_global_white_addrs_config_request_handler::UpdateGlobalWhiteAddrsConfigRequestHandler;
 use crate::processor::admin_broker_processor::update_user_request_handler::UpdateUserRequestHandler;
+use rocketmq_error::AuthError;
+use rocketmq_error::RocketMQError;
 use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::net::channel::Channel;
@@ -629,8 +631,28 @@ fn get_legacy_acl_cmd_response(request_code: RequestCode, remark: &str) -> Optio
     ))
 }
 
+fn map_auth_admin_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
+    let (code, remark) = match &error {
+        RocketMQError::IllegalArgument(message) | RocketMQError::RequestHeaderError(message) => {
+            (ResponseCode::InvalidParameter, message.clone())
+        }
+        RocketMQError::RequestBodyInvalid { reason, .. } => (ResponseCode::InvalidParameter, reason.clone()),
+        RocketMQError::ConfigParseFailed { reason, .. } => (ResponseCode::InvalidParameter, reason.clone()),
+        RocketMQError::ConfigMissing { key } => (ResponseCode::InvalidParameter, (*key).to_owned()),
+        RocketMQError::ConfigInvalidValue { reason, .. } => (ResponseCode::InvalidParameter, reason.clone()),
+        RocketMQError::Authentication(AuthError::UserNotFound(_)) => (ResponseCode::UserNotExist, error.to_string()),
+        RocketMQError::Authentication(_) => (ResponseCode::NoPermission, error.to_string()),
+        RocketMQError::BrokerPermissionDenied { operation } => (ResponseCode::NoPermission, operation.clone()),
+        other => (ResponseCode::SystemError, other.to_string()),
+    };
+
+    response.set_code(code).set_remark(remark)
+}
+
 #[cfg(test)]
 mod tests {
+    use rocketmq_error::RocketMQError;
+
     use super::*;
 
     #[test]
@@ -649,5 +671,30 @@ mod tests {
             .remark()
             .expect("legacy acl response should carry remark")
             .contains("deprecated"));
+    }
+
+    #[test]
+    fn auth_admin_error_response_maps_auth_and_config_errors_consistently() {
+        let response = map_auth_admin_error_response(
+            RemotingCommand::create_response_command(),
+            RocketMQError::user_not_found("alice"),
+        );
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::UserNotExist);
+
+        let response = map_auth_admin_error_response(
+            RemotingCommand::create_response_command(),
+            RocketMQError::authentication_failed("bad credentials"),
+        );
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
+
+        let response = map_auth_admin_error_response(
+            RemotingCommand::create_response_command(),
+            RocketMQError::ConfigInvalidValue {
+                key: "auth.authorization",
+                value: "local".to_owned(),
+                reason: "provider not ready".to_owned(),
+            },
+        );
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
@@ -101,15 +101,5 @@ impl<MS: MessageStore> CreateAclRequestHandler<MS> {
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
@@ -91,15 +91,5 @@ impl<MS: MessageStore> CreateUserRequestHandler<MS> {
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs
@@ -82,15 +82,5 @@ impl<MS: MessageStore> DeleteAclRequestHandler<MS> {
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
@@ -90,15 +90,5 @@ impl<MS: MessageStore> DeleteUserRequestHandler<MS> {
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
@@ -73,17 +73,7 @@ impl<MS: MessageStore> GetAclRequestHandler<MS> {
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }
 
 #[cfg(test)]

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs
@@ -73,15 +73,5 @@ impl<MS: MessageStore> GetUserRequestHandler<MS> {
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
@@ -66,15 +66,5 @@ fn non_empty(value: &str) -> Option<&str> {
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
@@ -76,15 +76,5 @@ fn non_empty(value: &str) -> Option<&str> {
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
@@ -101,15 +101,5 @@ impl<MS: MessageStore> UpdateAclRequestHandler<MS> {
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
@@ -102,17 +102,7 @@ fn parse_global_white_addrs(value: &str) -> Vec<String> {
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }
 
 #[cfg(test)]

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
@@ -67,7 +67,7 @@ impl<MS: MessageStore> UpdateUserRequestHandler<MS> {
         user_info.username = Option::from(request_header.username);
         let user = UserConverter::convert_user(&user_info);
 
-        if user.user_type() == Option::from(UserType::Super) && self.is_not_super_user_login(request).await {
+        if user.user_type() == Option::from(UserType::Super) && self.is_not_super_user_login(request).await? {
             return Ok(Some(
                 response
                     .set_code(ResponseCode::NoPermission)
@@ -81,32 +81,18 @@ impl<MS: MessageStore> UpdateUserRequestHandler<MS> {
         }
     }
 
-    async fn is_not_super_user_login(&self, _request: &RemotingCommand) -> bool {
-        let Some(access_key) = _request
+    async fn is_not_super_user_login(&self, request: &RemotingCommand) -> rocketmq_error::RocketMQResult<bool> {
+        let Some(access_key) = request
             .ext_fields()
             .and_then(|fields| fields.get(&CheetahString::from_static_str("AccessKey")))
         else {
-            return false;
+            return Ok(false);
         };
 
-        !self
-            .auth_admin_service
-            .is_super_user(access_key.as_str())
-            .await
-            .unwrap_or(false)
+        Ok(!self.auth_admin_service.is_super_user(access_key.as_str()).await?)
     }
 }
 
 fn map_error_response(response: RemotingCommand, error: RocketMQError) -> RemotingCommand {
-    match error {
-        RocketMQError::IllegalArgument(message) => {
-            response.set_code(ResponseCode::InvalidParameter).set_remark(message)
-        }
-        RocketMQError::BrokerPermissionDenied { operation } => {
-            response.set_code(ResponseCode::NoPermission).set_remark(operation)
-        }
-        other => response
-            .set_code(ResponseCode::SystemError)
-            .set_remark(other.to_string()),
-    }
+    super::map_auth_admin_error_response(response, error)
 }

--- a/rocketmq-proxy/src/auth.rs
+++ b/rocketmq-proxy/src/auth.rs
@@ -660,9 +660,15 @@ fn source_ip_from_channel_context(channel_context: &(dyn std::any::Any + Send + 
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::fs;
     use std::path::PathBuf;
 
+    use rocketmq_auth::authentication::acl_signer;
+    use rocketmq_auth::authentication::enums::user_status::UserStatus;
+    use rocketmq_auth::authentication::enums::user_type::UserType;
+    use rocketmq_auth::authorization::enums::decision::Decision;
+    use rocketmq_auth::authorization::model::policy::Policy;
     use rocketmq_auth::authorization::model::resource::Resource;
     use rocketmq_remoting::code::request_code::RequestCode;
     use rocketmq_remoting::protocol::header::client_request_header::GetRouteInfoRequestHeader;
@@ -673,6 +679,28 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("{prefix}-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&dir).expect("test temp directory should be created");
         dir
+    }
+
+    fn send_message_command(topic: &str, access_key: &str, secret_key: &str) -> RemotingCommand {
+        let signature = acl_signer::cal_signature(format!("{access_key}{topic}").as_bytes(), secret_key)
+            .expect("signature should be calculated");
+        let mut ext_fields = HashMap::new();
+        ext_fields.insert(
+            CheetahString::from_static_str("AccessKey"),
+            CheetahString::from(access_key),
+        );
+        ext_fields.insert(
+            CheetahString::from_static_str("Signature"),
+            CheetahString::from(signature),
+        );
+        ext_fields.insert(CheetahString::from_static_str("topic"), CheetahString::from(topic));
+        RemotingCommand::create_remoting_command(RequestCode::SendMessage.to_i32()).set_ext_fields(ext_fields)
+    }
+
+    fn normal_user(username: &str, password: &str) -> User {
+        let mut user = User::of_with_type(username, password, UserType::Normal);
+        user.set_user_status(UserStatus::Enable);
+        user
     }
 
     #[test]
@@ -776,6 +804,102 @@ accounts:
             .authorize_request("QueryRoute", Some(&principal), &contexts)
             .await
             .expect("white listed principal should bypass authorization metadata lookup");
+
+        runtime.shutdown().await.expect("runtime should shut down");
+        let _ = fs::remove_dir_all(test_dir);
+    }
+
+    #[tokio::test]
+    async fn remoting_auth_restores_persisted_metadata_after_restart() {
+        let test_dir = unique_test_dir("proxy-auth-persisted-remoting");
+        let config = ProxyAuthConfig {
+            authentication_enabled: true,
+            authorization_enabled: true,
+            auth_config_path: test_dir.join("auth-store").to_string_lossy().into_owned(),
+            ..ProxyAuthConfig::default()
+        };
+
+        let runtime = ProxyAuthRuntime::from_proxy_config(&config)
+            .await
+            .expect("runtime should build")
+            .expect("runtime should be enabled");
+        runtime.create_user(normal_user("alice", "secret")).await.unwrap();
+        runtime
+            .create_acl(Acl::of(
+                "alice",
+                SubjectType::User,
+                Policy::of(
+                    vec![Resource::of_topic("TopicA")],
+                    vec![Action::Pub],
+                    None,
+                    Decision::Allow,
+                ),
+            ))
+            .await
+            .unwrap();
+        runtime.shutdown().await.expect("runtime should shut down");
+
+        let restarted = ProxyAuthRuntime::from_proxy_config(&config)
+            .await
+            .expect("runtime should rebuild")
+            .expect("runtime should be enabled");
+        let command = send_message_command("TopicA", "alice", "secret");
+        let principal = restarted
+            .authenticate_remoting(&command, Some("channel-a"), Some("127.0.0.1"))
+            .await
+            .expect("authentication should use persisted user")
+            .expect("principal should exist");
+        assert_eq!(principal.username(), "alice");
+
+        restarted
+            .authorize_remoting(&(), &command)
+            .await
+            .expect("authorization should use persisted ACL");
+
+        restarted.shutdown().await.expect("runtime should shut down");
+        let _ = fs::remove_dir_all(test_dir);
+    }
+
+    #[tokio::test]
+    async fn remoting_authorization_denies_insufficient_permission() {
+        let test_dir = unique_test_dir("proxy-auth-remoting-deny");
+        let runtime = ProxyAuthRuntime::from_proxy_config(&ProxyAuthConfig {
+            authentication_enabled: true,
+            authorization_enabled: true,
+            auth_config_path: test_dir.join("auth-store").to_string_lossy().into_owned(),
+            ..ProxyAuthConfig::default()
+        })
+        .await
+        .expect("runtime should build")
+        .expect("runtime should be enabled");
+        runtime.create_user(normal_user("alice", "secret")).await.unwrap();
+        runtime
+            .create_acl(Acl::of(
+                "alice",
+                SubjectType::User,
+                Policy::of(
+                    vec![Resource::of_topic("TopicA")],
+                    vec![Action::Pub],
+                    None,
+                    Decision::Deny,
+                ),
+            ))
+            .await
+            .unwrap();
+
+        let command = send_message_command("TopicA", "alice", "secret");
+        runtime
+            .authenticate_remoting(&command, Some("channel-a"), Some("127.0.0.1"))
+            .await
+            .expect("authentication should pass");
+        let error = runtime
+            .authorize_remoting(&(), &command)
+            .await
+            .expect_err("authorization should deny");
+        assert!(matches!(
+            error,
+            ProxyError::RocketMQ(RocketMQError::BrokerPermissionDenied { .. })
+        ));
 
         runtime.shutdown().await.expect("runtime should shut down");
         let _ = fs::remove_dir_all(test_dir);

--- a/rocketmq-proxy/src/status.rs
+++ b/rocketmq-proxy/src/status.rs
@@ -190,6 +190,9 @@ impl ProxyStatusMapper {
             RocketMQError::MessageTooLarge { .. } => v2::Code::MessageBodyTooLarge,
             RocketMQError::IllegalArgument(_)
             | RocketMQError::InvalidProperty(_)
+            | RocketMQError::ConfigParseFailed { .. }
+            | RocketMQError::ConfigMissing { .. }
+            | RocketMQError::ConfigInvalidValue { .. }
             | RocketMQError::RequestBodyInvalid { .. }
             | RocketMQError::RequestHeaderError(_)
             | RocketMQError::ResponseProcessFailed { .. }
@@ -291,6 +294,22 @@ mod tests {
         assert_eq!(
             ProxyStatusMapper::to_tonic_status(&error).code(),
             tonic::Code::Unimplemented
+        );
+    }
+
+    #[test]
+    fn auth_config_errors_map_to_bad_request_payload_and_transport_status() {
+        let error = ProxyError::RocketMQ(RocketMQError::ConfigInvalidValue {
+            key: "auth.authorization",
+            value: "local".to_owned(),
+            reason: "provider not ready".to_owned(),
+        });
+
+        let payload_status = ProxyStatusMapper::from_error(&error);
+        assert_eq!(payload_status.code, v2::Code::BadRequest as i32);
+        assert_eq!(
+            ProxyStatusMapper::to_tonic_status(&error).code(),
+            tonic::Code::InvalidArgument
         );
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7373

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added persistence of authentication and authorization metadata to disk, enabling automatic recovery of users and access control lists after broker restarts.
  * Implemented data versioning for access control list changes to track modifications.

* **Improvements**
  * Enhanced error messages and response codes for authentication and authorization operations.
  * Strengthened request authentication validation before processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->