### PR TITLE
[ISSUE #7380]🚀add error handling for malformed requests and enhance debug output to redact sensitive information

### DIFF
--- a/rocketmq-auth/src/authentication/model/user.rs
+++ b/rocketmq-auth/src/authentication/model/user.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::fmt;
 use std::sync::OnceLock;
 
 use cheetah_string::CheetahString;
@@ -22,7 +23,7 @@ use crate::authentication::enums::user_status::UserStatus;
 use crate::authentication::enums::user_type::UserType;
 use crate::authentication::model::subject::Subject;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct User {
     username: CheetahString,
     password: Option<CheetahString>,
@@ -32,6 +33,17 @@ pub struct User {
     user_status: Option<UserStatus>,
     #[serde(skip)]
     subject_key_cache: OnceLock<String>,
+}
+
+impl fmt::Debug for User {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("User")
+            .field("username", &self.username)
+            .field("password", &self.password.as_ref().map(|_| "<redacted>"))
+            .field("user_type", &self.user_type)
+            .field("user_status", &self.user_status)
+            .finish_non_exhaustive()
+    }
 }
 
 impl User {
@@ -169,5 +181,16 @@ mod tests {
         let user = User::of(username);
         assert_eq!(user.subject_key(), "User:test_user");
         assert_eq!(user.subject_type(), SubjectType::User);
+    }
+
+    #[test]
+    fn user_debug_redacts_password() {
+        let user = User::of_with_password("alice", "top-secret-password");
+
+        let debug = format!("{user:?}");
+
+        assert!(debug.contains("alice"));
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("top-secret-password"));
     }
 }

--- a/rocketmq-auth/src/config.rs
+++ b/rocketmq-auth/src/config.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
 use cheetah_string::CheetahString;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::authentication::acl_signer::SignatureAlgorithm;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct AuthConfig {
     pub config_name: CheetahString,
@@ -61,6 +63,76 @@ pub struct AuthConfig {
     pub stateful_authentication_cache_expired_second: u32,
     pub stateful_authorization_cache_max_num: u32,
     pub stateful_authorization_cache_expired_second: u32,
+}
+
+impl fmt::Debug for AuthConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthConfig")
+            .field("config_name", &self.config_name)
+            .field("cluster_name", &self.cluster_name)
+            .field("auth_config_path", &self.auth_config_path)
+            .field("acl_file", &self.acl_file)
+            .field("acl_file_watch_enabled", &self.acl_file_watch_enabled)
+            .field("acl_file_watch_interval_millis", &self.acl_file_watch_interval_millis)
+            .field("authentication_enabled", &self.authentication_enabled)
+            .field("authentication_provider", &self.authentication_provider)
+            .field(
+                "authentication_metadata_provider",
+                &self.authentication_metadata_provider,
+            )
+            .field("authentication_strategy", &self.authentication_strategy)
+            .field("authentication_whitelist", &self.authentication_whitelist)
+            .field(
+                "init_authentication_user",
+                &redacted_if_present(&self.init_authentication_user),
+            )
+            .field(
+                "inner_client_authentication_credentials",
+                &redacted_if_present(&self.inner_client_authentication_credentials),
+            )
+            .field("signature_algorithm", &self.signature_algorithm)
+            .field(
+                "request_timestamp_expired_millis",
+                &self.request_timestamp_expired_millis,
+            )
+            .field("authorization_enabled", &self.authorization_enabled)
+            .field("authorization_provider", &self.authorization_provider)
+            .field("authorization_metadata_provider", &self.authorization_metadata_provider)
+            .field("authorization_strategy", &self.authorization_strategy)
+            .field("authorization_whitelist", &self.authorization_whitelist)
+            .field("migrate_auth_from_v1_enabled", &self.migrate_auth_from_v1_enabled)
+            .field("user_cache_max_num", &self.user_cache_max_num)
+            .field("user_cache_expired_second", &self.user_cache_expired_second)
+            .field("user_cache_refresh_second", &self.user_cache_refresh_second)
+            .field("acl_cache_max_num", &self.acl_cache_max_num)
+            .field("acl_cache_expired_second", &self.acl_cache_expired_second)
+            .field("acl_cache_refresh_second", &self.acl_cache_refresh_second)
+            .field(
+                "stateful_authentication_cache_max_num",
+                &self.stateful_authentication_cache_max_num,
+            )
+            .field(
+                "stateful_authentication_cache_expired_second",
+                &self.stateful_authentication_cache_expired_second,
+            )
+            .field(
+                "stateful_authorization_cache_max_num",
+                &self.stateful_authorization_cache_max_num,
+            )
+            .field(
+                "stateful_authorization_cache_expired_second",
+                &self.stateful_authorization_cache_expired_second,
+            )
+            .finish()
+    }
+}
+
+fn redacted_if_present(value: &CheetahString) -> Option<&'static str> {
+    if value.is_empty() {
+        None
+    } else {
+        Some("<redacted>")
+    }
 }
 
 impl Default for AuthConfig {
@@ -175,5 +247,22 @@ requestTimestampExpiredMillis: 300000
         assert_eq!(config.acl_file_watch_interval_millis, 250);
         assert_eq!(config.signature_algorithm, SignatureAlgorithm::HmacSha256);
         assert_eq!(config.request_timestamp_expired_millis, 300_000);
+    }
+
+    #[test]
+    fn auth_config_debug_redacts_embedded_credentials() {
+        let config = AuthConfig {
+            init_authentication_user: CheetahString::from("admin:init-secret"),
+            inner_client_authentication_credentials: CheetahString::from(
+                r#"{"accessKey":"inner","secretKey":"inner-secret"}"#,
+            ),
+            ..AuthConfig::default()
+        };
+
+        let debug = format!("{config:?}");
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("init-secret"));
+        assert!(!debug.contains("inner-secret"));
     }
 }

--- a/rocketmq-auth/src/migration/alc/plain_access_resource.rs
+++ b/rocketmq-auth/src/migration/alc/plain_access_resource.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use std::collections::HashMap;
+use std::fmt;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::key_builder::KeyBuilder;
 use rocketmq_common::common::mix_all;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct PlainAccessResource {
     /// Identify the user
     pub access_key: Option<CheetahString>,
@@ -41,6 +42,25 @@ pub struct PlainAccessResource {
     pub signature: Option<CheetahString>,
     pub secret_token: Option<CheetahString>,
     pub recognition: Option<CheetahString>,
+}
+
+impl fmt::Debug for PlainAccessResource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PlainAccessResource")
+            .field("access_key", &self.access_key)
+            .field("secret_key", &self.secret_key.as_ref().map(|_| "<redacted>"))
+            .field("white_remote_address", &self.white_remote_address)
+            .field("admin", &self.admin)
+            .field("default_topic_perm", &self.default_topic_perm)
+            .field("default_group_perm", &self.default_group_perm)
+            .field("resource_perm_map", &self.resource_perm_map)
+            .field("request_code", &self.request_code)
+            .field("content_len", &self.content.as_ref().map(Vec::len))
+            .field("signature", &self.signature)
+            .field("secret_token", &self.secret_token.as_ref().map(|_| "<redacted>"))
+            .field("recognition", &self.recognition)
+            .finish()
+    }
 }
 
 impl PlainAccessResource {
@@ -175,5 +195,20 @@ mod tests {
         assert_eq!(retry_topic, Some(CheetahString::from("%RETRY%group1")));
 
         assert_eq!(PlainAccessResource::get_retry_topic(None), None);
+    }
+
+    #[test]
+    fn plain_access_resource_debug_redacts_secrets() {
+        let mut resource = PlainAccessResource::new();
+        resource.set_access_key(CheetahString::from("ak"));
+        resource.set_secret_key(CheetahString::from("secret-key-value"));
+        resource.set_secret_token(CheetahString::from("secret-token-value"));
+
+        let debug = format!("{resource:?}");
+
+        assert!(debug.contains("ak"));
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("secret-key-value"));
+        assert!(!debug.contains("secret-token-value"));
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -640,6 +640,7 @@ fn map_auth_admin_error_response(response: RemotingCommand, error: RocketMQError
         RocketMQError::ConfigParseFailed { reason, .. } => (ResponseCode::InvalidParameter, reason.clone()),
         RocketMQError::ConfigMissing { key } => (ResponseCode::InvalidParameter, (*key).to_owned()),
         RocketMQError::ConfigInvalidValue { reason, .. } => (ResponseCode::InvalidParameter, reason.clone()),
+        RocketMQError::Serialization(_) => (ResponseCode::InvalidParameter, error.to_string()),
         RocketMQError::Authentication(AuthError::UserNotFound(_)) => (ResponseCode::UserNotExist, error.to_string()),
         RocketMQError::Authentication(_) => (ResponseCode::NoPermission, error.to_string()),
         RocketMQError::BrokerPermissionDenied { operation } => (ResponseCode::NoPermission, operation.clone()),
@@ -694,6 +695,12 @@ mod tests {
                 value: "local".to_owned(),
                 reason: "provider not ready".to_owned(),
             },
+        );
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
+
+        let response = map_auth_admin_error_response(
+            RemotingCommand::create_response_command(),
+            RocketMQError::deserialization_failed("JSON", "malformed auth admin body"),
         );
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
@@ -71,8 +71,14 @@ impl<MS: MessageStore> CreateAclRequestHandler<MS> {
                     .set_remark("Request body is empty"),
             ));
         };
-        let acl_info = AclInfo::decode(body)?;
-        let acl = AclConverter::convert_acl_info(&acl_info, request_header.subject.as_str())?;
+        let acl_info = match AclInfo::decode(body) {
+            Ok(acl_info) => acl_info,
+            Err(error) => return Ok(Some(map_error_response(response, error))),
+        };
+        let acl = match AclConverter::convert_acl_info(&acl_info, request_header.subject.as_str()) {
+            Ok(acl) => acl,
+            Err(error) => return Ok(Some(map_error_response(response, error))),
+        };
 
         if self.is_not_super_user_login(request).await? {
             return Ok(Some(

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
@@ -60,7 +60,10 @@ impl<MS: MessageStore> CreateUserRequestHandler<MS> {
             ));
         };
 
-        let mut user_info: UserInfo = UserInfo::decode(body)?;
+        let mut user_info: UserInfo = match UserInfo::decode(body) {
+            Ok(user_info) => user_info,
+            Err(error) => return Ok(Some(map_error_response(response, error))),
+        };
         user_info.username = Some(request_header.username);
         let user = UserConverter::convert_user(&user_info);
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
@@ -96,7 +96,9 @@ mod tests {
     use rocketmq_remoting::protocol::body::acl_info::PolicyEntryInfo;
     use rocketmq_remoting::protocol::body::acl_info::PolicyInfo;
     use rocketmq_remoting::protocol::header::create_acl_request_header::CreateAclRequestHeader;
+    use rocketmq_remoting::protocol::header::create_user_request_header::CreateUserRequestHeader;
     use rocketmq_remoting::protocol::header::update_acl_request_header::UpdateAclRequestHeader;
+    use rocketmq_remoting::protocol::header::update_user_request_header::UpdateUserRequestHeader;
     use rocketmq_remoting::protocol::RemotingDeserializable;
     use rocketmq_remoting::protocol::RemotingSerializable;
     use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
@@ -107,7 +109,9 @@ mod tests {
     use crate::auth::auth_admin_service::AuthAdminService;
     use crate::broker_runtime::BrokerRuntime;
     use crate::processor::admin_broker_processor::create_acl_request_handler::CreateAclRequestHandler;
+    use crate::processor::admin_broker_processor::create_user_request_handler::CreateUserRequestHandler;
     use crate::processor::admin_broker_processor::update_acl_request_handler::UpdateAclRequestHandler;
+    use crate::processor::admin_broker_processor::update_user_request_handler::UpdateUserRequestHandler;
 
     fn temp_test_root(label: &str) -> std::path::PathBuf {
         let millis = SystemTime::now()
@@ -272,6 +276,119 @@ mod tests {
             .and_then(|policy| policy.entries.as_ref())
             .expect("entries should exist");
         assert_eq!(entries.len(), 2);
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn auth_admin_handlers_return_invalid_parameter_for_malformed_body() {
+        let mut runtime = new_test_runtime("malformed-body").await;
+        let inner = runtime.inner_for_test().clone();
+        let auth_admin_service = Arc::new(
+            AuthAdminService::new(AuthConfig {
+                auth_config_path: inner.broker_config().auth_config_path.clone(),
+                ..AuthConfig::default()
+            })
+            .expect("create auth admin service"),
+        );
+        let mut create_user_handler = CreateUserRequestHandler::new(inner.clone(), auth_admin_service.clone());
+        let mut update_user_handler = UpdateUserRequestHandler::new(inner.clone(), auth_admin_service.clone());
+        let mut create_acl_handler = CreateAclRequestHandler::new(inner.clone(), auth_admin_service.clone());
+        let mut update_acl_handler = UpdateAclRequestHandler::new(inner.clone(), auth_admin_service);
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+
+        let mut create_user_request = RemotingCommand::create_request_command(
+            RequestCode::AuthCreateUser,
+            CreateUserRequestHeader {
+                username: CheetahString::from_static_str("alice"),
+            },
+        )
+        .set_body(b"{not-json".to_vec());
+        create_user_request.make_custom_header_to_net();
+        let create_user_response = create_user_handler
+            .create_user(
+                channel.clone(),
+                ctx.clone(),
+                RequestCode::AuthCreateUser,
+                &mut create_user_request,
+            )
+            .await
+            .expect("malformed user body should return a response")
+            .expect("malformed user body should return a response");
+        assert_eq!(
+            ResponseCode::from(create_user_response.code()),
+            ResponseCode::InvalidParameter
+        );
+
+        let mut update_user_request = RemotingCommand::create_request_command(
+            RequestCode::AuthUpdateUser,
+            UpdateUserRequestHeader {
+                username: CheetahString::from_static_str("alice"),
+            },
+        )
+        .set_body(b"{not-json".to_vec());
+        update_user_request.make_custom_header_to_net();
+        let update_user_response = update_user_handler
+            .update_user(
+                channel.clone(),
+                ctx.clone(),
+                RequestCode::AuthUpdateUser,
+                &mut update_user_request,
+            )
+            .await
+            .expect("malformed update user body should return a response")
+            .expect("malformed update user body should return a response");
+        assert_eq!(
+            ResponseCode::from(update_user_response.code()),
+            ResponseCode::InvalidParameter
+        );
+
+        let mut create_acl_request = RemotingCommand::create_request_command(
+            RequestCode::AuthCreateAcl,
+            CreateAclRequestHeader {
+                subject: CheetahString::from_static_str("User:alice"),
+            },
+        )
+        .set_body(b"{not-json".to_vec());
+        create_acl_request.make_custom_header_to_net();
+        let create_acl_response = create_acl_handler
+            .create_acl(
+                channel.clone(),
+                ctx.clone(),
+                RequestCode::AuthCreateAcl,
+                &mut create_acl_request,
+            )
+            .await
+            .expect("malformed acl body should return a response")
+            .expect("malformed acl body should return a response");
+        assert_eq!(
+            ResponseCode::from(create_acl_response.code()),
+            ResponseCode::InvalidParameter
+        );
+
+        let mut update_acl_request = RemotingCommand::create_request_command(
+            RequestCode::AuthUpdateAcl,
+            UpdateAclRequestHeader {
+                subject: CheetahString::from_static_str("User:alice"),
+            },
+        )
+        .set_body(b"{not-json".to_vec());
+        update_acl_request.make_custom_header_to_net();
+        let update_acl_response = update_acl_handler
+            .update_acl(
+                channel.clone(),
+                ctx.clone(),
+                RequestCode::AuthUpdateAcl,
+                &mut update_acl_request,
+            )
+            .await
+            .expect("malformed update acl body should return a response")
+            .expect("malformed update acl body should return a response");
+        assert_eq!(
+            ResponseCode::from(update_acl_response.code()),
+            ResponseCode::InvalidParameter
+        );
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
@@ -71,8 +71,14 @@ impl<MS: MessageStore> UpdateAclRequestHandler<MS> {
                     .set_remark("Request body is empty"),
             ));
         };
-        let acl_info = AclInfo::decode(body)?;
-        let acl = AclConverter::convert_acl_info(&acl_info, request_header.subject.as_str())?;
+        let acl_info = match AclInfo::decode(body) {
+            Ok(acl_info) => acl_info,
+            Err(error) => return Ok(Some(map_error_response(response, error))),
+        };
+        let acl = match AclConverter::convert_acl_info(&acl_info, request_header.subject.as_str()) {
+            Ok(acl) => acl,
+            Err(error) => return Ok(Some(map_error_response(response, error))),
+        };
 
         if self.is_not_super_user_login(request).await? {
             return Ok(Some(

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
@@ -62,7 +62,10 @@ impl<MS: MessageStore> UpdateUserRequestHandler<MS> {
                 ));
             }
         };
-        let mut user_info: UserInfo = UserInfo::decode(body)?;
+        let mut user_info: UserInfo = match UserInfo::decode(body) {
+            Ok(user_info) => user_info,
+            Err(error) => return Ok(Some(map_error_response(response, error))),
+        };
 
         user_info.username = Option::from(request_header.username);
         let user = UserConverter::convert_user(&user_info);

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2328,9 +2328,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b0187df4e614e42405b49511b82ff7a1774fbd9a816060ee465067847cac22"
+checksum = "aa08fb2b1ec3ea84575e94b489d06d4ce0cbf052d12acd515838f50e3c3d63e3"
 dependencies = [
  "libc",
  "neli",
@@ -2827,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-probe"

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1269,9 +1269,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b0187df4e614e42405b49511b82ff7a1774fbd9a816060ee465067847cac22"
+checksum = "aa08fb2b1ec3ea84575e94b489d06d4ce0cbf052d12acd515838f50e3c3d63e3"
 dependencies = [
  "libc",
  "neli",
@@ -1413,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-probe"

--- a/rocketmq-proxy/src/config.rs
+++ b/rocketmq-proxy/src/config.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::time::Duration;
@@ -225,7 +226,7 @@ impl SessionConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default, rename_all = "camelCase")]
 pub struct ProxyAuthConfig {
     pub config_name: String,
@@ -248,6 +249,53 @@ pub struct ProxyAuthConfig {
     pub authorization_metadata_provider: String,
     pub authorization_strategy: String,
     pub authorization_whitelist: Vec<String>,
+}
+
+impl fmt::Debug for ProxyAuthConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProxyAuthConfig")
+            .field("config_name", &self.config_name)
+            .field("cluster_name", &self.cluster_name)
+            .field("auth_config_path", &self.auth_config_path)
+            .field("acl_file", &self.acl_file)
+            .field("acl_file_watch_enabled", &self.acl_file_watch_enabled)
+            .field("acl_file_watch_interval_millis", &self.acl_file_watch_interval_millis)
+            .field("authentication_enabled", &self.authentication_enabled)
+            .field("authentication_provider", &self.authentication_provider)
+            .field(
+                "authentication_metadata_provider",
+                &self.authentication_metadata_provider,
+            )
+            .field("authentication_strategy", &self.authentication_strategy)
+            .field("authentication_whitelist", &self.authentication_whitelist)
+            .field(
+                "init_authentication_user",
+                &redacted_config_value(&self.init_authentication_user),
+            )
+            .field(
+                "inner_client_authentication_credentials",
+                &redacted_config_value(&self.inner_client_authentication_credentials),
+            )
+            .field("signature_algorithm", &self.signature_algorithm)
+            .field(
+                "request_timestamp_expired_millis",
+                &self.request_timestamp_expired_millis,
+            )
+            .field("authorization_enabled", &self.authorization_enabled)
+            .field("authorization_provider", &self.authorization_provider)
+            .field("authorization_metadata_provider", &self.authorization_metadata_provider)
+            .field("authorization_strategy", &self.authorization_strategy)
+            .field("authorization_whitelist", &self.authorization_whitelist)
+            .finish()
+    }
+}
+
+fn redacted_config_value(value: &str) -> Option<&'static str> {
+    if value.is_empty() {
+        None
+    } else {
+        Some("<redacted>")
+    }
 }
 
 impl Default for ProxyAuthConfig {
@@ -389,5 +437,20 @@ requestTimestampExpiredMillis: 300000
         assert_eq!(config.acl_file_watch_interval_millis, 250);
         assert_eq!(config.signature_algorithm, SignatureAlgorithm::HmacMd5);
         assert_eq!(config.request_timestamp_expired_millis, 300_000);
+    }
+
+    #[test]
+    fn proxy_auth_config_debug_redacts_embedded_credentials() {
+        let config = ProxyAuthConfig {
+            init_authentication_user: "admin:init-secret".to_owned(),
+            inner_client_authentication_credentials: r#"{"accessKey":"inner","secretKey":"inner-secret"}"#.to_owned(),
+            ..ProxyAuthConfig::default()
+        };
+
+        let output = format!("{config:?}");
+
+        assert!(!output.contains("init-secret"));
+        assert!(!output.contains("inner-secret"));
+        assert!(output.contains("<redacted>"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7380

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Sensitive credentials and authentication data (passwords, secret tokens, secret keys) are now automatically redacted in debug output to prevent accidental disclosure in logs.

* **Bug Fixes**
  * Improved error handling for malformed or invalid requests in authentication and ACL management endpoints, now returning appropriate error responses instead of propagating errors upstream.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->