### PR TITLE
[ISSUE #7444]add multiple consumer and producer examples; enhance documentation and structure in README

### DIFF
--- a/rocketmq-example/Cargo.toml
+++ b/rocketmq-example/Cargo.toml
@@ -59,6 +59,30 @@ name = "consumer-cluster"
 path = "examples/consumer/consumer_cluster.rs"
 
 [[example]]
+name = "consumer-broadcast"
+path = "examples/consumer/broadcast_consumer.rs"
+
+[[example]]
+name = "consumer-orderly"
+path = "examples/consumer/orderly_consumer.rs"
+
+[[example]]
+name = "consumer-tag-filter"
+path = "examples/consumer/tag_filter_consumer.rs"
+
+[[example]]
+name = "consumer-sql-filter"
+path = "examples/consumer/sql_filter_consumer.rs"
+
+[[example]]
+name = "consumer-lite-pull"
+path = "examples/consumer/lite_pull_consumer.rs"
+
+[[example]]
+name = "consumer-request-reply"
+path = "examples/consumer/request_reply_responder.rs"
+
+[[example]]
 name = "producer-simple"
 path = "examples/producer/producer_simple.rs"
 
@@ -85,6 +109,26 @@ path = "examples/producer/send_with_selector.rs"
 [[example]]
 name = "producer-send-with-selector-advanced"
 path = "examples/producer/send_with_selector_advanced.rs"
+
+[[example]]
+name = "producer-delay-send"
+path = "examples/producer/delay_send.rs"
+
+[[example]]
+name = "producer-order-send"
+path = "examples/producer/order_send.rs"
+
+[[example]]
+name = "producer-transaction-send"
+path = "examples/producer/transaction_send.rs"
+
+[[example]]
+name = "producer-request-send"
+path = "examples/producer/request_send.rs"
+
+[[example]]
+name = "producer-request-callback-send"
+path = "examples/producer/request_callback_send.rs"
 
 [[example]]
 name = "request-code-smoke"

--- a/rocketmq-example/README-zh_cn.md
+++ b/rocketmq-example/README-zh_cn.md
@@ -1,139 +1,102 @@
-# RocketMQ-Rust 示例
+# RocketMQ Rust 示例
 
-展示如何使用 RocketMQ-Rust 客户端 API 和功能的全面示例集合。
+这是 RocketMQ Rust client API 的独立示例项目。
 
-## 📋 概述
+该目录不是根 Cargo workspace 的一部分。所有命令都应在 `rocketmq-example/`
+目录下执行。
 
-这是一个**独立项目**，包含 RocketMQ-Rust 的实用示例。展示了各种使用模式，包括：
+## 前置条件
 
-- **消费者示例**：Push 消费者、Pop 消费者、消息监听器
-- **生产者示例**：*（即将推出）*
-- **管理操作**：*（即将推出）*
+- Rust 1.85.0 或更高版本。
+- 已启动 RocketMQ Namesrv 和 Broker。
+- 示例默认 Namesrv 地址为 `127.0.0.1:9876`。
+- 运行示例前先创建 topic 和 consumer group。示例本身不自动创建 broker 资源。
 
-## 🚀 快速开始
+使用 RocketMQ `mqadmin` 创建 topic 示例：
 
-### 前置要求
-
-- Rust 1.85.0 或更高版本
-- 运行中的 RocketMQ nameserver 和 broker（默认：`127.0.0.1:9876`）
-
-### 运行示例
-
-```bash
-# 进入示例目录
-cd rocketmq-example
-
-# 运行 pop 消费者示例
-cargo run --example pop-consumer
-
-# 列出所有可用示例
-cargo run --example <TAB>
+```powershell
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t BasicSendTestTopic -r 4 -w 4
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t DelaySendTestTopic -r 4 -w 4 -a +message.type=DELAY
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t OrderSendTestTopic -r 4 -w 4 -o true
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t TransactionSendTestTopic -r 4 -w 4 -a +message.type=TRANSACTION
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t RequestSendTestTopic -r 4 -w 4
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t BroadcastConsumerTestTopic -r 4 -w 4
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t TagFilterConsumerTestTopic -r 4 -w 4
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t SqlFilterConsumerTestTopic -r 4 -w 4
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t LitePullConsumerTestTopic -r 4 -w 4
 ```
 
-## 📚 可用示例
+按需创建消费组：
 
-### 消费者示例
-
-#### 集群消费者
-演示如何使用集群模式消费消息，在多个消费者实例之间实现负载均衡。
-
-**文件**：[examples/consumer/consumer_cluster.rs](examples/consumer/consumer_cluster.rs)
-
-**运行**：
-```bash
-cargo run --example consumer-cluster
+```powershell
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_broadcast_group -d true
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_orderly_group -o true
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_tag_filter_group
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_sql_filter_group
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_lite_pull_group
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_request_reply_group
 ```
 
-**功能特性**：
-- 集群模式消费（默认模式）
-- 消费者实例间负载均衡
-- 并发消息处理
-- 每条消息仅被一个实例消费
+## Producer 示例
 
-#### Pop 消费者
-演示如何使用 pop 消费模式并禁用客户端侧负载均衡。
+| 模式 | 示例 | 命令 | Topic | 说明 |
+| --- | --- | --- | --- | --- |
+| 简单发送 | `producer-simple` | `cargo run --example producer-simple` | `TopicTest` | 基础 producer 启动和发送。 |
+| 超时发送 | `producer-with-timeout` | `cargo run --example producer-with-timeout` | `TopicTest` | 已有超时和延迟消息示例。 |
+| 基础发送 API | `producer-basic-send` | `cargo run --example producer-basic-send` | `BasicSendTestTopic` | 同步、超时、callback、callback 超时、one-way。 |
+| 批量发送 | `producer-batch-send` | `cargo run --example producer-batch-send` | `BatchSendTestTopic` | 批量发送各种模式。 |
+| 指定队列发送 | `producer-send-to-queue` | `cargo run --example producer-send-to-queue` | `QueueSendTestTopic` | 发送到指定 message queue。 |
+| 队列选择器 | `producer-send-with-selector` | `cargo run --example producer-send-with-selector` | `SelectorSendTestTopic` | 自定义 queue selector。 |
+| 高级选择器 | `producer-send-with-selector-advanced` | `cargo run --example producer-send-with-selector-advanced` | `AdvancedSelectorTestTopic` | hash、round-robin、random、weighted 示例。 |
+| 延迟发送 | `producer-delay-send` | `cargo run --example producer-delay-send` | `DelaySendTestTopic` | `delay_level`、`delay_secs`、`delay_millis`、`deliver_time_ms`。 |
+| 顺序发送 | `producer-order-send` | `cargo run --example producer-order-send` | `OrderSendTestTopic` | 同一个 order id 路由到同一个队列。 |
+| 事务发送 | `producer-transaction-send` | `cargo run --example producer-transaction-send` | `TransactionSendTestTopic` | commit、rollback、unknown 本地事务状态。 |
+| Request/reply | `producer-request-send` | `cargo run --example producer-request-send` | `RequestSendTestTopic` | 先启动 `consumer-request-reply`。 |
+| Request/reply callback | `producer-request-callback-send` | `cargo run --example producer-request-callback-send` | `RequestSendTestTopic` | 先启动 `consumer-request-reply`。 |
 
-**文件**：[examples/consumer/pop_consumer.rs](examples/consumer/pop_consumer.rs)
+## Consumer 示例
 
-**运行**：
-```bash
-cargo run --example pop-consumer
+| 模式 | 示例 | 命令 | Topic | 说明 |
+| --- | --- | --- | --- | --- |
+| 集群 Push | `consumer-cluster` | `cargo run --example consumer-cluster` | `TopicTest` | 负载均衡消费。 |
+| Pop 消费 | `pop-consumer` | `cargo run --example pop-consumer` | `TopicTest` | Pop request mode 示例。 |
+| 广播 Push | `consumer-broadcast` | `cargo run --example consumer-broadcast` | `BroadcastConsumerTestTopic` | 每个 consumer 实例都会收到消息；消费组必须开启广播消费。 |
+| 顺序 Push | `consumer-orderly` | `cargo run --example consumer-orderly` | `OrderSendTestTopic` | 使用 `MessageListenerOrderly`。 |
+| Tag 过滤 Push | `consumer-tag-filter` | `cargo run --example consumer-tag-filter` | `TagFilterConsumerTestTopic` | 使用 `MessageSelector::by_tag("TagA || TagB")`。 |
+| SQL92 过滤 Push | `consumer-sql-filter` | `cargo run --example consumer-sql-filter` | `SqlFilterConsumerTestTopic` | 使用 `MessageSelector::by_sql`，Broker 需要支持 SQL 过滤。 |
+| Lite Pull | `consumer-lite-pull` | `cargo run --example consumer-lite-pull` | `LitePullConsumerTestTopic` | 主动 poll 消息并手动提交 offset。 |
+| Request/reply responder | `consumer-request-reply` | `cargo run --example consumer-request-reply` | `RequestSendTestTopic` | 为 request producer 示例发送 reply 消息。 |
+
+## 验证
+
+构建单个示例：
+
+```powershell
+cargo build --example producer-delay-send
 ```
 
-**功能特性**：
-- 基于 Pop 的消息消费
-- 并发消息处理
-- 自动创建主题/消费者组
-- 消息请求模式配置
+修改该项目后必须执行：
 
-## 🔧 配置
-
-大多数示例使用默认配置：
-
-```rust
-const NAMESRV_ADDR: &str = "127.0.0.1:9876";
-const TOPIC: &str = "TopicTest";
-const CONSUMER_GROUP: &str = "please_rename_unique_group_name_4";
+```powershell
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
 ```
 
-修改示例源文件中的这些常量以匹配您的 RocketMQ 集群设置。
+## 项目结构
 
-## 📖 开发指南
-
-### 添加新示例
-
-1. 在适当的类别文件夹中创建新文件（例如：`examples/consumer/my_example.rs`）
-2. 将示例配置添加到 `Cargo.toml`：
-
-```toml
-[[example]]
-name = "my-example"
-path = "examples/consumer/my_example.rs"
-```
-
-3. 运行示例：
-```bash
-cargo run --example my-example
-```
-
-### 依赖项
-
-该项目引用本地 RocketMQ-Rust crate：
-
-- `rocketmq-client-rust` - 客户端 API
-- `rocketmq-common` - 通用工具
-- `rocketmq-rust` - 核心运行时
-- `rocketmq-tools` - 管理工具
-
-## 🏗️ 项目结构
-
-```
+```text
 rocketmq-example/
-├── examples/
-│   └── consumer/
-│       ├── consumer_cluster.rs
-│       └── pop_consumer.rs
-├── Cargo.toml
-└── README.md
+|-- examples/
+|   |-- consumer/
+|   |-- interop/
+|   `-- producer/
+|-- Cargo.toml
+|-- README.md
+`-- README-zh_cn.md
 ```
 
-## 📝 注意事项
+## 注意事项
 
-- 这是一个**独立项目**，不属于主 RocketMQ-Rust workspace
-- 示例使用相对路径依赖来引用父 crate
-- 每个示例都是独立的，可以单独运行
-
-## 🤝 贡献
-
-欢迎贡献新示例！请确保：
-
-1. 示例有良好的内联注释文档
-2. 配置明确指定
-3. 示例遵循 Rust 最佳实践
-4. 每个示例演示单一、清晰的用例
-
-## 📄 许可证
-
-该项目继承 RocketMQ-Rust 的双重许可证：
-- Apache License 2.0
-- MIT License
+- 示例通过本地 path dependency 引用父目录中的 RocketMQ Rust crates。
+- topic、group、Namesrv 地址等常量在每个示例源码中定义。
+- Producer 示例发送完成后退出；Consumer 示例持续运行，按 Ctrl+C 退出。

--- a/rocketmq-example/README.md
+++ b/rocketmq-example/README.md
@@ -1,139 +1,105 @@
-# RocketMQ-Rust Examples
+# RocketMQ Rust Examples
 
-Comprehensive examples demonstrating how to use RocketMQ-Rust client APIs and features.
+Standalone examples for RocketMQ Rust client APIs.
 
-## 📋 Overview
+This project is not part of the root Cargo workspace. Run all commands from
+`rocketmq-example/`.
 
-This is a **standalone project** containing practical examples for RocketMQ-Rust. It showcases various usage patterns including:
+## Prerequisites
 
-- **Consumer Examples**: Push consumer, pop consumer, message listeners
-- **Producer Examples**: *(Coming soon)*
-- **Admin Operations**: *(Coming soon)*
+- Rust 1.85.0 or later.
+- A running RocketMQ name server and broker.
+- Default name server address used by examples: `127.0.0.1:9876`.
+- Create topics and subscription groups before running examples. The examples do
+  not create broker resources automatically.
 
-## 🚀 Quick Start
+Example topic setup with RocketMQ `mqadmin`:
 
-### Prerequisites
-
-- Rust 1.85.0 or later
-- Running RocketMQ nameserver and broker (default: `127.0.0.1:9876`)
-
-### Running Examples
-
-```bash
-# Navigate to the examples directory
-cd rocketmq-example
-
-# Run the pop consumer example
-cargo run --example pop-consumer
-
-# List all available examples
-cargo run --example <TAB>
+```powershell
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t BasicSendTestTopic -r 4 -w 4
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t DelaySendTestTopic -r 4 -w 4 -a +message.type=DELAY
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t OrderSendTestTopic -r 4 -w 4 -o true
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t TransactionSendTestTopic -r 4 -w 4 -a +message.type=TRANSACTION
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t RequestSendTestTopic -r 4 -w 4
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t BroadcastConsumerTestTopic -r 4 -w 4
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t TagFilterConsumerTestTopic -r 4 -w 4
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t SqlFilterConsumerTestTopic -r 4 -w 4
+bin\mqadmin.cmd updateTopic -n 127.0.0.1:9876 -c DefaultCluster -t LitePullConsumerTestTopic -r 4 -w 4
 ```
 
-## 📚 Available Examples
+Create subscription groups as needed:
 
-### Consumer Examples
-
-#### Cluster Consumer
-Demonstrates how to consume messages in cluster mode with load balancing across multiple consumer instances.
-
-**File**: [examples/consumer/consumer_cluster.rs](examples/consumer/consumer_cluster.rs)
-
-**Run**:
-```bash
-cargo run --example consumer-cluster
+```powershell
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_broadcast_group -d true
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_orderly_group -o true
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_tag_filter_group
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_sql_filter_group
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_lite_pull_group
+bin\mqadmin.cmd updateSubGroup -n 127.0.0.1:9876 -c DefaultCluster -g consumer_request_reply_group
 ```
 
-**Features**:
-- Cluster mode consumption (default mode)
-- Load balancing across consumer instances
-- Concurrent message processing
-- Each message consumed by only one instance
+## Producer Examples
 
-#### Pop Consumer
-Demonstrates how to use the pop consumption model with client-side load balancing disabled.
+| Mode | Example | Command | Topic | Notes |
+| --- | --- | --- | --- | --- |
+| Simple send | `producer-simple` | `cargo run --example producer-simple` | `TopicTest` | Basic producer startup and send. |
+| Timeout send | `producer-with-timeout` | `cargo run --example producer-with-timeout` | `TopicTest` | Existing timeout and delayed-message sample. |
+| Basic send APIs | `producer-basic-send` | `cargo run --example producer-basic-send` | `BasicSendTestTopic` | Sync, timeout, callback, callback timeout, one-way. |
+| Batch send | `producer-batch-send` | `cargo run --example producer-batch-send` | `BatchSendTestTopic` | Batch send variants. |
+| Send to queue | `producer-send-to-queue` | `cargo run --example producer-send-to-queue` | `QueueSendTestTopic` | Targets a selected message queue. |
+| Queue selector | `producer-send-with-selector` | `cargo run --example producer-send-with-selector` | `SelectorSendTestTopic` | Uses custom queue selector. |
+| Advanced selector | `producer-send-with-selector-advanced` | `cargo run --example producer-send-with-selector-advanced` | `AdvancedSelectorTestTopic` | Hash, round-robin, random, weighted examples. |
+| Delay send | `producer-delay-send` | `cargo run --example producer-delay-send` | `DelaySendTestTopic` | `delay_level`, `delay_secs`, `delay_millis`, `deliver_time_ms`. |
+| Ordered send | `producer-order-send` | `cargo run --example producer-order-send` | `OrderSendTestTopic` | Same order id is routed to the same queue. |
+| Transaction send | `producer-transaction-send` | `cargo run --example producer-transaction-send` | `TransactionSendTestTopic` | Commit, rollback, and unknown local states. |
+| Request/reply | `producer-request-send` | `cargo run --example producer-request-send` | `RequestSendTestTopic` | Start `consumer-request-reply` first. |
+| Request/reply callback | `producer-request-callback-send` | `cargo run --example producer-request-callback-send` | `RequestSendTestTopic` | Start `consumer-request-reply` first. |
 
-**File**: [examples/consumer/pop_consumer.rs](examples/consumer/pop_consumer.rs)
+## Consumer Examples
 
-**Run**:
-```bash
-cargo run --example pop-consumer
+| Mode | Example | Command | Topic | Notes |
+| --- | --- | --- | --- | --- |
+| Cluster push | `consumer-cluster` | `cargo run --example consumer-cluster` | `TopicTest` | Load-balanced push consumption. |
+| Pop consumer | `pop-consumer` | `cargo run --example pop-consumer` | `TopicTest` | Pop request mode example. |
+| Broadcast push | `consumer-broadcast` | `cargo run --example consumer-broadcast` | `BroadcastConsumerTestTopic` | Every consumer instance receives every message; group must enable broadcast consumption. |
+| Orderly push | `consumer-orderly` | `cargo run --example consumer-orderly` | `OrderSendTestTopic` | Uses `MessageListenerOrderly`. |
+| Tag filter push | `consumer-tag-filter` | `cargo run --example consumer-tag-filter` | `TagFilterConsumerTestTopic` | Uses `MessageSelector::by_tag("TagA || TagB")`. |
+| SQL92 filter push | `consumer-sql-filter` | `cargo run --example consumer-sql-filter` | `SqlFilterConsumerTestTopic` | Uses `MessageSelector::by_sql`; broker must support SQL filtering. |
+| Lite pull | `consumer-lite-pull` | `cargo run --example consumer-lite-pull` | `LitePullConsumerTestTopic` | Polls messages and commits offsets manually. |
+| Request/reply responder | `consumer-request-reply` | `cargo run --example consumer-request-reply` | `RequestSendTestTopic` | Sends reply messages for request producer examples. |
+
+## Validation
+
+Build an individual example:
+
+```powershell
+cargo build --example producer-delay-send
 ```
 
-**Features**:
-- Pop-based message consumption
-- Concurrent message processing
-- Automatic topic/consumer group creation
-- Message request mode configuration
+Required validation after changing this project:
 
-## 🔧 Configuration
-
-Most examples use default configuration:
-
-```rust
-const NAMESRV_ADDR: &str = "127.0.0.1:9876";
-const TOPIC: &str = "TopicTest";
-const CONSUMER_GROUP: &str = "please_rename_unique_group_name_4";
+```powershell
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
 ```
 
-Modify these constants in the example source files to match your RocketMQ cluster setup.
+## Project Structure
 
-## 📖 Development Guide
-
-### Adding New Examples
-
-1. Create a new file in the appropriate category folder (e.g., `examples/consumer/my_example.rs`)
-2. Add the example configuration to `Cargo.toml`:
-
-```toml
-[[example]]
-name = "my-example"
-path = "examples/consumer/my_example.rs"
-```
-
-3. Run the example:
-```bash
-cargo run --example my-example
-```
-
-### Dependencies
-
-This project references local RocketMQ-Rust crates:
-
-- `rocketmq-client-rust` - Client APIs
-- `rocketmq-common` - Common utilities
-- `rocketmq-rust` - Core runtime
-- `rocketmq-tools` - Admin tools
-
-## 🏗️ Project Structure
-
-```
+```text
 rocketmq-example/
-├── examples/
-│   └── consumer/
-│       ├── consumer_cluster.rs
-│       └── pop_consumer.rs
-├── Cargo.toml
-└── README.md
+|-- examples/
+|   |-- consumer/
+|   |-- interop/
+|   `-- producer/
+|-- Cargo.toml
+|-- README.md
+`-- README-zh_cn.md
 ```
 
-## 📝 Notes
+## Notes
 
-- This is a **standalone project**, not part of the main RocketMQ-Rust workspace
-- Examples use relative path dependencies to reference parent crates
-- Each example is self-contained and runnable independently
-
-## 🤝 Contributing
-
-Contributions of new examples are welcome! Please ensure:
-
-1. Examples are well-documented with inline comments
-2. Configuration is clearly specified
-3. Examples follow Rust best practices
-4. Each example demonstrates a single, clear use case
-
-## 📄 License
-
-This project inherits the dual-license from RocketMQ-Rust:
-- Apache License 2.0
-- MIT License
+- Examples use local path dependencies to the parent RocketMQ Rust crates.
+- Constants such as topic, group, and name server address are defined in each
+  example source file.
+- Producer examples exit after sending messages. Consumer examples run until
+  interrupted with Ctrl+C.

--- a/rocketmq-example/examples/consumer/broadcast_consumer.rs
+++ b/rocketmq-example/examples/consumer/broadcast_consumer.rs
@@ -1,0 +1,132 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Broadcast push consumer example.
+
+#![recursion_limit = "512"]
+
+use std::path::PathBuf;
+
+use cheetah_string::CheetahString;
+use rocketmq_client_rust::base::client_config::ClientConfig;
+use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
+use rocketmq_client_rust::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
+use rocketmq_client_rust::consumer::mq_push_consumer::MQPushConsumer;
+use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_rust::rocketmq;
+use rocketmq_rust::wait_for_signal;
+use tracing::info;
+
+pub const CONSUMER_GROUP: &str = "consumer_broadcast_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "BroadcastConsumerTestTopic";
+pub const TAG: &str = "*";
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let client_config = broadcast_client_config()?;
+
+    let mut consumer = DefaultMQPushConsumer::builder()
+        .client_config(client_config)
+        .consumer_group(CONSUMER_GROUP)
+        .message_model(MessageModel::Broadcasting)
+        .consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset)
+        .consume_message_batch_max_size(1)
+        .build();
+
+    consumer.subscribe(TOPIC, TAG).await?;
+    consumer.register_message_listener_concurrently(BroadcastListener);
+    consumer.start().await?;
+
+    info!("broadcast consumer started. group={}, topic={}", CONSUMER_GROUP, TOPIC);
+    let _ = wait_for_signal().await;
+    consumer.shutdown().await;
+    Ok(())
+}
+
+fn broadcast_client_config() -> RocketMQResult<ClientConfig> {
+    let mut client_config = ClientConfig::new();
+    client_config.set_namesrv_addr(CheetahString::from_static_str(DEFAULT_NAMESRVADDR));
+    client_config.client_ip = Some(CheetahString::from_static_str("127.0.0.1"));
+    client_config.set_instance_name(CheetahString::from_static_str("broadcast_example"));
+
+    let offset_dir = local_offset_store_dir()
+        .join(client_config.build_mq_client_id())
+        .join(CONSUMER_GROUP);
+    std::fs::create_dir_all(&offset_dir)?;
+    let offset_file = offset_dir.join("offsets.json");
+    if !offset_file.exists() {
+        std::fs::write(offset_file, r#"{"offsetTable":{}}"#)?;
+    }
+
+    Ok(client_config)
+}
+
+fn local_offset_store_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("rocketmq.client.localOffsetStoreDir") {
+        return PathBuf::from(dir);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var_os("USERPROFILE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("C:\\tmp"))
+            .join(".rocketmq_offsets")
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join(".rocketmq_offsets")
+    }
+}
+
+struct BroadcastListener;
+
+impl MessageListenerConcurrently for BroadcastListener {
+    fn consume_message(
+        &self,
+        messages: &[&MessageExt],
+        _context: &ConsumeConcurrentlyContext,
+    ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
+        for message in messages {
+            info!(
+                "broadcast receive msg_id={}, topic={}, tags={}, body={}",
+                message.msg_id(),
+                message.topic(),
+                message.tags().unwrap_or_default(),
+                message_body(message)
+            );
+        }
+        Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+    }
+}
+
+fn message_body(message: &MessageExt) -> String {
+    message
+        .get_body()
+        .map(|body| String::from_utf8_lossy(body.as_ref()).into_owned())
+        .unwrap_or_default()
+}

--- a/rocketmq-example/examples/consumer/lite_pull_consumer.rs
+++ b/rocketmq-example/examples/consumer/lite_pull_consumer.rs
@@ -1,0 +1,96 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Lite pull consumer example with manual offset commit.
+
+use rocketmq_client_rust::consumer::default_lite_pull_consumer::DefaultLitePullConsumer;
+use rocketmq_client_rust::consumer::message_selector::MessageSelector;
+use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_rust::rocketmq;
+use rocketmq_rust::wait_for_signal;
+use tracing::info;
+
+pub const CONSUMER_GROUP: &str = "consumer_lite_pull_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "LitePullConsumerTestTopic";
+pub const TAG_EXPRESSION: &str = "LitePullTag";
+pub const POLL_TIMEOUT_MS: u64 = 1000;
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let consumer = DefaultLitePullConsumer::builder()
+        .consumer_group(CONSUMER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .message_model(MessageModel::Clustering)
+        .consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset)
+        .pull_batch_size(16)
+        .poll_timeout_millis(POLL_TIMEOUT_MS)
+        .auto_commit(false)
+        .build()?;
+
+    consumer
+        .subscribe_with_selector(TOPIC, Some(MessageSelector::by_tag(TAG_EXPRESSION)))
+        .await?;
+    consumer.start().await?;
+
+    info!(
+        "lite pull consumer started. group={}, topic={}, expression={}",
+        CONSUMER_GROUP, TOPIC, TAG_EXPRESSION
+    );
+
+    let shutdown = wait_for_signal();
+    tokio::pin!(shutdown);
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => {
+                break;
+            }
+            messages = consumer.poll_with_timeout(POLL_TIMEOUT_MS) => {
+                if messages.is_empty() {
+                    continue;
+                }
+                for message in &messages {
+                    log_message(message);
+                }
+                consumer.commit_all().await?;
+            }
+        }
+    }
+
+    consumer.shutdown().await;
+    Ok(())
+}
+
+fn log_message(message: &MessageExt) {
+    info!(
+        "lite pull receive msg_id={}, topic={}, tags={}, body={}",
+        message.msg_id(),
+        message.topic(),
+        message.tags().unwrap_or_default(),
+        message_body(message)
+    );
+}
+
+fn message_body(message: &MessageExt) -> String {
+    message
+        .get_body()
+        .map(|body| String::from_utf8_lossy(body.as_ref()).into_owned())
+        .unwrap_or_default()
+}

--- a/rocketmq-example/examples/consumer/orderly_consumer.rs
+++ b/rocketmq-example/examples/consumer/orderly_consumer.rs
@@ -1,0 +1,88 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Ordered push consumer example.
+
+#![recursion_limit = "512"]
+
+use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
+use rocketmq_client_rust::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
+use rocketmq_client_rust::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
+use rocketmq_client_rust::consumer::listener::message_listener_orderly::MessageListenerOrderly;
+use rocketmq_client_rust::consumer::mq_push_consumer::MQPushConsumer;
+use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_rust::rocketmq;
+use rocketmq_rust::wait_for_signal;
+use tracing::info;
+
+pub const CONSUMER_GROUP: &str = "consumer_orderly_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "OrderSendTestTopic";
+pub const TAG: &str = "*";
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let mut consumer = DefaultMQPushConsumer::builder()
+        .consumer_group(CONSUMER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .message_model(MessageModel::Clustering)
+        .consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset)
+        .consume_message_batch_max_size(1)
+        .build();
+
+    consumer.subscribe(TOPIC, TAG).await?;
+    consumer.register_message_listener_orderly(OrderlyListener);
+    consumer.start().await?;
+
+    info!("orderly consumer started. group={}, topic={}", CONSUMER_GROUP, TOPIC);
+    let _ = wait_for_signal().await;
+    consumer.shutdown().await;
+    Ok(())
+}
+
+struct OrderlyListener;
+
+impl MessageListenerOrderly for OrderlyListener {
+    fn consume_message(
+        &self,
+        messages: &[&MessageExt],
+        context: &mut ConsumeOrderlyContext,
+    ) -> RocketMQResult<ConsumeOrderlyStatus> {
+        context.set_auto_commit(true);
+        for message in messages {
+            info!(
+                "orderly receive queue={} offset={} msg_id={} keys={:?} body={}",
+                context.get_message_queue(),
+                message.queue_offset(),
+                message.msg_id(),
+                message.get_keys(),
+                message_body(message)
+            );
+        }
+        Ok(ConsumeOrderlyStatus::Success)
+    }
+}
+
+fn message_body(message: &MessageExt) -> String {
+    message
+        .get_body()
+        .map(|body| String::from_utf8_lossy(body.as_ref()).into_owned())
+        .unwrap_or_default()
+}

--- a/rocketmq-example/examples/consumer/request_reply_responder.rs
+++ b/rocketmq-example/examples/consumer/request_reply_responder.rs
@@ -1,0 +1,106 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Request/reply responder example.
+
+#![recursion_limit = "512"]
+
+use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
+use rocketmq_client_rust::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
+use rocketmq_client_rust::consumer::mq_push_consumer::MQPushConsumer;
+use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
+use rocketmq_client_rust::utils::message_util::MessageUtil;
+use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_rust::rocketmq;
+use rocketmq_rust::wait_for_signal;
+use tracing::error;
+use tracing::info;
+
+pub const CONSUMER_GROUP: &str = "consumer_request_reply_group";
+pub const PRODUCER_GROUP: &str = "producer_request_reply_responder_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "RequestSendTestTopic";
+pub const TAG: &str = "*";
+pub const REPLY_TIMEOUT_MS: u64 = 3000;
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let mut reply_producer = DefaultMQProducer::builder()
+        .producer_group(PRODUCER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .build();
+    reply_producer.start().await?;
+
+    let mut consumer = DefaultMQPushConsumer::builder()
+        .consumer_group(CONSUMER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .message_model(MessageModel::Clustering)
+        .consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset)
+        .consume_message_batch_max_size(1)
+        .build();
+
+    consumer.subscribe(TOPIC, TAG).await?;
+    consumer.register_message_listener_concurrently(RequestReplyListener {
+        reply_producer: reply_producer.clone(),
+    });
+    consumer.start().await?;
+
+    info!(
+        "request/reply responder started. group={}, topic={}",
+        CONSUMER_GROUP, TOPIC
+    );
+    let _ = wait_for_signal().await;
+
+    consumer.shutdown().await;
+    reply_producer.shutdown().await;
+    Ok(())
+}
+
+#[derive(Clone)]
+struct RequestReplyListener {
+    reply_producer: DefaultMQProducer,
+}
+
+impl MessageListenerConcurrently for RequestReplyListener {
+    fn consume_message(
+        &self,
+        messages: &[&MessageExt],
+        _context: &ConsumeConcurrentlyContext,
+    ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
+        for message in messages {
+            let request = message.message.clone();
+            let mut producer = self.reply_producer.clone();
+            let response_body = format!("reply to {}", message.msg_id());
+
+            tokio::spawn(async move {
+                match MessageUtil::create_reply_message(&request, response_body.as_bytes()) {
+                    Ok(reply) => match producer.send_with_timeout(reply, REPLY_TIMEOUT_MS).await {
+                        Ok(result) => info!("request reply sent: {:?}", result),
+                        Err(error) => error!("request reply send failed: {error}"),
+                    },
+                    Err(error) => error!("create reply message failed: {error}"),
+                }
+            });
+        }
+
+        Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+    }
+}

--- a/rocketmq-example/examples/consumer/sql_filter_consumer.rs
+++ b/rocketmq-example/examples/consumer/sql_filter_consumer.rs
@@ -1,0 +1,91 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Push consumer example using a SQL92 selector.
+
+#![recursion_limit = "512"]
+
+use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
+use rocketmq_client_rust::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
+use rocketmq_client_rust::consumer::message_selector::MessageSelector;
+use rocketmq_client_rust::consumer::mq_push_consumer::MQPushConsumer;
+use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_rust::rocketmq;
+use rocketmq_rust::wait_for_signal;
+use tracing::info;
+
+pub const CONSUMER_GROUP: &str = "consumer_sql_filter_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "SqlFilterConsumerTestTopic";
+pub const SQL_EXPRESSION: &str = "region = 'cn' AND priority >= 3";
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let mut consumer = DefaultMQPushConsumer::builder()
+        .consumer_group(CONSUMER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .message_model(MessageModel::Clustering)
+        .consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset)
+        .consume_message_batch_max_size(1)
+        .build();
+
+    consumer
+        .subscribe_with_selector(TOPIC, Some(MessageSelector::by_sql(SQL_EXPRESSION)))
+        .await?;
+    consumer.register_message_listener_concurrently(SqlFilterListener);
+    consumer.start().await?;
+
+    info!(
+        "sql filter consumer started. group={}, topic={}, expression={}",
+        CONSUMER_GROUP, TOPIC, SQL_EXPRESSION
+    );
+    let _ = wait_for_signal().await;
+    consumer.shutdown().await;
+    Ok(())
+}
+
+struct SqlFilterListener;
+
+impl MessageListenerConcurrently for SqlFilterListener {
+    fn consume_message(
+        &self,
+        messages: &[&MessageExt],
+        _context: &ConsumeConcurrentlyContext,
+    ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
+        for message in messages {
+            info!(
+                "sql filter receive msg_id={}, properties={:?}, body={}",
+                message.msg_id(),
+                message.get_properties(),
+                message_body(message)
+            );
+        }
+        Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+    }
+}
+
+fn message_body(message: &MessageExt) -> String {
+    message
+        .get_body()
+        .map(|body| String::from_utf8_lossy(body.as_ref()).into_owned())
+        .unwrap_or_default()
+}

--- a/rocketmq-example/examples/consumer/tag_filter_consumer.rs
+++ b/rocketmq-example/examples/consumer/tag_filter_consumer.rs
@@ -1,0 +1,91 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Push consumer example using a tag selector.
+
+#![recursion_limit = "512"]
+
+use rocketmq_client_rust::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_context::ConsumeConcurrentlyContext;
+use rocketmq_client_rust::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyStatus;
+use rocketmq_client_rust::consumer::listener::message_listener_concurrently::MessageListenerConcurrently;
+use rocketmq_client_rust::consumer::message_selector::MessageSelector;
+use rocketmq_client_rust::consumer::mq_push_consumer::MQPushConsumer;
+use rocketmq_common::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_error::RocketMQResult;
+use rocketmq_remoting::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_rust::rocketmq;
+use rocketmq_rust::wait_for_signal;
+use tracing::info;
+
+pub const CONSUMER_GROUP: &str = "consumer_tag_filter_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "TagFilterConsumerTestTopic";
+pub const TAG_EXPRESSION: &str = "TagA || TagB";
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let mut consumer = DefaultMQPushConsumer::builder()
+        .consumer_group(CONSUMER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .message_model(MessageModel::Clustering)
+        .consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset)
+        .consume_message_batch_max_size(1)
+        .build();
+
+    consumer
+        .subscribe_with_selector(TOPIC, Some(MessageSelector::by_tag(TAG_EXPRESSION)))
+        .await?;
+    consumer.register_message_listener_concurrently(TagFilterListener);
+    consumer.start().await?;
+
+    info!(
+        "tag filter consumer started. group={}, topic={}, expression={}",
+        CONSUMER_GROUP, TOPIC, TAG_EXPRESSION
+    );
+    let _ = wait_for_signal().await;
+    consumer.shutdown().await;
+    Ok(())
+}
+
+struct TagFilterListener;
+
+impl MessageListenerConcurrently for TagFilterListener {
+    fn consume_message(
+        &self,
+        messages: &[&MessageExt],
+        _context: &ConsumeConcurrentlyContext,
+    ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
+        for message in messages {
+            info!(
+                "tag filter receive msg_id={}, tags={}, body={}",
+                message.msg_id(),
+                message.tags().unwrap_or_default(),
+                message_body(message)
+            );
+        }
+        Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+    }
+}
+
+fn message_body(message: &MessageExt) -> String {
+    message
+        .get_body()
+        .map(|body| String::from_utf8_lossy(body.as_ref()).into_owned())
+        .unwrap_or_default()
+}

--- a/rocketmq-example/examples/producer/delay_send.rs
+++ b/rocketmq-example/examples/producer/delay_send.rs
@@ -1,0 +1,111 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Demonstrates delayed message send modes.
+
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_error::RocketMQResult;
+use rocketmq_rust::rocketmq;
+
+pub const PRODUCER_GROUP: &str = "producer_delay_send_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "DelaySendTestTopic";
+pub const TAG: &str = "DelayTag";
+pub const TIMEOUT_MS: u64 = 3000;
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let mut producer = DefaultMQProducer::builder()
+        .producer_group(PRODUCER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .build();
+
+    producer.start().await?;
+
+    send_delay_level(&mut producer).await?;
+    send_delay_seconds(&mut producer).await?;
+    send_delay_millis(&mut producer).await?;
+    send_deliver_time(&mut producer).await?;
+
+    producer.shutdown().await;
+    Ok(())
+}
+
+async fn send_delay_level(producer: &mut DefaultMQProducer) -> RocketMQResult<()> {
+    let message = Message::builder()
+        .topic(TOPIC)
+        .tags(TAG)
+        .key("delay-level-key")
+        .body("message delayed by broker delay level")
+        .delay_level(3)
+        .build()?;
+
+    let result = producer.send_with_timeout(message, TIMEOUT_MS).await?;
+    println!("delay_level send result: {:?}", result);
+    Ok(())
+}
+
+async fn send_delay_seconds(producer: &mut DefaultMQProducer) -> RocketMQResult<()> {
+    let message = Message::builder()
+        .topic(TOPIC)
+        .tags(TAG)
+        .key("delay-seconds-key")
+        .body("message delayed by seconds")
+        .delay_secs(5)
+        .build()?;
+
+    let result = producer.send_with_timeout(message, TIMEOUT_MS).await?;
+    println!("delay_secs send result: {:?}", result);
+    Ok(())
+}
+
+async fn send_delay_millis(producer: &mut DefaultMQProducer) -> RocketMQResult<()> {
+    let message = Message::builder()
+        .topic(TOPIC)
+        .tags(TAG)
+        .key("delay-millis-key")
+        .body("message delayed by milliseconds")
+        .delay_millis(5000)
+        .build()?;
+
+    let result = producer.send_with_timeout(message, TIMEOUT_MS).await?;
+    println!("delay_millis send result: {:?}", result);
+    Ok(())
+}
+
+async fn send_deliver_time(producer: &mut DefaultMQProducer) -> RocketMQResult<()> {
+    let deliver_time_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time must be after UNIX_EPOCH")
+        .as_millis() as u64
+        + 10_000;
+
+    let message = Message::builder()
+        .topic(TOPIC)
+        .tags(TAG)
+        .key("deliver-time-key")
+        .body("message delivered at an absolute timestamp")
+        .deliver_time_ms(deliver_time_ms)
+        .build()?;
+
+    let result = producer.send_with_timeout(message, TIMEOUT_MS).await?;
+    println!("deliver_time_ms send result: {:?}", result);
+    Ok(())
+}

--- a/rocketmq-example/examples/producer/order_send.rs
+++ b/rocketmq-example/examples/producer/order_send.rs
@@ -1,0 +1,64 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Demonstrates ordered sends by routing the same order id to the same queue.
+
+use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_error::RocketMQResult;
+use rocketmq_rust::rocketmq;
+
+pub const PRODUCER_GROUP: &str = "producer_order_send_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "OrderSendTestTopic";
+pub const TAG: &str = "OrderTag";
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let mut producer = DefaultMQProducer::builder()
+        .producer_group(PRODUCER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .build();
+
+    producer.start().await?;
+
+    for order_id in 0..4 {
+        for step in ["created", "paid", "packed", "shipped"] {
+            let message = Message::builder()
+                .topic(TOPIC)
+                .tags(TAG)
+                .key(format!("order-{order_id}"))
+                .body(format!("order_id={order_id}, step={step}"))
+                .build()?;
+
+            let result = producer
+                .send_with_selector(
+                    message,
+                    |queues, _message, selected_order_id: &usize| {
+                        let index = selected_order_id % queues.len();
+                        Some(queues[index].clone())
+                    },
+                    order_id,
+                )
+                .await?;
+
+            println!("order_id={order_id}, step={step}, send result: {:?}", result);
+        }
+    }
+
+    producer.shutdown().await;
+    Ok(())
+}

--- a/rocketmq-example/examples/producer/request_callback_send.rs
+++ b/rocketmq-example/examples/producer/request_callback_send.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Demonstrates request/reply send with a callback.
+
+use std::time::Duration;
+
+use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_rust::rocketmq;
+use tokio::sync::mpsc;
+
+pub const PRODUCER_GROUP: &str = "producer_request_callback_send_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "RequestSendTestTopic";
+pub const TAG: &str = "RequestTag";
+pub const REQUEST_TIMEOUT_MS: u64 = 3000;
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let mut producer = DefaultMQProducer::builder()
+        .producer_group(PRODUCER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .build();
+
+    producer.start().await?;
+
+    let request = Message::builder()
+        .topic(TOPIC)
+        .tags(TAG)
+        .key("request-callback-key")
+        .body("request callback body")
+        .build()?;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    producer
+        .request_with_callback(
+            request,
+            move |response, error| match (response, error) {
+                (Some(message), None) => {
+                    let body = message
+                        .get_body()
+                        .map(|body| String::from_utf8_lossy(body.as_ref()).into_owned())
+                        .unwrap_or_default();
+                    println!("request callback response: topic={}, body={}", message.topic(), body);
+                    let _ = tx.send(Ok(()));
+                }
+                (_, Some(error)) => {
+                    println!("request callback error: {error}");
+                    let _ = tx.send(Err(error.to_string()));
+                }
+                _ => {
+                    println!("request callback send completed; waiting for reply");
+                }
+            },
+            REQUEST_TIMEOUT_MS,
+        )
+        .await?;
+
+    match tokio::time::timeout(Duration::from_millis(REQUEST_TIMEOUT_MS.saturating_mul(3)), rx.recv()).await {
+        Ok(Some(Ok(()))) => {}
+        Ok(Some(Err(error))) => return Err(RocketMQError::Internal(error)),
+        Ok(None) => {
+            return Err(RocketMQError::Internal(
+                "request callback channel closed before receiving a reply".to_string(),
+            ));
+        }
+        Err(_) => {
+            return Err(RocketMQError::Timeout {
+                operation: "request_callback_reply",
+                timeout_ms: REQUEST_TIMEOUT_MS.saturating_mul(3),
+            });
+        }
+    }
+
+    producer.shutdown().await;
+    Ok(())
+}

--- a/rocketmq-example/examples/producer/request_send.rs
+++ b/rocketmq-example/examples/producer/request_send.rs
@@ -1,0 +1,55 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Demonstrates synchronous request/reply send.
+
+use rocketmq_client_rust::producer::default_mq_producer::DefaultMQProducer;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_error::RocketMQResult;
+use rocketmq_rust::rocketmq;
+
+pub const PRODUCER_GROUP: &str = "producer_request_send_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "RequestSendTestTopic";
+pub const TAG: &str = "RequestTag";
+pub const REQUEST_TIMEOUT_MS: u64 = 3000;
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let mut producer = DefaultMQProducer::builder()
+        .producer_group(PRODUCER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .build();
+
+    producer.start().await?;
+
+    let request = Message::builder()
+        .topic(TOPIC)
+        .tags(TAG)
+        .key("request-key")
+        .body("request body")
+        .build()?;
+
+    let response = producer.request(request, REQUEST_TIMEOUT_MS).await?;
+    let body = response
+        .get_body()
+        .map(|body| String::from_utf8_lossy(body.as_ref()).into_owned())
+        .unwrap_or_default();
+    println!("request response: topic={}, body={}", response.topic(), body);
+
+    producer.shutdown().await;
+    Ok(())
+}

--- a/rocketmq-example/examples/producer/transaction_send.rs
+++ b/rocketmq-example/examples/producer/transaction_send.rs
@@ -1,0 +1,113 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Demonstrates transactional message sending.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use cheetah_string::CheetahString;
+use rocketmq_client_rust::producer::local_transaction_state::LocalTransactionState;
+use rocketmq_client_rust::producer::transaction_listener::TransactionListener;
+use rocketmq_client_rust::producer::transaction_mq_producer::TransactionMQProducer;
+use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_error::RocketMQResult;
+use rocketmq_rust::rocketmq;
+
+pub const PRODUCER_GROUP: &str = "producer_transaction_send_group";
+pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
+pub const TOPIC: &str = "TransactionSendTestTopic";
+pub const TAG: &str = "TransactionTag";
+
+#[rocketmq::main]
+pub async fn main() -> RocketMQResult<()> {
+    rocketmq_common::log::init_logger()?;
+
+    let mut producer = TransactionMQProducer::builder()
+        .producer_group(PRODUCER_GROUP)
+        .name_server_addr(DEFAULT_NAMESRVADDR)
+        .topics(vec![TOPIC])
+        .transaction_listener(ExampleTransactionListener::default())
+        .build();
+
+    producer.start().await?;
+
+    for index in 0..6 {
+        let message = Message::builder()
+            .topic(TOPIC)
+            .tags(TAG)
+            .key(format!("transaction-key-{index}"))
+            .body(format!("transaction message {index}"))
+            .build()?;
+
+        let result = producer.send_message_in_transaction::<(), _>(message, None).await?;
+        println!("transaction index={index}, send result: {result}");
+    }
+
+    producer.shutdown().await;
+    Ok(())
+}
+
+#[derive(Default)]
+struct ExampleTransactionListener {
+    states: Arc<Mutex<HashMap<CheetahString, LocalTransactionState>>>,
+    next_state: AtomicUsize,
+}
+
+impl TransactionListener for ExampleTransactionListener {
+    fn execute_local_transaction(
+        &self,
+        msg: &dyn MessageTrait,
+        _arg: Option<&(dyn Any + Send + Sync)>,
+    ) -> LocalTransactionState {
+        let state = match self.next_state.fetch_add(1, Ordering::AcqRel) % 3 {
+            0 => LocalTransactionState::CommitMessage,
+            1 => LocalTransactionState::RollbackMessage,
+            _ => LocalTransactionState::Unknown,
+        };
+
+        if let Some(transaction_id) = msg.transaction_id() {
+            self.states
+                .lock()
+                .expect("transaction state mutex poisoned")
+                .insert(CheetahString::from(transaction_id), state);
+        }
+
+        println!(
+            "execute local transaction for {:?}, state={state:?}",
+            msg.transaction_id()
+        );
+        state
+    }
+
+    fn check_local_transaction(&self, msg: &MessageExt) -> LocalTransactionState {
+        let transaction_id = msg.get_transaction_id().cloned().unwrap_or_default();
+        let state = self
+            .states
+            .lock()
+            .expect("transaction state mutex poisoned")
+            .get(&transaction_id)
+            .copied()
+            .unwrap_or(LocalTransactionState::Unknown);
+
+        println!("check local transaction id={transaction_id}, state={state:?}");
+        state
+    }
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7444

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive examples demonstrating various messaging patterns: broadcast consumption, ordered messaging, transactional sends, request-reply communication, message filtering (tag-based and SQL), delayed sends, and lite pull consumption with manual offset management.

* **Documentation**
  * Updated setup guides with prerequisites, topic/consumer group creation commands, and example usage instructions.
  * Reorganized example project structure for better discoverability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->