### PR TITLE
[ISSUE #7442]♻️refactor: standardize command names and improve output formatting; add new container commands for broker management

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -4738,11 +4738,6 @@ accounts:
         root: &Path,
     ) -> ArcMut<TestControllerManager> {
         let node_id = controller_peer.id;
-        let raft_addr = raft_peers
-            .iter()
-            .find(|peer| peer.id == node_id)
-            .map(|peer| peer.addr)
-            .unwrap_or(controller_peer.addr);
         let config = TestControllerConfig::default()
             .with_node_info(node_id, controller_peer.addr)
             .with_controller_peers(controller_peers)
@@ -4774,7 +4769,6 @@ accounts:
         );
         manager.clone().start().await.expect("start controller manager");
         wait_for_tcp_listener(controller_peer.addr, "controller remoting server to listen").await;
-        wait_for_tcp_listener(raft_addr, "controller raft server to listen").await;
         manager
     }
 

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl.rs
@@ -1985,24 +1985,11 @@ impl MQAdminExt for DefaultMQAdminExtImpl {
         special_topic: bool,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<TopicConfigSerializeWrapper> {
-        let mut topic_config_wrapper = self.get_all_topic_config(broker_addr, timeout_millis).await?;
+        let mut topic_config_wrapper = self.get_all_topic_config(broker_addr.clone(), timeout_millis).await?;
+        let system_topic_list = self.get_system_topic_list_from_broker(broker_addr).await?;
 
         if let Some(ref mut topic_table) = topic_config_wrapper.topic_config_table_mut() {
-            topic_table.retain(|topic_name, topic_config| {
-                if TopicValidator::is_system_topic(topic_name.as_str()) {
-                    return false;
-                }
-                if !special_topic
-                    && (topic_name.starts_with(RETRY_GROUP_TOPIC_PREFIX)
-                        || topic_name.starts_with(DLQ_GROUP_TOPIC_PREFIX))
-                {
-                    return false;
-                }
-                if !PermName::is_valid(topic_config.perm) {
-                    return false;
-                }
-                true
-            });
+            retain_java_user_topic_config(topic_table, &system_topic_list.topic_list, special_topic);
         }
 
         Ok(topic_config_wrapper)
@@ -3896,6 +3883,32 @@ fn filter_consume_stats(stats: &mut ConsumeStats, topic: Option<&CheetahString>,
     });
 }
 
+fn retain_java_user_topic_config(
+    topic_table: &mut HashMap<CheetahString, TopicConfig>,
+    broker_system_topics: &[CheetahString],
+    special_topic: bool,
+) {
+    topic_table.retain(|topic_name, topic_config| {
+        let topic = topic_config
+            .topic_name
+            .as_ref()
+            .map(CheetahString::as_str)
+            .unwrap_or_else(|| topic_name.as_str());
+        if broker_system_topics
+            .iter()
+            .any(|system_topic| system_topic.as_str() == topic)
+            || TopicValidator::is_system_topic(topic)
+        {
+            return false;
+        }
+        if !special_topic && (topic.starts_with(RETRY_GROUP_TOPIC_PREFIX) || topic.starts_with(DLQ_GROUP_TOPIC_PREFIX))
+        {
+            return false;
+        }
+        PermName::is_valid(topic_config.perm)
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
@@ -3909,14 +3922,18 @@ mod tests {
     use cheetah_string::CheetahString;
     use rocketmq_common::common::base::plain_access_config::PlainAccessConfig;
     use rocketmq_common::common::config::TopicConfig;
+    use rocketmq_common::common::constant::PermName;
     use rocketmq_common::common::message::message_builder::MessageBuilder;
     use rocketmq_common::common::message::message_enum::MessageRequestMode;
     use rocketmq_common::common::message::message_ext::MessageExt;
     use rocketmq_common::common::message::message_queue::MessageQueue;
     use rocketmq_common::common::message::MessageConst;
     use rocketmq_common::common::mix_all;
+    use rocketmq_common::common::mix_all::DLQ_GROUP_TOPIC_PREFIX;
+    use rocketmq_common::common::mix_all::RETRY_GROUP_TOPIC_PREFIX;
     #[allow(deprecated)]
     use rocketmq_common::common::tools::track_type::TrackType;
+    use rocketmq_common::common::topic::TopicValidator;
     use rocketmq_remoting::code::response_code::ResponseCode;
     use rocketmq_remoting::protocol::admin::consume_stats::ConsumeStats;
     use rocketmq_remoting::protocol::admin::offset_wrapper::OffsetWrapper;
@@ -3955,6 +3972,7 @@ mod tests {
     use super::query_consume_queue_index_to_java_long;
     use super::reset_offset_by_queue_id_request_headers;
     use super::resolve_consumed_track_type;
+    use super::retain_java_user_topic_config;
     use super::search_offset_timestamp_to_java_long;
     use super::select_consumer_direct_connection;
     use super::timeout_millis_to_u64;
@@ -3973,6 +3991,68 @@ mod tests {
             ArcMut::new(ClientConfig::default()),
             CheetahString::from("admin-group"),
         )
+    }
+
+    #[test]
+    fn retain_java_user_topic_config_filters_java_internal_topics() {
+        let mut topic_table = HashMap::from([
+            (
+                CheetahString::from_static_str("UserTopic"),
+                TopicConfig::new("UserTopic"),
+            ),
+            (
+                CheetahString::from_static_str("BrokerInternalTopic"),
+                TopicConfig::new("BrokerInternalTopic"),
+            ),
+            (
+                CheetahString::from_static_str(TopicValidator::RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC),
+                TopicConfig::new(TopicValidator::RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC),
+            ),
+            (
+                CheetahString::from_string(format!("{RETRY_GROUP_TOPIC_PREFIX}group-a")),
+                TopicConfig::new(format!("{RETRY_GROUP_TOPIC_PREFIX}group-a")),
+            ),
+            (
+                CheetahString::from_string(format!("{DLQ_GROUP_TOPIC_PREFIX}group-a")),
+                TopicConfig::new(format!("{DLQ_GROUP_TOPIC_PREFIX}group-a")),
+            ),
+            (
+                CheetahString::from_static_str("InvalidPermTopic"),
+                TopicConfig {
+                    perm: PermName::PERM_PRIORITY,
+                    ..TopicConfig::new("InvalidPermTopic")
+                },
+            ),
+        ]);
+        let broker_system_topics = vec![CheetahString::from_static_str("BrokerInternalTopic")];
+
+        retain_java_user_topic_config(&mut topic_table, &broker_system_topics, false);
+
+        assert_eq!(topic_table.len(), 1);
+        assert!(topic_table.contains_key("UserTopic"));
+    }
+
+    #[test]
+    fn retain_java_user_topic_config_keeps_retry_and_dlq_when_special_topic_enabled() {
+        let retry_topic = CheetahString::from_string(format!("{RETRY_GROUP_TOPIC_PREFIX}group-a"));
+        let dlq_topic = CheetahString::from_string(format!("{DLQ_GROUP_TOPIC_PREFIX}group-a"));
+        let mut topic_table = HashMap::from([
+            (retry_topic.clone(), TopicConfig::new(retry_topic.clone())),
+            (dlq_topic.clone(), TopicConfig::new(dlq_topic.clone())),
+            (
+                CheetahString::from_static_str("InvalidPermTopic"),
+                TopicConfig {
+                    perm: PermName::PERM_PRIORITY,
+                    ..TopicConfig::new("InvalidPermTopic")
+                },
+            ),
+        ]);
+
+        retain_java_user_topic_config(&mut topic_table, &[], true);
+
+        assert_eq!(topic_table.len(), 2);
+        assert!(topic_table.contains_key(&retry_topic));
+        assert!(topic_table.contains_key(&dlq_topic));
     }
 
     #[test]

--- a/rocketmq-common/src/common/topic.rs
+++ b/rocketmq-common/src/common/topic.rs
@@ -70,6 +70,12 @@ static SYSTEM_TOPIC_SET: LazyLock<DashSet<CheetahString>> = LazyLock::new(|| {
     set.insert(CheetahString::from_static_str(
         TopicValidator::RMQ_SYS_ROCKSDB_OFFSET_TOPIC,
     ));
+    set.insert(CheetahString::from_static_str(
+        TopicValidator::RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC,
+    ));
+    set.insert(CheetahString::from_static_str(
+        TopicValidator::RMQ_SYS_ROCKSDB_TRANS_OP_HALF_TOPIC,
+    ));
     set
 });
 
@@ -87,6 +93,12 @@ static NOT_ALLOWED_SEND_TOPIC_SET: LazyLock<DashSet<CheetahString>> = LazyLock::
     set.insert(CheetahString::from_static_str(
         TopicValidator::RMQ_SYS_OFFSET_MOVED_EVENT,
     ));
+    set.insert(CheetahString::from_static_str(
+        TopicValidator::RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC,
+    ));
+    set.insert(CheetahString::from_static_str(
+        TopicValidator::RMQ_SYS_ROCKSDB_TRANS_OP_HALF_TOPIC,
+    ));
     set
 });
 
@@ -97,8 +109,10 @@ impl TopicValidator {
     pub const RMQ_SYS_SCHEDULE_TOPIC: &'static str = "SCHEDULE_TOPIC_XXXX";
     pub const RMQ_SYS_BENCHMARK_TOPIC: &'static str = "BenchmarkTest";
     pub const RMQ_SYS_TRANS_HALF_TOPIC: &'static str = "RMQ_SYS_TRANS_HALF_TOPIC";
+    pub const RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC: &'static str = "RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC";
     pub const RMQ_SYS_TRACE_TOPIC: &'static str = "RMQ_SYS_TRACE_TOPIC";
     pub const RMQ_SYS_TRANS_OP_HALF_TOPIC: &'static str = "RMQ_SYS_TRANS_OP_HALF_TOPIC";
+    pub const RMQ_SYS_ROCKSDB_TRANS_OP_HALF_TOPIC: &'static str = "RMQ_SYS_ROCKSDB_TRANS_OP_HALF_TOPIC";
     pub const RMQ_SYS_TRANS_CHECK_MAX_TIME_TOPIC: &'static str = "TRANS_CHECK_MAX_TIME_TOPIC";
     pub const RMQ_SYS_SELF_TEST_TOPIC: &'static str = "SELF_TEST_TOPIC";
     pub const RMQ_SYS_OFFSET_MOVED_EVENT: &'static str = "OFFSET_MOVED_EVENT";
@@ -263,6 +277,12 @@ mod tests {
     #[test]
     fn is_system_topic_with_system_topic() {
         assert!(TopicValidator::is_system_topic(TopicValidator::RMQ_SYS_SCHEDULE_TOPIC));
+        assert!(TopicValidator::is_system_topic(
+            TopicValidator::RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC
+        ));
+        assert!(TopicValidator::is_system_topic(
+            TopicValidator::RMQ_SYS_ROCKSDB_TRANS_OP_HALF_TOPIC
+        ));
     }
 
     #[test]
@@ -274,6 +294,12 @@ mod tests {
     fn is_not_allowed_send_topic_with_not_allowed_topic() {
         assert!(TopicValidator::is_not_allowed_send_topic(
             TopicValidator::RMQ_SYS_SCHEDULE_TOPIC
+        ));
+        assert!(TopicValidator::is_not_allowed_send_topic(
+            TopicValidator::RMQ_SYS_ROCKSDB_TRANS_HALF_TOPIC
+        ));
+        assert!(TopicValidator::is_not_allowed_send_topic(
+            TopicValidator::RMQ_SYS_ROCKSDB_TRANS_OP_HALF_TOPIC
         ));
     }
 

--- a/rocketmq-controller/Cargo.toml
+++ b/rocketmq-controller/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = { workspace = true }
 bytes        = { workspace = true }
 prost        = "0.14"
 futures      = "0.3"
-tokio-stream = { version = "0.1", features = ["sync"] }
+tokio-stream = { version = "0.1", features = ["net", "sync"] }
 
 cheetah-string = { workspace = true }
 

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -69,8 +69,10 @@ use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::CommandCustomHeader;
 use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_rust::ArcMut;
+use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
+use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server;
 use tracing::info;
 
@@ -419,13 +421,18 @@ impl Controller for OpenRaftController {
 
         let addr = raft_addr;
         let node_id = self.config.node_id;
+        let listener = TcpListener::bind(addr).await.map_err(|error| {
+            rocketmq_error::RocketMQError::Internal(format!(
+                "Failed to bind OpenRaft gRPC server for node {node_id} on {addr}: {error}"
+            ))
+        })?;
 
         let handle = tokio::spawn(async move {
             info!("gRPC server starting for node {} on {}", node_id, addr);
 
             let result = Server::builder()
                 .add_service(OpenRaftServiceServer::new(service))
-                .serve_with_shutdown(addr, async {
+                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     shutdown_rx.await.ok();
                     info!("Shutdown signal received for node {}, stopping gRPC server", node_id);
                 })
@@ -802,5 +809,36 @@ impl Controller for OpenRaftController {
 
     fn register_broker_lifecycle_listener(&self, listener: Arc<dyn BrokerLifecycleListener>) {
         self.lifecycle_listeners.write().push(listener);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener as StdTcpListener;
+
+    use rocketmq_common::common::controller::controller_config::RaftPeer;
+    use rocketmq_common::common::controller::ControllerConfig;
+    use rocketmq_rust::ArcMut;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn startup_binds_grpc_listener_before_returning() {
+        let probe = StdTcpListener::bind("127.0.0.1:0").expect("bind probe listener");
+        let addr = probe.local_addr().expect("read probe address");
+        drop(probe);
+
+        let config = ControllerConfig::default()
+            .with_node_info(1, addr)
+            .with_raft_peers(vec![RaftPeer { id: 1, addr }]);
+        let mut controller = OpenRaftController::new(ArcMut::new(config));
+
+        controller.startup().await.expect("start OpenRaft controller");
+        assert!(
+            StdTcpListener::bind(addr).is_err(),
+            "OpenRaft controller startup should return only after binding the gRPC listener"
+        );
+
+        controller.shutdown().await.expect("shutdown OpenRaft controller");
     }
 }

--- a/rocketmq-remoting/src/protocol/admin/topic_stats_table.rs
+++ b/rocketmq-remoting/src/protocol/admin/topic_stats_table.rs
@@ -19,11 +19,14 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json_any_key::*;
 
+use crate::protocol::admin::consume_stats::normalize_nonstandard_offset_table_keys;
 use crate::protocol::admin::topic_offset::TopicOffset;
+use crate::protocol::RemotingDeserializable;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct TopicStatsTable {
+    topic_put_tps: f64,
     #[serde(with = "any_key_map")]
     offset_table: HashMap<MessageQueue, TopicOffset>,
 }
@@ -31,8 +34,17 @@ pub struct TopicStatsTable {
 impl TopicStatsTable {
     pub fn new() -> Self {
         Self {
+            topic_put_tps: 0.0,
             offset_table: HashMap::new(),
         }
+    }
+
+    pub fn get_topic_put_tps(&self) -> f64 {
+        self.topic_put_tps
+    }
+
+    pub fn set_topic_put_tps(&mut self, topic_put_tps: f64) {
+        self.topic_put_tps = topic_put_tps;
     }
 
     pub fn get_offset_table(&self) -> &HashMap<MessageQueue, TopicOffset> {
@@ -49,6 +61,22 @@ impl TopicStatsTable {
 
     pub fn set_offset_table(&mut self, offset_table: HashMap<MessageQueue, TopicOffset>) {
         self.offset_table = offset_table;
+    }
+
+    pub fn decode(body: &[u8]) -> rocketmq_error::RocketMQResult<Self> {
+        match <Self as RemotingDeserializable>::decode(body) {
+            Ok(stats) => Ok(stats),
+            Err(error) => {
+                let Ok(raw_body) = std::str::from_utf8(body) else {
+                    return Err(error);
+                };
+                let normalized_body = normalize_nonstandard_offset_table_keys(raw_body);
+                if normalized_body == raw_body {
+                    return Err(error);
+                }
+                <Self as RemotingDeserializable>::decode_str(&normalized_body)
+            }
+        }
     }
 }
 
@@ -119,6 +147,22 @@ mod tests {
 
         let offset_val = deserialized.get_offset_table().values().next().unwrap().clone();
         assert_eq!(offset_val.get_last_update_timestamp(), 11111111);
+    }
+
+    #[test]
+    fn test_decode_java_fastjson_message_queue_keys() {
+        let body = br#"{"offsetTable":{{"topic":"TBW102","brokerName":"broker-a","queueId":0}:{"minOffset":0,"maxOffset":0,"lastUpdateTimestamp":0}},"topicPutTps":1.5}"#;
+
+        let table = TopicStatsTable::decode(body).expect("decode Java fastjson topic stats");
+
+        let queue = MessageQueue::from_parts("TBW102", "broker-a", 0);
+        let offset = table
+            .get_offset_table()
+            .get(&queue)
+            .expect("queue offset should decode");
+        assert_eq!(offset.get_min_offset(), 0);
+        assert_eq!(offset.get_max_offset(), 0);
+        assert_eq!(table.get_topic_put_tps(), 1.5);
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/body/broker_body/cluster_info.rs
+++ b/rocketmq-remoting/src/protocol/body/broker_body/cluster_info.rs
@@ -20,6 +20,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::route::route_data_view::BrokerData;
+use crate::protocol::RemotingDeserializable;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ClusterInfo {
@@ -39,6 +40,96 @@ impl ClusterInfo {
             broker_addr_table,
             cluster_addr_table,
         }
+    }
+
+    pub fn decode(bytes: &[u8]) -> rocketmq_error::RocketMQResult<Self> {
+        match <Self as RemotingDeserializable>::decode(bytes) {
+            Ok(cluster_info) => Ok(cluster_info),
+            Err(error) => {
+                let Ok(raw_body) = std::str::from_utf8(bytes) else {
+                    return Err(error);
+                };
+                let Some(normalized_body) = quote_unquoted_numeric_object_keys(raw_body) else {
+                    return Err(error);
+                };
+                <Self as RemotingDeserializable>::decode_str(&normalized_body)
+            }
+        }
+    }
+}
+
+fn quote_unquoted_numeric_object_keys(input: &str) -> Option<String> {
+    let bytes = input.as_bytes();
+    let mut output = String::with_capacity(input.len() + 8);
+    let mut last_copied = 0;
+    let mut index = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut changed = false;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if byte == b'"' {
+            in_string = true;
+            index += 1;
+            continue;
+        }
+
+        if byte == b'{' || byte == b',' {
+            let mut key_start = index + 1;
+            while key_start < bytes.len() && bytes[key_start].is_ascii_whitespace() {
+                key_start += 1;
+            }
+
+            let mut digit_start = key_start;
+            if digit_start < bytes.len() && bytes[digit_start] == b'-' {
+                digit_start += 1;
+            }
+
+            if digit_start < bytes.len() && bytes[digit_start].is_ascii_digit() {
+                let mut digit_end = digit_start + 1;
+                while digit_end < bytes.len() && bytes[digit_end].is_ascii_digit() {
+                    digit_end += 1;
+                }
+
+                let mut colon_index = digit_end;
+                while colon_index < bytes.len() && bytes[colon_index].is_ascii_whitespace() {
+                    colon_index += 1;
+                }
+
+                if colon_index < bytes.len() && bytes[colon_index] == b':' {
+                    output.push_str(&input[last_copied..key_start]);
+                    output.push('"');
+                    output.push_str(&input[key_start..digit_end]);
+                    output.push('"');
+                    last_copied = digit_end;
+                    changed = true;
+                    index = digit_end;
+                    continue;
+                }
+            }
+        }
+
+        index += 1;
+    }
+
+    if changed {
+        output.push_str(&input[last_copied..]);
+        Some(output)
+    } else {
+        None
     }
 }
 
@@ -89,7 +180,7 @@ mod tests {
     #[test]
     fn test_cluster_info_deserialization() {
         let json = r#"{"brokerAddrTable":{"broker1":{"cluster":"c1","brokerName":"b1","brokerAddrs":{"0":"127.0.0.1:10911"},"enableActingMaster":false}},"clusterAddrTable":{"cluster1":["broker1"]}}"#;
-        let cluster_info: ClusterInfo = serde_json::from_str(json).unwrap();
+        let cluster_info = ClusterInfo::decode(json.as_bytes()).unwrap();
         assert!(cluster_info.broker_addr_table.is_some());
         assert!(cluster_info.cluster_addr_table.is_some());
         assert_eq!(
@@ -100,6 +191,23 @@ mod tests {
                 .unwrap()
                 .broker_name(),
             "b1"
+        );
+    }
+
+    #[test]
+    fn test_cluster_info_decode_java_fastjson_numeric_broker_ids() {
+        let java_body = br#"{"brokerAddrTable":{"broker-a":{"brokerAddrs":{0:"127.0.0.1:10911"},"brokerName":"broker-a","cluster":"DefaultCluster","enableActingMaster":false}},"clusterAddrTable":{"DefaultCluster":["broker-a"]}}"#;
+
+        let cluster_info = ClusterInfo::decode(java_body).expect("decode Java fastjson cluster info");
+
+        let broker_data = cluster_info
+            .broker_addr_table
+            .as_ref()
+            .and_then(|items| items.get(&CheetahString::from("broker-a")))
+            .expect("broker-a should decode");
+        assert_eq!(
+            broker_data.broker_addrs().get(&0),
+            Some(&CheetahString::from("127.0.0.1:10911"))
         );
     }
 }

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -637,6 +637,7 @@ mod tests {
 
         let message_store_config = MessageStoreConfig {
             enable_controller_mode,
+            ha_max_time_slave_not_catchup: 1000,
             store_path_root_dir: root.to_string_lossy().into_owned().into(),
             ..MessageStoreConfig::default()
         };
@@ -843,6 +844,7 @@ mod tests {
         connection.set_slave_broker_id(Some(9));
 
         service.handle_connection_caught_up(connection.as_ref());
+        sleep(Duration::from_millis(2)).await;
 
         let shrunk = auto_switch_service.maybe_shrink_sync_state_set();
         assert_eq!(shrunk, HashSet::from([7_i64, 9_i64]));

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -3938,6 +3938,8 @@ struct CleanCommitLogService {
     commit_log: ArcMut<CommitLog>,
     running_flags: Arc<RunningFlags>,
     manual_delete_requests: AtomicI32,
+    #[cfg(test)]
+    disk_clean_decision_override: StdMutex<Option<DiskCleanDecision>>,
 }
 
 impl CleanCommitLogService {
@@ -3953,6 +3955,8 @@ impl CleanCommitLogService {
             commit_log,
             running_flags,
             manual_delete_requests: AtomicI32::new(0),
+            #[cfg(test)]
+            disk_clean_decision_override: StdMutex::new(None),
         }
     }
 
@@ -4006,7 +4010,24 @@ impl CleanCommitLogService {
             .is_ok()
     }
 
+    #[cfg(test)]
+    fn set_disk_clean_decision_override(&self, decision: Option<DiskCleanDecision>) {
+        *self
+            .disk_clean_decision_override
+            .lock()
+            .expect("lock disk clean decision override") = decision;
+    }
+
     fn is_space_to_delete(&self) -> DiskCleanDecision {
+        #[cfg(test)]
+        if let Some(decision) = *self
+            .disk_clean_decision_override
+            .lock()
+            .expect("lock disk clean decision override")
+        {
+            return decision;
+        }
+
         let warning_ratio = self.disk_space_warning_level_ratio();
         let clean_forcibly_ratio = self.disk_space_clean_forcibly_ratio();
         let (min_physic_ratio, min_store_path) = self.min_physic_disk_ratio();
@@ -4374,6 +4395,7 @@ mod tests {
 
     use super::run_blocking_scheduled_task;
     use super::CleanCommitLogService;
+    use super::DiskCleanDecision;
     use super::LocalFileMessageStore;
     use super::ReputMessageServiceInner;
     use super::StoreLifecycleState;
@@ -6594,6 +6616,9 @@ mod tests {
                 .expect("append commitlog file"));
         }
 
+        store
+            .clean_commit_log_service
+            .set_disk_clean_decision_override(Some(DiskCleanDecision::default()));
         store.clean_commit_log_service.run();
 
         assert_eq!(store.get_min_phy_offset(), 0);

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/README.md
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/README.md
@@ -73,12 +73,17 @@ rocketmq-admin-cli topic updateTopic -t MyTopic -c DefaultCluster -r 8 -w 8 -n 1
 rocketmq-admin-cli topic deleteTopic -t MyTopic -c DefaultCluster -n 127.0.0.1:9876
 
 # NameServer commands
-rocketmq-admin-cli nameserver getKVConfig -s namespace -k key -n 127.0.0.1:9876
-rocketmq-admin-cli nameserver updateKVConfig -s namespace -k key -v value -n 127.0.0.1:9876
+rocketmq-admin-cli nameserver updateKvConfig -s namespace -k key -v value -n 127.0.0.1:9876
+rocketmq-admin-cli nameserver deleteKvConfig -s namespace -k key -n 127.0.0.1:9876
 
 # Broker config commands
 rocketmq-admin-cli broker getBrokerConfig -c DefaultCluster -n 127.0.0.1:9876
 rocketmq-admin-cli broker updateBrokerConfig -c DefaultCluster -k flushDiskType -v ASYNC_FLUSH -n 127.0.0.1:9876
+
+# Container and export commands
+rocketmq-admin-cli container addBroker -c 127.0.0.1:10911 -b ./conf/broker.conf
+rocketmq-admin-cli export exportMetrics -c DefaultCluster -f /tmp/rocketmq/export -n 127.0.0.1:9876
+rocketmq-admin-cli export rocksDBConfigToJson -p /tmp/rocketmq/config -t topics -j true
 ```
 
 ## Command Domains
@@ -89,17 +94,18 @@ rocketmq-admin-cli broker updateBrokerConfig -c DefaultCluster -k flushDiskType 
 | `nameserver` | NameServer config, KV config, and write permission operations. |
 | `broker` | Broker config, status, cleanup, cold-data, timer, and commit-log operations. |
 | `cluster` | Cluster listing and cluster send-RT diagnostics. |
+| `container` | Broker container add/remove operations. |
 | `consumer` | Subscription group, consumer progress, running info, and consume mode operations. |
 | `connection` | Consumer and producer connection inspection. |
 | `offset` | Clone, reset, skip, and query consumer offsets. |
 | `queue` | ConsumeQueue query and RocksDB CQ write-progress checks. |
 | `message` | Message query, decode, print, consume, and send diagnostics. |
 | `producer` | Producer info and send diagnostic operations. |
-| `controller` | Controller config and metadata operations. |
+| `controller` | Controller config, metadata, and master election operations. |
 | `auth` | User and ACL management. |
 | `ha` | HA status and sync-state-set inspection. |
 | `stats` | Cluster-wide topic and consumer statistics. |
-| `export` | Config, metadata, pop-record, and optional RocksDB metadata export. |
+| `export` | Config, metadata, metrics, pop-record, and RocksDB metadata export. |
 | `lite` | Lite topic/group/client inspection and dispatch operations. |
 
 ## Environment

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands.rs
@@ -17,6 +17,7 @@ mod broker;
 mod cluster;
 mod connection;
 mod consumer;
+mod container;
 mod controller;
 mod export;
 mod ha;
@@ -105,6 +106,11 @@ pub enum Commands {
     Consumer(consumer::ConsumerCommands),
 
     #[command(subcommand)]
+    #[command(about = "Broker container commands")]
+    #[command(name = "container")]
+    Container(container::ContainerCommands),
+
+    #[command(subcommand)]
     #[command(about = "Controller commands")]
     #[command(name = "controller")]
     Controller(controller::ControllerCommands),
@@ -170,6 +176,7 @@ impl CommandExecute for Commands {
             Commands::Cluster(value) => value.execute(rpc_hook).await,
             Commands::Connection(value) => value.execute(rpc_hook).await,
             Commands::Consumer(value) => value.execute(rpc_hook).await,
+            Commands::Container(value) => value.execute(rpc_hook).await,
             Commands::Controller(value) => value.execute(rpc_hook).await,
             Commands::Export(value) => value.execute(rpc_hook).await,
             Commands::HA(value) => value.execute(rpc_hook).await,
@@ -237,13 +244,33 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Auth",
+                command: "getAcl",
+                remark: "Get acl from cluster.",
+            },
+            Command {
+                category: "Auth",
+                command: "getUser",
+                remark: "Get user from cluster.",
+            },
+            Command {
+                category: "Auth",
                 command: "listAcl",
                 remark: "List acl from cluster.",
             },
             Command {
                 category: "Auth",
+                command: "listUser",
+                remark: "List users from cluster.",
+            },
+            Command {
+                category: "Auth",
                 command: "updateAcl",
                 remark: "Update ACL.",
+            },
+            Command {
+                category: "Auth",
+                command: "updateUser",
+                remark: "Update user to cluster.",
             },
             Command {
                 category: "Broker",
@@ -312,6 +339,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Broker",
+                command: "updateColdDataFlowCtrGroupConfig",
+                remark: "Update cold data flow ctr group config.",
+            },
+            Command {
+                category: "Broker",
                 command: "setCommitLogReadAheadMode",
                 remark: "Set read ahead mode for all commitlog files.",
             },
@@ -336,9 +368,24 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Query producer's socket connection and client version.",
             },
             Command {
+                category: "Container",
+                command: "addBroker",
+                remark: "Add a broker to specified container.",
+            },
+            Command {
+                category: "Container",
+                command: "removeBroker",
+                remark: "Remove a broker from specified container.",
+            },
+            Command {
                 category: "Consumer",
                 command: "consumerStatus",
                 remark: "Query and display consumer's internal data structures.",
+            },
+            Command {
+                category: "Consumer",
+                command: "consumerProgress",
+                remark: "Query consumer progress.",
             },
             Command {
                 category: "Consumer",
@@ -371,6 +418,11 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Start Monitoring.",
             },
             Command {
+                category: "Consumer",
+                command: "setConsumeMode",
+                remark: "Set consume mode for consumer group.",
+            },
+            Command {
                 category: "Controller",
                 command: "cleanBrokerMetadata",
                 remark: "Clean metadata of broker on controller.",
@@ -386,6 +438,16 @@ impl CommandExecute for ClassificationTablePrint {
                 remark: "Get meta data of controller.",
             },
             Command {
+                category: "Controller",
+                command: "electMaster",
+                remark: "Re-elect the specified broker as master.",
+            },
+            Command {
+                category: "Controller",
+                command: "updateControllerConfig",
+                remark: "Update configuration of controller(s).",
+            },
+            Command {
                 category: "Export",
                 command: "exportConfigs",
                 remark: "Export configs",
@@ -397,6 +459,11 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Export",
+                command: "exportMetrics",
+                remark: "Export metrics.",
+            },
+            Command {
+                category: "Export",
                 command: "exportMetadataInRocksDB",
                 remark: "Export RocksDB kv config (topics/subscriptionGroups). Recommend to use [mqadmin \
                          rocksDBConfigToJson]",
@@ -405,6 +472,11 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "Export",
                 command: "exportPopRecord",
                 remark: "Export pop consumer records.",
+            },
+            Command {
+                category: "Export",
+                command: "rocksDBConfigToJson",
+                remark: "Convert RocksDB kv config to json.",
             },
             Command {
                 category: "HA",
@@ -468,7 +540,7 @@ impl CommandExecute for ClassificationTablePrint {
             },
             Command {
                 category: "Message",
-                command: "printMessage",
+                command: "printMsg",
                 remark: "Print Message Detail.",
             },
             Command {
@@ -630,6 +702,11 @@ impl CommandExecute for ClassificationTablePrint {
                 category: "Topic",
                 command: "updateTopicPerm",
                 remark: "Update topic perm.",
+            },
+            Command {
+                category: "Topic",
+                command: "updateTopicList",
+                remark: "Create or update topic configs in batch.",
             },
             Command {
                 category: "Topic",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/auth.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/auth.rs
@@ -110,7 +110,8 @@ pub enum AuthCommands {
     ListAcl(ListAclSubCommand),
 
     #[command(
-        name = "listUsers",
+        name = "listUser",
+        visible_alias = "listUsers",
         about = "List users from cluster.",
         long_about = None,
     )]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/consumer/update_sub_group_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/consumer/update_sub_group_sub_command.rs
@@ -119,6 +119,8 @@ pub struct UpdateSubGroupSubCommand {
 impl UpdateSubGroupSubCommand {
     fn request(&self) -> RocketMQResult<UpdateSubscriptionGroupRequest> {
         let mut subscription_group_config = SubscriptionGroupConfig::new(self.group_name.as_str().into());
+        subscription_group_config.set_consume_broadcast_enable(false);
+        subscription_group_config.set_consume_from_min_enable(false);
 
         if let Some(consume_enable) = self.consume_enable {
             subscription_group_config.set_consume_enable(consume_enable);
@@ -321,5 +323,22 @@ mod tests {
         assert_eq!(Some(3), cmd.which_broker_when_consume_slowly);
         assert_eq!(Some(true), cmd.notify_consumer_ids_changed);
         assert_eq!(Some("+a=b,+c=d,-e"), cmd.attributes.as_deref());
+    }
+
+    #[test]
+    fn test_java_default_subscription_flags_are_preserved() {
+        let cmd = UpdateSubGroupSubCommand::try_parse_from([
+            "updateSubGroup",
+            "--brokerAddr",
+            "127.0.0.1:10911",
+            "--groupName",
+            "group-a",
+        ])
+        .unwrap();
+
+        let request = cmd.request().unwrap();
+
+        assert!(!request.config().consume_from_min_enable());
+        assert!(!request.config().consume_broadcast_enable());
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/container.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/container.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod add_broker_sub_command;
+mod remove_broker_sub_command;
+
+use std::sync::Arc;
+
+use clap::Subcommand;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::CommandExecute;
+use crate::commands::container::add_broker_sub_command::AddBrokerSubCommand;
+use crate::commands::container::remove_broker_sub_command::RemoveBrokerSubCommand;
+
+#[derive(Subcommand)]
+pub enum ContainerCommands {
+    #[command(
+        name = "addBroker",
+        about = "Add a broker to specified container.",
+        long_about = None,
+    )]
+    AddBroker(AddBrokerSubCommand),
+
+    #[command(
+        name = "removeBroker",
+        about = "Remove a broker from specified container.",
+        long_about = None,
+    )]
+    RemoveBroker(RemoveBrokerSubCommand),
+}
+
+impl CommandExecute for ContainerCommands {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self {
+            ContainerCommands::AddBroker(cmd) => cmd.execute(rpc_hook).await,
+            ContainerCommands::RemoveBroker(cmd) => cmd.execute(rpc_hook).await,
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/container/add_broker_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/container/add_broker_sub_command.rs
@@ -1,0 +1,81 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_admin_core::core::container::ContainerAddBrokerRequest;
+use rocketmq_admin_core::core::container::ContainerService;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct AddBrokerSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(
+        short = 'c',
+        long = "brokerContainerAddr",
+        required = true,
+        help = "Broker container address"
+    )]
+    broker_container_addr: String,
+
+    #[arg(short = 'b', long = "brokerConfigPath", required = true, help = "Broker config path")]
+    broker_config_path: String,
+}
+
+impl CommandExecute for AddBrokerSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let result = ContainerService::add_broker_by_request_with_rpc_hook(self.request()?, rpc_hook).await?;
+        println!("add broker to {} success", result.broker_container_addr);
+        Ok(())
+    }
+}
+
+impl AddBrokerSubCommand {
+    fn request(&self) -> RocketMQResult<ContainerAddBrokerRequest> {
+        ContainerAddBrokerRequest::try_new(self.broker_container_addr.clone(), self.broker_config_path.clone())
+            .map(|request| request.with_optional_namesrv_addr(self.common_args.namesrv_addr.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_broker_sub_command_builds_core_request() {
+        let cmd = AddBrokerSubCommand::try_parse_from([
+            "addBroker",
+            "-c",
+            " 127.0.0.1:10911 ",
+            "-b",
+            " /tmp/broker.conf ",
+            "-n",
+            " 127.0.0.1:9876 ",
+        ])
+        .unwrap();
+
+        let request = cmd.request().unwrap();
+
+        assert_eq!(request.broker_container_addr().as_str(), "127.0.0.1:10911");
+        assert_eq!(request.broker_config_path().as_str(), "/tmp/broker.conf");
+        assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/container/remove_broker_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/container/remove_broker_sub_command.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_admin_core::core::container::ContainerRemoveBrokerRequest;
+use rocketmq_admin_core::core::container::ContainerService;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::ToolsError;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct RemoveBrokerSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(
+        short = 'c',
+        long = "brokerContainerAddr",
+        required = true,
+        help = "Broker container address"
+    )]
+    broker_container_addr: String,
+
+    #[arg(
+        short = 'b',
+        long = "brokerIdentity",
+        required = true,
+        help = "Information to identify a broker: clusterName:brokerName:brokerId"
+    )]
+    broker_identity: String,
+}
+
+impl CommandExecute for RemoveBrokerSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let result = ContainerService::remove_broker_by_request_with_rpc_hook(self.request()?, rpc_hook).await?;
+        println!("remove broker from {} success", result.broker_container_addr);
+        Ok(())
+    }
+}
+
+impl RemoveBrokerSubCommand {
+    fn request(&self) -> RocketMQResult<ContainerRemoveBrokerRequest> {
+        let (cluster_name, broker_name, broker_id) = parse_broker_identity(&self.broker_identity)?;
+        ContainerRemoveBrokerRequest::try_new(self.broker_container_addr.clone(), cluster_name, broker_name, broker_id)
+            .map(|request| request.with_optional_namesrv_addr(self.common_args.namesrv_addr.clone()))
+    }
+}
+
+fn parse_broker_identity(value: &str) -> RocketMQResult<(String, String, i64)> {
+    let parts = value.split(':').map(str::trim).collect::<Vec<_>>();
+    if parts.len() != 3 || parts.iter().any(|part| part.is_empty()) {
+        return Err(ToolsError::validation_error(
+            "brokerIdentity",
+            "brokerIdentity must be formatted as clusterName:brokerName:brokerId",
+        )
+        .into());
+    }
+
+    let broker_id = parts[2].parse::<i64>().map_err(|_| {
+        ToolsError::validation_error(
+            "brokerIdentity",
+            format!("brokerIdentity contains invalid brokerId: {}", parts[2]),
+        )
+    })?;
+
+    Ok((parts[0].to_string(), parts[1].to_string(), broker_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remove_broker_sub_command_builds_core_request() {
+        let cmd = RemoveBrokerSubCommand::try_parse_from([
+            "removeBroker",
+            "-c",
+            " 127.0.0.1:10911 ",
+            "-b",
+            " DefaultCluster : broker-a : 1 ",
+            "-n",
+            " 127.0.0.1:9876 ",
+        ])
+        .unwrap();
+
+        let request = cmd.request().unwrap();
+
+        assert_eq!(request.broker_container_addr().as_str(), "127.0.0.1:10911");
+        assert_eq!(request.cluster_name().as_str(), "DefaultCluster");
+        assert_eq!(request.broker_name().as_str(), "broker-a");
+        assert_eq!(request.broker_id(), 1);
+        assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+    }
+
+    #[test]
+    fn remove_broker_sub_command_rejects_invalid_identity() {
+        let cmd =
+            RemoveBrokerSubCommand::try_parse_from(["removeBroker", "-c", "127.0.0.1:10911", "-b", "cluster:broker"])
+                .unwrap();
+        assert!(cmd.request().is_err());
+
+        let cmd = RemoveBrokerSubCommand::try_parse_from([
+            "removeBroker",
+            "-c",
+            "127.0.0.1:10911",
+            "-b",
+            "cluster:broker:bad",
+        ])
+        .unwrap();
+        assert!(cmd.request().is_err());
+    }
+
+    #[test]
+    fn remove_broker_sub_command_rejects_negative_broker_id() {
+        let cmd = RemoveBrokerSubCommand::try_parse_from([
+            "removeBroker",
+            "-c",
+            "127.0.0.1:10911",
+            "-b",
+            "cluster:broker:-1",
+        ])
+        .unwrap();
+        assert!(cmd.request().is_err());
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/controller.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/controller.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod clean_broker_metadata_sub_command;
+mod elect_master_sub_command;
 mod get_controller_config_sub_command;
 mod get_controller_metadata_sub_command;
 mod update_controller_config_sub_command;
@@ -25,6 +26,7 @@ use rocketmq_remoting::runtime::RPCHook;
 
 use crate::commands::CommandExecute;
 use crate::commands::controller::clean_broker_metadata_sub_command::CleanBrokerMetadataSubCommand;
+use crate::commands::controller::elect_master_sub_command::ElectMasterSubCommand;
 use crate::commands::controller::get_controller_config_sub_command::GetControllerConfigSubCommand;
 use crate::commands::controller::get_controller_metadata_sub_command::GetControllerMetadataSubCommand;
 use crate::commands::controller::update_controller_config_sub_command::UpdateControllerConfigSubCommand;
@@ -39,6 +41,13 @@ pub enum ControllerCommands {
     CleanBrokerMetadata(CleanBrokerMetadataSubCommand),
 
     #[command(
+        name = "electMaster",
+        about = "Re-elect the specified broker as master.",
+        long_about = None,
+    )]
+    ElectMaster(ElectMasterSubCommand),
+
+    #[command(
         name = "getControllerConfig",
         about = "Get configuration of controller(s)",
         long_about = None,
@@ -46,7 +55,8 @@ pub enum ControllerCommands {
     GetControllerConfig(GetControllerConfigSubCommand),
 
     #[command(
-        name = "getControllerMetadata",
+        name = "getControllerMetaData",
+        visible_alias = "getControllerMetadata",
         about = "Get meta data of controller",
         long_about = None,
     )]
@@ -64,6 +74,7 @@ impl CommandExecute for ControllerCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             ControllerCommands::CleanBrokerMetadata(cmd) => cmd.execute(rpc_hook).await,
+            ControllerCommands::ElectMaster(value) => value.execute(rpc_hook).await,
             ControllerCommands::GetControllerConfig(value) => value.execute(rpc_hook).await,
             ControllerCommands::GetControllerMetadata(value) => value.execute(rpc_hook).await,
             ControllerCommands::UpdateControllerConfig(value) => value.execute(rpc_hook).await,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/controller/elect_master_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/controller/elect_master_sub_command.rs
@@ -1,0 +1,158 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_admin_core::core::controller::ControllerElectMasterRequest;
+use rocketmq_admin_core::core::controller::ControllerElectMasterResult;
+use rocketmq_admin_core::core::controller::ControllerService;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+#[derive(Debug, Clone, Parser)]
+pub struct ElectMasterSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(
+        short = 'a',
+        long = "controllerAddress",
+        required = true,
+        help = "The address of controller"
+    )]
+    controller_address: String,
+
+    #[arg(
+        short = 'b',
+        long = "brokerId",
+        required = true,
+        allow_hyphen_values = true,
+        help = "The id of the broker which requires to become master"
+    )]
+    broker_id: i64,
+
+    #[arg(
+        long = "brokerName",
+        visible_alias = "bn",
+        required = true,
+        help = "The broker name of the replicas that require to be manipulated"
+    )]
+    broker_name: String,
+
+    #[arg(
+        short = 'c',
+        long = "clusterName",
+        required = true,
+        help = "The clusterName of broker"
+    )]
+    cluster_name: String,
+}
+
+impl CommandExecute for ElectMasterSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let result = ControllerService::elect_master_by_request_with_rpc_hook(self.request()?, rpc_hook).await?;
+        Self::print_result(&result);
+        Ok(())
+    }
+}
+
+impl ElectMasterSubCommand {
+    fn request(&self) -> RocketMQResult<ControllerElectMasterRequest> {
+        ControllerElectMasterRequest::try_new(
+            self.controller_address.clone(),
+            self.cluster_name.clone(),
+            self.broker_name.clone(),
+            self.broker_id,
+        )
+        .map(|request| request.with_optional_namesrv_addr(self.common_args.namesrv_addr.clone()))
+    }
+
+    fn print_result(result: &ControllerElectMasterResult) {
+        let meta_data = &result.response_header;
+        let broker_member_group = &result.broker_member_group;
+
+        println!("\n#ClusterName\t{}", broker_member_group.cluster);
+        println!("#BrokerName\t{}", broker_member_group.broker_name);
+        println!(
+            "#BrokerMasterAddr\t{}",
+            meta_data
+                .master_address
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_default()
+        );
+        println!("#MasterEpoch\t{}", meta_data.master_epoch.unwrap_or_default());
+        println!(
+            "#SyncStateSetEpoch\t{}",
+            meta_data.sync_state_set_epoch.unwrap_or_default()
+        );
+
+        for (broker_id, broker_addr) in &broker_member_group.broker_addrs {
+            println!("\t#Broker\t{}\t{}", broker_id, broker_addr);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn elect_master_sub_command_builds_core_request() {
+        let cmd = ElectMasterSubCommand::try_parse_from([
+            "electMaster",
+            "-a",
+            " 127.0.0.1:9878 ",
+            "-b",
+            "1",
+            "--brokerName",
+            " broker-a ",
+            "-c",
+            " DefaultCluster ",
+            "-n",
+            " 127.0.0.1:9876 ",
+        ])
+        .unwrap();
+
+        let request = cmd.request().unwrap();
+
+        assert_eq!(request.controller_addr().as_str(), "127.0.0.1:9878");
+        assert_eq!(request.broker_id(), 1);
+        assert_eq!(request.broker_name().as_str(), "broker-a");
+        assert_eq!(request.cluster_name().as_str(), "DefaultCluster");
+        assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+    }
+
+    #[test]
+    fn elect_master_sub_command_rejects_negative_broker_id() {
+        let cmd = ElectMasterSubCommand::try_parse_from([
+            "electMaster",
+            "-a",
+            "127.0.0.1:9878",
+            "-b",
+            "-1",
+            "--brokerName",
+            "broker-a",
+            "-c",
+            "DefaultCluster",
+        ])
+        .unwrap();
+
+        assert!(cmd.request().is_err());
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/controller/get_controller_metadata_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/controller/get_controller_metadata_sub_command.rs
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn get_controller_metadata_sub_command_parse_request() {
-        let cmd = GetControllerMetadataSubCommand::try_parse_from(["getControllerMetadata", "-a", " 127.0.0.1:9878 "])
+        let cmd = GetControllerMetadataSubCommand::try_parse_from(["getControllerMetaData", "-a", " 127.0.0.1:9878 "])
             .unwrap();
 
         assert_eq!(cmd.request().unwrap().controller_addr().as_str(), "127.0.0.1:9878");

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/export.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/export.rs
@@ -15,7 +15,9 @@
 mod export_configs_sub_command;
 mod export_metadata_in_rocks_db_sub_command;
 mod export_metadata_sub_command;
+mod export_metrics_sub_command;
 mod export_pop_record_sub_command;
+mod rocksdb_config_to_json_sub_command;
 
 use std::sync::Arc;
 
@@ -27,7 +29,9 @@ use crate::commands::CommandExecute;
 use crate::commands::export::export_configs_sub_command::ExportConfigsSubCommand;
 use crate::commands::export::export_metadata_in_rocks_db_sub_command::ExportMetadataInRocksDBSubCommand;
 use crate::commands::export::export_metadata_sub_command::ExportMetadataSubCommand;
+use crate::commands::export::export_metrics_sub_command::ExportMetricsSubCommand;
 use crate::commands::export::export_pop_record_sub_command::ExportPopRecordSubCommand;
+use crate::commands::export::rocksdb_config_to_json_sub_command::RocksDBConfigToJsonSubCommand;
 
 #[derive(Subcommand)]
 pub enum ExportCommands {
@@ -37,6 +41,13 @@ pub enum ExportCommands {
         long_about = None,
     )]
     ExportConfigs(ExportConfigsSubCommand),
+
+    #[command(
+        name = "exportMetrics",
+        about = "Export metrics.",
+        long_about = None,
+    )]
+    ExportMetrics(ExportMetricsSubCommand),
 
     #[command(
         name = "exportMetadataInRocksDB",
@@ -58,15 +69,24 @@ pub enum ExportCommands {
         long_about = None,
     )]
     ExportPopRecord(ExportPopRecordSubCommand),
+
+    #[command(
+        name = "rocksDBConfigToJson",
+        about = "Convert RocksDB kv config to json.",
+        long_about = None,
+    )]
+    RocksDBConfigToJson(RocksDBConfigToJsonSubCommand),
 }
 
 impl CommandExecute for ExportCommands {
     async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
         match self {
             ExportCommands::ExportConfigs(cmd) => cmd.execute(rpc_hook).await,
+            ExportCommands::ExportMetrics(cmd) => cmd.execute(rpc_hook).await,
             ExportCommands::ExportMetadataInRocksDB(cmd) => cmd.execute(rpc_hook).await,
             ExportCommands::ExportMetadata(cmd) => cmd.execute(rpc_hook).await,
             ExportCommands::ExportPopRecord(cmd) => cmd.execute(rpc_hook).await,
+            ExportCommands::RocksDBConfigToJson(cmd) => cmd.execute(rpc_hook).await,
         }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/export/export_metrics_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/export/export_metrics_sub_command.rs
@@ -1,0 +1,116 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_admin_core::core::export_data::ExportMetricsRequest;
+use rocketmq_admin_core::core::export_data::ExportService;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
+
+const DEFAULT_FILE_PATH: &str = "/tmp/rocketmq/export";
+
+#[derive(Debug, Clone, Parser)]
+pub struct ExportMetricsSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
+    #[arg(
+        short = 'c',
+        long = "clusterName",
+        required = true,
+        help = "choose a cluster to export"
+    )]
+    cluster_name: String,
+
+    #[arg(
+        short = 'f',
+        long = "filePath",
+        required = false,
+        default_value = DEFAULT_FILE_PATH,
+        help = "export metrics.json path | default /tmp/rocketmq/export"
+    )]
+    file_path: String,
+}
+
+impl CommandExecute for ExportMetricsSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        let result = ExportService::export_metrics_by_request_with_rpc_hook(self.request()?, rpc_hook).await?;
+        let output_path = self.output_path();
+        let json_content = serde_json::to_string_pretty(&result)
+            .map_err(|error| RocketMQError::Internal(format!("ExportMetricsSubCommand: {error}")))?;
+        rocketmq_common::FileUtils::string_to_file(&json_content, &output_path)?;
+        println!("export {} success", output_path);
+        Ok(())
+    }
+}
+
+impl ExportMetricsSubCommand {
+    fn request(&self) -> RocketMQResult<ExportMetricsRequest> {
+        ExportMetricsRequest::try_new(self.cluster_name.clone())
+            .map(|request| request.with_optional_namesrv_addr(self.common_args.namesrv_addr.clone()))
+    }
+
+    fn output_path(&self) -> String {
+        Path::new(self.file_path.trim())
+            .join("metrics.json")
+            .to_string_lossy()
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_metrics_sub_command_builds_core_request() {
+        let cmd = ExportMetricsSubCommand::try_parse_from([
+            "exportMetrics",
+            "-c",
+            " DefaultCluster ",
+            "-n",
+            " 127.0.0.1:9876 ",
+            "-f",
+            " C:/tmp/export ",
+        ])
+        .unwrap();
+
+        let request = cmd.request().unwrap();
+
+        assert_eq!(request.cluster_name().as_str(), "DefaultCluster");
+        assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+        assert!(
+            cmd.output_path()
+                .replace('\\', "/")
+                .ends_with("C:/tmp/export/metrics.json")
+        );
+    }
+
+    #[test]
+    fn export_metrics_sub_command_uses_java_default_path() {
+        let cmd = ExportMetricsSubCommand::try_parse_from(["exportMetrics", "-c", "DefaultCluster"]).unwrap();
+
+        assert_eq!(
+            cmd.output_path().replace('\\', "/"),
+            "/tmp/rocketmq/export/metrics.json"
+        );
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/export/rocksdb_config_to_json_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/export/rocksdb_config_to_json_sub_command.rs
@@ -1,0 +1,375 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use rocketmq_admin_core::core::export_data::ExportFileOverwritePolicy;
+use rocketmq_admin_core::core::export_data::ExportFileWriteRequest;
+use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbConfigType;
+use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbRequest;
+use rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbResult;
+use rocketmq_admin_core::core::export_data::ExportRocksDbConfigRpcRequest;
+use rocketmq_admin_core::core::export_data::ExportRocksDbConfigRpcResult;
+use rocketmq_admin_core::core::export_data::ExportService;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::ToolsError;
+use rocketmq_remoting::runtime::RPCHook;
+
+use crate::commands::CommandExecute;
+
+const ALL_ROCKSDB_CONFIG_TYPES: &str = "topics;subscriptionGroups;consumerOffsets";
+
+#[derive(Debug, Clone, Parser)]
+pub struct RocksDBConfigToJsonSubCommand {
+    #[arg(
+        short = 't',
+        long = "configType",
+        required = false,
+        help = "Name of kv config, e.g. topics/subscriptionGroups/consumerOffsets. Required in local mode and default \
+                all in rpc mode."
+    )]
+    config_type: Option<String>,
+
+    #[arg(
+        short = 'p',
+        long = "configPath",
+        required = false,
+        help = "[local mode] Absolute path to the metadata config directory"
+    )]
+    config_path: Option<String>,
+
+    #[arg(
+        short = 'e',
+        long = "exportFile",
+        required = false,
+        help = "[local mode] Absolute file path for exporting. If provided, jsonEnable is ignored."
+    )]
+    export_file: Option<String>,
+
+    #[arg(
+        short = 'j',
+        long = "jsonEnable",
+        required = false,
+        default_value_t = true,
+        action = clap::ArgAction::Set,
+        help = "[local mode] Json format enable, Default: true"
+    )]
+    json_enable: bool,
+
+    #[arg(
+        short = 'n',
+        long = "nameserverAddr",
+        visible_alias = "namesrvAddr",
+        required = false,
+        help = "[rpc mode] nameserverAddr. If nameserverAddr and cluster are provided, cluster mode is used."
+    )]
+    nameserver_addr: Option<String>,
+
+    #[arg(short = 'c', long = "cluster", required = false, help = "[rpc mode] Cluster name")]
+    cluster: Option<String>,
+
+    #[arg(
+        short = 'b',
+        long = "brokerAddr",
+        required = false,
+        help = "[rpc mode] Broker address"
+    )]
+    broker_addr: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+enum RocksDBConfigToJsonMode {
+    Local {
+        request: ExportMetadataInRocksDbRequest,
+        export_file: Option<String>,
+    },
+    Rpc(ExportRocksDbConfigRpcRequest),
+}
+
+impl CommandExecute for RocksDBConfigToJsonSubCommand {
+    async fn execute(&self, rpc_hook: Option<Arc<dyn RPCHook>>) -> RocketMQResult<()> {
+        match self.mode()? {
+            RocksDBConfigToJsonMode::Local { request, export_file } => {
+                println!("Use [local mode] load rocksdb to print or export file");
+                let result = ExportService::export_metadata_in_rocksdb_by_request(&request)?;
+                Self::handle_local_result(&result, export_file.as_deref())
+            }
+            RocksDBConfigToJsonMode::Rpc(request) => {
+                println!("Use [rpc mode] call broker(s) to export to json file");
+                let result =
+                    ExportService::export_rocksdb_config_rpc_by_request_with_rpc_hook(request, rpc_hook).await?;
+                Self::print_rpc_result(&result);
+                Ok(())
+            }
+        }
+    }
+}
+
+impl RocksDBConfigToJsonSubCommand {
+    fn mode(&self) -> RocketMQResult<RocksDBConfigToJsonMode> {
+        if let Some(nameserver_addr) = trim_optional(&self.nameserver_addr) {
+            let cluster = trim_optional(&self.cluster).ok_or_else(|| {
+                ToolsError::validation_error("cluster", "rpc mode with nameserverAddr requires cluster")
+            })?;
+            let request = ExportRocksDbConfigRpcRequest::try_new(Some(cluster), None, self.rpc_config_types(), None)?
+                .with_optional_namesrv_addr(Some(nameserver_addr));
+            return Ok(RocksDBConfigToJsonMode::Rpc(request));
+        }
+
+        if let Some(broker_addr) = trim_optional(&self.broker_addr) {
+            let request =
+                ExportRocksDbConfigRpcRequest::try_new(None, Some(broker_addr), self.rpc_config_types(), None)?;
+            return Ok(RocksDBConfigToJsonMode::Rpc(request));
+        }
+
+        if let Some(config_path) = trim_optional(&self.config_path) {
+            let config_type = trim_optional(&self.config_type)
+                .ok_or_else(|| ToolsError::validation_error("configType", "local mode requires configType"))?;
+            return Ok(RocksDBConfigToJsonMode::Local {
+                request: ExportMetadataInRocksDbRequest::new(config_path, config_type, self.json_enable),
+                export_file: trim_optional(&self.export_file),
+            });
+        }
+
+        Err(ToolsError::validation_error("mode", "provide nameserverAddr+cluster, brokerAddr, or configPath").into())
+    }
+
+    fn rpc_config_types(&self) -> String {
+        trim_optional(&self.config_type).unwrap_or_else(|| ALL_ROCKSDB_CONFIG_TYPES.to_string())
+    }
+
+    fn handle_local_result(result: &ExportMetadataInRocksDbResult, export_file: Option<&str>) -> RocketMQResult<()> {
+        if let Some(export_file) = export_file {
+            if let Some(json_value) = Self::local_result_json_value(result)? {
+                let request = ExportFileWriteRequest::try_new(export_file, ExportFileOverwritePolicy::Overwrite)?;
+                let write_result = ExportService::write_json_export_file(&request, &json_value)?;
+                println!("export {} success", write_result.output_path().display());
+                return Ok(());
+            }
+        }
+
+        Self::print_local_result(result)
+    }
+
+    fn print_local_result(result: &ExportMetadataInRocksDbResult) -> RocketMQResult<()> {
+        match result {
+            ExportMetadataInRocksDbResult::InvalidPath => {
+                println!("Rocksdb path is invalid.");
+            }
+            ExportMetadataInRocksDbResult::InvalidConfigType { config_type } => {
+                println!(
+                    "Invalid configType: {} please input topics/subscriptionGroups/consumerOffsets",
+                    config_type
+                );
+            }
+            ExportMetadataInRocksDbResult::Data {
+                config_type,
+                json_enable,
+                entries,
+            } if *json_enable => {
+                let json_value = Self::entries_json_value(*config_type, entries)?;
+                let json = serde_json::to_string_pretty(&json_value)
+                    .map_err(|error| RocketMQError::Internal(format!("RocksDBConfigToJsonSubCommand: {error}")))?;
+                println!("{json}");
+            }
+            ExportMetadataInRocksDbResult::Data {
+                config_type, entries, ..
+            } => {
+                println!("type: {}", config_type.type_name());
+                for (index, entry) in entries.iter().enumerate() {
+                    println!("{}, Key: {}, Value: {}", index + 1, entry.key, entry.value);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn local_result_json_value(result: &ExportMetadataInRocksDbResult) -> RocketMQResult<Option<serde_json::Value>> {
+        match result {
+            ExportMetadataInRocksDbResult::Data {
+                config_type, entries, ..
+            } => Self::entries_json_value(*config_type, entries).map(Some),
+            ExportMetadataInRocksDbResult::InvalidPath | ExportMetadataInRocksDbResult::InvalidConfigType { .. } => {
+                Self::print_local_result(result)?;
+                Ok(None)
+            }
+        }
+    }
+
+    fn entries_json_value(
+        config_type: ExportMetadataInRocksDbConfigType,
+        entries: &[rocketmq_admin_core::core::export_data::ExportMetadataInRocksDbEntry],
+    ) -> RocketMQResult<serde_json::Value> {
+        let mut config_table = serde_json::Map::new();
+        for entry in entries {
+            let value = serde_json::from_str::<serde_json::Value>(&entry.value)
+                .unwrap_or_else(|_| serde_json::Value::String(entry.value.clone()));
+            config_table.insert(entry.key.clone(), value);
+        }
+
+        let mut root = serde_json::Map::new();
+        root.insert(
+            config_type.table_key().to_string(),
+            serde_json::Value::Object(config_table),
+        );
+        Ok(serde_json::Value::Object(root))
+    }
+
+    fn print_rpc_result(result: &ExportRocksDbConfigRpcResult) {
+        for target in &result.targets {
+            if let Some(error) = &target.error {
+                eprintln!(
+                    "{} export error: {}",
+                    if target.broker_name.is_empty() {
+                        target.broker_addr.as_str()
+                    } else {
+                        target.broker_name.as_str()
+                    },
+                    error
+                );
+            } else {
+                println!(
+                    "{} export done.",
+                    if target.broker_name.is_empty() {
+                        target.broker_addr.as_str()
+                    } else {
+                        target.broker_name.as_str()
+                    }
+                );
+            }
+        }
+        println!("broker export done.");
+    }
+}
+
+fn trim_optional(value: &Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocketmq_admin_core::core::export_data::ExportRocksDbConfigRpcTarget;
+
+    #[test]
+    fn rocksdb_config_to_json_builds_local_request_with_export_file() {
+        let cmd = RocksDBConfigToJsonSubCommand::try_parse_from([
+            "rocksDBConfigToJson",
+            "-p",
+            " /tmp/metadata ",
+            "-t",
+            " topics ",
+            "-e",
+            " /tmp/topics.json ",
+            "-j",
+            "false",
+        ])
+        .unwrap();
+
+        match cmd.mode().unwrap() {
+            RocksDBConfigToJsonMode::Local { request, export_file } => {
+                assert_eq!(request.path().to_string_lossy(), "/tmp/metadata");
+                assert_eq!(request.config_type(), "topics");
+                assert!(!request.json_enable());
+                assert_eq!(export_file.as_deref(), Some("/tmp/topics.json"));
+            }
+            RocksDBConfigToJsonMode::Rpc(_) => panic!("expected local mode"),
+        }
+    }
+
+    #[test]
+    fn rocksdb_config_to_json_local_mode_requires_config_type() {
+        let cmd =
+            RocksDBConfigToJsonSubCommand::try_parse_from(["rocksDBConfigToJson", "-p", "/tmp/metadata"]).unwrap();
+
+        assert!(cmd.mode().is_err());
+    }
+
+    #[test]
+    fn rocksdb_config_to_json_builds_rpc_cluster_request_and_defaults_all_types() {
+        let cmd = RocksDBConfigToJsonSubCommand::try_parse_from([
+            "rocksDBConfigToJson",
+            "-n",
+            " 127.0.0.1:9876 ",
+            "-c",
+            " DefaultCluster ",
+            "-b",
+            " 127.0.0.1:10911 ",
+            "-p",
+            " /tmp/metadata ",
+        ])
+        .unwrap();
+
+        match cmd.mode().unwrap() {
+            RocksDBConfigToJsonMode::Rpc(request) => {
+                assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
+                assert_eq!(
+                    request.target(),
+                    &ExportRocksDbConfigRpcTarget::Cluster("DefaultCluster".into())
+                );
+                assert_eq!(
+                    request.config_types(),
+                    &[
+                        ExportMetadataInRocksDbConfigType::Topics,
+                        ExportMetadataInRocksDbConfigType::SubscriptionGroups,
+                        ExportMetadataInRocksDbConfigType::ConsumerOffsets,
+                    ]
+                );
+            }
+            RocksDBConfigToJsonMode::Local { .. } => panic!("expected rpc mode"),
+        }
+    }
+
+    #[test]
+    fn rocksdb_config_to_json_builds_rpc_broker_request() {
+        let cmd = RocksDBConfigToJsonSubCommand::try_parse_from([
+            "rocksDBConfigToJson",
+            "-b",
+            " 127.0.0.1:10911 ",
+            "-t",
+            " topics;consumerOffsets ",
+        ])
+        .unwrap();
+
+        match cmd.mode().unwrap() {
+            RocksDBConfigToJsonMode::Rpc(request) => {
+                assert_eq!(
+                    request.target(),
+                    &ExportRocksDbConfigRpcTarget::Broker("127.0.0.1:10911".into())
+                );
+                assert_eq!(
+                    request.config_types(),
+                    &[
+                        ExportMetadataInRocksDbConfigType::Topics,
+                        ExportMetadataInRocksDbConfigType::ConsumerOffsets,
+                    ]
+                );
+            }
+            RocksDBConfigToJsonMode::Local { .. } => panic!("expected rpc mode"),
+        }
+    }
+
+    #[test]
+    fn rocksdb_config_to_json_rejects_missing_mode() {
+        let cmd = RocksDBConfigToJsonSubCommand::try_parse_from(["rocksDBConfigToJson"]).unwrap();
+
+        assert!(cmd.mode().is_err());
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/message.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/message.rs
@@ -76,7 +76,8 @@ pub enum MessageCommands {
     DumpCompactionLog(DumpCompactionLogSubCommand),
 
     #[command(
-        name = "printMessage",
+        name = "printMsg",
+        visible_alias = "printMessage",
         about = "Print Message Detail.",
         long_about = None,
     )]
@@ -118,6 +119,7 @@ pub enum MessageCommands {
 
     #[command(
         name = "queryMsgTraceById",
+        visible_alias = "QueryMsgTraceById",
         about = "Query message trace by message ID.",
         long_about = None,
     )]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/message/consume_message_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/message/consume_message_sub_command.rs
@@ -130,10 +130,10 @@ impl CommandExecute for ConsumeMessageSubCommand {
                 MessagePullEvent::ConsumeOk => println!("Consume ok"),
                 MessagePullEvent::Messages { messages } => Self::print_messages(&messages),
                 MessagePullEvent::NoMatched { mq, status, offset } => {
-                    println!("{} no matched msg. status={:?}, offset={}", mq, status, offset)
+                    println!("{} no matched msg. status={}, offset={}", mq, status, offset)
                 }
                 MessagePullEvent::Finished { mq, status, offset } => {
-                    println!("{} print msg finished. status={:?}, offset={}", mq, status, offset)
+                    println!("{} print msg finished. status={}, offset={}", mq, status, offset)
                 }
                 MessagePullEvent::PullError { error } => eprintln!("{}", error),
                 MessagePullEvent::OffsetNotMatched { mq, offset } => {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/stats/stats_all_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/stats/stats_all_sub_command.rs
@@ -23,9 +23,13 @@ use rocketmq_remoting::runtime::RPCHook;
 use tracing::warn;
 
 use crate::commands::CommandExecute;
+use crate::commands::CommonArgs;
 
 #[derive(Debug, Clone, Parser)]
 pub struct StatsAllSubCommand {
+    #[command(flatten)]
+    common_args: CommonArgs,
+
     #[arg(
         short = 'a',
         long = "activeTopic",
@@ -41,6 +45,7 @@ pub struct StatsAllSubCommand {
 impl StatsAllSubCommand {
     fn request(&self) -> StatsAllQueryRequest {
         StatsAllQueryRequest::new(self.active_topic, self.topic.clone())
+            .with_optional_namesrv_addr(self.common_args.namesrv_addr.clone())
     }
 
     fn print_row(row: &StatsAllRow) {
@@ -98,11 +103,13 @@ mod tests {
 
     #[test]
     fn stats_all_sub_command_builds_core_request() {
-        let cmd = StatsAllSubCommand::try_parse_from(["statsAll", "-a", "-t", " TopicA "]).unwrap();
+        let cmd =
+            StatsAllSubCommand::try_parse_from(["statsAll", "-a", "-t", " TopicA ", "-n", " 127.0.0.1:9876 "]).unwrap();
 
         let request = cmd.request();
 
         assert!(request.active_topic());
         assert_eq!(request.topic().map(|topic| topic.as_str()), Some("TopicA"));
+        assert_eq!(request.namesrv_addr(), Some("127.0.0.1:9876"));
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/topic_status_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/topic/topic_status_sub_command.rs
@@ -50,24 +50,31 @@ impl CommandExecute for TopicStatusSubCommand {
         let mut mq_list: Vec<_> = offset_table.keys().cloned().collect();
         mq_list.sort();
 
-        println!("#Broker Name #QID #Min Offset #Max Offset #Last Updated");
+        println!(
+            "{:<32}  {:<4}  {:<20}  {:<20}    #Last Updated",
+            "#Broker Name", "#QID", "#Min Offset", "#Max Offset"
+        );
 
         for queue in &mq_list {
-            let topic_offset = offset_table.get(queue);
-            if let Some(offset) = topic_offset {
-                if offset.get_last_update_timestamp() > 0 {
-                    let human_timestamp = time_millis_to_human_string2(offset.get_last_update_timestamp());
-                    println!(
-                        "{}  {}  {}  {}  {}",
-                        queue.broker_name(),
-                        queue.queue_id(),
-                        offset.get_min_offset(),
-                        offset.get_max_offset(),
-                        human_timestamp
-                    );
-                }
+            if let Some(offset) = offset_table.get(queue) {
+                let human_timestamp = if offset.get_last_update_timestamp() > 0 {
+                    time_millis_to_human_string2(offset.get_last_update_timestamp())
+                } else {
+                    String::new()
+                };
+                println!(
+                    "{:<32}  {:<4}  {:<20}  {:<20}    {}",
+                    queue.broker_name(),
+                    queue.queue_id(),
+                    offset.get_min_offset(),
+                    offset.get_max_offset(),
+                    human_timestamp
+                );
             }
         }
+
+        println!();
+        println!("Topic Put TPS: {:?}", topic_status.get_topic_put_tps());
 
         Ok(())
     }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
@@ -12,19 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::Parser;
 use rocketmq_admin_cli::rocketmq_cli::RocketMQCli;
 use rocketmq_common::EnvUtils::EnvUtils;
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_remoting::protocol::remoting_command;
 
-#[rocketmq_rust::main]
-async fn main() {
+const CLI_RUNTIME_STACK_SIZE: usize = 16 * 1024 * 1024;
+
+fn main() {
+    let handle = std::thread::Builder::new()
+        .name("rocketmq-admin-cli-main".to_string())
+        .stack_size(CLI_RUNTIME_STACK_SIZE)
+        .spawn(|| {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .thread_stack_size(CLI_RUNTIME_STACK_SIZE)
+                .build()
+                .expect("failed to build rocketmq-admin-cli runtime");
+            runtime.block_on(async_main());
+        })
+        .expect("failed to spawn rocketmq-admin-cli main thread");
+
+    if let Err(payload) = handle.join() {
+        std::panic::resume_unwind(payload);
+    }
+}
+
+async fn async_main() {
     EnvUtils::put_property(
         remoting_command::REMOTING_VERSION_KEY,
         (CURRENT_VERSION as u32).to_string(),
     );
 
-    let cli = RocketMQCli::parse();
+    let cli = RocketMQCli::parse_from_java_compatible_args();
     cli.handle().await;
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/rocketmq_cli.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/rocketmq_cli.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ffi::OsString;
+
 use clap::CommandFactory;
 use clap::Parser;
 use clap_complete::generate;
@@ -38,6 +40,10 @@ pub struct RocketMQCli {
 }
 
 impl RocketMQCli {
+    pub fn parse_from_java_compatible_args() -> Self {
+        Self::parse_from(normalize_java_compatible_args(std::env::args_os()))
+    }
+
     pub async fn handle(&self) {
         if let Some(shell) = &self.completion {
             let mut cmd = RocketMQCli::command();
@@ -69,5 +75,39 @@ impl RocketMQCli {
         } else {
             eprintln!("No command specified. Use --help for usage information.");
         }
+    }
+}
+
+fn normalize_java_compatible_args<I>(args: I) -> Vec<OsString>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    args.into_iter()
+        .map(|arg| {
+            if arg == "-bn" {
+                OsString::from("--brokerName")
+            } else {
+                arg
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_java_compatible_args;
+    use std::ffi::OsString;
+
+    #[test]
+    fn normalizes_java_multi_character_short_broker_name_option() {
+        let args = normalize_java_compatible_args([
+            OsString::from("rocketmq-admin-cli"),
+            OsString::from("controller"),
+            OsString::from("electMaster"),
+            OsString::from("-bn"),
+            OsString::from("broker-a"),
+        ]);
+
+        assert_eq!(args[3], OsString::from("--brokerName"));
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/tests/cli_help.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/tests/cli_help.rs
@@ -99,3 +99,119 @@ fn broker_help_exposes_update_broker_config_slice() {
         "broker help should expose broker config query command, got: {stdout}"
     );
 }
+
+#[test]
+fn container_help_exposes_java_container_commands() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rocketmq-admin-cli"))
+        .args(["container", "--help"])
+        .output()
+        .expect("run rocketmq-admin-cli container --help");
+
+    assert!(
+        output.status.success(),
+        "expected container help to exit successfully, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for command in ["addBroker", "removeBroker"] {
+        assert!(
+            stdout.contains(command),
+            "container help should expose Java command {command}, got: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn controller_help_exposes_java_controller_commands() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rocketmq-admin-cli"))
+        .args(["controller", "--help"])
+        .output()
+        .expect("run rocketmq-admin-cli controller --help");
+
+    assert!(
+        output.status.success(),
+        "expected controller help to exit successfully, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for command in ["electMaster", "getControllerMetaData"] {
+        assert!(
+            stdout.contains(command),
+            "controller help should expose Java command {command}, got: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn export_help_exposes_java_export_commands() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rocketmq-admin-cli"))
+        .args(["export", "--help"])
+        .output()
+        .expect("run rocketmq-admin-cli export --help");
+
+    assert!(
+        output.status.success(),
+        "expected export help to exit successfully, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for command in ["exportMetrics", "rocksDBConfigToJson"] {
+        assert!(
+            stdout.contains(command),
+            "export help should expose Java command {command}, got: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn java_renamed_commands_keep_old_rust_aliases() {
+    for args in [
+        &["auth", "listUser", "--help"][..],
+        &["auth", "listUsers", "--help"][..],
+        &["message", "printMsg", "--help"][..],
+        &["message", "printMessage", "--help"][..],
+        &["controller", "getControllerMetaData", "--help"][..],
+        &["controller", "getControllerMetadata", "--help"][..],
+        &["message", "QueryMsgTraceById", "--help"][..],
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_rocketmq-admin-cli"))
+            .args(args)
+            .output()
+            .unwrap_or_else(|error| panic!("run rocketmq-admin-cli {args:?}: {error}"));
+
+        assert!(
+            output.status.success(),
+            "expected alias command {args:?} to show help, stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn java_broker_name_short_option_is_normalized_before_clap_parse() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rocketmq-admin-cli"))
+        .args([
+            "controller",
+            "electMaster",
+            "-a",
+            "127.0.0.1:9878",
+            "-b",
+            "1",
+            "-bn",
+            "broker-a",
+            "-c",
+            "DefaultCluster",
+            "--help",
+        ])
+        .output()
+        .expect("run rocketmq-admin-cli controller electMaster -bn ... --help");
+
+    assert!(
+        output.status.success(),
+        "expected -bn normalized help to exit successfully, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/tests/java_parity_inventory.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/tests/java_parity_inventory.rs
@@ -1,0 +1,133 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use clap::CommandFactory;
+use rocketmq_admin_cli::rocketmq_cli::RocketMQCli;
+
+#[test]
+fn java_registered_commands_are_reachable_under_expected_rust_domains() {
+    let command = RocketMQCli::command();
+    let domains = command
+        .get_subcommands()
+        .map(|domain| {
+            (
+                domain.get_name().to_string(),
+                domain
+                    .get_subcommands()
+                    .map(|subcommand| subcommand.get_name().to_string())
+                    .collect::<HashSet<_>>(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    let java_registered_commands = [
+        ("container", "addBroker"),
+        ("nameserver", "addWritePerm"),
+        ("topic", "allocateMQ"),
+        ("broker", "brokerConsumeStats"),
+        ("broker", "brokerStatus"),
+        ("message", "checkMsgSendRT"),
+        ("queue", "checkRocksdbCqWriteProgress"),
+        ("controller", "cleanBrokerMetadata"),
+        ("broker", "cleanExpiredCQ"),
+        ("broker", "cleanUnusedTopic"),
+        ("offset", "cloneGroupOffset"),
+        ("cluster", "clusterList"),
+        ("cluster", "clusterRT"),
+        ("message", "consumeMessage"),
+        ("connection", "consumerConnection"),
+        ("consumer", "consumerProgress"),
+        ("consumer", "consumerStatus"),
+        ("auth", "copyAcl"),
+        ("auth", "copyUser"),
+        ("auth", "createAcl"),
+        ("auth", "createUser"),
+        ("auth", "deleteAcl"),
+        ("broker", "deleteExpiredCommitLog"),
+        ("nameserver", "deleteKvConfig"),
+        ("consumer", "deleteSubGroup"),
+        ("topic", "deleteTopic"),
+        ("auth", "deleteUser"),
+        ("message", "dumpCompactionLog"),
+        ("controller", "electMaster"),
+        ("export", "exportConfigs"),
+        ("export", "exportMetadata"),
+        ("export", "exportMetadataInRocksDB"),
+        ("export", "exportMetrics"),
+        ("export", "exportPopRecord"),
+        ("auth", "getAcl"),
+        ("broker", "getBrokerConfig"),
+        ("broker", "getBrokerEpoch"),
+        ("lite", "getBrokerLiteInfo"),
+        ("broker", "getColdDataFlowCtrInfo"),
+        ("consumer", "getConsumerConfig"),
+        ("controller", "getControllerConfig"),
+        ("controller", "getControllerMetaData"),
+        ("lite", "getLiteClientInfo"),
+        ("lite", "getLiteGroupInfo"),
+        ("lite", "getLiteTopicInfo"),
+        ("nameserver", "getNamesrvConfig"),
+        ("lite", "getParentTopicInfo"),
+        ("ha", "getSyncStateSet"),
+        ("auth", "getUser"),
+        ("ha", "haStatus"),
+        ("auth", "listAcl"),
+        ("auth", "listUser"),
+        ("message", "printMsg"),
+        ("message", "printMsgByQueue"),
+        ("producer", "producer"),
+        ("connection", "producerConnection"),
+        ("queue", "queryCq"),
+        ("message", "queryMsgById"),
+        ("message", "queryMsgByKey"),
+        ("message", "queryMsgByOffset"),
+        ("message", "queryMsgByUniqueKey"),
+        ("message", "queryMsgTraceById"),
+        ("topic", "remappingStaticTopic"),
+        ("container", "removeBroker"),
+        ("broker", "removeColdDataFlowCtrGroupConfig"),
+        ("broker", "resetMasterFlushOffset"),
+        ("offset", "resetOffsetByTime"),
+        ("export", "rocksDBConfigToJson"),
+        ("message", "sendMessage"),
+        ("broker", "sendMsgStatus"),
+        ("broker", "setCommitLogReadAheadMode"),
+        ("consumer", "setConsumeMode"),
+        ("offset", "skipAccumulatedMessage"),
+        ("consumer", "startMonitoring"),
+        ("stats", "statsAll"),
+        ("broker", "switchTimerEngine"),
+        ("topic", "topicClusterList"),
+        ("topic", "topicList"),
+        ("topic", "topicRoute"),
+        ("topic", "topicStatus"),
+        ("lite", "triggerLiteDispatch"),
+        ("auth", "updateAcl"),
+        ("broker", "updateBrokerConfig"),
+        ("broker", "updateColdDataFlowCtrGroupConfig"),
+        ("controller", "updateControllerConfig"),
+        ("nameserver", "updateKvConfig"),
+        ("nameserver", "updateNamesrvConfig"),
+        ("topic", "updateOrderConf"),
+        ("topic", "updateStaticTopic"),
+        ("consumer", "updateSubGroup"),
+        ("consumer", "updateSubGroupList"),
+        ("topic", "updateTopic"),
+        ("topic", "updateTopicList"),
+        ("topic", "updateTopicPerm"),
+        ("auth", "updateUser"),
+        ("nameserver", "wipeWritePerm"),
+    ];
+
+    assert_eq!(java_registered_commands.len(), 96);
+
+    for (domain, command_name) in java_registered_commands {
+        let commands = domains
+            .get(domain)
+            .unwrap_or_else(|| panic!("expected Rust CLI domain {domain} to exist"));
+        assert!(
+            commands.contains(command_name),
+            "expected Java command {command_name} to be reachable under Rust domain {domain}"
+        );
+    }
+}

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/export_data.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/export_data.rs
@@ -979,7 +979,8 @@ impl ExportService {
                 group_size,
             },
             runtime_version: ExportMetricsRuntimeVersion {
-                rocketmq_version: CURRENT_VERSION.name().to_string(),
+                rocketmq_version: kv_value(runtime_stats, "brokerVersionDesc")
+                    .unwrap_or_else(|| CURRENT_VERSION.name().to_string()),
                 client_info: normalize_client_info(client_info),
             },
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/producer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/producer.rs
@@ -342,7 +342,7 @@ impl ProducerService {
                     .as_ref()
                     .map(|mq| mq.queue_id().to_string())
                     .unwrap_or_else(|| "Unknown".to_string()),
-                send_status: format!("{:?}", result.send_status),
+                send_status: result.send_status.to_string(),
                 msg_id: result
                     .msg_id
                     .as_ref()

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/topic/operations.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/topic/operations.rs
@@ -119,15 +119,15 @@ impl TopicService {
             let mut topic_stats_table = rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable::new();
             if let Some(route_data) = &topic_route_data {
                 let mut total_offset_table = HashMap::new();
+                let mut topic_put_tps = 0.0;
                 for broker_data in &route_data.broker_datas {
                     let addr = broker_data.select_broker_addr();
-                    let offset_table = admin
-                        .examine_topic_stats(topic.clone(), addr)
-                        .await?
-                        .into_offset_table();
-                    total_offset_table.extend(offset_table);
+                    let stats = admin.examine_topic_stats(topic.clone(), addr).await?;
+                    topic_put_tps += stats.get_topic_put_tps();
+                    total_offset_table.extend(stats.into_offset_table());
                 }
                 topic_stats_table.set_offset_table(total_offset_table);
+                topic_stats_table.set_topic_put_tps(topic_put_tps);
             }
             Ok(topic_stats_table)
         } else {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/export_core_models.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/tests/export_core_models.rs
@@ -196,6 +196,10 @@ fn export_metrics_report_parses_runtime_quota_like_java() {
         CheetahString::from_static_str("putMessageAverageSize"),
         CheetahString::from_static_str("512"),
     );
+    runtime_stats.table.insert(
+        CheetahString::from_static_str("brokerVersionDesc"),
+        CheetahString::from_static_str("V5_5_0"),
+    );
 
     let broker_config = HashMap::from([(
         CheetahString::from_static_str("clientCallbackExecutorThreads"),
@@ -236,6 +240,7 @@ fn export_metrics_report_parses_runtime_quota_like_java() {
     assert_eq!(report.runtime_quota.one_day_num.schedule_one_day_in_num, 20);
     assert_eq!(report.runtime_quota.topic_size, 12);
     assert_eq!(report.runtime_quota.group_size, 4);
+    assert_eq!(report.runtime_version.rocketmq_version, "V5_5_0");
     assert_eq!(report.runtime_version.client_info, vec!["JAVA%V5_1_0"]);
     assert_eq!(totals.total_tps.total_normal_in_tps, 123.5);
     assert_eq!(totals.total_one_day_num.normal_one_day_out_num, 50);


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7442

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container management commands for broker registration and removal.
  * Added controller master election command.
  * Added export functionality for metrics and RocksDB configuration as JSON.
  * Topic throughput (TPS) metrics now displayed in topic status output.

* **Improvements**
  * Enhanced command aliases for better usability and backward compatibility.
  * Improved output formatting for topic status display with aligned columns.
  * Better Java compatibility for configuration serialization and deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->