### PR TITLE
[ISSUE #7425]🚀implement broker heartbeat management; add support for recording broker heartbeats, removing inactive brokers, and updating broker live info; enhance related types and methods for better broker lifecycle handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -271,6 +271,18 @@ dependencies = [
  "tower-layer",
  "tower-service",
 ]
+
+[[package]]
+name = "backoff-series"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b143524c9d0b6c3e8e80542a0a17e1e472ccfd5a3d3696bd6ad2b18248d3350"
+
+[[package]]
+name = "base2histogram"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74d05707c315a6c0601b1089186476cf11ee5fe8d6e035ea43c44ae1a0215cd"
 
 [[package]]
 name = "base64"
@@ -545,12 +557,35 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf 0.11.3",
+ "serde",
+]
+
+[[package]]
+name = "chrono-tz"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf 0.12.1",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf 0.11.3",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -666,7 +701,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -944,7 +979,7 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.12.1",
  "crossterm_winapi",
- "derive_more 2.1.1",
+ "derive_more",
  "document-features",
  "futures-core",
  "mio",
@@ -1140,32 +1175,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl 2.1.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "unicode-xid",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -1179,6 +1193,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1233,7 +1248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1244,6 +1259,16 @@ checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.12.1",
  "objc2",
+]
+
+[[package]]
+name = "display-more"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8aaad655bf39f0691f6f4025a8b58f1ff46fb12cb70f6d69e4f0dd2eb717a8"
+dependencies = [
+ "chrono",
+ "chrono-tz 0.8.6",
 ]
 
 [[package]]
@@ -1359,7 +1384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2165,7 +2190,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2662,7 +2687,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2787,31 +2812,38 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openraft"
-version = "0.10.0"
-source = "git+https://github.com/databendlabs/openraft.git?rev=a90c841#a90c8414ccc1fb7b2703f244a53e6ed76b83efdd"
+version = "0.10.0-alpha.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40148cf75ead81993d5910bc72275e542e4e01a90241bf1905236843fe3009d"
 dependencies = [
  "anyerror",
+ "backoff-series",
+ "base2histogram",
  "byte-unit",
  "chrono",
  "clap",
- "derive_more 1.0.0",
- "futures",
+ "derive_more",
+ "display-more",
+ "futures-util",
+ "itertools 0.14.0",
  "maplit",
  "openraft-macros",
  "openraft-rt",
  "openraft-rt-tokio",
- "rand 0.9.4",
+ "peel-off",
+ "rand 0.10.1",
  "serde",
- "thiserror 1.0.69",
+ "smallvec",
+ "thiserror 2.0.18",
  "tracing",
- "tracing-futures",
  "validit",
 ]
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0"
-source = "git+https://github.com/databendlabs/openraft.git?rev=a90c841#a90c8414ccc1fb7b2703f244a53e6ed76b83efdd"
+version = "0.10.0-alpha.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec23cd291c763fb17d8dabf7cc4eacaefd45d02e52a4df88ce50c702f030689"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -2822,22 +2854,26 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0"
-source = "git+https://github.com/databendlabs/openraft.git?rev=a90c841#a90c8414ccc1fb7b2703f244a53e6ed76b83efdd"
+version = "0.10.0-alpha.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c2d12e376df204612bb2016d652ea2d48b8edeaa04263facbe2fc7a11e3ef"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "openraft-macros",
- "rand 0.9.4",
+ "pin-project-lite",
+ "rand 0.10.1",
 ]
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0"
-source = "git+https://github.com/databendlabs/openraft.git?rev=a90c841#a90c8414ccc1fb7b2703f244a53e6ed76b83efdd"
+version = "0.10.0-alpha.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8c01f2a456a864282bc4eaf76f1f78ab040d80416fd30fd15b8ab88faa337a"
 dependencies = [
- "futures",
+ "futures-util",
  "openraft-rt",
- "rand 0.9.4",
+ "rand 0.10.1",
  "tokio",
 ]
 
@@ -3018,10 +3054,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "peel-off"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3420ea4424090cbd75a688996f696a807c68d6744b4863591b86435dc3078e9"
 
 [[package]]
 name = "percent-encoding"
@@ -3336,7 +3387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -3357,7 +3408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4085,7 +4136,7 @@ dependencies = [
  "bytes",
  "cheetah-string",
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.10.4",
  "config",
  "crc",
  "criterion",
@@ -4471,7 +4522,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4528,7 +4579,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4950,7 +5001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5143,7 +5194,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5152,7 +5203,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5657,16 +5708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6132,7 +6173,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/rocketmq-common/src/common/controller/controller_config.rs
+++ b/rocketmq-common/src/common/controller/controller_config.rs
@@ -138,6 +138,11 @@ pub struct ControllerConfig {
     /// Default: 5000 (5 seconds)
     pub scan_inactive_master_interval: u64,
 
+    /// Wait time after the first broker heartbeat before OpenRaft inactive scanning starts.
+    ///
+    /// Default: 1000 (1 second), matching Java jRaftScanWaitTimeoutMs.
+    pub raft_scan_wait_timeout_ms: u64,
+
     /// Metrics exporter type
     ///
     /// Default: Disable
@@ -234,6 +239,7 @@ impl Clone for ControllerConfig {
             is_process_read_event: self.is_process_read_event,
             notify_broker_role_changed: self.notify_broker_role_changed,
             scan_inactive_master_interval: self.scan_inactive_master_interval,
+            raft_scan_wait_timeout_ms: self.raft_scan_wait_timeout_ms,
             metrics_exporter_type: self.metrics_exporter_type,
             metrics_grpc_exporter_target: self.metrics_grpc_exporter_target.clone(),
             metrics_grpc_exporter_header: self.metrics_grpc_exporter_header.clone(),
@@ -289,6 +295,7 @@ impl Default for ControllerConfig {
             is_process_read_event: false,
             notify_broker_role_changed: true,
             scan_inactive_master_interval: 5 * 1000,
+            raft_scan_wait_timeout_ms: 1000,
             metrics_exporter_type: MetricsExporterType::Disable,
             metrics_grpc_exporter_target: String::new(),
             metrics_grpc_exporter_header: String::new(),
@@ -395,6 +402,12 @@ impl ControllerConfig {
     /// Set scan inactive master interval
     pub fn with_scan_inactive_master_interval(mut self, interval_ms: u64) -> Self {
         self.scan_inactive_master_interval = interval_ms;
+        self
+    }
+
+    /// Set OpenRaft inactive-scan wait timeout.
+    pub fn with_raft_scan_wait_timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.raft_scan_wait_timeout_ms = timeout_ms;
         self
     }
 
@@ -599,6 +612,7 @@ impl ControllerConfig {
             self.scan_inactive_master_interval
         )
         .unwrap();
+        writeln!(result, "raftScanWaitTimeoutMs={}", self.raft_scan_wait_timeout_ms).unwrap();
         writeln!(result, "metricsExporterType={}", self.metrics_exporter_type).unwrap();
         writeln!(
             result,
@@ -728,6 +742,11 @@ impl ControllerConfig {
 
                 "scanInactiveMasterInterval" => {
                     self.scan_inactive_master_interval =
+                        serde_json::from_str::<u64>(value).map_err(|e| RocketMQError::Internal(e.to_string()))?;
+                }
+
+                "raftScanWaitTimeoutMs" | "jRaftScanWaitTimeoutMs" => {
+                    self.raft_scan_wait_timeout_ms =
                         serde_json::from_str::<u64>(value).map_err(|e| RocketMQError::Internal(e.to_string()))?;
                 }
 

--- a/rocketmq-controller/Cargo.toml
+++ b/rocketmq-controller/Cargo.toml
@@ -43,7 +43,7 @@ tokio-util = { workspace = true }
 raft     = { version = "0.7.0", git = "https://github.com/tikv/raft-rs.git", rev = "1fd05e0" }
 protobuf = "2.28"
 # New openraft implementation
-openraft = { version = "0.10.0", git = "https://github.com/databendlabs/openraft.git", rev = "a90c841", features = [
+openraft = { version = "=0.10.0-alpha.21", features = [
   "serde",
   "tokio-rt",
 ] }

--- a/rocketmq-controller/src/controller.rs
+++ b/rocketmq-controller/src/controller.rs
@@ -473,8 +473,8 @@ pub trait Controller: Send + Sync {
     /// struct MyListener;
     ///
     /// impl BrokerLifecycleListener for MyListener {
-    ///     fn on_broker_inactive(&self, cluster: &str, broker: &str, id: i64) {
-    ///         log::warn!("Broker {}/{}/{} is now inactive", cluster, broker, id);
+    ///     fn on_broker_inactive(&self, cluster: Option<&str>, broker: &str, id: Option<i64>) {
+    ///         log::warn!("Broker {:?}/{}/ {:?} is now inactive", cluster, broker, id);
     ///     }
     /// }
     ///

--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -46,6 +46,8 @@ use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::body::elect_master_response_body::ElectMasterResponseBody;
 use rocketmq_remoting::protocol::body::sync_state_set_body::SyncStateSet;
 use rocketmq_remoting::protocol::header::controller::elect_master_request_header::ElectMasterRequestHeader;
+use rocketmq_remoting::protocol::header::controller::get_replica_info_request_header::GetReplicaInfoRequestHeader;
+use rocketmq_remoting::protocol::header::controller::get_replica_info_response_header::GetReplicaInfoResponseHeader;
 use rocketmq_remoting::protocol::header::elect_master_response_header::ElectMasterResponseHeader;
 use rocketmq_remoting::protocol::header::notify_broker_role_change_request_header::NotifyBrokerRoleChangedRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
@@ -134,67 +136,172 @@ impl BrokerInactiveListener {
 }
 
 impl BrokerLifecycleListener for BrokerInactiveListener {
-    fn on_broker_inactive(&self, cluster_name: &str, broker_name: &str, broker_id: i64) {
+    fn on_broker_inactive(&self, cluster_name: Option<&str>, broker_name: &str, broker_id: Option<i64>) {
         let Some(controller_manager) = self.controller_manager.upgrade() else {
             return;
         };
 
-        let cluster_name = CheetahString::from_string(cluster_name.to_owned());
+        let cluster_name = cluster_name.map(str::to_owned);
         let broker_name = CheetahString::from_string(broker_name.to_owned());
 
         tokio::spawn(async move {
             if !controller_manager.is_leader() {
                 warn!(
-                    "Broker inactive event ignored on follower controller, cluster={}, broker={}, broker_id={}",
+                    "Broker inactive event ignored on follower controller, cluster={:?}, broker={}, broker_id={:?}",
                     cluster_name, broker_name, broker_id
                 );
                 return;
             }
 
-            let request =
-                ElectMasterRequestHeader::new(cluster_name.clone(), broker_name.clone(), -1, false, current_millis());
+            if let Err(error) = controller_manager
+                .controller()
+                .remove_broker_live_info(cluster_name.as_deref(), broker_name.as_str(), broker_id)
+                .await
+            {
+                warn!(
+                    "Failed to remove inactive broker live state, cluster={:?}, broker={}, broker_id={:?}, error={}",
+                    cluster_name, broker_name, broker_id, error
+                );
+            }
 
-            match controller_manager.controller().elect_master(&request).await {
-                Ok(Some(response)) if response.code() == ResponseCode::Success as i32 => {
-                    info!(
-                        "Triggered controller-side elect-master after broker inactive, cluster={}, broker={}, \
-                         broker_id={}",
-                        cluster_name, broker_name, broker_id
-                    );
-
-                    if controller_manager.controller_config().notify_broker_role_changed {
-                        if let Err(error) = controller_manager.notify_broker_role_changed(response).await {
-                            warn!(
-                                "Failed to notify brokers after role change, cluster={}, broker={}, error={}",
-                                cluster_name, broker_name, error
-                            );
-                        }
+            if let Some(inactive_broker_id) = broker_id {
+                let replica_request = GetReplicaInfoRequestHeader {
+                    broker_name: broker_name.clone(),
+                };
+                let should_elect = match controller_manager.controller().get_replica_info(&replica_request).await {
+                    Ok(Some(response)) if response.code() == ResponseCode::Success as i32 => {
+                        response
+                            .decode_command_custom_header::<GetReplicaInfoResponseHeader>()
+                            .ok()
+                            .and_then(|header| header.master_broker_id)
+                            == Some(inactive_broker_id)
                     }
-                }
-                Ok(Some(response)) => {
-                    warn!(
-                        "Elect-master after broker inactive did not succeed, cluster={}, broker={}, broker_id={}, \
-                         code={}, remark={:?}",
-                        cluster_name,
-                        broker_name,
-                        broker_id,
-                        response.code(),
-                        response.remark()
+                    Ok(Some(response)) => {
+                        warn!(
+                            "Skip inactive broker election because replica info query failed, broker={}, code={}, \
+                             remark={:?}",
+                            broker_name,
+                            response.code(),
+                            response.remark()
+                        );
+                        false
+                    }
+                    Ok(None) => {
+                        warn!(
+                            "Skip inactive broker election because replica info query returned no response, broker={}",
+                            broker_name
+                        );
+                        false
+                    }
+                    Err(error) => {
+                        warn!(
+                            "Skip inactive broker election because replica info query errored, broker={}, error={}",
+                            broker_name, error
+                        );
+                        false
+                    }
+                };
+
+                if !should_elect {
+                    info!(
+                        "Inactive broker is not current master, skip election, cluster={:?}, broker={}, broker_id={}",
+                        cluster_name, broker_name, inactive_broker_id
                     );
-                }
-                Ok(None) => {
-                    warn!(
-                        "Elect-master after broker inactive returned no response, cluster={}, broker={}, broker_id={}",
-                        cluster_name, broker_name, broker_id
-                    );
-                }
-                Err(error) => {
-                    error!(
-                        "Elect-master after broker inactive failed, cluster={}, broker={}, broker_id={}, error={}",
-                        cluster_name, broker_name, broker_id, error
-                    );
+                    return;
                 }
             }
+
+            let request = ElectMasterRequestHeader::new(
+                cluster_name.as_deref().unwrap_or_default(),
+                broker_name.clone(),
+                -1,
+                false,
+                current_millis(),
+            );
+
+            let max_retry = controller_manager.controller_config().elect_master_max_retry_count;
+            for attempt in 0..max_retry {
+                let elect_result = tokio::time::timeout(
+                    Duration::from_secs(3),
+                    controller_manager.controller().elect_master(&request),
+                )
+                .await;
+
+                match elect_result {
+                    Ok(Ok(Some(response))) if response.code() == ResponseCode::Success as i32 => {
+                        info!(
+                            "Triggered controller-side elect-master after broker inactive, cluster={:?}, broker={}, \
+                             broker_id={:?}, attempt={}",
+                            cluster_name,
+                            broker_name,
+                            broker_id,
+                            attempt + 1
+                        );
+
+                        if controller_manager.controller_config().notify_broker_role_changed {
+                            if let Err(error) = controller_manager.notify_broker_role_changed(response).await {
+                                warn!(
+                                    "Failed to notify brokers after role change, cluster={:?}, broker={}, error={}",
+                                    cluster_name, broker_name, error
+                                );
+                            }
+                        }
+                        return;
+                    }
+                    Ok(Ok(Some(response))) => {
+                        warn!(
+                            "Elect-master after broker inactive did not succeed, cluster={:?}, broker={}, \
+                             broker_id={:?}, attempt={}, code={}, remark={:?}",
+                            cluster_name,
+                            broker_name,
+                            broker_id,
+                            attempt + 1,
+                            response.code(),
+                            response.remark()
+                        );
+                    }
+                    Ok(Ok(None)) => {
+                        warn!(
+                            "Elect-master after broker inactive returned no response, cluster={:?}, broker={}, \
+                             broker_id={:?}, attempt={}",
+                            cluster_name,
+                            broker_name,
+                            broker_id,
+                            attempt + 1
+                        );
+                    }
+                    Ok(Err(error)) => {
+                        error!(
+                            "Elect-master after broker inactive failed, cluster={:?}, broker={}, broker_id={:?}, \
+                             attempt={}, error={}",
+                            cluster_name,
+                            broker_name,
+                            broker_id,
+                            attempt + 1,
+                            error
+                        );
+                    }
+                    Err(_) => {
+                        warn!(
+                            "Elect-master after broker inactive timed out, cluster={:?}, broker={}, broker_id={:?}, \
+                             attempt={}",
+                            cluster_name,
+                            broker_name,
+                            broker_id,
+                            attempt + 1
+                        );
+                    }
+                }
+
+                if attempt + 1 < max_retry {
+                    sleep(Duration::from_millis(100)).await;
+                }
+            }
+
+            warn!(
+                "Elect-master after broker inactive exhausted retries, cluster={:?}, broker={}, broker_id={:?}",
+                cluster_name, broker_name, broker_id
+            );
         });
     }
 }
@@ -1078,7 +1185,8 @@ impl ControllerManager {
         *self.notify_worker_task.lock() = Some(handle);
     }
 
-    async fn notify_broker_role_changed(&self, response: RemotingCommand) -> Result<()> {
+    pub async fn notify_broker_role_changed(&self, mut response: RemotingCommand) -> Result<()> {
+        response.make_custom_header_to_net();
         let response_header = response
             .decode_command_custom_header::<ElectMasterResponseHeader>()
             .map_err(|error| {
@@ -1244,10 +1352,54 @@ impl Drop for ControllerManager {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::net::SocketAddr;
 
     use super::*;
     use crate::typ::Node;
+    use rocketmq_remoting::base::response_future::ResponseFuture;
+    use rocketmq_remoting::connection::Connection;
+    use rocketmq_remoting::net::channel::Channel;
+    use rocketmq_remoting::net::channel::ChannelInner;
+    use rocketmq_remoting::protocol::body::sync_state_set_body::SyncStateSet;
+    use rocketmq_remoting::protocol::header::controller::alter_sync_state_set_request_header::AlterSyncStateSetRequestHeader;
+    use rocketmq_remoting::protocol::header::controller::apply_broker_id_request_header::ApplyBrokerIdRequestHeader;
+    use rocketmq_remoting::protocol::header::controller::register_broker_to_controller_request_header::RegisterBrokerToControllerRequestHeader;
+    use rocketmq_remoting::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
+    use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+    use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
+    use rocketmq_remoting::runtime::processor::RequestProcessor;
+
+    async fn wait_until<F>(timeout: Duration, mut predicate: F, context: &str)
+    where
+        F: FnMut() -> bool,
+    {
+        let start = current_millis();
+        loop {
+            if predicate() {
+                return;
+            }
+            assert!(
+                current_millis().saturating_sub(start) < timeout.as_millis() as u64,
+                "timed out waiting for {context}"
+            );
+            sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    async fn create_test_channel() -> Channel {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
+        let local_addr = listener.local_addr().expect("local listener addr");
+        let std_stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
+        std_stream.set_nonblocking(true).expect("set nonblocking");
+        drop(listener);
+        let tcp_stream = tokio::net::TcpStream::from_std(std_stream).expect("convert tcp stream");
+        let connection = Connection::new(tcp_stream);
+        let response_table = ArcMut::new(HashMap::<i32, ResponseFuture>::new());
+        let inner = ArcMut::new(ChannelInner::new(connection, response_table));
+        Channel::new(inner, local_addr, local_addr)
+    }
 
     #[tokio::test]
     async fn test_manager_lifecycle() {
@@ -1471,6 +1623,358 @@ mod tests {
         );
 
         manager.shutdown().await.expect("shutdown manager");
+        std::mem::forget(manager);
+    }
+
+    #[tokio::test]
+    async fn inactive_slave_does_not_elect_but_inactive_master_does() {
+        let port = 9886;
+        let config = ControllerConfig::default()
+            .with_node_info(1, format!("127.0.0.1:{port}").parse::<SocketAddr>().unwrap())
+            .with_heartbeat_interval_ms(100)
+            .with_election_timeout_ms(300)
+            .with_notify_broker_role_changed(false);
+
+        let manager = ArcMut::new(ControllerManager::new(config).await.expect("create manager"));
+        manager.clone().initialize().await.expect("initialize manager");
+        manager.clone().start().await.expect("start manager");
+
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            1,
+            Node {
+                node_id: 1,
+                rpc_addr: format!("127.0.0.1:{port}"),
+            },
+        );
+        manager
+            .controller()
+            .initialize_cluster(nodes)
+            .await
+            .expect("initialize cluster");
+        wait_until(Duration::from_secs(5), || manager.is_leader(), "controller leader").await;
+
+        for (broker_id, addr, check_code) in [
+            (1_i64, "127.0.0.1:10911", "master-check"),
+            (2_i64, "127.0.0.1:10912", "slave-check"),
+        ] {
+            let apply_header = ApplyBrokerIdRequestHeader {
+                cluster_name: CheetahString::from_static_str("test-cluster"),
+                broker_name: CheetahString::from_static_str("broker-a"),
+                applied_broker_id: broker_id,
+                register_check_code: CheetahString::from_string(format!("{addr};{check_code}")),
+            };
+            let apply_response = manager
+                .controller()
+                .apply_broker_id(&apply_header)
+                .await
+                .expect("apply broker id")
+                .expect("apply response");
+            assert_eq!(apply_response.code(), ResponseCode::Success as i32);
+
+            let register_header = RegisterBrokerToControllerRequestHeader {
+                cluster_name: Some(CheetahString::from_static_str("test-cluster")),
+                broker_name: Some(CheetahString::from_static_str("broker-a")),
+                broker_id: Some(broker_id),
+                broker_address: Some(CheetahString::from_static_str(addr)),
+                ..Default::default()
+            };
+            let register_response = manager
+                .controller()
+                .register_broker(&register_header)
+                .await
+                .expect("register broker")
+                .expect("register response");
+            assert_eq!(register_response.code(), ResponseCode::Success as i32);
+
+            let heartbeat_header = BrokerHeartbeatRequestHeader {
+                cluster_name: CheetahString::from_static_str("test-cluster"),
+                broker_addr: CheetahString::from_static_str(addr),
+                broker_name: CheetahString::from_static_str("broker-a"),
+                broker_id: Some(broker_id),
+                epoch: Some(1),
+                max_offset: Some(100),
+                confirm_offset: Some(80),
+                heartbeat_timeout_mills: Some(60_000),
+                election_priority: Some(1),
+            };
+            let heartbeat_response = manager
+                .controller()
+                .record_broker_heartbeat(&heartbeat_header)
+                .await
+                .expect("record heartbeat")
+                .expect("heartbeat response");
+            assert_eq!(heartbeat_response.code(), ResponseCode::Success as i32);
+        }
+
+        let elect_header = ElectMasterRequestHeader::new("test-cluster", "broker-a", 1, false, current_millis());
+        let mut elect_response = manager
+            .controller()
+            .elect_master(&elect_header)
+            .await
+            .expect("elect master")
+            .expect("elect response");
+        assert_eq!(elect_response.code(), ResponseCode::Success as i32);
+        elect_response.make_custom_header_to_net();
+        let elect_response_header = elect_response
+            .decode_command_custom_header::<ElectMasterResponseHeader>()
+            .expect("decode elect response");
+        let alter_header = AlterSyncStateSetRequestHeader {
+            broker_name: CheetahString::from_static_str("broker-a"),
+            master_broker_id: 1,
+            master_epoch: elect_response_header.master_epoch.expect("master epoch"),
+        };
+        let alter_body = SyncStateSet::with_values(
+            HashSet::from([1_i64, 2_i64]),
+            elect_response_header
+                .sync_state_set_epoch
+                .expect("sync state set epoch"),
+        );
+        let alter_response = manager
+            .controller()
+            .alter_sync_state_set(&alter_header, alter_body)
+            .await
+            .expect("alter sync state")
+            .expect("alter response");
+        assert_eq!(alter_response.code(), ResponseCode::Success as i32);
+
+        let listener = BrokerInactiveListener::new(ArcMut::downgrade(&manager));
+        listener.on_broker_inactive(Some("test-cluster"), "broker-a", Some(2));
+        sleep(Duration::from_millis(300)).await;
+
+        let replica_header = GetReplicaInfoRequestHeader {
+            broker_name: CheetahString::from_static_str("broker-a"),
+        };
+        let mut replica_response = manager
+            .controller()
+            .get_replica_info(&replica_header)
+            .await
+            .expect("get replica info after inactive slave")
+            .expect("replica response");
+        replica_response.make_custom_header_to_net();
+        let replica_info = replica_response
+            .decode_command_custom_header::<GetReplicaInfoResponseHeader>()
+            .expect("decode replica info");
+        assert_eq!(replica_info.master_broker_id, Some(1));
+
+        let slave_heartbeat_header = BrokerHeartbeatRequestHeader {
+            cluster_name: CheetahString::from_static_str("test-cluster"),
+            broker_addr: CheetahString::from_static_str("127.0.0.1:10912"),
+            broker_name: CheetahString::from_static_str("broker-a"),
+            broker_id: Some(2),
+            epoch: Some(1),
+            max_offset: Some(100),
+            confirm_offset: Some(80),
+            heartbeat_timeout_mills: Some(60_000),
+            election_priority: Some(1),
+        };
+        let slave_heartbeat_response = manager
+            .controller()
+            .record_broker_heartbeat(&slave_heartbeat_header)
+            .await
+            .expect("record slave heartbeat before master inactive")
+            .expect("heartbeat response");
+        assert_eq!(slave_heartbeat_response.code(), ResponseCode::Success as i32);
+
+        listener.on_broker_inactive(Some("test-cluster"), "broker-a", Some(1));
+        let start = current_millis();
+        loop {
+            let mut replica_response = manager
+                .controller()
+                .get_replica_info(&replica_header)
+                .await
+                .expect("get replica info after inactive master")
+                .expect("replica response");
+            replica_response.make_custom_header_to_net();
+            let replica_info = replica_response
+                .decode_command_custom_header::<GetReplicaInfoResponseHeader>()
+                .expect("decode replica info");
+            if replica_info.master_broker_id == Some(2) {
+                break;
+            }
+            assert!(
+                current_millis().saturating_sub(start) < 5_000,
+                "timed out waiting for master reelection after inactive master"
+            );
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        manager.shutdown().await.expect("shutdown manager");
+        std::mem::forget(manager);
+    }
+
+    #[tokio::test]
+    async fn processor_successful_manual_election_records_role_change_notification() {
+        let port = 9887;
+        let config = ControllerConfig::default()
+            .with_node_info(1, format!("127.0.0.1:{port}").parse::<SocketAddr>().unwrap())
+            .with_heartbeat_interval_ms(100)
+            .with_election_timeout_ms(300)
+            .with_notify_broker_role_changed(true);
+
+        let manager = ArcMut::new(ControllerManager::new(config).await.expect("create manager"));
+        manager.clone().initialize().await.expect("initialize manager");
+        manager.clone().start().await.expect("start manager");
+
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            1,
+            Node {
+                node_id: 1,
+                rpc_addr: format!("127.0.0.1:{port}"),
+            },
+        );
+        manager
+            .controller()
+            .initialize_cluster(nodes)
+            .await
+            .expect("initialize cluster");
+        wait_until(Duration::from_secs(5), || manager.is_leader(), "controller leader").await;
+
+        let channel = create_test_channel().await;
+        for (broker_id, addr, check_code) in [
+            (1_i64, "127.0.0.1:10911", "master-check"),
+            (2_i64, "127.0.0.1:10912", "slave-check"),
+        ] {
+            let apply_header = ApplyBrokerIdRequestHeader {
+                cluster_name: CheetahString::from_static_str("test-cluster"),
+                broker_name: CheetahString::from_static_str("broker-a"),
+                applied_broker_id: broker_id,
+                register_check_code: CheetahString::from_string(format!("{addr};{check_code}")),
+            };
+            let apply_response = manager
+                .controller()
+                .apply_broker_id(&apply_header)
+                .await
+                .expect("apply broker id")
+                .expect("apply response");
+            assert_eq!(apply_response.code(), ResponseCode::Success as i32);
+
+            let register_header = RegisterBrokerToControllerRequestHeader {
+                cluster_name: Some(CheetahString::from_static_str("test-cluster")),
+                broker_name: Some(CheetahString::from_static_str("broker-a")),
+                broker_id: Some(broker_id),
+                broker_address: Some(CheetahString::from_static_str(addr)),
+                ..Default::default()
+            };
+            let register_response = manager
+                .controller()
+                .register_broker(&register_header)
+                .await
+                .expect("register broker")
+                .expect("register response");
+            assert_eq!(register_response.code(), ResponseCode::Success as i32);
+
+            let heartbeat_header = BrokerHeartbeatRequestHeader {
+                cluster_name: CheetahString::from_static_str("test-cluster"),
+                broker_addr: CheetahString::from_static_str(addr),
+                broker_name: CheetahString::from_static_str("broker-a"),
+                broker_id: Some(broker_id),
+                epoch: Some(1),
+                max_offset: Some(100),
+                confirm_offset: Some(80),
+                heartbeat_timeout_mills: Some(60_000),
+                election_priority: Some(1),
+            };
+            let heartbeat_response = manager
+                .controller()
+                .record_broker_heartbeat(&heartbeat_header)
+                .await
+                .expect("record replicated heartbeat")
+                .expect("heartbeat response");
+            assert_eq!(heartbeat_response.code(), ResponseCode::Success as i32);
+            manager.heartbeat_manager().on_broker_heartbeat(
+                "test-cluster",
+                "broker-a",
+                addr,
+                broker_id,
+                Some(60_000),
+                channel.clone(),
+                Some(1),
+                Some(100),
+                Some(80),
+                Some(1),
+            );
+        }
+
+        let initial_elect_header =
+            ElectMasterRequestHeader::new("test-cluster", "broker-a", 1, false, current_millis());
+        let mut initial_elect_response = manager
+            .controller()
+            .elect_master(&initial_elect_header)
+            .await
+            .expect("elect initial master")
+            .expect("initial elect response");
+        assert_eq!(initial_elect_response.code(), ResponseCode::Success as i32);
+        initial_elect_response.make_custom_header_to_net();
+        let initial_header = initial_elect_response
+            .decode_command_custom_header::<ElectMasterResponseHeader>()
+            .expect("decode initial elect response");
+
+        let alter_header = AlterSyncStateSetRequestHeader {
+            broker_name: CheetahString::from_static_str("broker-a"),
+            master_broker_id: 1,
+            master_epoch: initial_header.master_epoch.expect("master epoch"),
+        };
+        let alter_body = SyncStateSet::with_values(
+            HashSet::from([1_i64, 2_i64]),
+            initial_header.sync_state_set_epoch.expect("sync state set epoch"),
+        );
+        let alter_response = manager
+            .controller()
+            .alter_sync_state_set(&alter_header, alter_body)
+            .await
+            .expect("alter sync state")
+            .expect("alter response");
+        assert_eq!(alter_response.code(), ResponseCode::Success as i32);
+        assert!(
+            manager
+                .heartbeat_manager()
+                .is_broker_active("test-cluster", "broker-a", 2),
+            "local heartbeat manager must consider target broker active for role-change notification"
+        );
+
+        let mut processor = ControllerRequestProcessor::new(manager.clone());
+        let ctx = ArcMut::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::ControllerElectMaster,
+            ElectMasterRequestHeader::new("test-cluster", "broker-a", 2, true, current_millis()),
+        );
+        request.make_custom_header_to_net();
+        let mut response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("processor elect request")
+            .expect("processor elect response");
+        response.make_custom_header_to_net();
+        assert_eq!(response.code(), ResponseCode::Success as i32);
+        let response_header = response
+            .decode_command_custom_header::<ElectMasterResponseHeader>()
+            .expect("decode processor elect response");
+        assert_eq!(response_header.master_broker_id, Some(2));
+        let response_body = ElectMasterResponseBody::decode(response.body().expect("elect response body").as_ref())
+            .expect("decode processor elect response body");
+        assert!(
+            response_body.broker_member_group.is_some(),
+            "successful manual election must carry broker member group for role-change notification"
+        );
+
+        wait_until(
+            Duration::from_secs(2),
+            || {
+                let key = NotifyCacheKey {
+                    cluster_name: "test-cluster".to_string(),
+                    broker_name: "broker-a".to_string(),
+                    broker_id: 2,
+                };
+                manager.notify_cache.read().contains_key(&key) || manager.pending_notify_state.read().contains_key(&key)
+            },
+            "processor elect-master to record broker role notification",
+        )
+        .await;
+
+        manager.shutdown().await.expect("shutdown manager");
+        std::mem::forget(processor);
         std::mem::forget(manager);
     }
 }

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -25,10 +25,12 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 
-use crate::controller::broker_heartbeat_manager::BrokerHeartbeatManager;
+use crate::controller::broker_heartbeat_manager::DEFAULT_BROKER_CHANNEL_EXPIRED_TIME;
 use crate::controller::Controller;
 use crate::error::ControllerError;
 use crate::error::Result;
@@ -38,14 +40,18 @@ use crate::helper::broker_lifecycle_listener::BrokerLifecycleListener;
 use crate::openraft::GrpcRaftService;
 use crate::openraft::RaftNodeManager;
 use crate::protobuf::openraft::open_raft_service_server::OpenRaftServiceServer;
+use crate::typ::BrokerIdentityInfoSnapshot;
 use crate::typ::BrokerLiveInfoSnapshot;
 use crate::typ::ControllerRequest;
+use crate::typ::ControllerResponse;
 use crate::typ::Node;
 use crate::typ::NodeId;
 use crate::ReplicasInfoManager;
 use cheetah_string::CheetahString;
+use parking_lot::Mutex;
 use parking_lot::RwLock;
 use rocketmq_common::common::controller::ControllerConfig;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::body::sync_state_set_body::SyncStateSet;
@@ -58,6 +64,7 @@ use rocketmq_remoting::protocol::header::controller::get_replica_info_request_he
 use rocketmq_remoting::protocol::header::controller::register_broker_to_controller_request_header::RegisterBrokerToControllerRequestHeader;
 use rocketmq_remoting::protocol::header::controller::register_broker_to_controller_response_header::RegisterBrokerToControllerResponseHeader;
 use rocketmq_remoting::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
+use rocketmq_remoting::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::CommandCustomHeader;
 use rocketmq_remoting::protocol::RemotingDeserializable;
@@ -87,6 +94,8 @@ pub struct OpenRaftController {
     heartbeat_manager: ArcMut<DefaultBrokerHeartbeatManager>,
     lifecycle_listeners: Arc<RwLock<Vec<Arc<dyn BrokerLifecycleListener>>>>,
     scheduling: Arc<AtomicBool>,
+    first_received_heartbeat_time: Arc<AtomicU64>,
+    scan_task_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 impl OpenRaftController {
@@ -107,6 +116,8 @@ impl OpenRaftController {
             heartbeat_manager,
             lifecycle_listeners: Arc::new(RwLock::new(Vec::new())),
             scheduling: Arc::new(AtomicBool::new(false)),
+            first_received_heartbeat_time: Arc::new(AtomicU64::new(0)),
+            scan_task_handle: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -172,16 +183,7 @@ impl OpenRaftController {
 
     fn snapshot_alive_broker_ids(&self, cluster_name: &str, broker_name: &str) -> HashSet<u64> {
         self.replicas_info_manager()
-            .map(|manager| {
-                manager
-                    .broker_ids(broker_name)
-                    .into_iter()
-                    .filter(|broker_id| {
-                        self.heartbeat_manager
-                            .is_broker_active(cluster_name, broker_name, *broker_id as i64)
-                    })
-                    .collect()
-            })
+            .map(|manager| manager.active_broker_ids(cluster_name, broker_name))
             .unwrap_or_default()
     }
 
@@ -194,19 +196,9 @@ impl OpenRaftController {
         alive_broker_ids
             .iter()
             .filter_map(|broker_id| {
-                self.heartbeat_manager
-                    .get_broker_live_info(cluster_name, broker_name, *broker_id as i64)
-                    .map(|live_info| {
-                        (
-                            *broker_id,
-                            BrokerLiveInfoSnapshot {
-                                broker_id: *broker_id,
-                                epoch: live_info.epoch(),
-                                max_offset: live_info.max_offset(),
-                                election_priority: live_info.election_priority(),
-                            },
-                        )
-                    })
+                self.replicas_info_manager()
+                    .and_then(|manager| manager.get_broker_live_info(cluster_name, broker_name, *broker_id as i64))
+                    .map(|live_info| (*broker_id, live_info))
             })
             .collect()
     }
@@ -222,6 +214,122 @@ impl OpenRaftController {
 
         let response = node.client_write(request).await?;
         Ok(Some(response.data.into_remoting_command()))
+    }
+
+    async fn write_internal_request(&self, request: ControllerRequest) -> RocketMQResult<Option<ControllerResponse>> {
+        if !self.is_current_leader() {
+            return Ok(None);
+        }
+
+        let Some(node) = &self.node else {
+            return Ok(None);
+        };
+
+        let response = node.client_write(request).await?;
+        Ok(Some(response.data))
+    }
+
+    pub async fn record_broker_heartbeat(
+        &self,
+        request: &BrokerHeartbeatRequestHeader,
+    ) -> RocketMQResult<Option<RemotingCommand>> {
+        let Some(broker_id) = request.broker_id else {
+            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                ResponseCode::ControllerInvalidRequest,
+                "Heart beat with empty brokerId",
+            )));
+        };
+
+        if broker_id < 0 {
+            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                ResponseCode::ControllerInvalidRequest,
+                "Heart beat with invalid brokerId",
+            )));
+        }
+
+        let now_millis = current_millis();
+        let _ = self
+            .first_received_heartbeat_time
+            .compare_exchange(0, now_millis, Ordering::AcqRel, Ordering::Acquire);
+
+        let heartbeat_timeout_millis = request
+            .heartbeat_timeout_mills
+            .and_then(|timeout| u64::try_from(timeout).ok())
+            .unwrap_or(DEFAULT_BROKER_CHANNEL_EXPIRED_TIME);
+        let broker_id = broker_id as u64;
+        let broker_identity = BrokerIdentityInfoSnapshot::new(
+            request.cluster_name.to_string(),
+            request.broker_name.to_string(),
+            Some(broker_id),
+        );
+        let broker_live_info = BrokerLiveInfoSnapshot {
+            cluster_name: request.cluster_name.to_string(),
+            broker_name: request.broker_name.to_string(),
+            broker_addr: request.broker_addr.to_string(),
+            broker_id,
+            last_update_timestamp: now_millis,
+            heartbeat_timeout_millis,
+            epoch: request.epoch.unwrap_or(-1),
+            max_offset: request.max_offset.unwrap_or(-1),
+            confirm_offset: request.confirm_offset.unwrap_or(-1),
+            election_priority: request.election_priority.or(Some(i32::MAX)),
+        };
+
+        match self
+            .write_internal_request(ControllerRequest::BrokerHeartbeat {
+                broker_identity,
+                broker_live_info,
+            })
+            .await?
+        {
+            Some(response) => Ok(Some(response.into_remoting_command())),
+            None => Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                ResponseCode::Success,
+                "Heart beat success",
+            ))),
+        }
+    }
+
+    pub async fn remove_broker_live_info(
+        &self,
+        cluster_name: Option<&str>,
+        broker_name: &str,
+        broker_id: Option<i64>,
+    ) -> RocketMQResult<()> {
+        let Some(broker_id) = broker_id else {
+            return Ok(());
+        };
+        if broker_id < 0 {
+            return Ok(());
+        }
+
+        let broker_identity = BrokerIdentityInfoSnapshot::new(
+            cluster_name.unwrap_or_default().to_string(),
+            broker_name.to_string(),
+            Some(broker_id as u64),
+        );
+        let _ = self
+            .write_internal_request(ControllerRequest::BrokerChannelClose { broker_identity })
+            .await?;
+        Ok(())
+    }
+
+    async fn scan_not_active_broker_once(
+        node: Arc<RaftNodeManager>,
+        check_time_millis: u64,
+    ) -> RocketMQResult<Vec<BrokerIdentityInfoSnapshot>> {
+        let response = node
+            .client_write(ControllerRequest::CheckNotActiveBroker { check_time_millis })
+            .await?;
+        let Some(body) = response.data.body else {
+            return Ok(Vec::new());
+        };
+        serde_json::from_slice(&body).map_err(|error| {
+            rocketmq_error::RocketMQError::Internal(format!(
+                "Failed to decode replicated inactive broker scan response: {}",
+                error
+            ))
+        })
     }
 
     pub async fn initialize_cluster(&self, nodes: BTreeMap<NodeId, Node>) -> Result<()> {
@@ -341,6 +449,11 @@ impl Controller for OpenRaftController {
     async fn shutdown(&mut self) -> RocketMQResult<()> {
         info!("Shutting down OpenRaft controller");
 
+        self.scheduling.store(false, Ordering::Release);
+        if let Some(handle) = self.scan_task_handle.lock().take() {
+            handle.abort();
+        }
+
         // Take and send shutdown signal to gRPC server
         if let Some(tx) = self.shutdown_tx.take() {
             if tx.send(()).is_err() {
@@ -379,12 +492,70 @@ impl Controller for OpenRaftController {
     }
 
     async fn start_scheduling(&self) -> RocketMQResult<()> {
-        self.scheduling.store(true, Ordering::Release);
+        if self.scheduling.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+
+        let Some(node) = self.node.clone() else {
+            return Ok(());
+        };
+
+        let config = self.config.clone();
+        let listeners = self.lifecycle_listeners.clone();
+        let scheduling = self.scheduling.clone();
+        let first_received_heartbeat_time = self.first_received_heartbeat_time.clone();
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(2000)).await;
+            let mut interval =
+                tokio::time::interval(Duration::from_millis(config.scan_not_active_broker_interval.max(1)));
+
+            loop {
+                interval.tick().await;
+                if !scheduling.load(Ordering::Acquire) {
+                    break;
+                }
+
+                use openraft::async_runtime::WatchReceiver;
+                let metrics = node.raft().metrics().borrow_watched().clone();
+                if metrics.current_leader != Some(config.node_id) {
+                    continue;
+                }
+
+                let first_heartbeat = first_received_heartbeat_time.load(Ordering::Acquire);
+                let now_millis = current_millis();
+                if first_heartbeat == 0 || now_millis < first_heartbeat.saturating_add(config.raft_scan_wait_timeout_ms)
+                {
+                    continue;
+                }
+
+                match Self::scan_not_active_broker_once(node.clone(), now_millis).await {
+                    Ok(inactive_brokers) => {
+                        for broker_identity in inactive_brokers {
+                            for listener in listeners.read().iter() {
+                                listener.on_broker_inactive(
+                                    Some(broker_identity.cluster_name.as_str()),
+                                    broker_identity.broker_name.as_str(),
+                                    broker_identity.broker_id.map(|broker_id| broker_id as i64),
+                                );
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!("Failed to run replicated broker inactive scan: {}", error);
+                    }
+                }
+            }
+        });
+
+        *self.scan_task_handle.lock() = Some(handle);
         Ok(())
     }
 
     async fn stop_scheduling(&self) -> RocketMQResult<()> {
         self.scheduling.store(false, Ordering::Release);
+        if let Some(handle) = self.scan_task_handle.lock().take() {
+            handle.abort();
+        }
         Ok(())
     }
 
@@ -434,11 +605,8 @@ impl Controller for OpenRaftController {
 
         if let Some(replica_header) = replica_info.response() {
             if let Some(master_broker_id) = replica_header.master_broker_id {
-                if self.heartbeat_manager.is_broker_active(
-                    cluster_name.as_str(),
-                    broker_name.as_str(),
-                    master_broker_id,
-                ) {
+                if replicas_info_manager.is_broker_active(cluster_name.as_str(), broker_name.as_str(), master_broker_id)
+                {
                     register_header.master_broker_id = Some(master_broker_id);
                     register_header.master_address =
                         replica_header.master_address.clone().map(CheetahString::from_string);
@@ -627,7 +795,7 @@ impl Controller for OpenRaftController {
         };
 
         let broker_names_str: Vec<String> = broker_names.iter().map(|s| s.to_string()).collect();
-        let result = replicas_info_manager.get_sync_state_data(&broker_names_str, self.heartbeat_manager.as_ref());
+        let result = replicas_info_manager.get_sync_state_data(&broker_names_str, replicas_info_manager.as_ref());
 
         Ok(Some(self.command_from_result_without_header(result)))
     }

--- a/rocketmq-controller/src/controller/raft_controller.rs
+++ b/rocketmq-controller/src/controller/raft_controller.rs
@@ -29,6 +29,7 @@ use rocketmq_remoting::protocol::header::controller::elect_master_request_header
 use rocketmq_remoting::protocol::header::controller::get_next_broker_id_request_header::GetNextBrokerIdRequestHeader;
 use rocketmq_remoting::protocol::header::controller::get_replica_info_request_header::GetReplicaInfoRequestHeader;
 use rocketmq_remoting::protocol::header::controller::register_broker_to_controller_request_header::RegisterBrokerToControllerRequestHeader;
+use rocketmq_remoting::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::RocketMQRuntime;
 use rocketmq_rust::ArcMut;
@@ -152,6 +153,35 @@ impl RaftController {
         match self {
             Self::OpenRaft(controller) => controller.scheduling_enabled(),
             Self::RaftRs(_) => false,
+        }
+    }
+
+    pub async fn record_broker_heartbeat(
+        &self,
+        request: &BrokerHeartbeatRequestHeader,
+    ) -> RocketMQResult<Option<RemotingCommand>> {
+        match self {
+            Self::OpenRaft(controller) => controller.record_broker_heartbeat(request).await,
+            Self::RaftRs(_) => Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                rocketmq_remoting::code::response_code::ResponseCode::Success,
+                "Heart beat success",
+            ))),
+        }
+    }
+
+    pub async fn remove_broker_live_info(
+        &self,
+        cluster_name: Option<&str>,
+        broker_name: &str,
+        broker_id: Option<i64>,
+    ) -> RocketMQResult<()> {
+        match self {
+            Self::OpenRaft(controller) => {
+                controller
+                    .remove_broker_live_info(cluster_name, broker_name, broker_id)
+                    .await
+            }
+            Self::RaftRs(_) => Ok(()),
         }
     }
 }

--- a/rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs
+++ b/rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs
@@ -83,12 +83,13 @@ impl DefaultBrokerHeartbeatManager {
     ///
     /// * `config` - Controller configuration
     pub fn new(config: ArcMut<ControllerConfig>) -> Self {
+        let scan_interval_ms = config.scan_not_active_broker_interval.max(1);
         Self {
             config,
             broker_live_table: Arc::new(DashMap::with_capacity(256)),
             lifecycle_listeners: Vec::new(),
             scan_task_handle: None,
-            scan_interval_ms: 2000, // Default: scan every 2 seconds
+            scan_interval_ms,
         }
     }
 
@@ -144,7 +145,11 @@ impl DefaultBrokerHeartbeatManager {
 
             // Notify all listeners
             for listener in listeners.iter() {
-                listener.on_broker_inactive(&identity.cluster_name, &identity.broker_name, broker_id);
+                listener.on_broker_inactive(
+                    Some(identity.cluster_name.as_str()),
+                    identity.broker_name.as_str(),
+                    Some(broker_id),
+                );
             }
         }
     }
@@ -157,7 +162,7 @@ impl DefaultBrokerHeartbeatManager {
         broker_id: i64,
     ) {
         for listener in listeners.iter() {
-            listener.on_broker_inactive(cluster_name, broker_name, broker_id);
+            listener.on_broker_inactive(Some(cluster_name), broker_name, Some(broker_id));
         }
     }
 }
@@ -267,16 +272,11 @@ impl BrokerHeartbeatManager for DefaultBrokerHeartbeatManager {
     fn on_broker_channel_close(&self, channel: &Channel) {
         let mut broker_identity_to_remove = None;
         let mut broker_info_for_notify = None;
-        let mut should_remove = false;
-        let now_millis = current_millis();
-
         // Find the broker with this channel
         for entry in self.broker_live_table.iter() {
             if entry.value().channel() == channel {
                 let identity = entry.key().clone();
                 let live_info = entry.value();
-                let last_update_timestamp = live_info.last_update_timestamp();
-                let timeout_millis = live_info.heartbeat_timeout_millis();
 
                 info!(
                     "Channel inactive, broker {}, addr:{}, id:{}",
@@ -285,39 +285,25 @@ impl BrokerHeartbeatManager for DefaultBrokerHeartbeatManager {
                     live_info.broker_id()
                 );
 
-                if now_millis > last_update_timestamp + timeout_millis {
-                    broker_identity_to_remove = Some(identity.clone());
-                    broker_info_for_notify = Some((
-                        identity.cluster_name.to_string(),
-                        live_info.broker_name().to_string(),
-                        live_info.broker_id(),
-                    ));
-                    should_remove = true;
-                } else {
-                    info!(
-                        "Ignore broker channel close before heartbeat timeout, broker={}, addr={}, id={}, \
-                         remaining={}ms",
-                        live_info.broker_name(),
-                        live_info.broker_addr(),
-                        live_info.broker_id(),
-                        last_update_timestamp + timeout_millis - now_millis
-                    );
-                }
+                broker_identity_to_remove = Some(identity.clone());
+                broker_info_for_notify = Some((
+                    identity.cluster_name.to_string(),
+                    live_info.broker_name().to_string(),
+                    live_info.broker_id(),
+                ));
                 break;
             }
         }
 
         // Remove broker and notify listeners
-        if should_remove {
-            if let Some(identity) = broker_identity_to_remove {
-                self.broker_live_table.remove(&identity);
+        if let Some(identity) = broker_identity_to_remove {
+            self.broker_live_table.remove(&identity);
 
-                if let Some((cluster_name, broker_name, broker_id)) = broker_info_for_notify {
-                    let listeners = Arc::new(self.lifecycle_listeners.clone());
-                    tokio::spawn(async move {
-                        Self::notify_broker_inactive(listeners, &cluster_name, &broker_name, broker_id).await;
-                    });
-                }
+            if let Some((cluster_name, broker_name, broker_id)) = broker_info_for_notify {
+                let listeners = Arc::new(self.lifecycle_listeners.clone());
+                tokio::spawn(async move {
+                    Self::notify_broker_inactive(listeners, &cluster_name, &broker_name, broker_id).await;
+                });
             }
         }
     }
@@ -429,6 +415,6 @@ mod tests {
     fn test_default_broker_heartbeat_manager_creation() {
         let config = ArcMut::new(ControllerConfig::test_config());
         let manager = DefaultBrokerHeartbeatManager::new(config.clone());
-        assert_eq!(manager.scan_interval_ms, 2000);
+        assert_eq!(manager.scan_interval_ms, config.scan_not_active_broker_interval);
     }
 }

--- a/rocketmq-controller/src/helper/broker_lifecycle_listener.rs
+++ b/rocketmq-controller/src/helper/broker_lifecycle_listener.rs
@@ -20,8 +20,8 @@ pub trait BrokerLifecycleListener: Send + Sync {
     ///
     /// # Arguments
     ///
-    /// * `cluster_name` - The cluster name of the broker
+    /// * `cluster_name` - The cluster name of the broker, or None for broker-set-level reelection
     /// * `broker_name` - The broker name
-    /// * `broker_id` - The broker ID
-    fn on_broker_inactive(&self, cluster_name: &str, broker_name: &str, broker_id: i64);
+    /// * `broker_id` - The broker ID, or None for broker-set-level reelection
+    fn on_broker_inactive(&self, cluster_name: Option<&str>, broker_name: &str, broker_id: Option<i64>);
 }

--- a/rocketmq-controller/src/manager/replicas_info_manager.rs
+++ b/rocketmq-controller/src/manager/replicas_info_manager.rs
@@ -33,6 +33,7 @@
 //! Upper layer components must call methods sequentially to update the state machine.
 //! Methods return `ControllerResult` containing events that should be applied via `apply_event`.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -41,6 +42,7 @@ use bytes::Bytes;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_common::common::mix_all::FIRST_BROKER_CONTROLLER_ID;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::body::broker_body::broker_member_group::BrokerMemberGroup;
 use rocketmq_remoting::protocol::body::broker_replicas_info::BrokerReplicasInfo;
@@ -54,6 +56,7 @@ use rocketmq_remoting::protocol::header::controller::get_next_broker_id_response
 use rocketmq_remoting::protocol::header::controller::get_replica_info_response_header::GetReplicaInfoResponseHeader;
 use rocketmq_remoting::protocol::header::controller::register_broker_to_controller_response_header::RegisterBrokerToControllerResponseHeader;
 use rocketmq_remoting::protocol::header::elect_master_response_header::ElectMasterResponseHeader;
+use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_rust::ArcMut;
 use tracing::error;
 use tracing::info;
@@ -74,12 +77,16 @@ use crate::event::update_broker_address_event::UpdateBrokerAddressEvent;
 use crate::helper::broker_valid_predicate::BrokerValidPredicate;
 use crate::manager::broker_replica_info::BrokerReplicaInfo;
 use crate::manager::sync_state_info::SyncStateInfo;
+use crate::typ::BrokerIdentityInfoSnapshot;
+use crate::typ::BrokerLiveInfoSnapshot;
 
 /// Serialization structure for state machine persistence
 #[derive(serde::Serialize, serde::Deserialize)]
 struct SerializedState {
     replica_info_table: HashMap<String, BrokerReplicaInfo>,
     sync_state_set_info_table: HashMap<String, SyncStateInfo>,
+    #[serde(default)]
+    broker_live_table: Vec<(BrokerIdentityInfoSnapshot, BrokerLiveInfoSnapshot)>,
 }
 
 /// The manager that manages the replicas info for all brokers.
@@ -101,6 +108,10 @@ pub struct ReplicasInfoManager {
     /// Sync state set information table: broker_name -> SyncStateInfo
     /// Thread-safe concurrent map
     sync_state_set_info_table: Arc<DashMap<CheetahString, SyncStateInfo>>,
+
+    /// Replicated broker liveness table, equivalent to Java RaftReplicasInfoManager
+    /// brokerLiveTable.
+    broker_live_table: Arc<DashMap<BrokerIdentityInfoSnapshot, BrokerLiveInfoSnapshot>>,
 }
 
 impl ReplicasInfoManager {
@@ -110,6 +121,7 @@ impl ReplicasInfoManager {
             config,
             replica_info_table: Arc::new(DashMap::new()),
             sync_state_set_info_table: Arc::new(DashMap::new()),
+            broker_live_table: Arc::new(DashMap::new()),
         }
     }
 
@@ -250,7 +262,7 @@ impl ReplicasInfoManager {
         // Encode sync state set
         let sync_state_set_i64: HashSet<i64> = new_sync_state_set.iter().map(|&id| id as i64).collect();
         let sync_state_set_data = SyncStateSet::with_values(sync_state_set_i64, new_epoch);
-        result.set_body(Bytes::from(serde_json::to_vec(&sync_state_set_data).unwrap()));
+        result.set_body(Bytes::from(sync_state_set_data.encode().unwrap()));
 
         let event = AlterSyncStateSetEvent::new(broker_name, new_sync_state_set);
         result.add_event(Arc::new(event));
@@ -360,9 +372,9 @@ impl ReplicasInfoManager {
                     sync_state_set.iter().map(|&id| id as i64).collect();
                 let body = ElectMasterResponseBody {
                     sync_state_set: sync_state_set_i64,
-                    broker_member_group: Some(self.build_broker_member_group(&broker_replica_info)),
+                    broker_member_group: None,
                 };
-                result.set_body(Bytes::from(serde_json::to_vec(&body).unwrap()));
+                result.set_body(Bytes::from(body.encode().unwrap()));
                 result.set_code_and_remark(ResponseCode::ControllerMasterStillExist, &err);
                 return result;
             }
@@ -388,7 +400,7 @@ impl ReplicasInfoManager {
                 sync_state_set: sync_state_set_i64,
                 broker_member_group: Some(self.build_broker_member_group(&broker_replica_info)),
             };
-            result.set_body(Bytes::from(serde_json::to_vec(&body).unwrap()));
+            result.set_body(Bytes::from(body.encode().unwrap()));
 
             let event = ElectMasterEvent::with_new_master(broker_name, new_m);
             result.add_event(Arc::new(event));
@@ -558,7 +570,7 @@ impl ReplicasInfoManager {
 
         let sync_state_set_i64: HashSet<i64> = sync_state_info.sync_state_set().iter().map(|&id| id as i64).collect();
         let sync_state_set_data = SyncStateSet::with_values(sync_state_set_i64, sync_state_info.sync_state_set_epoch());
-        result.set_body(Bytes::from(serde_json::to_vec(&sync_state_set_data).unwrap()));
+        result.set_body(Bytes::from(sync_state_set_data.encode().unwrap()));
 
         // If this broker's address has been changed, we need to update it
         if let Some(current_addr) = broker_replica_info.get_broker_address(broker_id) {
@@ -598,7 +610,7 @@ impl ReplicasInfoManager {
                 sync_state_info.sync_state_set().iter().map(|&id| id as i64).collect();
             let sync_state_set_data =
                 SyncStateSet::with_values(sync_state_set_i64, sync_state_info.sync_state_set_epoch());
-            result.set_body(Bytes::from(serde_json::to_vec(&sync_state_set_data).unwrap()));
+            result.set_body(Bytes::from(sync_state_set_data.encode().unwrap()));
         } else {
             result.set_code_and_remark(
                 ResponseCode::ControllerBrokerMetadataNotExist,
@@ -675,7 +687,7 @@ impl ReplicasInfoManager {
             broker_replicas_info.add_replica_info(CheetahString::from_string(broker_name.to_string()), replicas_info);
         }
 
-        result.set_body(Bytes::from(serde_json::to_vec(&broker_replicas_info).unwrap()));
+        result.set_body(Bytes::from(broker_replicas_info.encode().unwrap()));
         result
     }
 
@@ -789,6 +801,132 @@ impl ReplicasInfoManager {
         need_reelect_broker_sets
     }
 
+    /// Apply a replicated broker heartbeat.
+    ///
+    /// This mirrors Java RaftReplicasInfoManager: timestamps, timeout and election priority
+    /// are always refreshed, while epoch/offset state only moves forward.
+    pub fn on_broker_heartbeat(
+        &self,
+        broker_identity: BrokerIdentityInfoSnapshot,
+        broker_live_info: BrokerLiveInfoSnapshot,
+    ) {
+        let broker_identity = BrokerIdentityInfoSnapshot::new(
+            broker_identity.cluster_name,
+            broker_identity.broker_name,
+            Some(broker_live_info.broker_id),
+        );
+
+        if let Some(mut prev) = self.broker_live_table.get_mut(&broker_identity) {
+            prev.broker_addr = broker_live_info.broker_addr;
+            prev.last_update_timestamp = broker_live_info.last_update_timestamp;
+            prev.heartbeat_timeout_millis = broker_live_info.heartbeat_timeout_millis;
+            prev.election_priority = broker_live_info.election_priority;
+
+            if broker_live_info.epoch > prev.epoch
+                || (broker_live_info.epoch == prev.epoch && broker_live_info.max_offset > prev.max_offset)
+            {
+                prev.epoch = broker_live_info.epoch;
+                prev.max_offset = broker_live_info.max_offset;
+                prev.confirm_offset = broker_live_info.confirm_offset;
+            }
+        } else {
+            info!(
+                "new broker live info replicated, {}, brokerId:{}",
+                broker_identity, broker_live_info.broker_id
+            );
+            self.broker_live_table.insert(broker_identity, broker_live_info);
+        }
+    }
+
+    /// Remove a broker from the replicated live table after a channel close event.
+    pub fn on_broker_channel_close(
+        &self,
+        broker_identity: &BrokerIdentityInfoSnapshot,
+    ) -> Option<BrokerIdentityInfoSnapshot> {
+        self.broker_live_table
+            .remove(broker_identity)
+            .map(|(identity, _)| identity)
+    }
+
+    /// Remove expired brokers and return broker inactive events to notify.
+    pub fn check_not_active_broker(&self, check_time_millis: u64) -> Vec<BrokerIdentityInfoSnapshot> {
+        let mut inactive_brokers = Vec::new();
+
+        for entry in self.broker_live_table.iter() {
+            let live_info = entry.value();
+            if !live_info.is_active_at(check_time_millis) {
+                inactive_brokers.push(entry.key().clone());
+            }
+        }
+
+        for broker_identity in &inactive_brokers {
+            self.broker_live_table.remove(broker_identity);
+            warn!(
+                "The broker channel expired, brokerInfo {}, checkTime={}",
+                broker_identity, check_time_millis
+            );
+        }
+
+        let mut broker_sets_already_reported: HashSet<String> = inactive_brokers
+            .iter()
+            .map(|identity| identity.broker_name.clone())
+            .collect();
+        for broker_name in self.scan_need_reelect_broker_sets(self) {
+            if !broker_sets_already_reported.insert(broker_name.clone()) {
+                continue;
+            }
+            inactive_brokers.push(BrokerIdentityInfoSnapshot::new(
+                self.cluster_name(&broker_name).unwrap_or_default(),
+                broker_name,
+                None,
+            ));
+        }
+
+        inactive_brokers
+    }
+
+    pub fn is_broker_active_at(
+        &self,
+        cluster_name: &str,
+        broker_name: &str,
+        broker_id: i64,
+        check_time_millis: u64,
+    ) -> bool {
+        if broker_id < 0 {
+            return false;
+        }
+
+        let identity = BrokerIdentityInfoSnapshot::new(cluster_name, broker_name, Some(broker_id as u64));
+        self.broker_live_table
+            .get(&identity)
+            .is_some_and(|live_info| live_info.is_active_at(check_time_millis))
+    }
+
+    pub fn is_broker_active(&self, cluster_name: &str, broker_name: &str, broker_id: i64) -> bool {
+        self.is_broker_active_at(cluster_name, broker_name, broker_id, current_millis())
+    }
+
+    pub fn get_broker_live_info(
+        &self,
+        cluster_name: &str,
+        broker_name: &str,
+        broker_id: i64,
+    ) -> Option<BrokerLiveInfoSnapshot> {
+        if broker_id < 0 {
+            return None;
+        }
+
+        let identity = BrokerIdentityInfoSnapshot::new(cluster_name, broker_name, Some(broker_id as u64));
+        self.broker_live_table.get(&identity).map(|entry| entry.clone())
+    }
+
+    pub fn active_broker_ids(&self, cluster_name: &str, broker_name: &str) -> HashSet<u64> {
+        self.broker_ids(broker_name)
+            .into_iter()
+            .filter(|broker_id| self.is_broker_active(cluster_name, broker_name, *broker_id as i64))
+            .collect()
+    }
+
     /// Apply events to memory state machine
     ///
     /// # Thread Safety
@@ -838,6 +976,11 @@ impl ReplicasInfoManager {
                 .iter()
                 .map(|entry| (entry.key().to_string(), entry.value().clone()))
                 .collect(),
+            broker_live_table: self
+                .broker_live_table
+                .iter()
+                .map(|entry| (entry.key().clone(), entry.value().clone()))
+                .collect(),
         };
 
         serde_json::to_vec(&state).map_err(|e| ControllerError::SerializationError(e.to_string()))
@@ -850,6 +993,7 @@ impl ReplicasInfoManager {
 
         self.replica_info_table.clear();
         self.sync_state_set_info_table.clear();
+        self.broker_live_table.clear();
 
         for (key, value) in state.replica_info_table {
             self.replica_info_table.insert(CheetahString::from_string(key), value);
@@ -858,6 +1002,10 @@ impl ReplicasInfoManager {
         for (key, value) in state.sync_state_set_info_table {
             self.sync_state_set_info_table
                 .insert(CheetahString::from_string(key), value);
+        }
+
+        for (key, value) in state.broker_live_table {
+            self.broker_live_table.insert(key, value);
         }
 
         Ok(())
@@ -1013,6 +1161,86 @@ impl ReplicasInfoManager {
             self.replica_info_table.remove(broker_name);
             self.sync_state_set_info_table.remove(broker_name);
         }
+    }
+}
+
+fn compare_live_info(left: &BrokerLiveInfoSnapshot, right: &BrokerLiveInfoSnapshot) -> Ordering {
+    match right.epoch.cmp(&left.epoch) {
+        Ordering::Equal => match right.max_offset.cmp(&left.max_offset) {
+            Ordering::Equal => left
+                .election_priority
+                .unwrap_or(i32::MAX)
+                .cmp(&right.election_priority.unwrap_or(i32::MAX)),
+            other => other,
+        },
+        other => other,
+    }
+}
+
+impl BrokerValidPredicate for ReplicasInfoManager {
+    fn check(&self, cluster_name: &str, broker_name: &str, broker_id: Option<i64>) -> bool {
+        broker_id.is_some_and(|broker_id| self.is_broker_active(cluster_name, broker_name, broker_id))
+    }
+}
+
+impl ReplicasInfoManager {
+    fn try_elect_from_live_table(
+        &self,
+        cluster_name: &str,
+        broker_name: &str,
+        brokers: &HashSet<i64>,
+        old_master: Option<i64>,
+        prefer_broker_id: Option<i64>,
+    ) -> Option<i64> {
+        let valid_brokers: HashSet<i64> = brokers
+            .iter()
+            .copied()
+            .filter(|broker_id| self.is_broker_active(cluster_name, broker_name, *broker_id))
+            .collect();
+
+        if valid_brokers.is_empty() {
+            return None;
+        }
+
+        if let Some(old_master_id) = old_master {
+            if valid_brokers.contains(&old_master_id)
+                && (prefer_broker_id.is_none() || prefer_broker_id == Some(old_master_id))
+            {
+                return Some(old_master_id);
+            }
+        }
+
+        if let Some(preferred_id) = prefer_broker_id {
+            return valid_brokers.contains(&preferred_id).then_some(preferred_id);
+        }
+
+        let mut broker_infos: Vec<BrokerLiveInfoSnapshot> = valid_brokers
+            .iter()
+            .filter_map(|broker_id| self.get_broker_live_info(cluster_name, broker_name, *broker_id))
+            .collect();
+        broker_infos.sort_by(compare_live_info);
+
+        broker_infos
+            .first()
+            .map(|broker| broker.broker_id as i64)
+            .or_else(|| valid_brokers.iter().min().copied())
+    }
+}
+
+impl ElectPolicy for ReplicasInfoManager {
+    fn elect(
+        &self,
+        cluster_name: &str,
+        broker_name: &str,
+        sync_state_brokers: &HashSet<i64>,
+        all_replica_brokers: &HashSet<i64>,
+        old_master: Option<i64>,
+        broker_id: Option<i64>,
+    ) -> Option<i64> {
+        self.try_elect_from_live_table(cluster_name, broker_name, sync_state_brokers, old_master, broker_id)
+            .or_else(|| {
+                self.try_elect_from_live_table(cluster_name, broker_name, all_replica_brokers, old_master, broker_id)
+            })
     }
 }
 

--- a/rocketmq-controller/src/openraft/grpc_server.rs
+++ b/rocketmq-controller/src/openraft/grpc_server.rs
@@ -96,10 +96,9 @@ impl OpenRaftService for GrpcRaftService {
                 let log_id = entry
                     .log_id
                     .ok_or_else(|| Status::invalid_argument("Missing append entry log id"))?;
-                let payload: openraft::EntryPayload<crate::typ::TypeConfig> = serde_json::from_slice(&entry.payload)
-                    .map_err(|e| {
-                        Status::invalid_argument(format!("Failed to deserialize append entry payload: {}", e))
-                    })?;
+                let payload: crate::typ::EntryPayload = serde_json::from_slice(&entry.payload).map_err(|e| {
+                    Status::invalid_argument(format!("Failed to deserialize append entry payload: {}", e))
+                })?;
                 Ok(openraft::Entry {
                     log_id: crate::typ::LogId {
                         leader_id: crate::typ::Vote::new(log_id.term, log_id.node_id).leader_id,
@@ -208,7 +207,7 @@ impl OpenRaftService for GrpcRaftService {
         let mut stream = request.into_inner();
 
         let mut vote: Option<crate::typ::Vote> = None;
-        let mut snapshot_meta: Option<openraft::SnapshotMeta<crate::typ::TypeConfig>> = None;
+        let mut snapshot_meta: Option<crate::typ::SnapshotMeta> = None;
         let mut snapshot_data = Vec::new();
 
         // Receive all chunks
@@ -224,12 +223,12 @@ impl OpenRaftService for GrpcRaftService {
 
             if snapshot_meta.is_none() {
                 if let Some(meta) = chunk.meta {
-                    let last_membership: openraft::StoredMembership<crate::typ::TypeConfig> =
-                        serde_json::from_slice(&meta.last_membership).map_err(|e| {
-                            Status::invalid_argument(format!("Failed to deserialize membership: {}", e))
-                        })?;
+                    let last_membership: crate::typ::StoredMembership = serde_json::from_slice(&meta.last_membership)
+                        .map_err(|e| {
+                        Status::invalid_argument(format!("Failed to deserialize membership: {}", e))
+                    })?;
 
-                    snapshot_meta = Some(openraft::SnapshotMeta {
+                    snapshot_meta = Some(crate::typ::SnapshotMeta {
                         last_log_id: meta.last_log_id.map(|id| crate::typ::LogId {
                             leader_id: crate::typ::Vote::new(id.term, id.node_id).leader_id,
                             index: id.index,
@@ -258,7 +257,7 @@ impl OpenRaftService for GrpcRaftService {
         );
 
         // Create snapshot with Cursor wrapper
-        let snapshot = openraft::Snapshot {
+        let snapshot = crate::typ::Snapshot {
             meta,
             snapshot: std::io::Cursor::new(snapshot_data),
         };

--- a/rocketmq-controller/src/openraft/network/grpc_client.rs
+++ b/rocketmq-controller/src/openraft/network/grpc_client.rs
@@ -29,8 +29,6 @@ use openraft::raft::SnapshotResponse;
 use openraft::raft::VoteRequest;
 use openraft::raft::VoteResponse;
 use openraft::OptionalSend;
-use openraft::Snapshot;
-use openraft::Vote;
 use tonic::transport::Channel;
 use tonic::Request;
 use tracing::debug;
@@ -41,7 +39,9 @@ use crate::protobuf::openraft::OpenRaftAppendRequest;
 use crate::protobuf::openraft::OpenRaftVote as ProtoVote;
 use crate::protobuf::openraft::OpenRaftVoteRequest as ProtoVoteRequest;
 use crate::typ::NodeId;
+use crate::typ::Snapshot;
 use crate::typ::TypeConfig;
+use crate::typ::Vote;
 
 /// gRPC-based network client for OpenRaft
 #[derive(Clone)]
@@ -106,7 +106,7 @@ impl GrpcNetworkClient {
     }
 }
 
-fn decode_vote(vote: ProtoVote) -> Vote<TypeConfig> {
+fn decode_vote(vote: ProtoVote) -> Vote {
     if vote.committed {
         Vote::new_committed(vote.term, crate::typ::NodeId::from(vote.node_id))
     } else {
@@ -199,8 +199,8 @@ impl RaftNetworkV2<TypeConfig> for GrpcNetworkClient {
 
     async fn full_snapshot(
         &mut self,
-        vote: Vote<TypeConfig>,
-        snapshot: Snapshot<TypeConfig>,
+        vote: Vote,
+        snapshot: Snapshot,
         _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,
     ) -> Result<SnapshotResponse<TypeConfig>, StreamingError<TypeConfig>> {

--- a/rocketmq-controller/src/openraft/state_machine.rs
+++ b/rocketmq-controller/src/openraft/state_machine.rs
@@ -14,119 +14,29 @@
 
 //! Raft state machine implementation backed by `ReplicasInfoManager`.
 
-use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use openraft::storage::RaftStateMachine;
-use openraft::storage::Snapshot;
 use openraft::EntryPayload;
 use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
-use openraft::SnapshotMeta;
-use openraft::StoredMembership;
 use rocketmq_rust::ArcMut;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::sync::RwLock;
 
 use crate::config::ControllerConfig;
-use crate::elect::elect_policy::ElectPolicy;
 use crate::event::controller_result::ControllerResult;
-use crate::helper::broker_valid_predicate::BrokerValidPredicate;
 use crate::manager::replicas_info_manager::ReplicasInfoManager;
 use crate::storage::SharedStorageBackend;
-use crate::typ::BrokerLiveInfoSnapshot;
 use crate::typ::ControllerRequest;
 use crate::typ::ControllerResponse;
 use crate::typ::ControllerResponseHeader;
 use crate::typ::LogId;
+use crate::typ::Snapshot;
+use crate::typ::SnapshotMeta;
+use crate::typ::StoredMembership;
 use crate::typ::TypeConfig;
-
-#[derive(Clone)]
-struct SnapshotBrokerValidPredicate {
-    alive_broker_ids: HashSet<u64>,
-}
-
-impl BrokerValidPredicate for SnapshotBrokerValidPredicate {
-    fn check(&self, _cluster_name: &str, _broker_name: &str, broker_id: Option<i64>) -> bool {
-        broker_id
-            .map(|id| id >= 0 && self.alive_broker_ids.contains(&(id as u64)))
-            .unwrap_or(false)
-    }
-}
-
-#[derive(Clone)]
-struct SnapshotElectPolicy {
-    alive_broker_ids: HashSet<u64>,
-    live_broker_infos: HashMap<u64, BrokerLiveInfoSnapshot>,
-}
-
-impl SnapshotElectPolicy {
-    fn try_elect(&self, brokers: &HashSet<i64>, old_master: Option<i64>, prefer_broker_id: Option<i64>) -> Option<i64> {
-        let valid_brokers: HashSet<i64> = brokers
-            .iter()
-            .copied()
-            .filter(|broker_id| *broker_id >= 0 && self.alive_broker_ids.contains(&(*broker_id as u64)))
-            .collect();
-
-        if valid_brokers.is_empty() {
-            return None;
-        }
-
-        if let Some(old_master_id) = old_master {
-            if valid_brokers.contains(&old_master_id)
-                && (prefer_broker_id.is_none() || prefer_broker_id == Some(old_master_id))
-            {
-                return Some(old_master_id);
-            }
-        }
-
-        if let Some(preferred_id) = prefer_broker_id {
-            return valid_brokers.contains(&preferred_id).then_some(preferred_id);
-        }
-
-        let mut broker_infos: Vec<&BrokerLiveInfoSnapshot> = valid_brokers
-            .iter()
-            .filter_map(|broker_id| self.live_broker_infos.get(&(*broker_id as u64)))
-            .collect();
-        broker_infos.sort_by(|left, right| compare_live_info(left, right));
-
-        broker_infos
-            .first()
-            .map(|broker| broker.broker_id as i64)
-            .or_else(|| valid_brokers.iter().next().copied())
-    }
-}
-
-impl ElectPolicy for SnapshotElectPolicy {
-    fn elect(
-        &self,
-        _cluster_name: &str,
-        _broker_name: &str,
-        sync_state_brokers: &HashSet<i64>,
-        all_replica_brokers: &HashSet<i64>,
-        old_master: Option<i64>,
-        broker_id: Option<i64>,
-    ) -> Option<i64> {
-        self.try_elect(sync_state_brokers, old_master, broker_id)
-            .or_else(|| self.try_elect(all_replica_brokers, old_master, broker_id))
-    }
-}
-
-fn compare_live_info(left: &BrokerLiveInfoSnapshot, right: &BrokerLiveInfoSnapshot) -> Ordering {
-    match right.epoch.cmp(&left.epoch) {
-        Ordering::Equal => match right.max_offset.cmp(&left.max_offset) {
-            Ordering::Equal => left
-                .election_priority
-                .unwrap_or(i32::MAX)
-                .cmp(&right.election_priority.unwrap_or(i32::MAX)),
-            other => other,
-        },
-        other => other,
-    }
-}
 
 const SNAPSHOT_META_KEY: &str = "openraft/state_machine/current_snapshot_meta";
 const SNAPSHOT_DATA_KEY: &str = "openraft/state_machine/current_snapshot_data";
@@ -163,19 +73,19 @@ async fn persist_json<T: Serialize>(
 pub struct SnapshotData {
     pub replicas_info_manager_state: Vec<u8>,
     pub last_applied: Option<LogId>,
-    pub last_membership: Option<StoredMembership<TypeConfig>>,
+    pub last_membership: Option<StoredMembership>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct PersistedSnapshotMeta {
     last_log_id: Option<LogId>,
-    last_membership: StoredMembership<TypeConfig>,
+    last_membership: StoredMembership,
     snapshot_id: String,
 }
 
 #[derive(Clone)]
 struct CurrentSnapshot {
-    meta: SnapshotMeta<TypeConfig>,
+    meta: SnapshotMeta,
     data: Vec<u8>,
 }
 
@@ -183,7 +93,7 @@ struct CurrentSnapshot {
 pub struct StateMachine {
     replicas_info_manager: Arc<ReplicasInfoManager>,
     last_applied: Arc<RwLock<Option<LogId>>>,
-    last_membership: Arc<RwLock<StoredMembership<TypeConfig>>>,
+    last_membership: Arc<RwLock<StoredMembership>>,
     current_snapshot: Arc<RwLock<Option<CurrentSnapshot>>>,
     backend: Option<SharedStorageBackend>,
 }
@@ -296,17 +206,14 @@ impl StateMachine {
                 broker_name,
                 broker_address,
                 broker_id,
-                alive_broker_ids,
+                alive_broker_ids: _,
             } => {
-                let alive_predicate = SnapshotBrokerValidPredicate {
-                    alive_broker_ids: alive_broker_ids.clone(),
-                };
                 let result = self.replicas_info_manager.register_broker(
                     cluster_name,
                     broker_name,
                     broker_address,
                     *broker_id,
-                    &alive_predicate,
+                    self.replicas_info_manager.as_ref(),
                 );
                 self.response_from_result(result, ControllerResponseHeader::RegisterBroker)
             }
@@ -317,18 +224,15 @@ impl StateMachine {
                 master_epoch,
                 new_sync_state_set,
                 sync_state_set_epoch,
-                alive_broker_ids,
+                alive_broker_ids: _,
             } => {
-                let alive_predicate = SnapshotBrokerValidPredicate {
-                    alive_broker_ids: alive_broker_ids.clone(),
-                };
                 let result = self.replicas_info_manager.alter_sync_state_set(
                     broker_name,
                     *master_broker_id,
                     *master_epoch,
                     new_sync_state_set.clone(),
                     *sync_state_set_epoch,
-                    &alive_predicate,
+                    self.replicas_info_manager.as_ref(),
                 );
                 self.response_from_result(result, ControllerResponseHeader::AlterSyncStateSet)
             }
@@ -337,16 +241,15 @@ impl StateMachine {
                 broker_name,
                 broker_id,
                 designate_elect,
-                alive_broker_ids,
-                live_broker_infos,
+                alive_broker_ids: _,
+                live_broker_infos: _,
             } => {
-                let elect_policy = SnapshotElectPolicy {
-                    alive_broker_ids: alive_broker_ids.clone(),
-                    live_broker_infos: live_broker_infos.clone(),
-                };
-                let result =
-                    self.replicas_info_manager
-                        .elect_master(broker_name, *broker_id, *designate_elect, &elect_policy);
+                let result = self.replicas_info_manager.elect_master(
+                    broker_name,
+                    *broker_id,
+                    *designate_elect,
+                    self.replicas_info_manager.as_ref(),
+                );
                 self.response_from_result(result, ControllerResponseHeader::ElectMaster)
             }
             ControllerRequest::CleanBrokerData {
@@ -354,19 +257,43 @@ impl StateMachine {
                 broker_name,
                 broker_controller_ids_to_clean,
                 clean_living_broker,
-                alive_broker_ids,
+                alive_broker_ids: _,
             } => {
-                let alive_predicate = SnapshotBrokerValidPredicate {
-                    alive_broker_ids: alive_broker_ids.clone(),
-                };
                 let result = self.replicas_info_manager.clean_broker_data(
                     cluster_name,
                     broker_name,
                     broker_controller_ids_to_clean.as_deref(),
                     *clean_living_broker,
-                    &alive_predicate,
+                    self.replicas_info_manager.as_ref(),
                 );
                 self.response_from_result_without_header(result)
+            }
+            ControllerRequest::BrokerHeartbeat {
+                broker_identity,
+                broker_live_info,
+            } => {
+                self.replicas_info_manager
+                    .on_broker_heartbeat(broker_identity.clone(), broker_live_info.clone());
+                ControllerResponse::new(
+                    rocketmq_remoting::code::response_code::ResponseCode::Success.into(),
+                    Some("Heart beat success".to_string()),
+                    None,
+                    None,
+                )
+            }
+            ControllerRequest::BrokerChannelClose { broker_identity } => {
+                self.replicas_info_manager.on_broker_channel_close(broker_identity);
+                ControllerResponse::success()
+            }
+            ControllerRequest::CheckNotActiveBroker { check_time_millis } => {
+                let inactive_brokers = self.replicas_info_manager.check_not_active_broker(*check_time_millis);
+                let body = serde_json::to_vec(&inactive_brokers).ok();
+                ControllerResponse::new(
+                    rocketmq_remoting::code::response_code::ResponseCode::Success.into(),
+                    None,
+                    None,
+                    body,
+                )
             }
         }
     }
@@ -444,14 +371,14 @@ impl StateMachine {
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for StateMachine {
-    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, std::io::Error> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot, std::io::Error> {
         let data = self.build_snapshot_data().await?;
         let last_applied = data.last_applied;
         let last_membership = data.last_membership.clone().unwrap_or_default();
         let snapshot_data = serde_json::to_vec(&data)
             .map_err(|error| std::io::Error::other(format!("Failed to serialize snapshot: {}", error)))?;
         let current_snapshot = CurrentSnapshot {
-            meta: openraft::SnapshotMeta {
+            meta: SnapshotMeta {
                 last_log_id: last_applied,
                 last_membership,
                 snapshot_id: format!("snapshot-{}", last_applied.map_or(0, |log_id| log_id.index)),
@@ -471,7 +398,7 @@ impl RaftSnapshotBuilder<TypeConfig> for StateMachine {
 impl RaftStateMachine<TypeConfig> for StateMachine {
     type SnapshotBuilder = Self;
 
-    async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMembership<TypeConfig>), std::io::Error> {
+    async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMembership), std::io::Error> {
         let last_applied = *self.last_applied.read().await;
         let last_membership = self.last_membership.read().await.clone();
         Ok((last_applied, last_membership))
@@ -528,7 +455,7 @@ impl RaftStateMachine<TypeConfig> for StateMachine {
 
     async fn install_snapshot(
         &mut self,
-        meta: &openraft::SnapshotMeta<TypeConfig>,
+        meta: &SnapshotMeta,
         snapshot: std::io::Cursor<Vec<u8>>,
     ) -> Result<(), std::io::Error> {
         let snapshot_data: SnapshotData = serde_json::from_slice(snapshot.get_ref()).map_err(|error| {
@@ -549,7 +476,7 @@ impl RaftStateMachine<TypeConfig> for StateMachine {
         Ok(())
     }
 
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, std::io::Error> {
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot>, std::io::Error> {
         Ok(self.current_snapshot.read().await.clone().map(|snapshot| Snapshot {
             meta: snapshot.meta,
             snapshot: std::io::Cursor::new(snapshot.data),
@@ -561,12 +488,32 @@ impl RaftStateMachine<TypeConfig> for StateMachine {
 mod tests {
     use super::*;
     use crate::config::ControllerConfig;
+    use crate::typ::BrokerIdentityInfoSnapshot;
+    use crate::typ::BrokerLiveInfoSnapshot;
     use rocketmq_remoting::code::response_code::ResponseCode;
 
     fn new_state_machine() -> StateMachine {
         let config =
             ArcMut::new(ControllerConfig::default().with_node_info(1, "127.0.0.1:39876".parse().expect("valid addr")));
         StateMachine::new(config)
+    }
+
+    fn heartbeat_request(last_update_timestamp: u64, heartbeat_timeout_millis: u64) -> ControllerRequest {
+        ControllerRequest::BrokerHeartbeat {
+            broker_identity: BrokerIdentityInfoSnapshot::new("test-cluster", "broker-a", Some(1)),
+            broker_live_info: BrokerLiveInfoSnapshot {
+                cluster_name: "test-cluster".to_string(),
+                broker_name: "broker-a".to_string(),
+                broker_addr: "127.0.0.1:10911".to_string(),
+                broker_id: 1,
+                last_update_timestamp,
+                heartbeat_timeout_millis,
+                epoch: 1,
+                max_offset: 100,
+                confirm_offset: 80,
+                election_priority: Some(1),
+            },
+        }
     }
 
     #[test]
@@ -602,6 +549,7 @@ mod tests {
             applied_broker_id: 1,
             register_check_code: "code-1".to_string(),
         });
+        state_machine.apply_request(&heartbeat_request(1_000, 60_000));
 
         let snapshot = state_machine.build_snapshot().await.expect("snapshot");
 
@@ -618,5 +566,44 @@ mod tests {
             .and_then(|header| header.next_broker_id)
             .expect("next broker id");
         assert_eq!(next_broker_id, 2);
+        assert!(restored
+            .replicas_info_manager()
+            .is_broker_active_at("test-cluster", "broker-a", 1, 2_000));
+    }
+
+    #[test]
+    fn broker_heartbeat_updates_replicated_live_table() {
+        let state_machine = new_state_machine();
+
+        let response = state_machine.apply_request(&heartbeat_request(1_000, 3_000));
+
+        assert_eq!(response.response_code, ResponseCode::Success.to_i32());
+        assert!(state_machine
+            .replicas_info_manager()
+            .is_broker_active_at("test-cluster", "broker-a", 1, 3_999));
+        assert!(!state_machine
+            .replicas_info_manager()
+            .is_broker_active_at("test-cluster", "broker-a", 1, 4_001));
+    }
+
+    #[test]
+    fn check_not_active_broker_removes_expired_live_info() {
+        let state_machine = new_state_machine();
+        state_machine.apply_request(&heartbeat_request(1_000, 3_000));
+
+        let response = state_machine.apply_request(&ControllerRequest::CheckNotActiveBroker {
+            check_time_millis: 4_001,
+        });
+
+        assert_eq!(response.response_code, ResponseCode::Success.to_i32());
+        let inactive_brokers: Vec<BrokerIdentityInfoSnapshot> =
+            serde_json::from_slice(response.body.as_deref().expect("inactive broker body")).expect("decode body");
+        assert_eq!(
+            inactive_brokers,
+            vec![BrokerIdentityInfoSnapshot::new("test-cluster", "broker-a", Some(1))]
+        );
+        assert!(!state_machine
+            .replicas_info_manager()
+            .is_broker_active_at("test-cluster", "broker-a", 1, 4_001));
     }
 }

--- a/rocketmq-controller/src/processor/controller_request_processor.rs
+++ b/rocketmq-controller/src/processor/controller_request_processor.rs
@@ -85,10 +85,15 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 
 use crate::controller::broker_heartbeat_manager::BrokerHeartbeatManager;
 use crate::heartbeat::default_broker_heartbeat_manager::DefaultBrokerHeartbeatManager;
 use crate::manager::ControllerManager;
+use crate::metrics::ControllerMetricsManager;
+use crate::metrics::RequestHandleStatus;
+use crate::metrics::RequestType as MetricsRequestType;
 use crate::Controller;
 use cheetah_string::CheetahString;
 use rocketmq_error::RocketMQError;
@@ -338,6 +343,20 @@ impl ControllerRequestProcessor {
             .elect_master(&request_header)
             .await?;
 
+        if let Some(response_command) = response.as_ref() {
+            if response_command.code() == ResponseCode::Success as i32
+                && self.controller_manager.controller_config().notify_broker_role_changed
+            {
+                if let Err(error) = self
+                    .controller_manager
+                    .notify_broker_role_changed(response_command.clone())
+                    .await
+                {
+                    warn!("Failed to notify brokers after elect-master request: {}", error);
+                }
+            }
+        }
+
         Ok(response)
     }
 
@@ -435,10 +454,10 @@ impl ControllerRequestProcessor {
                 request_header.confirm_offset,
                 request_header.election_priority,
             );
-            Ok(Some(RemotingCommand::create_response_command_with_code_remark(
-                ResponseCode::Success,
-                "Heart beat success",
-            )))
+            self.controller_manager
+                .controller()
+                .record_broker_heartbeat(&request_header)
+                .await
         } else {
             Ok(Some(RemotingCommand::create_response_command_with_code_remark(
                 ResponseCode::ControllerInvalidRequest,
@@ -888,7 +907,51 @@ impl RequestProcessor for ControllerRequestProcessor {
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> RocketMQResult<Option<RemotingCommand>> {
-        self.handle_request(channel, ctx, request).await
+        let request_code = RequestCode::from(request.code());
+        let request_name = request_code.get_controller_request_name();
+        let start = Instant::now();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(WAIT_TIMEOUT_SECONDS),
+            self.handle_request(channel, ctx, request),
+        )
+        .await;
+
+        let latency_us = start.elapsed().as_micros().try_into().unwrap_or(u64::MAX);
+        match result {
+            Ok(Ok(response)) => {
+                if let Some(name) = request_name {
+                    let status = if response
+                        .as_ref()
+                        .is_none_or(|command| command.code() == ResponseCode::Success as i32)
+                    {
+                        RequestHandleStatus::Success
+                    } else {
+                        RequestHandleStatus::Failed
+                    };
+                    ControllerMetricsManager::inc_request_total_static(name, status);
+                    ControllerMetricsManager::record_request_latency_static(name, latency_us);
+                }
+                Ok(response)
+            }
+            Ok(Err(error)) => {
+                if let Some(name) = request_name {
+                    ControllerMetricsManager::inc_request_total_static(name, RequestHandleStatus::Failed);
+                    ControllerMetricsManager::record_request_latency_static(name, latency_us);
+                }
+                Err(error)
+            }
+            Err(_) => {
+                if let Some(name) = request_name {
+                    ControllerMetricsManager::inc_request_total_static(name, RequestHandleStatus::Timeout);
+                    ControllerMetricsManager::record_request_latency_static(name, latency_us);
+                }
+                Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::SystemError,
+                    "Controller request timed out",
+                )))
+            }
+        }
     }
 }
 

--- a/rocketmq-controller/src/typ.rs
+++ b/rocketmq-controller/src/typ.rs
@@ -57,13 +57,59 @@ impl From<Node> for protobuf::Node {
     }
 }
 
-/// Serializable subset of heartbeat state needed for master election.
+/// Serializable broker identity used by replicated heartbeat state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct BrokerIdentityInfoSnapshot {
+    pub cluster_name: String,
+    pub broker_name: String,
+    pub broker_id: Option<u64>,
+}
+
+impl BrokerIdentityInfoSnapshot {
+    pub fn new(cluster_name: impl Into<String>, broker_name: impl Into<String>, broker_id: Option<u64>) -> Self {
+        Self {
+            cluster_name: cluster_name.into(),
+            broker_name: broker_name.into(),
+            broker_id,
+        }
+    }
+}
+
+impl std::fmt::Display for BrokerIdentityInfoSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "BrokerIdentityInfo{{clusterName='{}', brokerName='{}', brokerId={:?}}}",
+            self.cluster_name, self.broker_name, self.broker_id
+        )
+    }
+}
+
+/// Serializable heartbeat state needed for replicated liveness and master election.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BrokerLiveInfoSnapshot {
+    pub cluster_name: String,
+    pub broker_name: String,
+    pub broker_addr: String,
     pub broker_id: u64,
+    pub last_update_timestamp: u64,
+    pub heartbeat_timeout_millis: u64,
     pub epoch: i32,
     pub max_offset: i64,
+    pub confirm_offset: i64,
     pub election_priority: Option<i32>,
+}
+
+impl BrokerLiveInfoSnapshot {
+    pub fn identity(&self) -> BrokerIdentityInfoSnapshot {
+        BrokerIdentityInfoSnapshot::new(&self.cluster_name, &self.broker_name, Some(self.broker_id))
+    }
+
+    pub fn is_active_at(&self, timestamp_millis: u64) -> bool {
+        self.last_update_timestamp
+            .checked_add(self.heartbeat_timeout_millis)
+            .is_some_and(|expires_at| expires_at >= timestamp_millis)
+    }
 }
 
 /// Controller write requests that must be replicated through OpenRaft.
@@ -107,6 +153,16 @@ pub enum ControllerRequest {
         clean_living_broker: bool,
         alive_broker_ids: HashSet<u64>,
     },
+    BrokerHeartbeat {
+        broker_identity: BrokerIdentityInfoSnapshot,
+        broker_live_info: BrokerLiveInfoSnapshot,
+    },
+    BrokerChannelClose {
+        broker_identity: BrokerIdentityInfoSnapshot,
+    },
+    CheckNotActiveBroker {
+        check_time_millis: u64,
+    },
 }
 
 impl std::fmt::Display for ControllerRequest {
@@ -125,6 +181,19 @@ impl std::fmt::Display for ControllerRequest {
                 broker_name, broker_id, ..
             } => write!(f, "ElectMaster({}, broker_id={:?})", broker_name, broker_id),
             Self::CleanBrokerData { broker_name, .. } => write!(f, "CleanBrokerData({})", broker_name),
+            Self::BrokerHeartbeat { broker_identity, .. } => write!(
+                f,
+                "BrokerHeartbeat({}, id={:?})",
+                broker_identity.broker_name, broker_identity.broker_id
+            ),
+            Self::BrokerChannelClose { broker_identity } => write!(
+                f,
+                "BrokerChannelClose({}, id={:?})",
+                broker_identity.broker_name, broker_identity.broker_id
+            ),
+            Self::CheckNotActiveBroker { check_time_millis } => {
+                write!(f, "CheckNotActiveBroker({check_time_millis})")
+            }
         }
     }
 }
@@ -199,12 +268,16 @@ openraft::declare_raft_types!(
         SnapshotData = std::io::Cursor<Vec<u8>>,
 );
 
-pub type Raft = openraft::Raft<TypeConfig>;
+pub type Raft = openraft::Raft<TypeConfig, crate::openraft::StateMachine>;
 pub type RaftConfig = openraft::Config;
-pub type LogId = openraft::LogId<TypeConfig>;
-pub type LogEntry = openraft::Entry<TypeConfig>;
-pub type CommittedLogEntry = openraft::entry::Entry<TypeConfig>;
-pub type Vote = openraft::Vote<TypeConfig>;
+pub type LogId = openraft::type_config::alias::LogIdOf<TypeConfig>;
+pub type LogEntry = openraft::type_config::alias::EntryOf<TypeConfig>;
+pub type CommittedLogEntry = openraft::type_config::alias::EntryOf<TypeConfig>;
+pub type Vote = openraft::type_config::alias::VoteOf<TypeConfig>;
+pub type EntryPayload = openraft::type_config::alias::EntryPayloadOf<TypeConfig>;
+pub type SnapshotMeta = openraft::type_config::alias::SnapshotMetaOf<TypeConfig>;
+pub type Snapshot = openraft::type_config::alias::SnapshotOf<TypeConfig>;
+pub type StoredMembership = openraft::type_config::alias::StoredMembershipOf<TypeConfig>;
 pub type RaftMetrics = openraft::metrics::RaftMetrics<TypeConfig>;
 pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<TypeConfig>;
 pub type AppendEntriesRequest = openraft::raft::AppendEntriesRequest<TypeConfig>;

--- a/rocketmq-controller/tests/controller_request_processor_contract_test.rs
+++ b/rocketmq-controller/tests/controller_request_processor_contract_test.rs
@@ -492,10 +492,10 @@ async fn controller_request_contract_elect_master() {
     let body = ElectMasterResponseBody::decode(response.body().expect("elect master response body").as_ref())
         .expect("decode elect master body");
     assert_eq!(body.sync_state_set, HashSet::from([seed.master_broker_id]));
-    let broker_member_group = body
-        .broker_member_group
-        .expect("elect master body should include broker member group");
-    assert_eq!(broker_member_group.broker_addrs.len(), 2);
+    assert!(
+        body.broker_member_group.is_none(),
+        "master-still-exists response should match Java and omit broker member group"
+    );
 
     harness.shutdown().await;
 }

--- a/rocketmq-controller/tests/multi_node_cluster_test.rs
+++ b/rocketmq-controller/tests/multi_node_cluster_test.rs
@@ -26,12 +26,15 @@ use std::time::Duration;
 
 use openraft::async_runtime::WatchReceiver;
 use openraft::ServerState;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_controller::config::ControllerConfig;
 use rocketmq_controller::config::RaftPeer;
 use rocketmq_controller::config::StorageBackendType;
 use rocketmq_controller::openraft::GrpcRaftService;
 use rocketmq_controller::openraft::RaftNodeManager;
 use rocketmq_controller::protobuf::openraft::open_raft_service_server::OpenRaftServiceServer;
+use rocketmq_controller::typ::BrokerIdentityInfoSnapshot;
+use rocketmq_controller::typ::BrokerLiveInfoSnapshot;
 use rocketmq_controller::typ::ControllerRequest;
 use rocketmq_controller::typ::ControllerResponseHeader;
 use rocketmq_controller::typ::Node;
@@ -57,6 +60,29 @@ fn raft_node(node_id: u64, base_port: u16) -> Node {
     Node {
         node_id,
         rpc_addr: format!("127.0.0.1:{}", base_port + node_id as u16),
+    }
+}
+
+fn broker_heartbeat_request(
+    cluster_name: &str,
+    broker_name: &str,
+    broker_addr: &str,
+    broker_id: u64,
+) -> ControllerRequest {
+    ControllerRequest::BrokerHeartbeat {
+        broker_identity: BrokerIdentityInfoSnapshot::new(cluster_name, broker_name, Some(broker_id)),
+        broker_live_info: BrokerLiveInfoSnapshot {
+            cluster_name: cluster_name.to_string(),
+            broker_name: broker_name.to_string(),
+            broker_addr: broker_addr.to_string(),
+            broker_id,
+            last_update_timestamp: current_millis(),
+            heartbeat_timeout_millis: 60_000,
+            epoch: 1,
+            max_offset: 100,
+            confirm_offset: 80,
+            election_priority: Some(1),
+        },
     }
 }
 
@@ -319,6 +345,18 @@ async fn seed_replica_group_state(
         .await
         .expect("register replica broker");
     assert_eq!(register_replica.data.response_code, ResponseCode::Success as i32);
+
+    node.client_write(broker_heartbeat_request("test-cluster", broker_name, master_address, 1))
+        .await
+        .expect("replicate master heartbeat");
+    node.client_write(broker_heartbeat_request(
+        "test-cluster",
+        broker_name,
+        replica_address,
+        2,
+    ))
+    .await
+    .expect("replicate replica heartbeat");
 
     let elect_master = node
         .client_write(ControllerRequest::ElectMaster {

--- a/rocketmq-controller/tests/openraft_integration_test.rs
+++ b/rocketmq-controller/tests/openraft_integration_test.rs
@@ -18,11 +18,14 @@ use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::path::Path;
 
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_controller::config::ControllerConfig;
 use rocketmq_controller::config::StorageBackendType;
 use rocketmq_controller::openraft::RaftNodeManager;
 use rocketmq_controller::openraft::StateMachine;
 use rocketmq_controller::openraft::Store;
+use rocketmq_controller::typ::BrokerIdentityInfoSnapshot;
+use rocketmq_controller::typ::BrokerLiveInfoSnapshot;
 use rocketmq_controller::typ::ControllerRequest;
 use rocketmq_controller::typ::ControllerResponseHeader;
 use rocketmq_controller::typ::Node;
@@ -47,6 +50,29 @@ fn persistent_test_config(port: u16, storage_path: &Path) -> ArcMut<ControllerCo
             .with_storage_backend(StorageBackendType::File)
             .with_storage_path(storage_path.to_string_lossy().into_owned()),
     )
+}
+
+fn broker_heartbeat_request(
+    cluster_name: &str,
+    broker_name: &str,
+    broker_addr: &str,
+    broker_id: u64,
+) -> ControllerRequest {
+    ControllerRequest::BrokerHeartbeat {
+        broker_identity: BrokerIdentityInfoSnapshot::new(cluster_name, broker_name, Some(broker_id)),
+        broker_live_info: BrokerLiveInfoSnapshot {
+            cluster_name: cluster_name.to_string(),
+            broker_name: broker_name.to_string(),
+            broker_addr: broker_addr.to_string(),
+            broker_id,
+            last_update_timestamp: current_millis(),
+            heartbeat_timeout_millis: 60_000,
+            epoch: 1,
+            max_offset: 100,
+            confirm_offset: 80,
+            election_priority: Some(1),
+        },
+    }
 }
 
 #[tokio::test]
@@ -170,6 +196,14 @@ async fn test_client_write_updates_replicas_info_manager() {
         "RegisterBroker failed: {:?}",
         register_result.err()
     );
+    node.client_write(broker_heartbeat_request(
+        "test-cluster",
+        "test-broker",
+        "127.0.0.1:10911",
+        1,
+    ))
+    .await
+    .expect("replicate broker heartbeat");
 
     let next_broker_id = node
         .store()
@@ -250,6 +284,23 @@ async fn test_single_node_restart_recovers_state_from_file_storage() {
         .await
         .expect("register replica broker before restart");
     assert_eq!(register_replica.data.response_code, ResponseCode::Success as i32);
+
+    node.client_write(broker_heartbeat_request(
+        "test-cluster",
+        "restart-broker",
+        "127.0.0.1:10911",
+        1,
+    ))
+    .await
+    .expect("replicate master heartbeat before restart");
+    node.client_write(broker_heartbeat_request(
+        "test-cluster",
+        "restart-broker",
+        "127.0.0.1:10912",
+        2,
+    ))
+    .await
+    .expect("replicate replica heartbeat before restart");
 
     let elect_response = node
         .client_write(ControllerRequest::ElectMaster {

--- a/rocketmq-controller/tests/snapshot_test.rs
+++ b/rocketmq-controller/tests/snapshot_test.rs
@@ -20,9 +20,12 @@ use std::collections::HashSet;
 
 use openraft::storage::RaftStateMachine;
 use openraft::RaftSnapshotBuilder;
+use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_controller::config::ControllerConfig;
 use rocketmq_controller::openraft::RaftNodeManager;
 use rocketmq_controller::openraft::StateMachine;
+use rocketmq_controller::typ::BrokerIdentityInfoSnapshot;
+use rocketmq_controller::typ::BrokerLiveInfoSnapshot;
 use rocketmq_controller::typ::ControllerRequest;
 use rocketmq_controller::typ::ControllerResponseHeader;
 use rocketmq_controller::typ::Node;
@@ -37,6 +40,29 @@ fn test_config(port: u16) -> ArcMut<ControllerConfig> {
             .with_election_timeout_ms(1000)
             .with_heartbeat_interval_ms(300),
     )
+}
+
+fn broker_heartbeat_request(
+    cluster_name: &str,
+    broker_name: &str,
+    broker_addr: &str,
+    broker_id: u64,
+) -> ControllerRequest {
+    ControllerRequest::BrokerHeartbeat {
+        broker_identity: BrokerIdentityInfoSnapshot::new(cluster_name, broker_name, Some(broker_id)),
+        broker_live_info: BrokerLiveInfoSnapshot {
+            cluster_name: cluster_name.to_string(),
+            broker_name: broker_name.to_string(),
+            broker_addr: broker_addr.to_string(),
+            broker_id,
+            last_update_timestamp: current_millis(),
+            heartbeat_timeout_millis: 60_000,
+            epoch: 1,
+            max_offset: 100,
+            confirm_offset: 80,
+            election_priority: Some(1),
+        },
+    }
 }
 
 #[tokio::test]
@@ -74,6 +100,15 @@ async fn test_snapshot_creation() {
     })
     .await
     .unwrap();
+
+    node.client_write(broker_heartbeat_request(
+        "test-cluster",
+        "broker-a",
+        "127.0.0.1:10911",
+        1,
+    ))
+    .await
+    .expect("replicate broker heartbeat");
 
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
@@ -188,6 +223,23 @@ async fn test_snapshot_install_preserves_master_and_sync_state_set() {
         .await
         .unwrap();
     assert_eq!(register_replica.data.response_code, ResponseCode::Success as i32);
+
+    node.client_write(broker_heartbeat_request(
+        "test-cluster",
+        "broker-sync",
+        "127.0.0.1:10911",
+        1,
+    ))
+    .await
+    .expect("replicate master heartbeat");
+    node.client_write(broker_heartbeat_request(
+        "test-cluster",
+        "broker-sync",
+        "127.0.0.1:10912",
+        2,
+    ))
+    .await
+    .expect("replicate replica heartbeat");
 
     let elect_response = node
         .client_write(ControllerRequest::ElectMaster {


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7425

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable Raft scan wait timeout for controller operations
  * Enhanced broker liveness tracking and heartbeat management
  * Improved broker role-change notification system

* **Bug Fixes**
  * More reliable broker inactivity detection and election triggering
  * Fixed broker channel closure handling to immediately remove inactive brokers
  * Enhanced broker state consistency during failover scenarios

* **Improvements**
  * Added timeout enforcement for controller requests to prevent hangs
  * Optimized broker election logic based on live broker information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->