### PR TITLE
[ISSUE #7433]🚀feat: add TLS configuration support for RocketMQ client and server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -701,7 +701,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1248,7 +1248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1384,7 +1384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2190,7 +2190,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2687,7 +2687,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3075,6 +3075,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3420ea4424090cbd75a688996f696a807c68d6744b4863591b86435dc3078e9"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,7 +3397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -3408,7 +3418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3798,6 +3808,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -4323,6 +4346,7 @@ name = "rocketmq-remoting"
 version = "0.9.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bitvec",
  "bytemuck",
  "bytes",
@@ -4336,15 +4360,18 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "rand 0.10.1",
+ "rcgen",
  "rocketmq-common",
  "rocketmq-error",
  "rocketmq-macros",
  "rocketmq-rust",
  "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_json_any_key",
  "simd-json",
+ "tempfile",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -4525,7 +4552,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4556,6 +4583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4583,7 +4619,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5005,7 +5041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5198,7 +5234,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5207,7 +5243,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6177,7 +6213,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6599,6 +6635,15 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -141,8 +141,9 @@ fn parse_config_file(args: &Args) -> Result<(BrokerConfig, MessageStoreConfig)> 
     if let Some(config_file) = args.get_config_file() {
         info!("Loading configuration from: {}", config_file.display());
 
-        let broker_config = ParseConfigFile::parse_config_file::<BrokerConfig>(config_file.clone())
+        let mut broker_config = ParseConfigFile::parse_config_file::<BrokerConfig>(config_file.clone())
             .with_context(|| format!("Failed to parse BrokerConfig from {:?}", config_file))?;
+        apply_tls_properties_from_file(&mut broker_config, config_file.clone())?;
 
         let message_store_config = ParseConfigFile::parse_config_file::<MessageStoreConfig>(config_file.clone())
             .with_context(|| format!("Failed to parse MessageStoreConfig from {:?}", config_file))?;
@@ -152,6 +153,16 @@ fn parse_config_file(args: &Args) -> Result<(BrokerConfig, MessageStoreConfig)> 
         info!("Using default configuration (no config file specified)");
         Ok((BrokerConfig::default(), MessageStoreConfig::default()))
     }
+}
+
+fn apply_tls_properties_from_file(broker_config: &mut BrokerConfig, config_file: PathBuf) -> Result<()> {
+    let content = std::fs::read_to_string(&config_file)
+        .with_context(|| format!("Failed to read TLS properties from {:?}", config_file))?;
+    broker_config
+        .broker_server_config
+        .tls_config
+        .apply_java_properties_str(&content);
+    Ok(())
 }
 
 /// Extract properties from BrokerConfig for system property mapping
@@ -507,6 +518,9 @@ listenPort = 11911
 storePathRootDir = "{}"
 storePathCommitLog = "{}"
 enableControllerMode = false
+tls.enable = true
+tls.server.mode = "enforcing"
+tls.server.certPath = "/certs/server.pem"
 
 [brokerServerConfig]
 listenPort = 11911
@@ -533,6 +547,20 @@ brokerId = 0
         assert_eq!(broker_config.broker_identity.broker_name.as_str(), "rust-local-broker");
         assert_eq!(broker_config.listen_port, 11911);
         assert_eq!(broker_config.broker_server_config.listen_port, 11911);
+        assert!(broker_config.broker_server_config.tls_config.enable);
+        assert_eq!(
+            broker_config.broker_server_config.tls_config.server.mode,
+            rocketmq_common::common::tls_config::TlsMode::Enforcing
+        );
+        assert_eq!(
+            broker_config
+                .broker_server_config
+                .tls_config
+                .server
+                .cert_path
+                .as_deref(),
+            Some("/certs/server.pem")
+        );
         assert_eq!(broker_config.store_path_root_dir.as_str(), store_root);
         assert_eq!(message_store_config.store_path_root_dir.as_str(), store_root);
         assert_eq!(

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -4327,6 +4327,7 @@ accounts:
             broker_server_config: ServerConfig {
                 listen_port: listen_port as u32,
                 bind_address: "127.0.0.1".to_owned(),
+                ..ServerConfig::default()
             },
             broker_ip1: CheetahString::from_static_str("127.0.0.1"),
             listen_port: listen_port as u32,
@@ -4541,6 +4542,7 @@ accounts:
         let server_config = ServerConfig {
             bind_address: "127.0.0.1".to_string(),
             listen_port: port as u32,
+            ..ServerConfig::default()
         };
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let handle = tokio::spawn(async move {

--- a/rocketmq-client/src/base/client_config.rs
+++ b/rocketmq-client/src/base/client_config.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_queue::MessageQueue;
+use rocketmq_common::common::tls_config::TlsConfig;
 use rocketmq_common::utils::name_server_address_utils::NameServerAddressUtils;
 use rocketmq_common::utils::network_util::NetworkUtil;
 use rocketmq_common::TimeUtils::current_nano;
@@ -51,6 +52,7 @@ pub struct ClientConfig {
     pub use_heartbeat_v2: bool,
     pub enable_concurrent_heartbeat: bool,
     pub use_tls: bool,
+    pub tls_config: TlsConfig,
     pub socks_proxy_config: CheetahString,
     pub mq_client_api_timeout: u64,
     pub detect_timeout: u32,
@@ -126,6 +128,7 @@ impl ClientConfig {
                 .parse::<bool>()
                 .unwrap_or(false),
             use_tls: false,
+            tls_config: TlsConfig::default(),
             socks_proxy_config: env::var(Self::SOCKS_PROXY_CONFIG)
                 .unwrap_or_else(|_| "{}".to_string())
                 .into(),
@@ -447,6 +450,43 @@ impl ClientConfig {
     #[inline]
     pub fn set_use_tls(&mut self, use_tls: bool) {
         self.use_tls = use_tls;
+        self.tls_config.enable = use_tls;
+    }
+
+    #[inline]
+    pub fn tls_config(&self) -> &TlsConfig {
+        &self.tls_config
+    }
+
+    #[inline]
+    pub fn set_tls_config(&mut self, mut tls_config: TlsConfig) {
+        tls_config.enable = self.use_tls;
+        self.tls_config = tls_config;
+    }
+
+    #[inline]
+    pub fn set_tls_test_mode_enable(&mut self, enabled: bool) {
+        self.tls_config.test_mode_enable = enabled;
+    }
+
+    #[inline]
+    pub fn set_tls_client_auth_server(&mut self, enabled: bool) {
+        self.tls_config.client.auth_server = enabled;
+    }
+
+    #[inline]
+    pub fn set_tls_client_trust_cert_path(&mut self, path: impl Into<String>) {
+        self.tls_config.client.trust_cert_path = Some(path.into());
+    }
+
+    #[inline]
+    pub fn set_tls_client_cert_path(&mut self, path: impl Into<String>) {
+        self.tls_config.client.cert_path = Some(path.into());
+    }
+
+    #[inline]
+    pub fn set_tls_client_key_path(&mut self, path: impl Into<String>) {
+        self.tls_config.client.key_path = Some(path.into());
     }
 
     #[inline]
@@ -627,6 +667,7 @@ impl ClientConfig {
         self.vip_channel_enabled = other.vip_channel_enabled;
         self.use_heartbeat_v2 = other.use_heartbeat_v2;
         self.use_tls = other.use_tls;
+        self.tls_config = other.tls_config.clone();
         self.socks_proxy_config = other.socks_proxy_config.clone();
         self.language = other.language;
         self.mq_client_api_timeout = other.mq_client_api_timeout;
@@ -767,6 +808,7 @@ mod tests {
         target.reset_client_config(&source);
 
         assert!(target.is_use_tls());
+        assert!(target.tls_config().enable);
         assert!(target.is_enable_trace());
         assert_eq!(
             target.get_trace_topic().map(|topic| topic.as_str()),

--- a/rocketmq-client/src/base/client_config_builder.rs
+++ b/rocketmq-client/src/base/client_config_builder.rs
@@ -18,6 +18,7 @@
 //! making configuration more readable and allowing for validation before building.
 
 use cheetah_string::CheetahString;
+use rocketmq_common::common::tls_config::TlsConfig;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::LanguageCode;
 
@@ -211,6 +212,42 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Sets the complete TLS configuration while preserving the builder's enable_tls flag.
+    pub fn tls_config(mut self, tls_config: TlsConfig) -> Self {
+        self.config.set_tls_config(tls_config);
+        self
+    }
+
+    /// Enables RocketMQ Java-compatible TLS test mode.
+    pub fn tls_test_mode_enable(mut self, enabled: bool) -> Self {
+        self.config.set_tls_test_mode_enable(enabled);
+        self
+    }
+
+    /// Controls whether the client verifies the server certificate.
+    pub fn tls_client_auth_server(mut self, enabled: bool) -> Self {
+        self.config.set_tls_client_auth_server(enabled);
+        self
+    }
+
+    /// Sets the PEM trust certificate path for server verification.
+    pub fn tls_client_trust_cert_path(mut self, path: impl Into<String>) -> Self {
+        self.config.set_tls_client_trust_cert_path(path);
+        self
+    }
+
+    /// Sets the PEM client certificate path for mTLS.
+    pub fn tls_client_cert_path(mut self, path: impl Into<String>) -> Self {
+        self.config.set_tls_client_cert_path(path);
+        self
+    }
+
+    /// Sets the PEM client private key path for mTLS.
+    pub fn tls_client_key_path(mut self, path: impl Into<String>) -> Self {
+        self.config.set_tls_client_key_path(path);
+        self
+    }
+
     /// Sets decode read body enabled
     pub fn enable_decode_read_body(mut self, enabled: bool) -> Self {
         self.config.set_decode_read_body(enabled);
@@ -383,8 +420,31 @@ mod tests {
         assert_eq!(config.poll_name_server_interval, 60_000);
         assert_eq!(config.heartbeat_broker_interval, 30_000);
         assert!(config.use_tls);
+        assert!(config.tls_config.enable);
         assert!(config.enable_concurrent_heartbeat);
         assert_eq!(config.concurrent_heartbeat_thread_pool_size, 4);
+    }
+
+    #[test]
+    fn builder_sets_tls_certificate_fields() {
+        let config = ClientConfig::builder()
+            .enable_tls(true)
+            .tls_client_auth_server(false)
+            .tls_client_trust_cert_path("/certs/ca.pem")
+            .tls_client_cert_path("/certs/client.pem")
+            .tls_client_key_path("/certs/client.key")
+            .build()
+            .unwrap();
+
+        assert!(config.use_tls);
+        assert!(config.tls_config.enable);
+        assert!(!config.tls_config.client.auth_server);
+        assert_eq!(
+            config.tls_config.client.trust_cert_path.as_deref(),
+            Some("/certs/ca.pem")
+        );
+        assert_eq!(config.tls_config.client.cert_path.as_deref(), Some("/certs/client.pem"));
+        assert_eq!(config.tls_config.client.key_path.as_deref(), Some("/certs/client.key"));
     }
 
     #[test]

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -2135,6 +2135,7 @@ mod tests {
     async fn mq_client_api_impl_inherits_tls_flag_from_client_config() {
         let mut client_config = ClientConfig::default();
         client_config.set_use_tls(true);
+        client_config.set_tls_client_trust_cert_path("/certs/ca.pem");
 
         let instance = MQClientInstance::new_arc(client_config, 0, "test-client-tls", None);
         let api_impl = instance
@@ -2142,6 +2143,15 @@ mod tests {
             .expect("MQClientInstance should initialize MQClientAPIImpl");
 
         assert!(api_impl.is_use_tls());
+        assert_eq!(
+            api_impl
+                .get_remoting_client()
+                .tls_config()
+                .client
+                .trust_cert_path
+                .as_deref(),
+            Some("/certs/ca.pem")
+        );
     }
 
     #[test]

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -2067,6 +2067,8 @@ impl MQClientAPIImpl {
 
         let mut remoting_config = (*tokio_client_config).clone();
         remoting_config.use_tls = client_config.use_tls;
+        remoting_config.tls_config = client_config.tls_config.clone();
+        remoting_config.tls_config.enable = client_config.use_tls;
         let mut default_client =
             RocketmqDefaultClient::new_with_cl(Arc::new(remoting_config), client_remoting_processor, tx);
         if let Some(hook) = rpc_hook {

--- a/rocketmq-client/tests/broker_backed_smoke.rs
+++ b/rocketmq-client/tests/broker_backed_smoke.rs
@@ -20,6 +20,13 @@
 //! production-readiness runs to fail instead of silently skipping missing
 //! broker/ACL/TLS/Trace/Recall scenarios. Keep each scenario small and explicit
 //! so it can be mirrored by the Java client during parity runs.
+//!
+//! TLS smoke extras:
+//! - `ROCKETMQ_TLS_TEST_MODE_ENABLE=true` skips server certificate verification.
+//! - `ROCKETMQ_TLS_CLIENT_AUTH_SERVER=false` skips server certificate verification.
+//! - `ROCKETMQ_TLS_CLIENT_TRUST_CERT_PATH=/path/ca.pem` trusts a custom CA.
+//! - `ROCKETMQ_TLS_CLIENT_CERT_PATH=/path/client.pem` and
+//!   `ROCKETMQ_TLS_CLIENT_KEY_PATH=/path/client.key` enable mTLS.
 
 use std::any::Any;
 use std::collections::HashMap;
@@ -108,6 +115,68 @@ fn env_flag_enabled(name: &str) -> bool {
     std::env::var(name)
         .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
         .unwrap_or(false)
+}
+
+fn env_optional_bool(name: &str) -> RocketMQResult<Option<bool>> {
+    let value = match std::env::var(name) {
+        Ok(value) => value,
+        Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(error) => {
+            return Err(RocketMQError::illegal_argument(format!(
+                "failed to read {name} for TLS smoke test: {error}"
+            )));
+        }
+    };
+
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" => Ok(None),
+        "1" | "true" | "yes" | "on" => Ok(Some(true)),
+        "0" | "false" | "no" | "off" => Ok(Some(false)),
+        _ => Err(RocketMQError::illegal_argument(format!(
+            "{name} must be one of true/false/1/0/yes/no/on/off"
+        ))),
+    }
+}
+
+fn env_optional_string(name: &str) -> RocketMQResult<Option<String>> {
+    match std::env::var(name) {
+        Ok(value) => {
+            let value = value.trim();
+            if value.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(value.to_string()))
+            }
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(RocketMQError::illegal_argument(format!(
+            "failed to read {name} for TLS smoke test: {error}"
+        ))),
+    }
+}
+
+fn tls_smoke_client_config(env: &BrokerEnv) -> RocketMQResult<ClientConfig> {
+    let mut builder = ClientConfig::builder()
+        .namesrv_addr(env.namesrv_addr.clone())
+        .enable_tls(true);
+
+    if let Some(enabled) = env_optional_bool("ROCKETMQ_TLS_TEST_MODE_ENABLE")? {
+        builder = builder.tls_test_mode_enable(enabled);
+    }
+    if let Some(enabled) = env_optional_bool("ROCKETMQ_TLS_CLIENT_AUTH_SERVER")? {
+        builder = builder.tls_client_auth_server(enabled);
+    }
+    if let Some(path) = env_optional_string("ROCKETMQ_TLS_CLIENT_TRUST_CERT_PATH")? {
+        builder = builder.tls_client_trust_cert_path(path);
+    }
+    if let Some(path) = env_optional_string("ROCKETMQ_TLS_CLIENT_CERT_PATH")? {
+        builder = builder.tls_client_cert_path(path);
+    }
+    if let Some(path) = env_optional_string("ROCKETMQ_TLS_CLIENT_KEY_PATH")? {
+        builder = builder.tls_client_key_path(path);
+    }
+
+    builder.build()
 }
 
 fn strict_skip_error(reason: &str, strict: bool) -> RocketMQResult<()> {
@@ -661,10 +730,7 @@ async fn broker_backed_tls_producer_send_smoke() -> RocketMQResult<()> {
         return Ok(());
     }
 
-    let client_config = ClientConfig::builder()
-        .namesrv_addr(env.namesrv_addr)
-        .enable_tls(true)
-        .build()?;
+    let client_config = tls_smoke_client_config(&env)?;
     let mut producer = DefaultMQProducer::builder()
         .client_config(client_config)
         .producer_group(unique_group("tls-producer"))

--- a/rocketmq-common/src/common.rs
+++ b/rocketmq-common/src/common.rs
@@ -63,6 +63,7 @@ pub mod metrics;
 pub mod resource;
 pub mod system_clock;
 pub mod thread;
+pub mod tls_config;
 pub mod tools;
 pub mod topic;
 

--- a/rocketmq-common/src/common/broker/broker_config.rs
+++ b/rocketmq-common/src/common/broker/broker_config.rs
@@ -1837,6 +1837,9 @@ impl BrokerConfig {
             "statefulAuthorizationCacheExpiredSecond".into(),
             self.stateful_authorization_cache_expired_second.to_string().into(),
         );
+        for (key, value) in self.broker_server_config.tls_config.java_property_entries() {
+            properties.insert(key.into(), value.into());
+        }
         properties
     }
 }
@@ -2008,6 +2011,25 @@ mod tests {
         assert_eq!(
             properties.get("liteLagLatencyTopK").map(|value| value.as_str()),
             Some("50")
+        );
+    }
+
+    #[test]
+    fn get_properties_contains_java_tls_keys() {
+        let mut config = BrokerConfig::default();
+        config.broker_server_config.tls_config.enable = true;
+        config.broker_server_config.tls_config.server.cert_path = Some("/certs/server.pem".to_string());
+
+        let properties = config.get_properties();
+
+        assert_eq!(properties.get("tls.enable").map(|value| value.as_str()), Some("true"));
+        assert_eq!(
+            properties.get("tls.server.mode").map(|value| value.as_str()),
+            Some("permissive")
+        );
+        assert_eq!(
+            properties.get("tls.server.certPath").map(|value| value.as_str()),
+            Some("/certs/server.pem")
         );
     }
 

--- a/rocketmq-common/src/common/server/config.rs
+++ b/rocketmq-common/src/common/server/config.rs
@@ -15,6 +15,8 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::common::tls_config::TlsConfig;
+
 /// Default value functions for Serde deserialization
 mod defaults {
     pub fn listen_port() -> u32 {
@@ -34,6 +36,9 @@ pub struct ServerConfig {
 
     #[serde(default = "defaults::bind_address")]
     pub bind_address: String,
+
+    #[serde(default, alias = "tls")]
+    pub tls_config: TlsConfig,
 }
 
 impl Default for ServerConfig {
@@ -41,6 +46,7 @@ impl Default for ServerConfig {
         ServerConfig {
             listen_port: defaults::listen_port(),
             bind_address: defaults::bind_address(),
+            tls_config: TlsConfig::default(),
         }
     }
 }
@@ -52,6 +58,10 @@ impl ServerConfig {
 
     pub fn listen_port(&self) -> u32 {
         self.listen_port
+    }
+
+    pub fn tls_config(&self) -> &TlsConfig {
+        &self.tls_config
     }
 }
 
@@ -66,5 +76,10 @@ mod tests {
         assert_eq!(config.listen_port(), 10911);
 
         assert_eq!(config.bind_address(), "0.0.0.0".to_string());
+
+        assert_eq!(
+            config.tls_config().server.mode,
+            crate::common::tls_config::TlsMode::Permissive
+        );
     }
 }

--- a/rocketmq-common/src/common/tls_config.rs
+++ b/rocketmq-common/src/common/tls_config.rs
@@ -1,0 +1,479 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TlsMode {
+    Disabled,
+    #[default]
+    Permissive,
+    Enforcing,
+}
+
+impl TlsMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TlsMode::Disabled => "disabled",
+            TlsMode::Permissive => "permissive",
+            TlsMode::Enforcing => "enforcing",
+        }
+    }
+}
+
+impl FromStr for TlsMode {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(match value.trim().to_ascii_lowercase().as_str() {
+            "disabled" => TlsMode::Disabled,
+            "enforcing" => TlsMode::Enforcing,
+            "permissive" => TlsMode::Permissive,
+            _ => TlsMode::Permissive,
+        })
+    }
+}
+
+impl fmt::Display for TlsMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Serialize for TlsMode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for TlsMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(TlsMode::from_str(&value).unwrap_or_default())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TlsClientAuth {
+    #[default]
+    None,
+    Optional,
+    Require,
+}
+
+impl TlsClientAuth {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TlsClientAuth::None => "none",
+            TlsClientAuth::Optional => "optional",
+            TlsClientAuth::Require => "require",
+        }
+    }
+}
+
+impl FromStr for TlsClientAuth {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(match value.trim().to_ascii_lowercase().as_str() {
+            "optional" => TlsClientAuth::Optional,
+            "require" | "required" => TlsClientAuth::Require,
+            "none" => TlsClientAuth::None,
+            _ => TlsClientAuth::None,
+        })
+    }
+}
+
+impl fmt::Display for TlsClientAuth {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Serialize for TlsClientAuth {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for TlsClientAuth {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(TlsClientAuth::from_str(&value).unwrap_or_default())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TlsConfig {
+    #[serde(default)]
+    pub enable: bool,
+
+    #[serde(default)]
+    pub test_mode_enable: bool,
+
+    #[serde(default = "defaults::tls_config_file")]
+    pub config_file: String,
+
+    #[serde(default)]
+    pub server: TlsServerConfig,
+
+    #[serde(default)]
+    pub client: TlsClientConfig,
+
+    #[serde(default)]
+    pub ciphers: Option<String>,
+
+    #[serde(default)]
+    pub protocols: Option<String>,
+}
+
+impl Default for TlsConfig {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            test_mode_enable: false,
+            config_file: defaults::tls_config_file(),
+            server: TlsServerConfig::default(),
+            client: TlsClientConfig::default(),
+            ciphers: None,
+            protocols: None,
+        }
+    }
+}
+
+impl TlsConfig {
+    pub fn apply_java_property(&mut self, key: &str, value: &str) {
+        let value = strip_matching_quotes(strip_inline_comment(value.trim()).trim());
+        match key.trim() {
+            "tls.enable" | "tlsEnable" => self.enable = parse_bool(value, self.enable),
+            "tls.test.mode.enable" | "tlsTestModeEnable" => {
+                self.test_mode_enable = parse_bool(value, self.test_mode_enable);
+            }
+            "tls.config.file" | "tlsConfigFile" => self.config_file = value.to_string(),
+            "tls.server.mode" | "tlsServerMode" => {
+                self.server.mode = TlsMode::from_str(value).unwrap_or_default();
+            }
+            "tls.server.need.client.auth" | "tlsServerNeedClientAuth" => {
+                self.server.need_client_auth = TlsClientAuth::from_str(value).unwrap_or_default();
+            }
+            "tls.server.keyPath" | "tlsServerKeyPath" => self.server.key_path = non_empty(value),
+            "tls.server.keyPassword" | "tlsServerKeyPassword" => self.server.key_password = non_empty(value),
+            "tls.server.certPath" | "tlsServerCertPath" => self.server.cert_path = non_empty(value),
+            "tls.server.authClient" | "tlsServerAuthClient" => {
+                self.server.auth_client = parse_bool(value, self.server.auth_client);
+            }
+            "tls.server.trustCertPath" | "tlsServerTrustCertPath" => {
+                self.server.trust_cert_path = non_empty(value);
+            }
+            "tls.client.keyPath" | "tlsClientKeyPath" => self.client.key_path = non_empty(value),
+            "tls.client.keyPassword" | "tlsClientKeyPassword" => self.client.key_password = non_empty(value),
+            "tls.client.certPath" | "tlsClientCertPath" => self.client.cert_path = non_empty(value),
+            "tls.client.authServer" | "tlsClientAuthServer" => {
+                self.client.auth_server = parse_bool(value, self.client.auth_server);
+            }
+            "tls.client.trustCertPath" | "tlsClientTrustCertPath" => {
+                self.client.trust_cert_path = non_empty(value);
+            }
+            "tls.ciphers" | "tlsCiphers" => self.ciphers = non_empty(value),
+            "tls.protocols" | "tlsProtocols" => self.protocols = non_empty(value),
+            _ => {}
+        }
+    }
+
+    pub fn apply_java_properties_str(&mut self, content: &str) {
+        for raw_line in content.lines() {
+            let line = raw_line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with('!') {
+                continue;
+            }
+
+            let Some((key, value)) = split_property(line) else {
+                continue;
+            };
+            self.apply_java_property(key, value);
+        }
+    }
+
+    pub fn watched_server_paths(&self) -> Vec<String> {
+        let mut paths = Vec::new();
+        push_path(&mut paths, &self.config_file);
+        if let Some(path) = self.server.cert_path.as_deref() {
+            push_path(&mut paths, path);
+        }
+        if let Some(path) = self.server.key_path.as_deref() {
+            push_path(&mut paths, path);
+        }
+        if let Some(path) = self.server.trust_cert_path.as_deref() {
+            push_path(&mut paths, path);
+        }
+        paths
+    }
+
+    pub fn java_property_entries(&self) -> Vec<(&'static str, String)> {
+        let mut entries = vec![
+            ("tls.enable", self.enable.to_string()),
+            ("tls.config.file", self.config_file.clone()),
+            ("tls.test.mode.enable", self.test_mode_enable.to_string()),
+            ("tls.server.mode", self.server.mode.to_string()),
+            ("tls.server.need.client.auth", self.server.need_client_auth.to_string()),
+            ("tls.server.authClient", self.server.auth_client.to_string()),
+            ("tls.client.authServer", self.client.auth_server.to_string()),
+        ];
+
+        push_optional_entry(&mut entries, "tls.server.keyPath", self.server.key_path.as_deref());
+        push_optional_entry(
+            &mut entries,
+            "tls.server.keyPassword",
+            self.server.key_password.as_deref(),
+        );
+        push_optional_entry(&mut entries, "tls.server.certPath", self.server.cert_path.as_deref());
+        push_optional_entry(
+            &mut entries,
+            "tls.server.trustCertPath",
+            self.server.trust_cert_path.as_deref(),
+        );
+        push_optional_entry(&mut entries, "tls.client.keyPath", self.client.key_path.as_deref());
+        push_optional_entry(
+            &mut entries,
+            "tls.client.keyPassword",
+            self.client.key_password.as_deref(),
+        );
+        push_optional_entry(&mut entries, "tls.client.certPath", self.client.cert_path.as_deref());
+        push_optional_entry(
+            &mut entries,
+            "tls.client.trustCertPath",
+            self.client.trust_cert_path.as_deref(),
+        );
+        push_optional_entry(&mut entries, "tls.ciphers", self.ciphers.as_deref());
+        push_optional_entry(&mut entries, "tls.protocols", self.protocols.as_deref());
+
+        entries
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TlsServerConfig {
+    #[serde(default)]
+    pub mode: TlsMode,
+
+    #[serde(default)]
+    pub need_client_auth: TlsClientAuth,
+
+    #[serde(default)]
+    pub key_path: Option<String>,
+
+    #[serde(default)]
+    pub key_password: Option<String>,
+
+    #[serde(default)]
+    pub cert_path: Option<String>,
+
+    #[serde(default)]
+    pub auth_client: bool,
+
+    #[serde(default)]
+    pub trust_cert_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TlsClientConfig {
+    #[serde(default)]
+    pub key_path: Option<String>,
+
+    #[serde(default)]
+    pub key_password: Option<String>,
+
+    #[serde(default)]
+    pub cert_path: Option<String>,
+
+    #[serde(default)]
+    pub auth_server: bool,
+
+    #[serde(default)]
+    pub trust_cert_path: Option<String>,
+}
+
+impl Default for TlsClientConfig {
+    fn default() -> Self {
+        Self {
+            key_path: None,
+            key_password: None,
+            cert_path: None,
+            auth_server: true,
+            trust_cert_path: None,
+        }
+    }
+}
+
+fn parse_bool(value: &str, default: bool) -> bool {
+    value.parse::<bool>().unwrap_or(default)
+}
+
+fn non_empty(value: &str) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn strip_matching_quotes(value: &str) -> &str {
+    if value.len() >= 2 {
+        let first = value.as_bytes()[0];
+        let last = value.as_bytes()[value.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &value[1..value.len() - 1];
+        }
+    }
+    value
+}
+
+fn strip_inline_comment(value: &str) -> &str {
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+
+    for (index, character) in value.char_indices() {
+        match character {
+            '\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            '"' if !in_single_quote => in_double_quote = !in_double_quote,
+            '#' | '!'
+                if !in_single_quote
+                    && !in_double_quote
+                    && (index == 0 || value[..index].chars().last().is_some_and(char::is_whitespace)) =>
+            {
+                return value[..index].trim_end();
+            }
+            _ => {}
+        }
+    }
+
+    value
+}
+
+fn split_property(line: &str) -> Option<(&str, &str)> {
+    let separator_index = line.find(['=', ':'])?;
+    let key = line[..separator_index].trim();
+    let value = line[separator_index + 1..].trim();
+    if key.is_empty() {
+        None
+    } else {
+        Some((key, value))
+    }
+}
+
+fn push_path(paths: &mut Vec<String>, path: &str) {
+    if !path.is_empty() && !paths.iter().any(|existing| existing == path) {
+        paths.push(path.to_string());
+    }
+}
+
+fn push_optional_entry(entries: &mut Vec<(&'static str, String)>, key: &'static str, value: Option<&str>) {
+    if let Some(value) = value {
+        entries.push((key, value.to_string()));
+    }
+}
+
+mod defaults {
+    pub fn tls_config_file() -> String {
+        "/etc/rocketmq/tls.properties".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tls_mode_parse_defaults_to_permissive_like_java() {
+        assert_eq!(TlsMode::from_str("disabled").unwrap(), TlsMode::Disabled);
+        assert_eq!(TlsMode::from_str("enforcing").unwrap(), TlsMode::Enforcing);
+        assert_eq!(TlsMode::from_str("unknown").unwrap(), TlsMode::Permissive);
+    }
+
+    #[test]
+    fn java_properties_update_nested_tls_config() {
+        let mut config = TlsConfig::default();
+
+        config.apply_java_properties_str(
+            r#"
+            tls.enable=true
+            tls.test.mode.enable=true
+            tls.server.mode="enforcing" # inline comment from TOML-style config
+            tls.server.need.client.auth=require
+            tls.server.certPath=/certs/server.pem
+            tls.server.keyPath=/certs/server.key
+            tls.server.authClient=true
+            tls.server.trustCertPath=/certs/ca.pem
+            tls.client.authServer=true
+            tls.client.trustCertPath=/certs/ca.pem
+            tls.protocols=TLSv1.3,TLSv1.2
+            "#,
+        );
+
+        assert!(config.enable);
+        assert!(config.test_mode_enable);
+        assert_eq!(config.server.mode, TlsMode::Enforcing);
+        assert_eq!(config.server.need_client_auth, TlsClientAuth::Require);
+        assert_eq!(config.server.cert_path.as_deref(), Some("/certs/server.pem"));
+        assert!(config.server.auth_client);
+        assert!(config.client.auth_server);
+        assert_eq!(config.client.trust_cert_path.as_deref(), Some("/certs/ca.pem"));
+        assert_eq!(config.protocols.as_deref(), Some("TLSv1.3,TLSv1.2"));
+    }
+
+    #[test]
+    fn java_property_entries_use_rocketmq_java_tls_keys() {
+        let config = TlsConfig {
+            enable: true,
+            server: TlsServerConfig {
+                mode: TlsMode::Enforcing,
+                cert_path: Some("/certs/server.pem".to_string()),
+                ..TlsServerConfig::default()
+            },
+            client: TlsClientConfig {
+                trust_cert_path: Some("/certs/ca.pem".to_string()),
+                ..TlsClientConfig::default()
+            },
+            ..TlsConfig::default()
+        };
+
+        let entries = config.java_property_entries();
+
+        assert!(entries.contains(&("tls.enable", "true".to_string())));
+        assert!(entries.contains(&("tls.server.mode", "enforcing".to_string())));
+        assert!(entries.contains(&("tls.server.certPath", "/certs/server.pem".to_string())));
+        assert!(entries.contains(&("tls.client.trustCertPath", "/certs/ca.pem".to_string())));
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -88,6 +88,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3044,6 +3053,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3670,6 +3689,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4009,6 +4041,7 @@ name = "rocketmq-remoting"
 version = "0.9.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bitvec",
  "bytemuck",
  "bytes",
@@ -4021,11 +4054,13 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "rand 0.10.1",
+ "rcgen",
  "rocketmq-common",
  "rocketmq-error",
  "rocketmq-macros",
  "rocketmq-rust",
  "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_json_any_key",
@@ -4167,6 +4202,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6750,6 +6794,15 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink 0.11.0",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -45,6 +45,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1762,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,6 +2108,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,6 +2394,7 @@ name = "rocketmq-remoting"
 version = "0.9.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bitvec",
  "bytemuck",
  "bytes",
@@ -2374,11 +2407,13 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "rand 0.10.1",
+ "rcgen",
  "rocketmq-common",
  "rocketmq-error",
  "rocketmq-macros",
  "rocketmq-rust",
  "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_json_any_key",
@@ -2504,6 +2539,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3911,6 +3955,15 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink 0.11.1",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,6 +1609,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,6 +1970,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2239,7 @@ name = "rocketmq-remoting"
 version = "0.9.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bitvec",
  "bytemuck",
  "bytes",
@@ -2219,11 +2252,13 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "rand 0.10.1",
+ "rcgen",
  "rocketmq-common",
  "rocketmq-error",
  "rocketmq-macros",
  "rocketmq-rust",
  "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_json_any_key",
@@ -2326,6 +2361,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3756,6 +3800,15 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 use std::process;
 
 use anyhow::bail;
+use anyhow::Context;
 use clap::Parser;
 use config::Config;
 use rocketmq_common::common::controller::controller_config::RaftPeer;
@@ -134,10 +135,14 @@ fn parse_and_merge_config(args: &Args) -> Result<(NamesrvConfig, ServerConfig, O
         namesrv_config.kv_config_path = kv_path.to_string_lossy().to_string();
     }
 
-    let server_config = ServerConfig {
+    let mut server_config = ServerConfig {
         listen_port: args.listen_port.unwrap_or(9876),
         bind_address: args.bind_address.clone().unwrap_or_else(|| "0.0.0.0".to_string()),
+        ..ServerConfig::default()
     };
+    if let Some(config_file) = args.config_file.clone() {
+        apply_tls_properties_from_file(&mut server_config, config_file)?;
+    }
 
     let controller_config = if namesrv_config.enable_controller_in_namesrv {
         Some(load_controller_config(args.config_file.clone(), &namesrv_config)?)
@@ -146,6 +151,13 @@ fn parse_and_merge_config(args: &Args) -> Result<(NamesrvConfig, ServerConfig, O
     };
 
     Ok((namesrv_config, server_config, controller_config))
+}
+
+fn apply_tls_properties_from_file(server_config: &mut ServerConfig, config_file: PathBuf) -> Result<()> {
+    let content = std::fs::read_to_string(&config_file)
+        .with_context(|| format!("Failed to read TLS properties from {:?}", config_file))?;
+    server_config.tls_config.apply_java_properties_str(&content);
+    Ok(())
 }
 
 /// Print all configuration items and exit

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -1017,6 +1017,9 @@ impl NameServerRuntimeInner {
 
         push_config_entry(&mut entries, "listenPort", self.server_config.listen_port);
         push_config_entry(&mut entries, "bindAddress", &self.server_config.bind_address);
+        for (key, value) in self.server_config.tls_config.java_property_entries() {
+            push_config_entry(&mut entries, key, value);
+        }
 
         push_config_entry(
             &mut entries,
@@ -1171,6 +1174,9 @@ impl NameServerRuntimeInner {
                 "bindAddress" => {
                     self.server_config.bind_address = value.to_string();
                 }
+                key if is_tls_config_key(key) => {
+                    self.server_config.tls_config.apply_java_property(key, value.as_str());
+                }
                 "clientWorkerThreads" => {
                     self.tokio_client_config.client_worker_threads = parse_config_value(&key, &value)?;
                 }
@@ -1314,6 +1320,29 @@ fn push_config_entry(entries: &mut Vec<(&'static str, String)>, key: &'static st
     entries.push((key, value.to_string()));
 }
 
+fn is_tls_config_key(key: &str) -> bool {
+    matches!(
+        key,
+        "tls.enable"
+            | "tls.test.mode.enable"
+            | "tls.config.file"
+            | "tls.server.mode"
+            | "tls.server.need.client.auth"
+            | "tls.server.keyPath"
+            | "tls.server.keyPassword"
+            | "tls.server.certPath"
+            | "tls.server.authClient"
+            | "tls.server.trustCertPath"
+            | "tls.client.keyPath"
+            | "tls.client.keyPassword"
+            | "tls.client.certPath"
+            | "tls.client.authServer"
+            | "tls.client.trustCertPath"
+            | "tls.ciphers"
+            | "tls.protocols"
+    )
+}
+
 fn parse_config_value<T>(key: &str, value: &CheetahString) -> Result<T, String>
 where
     T: std::str::FromStr,
@@ -1340,6 +1369,7 @@ mod tests {
     use rocketmq_common::common::mq_version::RocketMqVersion;
     use rocketmq_common::common::namesrv::namesrv_config::NamesrvConfig;
     use rocketmq_common::common::server::config::ServerConfig;
+    use rocketmq_common::common::tls_config::TlsMode;
     use rocketmq_common::common::TopicSysFlag;
     use rocketmq_common::CRC32Utils;
     use rocketmq_remoting::code::request_code::RequestCode;
@@ -1412,6 +1442,7 @@ mod tests {
         ServerConfig {
             listen_port: reserve_local_port() as u32,
             bind_address: "127.0.0.1".to_string(),
+            ..ServerConfig::default()
         }
     }
 
@@ -2998,6 +3029,7 @@ mod tests {
         let server_config = ServerConfig {
             listen_port: 19876,
             bind_address: "127.0.0.2".to_string(),
+            ..ServerConfig::default()
         };
         let bootstrap = Builder::new()
             .set_name_server_config(namesrv_config)
@@ -3039,6 +3071,14 @@ mod tests {
             properties.get("useRouteInfoManagerV2").map(|value| value.as_str()),
             Some("true")
         );
+        assert_eq!(
+            properties.get("tls.server.mode").map(|value| value.as_str()),
+            Some("permissive")
+        );
+        assert_eq!(
+            properties.get("tls.client.authServer").map(|value| value.as_str()),
+            Some("true")
+        );
     }
 
     #[tokio::test]
@@ -3046,7 +3086,7 @@ mod tests {
         let bootstrap = build_bootstrap_with_default_v2();
         let harness = LocalRequestHarness::new().await.unwrap();
         let mut request = RemotingCommand::create_remoting_command(RequestCode::UpdateNamesrvConfig).set_body(
-            b"listenPort=19876\nbindAddress=127.0.0.2\nclientWorkerThreads=9\nenableTopicList=false\nunknownKey=42"
+            b"listenPort=19876\nbindAddress=127.0.0.2\nclientWorkerThreads=9\nenableTopicList=false\ntls.server.mode=enforcing\ntls.server.certPath=/certs/server.pem\nunknownKey=42"
                 .as_slice(),
         );
 
@@ -3072,6 +3112,27 @@ mod tests {
                 .inner
                 .name_server_config()
                 .enable_topic_list
+        );
+        assert_eq!(
+            bootstrap
+                .name_server_runtime
+                .inner
+                .server_config()
+                .tls_config
+                .server
+                .mode,
+            TlsMode::Enforcing
+        );
+        assert_eq!(
+            bootstrap
+                .name_server_runtime
+                .inner
+                .server_config()
+                .tls_config
+                .server
+                .cert_path
+                .as_deref(),
+            Some("/certs/server.pem")
         );
     }
 

--- a/rocketmq-namesrv/tests/route_info_manager_integration.rs
+++ b/rocketmq-namesrv/tests/route_info_manager_integration.rs
@@ -82,6 +82,7 @@ impl NamesrvHarness {
             let server_config = ServerConfig {
                 listen_port: port as u32,
                 bind_address: "127.0.0.1".to_string(),
+                ..ServerConfig::default()
             };
             let bootstrap = Builder::new()
                 .set_name_server_config(namesrv_config.clone())

--- a/rocketmq-remoting/Cargo.toml
+++ b/rocketmq-remoting/Cargo.toml
@@ -77,17 +77,21 @@ simd-json = { version = "0.17", optional = true }
 
 # TLS transport for client connections. Enabled by default so `ClientConfig::use_tls`
 # can be honored without requiring downstream feature wiring.
+arc-swap            = { version = "1.9", optional = true }
+rcgen               = { version = "0.13", optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
+rustls-pemfile      = { version = "2.2", optional = true }
 tokio-rustls        = { version = "0.26", optional = true }
 
 [features]
 default = ["tls"]
 simd    = ["simd-json"]
-tls     = ["rustls-native-certs", "tokio-rustls"]
+tls     = ["arc-swap", "rcgen", "rustls-native-certs", "rustls-pemfile", "tokio-rustls"]
 
 [dev-dependencies]
 bytes     = "1.11.1"
 criterion = { version = "0.8", features = ["html_reports"] }
+tempfile  = "3.27.0"
 
 [[bench]]
 name    = "encode_decode_bench"

--- a/rocketmq-remoting/src/clients/client.rs
+++ b/rocketmq-remoting/src/clients/client.rs
@@ -12,20 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::IpAddr;
 use std::net::SocketAddr;
-#[cfg(feature = "tls")]
-use std::sync::Arc as StdArc;
 
+use rocketmq_common::common::tls_config::TlsConfig;
 use rocketmq_error::RocketMQResult;
 use rocketmq_rust::ArcMut;
 use tokio::net::TcpStream;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::Receiver;
-#[cfg(feature = "tls")]
-use tokio_rustls::rustls::pki_types::ServerName;
-#[cfg(feature = "tls")]
-use tokio_rustls::TlsConnector;
 
 use crate::base::connection_net_event::ConnectionNetEvent;
 use crate::base::response_future::ResponseFuture;
@@ -42,6 +36,10 @@ use crate::remoting_server::rocketmq_tokio_server::Shutdown;
 use crate::runtime::connection_handler_context::ConnectionHandlerContext;
 use crate::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
 use crate::runtime::processor::RequestProcessor;
+#[cfg(feature = "tls")]
+use crate::tls::connect_tls_stream;
+#[cfg(not(feature = "tls"))]
+use crate::tls::tls_disabled_error;
 
 #[derive(Clone)]
 pub struct Client<PR> {
@@ -79,16 +77,16 @@ where
         cmd_handler: ArcMut<RemotingGeneralHandler<PR>>,
         tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
         notify: broadcast::Receiver<()>,
-        use_tls: bool,
+        tls_config: TlsConfig,
     ) -> RocketMQResult<(tokio::sync::mpsc::Sender<SendMessage>, ArcMut<ClientInner<PR>>)> {
         let stream = TcpStream::connect(addr.as_str()).await.map_err(io_error)?;
         let local_addr = stream.local_addr()?;
         let remote_address = stream.peer_addr()?;
-        let connection = if use_tls {
+        let connection = if tls_config.enable {
             #[cfg(feature = "tls")]
             {
                 let server_name = server_name_from_addr(addr.as_str());
-                let tls_stream = connect_tls_stream(stream, &server_name).await?;
+                let tls_stream = connect_tls_stream(stream, &server_name, &tls_config).await?;
                 Connection::new_with_stream(tls_stream)
             }
             #[cfg(not(feature = "tls"))]
@@ -203,11 +201,11 @@ where
         addr: String,
         cmd_handler: ArcMut<RemotingGeneralHandler<PR>>,
         tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
-        use_tls: bool,
+        tls_config: TlsConfig,
     ) -> RocketMQResult<Client<PR>> {
         let (notify_shutdown, _) = broadcast::channel(1);
         let receiver = notify_shutdown.subscribe();
-        let (tx, inner) = ClientInner::connect(addr, cmd_handler, tx, receiver, use_tls).await?;
+        let (tx, inner) = ClientInner::connect(addr, cmd_handler, tx, receiver, tls_config).await?;
         Ok(Client {
             inner,
             notify_shutdown,
@@ -426,76 +424,6 @@ fn server_name_from_addr(addr: &str) -> String {
     match addr.rsplit_once(':') {
         Some((host, _)) if !host.contains(':') => host.to_string(),
         _ => addr.to_string(),
-    }
-}
-
-#[cfg(feature = "tls")]
-async fn connect_tls_stream(
-    stream: TcpStream,
-    server_name: &str,
-) -> RocketMQResult<tokio_rustls::client::TlsStream<TcpStream>> {
-    let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
-    let cert_result = rustls_native_certs::load_native_certs();
-    let mut added_roots = 0usize;
-
-    for cert in cert_result.certs {
-        root_store
-            .add(cert)
-            .map_err(|error| rocketmq_error::RocketMQError::ConfigInvalidValue {
-                key: "tls.root_certificates",
-                value: "native-certs".to_string(),
-                reason: format!("failed to add native root certificate: {error}"),
-            })?;
-        added_roots += 1;
-    }
-
-    for error in cert_result.errors {
-        tracing::warn!("failed to load a native TLS root certificate: {error}");
-    }
-
-    if added_roots == 0 {
-        return Err(rocketmq_error::RocketMQError::ConfigInvalidValue {
-            key: "tls.root_certificates",
-            value: "native-certs".to_string(),
-            reason: "no native root certificates were loaded".to_string(),
-        });
-    }
-
-    let config = tokio_rustls::rustls::ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
-    let connector = TlsConnector::from(StdArc::new(config));
-    connector
-        .connect(parse_server_name(server_name)?, stream)
-        .await
-        .map_err(|error| {
-            rocketmq_error::RocketMQError::network_connection_failed(
-                server_name,
-                format!("TLS handshake failed: {error}"),
-            )
-        })
-}
-
-#[cfg(feature = "tls")]
-fn parse_server_name(server_name: &str) -> RocketMQResult<ServerName<'static>> {
-    let value = server_name.trim_matches(['[', ']']);
-    if let Ok(ip_addr) = value.parse::<IpAddr>() {
-        return Ok(ServerName::IpAddress(ip_addr.into()));
-    }
-
-    ServerName::try_from(value.to_string()).map_err(|error| rocketmq_error::RocketMQError::ConfigInvalidValue {
-        key: "tls.server_name",
-        value: server_name.to_string(),
-        reason: error.to_string(),
-    })
-}
-
-#[cfg(not(feature = "tls"))]
-fn tls_disabled_error() -> rocketmq_error::RocketMQError {
-    rocketmq_error::RocketMQError::ConfigInvalidValue {
-        key: "use_tls",
-        value: "true".to_string(),
-        reason: "rocketmq-remoting was compiled without the tls feature".to_string(),
     }
 }
 

--- a/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
@@ -41,6 +41,7 @@ use crate::request_processor::default_request_processor::DefaultRemotingRequestP
 use crate::runtime::config::client_config::TokioClientConfig;
 use crate::runtime::processor::RequestProcessor;
 use crate::runtime::RPCHook;
+use crate::tls::TlsConfig;
 
 /// High-performance async RocketMQ client with connection pooling and auto-reconnection.
 ///
@@ -231,6 +232,12 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
     #[inline]
     pub fn is_use_tls(&self) -> bool {
         self.tokio_client_config.use_tls
+    }
+
+    /// Returns the TLS configuration used when creating new outbound connections.
+    #[inline]
+    pub fn tls_config(&self) -> &TlsConfig {
+        &self.tokio_client_config.tls_config
     }
 }
 
@@ -510,10 +517,11 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
         }
 
         let addr_inner = addr.to_string();
-        let use_tls = self.tokio_client_config.use_tls;
+        let mut tls_config = self.tokio_client_config.tls_config.clone();
+        tls_config.enable = self.tokio_client_config.use_tls;
 
         let connect_result = time::timeout(duration, async {
-            Client::connect(addr_inner, self.cmd_handler.clone(), self.tx.as_ref(), use_tls).await
+            Client::connect(addr_inner, self.cmd_handler.clone(), self.tx.as_ref(), tls_config).await
         })
         .await;
 
@@ -1191,11 +1199,16 @@ mod tests {
     fn is_use_tls_reflects_client_config() {
         let config = TokioClientConfig {
             use_tls: true,
+            tls_config: TlsConfig {
+                enable: true,
+                ..TlsConfig::default()
+            },
             ..Default::default()
         };
         let client = RocketmqDefaultClient::new(Arc::new(config), DefaultRemotingRequestProcessor);
 
         assert!(client.is_use_tls());
+        assert!(client.tls_config().enable);
     }
 
     #[tokio::test]

--- a/rocketmq-remoting/src/lib.rs
+++ b/rocketmq-remoting/src/lib.rs
@@ -34,6 +34,7 @@ pub mod remoting_server;
 pub mod request_processor;
 pub mod rpc;
 pub mod runtime;
+pub mod tls;
 
 // Error helpers for unified error system
 pub mod connection_v2;

--- a/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
@@ -35,7 +35,6 @@ use tracing::warn;
 use crate::base::channel_event_listener::ChannelEventListener;
 use crate::base::connection_net_event::ConnectionNetEvent;
 use crate::base::tokio_event::TokioEvent;
-use crate::connection::Connection;
 use crate::net::channel::Channel;
 use crate::net::channel::ChannelInner;
 use crate::remoting::inner::RemotingGeneralHandler;
@@ -43,6 +42,7 @@ use crate::runtime::connection_handler_context::ConnectionHandlerContext;
 use crate::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
 use crate::runtime::processor::RequestProcessor;
 use crate::runtime::RPCHook;
+use crate::tls::TlsServerRuntime;
 
 /// Default limit the max number of connections.
 const DEFAULT_MAX_CONNECTIONS: usize = 1000;
@@ -268,6 +268,9 @@ struct ConnectionListener<RP> {
     /// Contains request processor, RPC hooks, and response routing table.
     /// Arc-wrapped to share across all connection handlers efficiently.
     cmd_handler: ArcMut<RemotingGeneralHandler<RP>>,
+
+    /// TLS mode and acceptor state for newly accepted connections.
+    tls_runtime: TlsServerRuntime,
 }
 
 impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
@@ -346,37 +349,45 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
             let local_addr = socket.local_addr()?;
             info!("Accepted connection: {} → {}", remote_addr, local_addr);
 
-            // Create connection channel wrapper
-            let channel_inner = ArcMut::new(ChannelInner::new(
-                Connection::new(socket),
-                self.cmd_handler.response_table.clone(),
-            ));
-            let channel = Channel::new(channel_inner, local_addr, remote_addr);
-
-            // Notify CONNECTED event
-            let _ = event_tx.send(TokioEvent::new(
-                ConnectionNetEvent::CONNECTED(remote_addr),
-                remote_addr,
-                channel.clone(),
-            ));
-
-            // Build connection handler
-            let idle_timeout = Duration::from_secs(DEFAULT_CHANNEL_IDLE_TIMEOUT_SECONDS);
-            let handler = ConnectionHandler {
-                connection_handler_context: ArcMut::new(ConnectionHandlerContextWrapper {
-                    channel: channel.clone(),
-                }),
-                shutdown: Shutdown::new(self.notify_shutdown.subscribe()),
-                _shutdown_complete: self.shutdown_complete_tx.clone(),
-                conn_disconnect_notify: self.conn_disconnect_notify.clone(),
-                cmd_handler: self.cmd_handler.clone(),
-                event_tx: Some(event_tx.clone()),
-                idle_timeout,
-            };
+            let tls_runtime = self.tls_runtime.clone();
+            let cmd_handler = self.cmd_handler.clone();
+            let notify_shutdown = self.notify_shutdown.subscribe();
+            let shutdown_complete_tx = self.shutdown_complete_tx.clone();
+            let conn_disconnect_notify = self.conn_disconnect_notify.clone();
+            let event_tx_clone = event_tx.clone();
 
             // Spawn dedicated task for this connection
-            let event_tx_clone = event_tx.clone();
             tokio::spawn(async move {
+                let Some(connection) = tls_runtime.into_connection(socket, remote_addr).await else {
+                    drop(permit);
+                    return;
+                };
+
+                // Create connection channel wrapper
+                let channel_inner = ArcMut::new(ChannelInner::new(connection, cmd_handler.response_table.clone()));
+                let channel = Channel::new(channel_inner, local_addr, remote_addr);
+
+                // Notify CONNECTED event after plaintext/TLS negotiation succeeds
+                let _ = event_tx_clone.send(TokioEvent::new(
+                    ConnectionNetEvent::CONNECTED(remote_addr),
+                    remote_addr,
+                    channel.clone(),
+                ));
+
+                // Build connection handler
+                let idle_timeout = Duration::from_secs(DEFAULT_CHANNEL_IDLE_TIMEOUT_SECONDS);
+                let handler_event_tx = event_tx_clone.clone();
+                let handler = ConnectionHandler {
+                    connection_handler_context: ArcMut::new(ConnectionHandlerContextWrapper {
+                        channel: channel.clone(),
+                    }),
+                    shutdown: Shutdown::new(notify_shutdown),
+                    _shutdown_complete: shutdown_complete_tx,
+                    conn_disconnect_notify,
+                    cmd_handler,
+                    event_tx: Some(handler_event_tx),
+                    idle_timeout,
+                };
                 let mut handler = handler;
 
                 // Run handler until completion
@@ -510,15 +521,17 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> RocketMQServer<RP> {
             }
         };
         let rpc_hooks = self.rpc_hooks.take().unwrap_or_default();
+        let tls_runtime = TlsServerRuntime::new(self.config.tls_config.clone());
         info!("Starting remoting_server at: {}", addr);
         let (notify_conn_disconnect, _) = broadcast::channel::<SocketAddr>(100);
-        run(
+        run_with_tls_config(
             listener,
             shutdown,
             request_processor,
             Some(notify_conn_disconnect),
             rpc_hooks,
             channel_event_listener,
+            tls_runtime,
         )
         .await;
     }
@@ -531,6 +544,27 @@ pub async fn run<RP: RequestProcessor + Sync + 'static + Clone>(
     conn_disconnect_notify: Option<broadcast::Sender<SocketAddr>>,
     rpc_hooks: Vec<Arc<dyn RPCHook>>,
     channel_event_listener: Option<Arc<dyn ChannelEventListener>>,
+) {
+    run_with_tls_config(
+        listener,
+        shutdown,
+        request_processor,
+        conn_disconnect_notify,
+        rpc_hooks,
+        channel_event_listener,
+        TlsServerRuntime::new(Default::default()),
+    )
+    .await;
+}
+
+async fn run_with_tls_config<RP: RequestProcessor + Sync + 'static + Clone>(
+    listener: TcpListener,
+    shutdown: impl Future,
+    request_processor: RP,
+    conn_disconnect_notify: Option<broadcast::Sender<SocketAddr>>,
+    rpc_hooks: Vec<Arc<dyn RPCHook>>,
+    channel_event_listener: Option<Arc<dyn ChannelEventListener>>,
+    tls_runtime: TlsServerRuntime,
 ) {
     let (notify_shutdown, _) = broadcast::channel(1);
     let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel(1);
@@ -549,6 +583,7 @@ pub async fn run<RP: RequestProcessor + Sync + 'static + Clone>(
         limit_connections: Arc::new(Semaphore::new(DEFAULT_MAX_CONNECTIONS)),
         channel_event_listener,
         cmd_handler: ArcMut::new(handler),
+        tls_runtime,
     };
 
     tokio::select! {
@@ -646,6 +681,7 @@ mod tests {
         let config = Arc::new(ServerConfig {
             bind_address: "127.0.0.1".to_string(),
             listen_port: 70000,
+            ..ServerConfig::default()
         });
         let mut server = RocketMQServer::<DefaultRemotingRequestProcessor>::new(config);
 

--- a/rocketmq-remoting/src/runtime/config/client_config.rs
+++ b/rocketmq-remoting/src/runtime/config/client_config.rs
@@ -14,6 +14,8 @@
 
 use std::sync::LazyLock;
 
+use rocketmq_common::common::tls_config::TlsConfig;
+
 use crate::runtime::config::net_system_config::NetSystemConfig;
 
 static NET_SYSTEM_CONFIG: LazyLock<NetSystemConfig> = LazyLock::new(NetSystemConfig::new);
@@ -33,6 +35,7 @@ pub struct TokioClientConfig {
     pub client_pooled_byte_buf_allocator_enable: bool,
     pub client_close_socket_if_timeout: bool,
     pub use_tls: bool,
+    pub tls_config: TlsConfig,
     pub socks_proxy_config: String,
     pub write_buffer_high_water_mark: i32,
     pub write_buffer_low_water_mark: i32,
@@ -58,6 +61,7 @@ impl Default for TokioClientConfig {
             client_pooled_byte_buf_allocator_enable: false,
             client_close_socket_if_timeout: NET_SYSTEM_CONFIG.client_close_socket_if_timeout,
             use_tls: false,
+            tls_config: TlsConfig::default(),
             socks_proxy_config: "{}".to_string(),
             write_buffer_high_water_mark: NET_SYSTEM_CONFIG.write_buffer_high_water_mark_value,
             write_buffer_low_water_mark: NET_SYSTEM_CONFIG.write_buffer_low_water_mark,

--- a/rocketmq-remoting/src/tls.rs
+++ b/rocketmq-remoting/src/tls.rs
@@ -1,0 +1,963 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "tls")]
+use std::fs;
+#[cfg(feature = "tls")]
+use std::net::IpAddr;
+use std::net::SocketAddr;
+#[cfg(feature = "tls")]
+use std::sync::Arc as StdArc;
+use std::time::Duration;
+#[cfg(feature = "tls")]
+use std::time::SystemTime;
+
+#[cfg(feature = "tls")]
+use rocketmq_common::common::tls_config::TlsClientAuth;
+pub use rocketmq_common::common::tls_config::TlsConfig;
+pub use rocketmq_common::common::tls_config::TlsMode;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use tokio::net::TcpStream;
+#[cfg(feature = "tls")]
+use tokio::time;
+#[cfg(feature = "tls")]
+use tracing::debug;
+use tracing::warn;
+
+use crate::connection::Connection;
+
+const TLS_HANDSHAKE_MAGIC_CODE: u8 = 0x16;
+const TLS_RELOAD_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+#[cfg(feature = "tls")]
+type TlsAcceptorSlot = arc_swap::ArcSwapOption<tokio_rustls::TlsAcceptor>;
+
+#[cfg(feature = "tls")]
+#[derive(Clone)]
+pub struct TlsServerRuntime {
+    mode: TlsMode,
+    acceptor: StdArc<TlsAcceptorSlot>,
+    base_config: StdArc<TlsConfig>,
+}
+
+#[cfg(not(feature = "tls"))]
+#[derive(Clone)]
+pub struct TlsServerRuntime {
+    mode: TlsMode,
+}
+
+impl TlsServerRuntime {
+    pub fn new(base_config: TlsConfig) -> Self {
+        #[cfg(feature = "tls")]
+        {
+            let effective_config = effective_tls_config(&base_config);
+            let acceptor = StdArc::new(TlsAcceptorSlot::empty());
+            let mode = base_config.server.mode;
+
+            if mode != TlsMode::Disabled {
+                match build_server_acceptor(&effective_config) {
+                    Ok(tls_acceptor) => acceptor.store(Some(StdArc::new(tls_acceptor))),
+                    Err(error) => {
+                        warn!("failed to build initial TLS server acceptor: {error}");
+                    }
+                }
+            }
+
+            let runtime = Self {
+                mode,
+                acceptor,
+                base_config: StdArc::new(base_config),
+            };
+            runtime.spawn_reload_task();
+            runtime
+        }
+
+        #[cfg(not(feature = "tls"))]
+        {
+            Self {
+                mode: base_config.server.mode,
+            }
+        }
+    }
+
+    pub async fn into_connection(&self, stream: TcpStream, remote_addr: SocketAddr) -> Option<Connection> {
+        let is_tls_handshake = match peek_tls_handshake(&stream).await {
+            Ok(value) => value,
+            Err(error) => {
+                warn!("failed to inspect TLS handshake byte from {remote_addr}: {error}");
+                return None;
+            }
+        };
+
+        match self.mode {
+            TlsMode::Disabled => {
+                if is_tls_handshake {
+                    warn!("client {remote_addr} attempted TLS while server TLS mode is disabled");
+                    None
+                } else {
+                    Some(Connection::new(stream))
+                }
+            }
+            TlsMode::Permissive => {
+                if is_tls_handshake {
+                    self.accept_tls(stream, remote_addr).await
+                } else {
+                    Some(Connection::new(stream))
+                }
+            }
+            TlsMode::Enforcing => {
+                if is_tls_handshake {
+                    self.accept_tls(stream, remote_addr).await
+                } else {
+                    warn!("client {remote_addr} attempted plaintext while server TLS mode is enforcing");
+                    None
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "tls")]
+    async fn accept_tls(&self, stream: TcpStream, remote_addr: SocketAddr) -> Option<Connection> {
+        let Some(acceptor) = self.acceptor.load_full() else {
+            warn!("client {remote_addr} attempted TLS but no TLS server acceptor is configured");
+            return None;
+        };
+
+        match acceptor.accept(stream).await {
+            Ok(tls_stream) => Some(Connection::new_with_stream(tls_stream)),
+            Err(error) => {
+                warn!("TLS handshake from {remote_addr} failed: {error}");
+                None
+            }
+        }
+    }
+
+    #[cfg(not(feature = "tls"))]
+    async fn accept_tls(&self, _stream: TcpStream, remote_addr: SocketAddr) -> Option<Connection> {
+        warn!("client {remote_addr} attempted TLS but rocketmq-remoting was compiled without TLS support");
+        None
+    }
+
+    #[cfg(feature = "tls")]
+    fn spawn_reload_task(&self) {
+        if self.mode == TlsMode::Disabled {
+            return;
+        }
+
+        let base_config = self.base_config.clone();
+        let acceptor = self.acceptor.clone();
+        tokio::spawn(async move {
+            let mut previous_snapshot = file_snapshot(&effective_tls_config(&base_config).watched_server_paths());
+            loop {
+                time::sleep(TLS_RELOAD_POLL_INTERVAL).await;
+
+                let effective_config = effective_tls_config(&base_config);
+                let paths = effective_config.watched_server_paths();
+                let current_snapshot = file_snapshot(&paths);
+                if current_snapshot == previous_snapshot {
+                    continue;
+                }
+
+                previous_snapshot = current_snapshot;
+                match build_server_acceptor(&effective_config) {
+                    Ok(tls_acceptor) => {
+                        acceptor.store(Some(StdArc::new(tls_acceptor)));
+                        debug!("TLS server acceptor reloaded after file change");
+                    }
+                    Err(error) => {
+                        warn!("failed to reload TLS server acceptor; keeping previous acceptor: {error}");
+                    }
+                }
+            }
+        });
+    }
+}
+
+#[cfg(feature = "tls")]
+pub async fn connect_tls_stream(
+    stream: TcpStream,
+    server_name: &str,
+    tls_config: &TlsConfig,
+) -> RocketMQResult<tokio_rustls::client::TlsStream<TcpStream>> {
+    let config = build_client_config(tls_config)?;
+    let connector = tokio_rustls::TlsConnector::from(StdArc::new(config));
+    connector
+        .connect(parse_server_name(server_name)?, stream)
+        .await
+        .map_err(|error| {
+            RocketMQError::network_connection_failed(server_name, format!("TLS handshake failed: {error}"))
+        })
+}
+
+#[cfg(not(feature = "tls"))]
+pub async fn connect_tls_stream(
+    _stream: TcpStream,
+    _server_name: &str,
+    _tls_config: &TlsConfig,
+) -> RocketMQResult<TcpStream> {
+    Err(tls_disabled_error())
+}
+
+#[cfg(feature = "tls")]
+pub fn build_client_config(tls_config: &TlsConfig) -> RocketMQResult<tokio_rustls::rustls::ClientConfig> {
+    use tokio_rustls::rustls::client::danger::HandshakeSignatureValid;
+    use tokio_rustls::rustls::client::danger::ServerCertVerified;
+    use tokio_rustls::rustls::client::danger::ServerCertVerifier;
+    use tokio_rustls::rustls::pki_types::CertificateDer;
+    use tokio_rustls::rustls::pki_types::UnixTime;
+    use tokio_rustls::rustls::DigitallySignedStruct;
+    use tokio_rustls::rustls::Error;
+    use tokio_rustls::rustls::SignatureScheme;
+
+    #[derive(Debug)]
+    struct NoCertificateVerification;
+
+    impl ServerCertVerifier for NoCertificateVerification {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &tokio_rustls::rustls::pki_types::ServerName<'_>,
+            _ocsp_response: &[u8],
+            _now: UnixTime,
+        ) -> Result<ServerCertVerified, Error> {
+            Ok(ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            vec![
+                SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::ECDSA_NISTP384_SHA384,
+                SignatureScheme::ED25519,
+                SignatureScheme::RSA_PSS_SHA256,
+                SignatureScheme::RSA_PSS_SHA384,
+                SignatureScheme::RSA_PSS_SHA512,
+                SignatureScheme::RSA_PKCS1_SHA256,
+                SignatureScheme::RSA_PKCS1_SHA384,
+                SignatureScheme::RSA_PKCS1_SHA512,
+            ]
+        }
+    }
+
+    let effective_config = effective_tls_config(tls_config);
+    let protocol_versions = configured_protocol_versions(&effective_config)?;
+    let client_builder = match protocol_versions.as_deref() {
+        Some(versions) => tokio_rustls::rustls::ClientConfig::builder_with_protocol_versions(versions),
+        None => tokio_rustls::rustls::ClientConfig::builder(),
+    };
+    let builder = if effective_config.test_mode_enable || !effective_config.client.auth_server {
+        client_builder
+            .dangerous()
+            .with_custom_certificate_verifier(StdArc::new(NoCertificateVerification))
+    } else {
+        client_builder.with_root_certificates(load_client_root_store(
+            effective_config.client.trust_cert_path.as_deref(),
+        )?)
+    };
+
+    if effective_config.client.key_password.is_some() {
+        return Err(config_error(
+            "tls.client.keyPassword",
+            "<redacted>",
+            "encrypted private keys are not supported by rocketmq-rust TLS v1",
+        ));
+    }
+
+    match (
+        effective_config.client.cert_path.as_deref(),
+        effective_config.client.key_path.as_deref(),
+    ) {
+        (Some(cert_path), Some(key_path)) => {
+            let certs = load_certificates(cert_path, "tls.client.certPath")?;
+            let key = load_private_key(key_path, "tls.client.keyPath")?;
+            builder.with_client_auth_cert(certs, key).map_err(|error| {
+                config_error(
+                    "tls.client.certificate",
+                    cert_path,
+                    format!("failed to configure client certificate: {error}"),
+                )
+            })
+        }
+        (None, None) => Ok(builder.with_no_client_auth()),
+        _ => Err(config_error(
+            "tls.client.certificate",
+            "<partial>",
+            "tls.client.certPath and tls.client.keyPath must be configured together",
+        )),
+    }
+}
+
+#[cfg(feature = "tls")]
+pub fn build_server_acceptor(tls_config: &TlsConfig) -> RocketMQResult<tokio_rustls::TlsAcceptor> {
+    let effective_config = effective_tls_config(tls_config);
+
+    if effective_config.server.key_password.is_some() {
+        return Err(config_error(
+            "tls.server.keyPassword",
+            "<redacted>",
+            "encrypted private keys are not supported by rocketmq-rust TLS v1",
+        ));
+    }
+
+    let (certs, key) = if effective_config.test_mode_enable
+        && (effective_config.server.cert_path.is_none() || effective_config.server.key_path.is_none())
+    {
+        generate_self_signed_certificate()?
+    } else {
+        let cert_path = effective_config.server.cert_path.as_deref().ok_or_else(|| {
+            config_error(
+                "tls.server.certPath",
+                "",
+                "server certificate path is required when TLS test mode is disabled",
+            )
+        })?;
+        let key_path = effective_config.server.key_path.as_deref().ok_or_else(|| {
+            config_error(
+                "tls.server.keyPath",
+                "",
+                "server private key path is required when TLS test mode is disabled",
+            )
+        })?;
+        (
+            load_certificates(cert_path, "tls.server.certPath")?,
+            load_private_key(key_path, "tls.server.keyPath")?,
+        )
+    };
+
+    let verifier = build_client_cert_verifier(&effective_config)?;
+    let protocol_versions = configured_protocol_versions(&effective_config)?;
+    let server_builder = match protocol_versions.as_deref() {
+        Some(versions) => tokio_rustls::rustls::ServerConfig::builder_with_protocol_versions(versions),
+        None => tokio_rustls::rustls::ServerConfig::builder(),
+    };
+    let server_config = server_builder
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(certs, key)
+        .map_err(|error| config_error("tls.server.certificate", "<configured>", error.to_string()))?;
+
+    Ok(tokio_rustls::TlsAcceptor::from(StdArc::new(server_config)))
+}
+
+#[cfg(feature = "tls")]
+fn build_client_cert_verifier(
+    tls_config: &TlsConfig,
+) -> RocketMQResult<StdArc<dyn tokio_rustls::rustls::server::danger::ClientCertVerifier>> {
+    use tokio_rustls::rustls::server::WebPkiClientVerifier;
+
+    match tls_config.server.need_client_auth {
+        TlsClientAuth::None => Ok(WebPkiClientVerifier::no_client_auth()),
+        TlsClientAuth::Optional | TlsClientAuth::Require => {
+            if !tls_config.server.auth_client {
+                return Err(config_error(
+                    "tls.server.authClient",
+                    "false",
+                    "client certificate verification requires tls.server.authClient=true",
+                ));
+            }
+
+            let trust_path = tls_config.server.trust_cert_path.as_deref().ok_or_else(|| {
+                config_error(
+                    "tls.server.trustCertPath",
+                    "",
+                    "server trust certificate path is required for client certificate authentication",
+                )
+            })?;
+            let root_store = StdArc::new(load_root_store_from_pem(trust_path, "tls.server.trustCertPath")?);
+            let builder = WebPkiClientVerifier::builder(root_store);
+            let builder = if tls_config.server.need_client_auth == TlsClientAuth::Optional {
+                builder.allow_unauthenticated()
+            } else {
+                builder
+            };
+            builder.build().map(|verifier| verifier as StdArc<_>).map_err(|error| {
+                config_error(
+                    "tls.server.trustCertPath",
+                    trust_path,
+                    format!("failed to build client certificate verifier: {error}"),
+                )
+            })
+        }
+    }
+}
+
+#[cfg(feature = "tls")]
+fn generate_self_signed_certificate() -> RocketMQResult<(
+    Vec<tokio_rustls::rustls::pki_types::CertificateDer<'static>>,
+    tokio_rustls::rustls::pki_types::PrivateKeyDer<'static>,
+)> {
+    use tokio_rustls::rustls::pki_types::PrivateKeyDer;
+    use tokio_rustls::rustls::pki_types::PrivatePkcs8KeyDer;
+
+    let rcgen::CertifiedKey { cert, key_pair } = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .map_err(|error| {
+            config_error(
+                "tls.test.mode.enable",
+                "true",
+                format!("failed to generate self-signed test certificate: {error}"),
+            )
+        })?;
+    let certs = vec![cert.der().clone()];
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
+    Ok((certs, key))
+}
+
+#[cfg(feature = "tls")]
+fn load_client_root_store(trust_cert_path: Option<&str>) -> RocketMQResult<tokio_rustls::rustls::RootCertStore> {
+    match trust_cert_path {
+        Some(path) => load_root_store_from_pem(path, "tls.client.trustCertPath"),
+        None => load_native_root_store(),
+    }
+}
+
+#[cfg(feature = "tls")]
+fn load_native_root_store() -> RocketMQResult<tokio_rustls::rustls::RootCertStore> {
+    let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
+    let cert_result = rustls_native_certs::load_native_certs();
+    let mut added_roots = 0usize;
+
+    for cert in cert_result.certs {
+        root_store
+            .add(cert)
+            .map_err(|error| config_error("tls.root_certificates", "native-certs", error.to_string()))?;
+        added_roots += 1;
+    }
+
+    for error in cert_result.errors {
+        warn!("failed to load a native TLS root certificate: {error}");
+    }
+
+    if added_roots == 0 {
+        return Err(config_error(
+            "tls.root_certificates",
+            "native-certs",
+            "no native root certificates were loaded",
+        ));
+    }
+
+    Ok(root_store)
+}
+
+#[cfg(feature = "tls")]
+fn load_root_store_from_pem(path: &str, key: &'static str) -> RocketMQResult<tokio_rustls::rustls::RootCertStore> {
+    let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
+    for cert in load_certificates(path, key)? {
+        root_store
+            .add(cert)
+            .map_err(|error| config_error(key, path, format!("failed to add root certificate: {error}")))?;
+    }
+
+    if root_store.is_empty() {
+        return Err(config_error(key, path, "no PEM certificates were loaded"));
+    }
+
+    Ok(root_store)
+}
+
+#[cfg(feature = "tls")]
+pub fn load_certificates(
+    path: &str,
+    key: &'static str,
+) -> RocketMQResult<Vec<tokio_rustls::rustls::pki_types::CertificateDer<'static>>> {
+    let file = fs::File::open(path)
+        .map_err(|error| config_error(key, path, format!("failed to open certificate file: {error}")))?;
+    let mut reader = std::io::BufReader::new(file);
+    let certs = rustls_pemfile::certs(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| config_error(key, path, format!("failed to read PEM certificates: {error}")))?;
+
+    if certs.is_empty() {
+        return Err(config_error(key, path, "no PEM certificates were found"));
+    }
+
+    Ok(certs)
+}
+
+#[cfg(feature = "tls")]
+fn load_private_key(
+    path: &str,
+    key: &'static str,
+) -> RocketMQResult<tokio_rustls::rustls::pki_types::PrivateKeyDer<'static>> {
+    let file = fs::File::open(path)
+        .map_err(|error| config_error(key, path, format!("failed to open private key file: {error}")))?;
+    let mut reader = std::io::BufReader::new(file);
+    rustls_pemfile::private_key(&mut reader)
+        .map_err(|error| config_error(key, path, format!("failed to read PEM private key: {error}")))?
+        .ok_or_else(|| config_error(key, path, "no supported PEM private key was found"))
+}
+
+#[cfg(feature = "tls")]
+fn parse_server_name(server_name: &str) -> RocketMQResult<tokio_rustls::rustls::pki_types::ServerName<'static>> {
+    let value = server_name.trim_matches(['[', ']']);
+    if let Ok(ip_addr) = value.parse::<IpAddr>() {
+        return Ok(tokio_rustls::rustls::pki_types::ServerName::IpAddress(ip_addr.into()));
+    }
+
+    tokio_rustls::rustls::pki_types::ServerName::try_from(value.to_string()).map_err(|error| {
+        config_error(
+            "tls.server_name",
+            server_name,
+            format!("invalid TLS server name: {error}"),
+        )
+    })
+}
+
+#[cfg(feature = "tls")]
+fn configured_protocol_versions(
+    tls_config: &TlsConfig,
+) -> RocketMQResult<Option<Vec<&'static tokio_rustls::rustls::SupportedProtocolVersion>>> {
+    let Some(protocols) = tls_config.protocols.as_deref() else {
+        return Ok(None);
+    };
+
+    let mut versions = Vec::new();
+    for raw_protocol in protocols.split(',') {
+        let protocol = raw_protocol.trim();
+        if protocol.is_empty() {
+            continue;
+        }
+
+        let version = match protocol.to_ascii_lowercase().as_str() {
+            "tlsv1.3" | "tls1.3" | "tls13" | "1.3" => &tokio_rustls::rustls::version::TLS13,
+            "tlsv1.2" | "tls1.2" | "tls12" | "1.2" => &tokio_rustls::rustls::version::TLS12,
+            _ => {
+                return Err(config_error(
+                    "tls.protocols",
+                    protocol,
+                    "only TLSv1.3 and TLSv1.2 are supported by rocketmq-rust TLS",
+                ));
+            }
+        };
+
+        if !versions
+            .iter()
+            .any(|existing: &&tokio_rustls::rustls::SupportedProtocolVersion| existing.version == version.version)
+        {
+            versions.push(version);
+        }
+    }
+
+    if versions.is_empty() {
+        return Err(config_error(
+            "tls.protocols",
+            protocols,
+            "at least one TLS protocol version must be configured",
+        ));
+    }
+
+    Ok(Some(versions))
+}
+
+#[cfg(feature = "tls")]
+fn effective_tls_config(base_config: &TlsConfig) -> TlsConfig {
+    let mut effective_config = base_config.clone();
+    let enable = effective_config.enable;
+    let server_mode = effective_config.server.mode;
+    let config_file = effective_config.config_file.clone();
+
+    if let Ok(content) = fs::read_to_string(&config_file) {
+        effective_config.apply_java_properties_str(&content);
+        effective_config.enable = enable;
+        effective_config.server.mode = server_mode;
+        effective_config.config_file = config_file;
+    }
+
+    effective_config
+}
+
+#[cfg(feature = "tls")]
+fn file_snapshot(paths: &[String]) -> Vec<(String, Option<SystemTime>, Option<u64>)> {
+    paths
+        .iter()
+        .map(|path| {
+            let metadata = fs::metadata(path);
+            let modified = metadata.as_ref().ok().and_then(|metadata| metadata.modified().ok());
+            let len = metadata.as_ref().ok().map(|metadata| metadata.len());
+            (path.clone(), modified, len)
+        })
+        .collect()
+}
+
+async fn peek_tls_handshake(stream: &TcpStream) -> std::io::Result<bool> {
+    let mut first_byte = [0u8; 1];
+    let read = stream.peek(&mut first_byte).await?;
+    Ok(read > 0 && first_byte[0] == TLS_HANDSHAKE_MAGIC_CODE)
+}
+
+pub fn tls_disabled_error() -> RocketMQError {
+    RocketMQError::ConfigInvalidValue {
+        key: "use_tls",
+        value: "true".to_string(),
+        reason: "rocketmq-remoting was compiled without the tls feature".to_string(),
+    }
+}
+
+fn config_error(key: &'static str, value: impl Into<String>, reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::ConfigInvalidValue {
+        key,
+        value: value.into(),
+        reason: reason.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn tls_config_file_does_not_override_enable_or_server_mode() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let config_file = temp_dir.path().join("tls.properties");
+        fs::write(
+            &config_file,
+            r#"
+            tls.enable=false
+            tls.server.mode=disabled
+            tls.server.certPath=/tmp/server.pem
+            tls.client.authServer=false
+            "#,
+        )
+        .expect("write tls config file");
+        let base = TlsConfig {
+            enable: true,
+            config_file: config_file.to_string_lossy().to_string(),
+            server: rocketmq_common::common::tls_config::TlsServerConfig {
+                mode: TlsMode::Enforcing,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let effective = effective_tls_config(&base);
+
+        assert!(effective.enable);
+        assert_eq!(effective.server.mode, TlsMode::Enforcing);
+        assert_eq!(effective.server.cert_path.as_deref(), Some("/tmp/server.pem"));
+        assert!(!effective.client.auth_server);
+    }
+
+    #[cfg(not(feature = "tls"))]
+    #[test]
+    fn tls_disabled_error_mentions_feature() {
+        let error = tls_disabled_error();
+
+        assert!(error.to_string().contains("tls feature"));
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn test_mode_builds_self_signed_server_acceptor_without_cert_files() {
+        let config = TlsConfig {
+            test_mode_enable: true,
+            server: rocketmq_common::common::tls_config::TlsServerConfig {
+                mode: TlsMode::Enforcing,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        build_server_acceptor(&config).expect("test mode should generate a self-signed certificate");
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn non_test_mode_requires_server_certificate_files() {
+        let config = TlsConfig {
+            server: rocketmq_common::common::tls_config::TlsServerConfig {
+                mode: TlsMode::Enforcing,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let error = match build_server_acceptor(&config) {
+            Ok(_) => panic!("missing certs should fail"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("tls.server.certPath"));
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn configured_protocol_versions_accept_java_protocol_names() {
+        let mut config = TlsConfig {
+            protocols: Some("TLSv1.3,TLSv1.2,TLS13".to_string()),
+            ..Default::default()
+        };
+
+        let versions = configured_protocol_versions(&config)
+            .expect("valid protocols should parse")
+            .expect("protocols should be configured");
+
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].version, tokio_rustls::rustls::ProtocolVersion::TLSv1_3);
+        assert_eq!(versions[1].version, tokio_rustls::rustls::ProtocolVersion::TLSv1_2);
+
+        config.protocols = Some("TLSv1.1".to_string());
+        let error = configured_protocol_versions(&config).expect_err("unsupported protocols should fail");
+        assert!(error.to_string().contains("tls.protocols"));
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn pem_loader_rejects_missing_certificate_file() {
+        let error = load_certificates("missing.pem", "tls.server.certPath").expect_err("missing cert path should fail");
+        assert!(error.to_string().contains("missing.pem"));
+    }
+
+    #[cfg(feature = "tls")]
+    #[tokio::test]
+    async fn tls_modes_gate_plaintext_and_tls_connections() {
+        assert!(plaintext_connects(TlsMode::Disabled).await);
+        assert!(!tls_connects(TlsMode::Disabled, None).await);
+        assert!(plaintext_connects(TlsMode::Permissive).await);
+        assert!(tls_connects(TlsMode::Permissive, None).await);
+        assert!(!plaintext_connects(TlsMode::Enforcing).await);
+        assert!(tls_connects(TlsMode::Enforcing, None).await);
+    }
+
+    #[cfg(feature = "tls")]
+    #[tokio::test]
+    async fn mtls_require_rejects_missing_client_cert_and_accepts_configured_cert() {
+        let certs = TestCertificates::new();
+        let mut server_config = certs.server_tls_config(TlsMode::Enforcing);
+        server_config.server.need_client_auth = TlsClientAuth::Require;
+        server_config.server.auth_client = true;
+        server_config.server.trust_cert_path = Some(certs.ca_cert_path());
+
+        let no_client_cert_config = TlsConfig {
+            enable: true,
+            client: rocketmq_common::common::tls_config::TlsClientConfig {
+                auth_server: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(
+            !tls_connects(
+                TlsMode::Enforcing,
+                Some((server_config.clone(), Some(no_client_cert_config)))
+            )
+            .await
+        );
+
+        let mut client_config = certs.client_tls_config();
+        client_config.client.auth_server = false;
+        assert!(tls_connects(TlsMode::Enforcing, Some((server_config, Some(client_config)))).await);
+    }
+
+    #[cfg(feature = "tls")]
+    async fn plaintext_connects(mode: TlsMode) -> bool {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let server_config = TlsConfig {
+            test_mode_enable: true,
+            server: rocketmq_common::common::tls_config::TlsServerConfig {
+                mode,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let runtime = TlsServerRuntime::new(server_config);
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        let server = tokio::spawn(async move {
+            let (stream, remote_addr) = listener.accept().await.expect("accept client");
+            runtime.into_connection(stream, remote_addr).await.is_some()
+        });
+
+        let mut stream = TcpStream::connect(addr).await.expect("connect plaintext client");
+        stream.write_all(&[0]).await.expect("write first plaintext byte");
+
+        time::timeout(Duration::from_secs(3), server)
+            .await
+            .expect("server should complete")
+            .expect("server task should not panic")
+    }
+
+    #[cfg(feature = "tls")]
+    async fn tls_connects(mode: TlsMode, configs: Option<(TlsConfig, Option<TlsConfig>)>) -> bool {
+        use tokio::net::TcpListener;
+
+        let (server_config, client_config) = configs.unwrap_or_else(|| {
+            let server_config = TlsConfig {
+                test_mode_enable: true,
+                server: rocketmq_common::common::tls_config::TlsServerConfig {
+                    mode,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let client_config = TlsConfig {
+                test_mode_enable: true,
+                client: rocketmq_common::common::tls_config::TlsClientConfig {
+                    auth_server: false,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            (server_config, Some(client_config))
+        });
+        let runtime = TlsServerRuntime::new(server_config);
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        let server = tokio::spawn(async move {
+            let (stream, remote_addr) = listener.accept().await.expect("accept client");
+            runtime.into_connection(stream, remote_addr).await.is_some()
+        });
+
+        let stream = TcpStream::connect(addr).await.expect("connect tls client");
+        let client_result = if let Some(client_config) = client_config {
+            time::timeout(
+                Duration::from_secs(3),
+                connect_tls_stream(stream, "localhost", &client_config),
+            )
+            .await
+            .expect("client handshake should complete")
+            .is_ok()
+        } else {
+            drop(stream);
+            false
+        };
+        let server_result = time::timeout(Duration::from_secs(3), server)
+            .await
+            .expect("server should complete")
+            .expect("server task should not panic");
+
+        client_result && server_result
+    }
+
+    #[cfg(feature = "tls")]
+    struct TestCertificates {
+        _temp_dir: tempfile::TempDir,
+        ca_cert_path: String,
+        server_cert_path: String,
+        server_key_path: String,
+        client_cert_path: String,
+        client_key_path: String,
+    }
+
+    #[cfg(feature = "tls")]
+    impl TestCertificates {
+        fn new() -> Self {
+            use rcgen::BasicConstraints;
+            use rcgen::Certificate;
+            use rcgen::CertificateParams;
+            use rcgen::ExtendedKeyUsagePurpose;
+            use rcgen::IsCa;
+            use rcgen::KeyPair;
+            use rcgen::KeyUsagePurpose;
+
+            let temp_dir = tempfile::tempdir().expect("create cert temp dir");
+            let mut ca_params = CertificateParams::new(Vec::<String>::new()).expect("create ca params");
+            ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+            ca_params.key_usages.push(KeyUsagePurpose::KeyCertSign);
+            ca_params.key_usages.push(KeyUsagePurpose::CrlSign);
+            let ca_key = KeyPair::generate().expect("generate ca key");
+            let ca_cert = ca_params.self_signed(&ca_key).expect("self sign ca");
+
+            fn end_entity(
+                ca_cert: &Certificate,
+                ca_key: &KeyPair,
+                name: &str,
+                usage: ExtendedKeyUsagePurpose,
+            ) -> (Certificate, KeyPair) {
+                let mut params = CertificateParams::new(vec![name.to_string()]).expect("create leaf params");
+                params.use_authority_key_identifier_extension = true;
+                params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+                params.extended_key_usages.push(usage);
+                let key = KeyPair::generate().expect("generate leaf key");
+                let cert = params.signed_by(&key, ca_cert, ca_key).expect("sign leaf");
+                (cert, key)
+            }
+
+            let (server_cert, server_key) =
+                end_entity(&ca_cert, &ca_key, "localhost", ExtendedKeyUsagePurpose::ServerAuth);
+            let (client_cert, client_key) =
+                end_entity(&ca_cert, &ca_key, "client", ExtendedKeyUsagePurpose::ClientAuth);
+
+            let ca_cert_path = write_pem(temp_dir.path(), "ca.pem", ca_cert.pem());
+            let server_cert_path = write_pem(temp_dir.path(), "server.pem", server_cert.pem());
+            let server_key_path = write_pem(temp_dir.path(), "server.key", server_key.serialize_pem());
+            let client_cert_path = write_pem(temp_dir.path(), "client.pem", client_cert.pem());
+            let client_key_path = write_pem(temp_dir.path(), "client.key", client_key.serialize_pem());
+
+            Self {
+                _temp_dir: temp_dir,
+                ca_cert_path,
+                server_cert_path,
+                server_key_path,
+                client_cert_path,
+                client_key_path,
+            }
+        }
+
+        fn server_tls_config(&self, mode: TlsMode) -> TlsConfig {
+            TlsConfig {
+                server: rocketmq_common::common::tls_config::TlsServerConfig {
+                    mode,
+                    cert_path: Some(self.server_cert_path.clone()),
+                    key_path: Some(self.server_key_path.clone()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        }
+
+        fn client_tls_config(&self) -> TlsConfig {
+            TlsConfig {
+                enable: true,
+                client: rocketmq_common::common::tls_config::TlsClientConfig {
+                    cert_path: Some(self.client_cert_path.clone()),
+                    key_path: Some(self.client_key_path.clone()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        }
+
+        fn ca_cert_path(&self) -> String {
+            self.ca_cert_path.clone()
+        }
+    }
+
+    #[cfg(feature = "tls")]
+    fn write_pem(path: &std::path::Path, file_name: &str, content: String) -> String {
+        let path = path.join(file_name);
+        fs::write(&path, content).expect("write pem file");
+        path.to_string_lossy().to_string()
+    }
+}

--- a/rocketmq-website/docs/configuration/broker-config.md
+++ b/rocketmq-website/docs/configuration/broker-config.md
@@ -169,14 +169,41 @@ aclEnable = true
 
 ### TLS
 
+Broker and NameServer remoting servers use the same Java-compatible `tls.server.*` keys.
+
 ```toml
-# Enable TLS
-tlsEnable = true
-tlsTestModeEnable = false
-tlsServerCert = /path/to/server.pem
-tlsServerKey = /path/to/server.key
-tlsServerAuthClient = true
+# Enable TLS on the remoting server.
+tls.enable = true
+tls.server.mode = "enforcing"      # disabled, permissive, enforcing
+tls.test.mode.enable = false
+tls.server.certPath = "/path/to/server.pem"
+tls.server.keyPath = "/path/to/server.key"
+
+# Require client certificates for mTLS.
+tls.server.need.client.auth = "require"
+tls.server.authClient = true
+tls.server.trustCertPath = "/path/to/ca.pem"
+
+# Rust client-side TLS options use the same Java-compatible keys.
+tls.client.authServer = true
+tls.client.trustCertPath = "/path/to/ca.pem"
+tls.client.certPath = "/path/to/client.pem"
+tls.client.keyPath = "/path/to/client.key"
+tls.protocols = "TLSv1.3,TLSv1.2"
 ```
+
+Optional Java client -> Rust broker/NameServer TLS smoke:
+
+```bash
+export NAMESRV_ADDR=127.0.0.1:9876
+export JAVA_OPT="${JAVA_OPT} -Dtls.enable=true -Dtls.client.authServer=true -Dtls.client.trustCertPath=/path/to/ca.pem"
+
+# From a RocketMQ Java distribution.
+sh bin/mqadmin clusterList -n 127.0.0.1:9876
+```
+
+For Java mTLS smoke, add `-Dtls.client.certPath=/path/to/client.pem` and
+`-Dtls.client.keyPath=/path/to/client.key` to `JAVA_OPT`.
 
 ## Monitoring Configuration
 

--- a/rocketmq-website/docs/configuration/client-config.md
+++ b/rocketmq-website/docs/configuration/client-config.md
@@ -93,6 +93,38 @@ let consumer = DefaultLitePullConsumer::builder()
     .build();
 ```
 
+## TLS / mTLS Configuration
+
+```rust
+use rocketmq_client_rust::base::client_config::ClientConfig;
+
+let client_config = ClientConfig::builder()
+    .namesrv_addr("localhost:9876")
+    .enable_tls(true)
+    .tls_client_auth_server(true)
+    .tls_client_trust_cert_path("/path/to/ca.pem")
+    // Optional client certificate and key for mTLS.
+    .tls_client_cert_path("/path/to/client.pem")
+    .tls_client_key_path("/path/to/client.key")
+    .build()?;
+# Ok::<(), rocketmq_error::RocketMQError>(())
+```
+
+Broker-backed TLS smoke tests reuse `ROCKETMQ_ENABLE_TLS_SMOKE=true`.
+When the Java broker uses a private CA or mTLS, set the optional companion variables:
+
+```bash
+ROCKETMQ_NAMESRV_ADDR=127.0.0.1:9876
+ROCKETMQ_ENABLE_TLS_SMOKE=true
+ROCKETMQ_TLS_CLIENT_AUTH_SERVER=true
+ROCKETMQ_TLS_CLIENT_TRUST_CERT_PATH=/path/to/ca.pem
+ROCKETMQ_TLS_CLIENT_CERT_PATH=/path/to/client.pem
+ROCKETMQ_TLS_CLIENT_KEY_PATH=/path/to/client.key
+```
+
+For local test-mode brokers, use `ROCKETMQ_TLS_TEST_MODE_ENABLE=true` or
+`ROCKETMQ_TLS_CLIENT_AUTH_SERVER=false` to skip server certificate verification.
+
 ## Configuration Options Reference
 
 ### Producer Builder Options

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/configuration/broker-config.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/configuration/broker-config.md
@@ -169,13 +169,23 @@ aclEnable = true
 
 ### TLS
 
+Broker and NameServer remoting servers use the same Java-compatible `tls.server.*` keys.
+
 ```toml
 # 启用 TLS
-tlsEnable = true
-tlsTestModeEnable = false
-tlsServerCert = /path/to/server.pem
-tlsServerKey = /path/to/server.key
-tlsServerAuthClient = true
+tls.enable = true
+tls.server.mode = "enforcing"      # disabled, permissive, enforcing
+tls.test.mode.enable = false
+tls.server.certPath = "/path/to/server.pem"
+tls.server.keyPath = "/path/to/server.key"
+tls.server.need.client.auth = "require"
+tls.server.authClient = true
+tls.server.trustCertPath = "/path/to/ca.pem"
+tls.client.authServer = true
+tls.client.trustCertPath = "/path/to/ca.pem"
+tls.client.certPath = "/path/to/client.pem"
+tls.client.keyPath = "/path/to/client.key"
+tls.protocols = "TLSv1.3,TLSv1.2"
 ```
 
 ## 监控配置

--- a/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/configuration/client-config.md
+++ b/rocketmq-website/i18n/zh-CN/docusaurus-plugin-content-docs/current/configuration/client-config.md
@@ -93,6 +93,23 @@ let consumer = DefaultLitePullConsumer::builder()
     .build();
 ```
 
+## TLS / mTLS Configuration
+
+```rust
+use rocketmq_client_rust::base::client_config::ClientConfig;
+
+let client_config = ClientConfig::builder()
+    .namesrv_addr("localhost:9876")
+    .enable_tls(true)
+    .tls_client_auth_server(true)
+    .tls_client_trust_cert_path("/path/to/ca.pem")
+    // Optional client certificate and key for mTLS.
+    .tls_client_cert_path("/path/to/client.pem")
+    .tls_client_key_path("/path/to/client.key")
+    .build()?;
+# Ok::<(), rocketmq_error::RocketMQError>(())
+```
+
 ## 配置项速查
 
 ### Producer Builder


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7433

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive TLS/mTLS configuration support for brokers, nameservers, and clients with flexible operational modes.
  * Support for client certificate authentication, custom trust stores, and configurable TLS protocols.
  * Added test mode for local development with optional relaxed server verification.
  * Environment variable-driven TLS configuration in smoke tests.

* **Documentation**
  * Updated broker, nameserver, and client configuration documentation with TLS/mTLS setup examples and smoke-test instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->