### PR TITLE
[ISSUE #7494]♻️ Add tokio runtime audit tooling

### DIFF
--- a/.github/workflows/runtime-model-ci.yml
+++ b/.github/workflows/runtime-model-ci.yml
@@ -1,0 +1,79 @@
+name: Runtime Model CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'scripts/runtime-audit.*'
+      - 'scripts/bench-runtime-model.ps1'
+      - 'rocketmq-runtime/**'
+      - 'rocketmq-client/**'
+      - 'rocketmq-common/**'
+      - 'rocketmq-remoting/**'
+      - 'rocketmq-namesrv/**'
+      - 'rocketmq-broker/**'
+      - 'rocketmq-store/**'
+      - 'rocketmq-controller/**'
+      - 'rocketmq-tieredstore/**'
+      - 'rocketmq-auth/**'
+      - 'rocketmq-observability/**'
+      - '.github/workflows/runtime-model-ci.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'scripts/runtime-audit.*'
+      - 'scripts/bench-runtime-model.ps1'
+      - 'rocketmq-runtime/**'
+      - 'rocketmq-client/**'
+      - 'rocketmq-common/**'
+      - 'rocketmq-remoting/**'
+      - 'rocketmq-namesrv/**'
+      - 'rocketmq-broker/**'
+      - 'rocketmq-store/**'
+      - 'rocketmq-controller/**'
+      - 'rocketmq-tieredstore/**'
+      - 'rocketmq-auth/**'
+      - 'rocketmq-observability/**'
+      - '.github/workflows/runtime-model-ci.yml'
+
+env:
+  CI: true
+
+jobs:
+  runtime-model-artifacts:
+    name: Runtime model audit artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install audit dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+
+      - name: Run runtime audit
+        shell: pwsh
+        run: ./scripts/runtime-audit.ps1 -SkipBaseline
+
+      - name: Generate runtime model benchmark placeholders
+        shell: pwsh
+        run: ./scripts/bench-runtime-model.ps1 -Mode prototype
+
+      - name: Upload runtime audit report
+        uses: actions/upload-artifact@v6
+        with:
+          name: runtime-audit
+          path: target/runtime-audit
+          if-no-files-found: error
+
+      - name: Upload runtime model benchmark artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: runtime-model-prototype
+          path: target/runtime-baseline/prototype
+          if-no-files-found: error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4094,6 +4094,7 @@ dependencies = [
  "rocketmq-error",
  "rocketmq-observability",
  "rocketmq-remoting",
+ "rocketmq-runtime",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4207,6 +4208,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rocketmq-error",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "serde",
  "serde_json",
@@ -4417,6 +4419,7 @@ dependencies = [
  "rocketmq-error",
  "rocketmq-macros",
  "rocketmq-observability",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -4437,7 +4440,15 @@ dependencies = [
 name = "rocketmq-runtime"
 version = "1.0.0"
 dependencies = [
+ "dashmap",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/rocketmq-auth/Cargo.toml
+++ b/rocketmq-auth/Cargo.toml
@@ -36,6 +36,7 @@ rocketmq-common   = { workspace = true }
 rocketmq-remoting = { workspace = true }
 rocketmq-error    = { workspace = true }
 rocketmq-observability = { workspace = true }
+rocketmq-runtime  = { workspace = true }
 
 cheetah-string = { workspace = true }
 serde          = { workspace = true }

--- a/rocketmq-auth/src/authentication/factory/authentication_factory.rs
+++ b/rocketmq-auth/src/authentication/factory/authentication_factory.rs
@@ -54,6 +54,7 @@ use crate::authentication::strategy::StatefulAuthenticationStrategy;
 use crate::authentication::strategy::StatelessAuthenticationStrategy;
 use crate::authorization::metadata_provider::AuthorizationMetadataProvider;
 use crate::config::AuthConfig;
+use crate::runtime_bridge::block_on_sync_bridge;
 
 /// Global instance cache for authentication components
 ///
@@ -376,58 +377,48 @@ fn new_initialized_default_provider(
     config: AuthConfig,
     metadata_service: Option<Arc<dyn Any + Send + Sync>>,
 ) -> RocketMQResult<DefaultAuthenticationProvider> {
-    std::thread::spawn(move || {
-        let mut provider = DefaultAuthenticationProvider::new();
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|error| {
-                RocketMQError::auth_config_invalid(
-                    "authenticationProvider",
-                    format!("Failed to create initialization runtime: {error}"),
-                )
-            })?;
-        runtime
-            .block_on(provider.initialize(config, metadata_service))
-            .map_err(|error| RocketMQError::auth_config_invalid("authenticationProvider", error.to_string()))?;
-        Ok(provider)
-    })
-    .join()
-    .map_err(|_| {
-        RocketMQError::auth_config_invalid(
-            "authenticationProvider",
-            "DefaultAuthenticationProvider initialization panicked",
-        )
-    })?
+    let mut provider = DefaultAuthenticationProvider::new();
+    block_on_sync_bridge(
+        || provider.initialize(config, metadata_service),
+        |error| {
+            RocketMQError::auth_config_invalid(
+                "authenticationProvider",
+                format!("Failed to create initialization runtime: {error}"),
+            )
+        },
+        || {
+            RocketMQError::auth_config_invalid(
+                "authenticationProvider",
+                "DefaultAuthenticationProvider initialization panicked",
+            )
+        },
+    )
+    .map_err(|error| RocketMQError::auth_config_invalid("authenticationProvider", error.to_string()))?;
+    Ok(provider)
 }
 
 fn new_initialized_local_metadata_provider(
     config: AuthConfig,
     metadata_service: Option<Arc<dyn Any + Send + Sync>>,
 ) -> RocketMQResult<LocalAuthenticationMetadataProvider> {
-    std::thread::spawn(move || {
-        let mut provider = LocalAuthenticationMetadataProvider::new();
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|error| {
-                RocketMQError::auth_config_invalid(
-                    "authenticationMetadataProvider",
-                    format!("Failed to create initialization runtime: {error}"),
-                )
-            })?;
-        runtime
-            .block_on(provider.initialize(config, metadata_service))
-            .map_err(|error| RocketMQError::auth_config_invalid("authenticationMetadataProvider", error.to_string()))?;
-        Ok(provider)
-    })
-    .join()
-    .map_err(|_| {
-        RocketMQError::auth_config_invalid(
-            "authenticationMetadataProvider",
-            "LocalAuthenticationMetadataProvider initialization panicked",
-        )
-    })?
+    let mut provider = LocalAuthenticationMetadataProvider::new();
+    block_on_sync_bridge(
+        || provider.initialize(config, metadata_service),
+        |error| {
+            RocketMQError::auth_config_invalid(
+                "authenticationMetadataProvider",
+                format!("Failed to create initialization runtime: {error}"),
+            )
+        },
+        || {
+            RocketMQError::auth_config_invalid(
+                "authenticationMetadataProvider",
+                "LocalAuthenticationMetadataProvider initialization panicked",
+            )
+        },
+    )
+    .map_err(|error| RocketMQError::auth_config_invalid("authenticationMetadataProvider", error.to_string()))?;
+    Ok(provider)
 }
 
 fn is_blank_or_supported(configured: &str, supported: &[&str]) -> bool {

--- a/rocketmq-auth/src/authentication/strategy.rs
+++ b/rocketmq-auth/src/authentication/strategy.rs
@@ -25,10 +25,10 @@ pub mod stateless_authentication_strategy;
 
 use rocketmq_error::AuthError;
 use rocketmq_error::RocketMQError;
-use rocketmq_error::RocketMQResult;
 
 use crate::authentication::context::default_authentication_context::DefaultAuthenticationContext;
 use crate::authentication::provider::AuthenticationProvider;
+use crate::runtime_bridge::block_on_sync_bridge;
 
 // Re-export the main trait and implementations for convenience
 pub use abstract_authentication_strategy::AbstractAuthenticationStrategy;
@@ -39,23 +39,6 @@ pub use authentication_strategy::AuthenticationStrategy;
 pub use stateful_authentication_strategy::StatefulAuthenticationStrategy;
 pub use stateless_authentication_strategy::StatelessAuthenticationStrategy;
 
-fn authenticate_provider_on_current_thread_runtime<P>(
-    provider: &P,
-    context: &DefaultAuthenticationContext,
-) -> RocketMQResult<()>
-where
-    P: AuthenticationProvider<Context = DefaultAuthenticationContext> + Send + Sync + 'static,
-{
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| {
-            RocketMQError::authentication_failed(format!("failed to create authentication runtime: {error}"))
-        })?;
-
-    runtime.block_on(provider.authenticate(context))
-}
-
 pub(super) fn block_on_authentication_provider<P>(
     provider: &P,
     context: &DefaultAuthenticationContext,
@@ -63,18 +46,11 @@ pub(super) fn block_on_authentication_provider<P>(
 where
     P: AuthenticationProvider<Context = DefaultAuthenticationContext> + Send + Sync + 'static,
 {
-    let auth_result = match tokio::runtime::Handle::try_current() {
-        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
-            tokio::task::block_in_place(|| handle.block_on(provider.authenticate(context)))
-        }
-        Ok(_) => std::thread::scope(|scope| {
-            scope
-                .spawn(|| authenticate_provider_on_current_thread_runtime(provider, context))
-                .join()
-                .map_err(|_| RocketMQError::authentication_failed("authentication provider thread panicked"))?
-        }),
-        Err(_) => authenticate_provider_on_current_thread_runtime(provider, context),
-    };
+    let auth_result = block_on_sync_bridge(
+        || provider.authenticate(context),
+        |error| RocketMQError::authentication_failed(format!("failed to create authentication runtime: {error}")),
+        || RocketMQError::authentication_failed("authentication provider thread panicked"),
+    );
 
     auth_result.map_err(|error| AuthError::AuthenticationFailed(error.to_string()))
 }

--- a/rocketmq-auth/src/authorization/strategy.rs
+++ b/rocketmq-auth/src/authorization/strategy.rs
@@ -26,6 +26,7 @@ pub mod stateless_authorization_strategy;
 
 use crate::authorization::context::default_authorization_context::DefaultAuthorizationContext;
 use crate::authorization::provider::AuthorizationError;
+use crate::runtime_bridge::block_on_sync_bridge;
 
 pub use abstract_authorization_strategy::AbstractAuthorizationStrategy;
 pub use abstract_authorization_strategy::AuthorizationStrategy;
@@ -33,34 +34,13 @@ pub use abstract_authorization_strategy::StrategyResult;
 pub use stateful_authorization_strategy::StatefulAuthorizationStrategy;
 pub use stateless_authorization_strategy::StatelessAuthorizationStrategy;
 
-fn evaluate_base_on_current_thread_runtime(
-    base: &AbstractAuthorizationStrategy,
-    context: &DefaultAuthorizationContext,
-) -> StrategyResult<()> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| {
-            AuthorizationError::InternalError(format!("failed to create authorization runtime: {error}"))
-        })?;
-
-    runtime.block_on(base.do_evaluate(context))
-}
-
 pub(super) fn block_on_base_authorization(
     base: &AbstractAuthorizationStrategy,
     context: &DefaultAuthorizationContext,
 ) -> StrategyResult<()> {
-    match tokio::runtime::Handle::try_current() {
-        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
-            tokio::task::block_in_place(|| handle.block_on(base.do_evaluate(context)))
-        }
-        Ok(_) => std::thread::scope(|scope| {
-            scope
-                .spawn(|| evaluate_base_on_current_thread_runtime(base, context))
-                .join()
-                .map_err(|_| AuthorizationError::InternalError("authorization provider thread panicked".to_string()))?
-        }),
-        Err(_) => evaluate_base_on_current_thread_runtime(base, context),
-    }
+    block_on_sync_bridge(
+        || base.do_evaluate(context),
+        |error| AuthorizationError::InternalError(format!("failed to create authorization runtime: {error}")),
+        || AuthorizationError::InternalError("authorization provider thread panicked".to_string()),
+    )
 }

--- a/rocketmq-auth/src/lib.rs
+++ b/rocketmq-auth/src/lib.rs
@@ -21,6 +21,7 @@ pub mod config;
 pub mod migration;
 pub mod permission;
 pub mod runtime;
+pub(crate) mod runtime_bridge;
 
 // Re-export commonly used authentication types
 pub use authentication::acl_signer::SignatureAlgorithm;

--- a/rocketmq-auth/src/runtime_bridge.rs
+++ b/rocketmq-auth/src/runtime_bridge.rs
@@ -1,0 +1,75 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+
+static AUTH_SYNC_RUNTIME: OnceLock<Result<RuntimeOwner, String>> = OnceLock::new();
+
+pub(crate) fn block_on_sync_bridge<F, Fut, T, E, BuildError, ThreadPanic>(
+    future: F,
+    build_error: BuildError,
+    thread_panic: ThreadPanic,
+) -> Result<T, E>
+where
+    F: FnOnce() -> Fut + Send,
+    Fut: Future<Output = Result<T, E>>,
+    T: Send,
+    E: Send,
+    BuildError: FnOnce(String) -> E + Send,
+    ThreadPanic: FnOnce() -> E + Send,
+{
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(|| handle.block_on(future()))
+        }
+        Ok(_) => std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let runtime = auth_sync_runtime().map_err(build_error)?;
+                    runtime.block_on(future())
+                })
+                .join()
+                .map_err(|_| thread_panic())?
+        }),
+        Err(_) => {
+            let runtime = auth_sync_runtime().map_err(build_error)?;
+            runtime.block_on(future())
+        }
+    }
+}
+
+fn auth_sync_runtime() -> Result<&'static RuntimeOwner, String> {
+    match AUTH_SYNC_RUNTIME.get_or_init(|| {
+        let parallelism = std::thread::available_parallelism()
+            .map(|parallelism| parallelism.get())
+            .unwrap_or(2);
+        let worker_threads = parallelism.clamp(2, 4);
+        RuntimeOwner::new(RuntimeConfig {
+            worker_threads,
+            max_blocking_threads: worker_threads * 2,
+            thread_name: "rocketmq-auth-sync".to_string(),
+            shutdown_timeout: Duration::from_secs(10),
+            ..RuntimeConfig::default()
+        })
+        .map_err(|error| error.to_string())
+    }) {
+        Ok(runtime) => Ok(runtime),
+        Err(error) => Err(error.clone()),
+    }
+}

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -56,7 +56,6 @@ use rocketmq_remoting::protocol::subscription::subscription_group_config::Subscr
 use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::remoting_server::rocketmq_tokio_server::RocketMQServer;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
-use rocketmq_runtime::RocketMQRuntime;
 use rocketmq_rust::schedule::simple_scheduler::ScheduledTaskManager;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::commit_log_dispatcher::CommitLogDispatcher;
@@ -387,7 +386,6 @@ fn prepare_rocksdb_config_path_for_json_migration(path: &Path) -> bool {
 pub(crate) struct BrokerRuntime {
     #[cfg(feature = "local_file_store")]
     inner: ArcMut<BrokerRuntimeInner<GenericMessageStore>>,
-    broker_runtime: Option<RocketMQRuntime>,
     shutdown_hook: Option<BrokerShutdownHook>,
     proxy_request_processor: Option<DefaultServerProcessor>,
     consumer_ids_change_listener: Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static>,
@@ -400,9 +398,6 @@ impl Drop for BrokerRuntime {
         // ticker loops cannot spin at full speed and block the runtime from completing
         // shutdown when the broker is dropped (e.g. during test panic unwind).
         self.scheduled_task_manager.abort_all();
-        if let Some(broker_runtime) = self.broker_runtime.take() {
-            broker_runtime.shutdown();
-        }
     }
 }
 
@@ -414,7 +409,6 @@ impl BrokerRuntime {
     ) -> Self {
         let broker_address = format!("{}:{}", broker_config.broker_ip1, broker_config.listen_port);
         let store_host = broker_address.parse::<SocketAddr>().expect("parse store_host failed");
-        let runtime = RocketMQRuntime::new_multi(10, "broker-thread");
         let scheduled_task_manager = ScheduledTaskManager::default();
         let broker_outer_api = BrokerOuterAPI::new(Arc::new(TokioClientConfig::default()));
 
@@ -573,7 +567,6 @@ impl BrokerRuntime {
         inner.topic_queue_mapping_clean_service = Some(TopicQueueMappingCleanService::new(inner.clone()));
         Self {
             inner,
-            broker_runtime: Some(runtime),
             shutdown_hook: None,
             proxy_request_processor: None,
             consumer_ids_change_listener,
@@ -622,10 +615,6 @@ impl BrokerRuntime {
         self.inner.broker_outer_api.shutdown();
 
         self.scheduled_task_manager.abort_all();
-
-        if let Some(runtime) = self.broker_runtime.take() {
-            runtime.shutdown();
-        }
 
         if let Some(client_housekeeping_service) = self.inner.client_housekeeping_service.take() {
             client_housekeeping_service.shutdown();
@@ -1611,19 +1600,17 @@ impl BrokerRuntime {
             self.update_namesrv_addr().await;
             info!("Set user specified name remoting_server address: {}", namesrv_address);
             let mut broker_runtime = self.inner.clone();
-            self.broker_runtime.as_ref().unwrap().get_handle().spawn(async move {
-                tokio::time::sleep(Duration::from_secs(10)).await;
-                loop {
-                    if broker_runtime.shutdown.load(Ordering::Acquire) {
-                        break;
+            self.scheduled_task_manager.add_fixed_rate_no_overlap_task_async(
+                Duration::from_secs(10),
+                Duration::from_secs(60),
+                async move |ctx| {
+                    if ctx.is_cancelled() || broker_runtime.shutdown.load(Ordering::Acquire) {
+                        return Ok(());
                     }
-                    let current_execution_time = tokio::time::Instant::now();
                     broker_runtime.update_namesrv_addr_inner().await;
-                    let next_execution_time = current_execution_time + Duration::from_secs(60);
-                    let delay = next_execution_time.saturating_duration_since(tokio::time::Instant::now());
-                    tokio::time::sleep(delay).await;
-                }
-            });
+                    Ok(())
+                },
+            );
         }
     }
 

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -43,7 +43,6 @@ use rocketmq_remoting::rpc::rpc_request::RpcRequest;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RejectRequestResponse;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
-use rocketmq_runtime::RocketMQRuntime;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::get_message_result::GetMessageResult;
 use rocketmq_store::base::message_status_enum::GetMessageStatus;
@@ -85,7 +84,6 @@ use crate::processor::pull_message_result_handler::PullMessageResultHandler;
 /// - PULL consumers are either suspended or limited to 1 message
 pub struct PullMessageProcessor<MS: MessageStore> {
     pull_message_result_handler: ArcMut<DefaultPullMessageResultHandler<MS>>,
-    write_message_runtime: Arc<RocketMQRuntime>,
     /// Lock to serialize writes to channels when waking up suspended requests.
     ///
     /// This is a global lock which may become a bottleneck under high concurrency.
@@ -151,10 +149,8 @@ where
         pull_message_result_handler: ArcMut<DefaultPullMessageResultHandler<MS>>,
         broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     ) -> Self {
-        let cpus = num_cpus::get();
         Self {
             pull_message_result_handler,
-            write_message_runtime: Arc::new(RocketMQRuntime::new_multi(cpus, "write_consumer_message_runtime")),
             write_message_lock: Arc::new(Default::default()),
             broker_runtime_inner,
         }
@@ -990,7 +986,7 @@ where
         mut request: RemotingCommand,
     ) {
         let lock = Arc::clone(&self.write_message_lock);
-        self.write_message_runtime.get_handle().spawn(async move {
+        let task = async move {
             let broker_allow_flow_ctr_suspend =
                 !(request.ext_fields().is_some() && request.ext_fields().unwrap().contains_key(NO_SUSPEND_KEY));
             let opaque = request.opaque();
@@ -1012,7 +1008,15 @@ where
                 ctx.write_response(command).await;
                 drop(guard);
             }
-        });
+        };
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                drop(handle.spawn(task));
+            }
+            Err(error) => {
+                warn!("Cannot execute wakeup pull request without Tokio runtime: {}", error);
+            }
+        }
     }
 }
 pub(crate) fn is_broadcast(proxy_pull_broadcast: bool, consumer_group_info: Option<&ConsumerGroupInfo>) -> bool {

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -49,6 +49,7 @@ use crate::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyS
 use crate::consumer::listener::consume_return_type::ConsumeReturnType;
 use crate::consumer::listener::message_listener_concurrently::ArcMessageListenerConcurrently;
 use crate::hook::consume_message_context::ConsumeMessageContext;
+use crate::runtime::spawn_client_task;
 
 pub struct ConsumeMessageConcurrentlyService {
     pub(crate) default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
@@ -92,19 +93,10 @@ fn spawn_concurrent_task<F>(thread_name: &'static str, task: F) -> Option<Concur
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        return Some(ConcurrentTaskHandle::Tokio(handle.spawn(task)));
-    }
-
-    match thread::Builder::new().name(thread_name.to_string()).spawn(move || {
-        match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-            Ok(runtime) => runtime.block_on(task),
-            Err(error) => warn!("Failed to build {} runtime: {}", thread_name, error),
-        }
-    }) {
-        Ok(handle) => Some(ConcurrentTaskHandle::Thread(handle)),
+    match spawn_client_task(thread_name, task) {
+        Ok(handle) => Some(ConcurrentTaskHandle::Tokio(handle)),
         Err(error) => {
-            warn!("Failed to spawn {} background thread: {}", thread_name, error);
+            warn!("Failed to spawn {} background task: {}", thread_name, error);
             None
         }
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -55,6 +55,7 @@ use crate::consumer::listener::message_listener_orderly::ArcMessageListenerOrder
 use crate::consumer::message_queue_lock::MessageQueueLock;
 use crate::consumer::mq_consumer_inner::MQConsumerInnerLocal;
 use crate::hook::consume_message_context::ConsumeMessageContext;
+use crate::runtime::spawn_client_task;
 
 static MAX_TIME_CONSUME_CONTINUOUSLY: LazyLock<u64> = LazyLock::new(|| {
     std::env::var("rocketmq.client.maxTimeConsumeContinuously")
@@ -100,19 +101,10 @@ fn spawn_orderly_task<F>(thread_name: &'static str, task: F) -> Option<OrderlyTa
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        return Some(OrderlyTaskHandle::Tokio(handle.spawn(task)));
-    }
-
-    match thread::Builder::new().name(thread_name.to_string()).spawn(move || {
-        match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-            Ok(runtime) => runtime.block_on(task),
-            Err(error) => warn!("Failed to build {} runtime: {}", thread_name, error),
-        }
-    }) {
-        Ok(handle) => Some(OrderlyTaskHandle::Thread(handle)),
+    match spawn_client_task(thread_name, task) {
+        Ok(handle) => Some(OrderlyTaskHandle::Tokio(handle)),
         Err(error) => {
-            warn!("Failed to spawn {} background thread: {}", thread_name, error);
+            warn!("Failed to spawn {} background task: {}", thread_name, error);
             None
         }
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -18,7 +18,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -52,24 +51,14 @@ use crate::consumer::listener::consume_concurrently_status::ConsumeConcurrentlyS
 use crate::consumer::listener::consume_return_type::ConsumeReturnType;
 use crate::consumer::listener::message_listener_concurrently::ArcMessageListenerConcurrently;
 use crate::hook::consume_message_context::ConsumeMessageContext;
+use crate::runtime::spawn_detached_client_task;
 
 fn spawn_detached_pop_concurrent_task<F>(thread_name: &'static str, task: F)
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        drop(handle.spawn(task));
-        return;
-    }
-
-    match thread::Builder::new().name(thread_name.to_string()).spawn(move || {
-        match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-            Ok(runtime) => runtime.block_on(task),
-            Err(error) => warn!("Failed to build {} runtime: {}", thread_name, error),
-        }
-    }) {
-        Ok(handle) => drop(handle),
-        Err(error) => warn!("Failed to spawn {} background thread: {}", thread_name, error),
+    if let Err(error) = spawn_detached_client_task(thread_name, task) {
+        warn!("Failed to spawn {} background task: {}", thread_name, error);
     }
 }
 

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -50,6 +50,7 @@ use crate::consumer::listener::consume_orderly_context::ConsumeOrderlyContext;
 use crate::consumer::listener::consume_orderly_status::ConsumeOrderlyStatus;
 use crate::consumer::listener::message_listener_orderly::ArcMessageListenerOrderly;
 use crate::consumer::message_queue_lock::MessageQueueLock;
+use crate::runtime::spawn_client_task;
 
 pub struct ConsumeMessagePopOrderlyService {
     pub(crate) default_mqpush_consumer_impl: Option<ArcMut<DefaultMQPushConsumerImpl>>,
@@ -88,19 +89,10 @@ fn spawn_pop_orderly_task<F>(thread_name: &'static str, task: F) -> Option<PopOr
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        return Some(PopOrderlyTaskHandle::Tokio(handle.spawn(task)));
-    }
-
-    match thread::Builder::new().name(thread_name.to_string()).spawn(move || {
-        match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-            Ok(runtime) => runtime.block_on(task),
-            Err(error) => warn!("Failed to build {} runtime: {}", thread_name, error),
-        }
-    }) {
-        Ok(handle) => Some(PopOrderlyTaskHandle::Thread(handle)),
+    match spawn_client_task(thread_name, task) {
+        Ok(handle) => Some(PopOrderlyTaskHandle::Tokio(handle)),
         Err(error) => {
-            warn!("Failed to spawn {} background thread: {}", thread_name, error);
+            warn!("Failed to spawn {} background task: {}", thread_name, error);
             None
         }
     }

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -77,6 +77,8 @@ use crate::hook::consume_message_hook::ConsumeMessageHook;
 use crate::hook::filter_message_hook::FilterMessageHook;
 use crate::implementation::communication_mode::CommunicationMode;
 use crate::implementation::mq_client_manager::MQClientManager;
+use crate::runtime::spawn_client_task;
+use crate::runtime::spawn_detached_client_task;
 
 const QUERY_UNIQ_KEY_LOOKBACK_MILLIS: u64 = 3 * 24 * 60 * 60 * 1000;
 
@@ -143,18 +145,8 @@ fn spawn_lite_pull_task<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        return Ok(LitePullTaskHandle::Tokio {
-            handle: handle.spawn(task),
-            cancelled,
-        });
-    }
-
-    let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
-    let handle = thread::Builder::new()
-        .name(thread_name.to_string())
-        .spawn(move || runtime.block_on(task))?;
-    Ok(LitePullTaskHandle::Thread { handle, cancelled })
+    let handle = spawn_client_task(thread_name, task)?;
+    Ok(LitePullTaskHandle::Tokio { handle, cancelled })
 }
 
 async fn sleep_or_cancel(shutdown_signal: &Arc<AtomicBool>, cancelled: &Arc<AtomicBool>, delay: Duration) -> bool {
@@ -191,40 +183,33 @@ impl MessageQueueListener for LitePullRebalanceListener {
         let mq_assigned = mq_assigned.clone();
         let user_listener = self.user_listener.clone();
 
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => {
-                let join_handle = handle.spawn(async move {
-                    if let Err(error) = consumer_impl
-                        .update_assign_queue_and_start_pull_task(topic.as_str(), &mq_all, &mq_assigned)
-                        .await
-                    {
-                        warn!(
-                            "LitePull rebalance assignment update failed. topic={}, error={}",
-                            topic, error
-                        );
-                    }
-
-                    let listener = user_listener.read().ok().and_then(|listener| listener.clone());
-                    if let Some(listener) = listener {
-                        if let Err(error) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            listener.message_queue_changed(topic.as_str(), &mq_all, &mq_assigned);
-                        })) {
-                            warn!(
-                                "LitePull user message queue listener panicked. topic={}, error={:?}",
-                                topic, error
-                            );
-                        }
-                    }
-                });
-                drop(join_handle);
-            }
-            Err(error) => {
+        if let Err(error) = spawn_detached_client_task("rocketmq-client-lite-pull-rebalance-listener", async move {
+            if let Err(error) = consumer_impl
+                .update_assign_queue_and_start_pull_task(topic.as_str(), &mq_all, &mq_assigned)
+                .await
+            {
                 warn!(
-                    "LitePull rebalance listener ignored async assignment update because no Tokio runtime is \
-                     available. error={}",
-                    error
+                    "LitePull rebalance assignment update failed. topic={}, error={}",
+                    topic, error
                 );
             }
+
+            let listener = user_listener.read().ok().and_then(|listener| listener.clone());
+            if let Some(listener) = listener {
+                if let Err(error) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    listener.message_queue_changed(topic.as_str(), &mq_all, &mq_assigned);
+                })) {
+                    warn!(
+                        "LitePull user message queue listener panicked. topic={}, error={:?}",
+                        topic, error
+                    );
+                }
+            }
+        }) {
+            warn!(
+                "LitePull rebalance listener ignored async assignment update because task spawn failed. error={}",
+                error
+            );
         }
     }
 }
@@ -2956,7 +2941,7 @@ mod tests {
         let thread_name = rx
             .recv_timeout(Duration::from_secs(1))
             .expect("fallback lite pull task should complete");
-        assert_eq!(thread_name, "rocketmq-client-lite-pull-test");
+        assert_eq!(thread_name, "rocketmq-client-fallback");
         handle.abort();
     }
 

--- a/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
@@ -16,7 +16,6 @@ use std::future::Future;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::thread;
 use std::time::Duration;
 
 use rocketmq_common::common::message::message_enum::MessageRequestMode;
@@ -31,6 +30,7 @@ use crate::consumer::consumer_impl::message_request::MessageRequest;
 use crate::consumer::consumer_impl::pop_request::PopRequest;
 use crate::consumer::consumer_impl::pull_request::PullRequest;
 use crate::factory::mq_client_instance::MQClientInstance;
+use crate::runtime::spawn_detached_client_task;
 
 /// Default queue capacity for message requests
 const DEFAULT_QUEUE_CAPACITY: usize = 4096;
@@ -396,19 +396,8 @@ fn spawn_pull_message_task<F>(thread_name: &'static str, task: F)
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        drop(handle.spawn(task));
-        return;
-    }
-
-    match thread::Builder::new().name(thread_name.to_string()).spawn(move || {
-        match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-            Ok(runtime) => runtime.block_on(task),
-            Err(error) => error!("Failed to build {} runtime: {}", thread_name, error),
-        }
-    }) {
-        Ok(_handle) => {}
-        Err(error) => error!("Failed to spawn {} background thread: {}", thread_name, error),
+    if let Err(error) = spawn_detached_client_task(thread_name, task) {
+        error!("Failed to spawn {} background task: {}", thread_name, error);
     }
 }
 

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
@@ -17,7 +17,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::thread;
 use std::time::Duration;
 
 use rocketmq_common::TimeUtils::current_millis;
@@ -31,21 +30,14 @@ use tracing::info;
 use tracing::warn;
 
 use crate::factory::mq_client_instance::MQClientInstance;
+use crate::runtime::spawn_client_task;
 
 fn spawn_rebalance_task<F>(task: F) -> std::io::Result<Option<tokio::task::AbortHandle>>
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        let task = handle.spawn(task);
-        return Ok(Some(task.abort_handle()));
-    }
-
-    let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
-    thread::Builder::new()
-        .name("rocketmq-client-rebalance-service".to_string())
-        .spawn(move || runtime.block_on(task))?;
-    Ok(None)
+    let task = spawn_client_task("rocketmq-client-rebalance-service", task)?;
+    Ok(Some(task.abort_handle()))
 }
 
 /// Configuration for RebalanceService.
@@ -554,8 +546,8 @@ mod tests {
 
         assert!(service.is_running());
         assert!(
-            service.task_abort_handle.is_none(),
-            "fallback thread path does not expose a Tokio abort handle"
+            service.task_abort_handle.is_some(),
+            "shared fallback runtime should expose a Tokio abort handle"
         );
 
         let tx_shutdown = service

--- a/rocketmq-client/src/consumer/store/local_file_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/local_file_offset_store.rs
@@ -45,6 +45,7 @@ use crate::consumer::store::offset_serialize_wrapper::OffsetSerializeWrapper;
 use crate::consumer::store::offset_store::OffsetStoreTrait;
 use crate::consumer::store::read_offset_type::ReadOffsetType;
 use crate::factory::mq_client_instance::MQClientInstance;
+use crate::runtime::spawn_client_task;
 
 static LOCAL_OFFSET_STORE_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
     #[cfg(target_os = "windows")]
@@ -138,21 +139,10 @@ impl LocalFileOffsetStore {
             Self::background_persist_task(offset_table, dirty_flag, store_path, persist_rx).await;
         };
 
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            return PersistTaskHandle::Tokio(handle.spawn(task));
-        }
-
-        match thread::Builder::new()
-            .name("rocketmq-client-local-offset-store".to_string())
-            .spawn(
-                move || match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-                    Ok(runtime) => runtime.block_on(task),
-                    Err(error) => error!("Failed to build LocalFileOffsetStore runtime: {}", error),
-                },
-            ) {
-            Ok(handle) => PersistTaskHandle::Thread(handle),
+        match spawn_client_task("rocketmq-client-local-offset-store", task) {
+            Ok(handle) => PersistTaskHandle::Tokio(handle),
             Err(error) => {
-                error!("Failed to spawn LocalFileOffsetStore background thread: {}", error);
+                error!("Failed to spawn LocalFileOffsetStore background task: {}", error);
                 PersistTaskHandle::NotStarted
             }
         }

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -83,6 +83,8 @@ use crate::producer::default_mq_producer::DefaultMQProducer;
 use crate::producer::default_mq_producer::ProducerConfig;
 use crate::producer::producer_impl::mq_producer_inner::MQProducerInnerImpl;
 use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
+use crate::runtime::spawn_delayed_client_action;
+use crate::runtime::spawn_detached_client_task;
 use crate::stat::consumer_stats_manager::ConsumerStatsManager;
 
 const LOCK_TIMEOUT_MILLIS: u64 = 3000;
@@ -136,34 +138,14 @@ fn spawn_connection_net_event_listener(
     rx: tokio::sync::broadcast::Receiver<ConnectionNetEvent>,
     weak_instance: WeakArcMut<MQClientInstance>,
 ) {
-    match tokio::runtime::Handle::try_current() {
-        Ok(handle) => {
-            let task = handle.spawn(run_connection_net_event_listener(rx, weak_instance));
-            drop(task);
-        }
-        Err(error) => {
-            warn!(
-                "No Tokio runtime available while creating MQClientInstance; starting dedicated connection event \
-                 listener thread. error={}",
-                error
-            );
-            let thread = std::thread::Builder::new().name("rocketmq-client-connection-events".to_string());
-            if let Err(error) = thread.spawn(move || {
-                let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-                    Ok(runtime) => runtime,
-                    Err(error) => {
-                        error!("Failed to create MQClientInstance connection event runtime: {}", error);
-                        return;
-                    }
-                };
-                runtime.block_on(run_connection_net_event_listener(rx, weak_instance));
-            }) {
-                error!(
-                    "Failed to spawn MQClientInstance connection event listener thread: {}",
-                    error
-                );
-            }
-        }
+    if let Err(error) = spawn_detached_client_task(
+        "rocketmq-client-connection-events",
+        run_connection_net_event_listener(rx, weak_instance),
+    ) {
+        error!(
+            "Failed to spawn MQClientInstance connection event listener task: {}",
+            error
+        );
     }
 }
 
@@ -173,28 +155,7 @@ fn schedule_rebalance_wakeup(service: RebalanceService, delay: Duration) {
         return;
     }
 
-    match tokio::runtime::Handle::try_current() {
-        Ok(handle) => {
-            let task = handle.spawn(async move {
-                tokio::time::sleep(delay).await;
-                service.wakeup();
-            });
-            drop(task);
-        }
-        Err(error) => {
-            warn!(
-                "No Tokio runtime available for delayed rebalance wakeup; using a dedicated sleeper thread. error={}",
-                error
-            );
-            let thread = std::thread::Builder::new().name("rocketmq-client-rebalance-delay".to_string());
-            if let Err(error) = thread.spawn(move || {
-                std::thread::sleep(delay);
-                service.wakeup();
-            }) {
-                error!("Failed to spawn delayed rebalance wakeup thread: {}", error);
-            }
-        }
-    }
+    spawn_delayed_client_action("rocketmq-client-rebalance-delay", delay, move || service.wakeup());
 }
 
 pub struct MQClientInstance {

--- a/rocketmq-client/src/implementation/mq_client_api_factory.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_factory.rs
@@ -29,6 +29,7 @@ use tokio::time::Instant;
 
 use crate::common::nameserver_access_config::NameserverAccessConfig;
 use crate::implementation::mq_client_api_impl::MQClientAPIImpl;
+use crate::runtime::spawn_client_task;
 
 pub struct MQClientAPIFactory {
     nameserver_access_config: NameserverAccessConfig,
@@ -215,29 +216,16 @@ fn validate_nameserver_access_config(config: &NameserverAccessConfig) -> RocketM
 
 fn spawn_namesrv_refresh_task<F>(
     thread_name: &'static str,
-    stop_signal: Arc<AtomicBool>,
+    _stop_signal: Arc<AtomicBool>,
     task: F,
 ) -> Option<NamesrvRefreshTaskHandle>
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        return Some(NamesrvRefreshTaskHandle::Tokio(handle.spawn(task)));
-    }
-
-    match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-        Ok(runtime) => match thread::Builder::new()
-            .name(thread_name.to_string())
-            .spawn(move || runtime.block_on(task))
-        {
-            Ok(handle) => Some(NamesrvRefreshTaskHandle::Thread { stop_signal, handle }),
-            Err(error) => {
-                tracing::warn!("Failed to spawn {} background thread: {}", thread_name, error);
-                None
-            }
-        },
+    match spawn_client_task(thread_name, task) {
+        Ok(handle) => Some(NamesrvRefreshTaskHandle::Tokio(handle)),
         Err(error) => {
-            tracing::warn!("Failed to build {} runtime: {}", thread_name, error);
+            tracing::warn!("Failed to spawn {} background task: {}", thread_name, error);
             None
         }
     }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -19,7 +19,6 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::OnceLock;
-use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -47,6 +46,8 @@ use crate::producer::producer_impl::topic_publish_info::TopicPublishInfo;
 use crate::producer::send_callback::ArcSendCallback;
 use crate::producer::send_result::SendResult;
 use crate::producer::send_status::SendStatus;
+use crate::runtime::spawn_client_task_on;
+use crate::runtime::spawn_detached_client_task;
 use cheetah_string::CheetahString;
 
 use crate::base::validators::Validators;
@@ -2796,10 +2797,8 @@ impl MQClientAPIImpl {
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        if let Some(executor) = async_sender_executor {
-            drop(executor.spawn(task));
-        } else {
-            Self::spawn_api_background_task("rocketmq-client-async-send", task);
+        if let Err(error) = spawn_client_task_on("rocketmq-client-async-send", async_sender_executor.as_ref(), task) {
+            warn!("Failed to spawn rocketmq-client-async-send task: {}", error);
         }
     }
 
@@ -2807,21 +2806,8 @@ impl MQClientAPIImpl {
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            drop(handle.spawn(task));
-            return;
-        }
-
-        match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-            Ok(runtime) => {
-                if let Err(error) = thread::Builder::new()
-                    .name(thread_name.to_string())
-                    .spawn(move || runtime.block_on(task))
-                {
-                    warn!("Failed to spawn {} background thread: {}", thread_name, error);
-                }
-            }
-            Err(error) => warn!("Failed to build {} runtime: {}", thread_name, error),
+        if let Err(error) = spawn_detached_client_task(thread_name, task) {
+            warn!("Failed to spawn {} background task: {}", thread_name, error);
         }
     }
 
@@ -7103,7 +7089,7 @@ mod tests {
         let thread_name = rx
             .recv_timeout(Duration::from_secs(2))
             .expect("async send task should run on fallback runtime");
-        assert_eq!(thread_name, "rocketmq-client-async-send");
+        assert_eq!(thread_name, "rocketmq-client-fallback");
     }
 
     #[test]

--- a/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
@@ -20,6 +20,7 @@ use tokio_util::sync::CancellationToken;
 use crate::latency::latency_fault_tolerance::LatencyFaultTolerance;
 use crate::latency::resolver::Resolver;
 use crate::latency::service_detector::ServiceDetector;
+use crate::runtime::spawn_detached_client_task;
 
 pub struct LatencyFaultToleranceImpl<R, S> {
     fault_item_table: DashMap<CheetahString, FaultItem>,
@@ -198,7 +199,6 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use tracing::error;
 use tracing::info;
-use tracing::warn;
 
 async fn run_detector_loop<R, S>(this: ArcMut<LatencyFaultToleranceImpl<R, S>>, token: CancellationToken)
 where
@@ -230,31 +230,8 @@ where
     R: Resolver,
     S: ServiceDetector,
 {
-    match tokio::runtime::Handle::try_current() {
-        Ok(handle) => {
-            let task = handle.spawn(run_detector_loop(this, token));
-            drop(task);
-        }
-        Err(error) => {
-            warn!(
-                "No Tokio runtime available while starting fault tolerance detector; using a dedicated detector \
-                 thread. error={}",
-                error
-            );
-            let thread = std::thread::Builder::new().name("rocketmq-client-fault-detector".to_string());
-            if let Err(error) = thread.spawn(move || {
-                let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-                    Ok(runtime) => runtime,
-                    Err(error) => {
-                        error!("Failed to create fault tolerance detector runtime: {}", error);
-                        return;
-                    }
-                };
-                runtime.block_on(run_detector_loop(this, token));
-            }) {
-                error!("Failed to spawn fault tolerance detector thread: {}", error);
-            }
-        }
+    if let Err(error) = spawn_detached_client_task("rocketmq-client-fault-detector", run_detector_loop(this, token)) {
+        error!("Failed to spawn fault tolerance detector task: {}", error);
     }
 }
 

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -82,6 +82,7 @@ pub mod latency;
 pub mod legacy;
 pub mod lock;
 pub mod producer;
+mod runtime;
 pub mod stat;
 mod trace;
 mod types;

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -38,6 +38,7 @@ use tokio::sync::Mutex;
 use crate::producer::default_mq_producer::DefaultMQProducer;
 use crate::producer::send_callback::ArcSendCallback;
 use crate::producer::send_result::SendResult;
+use crate::runtime::spawn_client_task;
 
 #[derive(Default)]
 pub struct ProduceAccumulator {
@@ -891,19 +892,10 @@ fn spawn_guard_task<F>(thread_name: &'static str, task: F) -> Option<GuardTaskHa
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        return Some(GuardTaskHandle::Tokio(handle.spawn(task)));
-    }
-
-    match thread::Builder::new().name(thread_name.to_string()).spawn(move || {
-        match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-            Ok(runtime) => runtime.block_on(task),
-            Err(error) => tracing::error!("Failed to build {} runtime: {}", thread_name, error),
-        }
-    }) {
-        Ok(handle) => Some(GuardTaskHandle::Thread(handle)),
+    match spawn_client_task(thread_name, task) {
+        Ok(handle) => Some(GuardTaskHandle::Tokio(handle)),
         Err(error) => {
-            tracing::error!("Failed to spawn {} background thread: {}", thread_name, error);
+            tracing::error!("Failed to spawn {} background task: {}", thread_name, error);
             None
         }
     }

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -19,7 +19,6 @@ use std::future::Future;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -95,6 +94,7 @@ use crate::producer::send_result::SendResult;
 use crate::producer::send_status::SendStatus;
 use crate::producer::transaction_listener::ArcTransactionListener;
 use crate::producer::transaction_send_result::TransactionSendResult;
+use crate::runtime::spawn_client_task_on;
 use tokio::task::JoinHandle;
 
 type Topic = CheetahString;
@@ -161,20 +161,7 @@ fn spawn_producer_task<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Some(executor) = executor {
-        drop(executor.spawn(task));
-        return Ok(());
-    }
-
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        drop(handle.spawn(task));
-        return Ok(());
-    }
-
-    let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
-    thread::Builder::new()
-        .name(thread_name.to_string())
-        .spawn(move || runtime.block_on(task))?;
+    drop(spawn_client_task_on(thread_name, executor, task)?);
     Ok(())
 }
 
@@ -3504,7 +3491,7 @@ mod tests {
         let thread_name = rx
             .recv_timeout(Duration::from_secs(1))
             .expect("fallback producer task should complete");
-        assert_eq!(thread_name, "rocketmq-client-producer-test");
+        assert_eq!(thread_name, "rocketmq-client-fallback");
     }
 
     struct PanicTransactionListener;

--- a/rocketmq-client/src/runtime.rs
+++ b/rocketmq-client/src/runtime.rs
@@ -1,0 +1,385 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::io;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use tokio::runtime::Handle;
+use tokio::task::JoinHandle;
+
+static SHARED_FALLBACK: OnceLock<ClientSharedFallbackRegistry> = OnceLock::new();
+
+pub(crate) fn spawn_client_task<F>(task_name: &'static str, task: F) -> io::Result<JoinHandle<()>>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    spawn_client_task_on(task_name, None, task)
+}
+
+pub(crate) fn spawn_client_task_on<F>(
+    task_name: &'static str,
+    executor: Option<&Handle>,
+    task: F,
+) -> io::Result<JoinHandle<()>>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    if let Some(executor) = executor {
+        return Ok(executor.spawn(task));
+    }
+
+    if let Ok(handle) = Handle::try_current() {
+        return Ok(handle.spawn(task));
+    }
+
+    shared_fallback()?.spawn(task_name, task)
+}
+
+pub(crate) fn spawn_detached_client_task<F>(task_name: &'static str, task: F) -> io::Result<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    drop(spawn_client_task(task_name, task)?);
+    Ok(())
+}
+
+pub(crate) fn spawn_delayed_client_action<F>(task_name: &'static str, delay: std::time::Duration, action: F)
+where
+    F: FnOnce() + Send + 'static,
+{
+    if delay.is_zero() {
+        action();
+        return;
+    }
+
+    if let Err(error) = spawn_detached_client_task(task_name, async move {
+        tokio::time::sleep(delay).await;
+        action();
+    }) {
+        tracing::error!(%error, task_name, "failed to spawn delayed client action");
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn shared_fallback_snapshot() -> Option<ClientSharedFallbackSnapshot> {
+    SHARED_FALLBACK.get().map(ClientSharedFallbackRegistry::snapshot)
+}
+
+fn shared_fallback() -> io::Result<ClientSharedFallbackLease> {
+    shared_fallback_registry().acquire()
+}
+
+fn shared_fallback_registry() -> &'static ClientSharedFallbackRegistry {
+    SHARED_FALLBACK.get_or_init(ClientSharedFallbackRegistry::new)
+}
+
+struct ClientSharedFallbackRegistry {
+    state: Mutex<ClientSharedFallbackState>,
+    next_generation: AtomicUsize,
+    submitted_tasks: AtomicUsize,
+    active_tasks: AtomicUsize,
+    active_leases: AtomicUsize,
+    idle_shutdowns: AtomicUsize,
+    explicit_shutdowns: AtomicUsize,
+    idle_check_scheduled: AtomicBool,
+}
+
+#[derive(Default)]
+struct ClientSharedFallbackState {
+    runtime: Option<Arc<ClientSharedFallbackRuntime>>,
+    explicit_shutdown: bool,
+}
+
+struct ClientSharedFallbackRuntime {
+    owner: RuntimeOwner,
+    generation: usize,
+}
+
+struct ClientSharedFallbackLease {
+    registry: &'static ClientSharedFallbackRegistry,
+    runtime: Arc<ClientSharedFallbackRuntime>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ClientSharedFallbackSnapshot {
+    pub submitted_tasks: usize,
+    pub active_tasks: usize,
+    pub active_leases: usize,
+    pub runtime_generation: usize,
+    pub runtime_available: bool,
+    pub idle_shutdowns: usize,
+    pub explicit_shutdowns: usize,
+}
+
+impl ClientSharedFallbackRegistry {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(ClientSharedFallbackState::default()),
+            next_generation: AtomicUsize::new(0),
+            submitted_tasks: AtomicUsize::new(0),
+            active_tasks: AtomicUsize::new(0),
+            active_leases: AtomicUsize::new(0),
+            idle_shutdowns: AtomicUsize::new(0),
+            explicit_shutdowns: AtomicUsize::new(0),
+            idle_check_scheduled: AtomicBool::new(false),
+        }
+    }
+
+    fn acquire(&'static self) -> io::Result<ClientSharedFallbackLease> {
+        let runtime = {
+            let mut state = self.state.lock();
+            if state.explicit_shutdown {
+                return Err(io::Error::other(
+                    "client fallback runtime has been explicitly shut down",
+                ));
+            }
+
+            match &state.runtime {
+                Some(runtime) => runtime.clone(),
+                None => {
+                    let generation = self.next_generation.fetch_add(1, Ordering::AcqRel) + 1;
+                    let runtime = Arc::new(ClientSharedFallbackRuntime::new(generation)?);
+                    state.runtime = Some(runtime.clone());
+                    runtime
+                }
+            }
+        };
+
+        self.active_leases.fetch_add(1, Ordering::AcqRel);
+        Ok(ClientSharedFallbackLease {
+            registry: self,
+            runtime,
+        })
+    }
+
+    fn snapshot(&self) -> ClientSharedFallbackSnapshot {
+        let state = self.state.lock();
+        let runtime_generation = state
+            .runtime
+            .as_ref()
+            .map(|runtime| runtime.generation)
+            .unwrap_or_default();
+
+        ClientSharedFallbackSnapshot {
+            submitted_tasks: self.submitted_tasks.load(Ordering::Relaxed),
+            active_tasks: self.active_tasks.load(Ordering::Relaxed),
+            active_leases: self.active_leases.load(Ordering::Relaxed),
+            runtime_generation,
+            runtime_available: state.runtime.is_some(),
+            idle_shutdowns: self.idle_shutdowns.load(Ordering::Relaxed),
+            explicit_shutdowns: self.explicit_shutdowns.load(Ordering::Relaxed),
+        }
+    }
+
+    fn shutdown_explicit(&'static self) {
+        let runtime = {
+            let mut state = self.state.lock();
+            state.explicit_shutdown = true;
+            state.runtime.take()
+        };
+
+        if let Some(runtime) = runtime {
+            self.explicit_shutdowns.fetch_add(1, Ordering::Relaxed);
+            shutdown_runtime(runtime);
+        }
+    }
+
+    fn schedule_idle_shutdown(&'static self, generation: usize) {
+        if self
+            .idle_check_scheduled
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let registry = self;
+        if let Err(error) = std::thread::Builder::new()
+            .name("rocketmq-client-fallback-idle-shutdown".to_string())
+            .spawn(move || {
+                std::thread::sleep(fallback_idle_timeout());
+                registry.idle_check_scheduled.store(false, Ordering::Release);
+                registry.shutdown_idle_if_current(generation);
+            })
+        {
+            self.idle_check_scheduled.store(false, Ordering::Release);
+            tracing::warn!(%error, "failed to schedule client fallback idle shutdown");
+        }
+    }
+
+    fn shutdown_idle_if_current(&'static self, generation: usize) {
+        if self.active_leases.load(Ordering::Acquire) != 0 {
+            return;
+        }
+
+        let runtime = {
+            let mut state = self.state.lock();
+            let Some(runtime) = state.runtime.as_ref() else {
+                return;
+            };
+            if runtime.generation != generation || state.explicit_shutdown {
+                return;
+            }
+            state.runtime.take()
+        };
+
+        if let Some(runtime) = runtime {
+            self.idle_shutdowns.fetch_add(1, Ordering::Relaxed);
+            shutdown_runtime(runtime);
+        }
+    }
+}
+
+impl ClientSharedFallbackRuntime {
+    fn new(generation: usize) -> io::Result<Self> {
+        let parallelism = std::thread::available_parallelism()
+            .map(|parallelism| parallelism.get())
+            .unwrap_or(2);
+        let worker_threads = parallelism.clamp(2, 4);
+        let config = RuntimeConfig {
+            worker_threads,
+            max_blocking_threads: worker_threads * 2,
+            thread_name: "rocketmq-client-fallback".to_string(),
+            ..RuntimeConfig::default()
+        };
+        let owner = RuntimeOwner::new(config).map_err(io::Error::other)?;
+        Ok(Self { owner, generation })
+    }
+}
+
+impl ClientSharedFallbackLease {
+    fn spawn<F>(self, task_name: &'static str, task: F) -> io::Result<JoinHandle<()>>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.registry.submitted_tasks.fetch_add(1, Ordering::Relaxed);
+        self.registry.active_tasks.fetch_add(1, Ordering::Relaxed);
+        let runtime = self.runtime.clone();
+        Ok(runtime.owner.context().runtime().spawn(async move {
+            let _guard = ActiveTaskGuard {
+                registry: self.registry,
+                task_name,
+                _lease: self,
+            };
+            task.await;
+        }))
+    }
+}
+
+impl Drop for ClientSharedFallbackLease {
+    fn drop(&mut self) {
+        let previous = self.registry.active_leases.fetch_sub(1, Ordering::AcqRel);
+        if previous == 1 {
+            self.registry.schedule_idle_shutdown(self.runtime.generation);
+        }
+    }
+}
+
+struct ActiveTaskGuard {
+    registry: &'static ClientSharedFallbackRegistry,
+    task_name: &'static str,
+    _lease: ClientSharedFallbackLease,
+}
+
+impl Drop for ActiveTaskGuard {
+    fn drop(&mut self) {
+        self.registry.active_tasks.fetch_sub(1, Ordering::Relaxed);
+        tracing::debug!(task_name = self.task_name, "client fallback task finished");
+    }
+}
+
+fn shutdown_runtime(runtime: Arc<ClientSharedFallbackRuntime>) {
+    if let Ok(runtime) = Arc::try_unwrap(runtime) {
+        if let Err(error) = runtime.owner.shutdown_runtime_blocking() {
+            tracing::warn!(%error, "failed to shut down client fallback runtime");
+        }
+    }
+}
+
+fn fallback_idle_timeout() -> Duration {
+    #[cfg(test)]
+    {
+        Duration::from_millis(50)
+    }
+    #[cfg(not(test))]
+    {
+        Duration::from_secs(30)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn shared_fallback_runtime_reuses_one_runtime_for_multiple_tasks() {
+        let before = shared_fallback_snapshot()
+            .map(|snapshot| snapshot.submitted_tasks)
+            .unwrap_or_default();
+        let (tx, rx) = mpsc::channel();
+
+        for _ in 0..8 {
+            let tx = tx.clone();
+            spawn_detached_client_task("client-runtime-test", async move {
+                tx.send(()).expect("test receiver should be alive");
+            })
+            .expect("fallback task should spawn");
+        }
+        drop(tx);
+
+        for _ in 0..8 {
+            rx.recv_timeout(Duration::from_secs(2))
+                .expect("fallback task should complete");
+        }
+
+        let snapshot = shared_fallback_snapshot().expect("fallback runtime should exist");
+        assert!(snapshot.submitted_tasks >= before + 8);
+        assert!(snapshot.active_tasks <= snapshot.submitted_tasks);
+    }
+
+    #[test]
+    fn fallback_registry_tracks_leases_and_rejects_after_explicit_shutdown() {
+        let registry = Box::leak(Box::new(ClientSharedFallbackRegistry::new()));
+        let lease = registry.acquire().expect("fallback runtime should be created");
+
+        let snapshot = registry.snapshot();
+        assert_eq!(snapshot.active_leases, 1);
+        assert!(snapshot.runtime_available);
+        assert_eq!(snapshot.runtime_generation, 1);
+
+        drop(lease);
+        assert_eq!(registry.snapshot().active_leases, 0);
+
+        registry.shutdown_explicit();
+        let error = match registry.acquire() {
+            Ok(_) => panic!("explicit shutdown must reject new fallback leases"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("explicitly shut down"));
+        assert_eq!(registry.snapshot().explicit_shutdowns, 1);
+    }
+}

--- a/rocketmq-client/src/stat/consumer_stats_manager.rs
+++ b/rocketmq-client/src/stat/consumer_stats_manager.rs
@@ -16,9 +16,9 @@ use std::future::Future;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::thread;
 use std::time::Duration;
 
+use crate::runtime::spawn_detached_client_task;
 use rocketmq_common::common::stats::stats_item_set::StatsItemSet;
 use rocketmq_remoting::protocol::body::consume_status::ConsumeStatus;
 use tracing::warn;
@@ -242,21 +242,8 @@ fn spawn_stats_task<F>(thread_name: &'static str, task: F)
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        drop(handle.spawn(task));
-        return;
-    }
-
-    match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-        Ok(runtime) => {
-            if let Err(error) = thread::Builder::new()
-                .name(thread_name.to_string())
-                .spawn(move || runtime.block_on(task))
-            {
-                warn!("Failed to spawn {} background thread: {}", thread_name, error);
-            }
-        }
-        Err(error) => warn!("Failed to build {} runtime: {}", thread_name, error),
+    if let Err(error) = spawn_detached_client_task(thread_name, task) {
+        warn!("Failed to spawn {} background task: {}", thread_name, error);
     }
 }
 
@@ -279,6 +266,8 @@ async fn sleep_or_shutdown(shutdown_signal: &Arc<AtomicBool>, delay: Duration) -
 
 #[cfg(test)]
 mod tests {
+    use std::thread;
+
     use super::*;
 
     fn make_manager() -> ConsumerStatsManager {

--- a/rocketmq-client/src/trace/async_trace_dispatcher.rs
+++ b/rocketmq-client/src/trace/async_trace_dispatcher.rs
@@ -48,6 +48,7 @@ use crate::base::client_config::ClientConfig;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::producer::default_mq_producer::DefaultMQProducer;
 use crate::producer::producer_impl::default_mq_producer_impl::DefaultMQProducerImpl;
+use crate::runtime::spawn_client_task;
 use crate::trace::trace_constants::TraceConstants;
 use crate::trace::trace_context::TraceContext;
 use crate::trace::trace_data_encoder::TraceDataEncoder;
@@ -510,22 +511,9 @@ fn spawn_trace_task<F>(thread_name: &'static str, task: F) -> RocketMQResult<Tra
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        return Ok(TraceTaskHandle::Tokio(handle.spawn(task)));
-    }
-
-    match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-        Ok(runtime) => thread::Builder::new()
-            .name(thread_name.to_string())
-            .spawn(move || runtime.block_on(task))
-            .map(TraceTaskHandle::Thread)
-            .map_err(|error| {
-                RocketMQError::Internal(format!("failed to spawn {thread_name} background thread: {error}"))
-            }),
-        Err(error) => Err(RocketMQError::Internal(format!(
-            "failed to build {thread_name} runtime: {error}"
-        ))),
-    }
+    spawn_client_task(thread_name, task)
+        .map(TraceTaskHandle::Tokio)
+        .map_err(|error| RocketMQError::Internal(format!("failed to spawn {thread_name} task: {error}")))
 }
 
 // Main worker loop that processes trace contexts in batches.
@@ -802,7 +790,7 @@ mod tests {
         let thread_name = rx
             .recv_timeout(Duration::from_secs(2))
             .expect("trace task should run on fallback runtime");
-        assert_eq!(thread_name, "rocketmq-client-trace-test");
+        assert_eq!(thread_name, "rocketmq-client-fallback");
         handle.abort();
     }
 

--- a/rocketmq-common/Cargo.toml
+++ b/rocketmq-common/Cargo.toml
@@ -34,6 +34,7 @@ simd     = ["simd-json"]
 [dependencies]
 rocketmq-rust  = { workspace = true }
 rocketmq-error = { workspace = true, features = ["with_serde", "with_config"] }
+rocketmq-runtime = { workspace = true }
 
 anyhow.workspace = true
 tokio.workspace  = true

--- a/rocketmq-common/src/thread_pool.rs
+++ b/rocketmq-common/src/thread_pool.rs
@@ -16,10 +16,16 @@ use std::cmp;
 use std::future::Future;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use anyhow::bail;
 use anyhow::Context;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::ScheduledTaskConfig;
+use rocketmq_runtime::ScheduledTaskGroup;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 
@@ -167,6 +173,8 @@ impl FuturesExecutorServiceBuilder {
 
 pub struct ScheduledExecutorService {
     inner: tokio::runtime::Runtime,
+    context: RuntimeContext,
+    scheduled_tasks: ScheduledTaskGroup,
 }
 
 impl Default for ScheduledExecutorService {
@@ -180,13 +188,12 @@ impl ScheduledExecutorService {
     }
 
     pub fn try_new() -> anyhow::Result<ScheduledExecutorService> {
-        Ok(ScheduledExecutorService {
-            inner: tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(num_cpus::get())
-                .enable_all()
-                .build()
-                .context("failed to create ScheduledExecutorService runtime")?,
-        })
+        let inner = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(num_cpus::get())
+            .enable_all()
+            .build()
+            .context("failed to create ScheduledExecutorService runtime")?;
+        Self::from_runtime(inner)
     }
 
     pub fn new_with_config(
@@ -211,46 +218,62 @@ impl ScheduledExecutorService {
         } else {
             "rocketmq-thread-".to_string()
         };
-        Ok(ScheduledExecutorService {
-            inner: tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(thread_num)
-                .thread_keep_alive(keep_alive)
-                .max_blocking_threads(max_blocking_threads)
-                .thread_name_fn(move || {
-                    static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-                    let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-                    format!("{thread_prefix_inner}{id}")
-                })
-                .enable_all()
-                .build()
-                .context("failed to create configured ScheduledExecutorService runtime")?,
-        })
+        let inner = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(thread_num)
+            .thread_keep_alive(keep_alive)
+            .max_blocking_threads(max_blocking_threads)
+            .thread_name_fn(move || {
+                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+                let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+                format!("{thread_prefix_inner}{id}")
+            })
+            .enable_all()
+            .build()
+            .context("failed to create configured ScheduledExecutorService runtime")?;
+        Self::from_runtime(inner)
     }
 
-    pub fn schedule_at_fixed_rate<F>(&self, mut task: F, initial_delay: Option<Duration>, period: Duration)
+    pub fn schedule_at_fixed_rate<F>(&self, task: F, initial_delay: Option<Duration>, period: Duration)
     where
         F: FnMut() + Send + 'static,
     {
-        self.inner.spawn(async move {
-            // initial delay
+        static SCHEDULE_ID: AtomicUsize = AtomicUsize::new(0);
 
-            if let Some(initial_delay_inner) = initial_delay {
-                tokio::time::sleep(initial_delay_inner).await;
-            }
+        let task = Arc::new(Mutex::new(task));
+        let mut config = ScheduledTaskConfig::fixed_rate_no_overlap(
+            format!(
+                "rocketmq.common.schedule_at_fixed_rate.{}",
+                SCHEDULE_ID.fetch_add(1, Ordering::Relaxed)
+            ),
+            period,
+        );
+        config.initial_delay = initial_delay.unwrap_or(Duration::ZERO);
 
-            loop {
-                // record current execution time
-                let current_execution_time = tokio::time::Instant::now();
-                // execute task
-                task();
-                // Calculate the time of the next execution
-                let next_execution_time = current_execution_time + period;
-
-                // Wait until the next execution
-                let delay = next_execution_time.saturating_duration_since(tokio::time::Instant::now());
-                tokio::time::sleep(delay).await;
+        let schedule_result = self.scheduled_tasks.schedule_fixed_rate_no_overlap(config, move || {
+            let task = task.clone();
+            async move {
+                if let Ok(mut task) = task.lock() {
+                    task();
+                }
             }
         });
+        if let Err(error) = schedule_result {
+            tracing::warn!(%error, "failed to schedule fixed-rate task");
+        }
+    }
+
+    fn from_runtime(inner: tokio::runtime::Runtime) -> anyhow::Result<ScheduledExecutorService> {
+        let context = RuntimeContext::new(
+            RuntimeHandle::new(inner.handle().clone()),
+            "rocketmq.common.scheduled-executor",
+        )
+        .map_err(|error| anyhow::anyhow!("failed to create scheduled executor context: {error}"))?;
+        let scheduled_tasks = ScheduledTaskGroup::new(context.root_group().child("scheduled"));
+        Ok(ScheduledExecutorService {
+            inner,
+            context,
+            scheduled_tasks,
+        })
     }
 }
 
@@ -305,20 +328,31 @@ mod runtime_config_tests {
 
 impl ScheduledExecutorService {
     pub fn shutdown(self) {
-        self.inner.shutdown_background();
+        self.shutdown_timeout(Duration::from_secs(30));
     }
 
     pub fn shutdown_timeout(self, timeout: Duration) {
-        self.inner.shutdown_timeout(timeout);
+        let ScheduledExecutorService {
+            inner,
+            context,
+            scheduled_tasks: _,
+        } = self;
+        let report = inner.block_on(context.shutdown_tasks(timeout));
+        report.log_if_unhealthy();
+        inner.shutdown_timeout(timeout);
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
     use std::sync::mpsc;
+    use std::sync::Arc;
     use std::time::Duration;
 
     use super::FuturesExecutorServiceBuilder;
+    use super::ScheduledExecutorService;
 
     #[test]
     fn futures_executor_builder_create_returns_executor() {
@@ -331,5 +365,36 @@ mod tests {
         });
 
         assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), 42);
+    }
+
+    #[test]
+    fn scheduled_executor_fixed_rate_does_not_overlap() {
+        let executor =
+            ScheduledExecutorService::try_new_with_config(2, Some("schedule-test-"), Duration::from_secs(1), 2)
+                .expect("scheduled executor should be created");
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let runs = Arc::new(AtomicUsize::new(0));
+        let active_task = active.clone();
+        let max_active_task = max_active.clone();
+        let runs_task = runs.clone();
+
+        executor.schedule_at_fixed_rate(
+            move || {
+                let current = active_task.fetch_add(1, Ordering::SeqCst) + 1;
+                max_active_task.fetch_max(current, Ordering::SeqCst);
+                runs_task.fetch_add(1, Ordering::SeqCst);
+                std::thread::sleep(Duration::from_millis(30));
+                active_task.fetch_sub(1, Ordering::SeqCst);
+            },
+            Some(Duration::ZERO),
+            Duration::from_millis(5),
+        );
+
+        std::thread::sleep(Duration::from_millis(120));
+        executor.shutdown_timeout(Duration::from_secs(1));
+
+        assert!(runs.load(Ordering::SeqCst) > 0);
+        assert_eq!(max_active.load(Ordering::SeqCst), 1);
     }
 }

--- a/rocketmq-common/src/utils/http_tiny_client.rs
+++ b/rocketmq-common/src/utils/http_tiny_client.rs
@@ -26,6 +26,8 @@ use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
 
 use crate::common::mq_version::RocketMqVersion;
 use crate::common::mq_version::CURRENT_VERSION;
@@ -34,6 +36,7 @@ use crate::TimeUtils::current_millis;
 /// Global HTTP client with connection pool
 /// Reuses connections across requests for better performance
 static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
+static HTTP_SYNC_RUNTIME: OnceLock<Result<RuntimeOwner, String>> = OnceLock::new();
 
 fn build_http_client() -> RocketMQResult<Client> {
     Client::builder()
@@ -55,6 +58,26 @@ fn get_http_client() -> RocketMQResult<&'static Client> {
     HTTP_CLIENT.get().ok_or_else(|| {
         RocketMQError::network_request_failed("http-client", "HTTP client initialization did not complete")
     })
+}
+
+fn get_http_sync_runtime() -> io::Result<&'static RuntimeOwner> {
+    match HTTP_SYNC_RUNTIME.get_or_init(|| {
+        let parallelism = std::thread::available_parallelism()
+            .map(|parallelism| parallelism.get())
+            .unwrap_or(2);
+        let worker_threads = parallelism.clamp(2, 4);
+        RuntimeOwner::new(RuntimeConfig {
+            worker_threads,
+            max_blocking_threads: worker_threads * 2,
+            thread_name: "rocketmq-http-sync".to_string(),
+            shutdown_timeout: Duration::from_secs(10),
+            ..RuntimeConfig::default()
+        })
+        .map_err(|error| error.to_string())
+    }) {
+        Ok(runtime) => Ok(runtime),
+        Err(error) => Err(io::Error::other(error.clone())),
+    }
 }
 
 pub struct HttpTinyClient;
@@ -329,14 +352,11 @@ impl HttpTinyClient {
         read_timeout_ms: u64,
     ) -> Result<HttpResult, io::Error> {
         Self::ensure_not_in_tokio_runtime("http_get")?;
-        // Use tokio::runtime to bridge to async world
-        tokio::runtime::Runtime::new()
-            .map_err(io::Error::other)?
-            .block_on(async {
-                Self::http_get_async(url, headers, param_values, encoding, read_timeout_ms)
-                    .await
-                    .map_err(|e| io::Error::other(e.to_string()))
-            })
+        get_http_sync_runtime()?.block_on(async {
+            Self::http_get_async(url, headers, param_values, encoding, read_timeout_ms)
+                .await
+                .map_err(|e| io::Error::other(e.to_string()))
+        })
     }
 
     /// Perform HTTP POST request (blocking version - DEPRECATED)
@@ -365,14 +385,11 @@ impl HttpTinyClient {
         read_timeout_ms: u64,
     ) -> Result<HttpResult, io::Error> {
         Self::ensure_not_in_tokio_runtime("http_post")?;
-        // Use tokio::runtime to bridge to async world
-        tokio::runtime::Runtime::new()
-            .map_err(io::Error::other)?
-            .block_on(async {
-                Self::http_post_async(url, headers, param_values, encoding, read_timeout_ms)
-                    .await
-                    .map_err(|e| io::Error::other(e.to_string()))
-            })
+        get_http_sync_runtime()?.block_on(async {
+            Self::http_post_async(url, headers, param_values, encoding, read_timeout_ms)
+                .await
+                .map_err(|e| io::Error::other(e.to_string()))
+        })
     }
 
     /// Encode parameters for URL or form data using form_urlencoded
@@ -432,6 +449,7 @@ impl HttpTinyClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use tokio::io::AsyncReadExt;
     use tokio::io::AsyncWriteExt;
     use tokio::net::TcpListener;
@@ -595,6 +613,29 @@ mod tests {
             .expect_err("blocking http_post should reject async runtime contexts");
 
         assert!(error.to_string().contains("use the async API instead"));
+    }
+
+    #[test]
+    fn blocking_http_get_outside_tokio_runtime_uses_shared_bridge() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0; 1024];
+            let _ = stream.read(&mut buffer).unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\nok",
+                )
+                .unwrap();
+        });
+
+        #[allow(deprecated)]
+        let response = HttpTinyClient::http_get(&format!("http://{addr}"), None, None, "UTF-8", 1000).unwrap();
+
+        assert_eq!(response.code, 200);
+        assert_eq!(response.content, "ok");
+        server.join().unwrap();
     }
 
     #[tokio::test]

--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/Cargo.lock
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "cron"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
+checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
 dependencies = [
  "chrono",
  "once_cell",
@@ -3990,6 +3990,7 @@ dependencies = [
  "rocketmq-error",
  "rocketmq-observability",
  "rocketmq-remoting",
+ "rocketmq-runtime",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4055,6 +4056,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rocketmq-error",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "serde",
  "serde_json",
@@ -4167,6 +4169,7 @@ dependencies = [
  "rocketmq-common",
  "rocketmq-error",
  "rocketmq-macros",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -4185,7 +4188,15 @@ dependencies = [
 name = "rocketmq-runtime"
 version = "1.0.0"
 dependencies = [
+ "dashmap",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "cron"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
+checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
 dependencies = [
  "chrono",
  "once_cell",
@@ -2348,6 +2348,7 @@ dependencies = [
  "rocketmq-error",
  "rocketmq-observability",
  "rocketmq-remoting",
+ "rocketmq-runtime",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2413,6 +2414,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rocketmq-error",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "serde",
  "serde_json",
@@ -2520,6 +2522,7 @@ dependencies = [
  "rocketmq-common",
  "rocketmq-error",
  "rocketmq-macros",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -2538,7 +2541,15 @@ dependencies = [
 name = "rocketmq-runtime"
 version = "1.0.0"
 dependencies = [
+ "dashmap",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/rocketmq-example/Cargo.lock
+++ b/rocketmq-example/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "cron"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
+checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
 dependencies = [
  "chrono",
  "once_cell",
@@ -2210,6 +2210,7 @@ dependencies = [
  "rocketmq-error",
  "rocketmq-observability",
  "rocketmq-remoting",
+ "rocketmq-runtime",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2275,6 +2276,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rocketmq-error",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "serde",
  "serde_json",
@@ -2365,6 +2367,7 @@ dependencies = [
  "rocketmq-common",
  "rocketmq-error",
  "rocketmq-macros",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -2383,7 +2386,15 @@ dependencies = [
 name = "rocketmq-runtime"
 version = "1.0.0"
 dependencies = [
+ "dashmap",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -403,7 +403,7 @@ impl NameServerRuntime {
         let scan_not_active_broker_interval = self.inner.name_server_config().scan_not_active_broker_interval;
         let mut name_server_runtime_inner = self.inner.clone();
 
-        self.scheduled_task_manager.add_fixed_rate_task_async(
+        self.scheduled_task_manager.add_fixed_rate_no_overlap_task_async(
             Duration::from_secs(5), // Initial delay
             Duration::from_millis(scan_not_active_broker_interval),
             async move |_ctx| {

--- a/rocketmq-remoting/Cargo.toml
+++ b/rocketmq-remoting/Cargo.toml
@@ -33,6 +33,7 @@ rocketmq-common = { workspace = true }
 rocketmq-macros = { workspace = true }
 rocketmq-rust   = { workspace = true }
 rocketmq-error  = { workspace = true }
+rocketmq-runtime = { workspace = true }
 rocketmq-observability = { workspace = true, optional = true }
 
 anyhow.workspace = true

--- a/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
@@ -19,6 +19,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rocketmq_common::common::server::config::ServerConfig;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskKind;
 use rocketmq_rust::wait_for_signal;
 use rocketmq_rust::ArcMut;
 use tokio::net::TcpListener;
@@ -271,6 +274,9 @@ struct ConnectionListener<RP> {
 
     /// TLS mode and acceptor state for newly accepted connections.
     tls_runtime: TlsServerRuntime,
+
+    /// Tracks remoting event and connection tasks for shutdown diagnostics.
+    task_group: TaskGroup,
 }
 
 impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
@@ -306,29 +312,34 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
 
         // Spawn event dispatcher task if listener configured
         if let Some(listener) = self.channel_event_listener.take() {
-            tokio::spawn(async move {
-                while let Some(event) = event_rx.recv().await {
-                    let addr = event.remote_addr();
-                    let addr_str = addr.to_string();
+            let spawn_result =
+                self.task_group
+                    .spawn("rocketmq.remoting.event_dispatcher", TaskKind::Service, async move {
+                        while let Some(event) = event_rx.recv().await {
+                            let addr = event.remote_addr();
+                            let addr_str = addr.to_string();
 
-                    // HOT PATH: Match on event type and dispatch to listener
-                    match event.type_() {
-                        ConnectionNetEvent::CONNECTED(_) => {
-                            listener.on_channel_connect(&addr_str, event.channel());
+                            // HOT PATH: Match on event type and dispatch to listener
+                            match event.type_() {
+                                ConnectionNetEvent::CONNECTED(_) => {
+                                    listener.on_channel_connect(&addr_str, event.channel());
+                                }
+                                ConnectionNetEvent::DISCONNECTED => {
+                                    listener.on_channel_close(&addr_str, event.channel());
+                                }
+                                ConnectionNetEvent::EXCEPTION => {
+                                    listener.on_channel_exception(&addr_str, event.channel());
+                                }
+                                ConnectionNetEvent::IDLE => {
+                                    listener.on_channel_idle(&addr_str, event.channel());
+                                }
+                            }
                         }
-                        ConnectionNetEvent::DISCONNECTED => {
-                            listener.on_channel_close(&addr_str, event.channel());
-                        }
-                        ConnectionNetEvent::EXCEPTION => {
-                            listener.on_channel_exception(&addr_str, event.channel());
-                        }
-                        ConnectionNetEvent::IDLE => {
-                            listener.on_channel_idle(&addr_str, event.channel());
-                        }
-                    }
-                }
-                info!("Event dispatcher task terminated");
-            });
+                        info!("Event dispatcher task terminated");
+                    });
+            if let Err(error) = spawn_result {
+                error!("Failed to spawn remoting event dispatcher: {}", error);
+            }
         }
 
         // Main accept loop
@@ -355,9 +366,10 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
             let shutdown_complete_tx = self.shutdown_complete_tx.clone();
             let conn_disconnect_notify = self.conn_disconnect_notify.clone();
             let event_tx_clone = event_tx.clone();
+            let task_group = self.task_group.clone();
 
             // Spawn dedicated task for this connection
-            tokio::spawn(async move {
+            if let Err(error) = task_group.spawn("rocketmq.remoting.connection", TaskKind::Worker, async move {
                 let Some(connection) = tls_runtime.into_connection(socket, remote_addr).await else {
                     drop(permit);
                     return;
@@ -410,7 +422,9 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
 
                 // IMPORTANT: Permit released when `permit` drops here
                 drop(permit);
-            });
+            }) {
+                error!(remote_addr = %remote_addr, error = %error, "failed to spawn remoting connection task");
+            }
         }
     }
 
@@ -568,6 +582,10 @@ async fn run_with_tls_config<RP: RequestProcessor + Sync + 'static + Clone>(
 ) {
     let (notify_shutdown, _) = broadcast::channel(1);
     let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel(1);
+    let task_group = TaskGroup::root(
+        "rocketmq.remoting.server",
+        RuntimeHandle::new(tokio::runtime::Handle::current()),
+    );
     // Initialize the connection listener state
     let handler = RemotingGeneralHandler {
         request_processor,
@@ -584,6 +602,7 @@ async fn run_with_tls_config<RP: RequestProcessor + Sync + 'static + Clone>(
         channel_event_listener,
         cmd_handler: ArcMut::new(handler),
         tls_runtime,
+        task_group: task_group.clone(),
     };
 
     tokio::select! {
@@ -612,6 +631,8 @@ async fn run_with_tls_config<RP: RequestProcessor + Sync + 'static + Clone>(
     drop(shutdown_complete_tx);
 
     let _ = shutdown_complete_rx.recv().await;
+    let report = task_group.shutdown(Duration::from_secs(30)).await;
+    report.log_if_unhealthy();
 }
 
 #[derive(Debug)]
@@ -659,6 +680,8 @@ mod tests {
     use std::sync::Arc;
 
     use rocketmq_common::common::server::config::ServerConfig;
+    use tokio::net::TcpStream;
+    use tokio::sync::oneshot;
 
     use super::*;
     use crate::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
@@ -688,5 +711,36 @@ mod tests {
         server
             .run_with_shutdown(DefaultRemotingRequestProcessor, None, future::pending::<()>())
             .await;
+    }
+
+    #[tokio::test]
+    async fn run_shutdown_drains_connection_tasks() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let addr = listener.local_addr().expect("listener should have local addr");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let server_task = tokio::spawn(run(
+            listener,
+            async {
+                let _ = shutdown_rx.await;
+            },
+            DefaultRemotingRequestProcessor,
+            None,
+            Vec::new(),
+            None,
+        ));
+
+        let mut clients = Vec::new();
+        for _ in 0..4 {
+            clients.push(TcpStream::connect(addr).await.expect("client should connect"));
+        }
+        drop(clients);
+
+        let _ = shutdown_tx.send(());
+        tokio::time::timeout(Duration::from_secs(3), server_task)
+            .await
+            .expect("server should shut down before timeout")
+            .expect("server task should not panic");
     }
 }

--- a/rocketmq-runtime/Cargo.toml
+++ b/rocketmq-runtime/Cargo.toml
@@ -28,5 +28,12 @@ description.workspace  = true
 rust-version.workspace = true
 
 [dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }
-#once_cell = { workspace = true }
+dashmap.workspace = true
+futures.workspace = true
+parking_lot.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+tokio-util.workspace = true
+tracing.workspace = true

--- a/rocketmq-runtime/src/blocking.rs
+++ b/rocketmq-runtime/src/blocking.rs
@@ -1,0 +1,294 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use dashmap::DashMap;
+use serde::Serialize;
+use tokio::sync::Semaphore;
+
+use crate::error::RuntimeError;
+use crate::error::RuntimeResult;
+use crate::task_group::TaskGroup;
+use crate::task_group::TaskKind;
+
+#[derive(Debug, Clone)]
+pub struct BlockingPoolPolicy {
+    pub name: String,
+    pub max_concurrency: usize,
+    pub queue_timeout: Duration,
+    pub task_timeout: Duration,
+    pub warn_after: Duration,
+}
+
+impl BlockingPoolPolicy {
+    pub fn validate(&self) -> RuntimeResult<()> {
+        if self.max_concurrency == 0 {
+            return Err(RuntimeError::InvalidConfig(
+                "blocking max_concurrency must be greater than zero".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Default for BlockingPoolPolicy {
+    fn default() -> Self {
+        Self {
+            name: "rocketmq-blocking".to_string(),
+            max_concurrency: 64,
+            queue_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(30),
+            warn_after: Duration::from_secs(1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum BlockingKind {
+    ShortIo,
+    CpuBound,
+    LongRunning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub struct BlockingTaskId(u64);
+
+impl BlockingTaskId {
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum BlockingTaskState {
+    Queued,
+    Running,
+    Completed,
+    JoinFailed,
+    TimedOutStillRunning,
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockingExecutor {
+    policy: Arc<BlockingPoolPolicy>,
+    permits: Arc<Semaphore>,
+    tasks: Arc<DashMap<BlockingTaskId, BlockingTaskMeta>>,
+    reaper_group: TaskGroup,
+    next_task_id: Arc<AtomicU64>,
+}
+
+#[derive(Debug, Clone)]
+struct BlockingTaskMeta {
+    id: BlockingTaskId,
+    name: Arc<str>,
+    kind: BlockingKind,
+    state: BlockingTaskState,
+    queued_at: Instant,
+    started_at: Option<Instant>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BlockingExecutorSnapshot {
+    pub name: String,
+    pub max_concurrency: usize,
+    pub queued: usize,
+    pub running: usize,
+    pub timed_out_still_running: usize,
+    pub blocking_still_running: usize,
+    pub tasks: Vec<BlockingTaskSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BlockingTaskSnapshot {
+    pub id: BlockingTaskId,
+    pub name: String,
+    pub kind: BlockingKind,
+    pub state: BlockingTaskState,
+    #[serde(with = "duration_millis")]
+    pub elapsed: Duration,
+}
+
+impl BlockingExecutor {
+    pub fn new(policy: BlockingPoolPolicy, reaper_group: TaskGroup) -> RuntimeResult<Self> {
+        policy.validate()?;
+        Ok(Self {
+            permits: Arc::new(Semaphore::new(policy.max_concurrency)),
+            policy: Arc::new(policy),
+            tasks: Arc::new(DashMap::new()),
+            reaper_group,
+            next_task_id: Arc::new(AtomicU64::new(1)),
+        })
+    }
+
+    pub fn policy(&self) -> &BlockingPoolPolicy {
+        &self.policy
+    }
+
+    pub async fn spawn_io<F, R>(&self, name: impl Into<Arc<str>>, operation: F) -> RuntimeResult<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.spawn(name, BlockingKind::ShortIo, operation).await
+    }
+
+    pub async fn spawn<F, R>(&self, name: impl Into<Arc<str>>, kind: BlockingKind, operation: F) -> RuntimeResult<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let task_id = BlockingTaskId(self.next_task_id.fetch_add(1, Ordering::Relaxed));
+        let name = name.into();
+        self.tasks.insert(
+            task_id,
+            BlockingTaskMeta {
+                id: task_id,
+                name: name.clone(),
+                kind,
+                state: BlockingTaskState::Queued,
+                queued_at: Instant::now(),
+                started_at: None,
+            },
+        );
+
+        let permit = match tokio::time::timeout(self.policy.queue_timeout, self.permits.clone().acquire_owned()).await {
+            Ok(Ok(permit)) => permit,
+            Ok(Err(_closed)) => {
+                self.tasks.remove(&task_id);
+                return Err(RuntimeError::BlockingQueueTimeout { name });
+            }
+            Err(_elapsed) => {
+                self.tasks.remove(&task_id);
+                return Err(RuntimeError::BlockingQueueTimeout { name });
+            }
+        };
+
+        if let Some(mut meta) = self.tasks.get_mut(&task_id) {
+            meta.state = BlockingTaskState::Running;
+            meta.started_at = Some(Instant::now());
+        }
+
+        let tasks = self.tasks.clone();
+        let mut join_handle = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            operation()
+        });
+
+        match tokio::time::timeout(self.policy.task_timeout, &mut join_handle).await {
+            Ok(Ok(value)) => {
+                let elapsed = tasks
+                    .get(&task_id)
+                    .and_then(|meta| meta.started_at.map(|started_at| started_at.elapsed()));
+                self.finish_task(task_id, BlockingTaskState::Completed);
+                if let Some(elapsed) = elapsed {
+                    if elapsed > self.policy.warn_after {
+                        tracing::warn!(
+                            task_id = task_id.as_u64(),
+                            task_name = %name,
+                            elapsed_ms = elapsed.as_millis(),
+                            "blocking task exceeded warn_after"
+                        );
+                    }
+                }
+                Ok(value)
+            }
+            Ok(Err(error)) => {
+                self.finish_task(task_id, BlockingTaskState::JoinFailed);
+                Err(RuntimeError::BlockingJoin { name, error })
+            }
+            Err(_elapsed) => {
+                if let Some(mut meta) = self.tasks.get_mut(&task_id) {
+                    meta.state = BlockingTaskState::TimedOutStillRunning;
+                }
+                let tasks = self.tasks.clone();
+                let reaper_name = format!("blocking-reaper:{name}");
+                let _ = self
+                    .reaper_group
+                    .spawn_detached(reaper_name, TaskKind::BlockingReaper, async move {
+                        let _ = join_handle.await;
+                        tasks.remove(&task_id);
+                    });
+                Err(RuntimeError::BlockingTaskTimeoutStillRunning { name, task_id })
+            }
+        }
+    }
+
+    pub fn snapshot(&self) -> BlockingExecutorSnapshot {
+        let tasks = self
+            .tasks
+            .iter()
+            .map(|entry| entry.value().snapshot())
+            .collect::<Vec<_>>();
+        let queued = tasks
+            .iter()
+            .filter(|task| task.state == BlockingTaskState::Queued)
+            .count();
+        let running = tasks
+            .iter()
+            .filter(|task| task.state == BlockingTaskState::Running)
+            .count();
+        let timed_out_still_running = tasks
+            .iter()
+            .filter(|task| task.state == BlockingTaskState::TimedOutStillRunning)
+            .count();
+
+        BlockingExecutorSnapshot {
+            name: self.policy.name.clone(),
+            max_concurrency: self.policy.max_concurrency,
+            queued,
+            running,
+            timed_out_still_running,
+            blocking_still_running: running + timed_out_still_running,
+            tasks,
+        }
+    }
+
+    fn finish_task(&self, task_id: BlockingTaskId, state: BlockingTaskState) {
+        if let Some(mut meta) = self.tasks.get_mut(&task_id) {
+            meta.state = state;
+        }
+        self.tasks.remove(&task_id);
+    }
+}
+
+impl BlockingTaskMeta {
+    fn snapshot(&self) -> BlockingTaskSnapshot {
+        let elapsed = self.started_at.unwrap_or(self.queued_at).elapsed();
+        BlockingTaskSnapshot {
+            id: self.id,
+            name: self.name.to_string(),
+            kind: self.kind,
+            state: self.state,
+            elapsed,
+        }
+    }
+}
+
+mod duration_millis {
+    use std::time::Duration;
+
+    use serde::Serializer;
+
+    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(duration.as_millis() as u64)
+    }
+}

--- a/rocketmq-runtime/src/config.rs
+++ b/rocketmq-runtime/src/config.rs
@@ -1,0 +1,75 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use crate::error::RuntimeError;
+use crate::error::RuntimeResult;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    pub worker_threads: usize,
+    pub max_blocking_threads: usize,
+    pub thread_name: String,
+    pub thread_keep_alive: Duration,
+    pub shutdown_timeout: Duration,
+    pub enable_io: bool,
+    pub enable_time: bool,
+}
+
+impl RuntimeConfig {
+    pub fn server_default(thread_name: impl Into<String>) -> Self {
+        Self {
+            thread_name: thread_name.into(),
+            ..Self::default()
+        }
+    }
+
+    pub fn broker_default() -> Self {
+        Self::server_default("rocketmq-broker")
+    }
+
+    pub fn validate(&self) -> RuntimeResult<()> {
+        if self.worker_threads == 0 {
+            return Err(RuntimeError::InvalidConfig(
+                "worker_threads must be greater than zero".to_string(),
+            ));
+        }
+        if self.max_blocking_threads == 0 {
+            return Err(RuntimeError::InvalidConfig(
+                "max_blocking_threads must be greater than zero".to_string(),
+            ));
+        }
+        if self.thread_name.trim().is_empty() {
+            return Err(RuntimeError::InvalidConfig("thread_name must not be empty".to_string()));
+        }
+        Ok(())
+    }
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        let parallelism = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
+
+        Self {
+            worker_threads: parallelism,
+            max_blocking_threads: parallelism * 4,
+            thread_name: "rocketmq-runtime".to_string(),
+            thread_keep_alive: Duration::from_secs(30),
+            shutdown_timeout: Duration::from_secs(30),
+            enable_io: true,
+            enable_time: true,
+        }
+    }
+}

--- a/rocketmq-runtime/src/context.rs
+++ b/rocketmq-runtime/src/context.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::blocking::BlockingExecutor;
+use crate::blocking::BlockingPoolPolicy;
+use crate::diagnostics::RuntimeDiagnostics;
+use crate::error::RuntimeError;
+use crate::error::RuntimeResult;
+use crate::handle::RuntimeHandle;
+use crate::service_context::ServiceContext;
+use crate::shutdown_report::ShutdownReport;
+use crate::task_group::TaskGroup;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeContext {
+    runtime: RuntimeHandle,
+    root_group: TaskGroup,
+    blocking: BlockingExecutor,
+    diagnostics: RuntimeDiagnostics,
+}
+
+impl RuntimeContext {
+    pub fn new(runtime: RuntimeHandle, name: impl Into<Arc<str>>) -> RuntimeResult<Self> {
+        let root_group = TaskGroup::root(name, runtime.clone());
+        let blocking = BlockingExecutor::new(
+            BlockingPoolPolicy::default(),
+            root_group.child("runtime.blocking-reaper"),
+        )?;
+        let diagnostics = RuntimeDiagnostics::new(runtime.clone());
+        Ok(Self {
+            runtime,
+            root_group,
+            blocking,
+            diagnostics,
+        })
+    }
+
+    pub fn try_from_current(name: impl Into<Arc<str>>) -> RuntimeResult<Self> {
+        let handle = tokio::runtime::Handle::try_current().map_err(|_error| RuntimeError::NoCurrentRuntime)?;
+        Self::new(RuntimeHandle::new(handle), name)
+    }
+
+    pub fn from_current(name: impl Into<Arc<str>>) -> Self {
+        Self::try_from_current(name).expect("current Tokio runtime must be available")
+    }
+
+    pub fn runtime(&self) -> &RuntimeHandle {
+        &self.runtime
+    }
+
+    pub fn root_group(&self) -> &TaskGroup {
+        &self.root_group
+    }
+
+    pub fn blocking(&self) -> &BlockingExecutor {
+        &self.blocking
+    }
+
+    pub fn diagnostics(&self) -> &RuntimeDiagnostics {
+        &self.diagnostics
+    }
+
+    pub fn service_context(&self, name: impl Into<Arc<str>>) -> ServiceContext {
+        let name = name.into();
+        ServiceContext::new(
+            name.clone(),
+            self.runtime.clone(),
+            self.root_group.child(name),
+            self.blocking.clone(),
+            self.diagnostics.clone(),
+        )
+    }
+
+    pub async fn shutdown_tasks(&self, timeout: Duration) -> ShutdownReport {
+        let mut report = self.root_group.shutdown(timeout).await;
+        report.merge_blocking(self.blocking.snapshot());
+        report
+    }
+}

--- a/rocketmq-runtime/src/diagnostics.rs
+++ b/rocketmq-runtime/src/diagnostics.rs
@@ -1,0 +1,30 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::handle::RuntimeHandle;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeDiagnostics {
+    runtime: RuntimeHandle,
+}
+
+impl RuntimeDiagnostics {
+    pub fn new(runtime: RuntimeHandle) -> Self {
+        Self { runtime }
+    }
+
+    pub fn runtime(&self) -> &RuntimeHandle {
+        &self.runtime
+    }
+}

--- a/rocketmq-runtime/src/error.rs
+++ b/rocketmq-runtime/src/error.rs
@@ -1,0 +1,56 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::blocking::BlockingTaskId;
+use crate::task_group::TaskGroupId;
+
+pub type RuntimeResult<T> = Result<T, RuntimeError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("invalid runtime config: {0}")]
+    InvalidConfig(String),
+
+    #[error("failed to build tokio runtime: {0}")]
+    BuildRuntime(#[from] std::io::Error),
+
+    #[error("no current Tokio runtime is available")]
+    NoCurrentRuntime,
+
+    #[error("operation {0} cannot run inside a Tokio runtime")]
+    InsideTokioRuntime(&'static str),
+
+    #[error("task group {group_name} ({group_id:?}) is closing or closed")]
+    TaskGroupClosing {
+        group_id: TaskGroupId,
+        group_name: Arc<str>,
+    },
+
+    #[error("blocking queue timeout for {name}")]
+    BlockingQueueTimeout { name: Arc<str> },
+
+    #[error("blocking task {name} ({task_id:?}) timed out and is still running")]
+    BlockingTaskTimeoutStillRunning { name: Arc<str>, task_id: BlockingTaskId },
+
+    #[error("blocking task join failed for {name}: {error}")]
+    BlockingJoin {
+        name: Arc<str>,
+        error: tokio::task::JoinError,
+    },
+
+    #[error("scheduled task {name} already exists")]
+    ScheduledTaskExists { name: Arc<str> },
+}

--- a/rocketmq-runtime/src/handle.rs
+++ b/rocketmq-runtime/src/handle.rs
@@ -1,0 +1,36 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug, Clone)]
+pub struct RuntimeHandle {
+    handle: tokio::runtime::Handle,
+}
+
+impl RuntimeHandle {
+    pub fn new(handle: tokio::runtime::Handle) -> Self {
+        Self { handle }
+    }
+
+    pub fn inner(&self) -> &tokio::runtime::Handle {
+        &self.handle
+    }
+
+    pub fn spawn<F>(&self, future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.handle.spawn(future)
+    }
+}

--- a/rocketmq-runtime/src/legacy.rs
+++ b/rocketmq-runtime/src/legacy.rs
@@ -1,0 +1,109 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+pub enum RocketMQRuntime {
+    Multi(tokio::runtime::Runtime),
+}
+
+impl RocketMQRuntime {
+    #[inline]
+    pub fn new_multi(threads: usize, name: &str) -> Self {
+        Self::Multi(
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(threads)
+                .thread_name(name)
+                .enable_all()
+                .build()
+                .unwrap(),
+        )
+    }
+
+    #[inline]
+    pub fn get_handle(&self) -> &tokio::runtime::Handle {
+        match self {
+            Self::Multi(runtime) => runtime.handle(),
+        }
+    }
+
+    #[inline]
+    pub fn get_runtime(&self) -> &tokio::runtime::Runtime {
+        match self {
+            Self::Multi(runtime) => runtime,
+        }
+    }
+
+    #[inline]
+    pub fn shutdown(self) {
+        match self {
+            Self::Multi(runtime) => runtime.shutdown_background(),
+        }
+    }
+
+    #[inline]
+    pub fn shutdown_timeout(self, timeout: Duration) {
+        match self {
+            Self::Multi(runtime) => runtime.shutdown_timeout(timeout),
+        }
+    }
+
+    #[inline]
+    pub fn schedule_at_fixed_rate<F>(&self, task: F, initial_delay: Option<Duration>, period: Duration)
+    where
+        F: Fn() + Send + 'static,
+    {
+        match self {
+            RocketMQRuntime::Multi(runtime) => {
+                runtime.handle().spawn(async move {
+                    if let Some(initial_delay_inner) = initial_delay {
+                        tokio::time::sleep(initial_delay_inner).await;
+                    }
+
+                    loop {
+                        let current_execution_time = tokio::time::Instant::now();
+                        task();
+                        let next_execution_time = current_execution_time + period;
+                        let delay = next_execution_time.saturating_duration_since(tokio::time::Instant::now());
+                        tokio::time::sleep(delay).await;
+                    }
+                });
+            }
+        }
+    }
+
+    #[inline]
+    pub fn schedule_at_fixed_rate_mut<F>(&self, mut task: F, initial_delay: Option<Duration>, period: Duration)
+    where
+        F: FnMut() + Send + 'static,
+    {
+        match self {
+            RocketMQRuntime::Multi(runtime) => {
+                runtime.handle().spawn(async move {
+                    if let Some(initial_delay_inner) = initial_delay {
+                        tokio::time::sleep(initial_delay_inner).await;
+                    }
+
+                    loop {
+                        let current_execution_time = tokio::time::Instant::now();
+                        task();
+                        let next_execution_time = current_execution_time + period;
+                        let delay = next_execution_time.saturating_duration_since(tokio::time::Instant::now());
+                        tokio::time::sleep(delay).await;
+                    }
+                });
+            }
+        }
+    }
+}

--- a/rocketmq-runtime/src/lib.rs
+++ b/rocketmq-runtime/src/lib.rs
@@ -12,112 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
+pub mod blocking;
+pub mod config;
+pub mod context;
+pub mod diagnostics;
+pub mod error;
+pub mod handle;
+pub mod legacy;
+pub mod owner;
+pub mod scheduled;
+pub mod service_context;
+pub mod shutdown_report;
+pub mod task_group;
 
-pub enum RocketMQRuntime {
-    Multi(tokio::runtime::Runtime),
-}
-
-impl RocketMQRuntime {
-    #[inline]
-    pub fn new_multi(threads: usize, name: &str) -> Self {
-        Self::Multi(
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(threads)
-                .thread_name(name)
-                .enable_all()
-                .build()
-                .unwrap(),
-        )
-    }
-}
-
-impl RocketMQRuntime {
-    #[inline]
-    pub fn get_handle(&self) -> &tokio::runtime::Handle {
-        match self {
-            Self::Multi(runtime) => runtime.handle(),
-        }
-    }
-
-    #[inline]
-    pub fn get_runtime(&self) -> &tokio::runtime::Runtime {
-        match self {
-            Self::Multi(runtime) => runtime,
-        }
-    }
-
-    #[inline]
-    pub fn shutdown(self) {
-        match self {
-            Self::Multi(runtime) => runtime.shutdown_background(),
-        }
-    }
-
-    #[inline]
-    pub fn shutdown_timeout(self, timeout: Duration) {
-        match self {
-            Self::Multi(runtime) => runtime.shutdown_timeout(timeout),
-        }
-    }
-
-    #[inline]
-    pub fn schedule_at_fixed_rate<F>(&self, task: F, initial_delay: Option<Duration>, period: Duration)
-    where
-        F: Fn() + Send + 'static,
-    {
-        match self {
-            RocketMQRuntime::Multi(runtime) => {
-                runtime.handle().spawn(async move {
-                    // initial delay
-                    if let Some(initial_delay_inner) = initial_delay {
-                        tokio::time::sleep(initial_delay_inner).await;
-                    }
-
-                    loop {
-                        // record current execution time
-                        let current_execution_time = tokio::time::Instant::now();
-                        // execute task
-                        task();
-                        // Calculate the time of the next execution
-                        let next_execution_time = current_execution_time + period;
-
-                        // Wait until the next execution
-                        let delay = next_execution_time.saturating_duration_since(tokio::time::Instant::now());
-                        tokio::time::sleep(delay).await;
-                    }
-                });
-            }
-        }
-    }
-
-    #[inline]
-    pub fn schedule_at_fixed_rate_mut<F>(&self, mut task: F, initial_delay: Option<Duration>, period: Duration)
-    where
-        F: FnMut() + Send + 'static,
-    {
-        match self {
-            RocketMQRuntime::Multi(runtime) => {
-                runtime.handle().spawn(async move {
-                    // initial delay
-                    if let Some(initial_delay_inner) = initial_delay {
-                        tokio::time::sleep(initial_delay_inner).await;
-                    }
-
-                    loop {
-                        // record current execution time
-                        let current_execution_time = tokio::time::Instant::now();
-                        // execute task
-                        task();
-                        // Calculate the time of the next execution
-                        let next_execution_time = current_execution_time + period;
-
-                        // Wait until the next execution
-                        let delay = next_execution_time.saturating_duration_since(tokio::time::Instant::now());
-                        tokio::time::sleep(delay).await;
-                    }
-                });
-            }
-        }
-    }
-}
+pub use blocking::BlockingExecutor;
+pub use blocking::BlockingExecutorSnapshot;
+pub use blocking::BlockingKind;
+pub use blocking::BlockingPoolPolicy;
+pub use blocking::BlockingTaskSnapshot;
+pub use config::RuntimeConfig;
+pub use context::RuntimeContext;
+pub use diagnostics::RuntimeDiagnostics;
+pub use error::RuntimeError;
+pub use error::RuntimeResult;
+pub use handle::RuntimeHandle;
+pub use legacy::RocketMQRuntime;
+pub use owner::RuntimeOwner;
+pub use scheduled::ScheduleMode;
+pub use scheduled::ScheduledTaskConfig;
+pub use scheduled::ScheduledTaskGroup;
+pub use scheduled::ScheduledTaskSnapshot;
+pub use service_context::ServiceContext;
+pub use shutdown_report::ShutdownAnnotation;
+pub use shutdown_report::ShutdownReport;
+pub use shutdown_report::TaskSnapshot;
+pub use task_group::DetachedTaskPolicy;
+pub use task_group::TaskGroup;
+pub use task_group::TaskGroupId;
+pub use task_group::TaskGroupLifecycleState;
+pub use task_group::TaskId;
+pub use task_group::TaskKind;
+pub use task_group::TaskResult;

--- a/rocketmq-runtime/src/owner.rs
+++ b/rocketmq-runtime/src/owner.rs
@@ -1,0 +1,97 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+
+use crate::config::RuntimeConfig;
+use crate::context::RuntimeContext;
+use crate::error::RuntimeError;
+use crate::error::RuntimeResult;
+use crate::handle::RuntimeHandle;
+use crate::shutdown_report::ShutdownReport;
+
+pub struct RuntimeOwner {
+    config: RuntimeConfig,
+    runtime: Option<tokio::runtime::Runtime>,
+    context: RuntimeContext,
+}
+
+impl RuntimeOwner {
+    pub fn new(config: RuntimeConfig) -> RuntimeResult<Self> {
+        config.validate()?;
+
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder
+            .worker_threads(config.worker_threads)
+            .max_blocking_threads(config.max_blocking_threads)
+            .thread_name(config.thread_name.clone())
+            .thread_keep_alive(config.thread_keep_alive);
+        if config.enable_io {
+            builder.enable_io();
+        }
+        if config.enable_time {
+            builder.enable_time();
+        }
+
+        let runtime = builder.build()?;
+        let context = RuntimeContext::new(RuntimeHandle::new(runtime.handle().clone()), config.thread_name.clone())?;
+        Ok(Self {
+            config,
+            runtime: Some(runtime),
+            context,
+        })
+    }
+
+    pub fn context(&self) -> &RuntimeContext {
+        &self.context
+    }
+
+    pub fn config(&self) -> &RuntimeConfig {
+        &self.config
+    }
+
+    pub fn block_on<F>(&self, future: F) -> F::Output
+    where
+        F: Future,
+    {
+        self.runtime
+            .as_ref()
+            .expect("runtime owner must still own the runtime")
+            .block_on(future)
+    }
+
+    pub async fn shutdown_tasks(&self) -> ShutdownReport {
+        self.context.shutdown_tasks(self.config.shutdown_timeout).await
+    }
+
+    pub fn shutdown_runtime_blocking(mut self) -> RuntimeResult<ShutdownReport> {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            return Err(RuntimeError::InsideTokioRuntime("shutdown_runtime_blocking"));
+        }
+
+        let runtime = self.runtime.take().expect("runtime owner must still own the runtime");
+        let report = runtime.block_on(self.context.shutdown_tasks(self.config.shutdown_timeout));
+        report.log_if_unhealthy();
+        runtime.shutdown_timeout(self.config.shutdown_timeout);
+        Ok(report)
+    }
+}
+
+impl Drop for RuntimeOwner {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            runtime.shutdown_background();
+        }
+    }
+}

--- a/rocketmq-runtime/src/scheduled.rs
+++ b/rocketmq-runtime/src/scheduled.rs
@@ -1,0 +1,268 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use dashmap::DashMap;
+use serde::Serialize;
+use tokio_util::sync::CancellationToken;
+
+use crate::error::RuntimeError;
+use crate::error::RuntimeResult;
+use crate::task_group::TaskGroup;
+use crate::task_group::TaskId;
+use crate::task_group::TaskKind;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum ScheduleMode {
+    FixedDelay,
+    FixedRateNoOverlap,
+    FixedRateAllowOverlap,
+}
+
+#[derive(Debug, Clone)]
+pub struct ScheduledTaskConfig {
+    pub name: String,
+    pub initial_delay: Duration,
+    pub period: Duration,
+    pub mode: ScheduleMode,
+    pub max_run_time: Option<Duration>,
+    pub shutdown_timeout: Duration,
+}
+
+impl ScheduledTaskConfig {
+    pub fn fixed_delay(name: impl Into<String>, period: Duration) -> Self {
+        Self {
+            name: name.into(),
+            initial_delay: Duration::ZERO,
+            period,
+            mode: ScheduleMode::FixedDelay,
+            max_run_time: None,
+            shutdown_timeout: Duration::from_secs(30),
+        }
+    }
+
+    pub fn fixed_rate_no_overlap(name: impl Into<String>, period: Duration) -> Self {
+        Self {
+            mode: ScheduleMode::FixedRateNoOverlap,
+            ..Self::fixed_delay(name, period)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ScheduledTaskGroup {
+    group: TaskGroup,
+    schedules: Arc<DashMap<Arc<str>, Arc<ScheduledTaskMetrics>>>,
+}
+
+#[derive(Debug)]
+struct ScheduledTaskMetrics {
+    config: ScheduledTaskConfig,
+    running: AtomicBool,
+    runs: AtomicU64,
+    skips: AtomicU64,
+    failures: AtomicU64,
+    last_elapsed_ms: AtomicU64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ScheduledTaskSnapshot {
+    pub name: String,
+    pub mode: ScheduleMode,
+    pub running: bool,
+    pub runs: u64,
+    pub skips: u64,
+    pub failures: u64,
+    pub last_elapsed_ms: u64,
+}
+
+impl ScheduledTaskGroup {
+    pub fn new(group: TaskGroup) -> Self {
+        Self {
+            group,
+            schedules: Arc::new(DashMap::new()),
+        }
+    }
+
+    pub fn group(&self) -> &TaskGroup {
+        &self.group
+    }
+
+    pub fn schedule_fixed_delay<F, Fut>(&self, mut config: ScheduledTaskConfig, mut task: F) -> RuntimeResult<TaskId>
+    where
+        F: FnMut() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        config.mode = ScheduleMode::FixedDelay;
+        let name: Arc<str> = Arc::from(config.name.as_str());
+        let metrics = self.register(name.clone(), config.clone())?;
+        let token = self.group.cancellation_token();
+        self.group.spawn(
+            format!("scheduled-driver:{name}"),
+            TaskKind::ScheduledDriver,
+            async move {
+                if !sleep_or_cancel(&token, config.initial_delay).await {
+                    return;
+                }
+
+                loop {
+                    if token.is_cancelled() {
+                        return;
+                    }
+
+                    let started_at = Instant::now();
+                    metrics.running.store(true, Ordering::Release);
+                    let timed_out = run_with_optional_timeout(task(), config.max_run_time).await;
+                    metrics.running.store(false, Ordering::Release);
+                    metrics
+                        .last_elapsed_ms
+                        .store(started_at.elapsed().as_millis() as u64, Ordering::Relaxed);
+                    if timed_out {
+                        metrics.failures.fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        metrics.runs.fetch_add(1, Ordering::Relaxed);
+                    }
+
+                    if !sleep_or_cancel(&token, config.period).await {
+                        return;
+                    }
+                }
+            },
+        )
+    }
+
+    pub fn schedule_fixed_rate_no_overlap<F, Fut>(
+        &self,
+        mut config: ScheduledTaskConfig,
+        task: F,
+    ) -> RuntimeResult<TaskId>
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        config.mode = ScheduleMode::FixedRateNoOverlap;
+        let name: Arc<str> = Arc::from(config.name.as_str());
+        let metrics = self.register(name.clone(), config.clone())?;
+        let token = self.group.cancellation_token();
+        let run_group = self.group.clone();
+        let task = Arc::new(task);
+
+        self.group.spawn(
+            format!("scheduled-driver:{name}"),
+            TaskKind::ScheduledDriver,
+            async move {
+                if !sleep_or_cancel(&token, config.initial_delay).await {
+                    return;
+                }
+
+                loop {
+                    if token.is_cancelled() {
+                        return;
+                    }
+
+                    if metrics.running.swap(true, Ordering::AcqRel) {
+                        metrics.skips.fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        let run_name = format!("scheduled-run:{name}");
+                        let run_metrics = metrics.clone();
+                        let run_task = task.clone();
+                        let max_run_time = config.max_run_time;
+                        let _ = run_group.spawn(run_name, TaskKind::ScheduledRun, async move {
+                            let started_at = Instant::now();
+                            let timed_out = run_with_optional_timeout(run_task(), max_run_time).await;
+                            run_metrics.running.store(false, Ordering::Release);
+                            run_metrics
+                                .last_elapsed_ms
+                                .store(started_at.elapsed().as_millis() as u64, Ordering::Relaxed);
+                            if timed_out {
+                                run_metrics.failures.fetch_add(1, Ordering::Relaxed);
+                            } else {
+                                run_metrics.runs.fetch_add(1, Ordering::Relaxed);
+                            }
+                        });
+                    }
+
+                    if !sleep_or_cancel(&token, config.period).await {
+                        return;
+                    }
+                }
+            },
+        )
+    }
+
+    pub fn snapshot(&self) -> Vec<ScheduledTaskSnapshot> {
+        self.schedules.iter().map(|entry| entry.value().snapshot()).collect()
+    }
+
+    fn register(&self, name: Arc<str>, config: ScheduledTaskConfig) -> RuntimeResult<Arc<ScheduledTaskMetrics>> {
+        if self.schedules.contains_key(&name) {
+            return Err(RuntimeError::ScheduledTaskExists { name });
+        }
+
+        let metrics = Arc::new(ScheduledTaskMetrics {
+            config,
+            running: AtomicBool::new(false),
+            runs: AtomicU64::new(0),
+            skips: AtomicU64::new(0),
+            failures: AtomicU64::new(0),
+            last_elapsed_ms: AtomicU64::new(0),
+        });
+        self.schedules.insert(name, metrics.clone());
+        Ok(metrics)
+    }
+}
+
+impl ScheduledTaskMetrics {
+    fn snapshot(&self) -> ScheduledTaskSnapshot {
+        ScheduledTaskSnapshot {
+            name: self.config.name.clone(),
+            mode: self.config.mode,
+            running: self.running.load(Ordering::Acquire),
+            runs: self.runs.load(Ordering::Relaxed),
+            skips: self.skips.load(Ordering::Relaxed),
+            failures: self.failures.load(Ordering::Relaxed),
+            last_elapsed_ms: self.last_elapsed_ms.load(Ordering::Relaxed),
+        }
+    }
+}
+
+async fn run_with_optional_timeout<Fut>(future: Fut, max_run_time: Option<Duration>) -> bool
+where
+    Fut: Future<Output = ()> + Send,
+{
+    if let Some(timeout) = max_run_time {
+        tokio::time::timeout(timeout, future).await.is_err()
+    } else {
+        future.await;
+        false
+    }
+}
+
+async fn sleep_or_cancel(token: &CancellationToken, duration: Duration) -> bool {
+    if duration.is_zero() {
+        return !token.is_cancelled();
+    }
+
+    tokio::select! {
+        _ = token.cancelled() => false,
+        _ = tokio::time::sleep(duration) => true,
+    }
+}

--- a/rocketmq-runtime/src/service_context.rs
+++ b/rocketmq-runtime/src/service_context.rs
@@ -1,0 +1,101 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use crate::blocking::BlockingExecutor;
+use crate::diagnostics::RuntimeDiagnostics;
+use crate::error::RuntimeResult;
+use crate::handle::RuntimeHandle;
+use crate::scheduled::ScheduledTaskGroup;
+use crate::task_group::TaskGroup;
+use crate::task_group::TaskId;
+use crate::task_group::TaskKind;
+
+#[derive(Debug, Clone)]
+pub struct ServiceContext {
+    name: Arc<str>,
+    runtime: RuntimeHandle,
+    task_group: TaskGroup,
+    blocking: BlockingExecutor,
+    diagnostics: RuntimeDiagnostics,
+}
+
+impl ServiceContext {
+    pub fn new(
+        name: Arc<str>,
+        runtime: RuntimeHandle,
+        task_group: TaskGroup,
+        blocking: BlockingExecutor,
+        diagnostics: RuntimeDiagnostics,
+    ) -> Self {
+        Self {
+            name,
+            runtime,
+            task_group,
+            blocking,
+            diagnostics,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn runtime(&self) -> &RuntimeHandle {
+        &self.runtime
+    }
+
+    pub fn task_group(&self) -> &TaskGroup {
+        &self.task_group
+    }
+
+    pub fn blocking(&self) -> &BlockingExecutor {
+        &self.blocking
+    }
+
+    pub fn diagnostics(&self) -> &RuntimeDiagnostics {
+        &self.diagnostics
+    }
+
+    pub fn child(&self, name: impl Into<Arc<str>>) -> Self {
+        let name = name.into();
+        Self {
+            name: name.clone(),
+            runtime: self.runtime.clone(),
+            task_group: self.task_group.child(name),
+            blocking: self.blocking.clone(),
+            diagnostics: self.diagnostics.clone(),
+        }
+    }
+
+    pub fn scheduled_tasks(&self, name: impl Into<Arc<str>>) -> ScheduledTaskGroup {
+        ScheduledTaskGroup::new(self.task_group.child(name))
+    }
+
+    pub fn spawn<F>(&self, name: impl Into<Arc<str>>, kind: TaskKind, future: F) -> RuntimeResult<TaskId>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.task_group.spawn(name, kind, future)
+    }
+
+    pub fn spawn_service<F>(&self, name: impl Into<Arc<str>>, future: F) -> RuntimeResult<TaskId>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.task_group.spawn_service(name, future)
+    }
+}

--- a/rocketmq-runtime/src/shutdown_report.rs
+++ b/rocketmq-runtime/src/shutdown_report.rs
@@ -1,0 +1,138 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::blocking::BlockingTaskSnapshot;
+use crate::task_group::TaskGroupId;
+use crate::task_group::TaskId;
+use crate::task_group::TaskKind;
+use crate::task_group::TaskState;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ShutdownReport {
+    pub name: String,
+    #[serde(with = "duration_millis")]
+    pub elapsed: Duration,
+    pub completed: usize,
+    pub cancelled: usize,
+    pub aborted: usize,
+    pub panicked: usize,
+    pub timed_out: usize,
+    pub leaked: usize,
+    pub blocking_still_running: usize,
+    pub detached_still_running: usize,
+    pub children: Vec<ShutdownReport>,
+    pub remaining_tasks: Vec<TaskSnapshot>,
+    pub blocking_tasks: Vec<BlockingTaskSnapshot>,
+    pub annotations: Vec<ShutdownAnnotation>,
+}
+
+impl ShutdownReport {
+    pub fn new(name: impl Into<String>, elapsed: Duration) -> Self {
+        Self {
+            name: name.into(),
+            elapsed,
+            completed: 0,
+            cancelled: 0,
+            aborted: 0,
+            panicked: 0,
+            timed_out: 0,
+            leaked: 0,
+            blocking_still_running: 0,
+            detached_still_running: 0,
+            children: Vec::new(),
+            remaining_tasks: Vec::new(),
+            blocking_tasks: Vec::new(),
+            annotations: Vec::new(),
+        }
+    }
+
+    pub fn is_healthy(&self) -> bool {
+        self.leaked == 0
+            && self.panicked == 0
+            && self.timed_out == 0
+            && self.blocking_still_running == 0
+            && self.children.iter().all(Self::is_healthy)
+    }
+
+    pub fn assert_no_task_leak(&self) -> Result<(), String> {
+        if self.is_healthy() {
+            Ok(())
+        } else {
+            Err(format!("shutdown report is unhealthy: {}", self.to_json()))
+        }
+    }
+
+    pub fn log_if_unhealthy(&self) {
+        if !self.is_healthy() {
+            tracing::warn!(report = %self.to_json(), "runtime shutdown report is unhealthy");
+        }
+    }
+
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|error| format!("{{\"serialization_error\":\"{}\"}}", error))
+    }
+
+    pub fn merge_blocking(&mut self, snapshot: crate::blocking::BlockingExecutorSnapshot) {
+        self.blocking_still_running += snapshot.blocking_still_running;
+        self.blocking_tasks.extend(snapshot.tasks);
+        if self.blocking_still_running > 0 {
+            self.annotations.push(ShutdownAnnotation::new(
+                "spawn_blocking tasks may continue after timeout; see blocking_still_running",
+            ));
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskSnapshot {
+    pub id: TaskId,
+    pub name: String,
+    pub group_id: TaskGroupId,
+    pub group_name: String,
+    pub kind: TaskKind,
+    pub state: TaskState,
+    #[serde(with = "duration_millis")]
+    pub elapsed: Duration,
+    pub detached: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ShutdownAnnotation {
+    pub message: String,
+}
+
+impl ShutdownAnnotation {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+mod duration_millis {
+    use std::time::Duration;
+
+    use serde::Serializer;
+
+    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(duration.as_millis() as u64)
+    }
+}

--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -1,0 +1,460 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use dashmap::DashMap;
+use futures::future::BoxFuture;
+use futures::future::FutureExt;
+use parking_lot::Mutex;
+use serde::Serialize;
+use tokio::task::AbortHandle;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+use crate::error::RuntimeError;
+use crate::error::RuntimeResult;
+use crate::handle::RuntimeHandle;
+use crate::shutdown_report::ShutdownAnnotation;
+use crate::shutdown_report::ShutdownReport;
+use crate::shutdown_report::TaskSnapshot;
+
+const STATE_OPEN: u8 = 0;
+const STATE_CLOSING: u8 = 1;
+const STATE_CLOSED: u8 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub struct TaskId(u64);
+
+impl TaskId {
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub struct TaskGroupId(u64);
+
+impl TaskGroupId {
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum TaskKind {
+    Service,
+    Worker,
+    ScheduledDriver,
+    ScheduledRun,
+    BlockingReaper,
+    Shutdown,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum TaskState {
+    Queued,
+    Running,
+    Completed,
+    Cancelled,
+    Aborted,
+    Panicked,
+    Leaked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum TaskResult {
+    Completed,
+    Cancelled,
+    Aborted,
+    Panicked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetachedTaskPolicy {
+    TrackOnly,
+    AbortOnShutdown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum TaskGroupLifecycleState {
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskGroup {
+    inner: Arc<TaskGroupInner>,
+}
+
+#[derive(Debug)]
+struct TaskGroupInner {
+    id: TaskGroupId,
+    parent_id: Option<TaskGroupId>,
+    name: Arc<str>,
+    runtime: RuntimeHandle,
+    cancellation_token: CancellationToken,
+    tracker: TaskTracker,
+    tasks: DashMap<TaskId, TaskMeta>,
+    children: DashMap<TaskGroupId, TaskGroup>,
+    next_task_id: AtomicU64,
+    next_child_id: AtomicU64,
+    completed: AtomicUsize,
+    cancelled: AtomicUsize,
+    panicked: AtomicUsize,
+    lifecycle: AtomicU8,
+    spawn_gate: Mutex<()>,
+    shutdown_report: tokio::sync::OnceCell<ShutdownReport>,
+}
+
+#[derive(Debug, Clone)]
+struct TaskMeta {
+    id: TaskId,
+    name: Arc<str>,
+    group_id: TaskGroupId,
+    group_name: Arc<str>,
+    kind: TaskKind,
+    state: TaskState,
+    started_at: Instant,
+    detached: bool,
+    abort_handle: Option<AbortHandle>,
+}
+
+impl TaskGroup {
+    pub fn root(name: impl Into<Arc<str>>, runtime: RuntimeHandle) -> Self {
+        Self {
+            inner: Arc::new(TaskGroupInner::new(
+                TaskGroupId(1),
+                None,
+                name.into(),
+                runtime,
+                CancellationToken::new(),
+            )),
+        }
+    }
+
+    pub fn id(&self) -> TaskGroupId {
+        self.inner.id
+    }
+
+    pub fn parent_id(&self) -> Option<TaskGroupId> {
+        self.inner.parent_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    pub fn runtime(&self) -> &RuntimeHandle {
+        &self.inner.runtime
+    }
+
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.inner.cancellation_token.clone()
+    }
+
+    pub fn lifecycle_state(&self) -> TaskGroupLifecycleState {
+        self.inner.lifecycle_state()
+    }
+
+    pub fn task_count(&self) -> usize {
+        self.inner.tasks.len()
+    }
+
+    pub fn child(&self, name: impl Into<Arc<str>>) -> Self {
+        let child_id = TaskGroupId(self.inner.next_child_id.fetch_add(1, Ordering::Relaxed));
+        let child = Self {
+            inner: Arc::new(TaskGroupInner::new(
+                child_id,
+                Some(self.inner.id),
+                name.into(),
+                self.inner.runtime.clone(),
+                self.inner.cancellation_token.child_token(),
+            )),
+        };
+        self.inner.children.insert(child_id, child.clone());
+        child
+    }
+
+    pub fn spawn<F>(&self, name: impl Into<Arc<str>>, kind: TaskKind, future: F) -> RuntimeResult<TaskId>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.spawn_inner(name.into(), kind, false, future)
+    }
+
+    pub fn spawn_service<F>(&self, name: impl Into<Arc<str>>, future: F) -> RuntimeResult<TaskId>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.spawn(name, TaskKind::Service, future)
+    }
+
+    pub fn spawn_detached<F>(&self, name: impl Into<Arc<str>>, kind: TaskKind, future: F) -> RuntimeResult<TaskId>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.spawn_inner(name.into(), kind, true, future)
+    }
+
+    pub fn cancel(&self) {
+        self.inner.cancellation_token.cancel();
+    }
+
+    pub fn shutdown(&self, timeout: Duration) -> BoxFuture<'_, ShutdownReport> {
+        async move {
+            self.inner
+                .shutdown_report
+                .get_or_init(|| async { self.shutdown_inner(timeout).await })
+                .await
+                .clone()
+        }
+        .boxed()
+    }
+
+    fn spawn_inner<F>(&self, name: Arc<str>, kind: TaskKind, detached: bool, future: F) -> RuntimeResult<TaskId>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let _spawn_guard = self.inner.spawn_gate.lock();
+        if self.inner.lifecycle_state() != TaskGroupLifecycleState::Open {
+            return Err(RuntimeError::TaskGroupClosing {
+                group_id: self.inner.id,
+                group_name: self.inner.name.clone(),
+            });
+        }
+
+        let task_id = TaskId(self.inner.next_task_id.fetch_add(1, Ordering::Relaxed));
+        self.inner.tasks.insert(
+            task_id,
+            TaskMeta {
+                id: task_id,
+                name: name.clone(),
+                group_id: self.inner.id,
+                group_name: self.inner.name.clone(),
+                kind,
+                state: TaskState::Queued,
+                started_at: Instant::now(),
+                detached,
+                abort_handle: None,
+            },
+        );
+
+        let inner = self.inner.clone();
+        let token = inner.cancellation_token.clone();
+        let wrapped = async move {
+            let result = AssertUnwindSafe(future).catch_unwind().await;
+            let task_result = match result {
+                Ok(()) if token.is_cancelled() => TaskResult::Cancelled,
+                Ok(()) => TaskResult::Completed,
+                Err(error) => {
+                    tracing::error!(task_id = task_id.as_u64(), ?error, "task panicked");
+                    TaskResult::Panicked
+                }
+            };
+            inner.finish_task(task_id, task_result);
+        };
+
+        let join_handle = if detached {
+            self.inner.runtime.spawn(wrapped)
+        } else {
+            self.inner.tracker.spawn_on(wrapped, self.inner.runtime.inner())
+        };
+        let abort_handle = join_handle.abort_handle();
+        drop(join_handle);
+
+        if let Some(mut meta) = self.inner.tasks.get_mut(&task_id) {
+            meta.abort_handle = Some(abort_handle);
+            meta.state = TaskState::Running;
+        }
+
+        Ok(task_id)
+    }
+
+    async fn shutdown_inner(&self, timeout: Duration) -> ShutdownReport {
+        let started_at = Instant::now();
+        let children = self
+            .inner
+            .children
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect::<Vec<_>>();
+
+        {
+            let _spawn_guard = self.inner.spawn_gate.lock();
+            self.inner.lifecycle.store(STATE_CLOSING, Ordering::Release);
+            self.inner.tracker.close();
+            self.inner.cancellation_token.cancel();
+        }
+
+        let mut child_reports = Vec::with_capacity(children.len());
+        for child in children {
+            child_reports.push(child.shutdown(timeout).await);
+        }
+
+        let mut timed_out = false;
+        if tokio::time::timeout(timeout, self.inner.tracker.wait()).await.is_err() {
+            timed_out = true;
+            self.abort_tracked_tasks();
+            let drain_timeout = timeout.min(Duration::from_secs(1));
+            let _ = tokio::time::timeout(drain_timeout, self.inner.tracker.wait()).await;
+        }
+
+        let mut report = ShutdownReport::new(self.inner.name.to_string(), started_at.elapsed());
+        report.completed = self.inner.completed.load(Ordering::Relaxed);
+        report.cancelled = self.inner.cancelled.load(Ordering::Relaxed);
+        report.panicked = self.inner.panicked.load(Ordering::Relaxed);
+        report.children = child_reports;
+
+        let aborted = self.remove_aborted_tasks();
+        report.aborted = aborted;
+        if aborted > 0 {
+            report.annotations.push(ShutdownAnnotation::new(format!(
+                "aborted {aborted} tracked tasks after shutdown timeout"
+            )));
+        }
+
+        let remaining = self.remaining_snapshots(TaskState::Leaked);
+        report.detached_still_running = remaining.iter().filter(|task| task.detached).count();
+        report.leaked = remaining.iter().filter(|task| !task.detached).count();
+        report.remaining_tasks = remaining;
+        if timed_out {
+            report.timed_out = aborted + report.leaked;
+        }
+
+        if report.detached_still_running > 0 {
+            report.annotations.push(ShutdownAnnotation::new(format!(
+                "{} detached tasks are still running",
+                report.detached_still_running
+            )));
+        }
+
+        self.inner.lifecycle.store(STATE_CLOSED, Ordering::Release);
+        report
+    }
+
+    fn abort_tracked_tasks(&self) {
+        for mut entry in self.inner.tasks.iter_mut() {
+            if entry.detached {
+                continue;
+            }
+            entry.state = TaskState::Aborted;
+            if let Some(abort_handle) = &entry.abort_handle {
+                abort_handle.abort();
+            }
+        }
+    }
+
+    fn remove_aborted_tasks(&self) -> usize {
+        let aborted_ids = self
+            .inner
+            .tasks
+            .iter()
+            .filter_map(|entry| (!entry.detached && entry.state == TaskState::Aborted).then_some(*entry.key()))
+            .collect::<Vec<_>>();
+
+        for task_id in &aborted_ids {
+            self.inner.tasks.remove(task_id);
+        }
+
+        aborted_ids.len()
+    }
+
+    fn remaining_snapshots(&self, state: TaskState) -> Vec<TaskSnapshot> {
+        self.inner
+            .tasks
+            .iter()
+            .map(|entry| entry.value().snapshot(state))
+            .collect()
+    }
+}
+
+impl TaskGroupInner {
+    fn new(
+        id: TaskGroupId,
+        parent_id: Option<TaskGroupId>,
+        name: Arc<str>,
+        runtime: RuntimeHandle,
+        cancellation_token: CancellationToken,
+    ) -> Self {
+        Self {
+            id,
+            parent_id,
+            name,
+            runtime,
+            cancellation_token,
+            tracker: TaskTracker::new(),
+            tasks: DashMap::new(),
+            children: DashMap::new(),
+            next_task_id: AtomicU64::new(1),
+            next_child_id: AtomicU64::new(id.as_u64() * 1_000_000 + 1),
+            completed: AtomicUsize::new(0),
+            cancelled: AtomicUsize::new(0),
+            panicked: AtomicUsize::new(0),
+            lifecycle: AtomicU8::new(STATE_OPEN),
+            spawn_gate: Mutex::new(()),
+            shutdown_report: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    fn lifecycle_state(&self) -> TaskGroupLifecycleState {
+        match self.lifecycle.load(Ordering::Acquire) {
+            STATE_OPEN => TaskGroupLifecycleState::Open,
+            STATE_CLOSING => TaskGroupLifecycleState::Closing,
+            _ => TaskGroupLifecycleState::Closed,
+        }
+    }
+
+    fn finish_task(&self, task_id: TaskId, result: TaskResult) {
+        match result {
+            TaskResult::Completed => {
+                self.completed.fetch_add(1, Ordering::Relaxed);
+            }
+            TaskResult::Cancelled => {
+                self.cancelled.fetch_add(1, Ordering::Relaxed);
+            }
+            TaskResult::Panicked => {
+                self.panicked.fetch_add(1, Ordering::Relaxed);
+            }
+            TaskResult::Aborted => {}
+        }
+
+        self.tasks.remove(&task_id);
+    }
+}
+
+impl TaskMeta {
+    fn snapshot(&self, override_state: TaskState) -> TaskSnapshot {
+        TaskSnapshot {
+            id: self.id,
+            name: self.name.to_string(),
+            group_id: self.group_id,
+            group_name: self.group_name.to_string(),
+            kind: self.kind,
+            state: override_state,
+            elapsed: self.started_at.elapsed(),
+            detached: self.detached,
+        }
+    }
+}

--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -1,0 +1,132 @@
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_runtime::BlockingExecutor;
+use rocketmq_runtime::BlockingPoolPolicy;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_runtime::ScheduledTaskConfig;
+use rocketmq_runtime::ScheduledTaskGroup;
+use rocketmq_runtime::TaskKind;
+use tokio::sync::Notify;
+
+#[tokio::test]
+async fn task_group_shutdown_waits_for_completed_tasks() {
+    let context = RuntimeContext::from_current("task-group-complete-test");
+    let group = context.root_group().child("service");
+    let notify = Arc::new(Notify::new());
+    let notify_task = notify.clone();
+
+    group
+        .spawn_service("complete-task", async move {
+            notify_task.notify_one();
+        })
+        .unwrap();
+
+    notify.notified().await;
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+    assert_eq!(report.completed, 1);
+}
+
+#[tokio::test]
+async fn task_group_shutdown_reports_panics() {
+    let context = RuntimeContext::from_current("task-group-panic-test");
+    let group = context.root_group().child("service");
+
+    group
+        .spawn("panic-task", TaskKind::Worker, async move {
+            panic!("expected panic for runtime task accounting");
+        })
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert_eq!(report.panicked, 1);
+    assert!(!report.is_healthy());
+}
+
+#[tokio::test]
+async fn task_group_shutdown_aborts_after_timeout_without_leak() {
+    let context = RuntimeContext::from_current("task-group-abort-test");
+    let group = context.root_group().child("service");
+
+    group
+        .spawn_service("pending-task", async move {
+            std::future::pending::<()>().await;
+        })
+        .unwrap();
+
+    let report = group.shutdown(Duration::from_millis(20)).await;
+    assert_eq!(report.aborted, 1, "{}", report.to_json());
+    assert_eq!(report.leaked, 0, "{}", report.to_json());
+    assert_eq!(report.timed_out, 1, "{}", report.to_json());
+}
+
+#[tokio::test]
+async fn scheduled_no_overlap_skips_while_previous_run_is_active() {
+    let context = RuntimeContext::from_current("scheduled-test");
+    let service = context.service_context("service");
+    let scheduled = ScheduledTaskGroup::new(service.task_group().child("scheduled"));
+    let config = ScheduledTaskConfig::fixed_rate_no_overlap("slow-task", Duration::from_millis(10));
+
+    scheduled
+        .schedule_fixed_rate_no_overlap(config, || async {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        })
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(90)).await;
+    let snapshot = scheduled
+        .snapshot()
+        .into_iter()
+        .find(|task| task.name == "slow-task")
+        .expect("scheduled task snapshot should exist");
+
+    assert!(snapshot.runs >= 1, "{snapshot:?}");
+    assert!(snapshot.skips >= 1, "{snapshot:?}");
+
+    let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+    assert!(report.leaked == 0, "{}", report.to_json());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn blocking_executor_limits_concurrency() {
+    let context = RuntimeContext::from_current("blocking-test");
+    let policy = BlockingPoolPolicy {
+        max_concurrency: 1,
+        queue_timeout: Duration::from_secs(1),
+        task_timeout: Duration::from_secs(1),
+        ..BlockingPoolPolicy::default()
+    };
+    let executor = BlockingExecutor::new(policy, context.root_group().child("blocking")).unwrap();
+    let active = Arc::new(AtomicUsize::new(0));
+    let max_active = Arc::new(AtomicUsize::new(0));
+
+    let first = run_limited_blocking_task(executor.clone(), active.clone(), max_active.clone());
+    let second = run_limited_blocking_task(executor, active, max_active.clone());
+    let (first, second) = tokio::join!(first, second);
+
+    first.unwrap();
+    second.unwrap();
+    assert_eq!(max_active.load(Ordering::Relaxed), 1);
+}
+
+async fn run_limited_blocking_task(
+    executor: BlockingExecutor,
+    active: Arc<AtomicUsize>,
+    max_active: Arc<AtomicUsize>,
+) -> rocketmq_runtime::RuntimeResult<()> {
+    executor
+        .spawn_io("limited-io", move || {
+            let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+            max_active.fetch_max(current, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(50));
+            active.fetch_sub(1, Ordering::SeqCst);
+        })
+        .await
+}

--- a/scripts/bench-runtime-model.ps1
+++ b/scripts/bench-runtime-model.ps1
@@ -1,0 +1,100 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("before", "after", "prototype")]
+    [string]$Mode = "before",
+    [string]$OutputDirectory = "target/runtime-baseline",
+    [int]$SampleProcessId = 0,
+    [int]$SampleMilliseconds = 5000,
+    [int]$SampleIntervalMilliseconds = 200
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$workspaceRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$modeRoot = Join-Path (Join-Path $workspaceRoot $OutputDirectory) $Mode
+
+if (-not (Test-Path $modeRoot)) {
+    New-Item -ItemType Directory -Force -Path $modeRoot | Out-Null
+}
+
+function Write-JsonArtifact {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][hashtable]$Metrics
+    )
+
+    $payload = [ordered]@{
+        generated_at = (Get-Date -Format o)
+        mode = $Mode
+        source = "scripts/bench-runtime-model.ps1"
+        metrics = $Metrics
+    }
+
+    $payload | ConvertTo-Json -Depth 8 | Out-File -Encoding utf8 (Join-Path $modeRoot $Name)
+}
+
+function Measure-Threads {
+    param([Parameter(Mandatory = $true)][int]$Pid)
+
+    $path = Join-Path $modeRoot "thread-sampling.csv"
+    "ts,threads" | Out-File -Encoding utf8 $path
+    $deadline = [DateTimeOffset]::UtcNow.AddMilliseconds($SampleMilliseconds)
+
+    while ([DateTimeOffset]::UtcNow -lt $deadline) {
+        try {
+            $process = Get-Process -Id $Pid -ErrorAction Stop
+            $ts = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+            "$ts,$($process.Threads.Count)" | Out-File -Append -Encoding utf8 $path
+            Start-Sleep -Milliseconds $SampleIntervalMilliseconds
+        }
+        catch {
+            break
+        }
+    }
+}
+
+if ($SampleProcessId -gt 0) {
+    Measure-Threads -Pid $SampleProcessId
+}
+else {
+    "ts,threads" | Out-File -Encoding utf8 (Join-Path $modeRoot "thread-sampling.csv")
+}
+
+Write-JsonArtifact -Name "client-runtime-spawn.json" -Metrics @{
+    status = "pending-benchmark"
+    expected_bench = "cargo bench -p rocketmq-client-rust --bench client_runtime_spawn_benchmark"
+    required_metrics = @("total_elapsed_ms", "spawn_to_complete_p95_ms", "peak_thread_count", "runtime_creation_count")
+}
+
+Write-JsonArtifact -Name "namesrv-shutdown.json" -Metrics @{
+    status = "pending-benchmark"
+    expected_bench = "cargo bench -p rocketmq-namesrv --bench namesrv_shutdown_drain_bench"
+    required_metrics = @("shutdown_p95_ms", "tracked_task_after_shutdown", "unregister_pending_count")
+}
+
+Write-JsonArtifact -Name "broker-runtime-lifecycle.json" -Metrics @{
+    status = "pending-benchmark"
+    expected_bench = "cargo bench -p rocketmq-broker --bench broker_runtime_lifecycle_bench"
+    required_metrics = @("idle_thread_count", "shutdown_p99_ms", "task_leaked", "long_polling_wakeup_percent")
+}
+
+Write-JsonArtifact -Name "remoting-connection-lifecycle.json" -Metrics @{
+    status = "pending-benchmark"
+    expected_bench = "cargo bench -p rocketmq-remoting --bench remoting_connection_lifecycle_bench"
+    required_metrics = @("connection_handler_alive", "channel_send_alive", "shutdown_drain_ms")
+}
+
+Write-JsonArtifact -Name "scheduler.json" -Metrics @{
+    status = "pending-benchmark"
+    expected_bench = "cargo bench -p rocketmq --bench scheduled_task_group_bench"
+    required_metrics = @("run_count", "skip_count", "overlap_count", "shutdown_wait_ms")
+}
+
+Write-JsonArtifact -Name "store-blocking.json" -Metrics @{
+    status = "pending-benchmark"
+    expected_bench = "cargo bench -p rocketmq-store --bench store_blocking_executor_bench"
+    required_metrics = @("blocking_queue_wait_p95_ms", "blocking_duration_p95_ms", "blocking_still_running")
+}
+
+Write-Host "Runtime model baseline artifacts written to $modeRoot"

--- a/scripts/runtime-audit.ps1
+++ b/scripts/runtime-audit.ps1
@@ -1,0 +1,227 @@
+[CmdletBinding()]
+param(
+    [string]$OutputDirectory = "target/runtime-audit",
+    [string]$BaselineDirectory = "target/runtime-baseline/before",
+    [switch]$SkipBaseline
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
+    $PSNativeCommandUseErrorActionPreference = $false
+}
+
+$workspaceRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$auditRoot = Join-Path $workspaceRoot $OutputDirectory
+$baselineRoot = Join-Path $workspaceRoot $BaselineDirectory
+
+function New-DirectoryIfMissing {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+}
+
+function Invoke-Ripgrep {
+    param([Parameter(Mandatory = $true)][string]$Pattern)
+
+    $output = & rg --json --glob "*.rs" --glob "!target/**" $Pattern $workspaceRoot 2>$null
+    if ($LASTEXITCODE -gt 1) {
+        throw "rg failed while scanning pattern: $Pattern"
+    }
+    return @($output)
+}
+
+function Convert-RgJsonLine {
+    param([Parameter(Mandatory = $true)][string]$Line)
+
+    if ([string]::IsNullOrWhiteSpace($Line)) {
+        return $null
+    }
+
+    $event = $Line | ConvertFrom-Json
+    if ($event.type -ne "match") {
+        return $null
+    }
+
+    $path = $event.data.path.text
+    $lineNumber = [int]$event.data.line_number
+    $lineText = ($event.data.lines.text -replace "`r?`n$", "").Trim()
+    $resolvedPath = (Resolve-Path -LiteralPath $path).Path
+    $relativePath = $resolvedPath
+    if ($resolvedPath.StartsWith($workspaceRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $relativePath = $resolvedPath.Substring($workspaceRoot.Length).TrimStart("\", "/")
+    }
+    $relativePath = $relativePath.Replace("\", "/")
+    $crate = ($relativePath -split "/")[0]
+
+    [pscustomobject]@{
+        Crate = $crate
+        Path = $relativePath
+        Line = $lineNumber
+        Text = $lineText
+    }
+}
+
+function Get-RuntimeMatches {
+    param([Parameter(Mandatory = $true)][string]$Pattern)
+
+    $matches = @()
+    foreach ($line in (Invoke-Ripgrep -Pattern $Pattern)) {
+        $match = Convert-RgJsonLine -Line $line
+        if ($null -ne $match) {
+            $matches += $match
+        }
+    }
+    return @($matches)
+}
+
+function Write-MarkdownReport {
+    param(
+        [Parameter(Mandatory = $true)][string]$Title,
+        [Parameter(Mandatory = $true)][array]$Matches,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add("# $Title")
+    $lines.Add("")
+    $lines.Add("Generated: $(Get-Date -Format o)")
+    $lines.Add("")
+    $lines.Add("Total matches: $($Matches.Count)")
+    $lines.Add("")
+
+    if ($Matches.Count -gt 0) {
+        $lines.Add("| Crate | File | Line | Code |")
+        $lines.Add("|---|---|---:|---|")
+        foreach ($match in $Matches) {
+            $code = $match.Text.Replace("|", "\|")
+            $lines.Add("| $($match.Crate) | `$($match.Path)` | $($match.Line) | `$code` |")
+        }
+    }
+
+    $lines -join [Environment]::NewLine | Out-File -Encoding utf8 $Path
+}
+
+function Get-CountForCrate {
+    param(
+        [Parameter(Mandatory = $true)][array]$Matches,
+        [Parameter(Mandatory = $true)][string]$Crate
+    )
+
+    return @($Matches | Where-Object { $_.Crate -eq $Crate }).Count
+}
+
+function Write-BaselineJson {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][hashtable]$Metrics
+    )
+
+    $payload = [ordered]@{
+        generated_at = (Get-Date -Format o)
+        phase = "before"
+        source = "scripts/runtime-audit.ps1"
+        metrics = $Metrics
+    }
+
+    $payload | ConvertTo-Json -Depth 8 | Out-File -Encoding utf8 $Path
+}
+
+New-DirectoryIfMissing -Path $auditRoot
+if (-not $SkipBaseline) {
+    New-DirectoryIfMissing -Path $baselineRoot
+}
+
+$patterns = [ordered]@{
+    "runtime-spawn-sites" = "tokio::spawn|std::thread::spawn|thread::Builder::new|JoinHandle|JoinSet"
+    "runtime-creation-sites" = "Runtime::new|RocketMQRuntime::new|Builder::new_multi_thread|Builder::new_current_thread|Handle::try_current|Handle::current|block_on|block_in_place"
+    "blocking-sites" = "spawn_blocking|blocking_recv|blocking_send|std::fs::|RocksDB|rocksdb|thread::sleep"
+    "scheduler-sites" = "schedule_at_fixed_rate|ScheduledTaskManager|FixedRate|FixedDelay|FixedRateNoOverlap|tokio::time::interval|tokio::time::sleep"
+    "shutdown-sites" = "abort\(|shutdown_timeout|shutdown_background|CancellationToken|cancelled\(|Notify|wait_for_server_task|shutdown\("
+}
+
+$allMatches = @{}
+foreach ($entry in $patterns.GetEnumerator()) {
+    $matches = Get-RuntimeMatches -Pattern $entry.Value
+    $allMatches[$entry.Key] = $matches
+    Write-MarkdownReport `
+        -Title ($entry.Key -replace "-", " ") `
+        -Matches $matches `
+        -Path (Join-Path $auditRoot "$($entry.Key).md")
+}
+
+$classificationLines = @(
+    "# Runtime Task Classification",
+    "",
+    "Generated: $(Get-Date -Format o)",
+    "",
+    "| Classification | Migration target | Audit source |",
+    "|---|---|---|",
+    "| short async task | RuntimeHandle::spawn + tracing span | runtime-spawn-sites.md |",
+    "| long service task | TaskGroup::spawn_service | runtime-spawn-sites.md, shutdown-sites.md |",
+    "| scheduled task | ScheduledTaskGroup | scheduler-sites.md |",
+    "| connection task | remoting connection TaskGroup | runtime-spawn-sites.md |",
+    "| blocking task | BlockingExecutor | blocking-sites.md |",
+    "| dedicated loop | dedicated thread + CancellationToken | runtime-creation-sites.md, shutdown-sites.md |",
+    "| detached task | DetachedTaskPolicy or eliminate | runtime-spawn-sites.md |",
+    "",
+    "Manual review is still required before migrating each site."
+)
+$classificationLines -join [Environment]::NewLine | Out-File -Encoding utf8 (Join-Path $auditRoot "task-classification.md")
+
+$summary = [ordered]@{
+    generated_at = (Get-Date -Format o)
+    total = [ordered]@{}
+    by_crate = [ordered]@{}
+}
+
+foreach ($key in $patterns.Keys) {
+    $summary.total[$key] = $allMatches[$key].Count
+}
+
+$crates = $allMatches.Values | ForEach-Object { $_ } | Select-Object -ExpandProperty Crate -Unique | Sort-Object
+foreach ($crate in $crates) {
+    $summary.by_crate[$crate] = [ordered]@{}
+    foreach ($key in $patterns.Keys) {
+        $summary.by_crate[$crate][$key] = Get-CountForCrate -Matches $allMatches[$key] -Crate $crate
+    }
+}
+
+$summary | ConvertTo-Json -Depth 8 | Out-File -Encoding utf8 (Join-Path $auditRoot "summary.json")
+
+if (-not $SkipBaseline) {
+    Write-BaselineJson -Path (Join-Path $baselineRoot "client-runtime-spawn.json") -Metrics @{
+        spawn_sites = Get-CountForCrate -Matches $allMatches["runtime-spawn-sites"] -Crate "rocketmq-client"
+        runtime_creation_sites = Get-CountForCrate -Matches $allMatches["runtime-creation-sites"] -Crate "rocketmq-client"
+    }
+    Write-BaselineJson -Path (Join-Path $baselineRoot "namesrv-shutdown.json") -Metrics @{
+        shutdown_sites = Get-CountForCrate -Matches $allMatches["shutdown-sites"] -Crate "rocketmq-namesrv"
+        scheduler_sites = Get-CountForCrate -Matches $allMatches["scheduler-sites"] -Crate "rocketmq-namesrv"
+    }
+    Write-BaselineJson -Path (Join-Path $baselineRoot "broker-runtime-lifecycle.json") -Metrics @{
+        spawn_sites = Get-CountForCrate -Matches $allMatches["runtime-spawn-sites"] -Crate "rocketmq-broker"
+        runtime_creation_sites = Get-CountForCrate -Matches $allMatches["runtime-creation-sites"] -Crate "rocketmq-broker"
+        shutdown_sites = Get-CountForCrate -Matches $allMatches["shutdown-sites"] -Crate "rocketmq-broker"
+    }
+    Write-BaselineJson -Path (Join-Path $baselineRoot "remoting-connection-lifecycle.json") -Metrics @{
+        spawn_sites = Get-CountForCrate -Matches $allMatches["runtime-spawn-sites"] -Crate "rocketmq-remoting"
+        shutdown_sites = Get-CountForCrate -Matches $allMatches["shutdown-sites"] -Crate "rocketmq-remoting"
+    }
+    Write-BaselineJson -Path (Join-Path $baselineRoot "scheduler.json") -Metrics @{
+        rocketmq_scheduler_sites = Get-CountForCrate -Matches $allMatches["scheduler-sites"] -Crate "rocketmq"
+        namesrv_scheduler_sites = Get-CountForCrate -Matches $allMatches["scheduler-sites"] -Crate "rocketmq-namesrv"
+        broker_scheduler_sites = Get-CountForCrate -Matches $allMatches["scheduler-sites"] -Crate "rocketmq-broker"
+    }
+    Write-BaselineJson -Path (Join-Path $baselineRoot "store-blocking.json") -Metrics @{
+        blocking_sites = Get-CountForCrate -Matches $allMatches["blocking-sites"] -Crate "rocketmq-store"
+        shutdown_sites = Get-CountForCrate -Matches $allMatches["shutdown-sites"] -Crate "rocketmq-store"
+    }
+}
+
+Write-Host "Runtime audit written to $auditRoot"
+if (-not $SkipBaseline) {
+    Write-Host "Baseline JSON written to $baselineRoot"
+}

--- a/scripts/runtime-audit.sh
+++ b/scripts/runtime-audit.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT="${1:-target/runtime-audit}"
+BASELINE="${2:-target/runtime-baseline/before}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AUDIT_ROOT="$ROOT/$OUT"
+BASELINE_ROOT="$ROOT/$BASELINE"
+
+mkdir -p "$AUDIT_ROOT" "$BASELINE_ROOT"
+
+scan() {
+  local name="$1"
+  local pattern="$2"
+  local file="$AUDIT_ROOT/${name}.md"
+
+  {
+    echo "# ${name//-/ }"
+    echo
+    echo "Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    echo
+    echo "| File | Line | Code |"
+    echo "|---|---:|---|"
+    rg -n --glob "*.rs" --glob "!target/**" "$pattern" "$ROOT" \
+      | sed "s#^$ROOT/##" \
+      | awk -F: '{ code=$0; sub($1 ":" $2 ":", "", code); gsub(/\|/, "\\\\|", code); printf("| `%s` | %s | `%s` |\n", $1, $2, code) }' || true
+  } > "$file"
+}
+
+scan "runtime-spawn-sites" "tokio::spawn|std::thread::spawn|thread::Builder::new|JoinHandle|JoinSet"
+scan "runtime-creation-sites" "Runtime::new|RocketMQRuntime::new|Builder::new_multi_thread|Builder::new_current_thread|Handle::try_current|Handle::current|block_on|block_in_place"
+scan "blocking-sites" "spawn_blocking|blocking_recv|blocking_send|std::fs::|RocksDB|rocksdb|thread::sleep"
+scan "scheduler-sites" "schedule_at_fixed_rate|ScheduledTaskManager|FixedRate|FixedDelay|FixedRateNoOverlap|tokio::time::interval|tokio::time::sleep"
+scan "shutdown-sites" "abort\(|shutdown_timeout|shutdown_background|CancellationToken|cancelled\(|Notify|wait_for_server_task|shutdown\("
+
+cat > "$AUDIT_ROOT/task-classification.md" <<'MARKDOWN'
+# Runtime Task Classification
+
+| Classification | Migration target | Audit source |
+|---|---|---|
+| short async task | RuntimeHandle::spawn + tracing span | runtime-spawn-sites.md |
+| long service task | TaskGroup::spawn_service | runtime-spawn-sites.md, shutdown-sites.md |
+| scheduled task | ScheduledTaskGroup | scheduler-sites.md |
+| connection task | remoting connection TaskGroup | runtime-spawn-sites.md |
+| blocking task | BlockingExecutor | blocking-sites.md |
+| dedicated loop | dedicated thread + CancellationToken | runtime-creation-sites.md, shutdown-sites.md |
+| detached task | DetachedTaskPolicy or eliminate | runtime-spawn-sites.md |
+
+Manual review is still required before migrating each site.
+MARKDOWN
+
+count_pattern() {
+  local crate="$1"
+  local pattern="$2"
+  rg -n --glob "*.rs" --glob "!target/**" "$pattern" "$ROOT/$crate" 2>/dev/null | wc -l | tr -d ' '
+}
+
+write_json() {
+  local file="$1"
+  local body="$2"
+  cat > "$BASELINE_ROOT/$file" <<JSON
+{
+  "generated_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "phase": "before",
+  "source": "scripts/runtime-audit.sh",
+  "metrics": $body
+}
+JSON
+}
+
+write_json "client-runtime-spawn.json" "{\"spawn_sites\": $(count_pattern rocketmq-client 'tokio::spawn|std::thread::spawn|thread::Builder::new'), \"runtime_creation_sites\": $(count_pattern rocketmq-client 'Runtime::new|Builder::new_current_thread|Builder::new_multi_thread|Handle::try_current|block_on')}"
+write_json "namesrv-shutdown.json" "{\"shutdown_sites\": $(count_pattern rocketmq-namesrv 'abort\\(|shutdown_timeout|CancellationToken|cancelled\\(|Notify|shutdown\\('), \"scheduler_sites\": $(count_pattern rocketmq-namesrv 'ScheduledTaskManager|FixedRate|FixedDelay|tokio::time::interval')}"
+write_json "broker-runtime-lifecycle.json" "{\"spawn_sites\": $(count_pattern rocketmq-broker 'tokio::spawn|std::thread::spawn|thread::Builder::new'), \"runtime_creation_sites\": $(count_pattern rocketmq-broker 'Runtime::new|RocketMQRuntime::new|Builder::new_current_thread|Builder::new_multi_thread|Handle::try_current|block_on'), \"shutdown_sites\": $(count_pattern rocketmq-broker 'abort\\(|shutdown_timeout|CancellationToken|cancelled\\(|Notify|shutdown\\(')}"
+write_json "remoting-connection-lifecycle.json" "{\"spawn_sites\": $(count_pattern rocketmq-remoting 'tokio::spawn|std::thread::spawn|thread::Builder::new'), \"shutdown_sites\": $(count_pattern rocketmq-remoting 'abort\\(|shutdown_timeout|CancellationToken|cancelled\\(|Notify|shutdown\\(')}"
+write_json "scheduler.json" "{\"rocketmq_scheduler_sites\": $(count_pattern rocketmq 'ScheduledTaskManager|FixedRate|FixedDelay|FixedRateNoOverlap|tokio::time::interval'), \"namesrv_scheduler_sites\": $(count_pattern rocketmq-namesrv 'ScheduledTaskManager|FixedRate|FixedDelay|FixedRateNoOverlap|tokio::time::interval'), \"broker_scheduler_sites\": $(count_pattern rocketmq-broker 'ScheduledTaskManager|FixedRate|FixedDelay|FixedRateNoOverlap|tokio::time::interval')}"
+write_json "store-blocking.json" "{\"blocking_sites\": $(count_pattern rocketmq-store 'spawn_blocking|blocking_recv|blocking_send|RocksDB|rocksdb'), \"shutdown_sites\": $(count_pattern rocketmq-store 'abort\\(|shutdown_timeout|CancellationToken|cancelled\\(|Notify|shutdown\\(')}"
+
+cat > "$AUDIT_ROOT/summary.json" <<JSON
+{
+  "generated_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "audit_directory": "$OUT",
+  "baseline_directory": "$BASELINE"
+}
+JSON
+
+echo "Runtime audit written to $AUDIT_ROOT"
+echo "Baseline JSON written to $BASELINE_ROOT"


### PR DESCRIPTION
Closes #7494

## Summary

- Add shared Tokio runtime lifecycle primitives, task groups, scheduled execution support, and runtime diagnostics/audit tooling.
- Route initial client, remoting, broker, auth, common, and runtime ownership through the shared runtime model.
- Keep this PR to the first staged runtime-model commit for the linear merge flow.

## Validation

- Root workspace format check passed.
- Root workspace clippy passed with all targets, all features, no dependencies, and warnings denied.
- Example standalone format and clippy checks passed.
- Tauri backend standalone format and all-features clippy checks passed.
- Web dashboard backend standalone format, all-features clippy, and all-features build checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified runtime task spawning and management across codebase with new shared task scheduling infrastructure.
  * Standardized synchronous execution in async contexts using centralized bridge pattern.
  * Consolidated blocking task execution with timeout and concurrency controls.
  * Replaced ad-hoc thread/runtime creation with shared fallback runtime utilities.

* **Chores**
  * Added runtime audit and benchmark scripts for CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->