### PR TITLE
[ISSUE #7409]🚀enhance RocksDB configuration with new options for write buffer size, WAL recovery mode, and improved path handling for consume queues; refactor related components for better integration

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -5069,7 +5069,7 @@ accounts:
         let GenericMessageStore::RocksDBStore(rocksdb_owner) = message_store.as_ref() else {
             panic!("RocksDB store type should initialize the broker main store as GenericMessageStore::RocksDBStore");
         };
-        assert!(rocksdb_owner.rocksdb_config().path.ends_with("consumequeue"));
+        assert!(rocksdb_owner.rocksdb_config().path.ends_with("consumequeue_rocksdb"));
 
         if let Some(message_store) = runtime.inner.message_store.as_mut() {
             message_store.shutdown().await;

--- a/rocketmq-broker/src/config.rs
+++ b/rocketmq-broker/src/config.rs
@@ -22,9 +22,14 @@ mod tests {
     use std::time::SystemTime;
     use std::time::UNIX_EPOCH;
 
+    use rocketmq_store::rocksdb::config::RocksDbWalRecoveryMode;
+
     use super::rocksdb_manager::RocksDbBrokerConfigManager;
     use super::rocksdb_manager::RocksDbBrokerConfigManagerConfig;
     use super::rocksdb_manager::RocksDbBrokerConfigStorageLayout;
+
+    const MB: usize = 1024 * 1024;
+    const MB_U64: u64 = 1024 * 1024;
 
     #[test]
     fn rocksdb_config_storage_paths_match_java_single_and_separate_layouts() {
@@ -64,6 +69,16 @@ mod tests {
 
         assert!(manager.rocksdb_config().wal_enabled);
         assert!(!manager.rocksdb_config().sync_write);
+        assert_eq!(manager.rocksdb_config().db_write_buffer_size, Some(128 * MB));
+        assert_eq!(manager.rocksdb_config().wal_bytes_per_sync, Some(MB_U64));
+        assert_eq!(
+            manager.rocksdb_config().wal_recovery_mode,
+            RocksDbWalRecoveryMode::SkipAnyCorruptedRecord
+        );
+        assert_eq!(manager.rocksdb_config().stats_dump_period_sec, 600);
+        assert_eq!(manager.rocksdb_config().max_subcompactions, 4);
+        assert!(manager.rocksdb_config().use_direct_io_for_flush_and_compaction);
+        assert!(manager.rocksdb_config().use_direct_reads);
         assert_eq!(manager.default_cf(), "topic");
         assert_eq!(manager.version_cf(), "topicVersion");
 

--- a/rocketmq-broker/src/config/rocksdb_manager.rs
+++ b/rocketmq-broker/src/config/rocksdb_manager.rs
@@ -21,6 +21,7 @@ use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_store::rocksdb::batch::RocksDbWriteBatch;
 use rocketmq_store::rocksdb::config::RocksDbColumnFamilyConfig;
 use rocketmq_store::rocksdb::config::RocksDbConfig;
+use rocketmq_store::rocksdb::config::RocksDbWalRecoveryMode;
 use rocketmq_store::rocksdb::error::codec_error;
 use rocketmq_store::rocksdb::iterator::RocksDbRangeScanOptions;
 use rocketmq_store::rocksdb::store::KeyValueStore;
@@ -29,6 +30,8 @@ use rocketmq_store::rocksdb::store::RocksDbStore;
 const DEFAULT_COLUMN_FAMILY: &str = "default";
 const KV_DATA_VERSION_COLUMN_FAMILY: &str = "kvDataVersion";
 const KV_DATA_VERSION_KEY: &[u8] = b"kvDataVersionKey";
+const MB: usize = 1024 * 1024;
+const MB_U64: u64 = 1024 * 1024;
 
 type ConfigRecords = Vec<(Vec<u8>, Vec<u8>)>;
 
@@ -310,6 +313,13 @@ fn build_rocksdb_config(config: &RocksDbBrokerConfigManagerConfig) -> RocksDbCon
         sync_write: false,
         write_buffer_size: config.write_buffer_size,
         block_cache_size: config.block_cache_size,
+        db_write_buffer_size: Some(128 * MB),
+        wal_bytes_per_sync: Some(MB_U64),
+        wal_recovery_mode: RocksDbWalRecoveryMode::SkipAnyCorruptedRecord,
+        stats_dump_period_sec: 600,
+        max_subcompactions: 4,
+        use_direct_io_for_flush_and_compaction: true,
+        use_direct_reads: true,
         column_families: column_family_names
             .into_iter()
             .map(|name| config_column_family(&name, config.block_cache_size, config.write_buffer_size))
@@ -346,6 +356,13 @@ fn build_shared_rocksdb_config(configs: &[RocksDbBrokerConfigManagerConfig]) -> 
         sync_write: false,
         write_buffer_size: first.write_buffer_size,
         block_cache_size: first.block_cache_size,
+        db_write_buffer_size: Some(128 * MB),
+        wal_bytes_per_sync: Some(MB_U64),
+        wal_recovery_mode: RocksDbWalRecoveryMode::SkipAnyCorruptedRecord,
+        stats_dump_period_sec: 600,
+        max_subcompactions: 4,
+        use_direct_io_for_flush_and_compaction: true,
+        use_direct_reads: true,
         column_families: column_family_names
             .into_iter()
             .map(|name| config_column_family(&name, first.block_cache_size, first.write_buffer_size))
@@ -355,10 +372,5 @@ fn build_shared_rocksdb_config(configs: &[RocksDbBrokerConfigManagerConfig]) -> 
 }
 
 fn config_column_family(name: &str, block_cache_size: usize, write_buffer_size: usize) -> RocksDbColumnFamilyConfig {
-    RocksDbColumnFamilyConfig {
-        name: name.to_string(),
-        block_cache_size,
-        write_buffer_size,
-        ..RocksDbColumnFamilyConfig::consume_queue_default()
-    }
+    RocksDbColumnFamilyConfig::broker_config(name, block_cache_size, write_buffer_size)
 }

--- a/rocketmq-broker/src/pop/rocksdb_store.rs
+++ b/rocketmq-broker/src/pop/rocksdb_store.rs
@@ -19,8 +19,6 @@ use rocketmq_error::RocketMQError;
 use rocketmq_store::rocksdb::batch::RocksDbWriteBatch;
 use rocketmq_store::rocksdb::column_family::RocksDbColumnFamily;
 use rocketmq_store::rocksdb::config::RocksDbColumnFamilyConfig;
-use rocketmq_store::rocksdb::config::RocksDbCompactionStyle;
-use rocketmq_store::rocksdb::config::RocksDbCompressionType;
 use rocketmq_store::rocksdb::config::RocksDbConfig;
 use rocketmq_store::rocksdb::error::codec_error;
 use rocketmq_store::rocksdb::iterator::RocksDbRangeScanOptions;
@@ -194,17 +192,7 @@ fn pop_column_family_config(
     block_cache_size: usize,
     write_buffer_size: usize,
 ) -> RocksDbColumnFamilyConfig {
-    RocksDbColumnFamilyConfig {
-        name: name.to_string(),
-        write_buffer_size,
-        max_write_buffer_number: 4,
-        block_cache_size,
-        block_size: 32 * 1024,
-        bloom_filter_bits: 16.0,
-        compression_type: RocksDbCompressionType::Lz4,
-        bottommost_compression_type: RocksDbCompressionType::Lz4,
-        compaction_style: RocksDbCompactionStyle::Universal,
-    }
+    RocksDbColumnFamilyConfig::pop(name, block_cache_size, write_buffer_size)
 }
 
 fn validate_key_component(field: &'static str, value: &str) -> Result<(), RocketMQError> {

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -142,6 +142,10 @@ mod defaults {
         StoreType::default()
     }
 
+    pub fn use_separate_store_path_for_rocksdb_cq() -> bool {
+        true
+    }
+
     pub fn mapped_file_size_consume_queue() -> usize {
         300000 * 20
     }
@@ -912,6 +916,13 @@ pub struct MessageStoreConfig {
     #[serde(default)]
     pub rocksdb_cq_double_write_enable: bool,
 
+    #[serde(
+        default = "defaults::use_separate_store_path_for_rocksdb_cq",
+        alias = "useSeparateStorePathForRocksdbCQ",
+        alias = "useSeparateStorePathForRocksDBCQ"
+    )]
+    pub use_separate_store_path_for_rocksdb_cq: bool,
+
     #[serde(default)]
     pub read_uncommitted: bool,
 
@@ -1121,6 +1132,7 @@ impl Default for MessageStoreConfig {
             max_filter_message_size: 16000,
             enable_dleger_commit_log: false,
             rocksdb_cq_double_write_enable: false,
+            use_separate_store_path_for_rocksdb_cq: true,
             read_uncommitted: false,
             enable_controller_mode: false,
             #[cfg(feature = "tieredstore")]
@@ -1761,6 +1773,10 @@ impl MessageStoreConfig {
         properties.insert("enableRocksdbLog".into(), self.enable_rocksdb_log.to_string());
         properties.insert("topicQueueLockNum".into(), self.topic_queue_lock_num.to_string());
         properties.insert("maxFilterMessageSize".into(), self.max_filter_message_size.to_string());
+        properties.insert(
+            "useSeparateStorePathForRocksdbCQ".into(),
+            self.use_separate_store_path_for_rocksdb_cq.to_string(),
+        );
         properties
             .into_iter()
             .map(|(k, v)| (k.into(), v.into()))
@@ -1826,12 +1842,14 @@ mod tests {
         assert_eq!(config.max_rocksdb_index_query_days, 7);
         assert_eq!(config.pop_rocksdb_block_cache_size, 256 * 1024 * 1024);
         assert_eq!(config.pop_rocksdb_write_buffer_size, 32 * 1024 * 1024);
+        assert!(config.use_separate_store_path_for_rocksdb_cq);
 
         let properties = config.get_properties();
         assert_eq!(properties["transRocksDBEnable"], "false");
         assert_eq!(properties["maxRocksDBIndexQueryDays"], "7");
         assert_eq!(properties["popRocksdbBlockCacheSize"], (256 * 1024 * 1024).to_string());
         assert_eq!(properties["popRocksdbWriteBufferSize"], (32 * 1024 * 1024).to_string());
+        assert_eq!(properties["useSeparateStorePathForRocksdbCQ"], "true");
     }
 
     #[test]
@@ -1842,6 +1860,19 @@ mod tests {
         assert_eq!(config.max_rocksdb_index_query_days, 7);
         assert_eq!(config.pop_rocksdb_block_cache_size, 256 * 1024 * 1024);
         assert_eq!(config.pop_rocksdb_write_buffer_size, 32 * 1024 * 1024);
+        assert!(config.use_separate_store_path_for_rocksdb_cq);
+        Ok(())
+    }
+
+    #[test]
+    fn serde_loads_java_rocksdb_cq_separate_path_alias() -> Result<(), serde_json::Error> {
+        let config: MessageStoreConfig = serde_json::from_str(
+            r#"{
+                "useSeparateStorePathForRocksdbCQ": false
+            }"#,
+        )?;
+
+        assert!(!config.use_separate_store_path_for_rocksdb_cq);
         Ok(())
     }
 

--- a/rocketmq-store/src/config/store_path_config_helper.rs
+++ b/rocketmq-store/src/config/store_path_config_helper.rs
@@ -18,6 +18,11 @@ pub(crate) fn get_store_path_consume_queue(root_dir: &str) -> String {
 }
 
 #[inline]
+pub(crate) fn get_store_path_rocksdb_consume_queue(root_dir: &str) -> String {
+    format!("{}{}consumequeue_rocksdb", root_dir, std::path::MAIN_SEPARATOR,)
+}
+
+#[inline]
 pub(crate) fn get_store_path_consume_queue_ext(root_dir: &str) -> String {
     format!("{}{}consumequeue_ext", root_dir, std::path::MAIN_SEPARATOR,)
 }
@@ -86,6 +91,13 @@ mod tests {
         let root_dir = "/path/to/root";
         let expected_path = format!("{}{}consumequeue", root_dir, std::path::MAIN_SEPARATOR);
         assert_eq!(get_store_path_consume_queue(root_dir), expected_path);
+    }
+
+    #[test]
+    fn test_get_store_path_rocksdb_consume_queue() {
+        let root_dir = "/path/to/root";
+        let expected_path = format!("{}{}consumequeue_rocksdb", root_dir, std::path::MAIN_SEPARATOR);
+        assert_eq!(get_store_path_rocksdb_consume_queue(root_dir), expected_path);
     }
 
     #[test]

--- a/rocketmq-store/src/message_store/rocksdb_message_store.rs
+++ b/rocketmq-store/src/message_store/rocksdb_message_store.rs
@@ -129,6 +129,7 @@ impl RocksDBMessageStore {
                 "RocksDBMessageStore requires store_type=RocksDB".to_string(),
             ));
         }
+        validate_rocksdb_consume_queue_store_path(message_store_config.as_ref())?;
 
         let message_store_config_for_index = Arc::clone(&message_store_config);
         let message_store_config_for_timer = Arc::clone(&message_store_config);
@@ -591,6 +592,18 @@ impl RocksDBMessageStore {
             .map(|value| ConsumeQueueValue::decode(value.as_ref()).map_err(rocksdb_store_error))
             .transpose()
     }
+}
+
+fn validate_rocksdb_consume_queue_store_path(message_store_config: &MessageStoreConfig) -> Result<(), StoreError> {
+    let conflict_path = RocksDbConfig::consume_queue_conflict_path_from_message_store_config(message_store_config);
+    if conflict_path.join("CURRENT").is_file() {
+        return Err(StoreError::General(format!(
+            "found RocksDB consume queue in incompatible path: {}, maybe incompatible \
+             use_separate_store_path_for_rocksdb_cq config",
+            conflict_path.display()
+        )));
+    }
+    Ok(())
 }
 
 fn rocksdb_store_error(error: rocketmq_error::RocketMQError) -> StoreError {

--- a/rocketmq-store/src/rocksdb/config.rs
+++ b/rocketmq-store/src/rocksdb/config.rs
@@ -19,8 +19,15 @@ use rocketmq_error::RocketMQError;
 use crate::config::message_store_config::MessageStoreConfig;
 use crate::rocksdb::options::RocksDbWriteProfile;
 use crate::store_path_config_helper::get_store_path_consume_queue;
+use crate::store_path_config_helper::get_store_path_rocksdb_consume_queue;
 
 const ROCKSDB_MESSAGE_DIRECTORY: &str = "rocksdbstore";
+const KB: usize = 1024;
+const MB: usize = 1024 * KB;
+const GB: usize = 1024 * MB;
+const KB_U64: u64 = 1024;
+const MB_U64: u64 = 1024 * KB_U64;
+const GB_U64: u64 = 1024 * MB_U64;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum RocksDbCompressionType {
@@ -39,6 +46,30 @@ pub enum RocksDbCompactionStyle {
     Fifo,
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum RocksDbWalRecoveryMode {
+    TolerateCorruptedTailRecords,
+    AbsoluteConsistency,
+    #[default]
+    PointInTime,
+    SkipAnyCorruptedRecord,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum RocksDbBlockBasedIndexType {
+    #[default]
+    BinarySearch,
+    HashSearch,
+    TwoLevelIndexSearch,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum RocksDbDataBlockIndexType {
+    #[default]
+    BinarySearch,
+    BinaryAndHash,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RocksDbColumnFamilyConfig {
     pub name: String,
@@ -46,73 +77,234 @@ pub struct RocksDbColumnFamilyConfig {
     pub max_write_buffer_number: i32,
     pub block_cache_size: usize,
     pub block_size: usize,
+    pub metadata_block_size: Option<usize>,
     pub bloom_filter_bits: f64,
+    pub format_version: i32,
+    pub index_type: RocksDbBlockBasedIndexType,
+    pub data_block_index_type: RocksDbDataBlockIndexType,
+    pub data_block_hash_ratio: Option<f64>,
+    pub whole_key_filtering: bool,
     pub compression_type: RocksDbCompressionType,
     pub bottommost_compression_type: RocksDbCompressionType,
     pub compaction_style: RocksDbCompactionStyle,
+    pub min_write_buffer_number_to_merge: i32,
+    pub num_levels: i32,
+    pub level_zero_file_num_compaction_trigger: i32,
+    pub level_zero_slowdown_writes_trigger: i32,
+    pub level_zero_stop_writes_trigger: i32,
+    pub target_file_size_base: u64,
+    pub target_file_size_multiplier: i32,
+    pub max_bytes_for_level_base: Option<u64>,
+    pub max_bytes_for_level_multiplier: Option<f64>,
+    pub max_compaction_bytes: Option<u64>,
+    pub soft_pending_compaction_bytes_limit: Option<usize>,
+    pub hard_pending_compaction_bytes_limit: Option<usize>,
+    pub report_bg_io_stats: bool,
+    pub optimize_filters_for_hits: bool,
+    pub optimize_filters_for_memory: bool,
+    pub cache_index_and_filter_blocks: bool,
+    pub pin_l0_filter_and_index_blocks_in_cache: bool,
+    pub pin_top_level_index_and_filter: bool,
+    pub inplace_update_support: bool,
 }
 
 impl RocksDbColumnFamilyConfig {
     pub fn consume_queue_default() -> Self {
-        Self {
-            name: "default".to_string(),
-            write_buffer_size: 128 * 1024 * 1024,
-            max_write_buffer_number: 4,
-            block_cache_size: 1024 * 1024 * 1024,
-            block_size: 32 * 1024,
-            bloom_filter_bits: 16.0,
-            compression_type: RocksDbCompressionType::Lz4,
-            bottommost_compression_type: RocksDbCompressionType::Lz4,
-            compaction_style: RocksDbCompactionStyle::Universal,
-        }
+        let mut config = Self::java_cf_base(
+            "default",
+            128 * MB,
+            4,
+            1024 * MB,
+            32 * KB,
+            RocksDbCompressionType::Lz4,
+            RocksDbCompressionType::Lz4,
+            RocksDbCompactionStyle::Universal,
+        );
+        config.max_compaction_bytes = Some(100 * GB_U64);
+        config.soft_pending_compaction_bytes_limit = Some(100 * GB);
+        config.hard_pending_compaction_bytes_limit = Some(256 * GB);
+        config.use_data_block_hash_index();
+        config.report_bg_io_stats = true;
+        config.optimize_filters_for_hits = true;
+        config
     }
 
     pub fn consume_queue_offset() -> Self {
-        Self {
-            name: "offset".to_string(),
-            write_buffer_size: 64 * 1024 * 1024,
-            max_write_buffer_number: 4,
-            block_cache_size: 128 * 1024 * 1024,
-            block_size: 32 * 1024,
-            bloom_filter_bits: 16.0,
-            compression_type: RocksDbCompressionType::None,
-            bottommost_compression_type: RocksDbCompressionType::None,
-            compaction_style: RocksDbCompactionStyle::Level,
-        }
+        let mut config = Self::java_cf_base(
+            "offset",
+            64 * MB,
+            4,
+            128 * MB,
+            32 * KB,
+            RocksDbCompressionType::None,
+            RocksDbCompressionType::None,
+            RocksDbCompactionStyle::Level,
+        );
+        config.target_file_size_base = 64 * MB_U64;
+        config.max_bytes_for_level_base = Some(256 * MB_U64);
+        config.max_bytes_for_level_multiplier = Some(2.0);
+        config.metadata_block_size = None;
+        config.inplace_update_support = true;
+        config
     }
 
     pub fn message_index_default() -> Self {
-        Self {
-            name: "default".to_string(),
-            ..Self::consume_queue_default()
-        }
+        let mut config = Self::java_cf_base(
+            "default",
+            128 * MB,
+            6,
+            1024 * MB,
+            128 * KB,
+            RocksDbCompressionType::None,
+            RocksDbCompressionType::None,
+            RocksDbCompactionStyle::Universal,
+        );
+        config.max_compaction_bytes = Some(256 * MB_U64);
+        config.soft_pending_compaction_bytes_limit = Some(100 * GB);
+        config.hard_pending_compaction_bytes_limit = Some(256 * GB);
+        config.level_zero_file_num_compaction_trigger = 8;
+        config.level_zero_slowdown_writes_trigger = 8;
+        config.level_zero_stop_writes_trigger = 20;
+        config.use_data_block_hash_index();
+        config.report_bg_io_stats = true;
+        config.optimize_filters_for_hits = true;
+        config
     }
 
     pub fn message_timer() -> Self {
-        Self {
-            name: "timer".to_string(),
-            write_buffer_size: 128 * 1024 * 1024,
-            max_write_buffer_number: 4,
-            block_cache_size: 512 * 1024 * 1024,
-            block_size: 32 * 1024,
-            bloom_filter_bits: 16.0,
-            compression_type: RocksDbCompressionType::Lz4,
-            bottommost_compression_type: RocksDbCompressionType::Lz4,
-            compaction_style: RocksDbCompactionStyle::Universal,
-        }
+        let mut config = Self::java_cf_base(
+            "timer",
+            256 * MB,
+            6,
+            2048 * MB,
+            128 * KB,
+            RocksDbCompressionType::Zstd,
+            RocksDbCompressionType::None,
+            RocksDbCompactionStyle::Level,
+        );
+        config.max_compaction_bytes = Some(256 * MB_U64);
+        config.soft_pending_compaction_bytes_limit = Some(100 * GB);
+        config.hard_pending_compaction_bytes_limit = Some(256 * GB);
+        config.max_bytes_for_level_base = Some(512 * MB_U64);
+        config.use_data_block_hash_index();
+        config.report_bg_io_stats = true;
+        config.optimize_filters_for_hits = true;
+        config
     }
 
     pub fn message_transaction() -> Self {
+        let mut config = Self::java_cf_base(
+            "trans",
+            128 * MB,
+            6,
+            1024 * MB,
+            128 * KB,
+            RocksDbCompressionType::None,
+            RocksDbCompressionType::None,
+            RocksDbCompactionStyle::Universal,
+        );
+        config.max_compaction_bytes = Some(100 * GB_U64);
+        config.soft_pending_compaction_bytes_limit = Some(100 * GB);
+        config.hard_pending_compaction_bytes_limit = Some(256 * GB);
+        config.use_data_block_hash_index();
+        config.report_bg_io_stats = true;
+        config.optimize_filters_for_hits = true;
+        config
+    }
+
+    pub fn pop(name: &str, block_cache_size: usize, write_buffer_size: usize) -> Self {
+        let mut config = Self::java_cf_base(
+            name,
+            write_buffer_size,
+            4,
+            block_cache_size,
+            32 * KB,
+            RocksDbCompressionType::None,
+            RocksDbCompressionType::None,
+            RocksDbCompactionStyle::Universal,
+        );
+        config.max_compaction_bytes = Some(100 * GB_U64);
+        config.soft_pending_compaction_bytes_limit = Some(100 * GB);
+        config.hard_pending_compaction_bytes_limit = Some(256 * GB);
+        config.use_data_block_hash_index();
+        config.report_bg_io_stats = true;
+        config.optimize_filters_for_hits = true;
+        config
+    }
+
+    pub fn broker_config(name: &str, block_cache_size: usize, write_buffer_size: usize) -> Self {
+        let mut config = Self::java_cf_base(
+            name,
+            write_buffer_size,
+            4,
+            block_cache_size,
+            32 * KB,
+            RocksDbCompressionType::None,
+            RocksDbCompressionType::None,
+            RocksDbCompactionStyle::Level,
+        );
+        config.level_zero_file_num_compaction_trigger = 4;
+        config.level_zero_slowdown_writes_trigger = 8;
+        config.level_zero_stop_writes_trigger = 12;
+        config.target_file_size_base = 64 * MB_U64;
+        config.max_bytes_for_level_base = Some(256 * MB_U64);
+        config.max_bytes_for_level_multiplier = Some(2.0);
+        config.metadata_block_size = None;
+        config.cache_index_and_filter_blocks = true;
+        config.inplace_update_support = true;
+        config
+    }
+
+    fn use_data_block_hash_index(&mut self) {
+        self.data_block_index_type = RocksDbDataBlockIndexType::BinaryAndHash;
+        self.data_block_hash_ratio = Some(0.75);
+    }
+
+    fn java_cf_base(
+        name: &str,
+        write_buffer_size: usize,
+        max_write_buffer_number: i32,
+        block_cache_size: usize,
+        block_size: usize,
+        compression_type: RocksDbCompressionType,
+        bottommost_compression_type: RocksDbCompressionType,
+        compaction_style: RocksDbCompactionStyle,
+    ) -> Self {
         Self {
-            name: "trans".to_string(),
-            write_buffer_size: 64 * 1024 * 1024,
-            max_write_buffer_number: 4,
-            block_cache_size: 256 * 1024 * 1024,
-            block_size: 32 * 1024,
+            name: name.to_string(),
+            write_buffer_size,
+            max_write_buffer_number,
+            block_cache_size,
+            block_size,
+            metadata_block_size: Some(4 * KB),
             bloom_filter_bits: 16.0,
-            compression_type: RocksDbCompressionType::Lz4,
-            bottommost_compression_type: RocksDbCompressionType::Lz4,
-            compaction_style: RocksDbCompactionStyle::Level,
+            format_version: 5,
+            index_type: RocksDbBlockBasedIndexType::BinarySearch,
+            data_block_index_type: RocksDbDataBlockIndexType::BinarySearch,
+            data_block_hash_ratio: None,
+            whole_key_filtering: true,
+            compression_type,
+            bottommost_compression_type,
+            compaction_style,
+            min_write_buffer_number_to_merge: 1,
+            num_levels: 7,
+            level_zero_file_num_compaction_trigger: 2,
+            level_zero_slowdown_writes_trigger: 8,
+            level_zero_stop_writes_trigger: 10,
+            target_file_size_base: 256 * MB_U64,
+            target_file_size_multiplier: 2,
+            max_bytes_for_level_base: None,
+            max_bytes_for_level_multiplier: None,
+            max_compaction_bytes: None,
+            soft_pending_compaction_bytes_limit: None,
+            hard_pending_compaction_bytes_limit: None,
+            report_bg_io_stats: false,
+            optimize_filters_for_hits: false,
+            optimize_filters_for_memory: false,
+            cache_index_and_filter_blocks: false,
+            pin_l0_filter_and_index_blocks_in_cache: false,
+            pin_top_level_index_and_filter: true,
+            inplace_update_support: false,
         }
     }
 
@@ -157,6 +349,19 @@ pub struct RocksDbConfig {
     pub compression_type: RocksDbCompressionType,
     pub bottommost_compression_type: RocksDbCompressionType,
     pub compaction_style: RocksDbCompactionStyle,
+    pub db_write_buffer_size: Option<usize>,
+    pub bytes_per_sync: u64,
+    pub wal_bytes_per_sync: Option<u64>,
+    pub max_log_file_size: usize,
+    pub keep_log_file_num: usize,
+    pub max_manifest_file_size: usize,
+    pub allow_concurrent_memtable_write: bool,
+    pub paranoid_checks: bool,
+    pub compaction_readahead_size: usize,
+    pub use_direct_io_for_flush_and_compaction: bool,
+    pub use_direct_reads: bool,
+    pub wal_recovery_mode: RocksDbWalRecoveryMode,
+    pub stats_dump_period_sec: u32,
     pub max_background_jobs: i32,
     pub max_subcompactions: u32,
     pub max_open_files: i32,
@@ -186,6 +391,19 @@ impl Default for RocksDbConfig {
             compression_type: RocksDbCompressionType::Lz4,
             bottommost_compression_type: RocksDbCompressionType::Lz4,
             compaction_style: RocksDbCompactionStyle::Universal,
+            db_write_buffer_size: None,
+            bytes_per_sync: MB_U64,
+            wal_bytes_per_sync: None,
+            max_log_file_size: GB,
+            keep_log_file_num: 5,
+            max_manifest_file_size: GB,
+            allow_concurrent_memtable_write: false,
+            paranoid_checks: true,
+            compaction_readahead_size: 4 * MB,
+            use_direct_io_for_flush_and_compaction: false,
+            use_direct_reads: false,
+            wal_recovery_mode: RocksDbWalRecoveryMode::PointInTime,
+            stats_dump_period_sec: 0,
             max_background_jobs: 32,
             max_subcompactions: 8,
             max_open_files: -1,
@@ -205,12 +423,28 @@ impl Default for RocksDbConfig {
 }
 
 impl RocksDbConfig {
+    pub fn consume_queue_path_from_message_store_config(message_store_config: &MessageStoreConfig) -> PathBuf {
+        let root_dir = message_store_config.store_path_root_dir.as_str();
+        if message_store_config.use_separate_store_path_for_rocksdb_cq {
+            PathBuf::from(get_store_path_rocksdb_consume_queue(root_dir))
+        } else {
+            PathBuf::from(get_store_path_consume_queue(root_dir))
+        }
+    }
+
+    pub fn consume_queue_conflict_path_from_message_store_config(message_store_config: &MessageStoreConfig) -> PathBuf {
+        let root_dir = message_store_config.store_path_root_dir.as_str();
+        if message_store_config.use_separate_store_path_for_rocksdb_cq {
+            PathBuf::from(get_store_path_consume_queue(root_dir))
+        } else {
+            PathBuf::from(get_store_path_rocksdb_consume_queue(root_dir))
+        }
+    }
+
     pub fn consume_queue_from_message_store_config(message_store_config: &MessageStoreConfig) -> Self {
         Self {
             enabled: message_store_config.is_enable_rocksdb_store(),
-            path: PathBuf::from(get_store_path_consume_queue(
-                message_store_config.store_path_root_dir.as_str(),
-            )),
+            path: Self::consume_queue_path_from_message_store_config(message_store_config),
             wal_enabled: false,
             sync_write: false,
             column_families: vec![

--- a/rocketmq-store/src/rocksdb/message.rs
+++ b/rocketmq-store/src/rocksdb/message.rs
@@ -263,14 +263,26 @@ impl MessageRocksDbStorage {
             .put_cf(RocksDbColumnFamily::Timer.name(), key, &encode_i64(value))
     }
 
+    pub fn write_timeline_checkpoint_for_timer(&self, value: i64) -> Result<(), RocketMQError> {
+        self.write_checkpoint_for_timer(TIMER_TIMELINE_CHECKPOINT, value)
+    }
+
     pub fn get_checkpoint_for_timer(&self, key: &[u8]) -> Result<i64, RocketMQError> {
         validate_timer_checkpoint_key(key)?;
         self.get_i64_special_key(RocksDbColumnFamily::Timer.name(), key)
     }
 
+    pub fn get_timeline_checkpoint_for_timer(&self) -> Result<i64, RocketMQError> {
+        self.get_checkpoint_for_timer(TIMER_TIMELINE_CHECKPOINT)
+    }
+
     pub fn delete_checkpoint_for_timer(&self, key: &[u8]) -> Result<(), RocketMQError> {
         validate_timer_checkpoint_key(key)?;
         self.store.delete_cf(RocksDbColumnFamily::Timer.name(), key)
+    }
+
+    pub fn delete_timeline_checkpoint_for_timer(&self) -> Result<(), RocketMQError> {
+        self.delete_checkpoint_for_timer(TIMER_TIMELINE_CHECKPOINT)
     }
 
     pub fn write_records_for_trans(&self, records: &[TransRocksDbRecord]) -> Result<(), RocketMQError> {

--- a/rocketmq-store/src/rocksdb/options.rs
+++ b/rocketmq-store/src/rocksdb/options.rs
@@ -14,10 +14,13 @@
 
 use rocketmq_error::RocketMQError;
 
+use crate::rocksdb::config::RocksDbBlockBasedIndexType;
 use crate::rocksdb::config::RocksDbColumnFamilyConfig;
 use crate::rocksdb::config::RocksDbCompactionStyle;
 use crate::rocksdb::config::RocksDbCompressionType;
 use crate::rocksdb::config::RocksDbConfig;
+use crate::rocksdb::config::RocksDbDataBlockIndexType;
+use crate::rocksdb::config::RocksDbWalRecoveryMode;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RocksDbWriteProfile {
@@ -44,6 +47,28 @@ impl RocksDbOptionsFactory {
         options.set_compression_type(to_rocksdb_compression(config.compression_type));
         options.set_bottommost_compression_type(to_rocksdb_compression(config.bottommost_compression_type));
         options.set_compaction_style(to_rocksdb_compaction_style(config.compaction_style));
+        if let Some(db_write_buffer_size) = config.db_write_buffer_size {
+            options.set_db_write_buffer_size(db_write_buffer_size);
+        }
+        options.set_bytes_per_sync(config.bytes_per_sync);
+        if let Some(wal_bytes_per_sync) = config.wal_bytes_per_sync {
+            options.set_wal_bytes_per_sync(wal_bytes_per_sync);
+        }
+        options.set_max_log_file_size(config.max_log_file_size);
+        options.set_keep_log_file_num(config.keep_log_file_num);
+        options.set_max_manifest_file_size(config.max_manifest_file_size);
+        options.set_allow_concurrent_memtable_write(config.allow_concurrent_memtable_write);
+        options.set_paranoid_checks(config.paranoid_checks);
+        options.set_compaction_readahead_size(config.compaction_readahead_size);
+        options.set_use_direct_io_for_flush_and_compaction(config.use_direct_io_for_flush_and_compaction);
+        options.set_use_direct_reads(config.use_direct_reads);
+        options.set_wal_recovery_mode(to_rocksdb_recovery_mode(config.wal_recovery_mode));
+        if config.statistics_enabled {
+            options.enable_statistics();
+            if config.stats_dump_period_sec > 0 {
+                options.set_stats_dump_period_sec(config.stats_dump_period_sec);
+            }
+        }
         Ok(options)
     }
 
@@ -55,6 +80,51 @@ impl RocksDbOptionsFactory {
         options.set_compression_type(to_rocksdb_compression(config.compression_type));
         options.set_bottommost_compression_type(to_rocksdb_compression(config.bottommost_compression_type));
         options.set_compaction_style(to_rocksdb_compaction_style(config.compaction_style));
+        options.set_min_write_buffer_number_to_merge(config.min_write_buffer_number_to_merge);
+        options.set_num_levels(config.num_levels);
+        options.set_level_zero_file_num_compaction_trigger(config.level_zero_file_num_compaction_trigger);
+        options.set_level_zero_slowdown_writes_trigger(config.level_zero_slowdown_writes_trigger);
+        options.set_level_zero_stop_writes_trigger(config.level_zero_stop_writes_trigger);
+        options.set_target_file_size_base(config.target_file_size_base);
+        options.set_target_file_size_multiplier(config.target_file_size_multiplier);
+        if let Some(max_bytes_for_level_base) = config.max_bytes_for_level_base {
+            options.set_max_bytes_for_level_base(max_bytes_for_level_base);
+        }
+        if let Some(max_bytes_for_level_multiplier) = config.max_bytes_for_level_multiplier {
+            options.set_max_bytes_for_level_multiplier(max_bytes_for_level_multiplier);
+        }
+        if let Some(max_compaction_bytes) = config.max_compaction_bytes {
+            options.set_max_compaction_bytes(max_compaction_bytes);
+        }
+        if let Some(soft_pending_compaction_bytes_limit) = config.soft_pending_compaction_bytes_limit {
+            options.set_soft_pending_compaction_bytes_limit(soft_pending_compaction_bytes_limit);
+        }
+        if let Some(hard_pending_compaction_bytes_limit) = config.hard_pending_compaction_bytes_limit {
+            options.set_hard_pending_compaction_bytes_limit(hard_pending_compaction_bytes_limit);
+        }
+        options.set_report_bg_io_stats(config.report_bg_io_stats);
+        options.set_optimize_filters_for_hits(config.optimize_filters_for_hits);
+        options.set_inplace_update_support(config.inplace_update_support);
+
+        let mut block_options = ::rocksdb::BlockBasedOptions::default();
+        block_options.set_format_version(config.format_version);
+        block_options.set_index_type(to_rocksdb_block_index_type(config.index_type));
+        block_options.set_data_block_index_type(to_rocksdb_data_block_index_type(config.data_block_index_type));
+        if let Some(data_block_hash_ratio) = config.data_block_hash_ratio {
+            block_options.set_data_block_hash_ratio(data_block_hash_ratio);
+        }
+        block_options.set_block_size(config.block_size);
+        if let Some(metadata_block_size) = config.metadata_block_size {
+            block_options.set_metadata_block_size(metadata_block_size);
+        }
+        block_options.set_bloom_filter(config.bloom_filter_bits, false);
+        block_options.set_block_cache(&::rocksdb::Cache::new_lru_cache(config.block_cache_size));
+        block_options.set_cache_index_and_filter_blocks(config.cache_index_and_filter_blocks);
+        block_options.set_pin_l0_filter_and_index_blocks_in_cache(config.pin_l0_filter_and_index_blocks_in_cache);
+        block_options.set_pin_top_level_index_and_filter(config.pin_top_level_index_and_filter);
+        block_options.set_optimize_filters_for_memory(config.optimize_filters_for_memory);
+        block_options.set_whole_key_filtering(config.whole_key_filtering);
+        options.set_block_based_table_factory(&block_options);
         Ok(options)
     }
 
@@ -99,5 +169,29 @@ fn to_rocksdb_compaction_style(compaction_style: RocksDbCompactionStyle) -> ::ro
         RocksDbCompactionStyle::Level => ::rocksdb::DBCompactionStyle::Level,
         RocksDbCompactionStyle::Universal => ::rocksdb::DBCompactionStyle::Universal,
         RocksDbCompactionStyle::Fifo => ::rocksdb::DBCompactionStyle::Fifo,
+    }
+}
+
+fn to_rocksdb_recovery_mode(recovery_mode: RocksDbWalRecoveryMode) -> ::rocksdb::DBRecoveryMode {
+    match recovery_mode {
+        RocksDbWalRecoveryMode::TolerateCorruptedTailRecords => ::rocksdb::DBRecoveryMode::TolerateCorruptedTailRecords,
+        RocksDbWalRecoveryMode::AbsoluteConsistency => ::rocksdb::DBRecoveryMode::AbsoluteConsistency,
+        RocksDbWalRecoveryMode::PointInTime => ::rocksdb::DBRecoveryMode::PointInTime,
+        RocksDbWalRecoveryMode::SkipAnyCorruptedRecord => ::rocksdb::DBRecoveryMode::SkipAnyCorruptedRecord,
+    }
+}
+
+fn to_rocksdb_block_index_type(index_type: RocksDbBlockBasedIndexType) -> ::rocksdb::BlockBasedIndexType {
+    match index_type {
+        RocksDbBlockBasedIndexType::BinarySearch => ::rocksdb::BlockBasedIndexType::BinarySearch,
+        RocksDbBlockBasedIndexType::HashSearch => ::rocksdb::BlockBasedIndexType::HashSearch,
+        RocksDbBlockBasedIndexType::TwoLevelIndexSearch => ::rocksdb::BlockBasedIndexType::TwoLevelIndexSearch,
+    }
+}
+
+fn to_rocksdb_data_block_index_type(index_type: RocksDbDataBlockIndexType) -> ::rocksdb::DataBlockIndexType {
+    match index_type {
+        RocksDbDataBlockIndexType::BinarySearch => ::rocksdb::DataBlockIndexType::BinarySearch,
+        RocksDbDataBlockIndexType::BinaryAndHash => ::rocksdb::DataBlockIndexType::BinaryAndHash,
     }
 }

--- a/rocketmq-store/src/rocksdb/snapshot.rs
+++ b/rocketmq-store/src/rocksdb/snapshot.rs
@@ -34,8 +34,10 @@ impl<'a> RocksDbSnapshot<'a> {
 
     pub fn get_cf(&self, cf: &str, key: &[u8]) -> Result<Option<Bytes>, RocketMQError> {
         let handle = self.db.cf_handle(cf).ok_or_else(|| column_family_missing_error(cf))?;
-        self.snapshot
-            .get_cf(&handle, key)
+        let mut read_options = ::rocksdb::ReadOptions::default();
+        read_options.set_snapshot(&self.snapshot);
+        self.db
+            .get_cf_opt(&handle, key, &read_options)
             .map(|value| value.map(Bytes::from))
             .map_rocksdb(RocksDbErrorKind::Snapshot)
     }

--- a/rocketmq-store/src/rocksdb/store.rs
+++ b/rocketmq-store/src/rocksdb/store.rs
@@ -191,6 +191,19 @@ impl RocksDbStore {
         result
     }
 
+    pub async fn prefix_scan_blocking(
+        &self,
+        options: RocksDbScanOptions,
+    ) -> Result<Vec<RocksDbScanItem>, RocketMQError> {
+        self.ensure_open()?;
+        let db = Arc::clone(&self.db);
+        let result = tokio::task::spawn_blocking(move || prefix_scan_on_db(&db, &options))
+            .await
+            .map_err(|error| RocketMQError::storage_read_failed("rocksdb", format!("Iterator: {error}")))?;
+        self.record_result(&result, RocksDbMetricsCollector::record_scan);
+        result
+    }
+
     pub fn range_scan(&self, options: &RocksDbRangeScanOptions) -> Result<Vec<RocksDbScanItem>, RocketMQError> {
         self.ensure_open()?;
         let handle = self.cf_handle(&options.cf)?;
@@ -213,6 +226,19 @@ impl RocksDbStore {
             }
         }
         let result = Ok(items);
+        self.record_result(&result, RocksDbMetricsCollector::record_scan);
+        result
+    }
+
+    pub async fn range_scan_blocking(
+        &self,
+        options: RocksDbRangeScanOptions,
+    ) -> Result<Vec<RocksDbScanItem>, RocketMQError> {
+        self.ensure_open()?;
+        let db = Arc::clone(&self.db);
+        let result = tokio::task::spawn_blocking(move || range_scan_on_db(&db, &options))
+            .await
+            .map_err(|error| RocketMQError::storage_read_failed("rocksdb", format!("Iterator: {error}")))?;
         self.record_result(&result, RocksDbMetricsCollector::record_scan);
         result
     }
@@ -435,6 +461,26 @@ impl RocksDbStore {
         );
     }
 
+    pub fn mark_recovered(&self) -> Result<(), RocketMQError> {
+        match self.state() {
+            RocksDbStoreState::Open => Ok(()),
+            RocksDbStoreState::Closed => Err(closed_error()),
+            RocksDbStoreState::Reloading => match self.state.compare_exchange(
+                RocksDbStoreState::Reloading.as_u8(),
+                RocksDbStoreState::Open.as_u8(),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => Ok(()),
+                Err(state) => match RocksDbStoreState::from_u8(state) {
+                    RocksDbStoreState::Open => Ok(()),
+                    RocksDbStoreState::Reloading => Err(reloading_error()),
+                    RocksDbStoreState::Closed => Err(closed_error()),
+                },
+            },
+        }
+    }
+
     fn cf_handle(&self, cf: &str) -> Result<Arc<::rocksdb::BoundColumnFamily<'_>>, RocketMQError> {
         let result = self.db.cf_handle(cf).ok_or_else(|| column_family_missing_error(cf));
         if result.is_err() {
@@ -516,6 +562,63 @@ fn compact_range_cf_on_db(
     let handle = db.cf_handle(cf).ok_or_else(|| column_family_missing_error(cf))?;
     db.compact_range_cf(&handle, start, end);
     Ok(())
+}
+
+fn prefix_scan_on_db(db: &::rocksdb::DB, options: &RocksDbScanOptions) -> Result<Vec<RocksDbScanItem>, RocketMQError> {
+    let handle = db
+        .cf_handle(&options.cf)
+        .ok_or_else(|| column_family_missing_error(&options.cf))?;
+    let iter = db.iterator_cf(
+        &handle,
+        ::rocksdb::IteratorMode::From(&options.prefix, ::rocksdb::Direction::Forward),
+    );
+    let mut items = Vec::new();
+    for item in iter {
+        let (key, value) = item.map_err(|error| map_rocksdb_error(error, RocksDbErrorKind::Iterator))?;
+        if !key.starts_with(&options.prefix) {
+            break;
+        }
+        items.push(RocksDbScanItem {
+            key: Bytes::copy_from_slice(&key),
+            value: Bytes::copy_from_slice(&value),
+        });
+        if options.limit > 0 && items.len() >= options.limit {
+            break;
+        }
+    }
+    Ok(items)
+}
+
+fn range_scan_on_db(
+    db: &::rocksdb::DB,
+    options: &RocksDbRangeScanOptions,
+) -> Result<Vec<RocksDbScanItem>, RocketMQError> {
+    let handle = db
+        .cf_handle(&options.cf)
+        .ok_or_else(|| column_family_missing_error(&options.cf))?;
+    let iter = db.iterator_cf(
+        &handle,
+        ::rocksdb::IteratorMode::From(&options.start, ::rocksdb::Direction::Forward),
+    );
+    let mut items = Vec::new();
+    for item in iter {
+        let (key, value) = item.map_err(|error| map_rocksdb_error(error, RocksDbErrorKind::Iterator))?;
+        if !options.end.is_empty() && key.as_ref() >= options.end.as_slice() {
+            break;
+        }
+        items.push(RocksDbScanItem {
+            key: Bytes::copy_from_slice(&key),
+            value: Bytes::copy_from_slice(&value),
+        });
+        if options.limit > 0 && items.len() >= options.limit {
+            break;
+        }
+    }
+    Ok(items)
+}
+
+fn map_rocksdb_error(error: ::rocksdb::Error, kind: RocksDbErrorKind) -> RocketMQError {
+    Err::<(), _>(error).map_rocksdb(kind).unwrap_err()
 }
 
 impl KeyValueStore for RocksDbStore {

--- a/rocketmq-store/src/store_path_config_helper.rs
+++ b/rocketmq-store/src/store_path_config_helper.rs
@@ -21,6 +21,13 @@ pub fn get_store_path_consume_queue(root_dir: &str) -> String {
         .into_owned()
 }
 
+pub fn get_store_path_rocksdb_consume_queue(root_dir: &str) -> String {
+    PathBuf::from(root_dir)
+        .join("consumequeue_rocksdb")
+        .to_string_lossy()
+        .into_owned()
+}
+
 pub fn get_store_path_consume_queue_ext(root_dir: &str) -> String {
     PathBuf::from(root_dir)
         .join("consumequeue_ext")
@@ -102,6 +109,13 @@ mod tests {
             get_store_path_consume_queue(root_dir),
             PathBuf::from(root_dir)
                 .join("consumequeue")
+                .to_string_lossy()
+                .into_owned()
+        );
+        assert_eq!(
+            get_store_path_rocksdb_consume_queue(root_dir),
+            PathBuf::from(root_dir)
+                .join("consumequeue_rocksdb")
                 .to_string_lossy()
                 .into_owned()
         );

--- a/rocketmq-store/tests/rocksdb_foundation_tests.rs
+++ b/rocketmq-store/tests/rocksdb_foundation_tests.rs
@@ -33,6 +33,7 @@ use rocketmq_store::rocksdb::config::RocksDbColumnFamilyConfig;
 use rocketmq_store::rocksdb::config::RocksDbCompactionStyle;
 use rocketmq_store::rocksdb::config::RocksDbCompressionType;
 use rocketmq_store::rocksdb::config::RocksDbConfig;
+use rocketmq_store::rocksdb::config::RocksDbDataBlockIndexType;
 use rocketmq_store::rocksdb::consume_queue::CommitLogDispatcherBuildRocksDbConsumeQueue;
 use rocketmq_store::rocksdb::consume_queue::ConsumeQueueBatchEntry;
 use rocketmq_store::rocksdb::consume_queue::ConsumeQueueBatchWriteRequest;
@@ -58,6 +59,7 @@ use rocketmq_store::rocksdb::message::MessageRocksDbStorage;
 use rocketmq_store::rocksdb::message::TimerRocksDbAction;
 use rocketmq_store::rocksdb::message::TimerRocksDbRecord;
 use rocketmq_store::rocksdb::message::TransRocksDbRecord;
+use rocketmq_store::rocksdb::options::RocksDbOptionsFactory;
 use rocketmq_store::rocksdb::options::RocksDbWriteProfile;
 use rocketmq_store::rocksdb::store::KeyValueStore;
 use rocketmq_store::rocksdb::store::RocksDbStore;
@@ -84,6 +86,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tempfile::TempDir;
 
+const KB: usize = 1024;
+const MB: usize = 1024 * KB;
+const GB: usize = 1024 * MB;
+const MB_U64: u64 = 1024 * 1024;
+const GB_U64: u64 = 1024 * MB_U64;
+
 #[test]
 fn rocksdb_config_defaults_match_java_baseline() {
     let config = RocksDbConfig::default();
@@ -94,11 +102,20 @@ fn rocksdb_config_defaults_match_java_baseline() {
     assert_eq!(config.max_background_jobs, 32);
     assert_eq!(config.max_subcompactions, 8);
     assert_eq!(config.max_open_files, -1);
-    assert_eq!(config.write_buffer_size, 128 * 1024 * 1024);
+    assert_eq!(config.write_buffer_size, 128 * MB);
     assert_eq!(config.max_write_buffer_number, 4);
-    assert_eq!(config.block_size, 32 * 1024);
+    assert_eq!(config.block_size, 32 * KB);
     assert_eq!(config.compression_type, RocksDbCompressionType::Lz4);
     assert_eq!(config.compaction_style, RocksDbCompactionStyle::Universal);
+    assert_eq!(config.bytes_per_sync, MB_U64);
+    assert_eq!(config.max_log_file_size, GB);
+    assert_eq!(config.keep_log_file_num, 5);
+    assert_eq!(config.max_manifest_file_size, GB);
+    assert!(!config.allow_concurrent_memtable_write);
+    assert!(config.paranoid_checks);
+    assert_eq!(config.compaction_readahead_size, 4 * MB);
+    assert!(!config.use_direct_io_for_flush_and_compaction);
+    assert!(!config.use_direct_reads);
     assert_eq!(config.flush_interval_ms, 0);
     assert_eq!(config.compaction_interval_ms, 0);
     assert_eq!(config.checkpoint_interval_ms, 0);
@@ -118,7 +135,7 @@ fn rocksdb_consume_queue_config_from_message_store_config_uses_java_default_path
     let rocksdb_config = RocksDbConfig::consume_queue_from_message_store_config(&store_config);
 
     assert!(rocksdb_config.enabled);
-    assert_eq!(rocksdb_config.path, temp_dir.path().join("consumequeue"));
+    assert_eq!(rocksdb_config.path, temp_dir.path().join("consumequeue_rocksdb"));
     assert_eq!(rocksdb_config.column_families.len(), 2);
     assert_eq!(
         rocksdb_config.column_families[0].name,
@@ -131,6 +148,25 @@ fn rocksdb_consume_queue_config_from_message_store_config_uses_java_default_path
     assert!(rocksdb_config.manual_wal_flush);
     assert!(!rocksdb_config.wal_enabled);
     assert_eq!(rocksdb_config.write_profile(), RocksDbWriteProfile::DisableWal);
+}
+
+#[test]
+fn rocksdb_consume_queue_config_can_use_legacy_consumequeue_path() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let store_config = MessageStoreConfig {
+        store_path_root_dir: CheetahString::from_string(temp_dir.path().to_string_lossy().to_string()),
+        store_type: StoreType::RocksDB,
+        use_separate_store_path_for_rocksdb_cq: false,
+        ..MessageStoreConfig::default()
+    };
+
+    let rocksdb_config = RocksDbConfig::consume_queue_from_message_store_config(&store_config);
+
+    assert_eq!(rocksdb_config.path, temp_dir.path().join("consumequeue"));
+    assert_eq!(
+        RocksDbConfig::consume_queue_conflict_path_from_message_store_config(&store_config),
+        temp_dir.path().join("consumequeue_rocksdb")
+    );
 }
 
 #[test]
@@ -188,6 +224,142 @@ fn rocksdb_message_config_from_message_store_config_uses_java_cf_layout() {
 }
 
 #[test]
+fn rocksdb_column_family_configs_match_java_options_baseline() {
+    let cq_default = RocksDbColumnFamilyConfig::consume_queue_default();
+    assert_eq!(cq_default.name, RocksDbColumnFamily::Default.name());
+    assert_eq!(cq_default.write_buffer_size, 128 * MB);
+    assert_eq!(cq_default.max_write_buffer_number, 4);
+    assert_eq!(cq_default.block_cache_size, 1024 * MB);
+    assert_eq!(cq_default.block_size, 32 * KB);
+    assert_eq!(cq_default.metadata_block_size, Some(4 * KB));
+    assert_eq!(cq_default.format_version, 5);
+    assert_eq!(
+        cq_default.data_block_index_type,
+        RocksDbDataBlockIndexType::BinaryAndHash
+    );
+    assert_eq!(cq_default.data_block_hash_ratio, Some(0.75));
+    assert!(cq_default.whole_key_filtering);
+    assert!(cq_default.pin_top_level_index_and_filter);
+    assert_eq!(cq_default.compression_type, RocksDbCompressionType::Lz4);
+    assert_eq!(cq_default.bottommost_compression_type, RocksDbCompressionType::Lz4);
+    assert_eq!(cq_default.compaction_style, RocksDbCompactionStyle::Universal);
+    assert_eq!(cq_default.max_compaction_bytes, Some(100 * GB_U64));
+    assert_eq!(cq_default.soft_pending_compaction_bytes_limit, Some(100 * GB));
+    assert_eq!(cq_default.hard_pending_compaction_bytes_limit, Some(256 * GB));
+    assert_eq!(cq_default.level_zero_file_num_compaction_trigger, 2);
+    assert_eq!(cq_default.level_zero_slowdown_writes_trigger, 8);
+    assert_eq!(cq_default.level_zero_stop_writes_trigger, 10);
+    assert_eq!(cq_default.target_file_size_base, 256 * MB_U64);
+    assert_eq!(cq_default.target_file_size_multiplier, 2);
+    assert!(cq_default.report_bg_io_stats);
+    assert!(cq_default.optimize_filters_for_hits);
+
+    let offset = RocksDbColumnFamilyConfig::consume_queue_offset();
+    assert_eq!(offset.name, RocksDbColumnFamily::ConsumeQueueOffset.name());
+    assert_eq!(offset.write_buffer_size, 64 * MB);
+    assert_eq!(offset.block_cache_size, 128 * MB);
+    assert_eq!(offset.metadata_block_size, None);
+    assert_eq!(offset.data_block_index_type, RocksDbDataBlockIndexType::BinarySearch);
+    assert_eq!(offset.data_block_hash_ratio, None);
+    assert_eq!(offset.compression_type, RocksDbCompressionType::None);
+    assert_eq!(offset.compaction_style, RocksDbCompactionStyle::Level);
+    assert_eq!(offset.target_file_size_base, 64 * MB_U64);
+    assert_eq!(offset.max_bytes_for_level_base, Some(256 * MB_U64));
+    assert_eq!(offset.max_bytes_for_level_multiplier, Some(2.0));
+    assert!(offset.inplace_update_support);
+
+    let index = RocksDbColumnFamilyConfig::message_index_default();
+    assert_eq!(index.write_buffer_size, 128 * MB);
+    assert_eq!(index.max_write_buffer_number, 6);
+    assert_eq!(index.block_size, 128 * KB);
+    assert_eq!(index.metadata_block_size, Some(4 * KB));
+    assert_eq!(index.data_block_index_type, RocksDbDataBlockIndexType::BinaryAndHash);
+    assert_eq!(index.data_block_hash_ratio, Some(0.75));
+    assert_eq!(index.compression_type, RocksDbCompressionType::None);
+    assert_eq!(index.compaction_style, RocksDbCompactionStyle::Universal);
+    assert_eq!(index.max_compaction_bytes, Some(256 * MB_U64));
+    assert_eq!(index.level_zero_file_num_compaction_trigger, 8);
+    assert_eq!(index.level_zero_slowdown_writes_trigger, 8);
+    assert_eq!(index.level_zero_stop_writes_trigger, 20);
+
+    let timer = RocksDbColumnFamilyConfig::message_timer();
+    assert_eq!(timer.name, RocksDbColumnFamily::Timer.name());
+    assert_eq!(timer.write_buffer_size, 256 * MB);
+    assert_eq!(timer.max_write_buffer_number, 6);
+    assert_eq!(timer.block_cache_size, 2048 * MB);
+    assert_eq!(timer.block_size, 128 * KB);
+    assert_eq!(timer.metadata_block_size, Some(4 * KB));
+    assert_eq!(timer.data_block_index_type, RocksDbDataBlockIndexType::BinaryAndHash);
+    assert_eq!(timer.data_block_hash_ratio, Some(0.75));
+    assert_eq!(timer.compression_type, RocksDbCompressionType::Zstd);
+    assert_eq!(timer.bottommost_compression_type, RocksDbCompressionType::None);
+    assert_eq!(timer.compaction_style, RocksDbCompactionStyle::Level);
+    assert_eq!(timer.max_compaction_bytes, Some(256 * MB_U64));
+    assert_eq!(timer.max_bytes_for_level_base, Some(512 * MB_U64));
+
+    let trans = RocksDbColumnFamilyConfig::message_transaction();
+    assert_eq!(trans.name, RocksDbColumnFamily::Transaction.name());
+    assert_eq!(trans.write_buffer_size, 128 * MB);
+    assert_eq!(trans.max_write_buffer_number, 6);
+    assert_eq!(trans.block_cache_size, 1024 * MB);
+    assert_eq!(trans.block_size, 128 * KB);
+    assert_eq!(trans.metadata_block_size, Some(4 * KB));
+    assert_eq!(trans.data_block_index_type, RocksDbDataBlockIndexType::BinaryAndHash);
+    assert_eq!(trans.data_block_hash_ratio, Some(0.75));
+    assert_eq!(trans.compression_type, RocksDbCompressionType::None);
+    assert_eq!(trans.compaction_style, RocksDbCompactionStyle::Universal);
+    assert_eq!(trans.max_compaction_bytes, Some(100 * GB_U64));
+
+    let pop = RocksDbColumnFamilyConfig::pop(RocksDbColumnFamily::PopState.name(), 256 * MB, 32 * MB);
+    assert_eq!(pop.name, RocksDbColumnFamily::PopState.name());
+    assert_eq!(pop.write_buffer_size, 32 * MB);
+    assert_eq!(pop.block_cache_size, 256 * MB);
+    assert_eq!(pop.metadata_block_size, Some(4 * KB));
+    assert_eq!(pop.data_block_index_type, RocksDbDataBlockIndexType::BinaryAndHash);
+    assert_eq!(pop.data_block_hash_ratio, Some(0.75));
+    assert_eq!(pop.compression_type, RocksDbCompressionType::None);
+    assert_eq!(pop.bottommost_compression_type, RocksDbCompressionType::None);
+    assert_eq!(pop.compaction_style, RocksDbCompactionStyle::Universal);
+    assert_eq!(pop.max_compaction_bytes, Some(100 * GB_U64));
+
+    let broker_config = RocksDbColumnFamilyConfig::broker_config("topic", 4 * MB, 64 * MB);
+    assert_eq!(broker_config.write_buffer_size, 64 * MB);
+    assert_eq!(broker_config.block_cache_size, 4 * MB);
+    assert_eq!(broker_config.metadata_block_size, None);
+    assert_eq!(
+        broker_config.data_block_index_type,
+        RocksDbDataBlockIndexType::BinarySearch
+    );
+    assert_eq!(broker_config.data_block_hash_ratio, None);
+    assert_eq!(broker_config.compression_type, RocksDbCompressionType::None);
+    assert_eq!(broker_config.compaction_style, RocksDbCompactionStyle::Level);
+    assert_eq!(broker_config.level_zero_file_num_compaction_trigger, 4);
+    assert_eq!(broker_config.level_zero_stop_writes_trigger, 12);
+    assert_eq!(broker_config.target_file_size_base, 64 * MB_U64);
+    assert_eq!(broker_config.max_bytes_for_level_base, Some(256 * MB_U64));
+    assert!(broker_config.cache_index_and_filter_blocks);
+    assert!(broker_config.inplace_update_support);
+}
+
+#[test]
+fn rocksdb_options_factory_accepts_java_aligned_db_and_cf_options() {
+    let db_config = RocksDbConfig::default();
+    RocksDbOptionsFactory::db_options(&db_config).expect("db options should build");
+
+    for cf_config in [
+        RocksDbColumnFamilyConfig::consume_queue_default(),
+        RocksDbColumnFamilyConfig::consume_queue_offset(),
+        RocksDbColumnFamilyConfig::message_index_default(),
+        RocksDbColumnFamilyConfig::message_timer(),
+        RocksDbColumnFamilyConfig::message_transaction(),
+        RocksDbColumnFamilyConfig::pop(RocksDbColumnFamily::PopState.name(), 256 * MB, 32 * MB),
+        RocksDbColumnFamilyConfig::broker_config("topic", 4 * MB, 64 * MB),
+    ] {
+        RocksDbOptionsFactory::cf_options(&cf_config).expect("cf options should build");
+    }
+}
+
+#[test]
 fn rocksdb_consume_queue_config_is_disabled_for_local_file_store_type() {
     let temp_dir = TempDir::new().expect("temp dir should be created");
     let store_config = MessageStoreConfig {
@@ -199,7 +371,7 @@ fn rocksdb_consume_queue_config_is_disabled_for_local_file_store_type() {
     let rocksdb_config = RocksDbConfig::consume_queue_from_message_store_config(&store_config);
 
     assert!(!rocksdb_config.enabled);
-    assert_eq!(rocksdb_config.path, temp_dir.path().join("consumequeue"));
+    assert_eq!(rocksdb_config.path, temp_dir.path().join("consumequeue_rocksdb"));
 }
 
 #[test]
@@ -223,7 +395,7 @@ fn rocksdb_message_store_try_new_opens_real_rocksdb_consume_queue_backend() {
     assert!(message_store.rocksdb_config().enabled);
     assert_eq!(
         message_store.rocksdb_config().path,
-        temp_dir.path().join("consumequeue")
+        temp_dir.path().join("consumequeue_rocksdb")
     );
     assert_eq!(
         message_store.message_rocksdb_config().path,
@@ -261,6 +433,31 @@ fn rocksdb_message_store_try_new_opens_real_rocksdb_consume_queue_backend() {
             .expect("index last offset should read"),
         700
     );
+}
+
+#[test]
+fn rocksdb_message_store_try_new_rejects_conflicting_consume_queue_path() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let conflict_dir = temp_dir.path().join("consumequeue");
+    std::fs::create_dir_all(&conflict_dir).expect("conflict dir should be created");
+    std::fs::write(conflict_dir.join("CURRENT"), b"MANIFEST-000001\n").expect("CURRENT marker should be written");
+    let message_store_config = Arc::new(MessageStoreConfig {
+        store_path_root_dir: CheetahString::from_string(temp_dir.path().to_string_lossy().to_string()),
+        store_type: StoreType::RocksDB,
+        ..MessageStoreConfig::default()
+    });
+
+    let error = RocksDBMessageStore::try_new(
+        message_store_config,
+        Arc::new(BrokerConfig::default()),
+        Arc::new(DashMap::<CheetahString, ArcMut<TopicConfig>>::new()),
+        None,
+        true,
+    )
+    .expect_err("conflicting consume queue rocksdb path should be rejected");
+
+    assert!(error.to_string().contains("incompatible path"));
+    assert!(error.to_string().contains("consumequeue"));
 }
 
 #[test]
@@ -761,6 +958,34 @@ fn message_rocksdb_storage_scans_and_deletes_timer_records_with_java_range_bound
         vec![(2_000, "uniqB", 200)]
     );
 
+    let first_page = storage
+        .scan_records_for_timer(1_000, 4_000, 2, None)
+        .expect("timer first page should read");
+    assert_eq!(
+        first_page
+            .iter()
+            .map(|record| (record.delay_time, record.uniq_key.as_str(), record.offset_py))
+            .collect::<Vec<_>>(),
+        vec![(1_000, "uniqA", 100), (2_000, "uniqB", 200)]
+    );
+    let mut last_page_key = Vec::new();
+    TimerRocksDbKey {
+        delay_time: first_page[1].delay_time,
+        uniq_key: first_page[1].uniq_key.clone(),
+    }
+    .encode(&mut last_page_key)
+    .expect("timer page key should encode");
+    let second_page = storage
+        .scan_records_for_timer(1_000, 4_000, 2, Some(&last_page_key))
+        .expect("timer second page should read");
+    assert_eq!(
+        second_page
+            .iter()
+            .map(|record| (record.delay_time, record.uniq_key.as_str(), record.offset_py))
+            .collect::<Vec<_>>(),
+        vec![(3_000, "uniqC", 300)]
+    );
+
     storage
         .delete_records_for_timer(1_000, 2_000)
         .expect("timer range delete should include upper delay time");
@@ -787,6 +1012,43 @@ fn message_rocksdb_storage_scans_and_deletes_timer_records_with_java_range_bound
             .expect("timer third read should succeed")
             .map(|record| record.offset_py),
         Some(300)
+    );
+}
+
+#[test]
+fn message_rocksdb_storage_persists_timeline_checkpoint() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let store_config = MessageStoreConfig {
+        store_path_root_dir: CheetahString::from_string(temp_dir.path().to_string_lossy().to_string()),
+        store_type: StoreType::RocksDB,
+        ..MessageStoreConfig::default()
+    };
+    let storage = MessageRocksDbStorage::open(RocksDbConfig::message_from_message_store_config(&store_config))
+        .expect("message rocksdb storage should open");
+
+    assert_eq!(
+        storage
+            .get_timeline_checkpoint_for_timer()
+            .expect("empty timeline checkpoint should read"),
+        0
+    );
+    storage
+        .write_timeline_checkpoint_for_timer(1_700_000_123_000)
+        .expect("timeline checkpoint should write");
+    assert_eq!(
+        storage
+            .get_timeline_checkpoint_for_timer()
+            .expect("timeline checkpoint should read"),
+        1_700_000_123_000
+    );
+    storage
+        .delete_timeline_checkpoint_for_timer()
+        .expect("timeline checkpoint should delete");
+    assert_eq!(
+        storage
+            .get_timeline_checkpoint_for_timer()
+            .expect("deleted timeline checkpoint should read"),
+        0
     );
 }
 
@@ -1649,10 +1911,60 @@ fn rocksdb_store_prefix_and_range_scan_return_bounded_results() {
     );
 }
 
+#[tokio::test]
+async fn rocksdb_store_blocking_prefix_and_range_scan_return_bounded_results() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let store = RocksDbStore::open(test_config(&temp_dir)).expect("rocksdb store should open");
+
+    for (key, value) in [
+        (&b"timer:0001"[..], &b"a"[..]),
+        (&b"timer:0002"[..], &b"b"[..]),
+        (&b"timer:0003"[..], &b"c"[..]),
+        (&b"other:0001"[..], &b"d"[..]),
+    ] {
+        store
+            .put_cf(RocksDbColumnFamily::Default.name(), key, value)
+            .expect("seed put should succeed");
+    }
+
+    let prefix_items = store
+        .prefix_scan_blocking(RocksDbScanOptions::prefix(
+            RocksDbColumnFamily::Default.name(),
+            b"timer:",
+            2,
+        ))
+        .await
+        .expect("blocking prefix scan should succeed");
+    assert_eq!(
+        prefix_items.iter().map(|item| item.key.as_ref()).collect::<Vec<_>>(),
+        vec![&b"timer:0001"[..], &b"timer:0002"[..]]
+    );
+
+    let range_items = store
+        .range_scan_blocking(RocksDbRangeScanOptions::new(
+            RocksDbColumnFamily::Default.name(),
+            b"timer:0002",
+            b"timer:0004",
+            10,
+        ))
+        .await
+        .expect("blocking range scan should succeed");
+    assert_eq!(
+        range_items.iter().map(|item| item.key.as_ref()).collect::<Vec<_>>(),
+        vec![&b"timer:0002"[..], &b"timer:0003"[..]]
+    );
+
+    assert_eq!(store.metrics().scan_count, 2);
+}
+
 #[test]
 fn rocksdb_snapshot_keeps_consistent_read_view() {
     let temp_dir = TempDir::new().expect("temp dir should be created");
-    let store = RocksDbStore::open(test_config(&temp_dir)).expect("rocksdb store should open");
+    let store = RocksDbStore::open(RocksDbConfig {
+        column_families: vec![RocksDbColumnFamilyConfig::consume_queue_default()],
+        ..test_config(&temp_dir)
+    })
+    .expect("rocksdb store should open");
 
     store
         .put_cf(RocksDbColumnFamily::Default.name(), b"snapshot-key", b"before")
@@ -1743,6 +2055,29 @@ fn rocksdb_store_reloading_state_rejects_new_operations() {
         .put_cf(RocksDbColumnFamily::Default.name(), b"reloading-key", b"value")
         .expect_err("reloading store should reject writes");
     assert!(error.to_string().contains("reloading"));
+
+    store
+        .mark_recovered()
+        .expect("recovered store should reopen operations");
+    assert_eq!(store.state(), RocksDbStoreState::Open);
+    store
+        .put_cf(RocksDbColumnFamily::Default.name(), b"recovered-key", b"value")
+        .expect("recovered store should accept writes");
+}
+
+#[test]
+fn rocksdb_store_closed_state_cannot_be_marked_recovered() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let store = RocksDbStore::open(test_config(&temp_dir)).expect("rocksdb store should open");
+
+    store.mark_reloading();
+    store.close();
+
+    let error = store
+        .mark_recovered()
+        .expect_err("closed store should not be marked recovered");
+    assert!(error.to_string().contains("closed"));
+    assert_eq!(store.state(), RocksDbStoreState::Closed);
 }
 
 #[test]


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7409

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added async blocking scan operations for improved concurrent database access
  * Introduced dedicated timeline checkpoint operations for timer management
  * Added configurable storage path option for RocksDB consume queue

* **Bug Fixes**
  * Implemented validation to prevent incompatible RocksDB consume queue path configurations

* **Tests**
  * Expanded RocksDB configuration baseline test coverage
  * Added tests for path conflict detection and timer checkpoint operations
  * Added async blocking scan operation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->