### PR TITLE
[ISSUE #7382]🚀add list users and list ACL request handlers with empty response handling; enhance user update permissions check

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
@@ -95,8 +95,11 @@ mod tests {
     use rocketmq_remoting::protocol::body::acl_info::AclInfo;
     use rocketmq_remoting::protocol::body::acl_info::PolicyEntryInfo;
     use rocketmq_remoting::protocol::body::acl_info::PolicyInfo;
+    use rocketmq_remoting::protocol::body::user_info::UserInfo;
     use rocketmq_remoting::protocol::header::create_acl_request_header::CreateAclRequestHeader;
     use rocketmq_remoting::protocol::header::create_user_request_header::CreateUserRequestHeader;
+    use rocketmq_remoting::protocol::header::list_acl_request_header::ListAclRequestHeader;
+    use rocketmq_remoting::protocol::header::list_users_request_header::ListUsersRequestHeader;
     use rocketmq_remoting::protocol::header::update_acl_request_header::UpdateAclRequestHeader;
     use rocketmq_remoting::protocol::header::update_user_request_header::UpdateUserRequestHeader;
     use rocketmq_remoting::protocol::RemotingDeserializable;
@@ -110,6 +113,8 @@ mod tests {
     use crate::broker_runtime::BrokerRuntime;
     use crate::processor::admin_broker_processor::create_acl_request_handler::CreateAclRequestHandler;
     use crate::processor::admin_broker_processor::create_user_request_handler::CreateUserRequestHandler;
+    use crate::processor::admin_broker_processor::list_acl_request_handler::ListAclRequestHandler;
+    use crate::processor::admin_broker_processor::list_users_request_handler::ListUsersRequestHandler;
     use crate::processor::admin_broker_processor::update_acl_request_handler::UpdateAclRequestHandler;
     use crate::processor::admin_broker_processor::update_user_request_handler::UpdateUserRequestHandler;
 
@@ -389,6 +394,125 @@ mod tests {
             ResponseCode::from(update_acl_response.code()),
             ResponseCode::InvalidParameter
         );
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn auth_admin_empty_list_responses_match_java_without_body() {
+        let mut runtime = new_test_runtime("empty-list").await;
+        let inner = runtime.inner_for_test().clone();
+        let auth_admin_service = Arc::new(
+            AuthAdminService::new(AuthConfig {
+                auth_config_path: inner.broker_config().auth_config_path.clone(),
+                ..AuthConfig::default()
+            })
+            .expect("create auth admin service"),
+        );
+        let mut list_users_handler = ListUsersRequestHandler::new(inner.clone(), auth_admin_service.clone());
+        let mut list_acl_handler = ListAclRequestHandler::new(inner.clone(), auth_admin_service);
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+
+        let mut list_users_request = RemotingCommand::create_request_command(
+            RequestCode::AuthListUsers,
+            ListUsersRequestHeader {
+                filter: CheetahString::from_static_str("missing"),
+            },
+        );
+        list_users_request.make_custom_header_to_net();
+        let list_users_response = list_users_handler
+            .list_users(
+                channel.clone(),
+                ctx.clone(),
+                RequestCode::AuthListUsers,
+                &mut list_users_request,
+            )
+            .await
+            .expect("empty user list should return a response")
+            .expect("empty user list should return a response");
+        assert_eq!(ResponseCode::from(list_users_response.code()), ResponseCode::Success);
+        assert!(list_users_response.body().is_none());
+
+        let mut list_acl_request = RemotingCommand::create_request_command(
+            RequestCode::AuthListAcl,
+            ListAclRequestHeader {
+                subject_filter: CheetahString::from_static_str("User:missing"),
+                resource_filter: CheetahString::new(),
+            },
+        );
+        list_acl_request.make_custom_header_to_net();
+        let list_acl_response = list_acl_handler
+            .list_acl(
+                channel.clone(),
+                ctx.clone(),
+                RequestCode::AuthListAcl,
+                &mut list_acl_request,
+            )
+            .await
+            .expect("empty acl list should return a response")
+            .expect("empty acl list should return a response");
+        assert_eq!(ResponseCode::from(list_acl_response.code()), ResponseCode::Success);
+        assert!(list_acl_response.body().is_none());
+
+        let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[tokio::test]
+    async fn auth_update_user_rejects_non_super_updating_existing_super_user() {
+        let mut runtime = new_test_runtime("protect-super-user").await;
+        let inner = runtime.inner_for_test().clone();
+        let auth_admin_service = Arc::new(
+            AuthAdminService::new(AuthConfig {
+                auth_config_path: inner.broker_config().auth_config_path.clone(),
+                ..AuthConfig::default()
+            })
+            .expect("create auth admin service"),
+        );
+        let mut admin = User::of_with_type("admin", "admin-secret", UserType::Super);
+        admin.set_user_status(UserStatus::Enable);
+        auth_admin_service.create_user(admin).await.expect("create admin user");
+        let mut alice = User::of_with_type("alice", "alice-secret", UserType::Normal);
+        alice.set_user_status(UserStatus::Enable);
+        auth_admin_service.create_user(alice).await.expect("create alice user");
+
+        let mut handler = UpdateUserRequestHandler::new(inner.clone(), auth_admin_service.clone());
+        let channel = create_test_channel().await;
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::AuthUpdateUser,
+            UpdateUserRequestHeader {
+                username: CheetahString::from_static_str("admin"),
+            },
+        )
+        .set_body(
+            UserInfo {
+                username: None,
+                password: Some(CheetahString::from_static_str("downgraded-secret")),
+                user_type: Some(CheetahString::from_static_str("Normal")),
+                user_status: Some(CheetahString::from_static_str("enable")),
+            }
+            .encode()
+            .expect("encode user info"),
+        );
+        request.ensure_ext_fields_initialized();
+        request.add_ext_field("AccessKey", "alice");
+        request.make_custom_header_to_net();
+
+        let response = handler
+            .update_user(channel, ctx, RequestCode::AuthUpdateUser, &mut request)
+            .await
+            .expect("update should return response")
+            .expect("update should return response");
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
+
+        let admin = auth_admin_service
+            .get_user("admin")
+            .await
+            .expect("admin should still be readable")
+            .expect("admin should still exist");
+        assert_eq!(admin.user_type.as_deref(), Some(UserType::Super.name()));
+        assert_eq!(admin.password.as_deref(), Some("admin-secret"));
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
@@ -49,7 +49,9 @@ impl<MS: MessageStore> ListAclRequestHandler<MS> {
             .await
         {
             Ok(acls) => {
-                response.set_body_mut_ref(acls.encode()?);
+                if !acls.is_empty() {
+                    response.set_body_mut_ref(acls.encode()?);
+                }
                 Ok(Some(response.set_code(ResponseCode::Success)))
             }
             Err(error) => Ok(Some(map_error_response(response, error))),

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
@@ -59,7 +59,9 @@ impl<MS: MessageStore> ListUsersRequestHandler<MS> {
             .await
         {
             Ok(users) => {
-                response.set_body_mut_ref(users.encode()?);
+                if !users.is_empty() {
+                    response.set_body_mut_ref(users.encode()?);
+                }
                 Ok(Some(response.set_code(ResponseCode::Success)))
             }
             Err(error) => Ok(Some(map_error_response(response, error))),

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
@@ -69,13 +69,29 @@ impl<MS: MessageStore> UpdateUserRequestHandler<MS> {
 
         user_info.username = Option::from(request_header.username);
         let user = UserConverter::convert_user(&user_info);
+        let is_not_super_user_login = self.is_not_super_user_login(request).await?;
 
-        if user.user_type() == Option::from(UserType::Super) && self.is_not_super_user_login(request).await? {
+        if user.user_type() == Option::from(UserType::Super) && is_not_super_user_login {
             return Ok(Some(
                 response
                     .set_code(ResponseCode::NoPermission)
                     .set_remark("The super user can only be update by super user"),
             ));
+        }
+
+        match self.auth_admin_service.get_user(user.username().as_str()).await {
+            Ok(Some(existing_user))
+                if existing_user.user_type.as_deref().and_then(UserType::get_by_name) == Some(UserType::Super)
+                    && is_not_super_user_login =>
+            {
+                return Ok(Some(
+                    response
+                        .set_code(ResponseCode::NoPermission)
+                        .set_remark("The super user can only be update by super user"),
+                ));
+            }
+            Ok(_) => {}
+            Err(error) => return Ok(Some(map_error_response(response, error))),
         }
 
         match self.auth_admin_service.update_user(user).await {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7382

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Empty ACL and user list responses now omit unnecessary response body
  * Super user update permission validation enhanced—non-super users can no longer modify existing super user accounts

* **Tests**
  * Added validation tests for list handler behavior and super user modification restrictions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mxsm/rocketmq-rust/pull/7383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->