### PR TITLE
[ISSUE #7496]♻️ Track kv and stats workers with task groups

### DIFF
--- a/rocketmq-store/src/base/allocate_mapped_file_service.rs
+++ b/rocketmq-store/src/base/allocate_mapped_file_service.rs
@@ -721,7 +721,11 @@ impl AllocateMappedFileService {
         // Wait for worker to complete
         let handle = self.worker_handle.lock().take();
         if let Some(handle) = handle {
-            let _ = tokio::task::spawn_blocking(move || handle.join()).await;
+            match crate::runtime::spawn_io("allocate-mapped-file-worker-join", move || handle.join()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_panic)) => error!("AllocateMappedFileService worker panicked during shutdown"),
+                Err(error) => error!("AllocateMappedFileService worker join task failed: {error}"),
+            }
         }
 
         // Clean up pre-allocated files

--- a/rocketmq-store/src/base/store_stats_service.rs
+++ b/rocketmq-store/src/base/store_stats_service.rs
@@ -30,7 +30,6 @@ use rocketmq_common::common::broker::broker_config::BrokerIdentity;
 use rocketmq_common::common::system_clock::SystemClock;
 use rocketmq_common::TimeUtils::current_millis;
 use tokio::sync::Notify;
-use tokio::task::JoinHandle;
 use tracing::info;
 use tracing::warn;
 
@@ -103,7 +102,7 @@ pub struct StoreStatsService {
     last_print_timestamp: AtomicU64,
     stopped: AtomicBool,
     shutdown_notify: Notify,
-    worker_handle: Mutex<Option<JoinHandle<()>>>,
+    worker_group: Mutex<Option<rocketmq_runtime::TaskGroup>>,
     broker_identity: Option<BrokerIdentity>,
 }
 
@@ -134,21 +133,30 @@ impl StoreStatsService {
             last_print_timestamp: AtomicU64::new(current_millis()),
             stopped: AtomicBool::new(true),
             shutdown_notify: Notify::new(),
-            worker_handle: Mutex::new(None),
+            worker_group: Mutex::new(None),
             broker_identity,
         }
     }
 
     pub fn start(self: &Arc<Self>) {
-        let mut worker_handle = self.worker_handle.lock();
-        if worker_handle.is_some() {
+        let mut worker_group_guard = self.worker_group.lock();
+        if worker_group_guard.is_some() {
             return;
         }
 
         self.stopped.store(false, Ordering::Release);
         let service = Arc::clone(self);
         let service_name = service.get_service_name();
-        let handle = tokio::spawn(async move {
+        let worker_group = match crate::runtime::task_group("rocketmq-store.stats") {
+            Ok(worker_group) => worker_group,
+            Err(error) => {
+                self.stopped.store(true, Ordering::Release);
+                warn!("failed to create StoreStatsService task group: {error}");
+                return;
+            }
+        };
+        let task_name = service_name.clone();
+        if let Err(error) = worker_group.spawn_service(task_name, async move {
             info!("{} service started", service_name);
             let mut interval = tokio::time::interval(Duration::from_millis(FREQUENCY_OF_SAMPLING));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -167,34 +175,37 @@ impl StoreStatsService {
             }
 
             info!("{} service end", service.get_service_name());
-        });
-        *worker_handle = Some(handle);
+        }) {
+            self.stopped.store(true, Ordering::Release);
+            warn!("failed to spawn StoreStatsService task: {error}");
+            return;
+        }
+        *worker_group_guard = Some(worker_group);
     }
 
     pub fn shutdown(&self) {
         self.stopped.store(true, Ordering::Release);
         self.shutdown_notify.notify_waiters();
-        if let Some(handle) = self.worker_handle.lock().take() {
-            handle.abort();
+        if let Some(worker_group) = self.worker_group.lock().take() {
+            worker_group.cancel();
         }
     }
 
     pub async fn shutdown_gracefully(&self) {
         self.stopped.store(true, Ordering::Release);
         self.shutdown_notify.notify_waiters();
-        let handle = self.worker_handle.lock().take();
-        if let Some(handle) = handle {
-            if let Err(error) = handle.await {
-                if !error.is_cancelled() {
-                    warn!("StoreStatsService task failed during shutdown: {error}");
-                }
+        let worker_group = self.worker_group.lock().take();
+        if let Some(worker_group) = worker_group {
+            let report = worker_group.shutdown(Duration::from_secs(5)).await;
+            if let Err(error) = crate::runtime::shutdown_report_result("StoreStatsService", report) {
+                warn!("StoreStatsService task failed during shutdown: {error}");
             }
         }
     }
 
     #[cfg(test)]
     pub(crate) fn has_worker_handle(&self) -> bool {
-        self.worker_handle.lock().is_some()
+        self.worker_group.lock().is_some()
     }
 
     #[inline]
@@ -618,8 +629,9 @@ impl StoreStatsService {
 impl Drop for StoreStatsService {
     fn drop(&mut self) {
         self.stopped.store(true, Ordering::Release);
-        if let Some(handle) = self.worker_handle.get_mut().take() {
-            handle.abort();
+        self.shutdown_notify.notify_waiters();
+        if let Some(worker_group) = self.worker_group.get_mut().take() {
+            worker_group.cancel();
         }
     }
 }
@@ -907,17 +919,17 @@ mod call_snapshot_tests {
 
         stats.start();
         stats.start();
-        assert!(stats.worker_handle.lock().is_some());
+        assert!(stats.has_worker_handle());
         assert!(!stats.stopped.load(Ordering::Acquire));
 
         task::yield_now().await;
         stats.shutdown_gracefully().await;
         stats.shutdown_gracefully().await;
-        assert!(stats.worker_handle.lock().is_none());
+        assert!(!stats.has_worker_handle());
         assert!(stats.stopped.load(Ordering::Acquire));
 
         stats.start();
-        assert!(stats.worker_handle.lock().is_some());
+        assert!(stats.has_worker_handle());
         stats.shutdown_gracefully().await;
     }
 }

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -134,8 +134,7 @@ pub struct DefaultHAConnection {
     ha_service: ArcMut<DefaultHAService>,
     socket_stream: Option<TcpStream>,
     client_address: String,
-    read_service_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
-    write_service_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    task_group: Arc<Mutex<Option<rocketmq_runtime::TaskGroup>>>,
     current_state: Arc<RwLock<HAConnectionState>>,
     slave_request_offset: Arc<AtomicI64>,
     slave_ack_offset: Arc<AtomicI64>,
@@ -181,8 +180,7 @@ impl DefaultHAConnection {
             ha_service,
             socket_stream,
             client_address,
-            read_service_handle: Arc::new(Mutex::new(None)),
-            write_service_handle: Arc::new(Mutex::new(None)),
+            task_group: Arc::new(Mutex::new(None)),
             current_state: Arc::new(RwLock::new(HAConnectionState::Transfer)),
             slave_request_offset: Arc::new(AtomicI64::new(-1)),
             slave_ack_offset: Arc::new(AtomicI64::new(-1)),
@@ -266,17 +264,30 @@ impl HAConnection for DefaultHAConnection {
         )
         .await?;
 
-        let read_handle = tokio::spawn(async move {
-            read_service.run(read_shutdown_rx).await;
-        });
+        let task_group = crate::runtime::task_group("rocketmq-store.ha.connection")
+            .map_err(|error| HAConnectionError::Service(error.to_string()))?;
+        task_group
+            .spawn_service("ha-read-socket-service", async move {
+                read_service.run(read_shutdown_rx).await;
+            })
+            .map_err(|error| HAConnectionError::Service(error.to_string()))?;
 
-        let write_handle = tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("ha-write-socket-service", async move {
             write_service.run(write_shutdown_rx).await;
-        });
+        }) {
+            if let Some(tx) = self.shutdown_tx.lock().await.take() {
+                let _ = tx.send(());
+            }
+            let report = task_group.shutdown(Duration::from_secs(3)).await;
+            if let Err(shutdown_error) =
+                crate::runtime::shutdown_report_result("DefaultHAConnection partial start", report)
+            {
+                warn!("DefaultHAConnection partial start cleanup reported an error: {shutdown_error}");
+            }
+            return Err(HAConnectionError::Service(error.to_string()));
+        }
 
-        // Start services
-        *self.read_service_handle.lock().await = Some(read_handle);
-        *self.write_service_handle.lock().await = Some(write_handle);
+        *self.task_group.lock().await = Some(task_group);
 
         info!("HAConnection started for {}", self.client_address);
         Ok(())
@@ -291,12 +302,11 @@ impl HAConnection for DefaultHAConnection {
         }
 
         // Wait for services to stop
-        if let Some(handle) = self.read_service_handle.lock().await.take() {
-            let _ = handle.await;
-        }
-
-        if let Some(handle) = self.write_service_handle.lock().await.take() {
-            let _ = handle.await;
+        if let Some(task_group) = self.task_group.lock().await.take() {
+            let report = task_group.shutdown(Duration::from_secs(3)).await;
+            if let Err(error) = crate::runtime::shutdown_report_result("DefaultHAConnection", report) {
+                warn!("DefaultHAConnection task shutdown reported an error: {error}");
+            }
         }
 
         // Shutdown flow monitor

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -31,7 +31,6 @@ use tokio::net::TcpStream;
 use tokio::select;
 use tokio::sync::Mutex;
 use tokio::sync::Notify;
-use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
@@ -491,7 +490,7 @@ struct AcceptSocketService {
     is_auto_switch: bool,
     shutdown_token: CancellationToken,
     default_ha_service: ArcMut<DefaultHAService>,
-    worker_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
+    worker_group: Arc<Mutex<Option<rocketmq_runtime::TaskGroup>>>,
 }
 
 impl AcceptSocketService {
@@ -508,7 +507,7 @@ impl AcceptSocketService {
             is_auto_switch,
             shutdown_token: CancellationToken::new(),
             default_ha_service,
-            worker_handle: Arc::new(Mutex::new(None)),
+            worker_group: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -530,8 +529,8 @@ impl AcceptSocketService {
     }
 
     pub async fn start(&mut self) -> HAResult<()> {
-        let mut worker_handle = self.worker_handle.lock().await;
-        if worker_handle.is_some() {
+        let mut worker_group_guard = self.worker_group.lock().await;
+        if worker_group_guard.is_some() {
             warn!("AcceptSocketService is already started");
             return Ok(());
         }
@@ -544,70 +543,69 @@ impl AcceptSocketService {
         let is_auto_switch = self.is_auto_switch;
         let message_store_config = self.message_store_config.clone();
         let default_ha_service = self.default_ha_service.clone();
-        *worker_handle = Some(tokio::spawn(async move {
-            let message_store_config = message_store_config;
-            let default_ha_service = default_ha_service;
-            loop {
-                select! {
-                    _ = shutdown_token.cancelled() => {
-                        info!("AcceptSocketService is shutting down");
-                        break;
-                    }
-                // Accept new connections
-                    accept_result = listener.accept() => {
-                        match accept_result {
-                            Ok((stream, addr)) => {
-                                info!("HAService receive new connection, {}", addr);
-                                match AcceptSocketService::build_connection(
-                                    default_ha_service.clone(),
-                                    message_store_config.clone(),
-                                    stream,
-                                    addr,
-                                    is_auto_switch,
-                                )
-                                .await
-                                {
-                                    Ok(mut general_conn) => {
-                                        let conn_weak = ArcMut::downgrade(&general_conn);
-                                        if let Err(e) = general_conn.start(conn_weak).await {
-                                            error!("Error starting HAService: {}", e);
-                                        } else {
-                                            info!("HAService accept new connection, {}", addr);
-                                            default_ha_service.add_connection(general_conn).await;
+        let worker_group = crate::runtime::task_group("rocketmq-store.ha.accept")
+            .map_err(|error| HAError::Service(error.to_string()))?;
+        worker_group
+            .spawn_service("ha-accept-socket-service", async move {
+                let message_store_config = message_store_config;
+                let default_ha_service = default_ha_service;
+                loop {
+                    select! {
+                        _ = shutdown_token.cancelled() => {
+                            info!("AcceptSocketService is shutting down");
+                            break;
+                        }
+                    // Accept new connections
+                        accept_result = listener.accept() => {
+                            match accept_result {
+                                Ok((stream, addr)) => {
+                                    info!("HAService receive new connection, {}", addr);
+                                    match AcceptSocketService::build_connection(
+                                        default_ha_service.clone(),
+                                        message_store_config.clone(),
+                                        stream,
+                                        addr,
+                                        is_auto_switch,
+                                    )
+                                    .await
+                                    {
+                                        Ok(mut general_conn) => {
+                                            let conn_weak = ArcMut::downgrade(&general_conn);
+                                            if let Err(e) = general_conn.start(conn_weak).await {
+                                                error!("Error starting HAService: {}", e);
+                                            } else {
+                                                info!("HAService accept new connection, {}", addr);
+                                                default_ha_service.add_connection(general_conn).await;
+                                            }
+                                        }
+                                        Err(e) => {
+                                            error!("Error creating HAConnection: {}", e);
                                         }
                                     }
-                                    Err(e) => {
-                                        error!("Error creating HAConnection: {}", e);
-                                    }
                                 }
-                            }
-                            Err(e) => {
-                                error!("Failed to accept connection: {}", e);
-                                // Add a small delay to prevent busy-waiting on persistent errors
-                                sleep(Duration::from_millis(100)).await;
+                                Err(e) => {
+                                    error!("Failed to accept connection: {}", e);
+                                    // Add a small delay to prevent busy-waiting on persistent errors
+                                    sleep(Duration::from_millis(100)).await;
+                                }
                             }
                         }
                     }
                 }
-            }
-        }));
+            })
+            .map_err(|error| HAError::Service(error.to_string()))?;
+        *worker_group_guard = Some(worker_group);
         Ok(())
     }
 
     pub async fn shutdown(&self) {
         info!("Shutting down AcceptSocketService");
         self.shutdown_token.cancel();
-        let worker_handle = self.worker_handle.lock().await.take();
-        if let Some(handle) = worker_handle {
-            match timeout(Duration::from_secs(3), handle).await {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) if error.is_cancelled() => {}
-                Ok(Err(error)) => {
-                    error!("AcceptSocketService failed during shutdown: {error}");
-                }
-                Err(_) => {
-                    warn!("Timed out waiting for AcceptSocketService to stop");
-                }
+        let worker_group = self.worker_group.lock().await.take();
+        if let Some(worker_group) = worker_group {
+            let report = worker_group.shutdown(Duration::from_secs(3)).await;
+            if let Err(error) = crate::runtime::shutdown_report_result("AcceptSocketService", report) {
+                warn!("AcceptSocketService failed during shutdown: {error}");
             }
         }
     }
@@ -711,11 +709,11 @@ mod tests {
         accept_service.socket_address_listen = SocketAddr::from(([127u8, 0u8, 0u8, 1u8], 0));
 
         accept_service.start().await.expect("start accept socket service");
-        assert!(accept_service.worker_handle.lock().await.is_some());
+        assert!(accept_service.worker_group.lock().await.is_some());
 
         accept_service.shutdown().await;
 
-        assert!(accept_service.worker_handle.lock().await.is_none());
+        assert!(accept_service.worker_group.lock().await.is_none());
         let _ = std::fs::remove_dir_all(temp_root);
     }
 

--- a/rocketmq-store/src/index/index_service.rs
+++ b/rocketmq-store/src/index/index_service.rs
@@ -488,12 +488,15 @@ impl IndexService {
 
             index_file = Some(new_index_file);
 
-            // Spawn async flush task for previous file
-            if prev_index_file.is_some() {
+            if let Some(prev_index_file) = prev_index_file {
                 let index_service = self.clone();
-                tokio::task::spawn_blocking(move || {
-                    index_service.flush(prev_index_file);
-                });
+                let fallback_index_file = prev_index_file.clone();
+                if let Err(error) = crate::runtime::spawn_detached_io("index-file-flush", move || {
+                    index_service.flush(Some(prev_index_file));
+                }) {
+                    warn!("failed to spawn index file flush task, flushing inline: {error}");
+                    self.flush(Some(fallback_index_file));
+                }
             }
         }
         index_file

--- a/rocketmq-store/src/kv/compaction_service.rs
+++ b/rocketmq-store/src/kv/compaction_service.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
@@ -27,7 +26,7 @@ pub struct CompactionService {
     compaction_store: Arc<CompactionStore>,
     schedule_interval: Duration,
     shutdown_token: CancellationToken,
-    worker_handle: Option<JoinHandle<()>>,
+    worker_group: Option<rocketmq_runtime::TaskGroup>,
     loaded: bool,
 }
 
@@ -37,7 +36,7 @@ impl CompactionService {
             compaction_store,
             schedule_interval: Duration::from_millis(schedule_interval_ms.max(1) as u64),
             shutdown_token: CancellationToken::new(),
-            worker_handle: None,
+            worker_group: None,
             loaded: false,
         }
     }
@@ -49,7 +48,7 @@ impl CompactionService {
     }
 
     pub fn start(&mut self) {
-        if self.worker_handle.is_some() {
+        if self.worker_group.is_some() {
             return;
         }
 
@@ -57,8 +56,15 @@ impl CompactionService {
         let shutdown = self.shutdown_token.clone();
         let compaction_store = self.compaction_store.clone();
         let schedule_interval = self.schedule_interval;
+        let worker_group = match crate::runtime::task_group("rocketmq-store.kv.compaction") {
+            Ok(worker_group) => worker_group,
+            Err(error) => {
+                error!("failed to create compaction service task group: {error}");
+                return;
+            }
+        };
 
-        self.worker_handle = Some(tokio::spawn(async move {
+        if let Err(error) = worker_group.spawn_service("kv-compaction-service", async move {
             let mut interval = tokio::time::interval(schedule_interval);
             interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
             interval.tick().await;
@@ -76,13 +82,19 @@ impl CompactionService {
                     }
                 }
             }
-        }));
+        }) {
+            error!("failed to spawn compaction service task: {error}");
+            return;
+        }
+
+        self.worker_group = Some(worker_group);
     }
 
     pub async fn shutdown_gracefully(&mut self) {
         self.shutdown_token.cancel();
-        if let Some(worker_handle) = self.worker_handle.take() {
-            if let Err(error) = worker_handle.await {
+        if let Some(worker_group) = self.worker_group.take() {
+            let report = worker_group.shutdown(Duration::from_secs(5)).await;
+            if let Err(error) = crate::runtime::shutdown_report_result("CompactionService", report) {
                 error!("compaction service task failed during shutdown: {error}");
             }
         }
@@ -95,7 +107,7 @@ impl CompactionService {
     }
 
     pub fn has_worker_handle(&self) -> bool {
-        self.worker_handle.is_some()
+        self.worker_group.is_some()
     }
 }
 

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -30,6 +30,7 @@ pub mod pop;
 pub mod queue;
 #[cfg(feature = "rocksdb_store")]
 pub mod rocksdb;
+pub(crate) mod runtime;
 pub(crate) mod services;
 pub mod stats;
 pub mod store;

--- a/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
@@ -567,7 +567,7 @@ async fn flush_mapped_file_queue(
     mapped_file_queue: ArcMut<MappedFileQueue>,
     flush_least_pages: i32,
 ) -> Option<FlushMappedFileQueueResult> {
-    match tokio::task::spawn_blocking(move || {
+    match crate::runtime::spawn_io("commitlog-flush", move || {
         let flush_ok = mapped_file_queue.flush(flush_least_pages);
         FlushMappedFileQueueResult {
             flush_ok,
@@ -595,7 +595,7 @@ async fn commit_mapped_file_queue(
     mapped_file_queue: ArcMut<MappedFileQueue>,
     commit_least_pages: i32,
 ) -> Option<CommitMappedFileQueueResult> {
-    match tokio::task::spawn_blocking(move || {
+    match crate::runtime::spawn_io("commitlog-commit", move || {
         let commit_ok = mapped_file_queue.commit(commit_least_pages);
         CommitMappedFileQueueResult {
             commit_ok,

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -343,7 +343,7 @@ pub struct LocalFileMessageStore {
     ha_service: Option<GeneralHAService>,
     flush_consume_queue_service: FlushConsumeQueueService,
     scheduled_task_shutdown: CancellationToken,
-    scheduled_task_handles: Vec<JoinHandle<()>>,
+    scheduled_task_group: Option<rocketmq_runtime::TaskGroup>,
     ha_update_master_handles: Arc<StdMutex<Vec<JoinHandle<()>>>>,
     delay_level_table: ArcMut<BTreeMap<i32 /* level */, i64 /* delay timeMillis */>>,
     max_delay_level: i32,
@@ -543,8 +543,7 @@ impl LocalFileMessageStore {
                 reput_from_offset: None,
                 dispatch_tx: None,
                 inner: None,
-                reader_handle: None,
-                dispatcher_handle: None,
+                task_group: None,
             },
             clean_commit_log_service: Arc::new(CleanCommitLogService::new(
                 message_store_config.clone(),
@@ -577,7 +576,7 @@ impl LocalFileMessageStore {
                 store_checkpoint,
             ),
             scheduled_task_shutdown: CancellationToken::new(),
-            scheduled_task_handles: Vec::new(),
+            scheduled_task_group: None,
             ha_update_master_handles: Arc::new(StdMutex::new(Vec::new())),
             delay_level_table: ArcMut::new(delay_level_table),
             max_delay_level,
@@ -1310,7 +1309,7 @@ impl LocalFileMessageStore {
     }
 
     fn add_schedule_task(&mut self) {
-        if !self.scheduled_task_handles.is_empty() {
+        if self.scheduled_task_group.is_some() {
             return;
         }
 
@@ -1327,12 +1326,19 @@ impl LocalFileMessageStore {
         };
 
         self.scheduled_task_shutdown = CancellationToken::new();
+        let task_group = match crate::runtime::task_group("rocketmq-store.local-file.scheduled") {
+            Ok(task_group) => task_group,
+            Err(error) => {
+                error!("scheduled store tasks not started: {error}");
+                return;
+            }
+        };
 
         // clean files  Periodically
         let clean_commit_log_service_arc = self.clean_commit_log_service.clone();
         let clean_resource_interval = self.message_store_config.clean_resource_interval as u64;
         let shutdown_token = self.scheduled_task_shutdown.clone();
-        self.scheduled_task_handles.push(tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("clean-commit-log-scheduler", async move {
             let mut interval = tokio::time::interval(Duration::from_millis(clean_resource_interval.max(1)));
             loop {
                 tokio::select! {
@@ -1345,10 +1351,14 @@ impl LocalFileMessageStore {
                     },
                 }
             }
-        }));
+        }) {
+            self.scheduled_task_shutdown.cancel();
+            error!("failed to spawn scheduled store task clean commit log: {error}");
+            return;
+        }
 
         let shutdown_token = self.scheduled_task_shutdown.clone();
-        self.scheduled_task_handles.push(tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("store-self-check-scheduler", async move {
             let mut interval = tokio::time::interval(Duration::from_secs(10 * 60));
             loop {
                 tokio::select! {
@@ -1361,11 +1371,15 @@ impl LocalFileMessageStore {
                     },
                 }
             }
-        }));
+        }) {
+            self.scheduled_task_shutdown.cancel();
+            error!("failed to spawn scheduled store task self check: {error}");
+            return;
+        }
 
         // store check point flush
         let shutdown_token = self.scheduled_task_shutdown.clone();
-        self.scheduled_task_handles.push(tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("store-checkpoint-flush-scheduler", async move {
             let mut interval = tokio::time::interval(Duration::from_secs(1));
             loop {
                 tokio::select! {
@@ -1380,12 +1394,16 @@ impl LocalFileMessageStore {
                     }
                 }
             }
-        }));
+        }) {
+            self.scheduled_task_shutdown.cancel();
+            error!("failed to spawn scheduled store task checkpoint flush: {error}");
+            return;
+        }
 
         let correct_logic_offset_service_arc = self.correct_logic_offset_service.clone();
         let clean_consume_queue_service_arc = self.clean_consume_queue_service.clone();
         let shutdown_token = self.scheduled_task_shutdown.clone();
-        self.scheduled_task_handles.push(tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("clean-consume-queue-scheduler", async move {
             let mut interval = tokio::time::interval(Duration::from_millis(clean_resource_interval.max(1)));
             loop {
                 tokio::select! {
@@ -1402,18 +1420,29 @@ impl LocalFileMessageStore {
                     }
                 }
             }
-        }));
+        }) {
+            self.scheduled_task_shutdown.cancel();
+            error!("failed to spawn scheduled store task clean consume queue: {error}");
+            return;
+        }
+
+        self.scheduled_task_group = Some(task_group);
     }
 
     async fn shutdown_schedule_tasks(&mut self) {
         self.scheduled_task_shutdown.cancel();
-        for handle in self.scheduled_task_handles.drain(..) {
-            if let Err(error) = handle.await {
-                if !error.is_cancelled() {
-                    error!("scheduled store task failed during shutdown: {error}");
-                }
+        if let Some(task_group) = self.scheduled_task_group.take() {
+            let report = task_group.shutdown(Duration::from_secs(5)).await;
+            if let Err(error) = crate::runtime::shutdown_report_result("LocalFileMessageStore scheduled tasks", report)
+            {
+                error!("scheduled store task failed during shutdown: {error}");
             }
         }
+    }
+
+    #[cfg(test)]
+    fn has_scheduled_task_group(&self) -> bool {
+        self.scheduled_task_group.is_some()
     }
 
     async fn shutdown_ha_update_master_tasks(&self) {
@@ -3368,8 +3397,7 @@ struct ReputMessageService {
     reput_from_offset: Option<Arc<AtomicI64>>,
     dispatch_tx: Option<tokio::sync::mpsc::Sender<Vec<DispatchRequest>>>,
     inner: Option<ReputMessageServiceInner>,
-    reader_handle: Option<tokio::task::JoinHandle<()>>,
-    dispatcher_handle: Option<tokio::task::JoinHandle<()>>,
+    task_group: Option<rocketmq_runtime::TaskGroup>,
 }
 
 impl ReputMessageService {
@@ -3398,6 +3426,18 @@ impl ReputMessageService {
         notify_message_arrive_in_batch: bool,
         message_store: ArcMut<LocalFileMessageStore>,
     ) {
+        if self.task_group.is_some() {
+            return;
+        }
+
+        let task_group = match crate::runtime::task_group("rocketmq-store.local-file.reput") {
+            Ok(task_group) => task_group,
+            Err(error) => {
+                error!("ReputMessageService not started: {error}");
+                return;
+            }
+        };
+
         // Create channel for decoupling read and dispatch
         let (dispatch_tx, mut dispatch_rx) = tokio::sync::mpsc::channel::<Vec<DispatchRequest>>(128);
         self.dispatch_tx = Some(dispatch_tx.clone());
@@ -3423,7 +3463,7 @@ impl ReputMessageService {
 
         // Task 1: Read messages from CommitLog and send to channel
         let shutdown_reader = shutdown.clone();
-        let reader_handle = tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("reput-reader", async move {
             let mut fallback_interval = tokio::time::interval(Duration::from_millis(1));
             fallback_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
             loop {
@@ -3486,11 +3526,16 @@ impl ReputMessageService {
                     }
                 }
             }
-        });
+        }) {
+            self.shutdown_token.cancel();
+            self.dispatch_tx.take();
+            error!("failed to spawn ReputMessageService reader: {error}");
+            return;
+        }
 
         // Task 2: Receive from channel and dispatch
         let shutdown_dispatcher = shutdown;
-        let dispatcher_handle = tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("reput-dispatcher", async move {
             loop {
                 tokio::select! {
                     Some(mut batch) = dispatch_rx.recv() => {
@@ -3518,11 +3563,16 @@ impl ReputMessageService {
                     }
                 }
             }
-        });
+        }) {
+            self.shutdown_token.cancel();
+            self.dispatch_tx.take();
+            task_group.cancel();
+            error!("failed to spawn ReputMessageService dispatcher: {error}");
+            self.task_group = Some(task_group);
+            return;
+        }
 
-        // Store task handles for graceful shutdown
-        self.reader_handle = Some(reader_handle);
-        self.dispatcher_handle = Some(dispatcher_handle);
+        self.task_group = Some(task_group);
     }
 
     pub async fn run_once(
@@ -3578,25 +3628,23 @@ impl ReputMessageService {
 
         // Step 2: Notify tasks to shutdown
         self.shutdown_token.cancel();
+        self.dispatch_tx.take();
 
         // Step 3: Wait for tasks to complete with timeout (3 seconds)
-        if let Some(handle) = self.reader_handle.take() {
-            match tokio::time::timeout(Duration::from_secs(3), handle).await {
-                Ok(Ok(())) => info!("Reader task shut down successfully"),
-                Ok(Err(e)) => warn!("Reader task panicked during shutdown: {:?}", e),
-                Err(_) => warn!("Reader task shutdown timeout after 3s"),
-            }
-        }
-
-        if let Some(handle) = self.dispatcher_handle.take() {
-            match tokio::time::timeout(Duration::from_secs(3), handle).await {
-                Ok(Ok(())) => info!("Dispatcher task shut down successfully"),
-                Ok(Err(e)) => warn!("Dispatcher task panicked during shutdown: {:?}", e),
-                Err(_) => warn!("Dispatcher task shutdown timeout after 3s"),
+        if let Some(task_group) = self.task_group.take() {
+            let report = task_group.shutdown(Duration::from_secs(3)).await;
+            match crate::runtime::shutdown_report_result("ReputMessageService", report) {
+                Ok(()) => info!("ReputMessageService tasks shut down successfully"),
+                Err(error) => warn!("ReputMessageService task shutdown reported an error: {error}"),
             }
         }
 
         info!("ReputMessageService shutdown complete");
+    }
+
+    #[cfg(test)]
+    fn has_task_group(&self) -> bool {
+        self.task_group.is_some()
     }
 
     #[inline]
@@ -3903,7 +3951,7 @@ async fn run_blocking_scheduled_task<F>(task_name: &'static str, task: F) -> boo
 where
     F: FnOnce() + Send + 'static,
 {
-    match tokio::task::spawn_blocking(task).await {
+    match crate::runtime::spawn_io(task_name, task).await {
         Ok(()) => true,
         Err(error) => {
             error!("scheduled store task {task_name} failed: {error}");
@@ -5247,13 +5295,13 @@ mod tests {
         store.init().await.expect("init store");
         store.start().await.expect("start store");
 
+        assert!(store.has_scheduled_task_group());
         assert!(store.store_stats_service.has_worker_handle());
         assert!(store
             .compaction_service
             .as_ref()
             .is_some_and(CompactionService::has_worker_handle));
-        assert!(store.reput_message_service.reader_handle.is_some());
-        assert!(store.reput_message_service.dispatcher_handle.is_some());
+        assert!(store.reput_message_service.has_task_group());
         assert!(store
             .timer_message_store
             .as_ref()
@@ -5262,13 +5310,13 @@ mod tests {
 
         store.shutdown().await;
 
+        assert!(!store.has_scheduled_task_group());
         assert!(!store.store_stats_service.has_worker_handle());
         assert!(store
             .compaction_service
             .as_ref()
             .is_some_and(|service| !service.has_worker_handle()));
-        assert!(store.reput_message_service.reader_handle.is_none());
-        assert!(store.reput_message_service.dispatcher_handle.is_none());
+        assert!(!store.reput_message_service.has_task_group());
         assert!(!store
             .timer_message_store
             .as_ref()

--- a/rocketmq-store/src/runtime.rs
+++ b/rocketmq-store/src/runtime.rs
@@ -1,0 +1,89 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::OnceLock;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_runtime::BlockingExecutor;
+use rocketmq_runtime::BlockingPoolPolicy;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::ShutdownReport;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskKind;
+
+static STORE_BLOCKING: OnceLock<BlockingExecutor> = OnceLock::new();
+
+pub(crate) async fn spawn_io<F, R>(name: &'static str, operation: F) -> Result<R, RocketMQError>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    blocking_executor()?
+        .spawn_io(name, operation)
+        .await
+        .map_err(|error| RocketMQError::storage_write_failed("store", format!("{name}: {error}")))
+}
+
+pub(crate) fn spawn_detached_io<F>(name: &'static str, operation: F) -> Result<(), RocketMQError>
+where
+    F: FnOnce() + Send + 'static,
+{
+    let task_group = task_group(name)?;
+    task_group
+        .spawn_detached(name, TaskKind::Worker, async move {
+            if let Err(error) = spawn_io(name, operation).await {
+                tracing::warn!(error = %error, task_name = name, "store detached blocking task failed");
+            }
+        })
+        .map_err(|error| RocketMQError::storage_write_failed("store", format!("{name}: {error}")))?;
+    Ok(())
+}
+
+pub(crate) fn task_group(name: &'static str) -> Result<TaskGroup, RocketMQError> {
+    let handle = tokio::runtime::Handle::try_current()
+        .map_err(|error| RocketMQError::storage_write_failed("store", format!("{name}: {error}")))?;
+    Ok(TaskGroup::root(name, RuntimeHandle::new(handle)))
+}
+
+pub(crate) fn shutdown_report_result(component: &'static str, report: ShutdownReport) -> Result<(), RocketMQError> {
+    report
+        .assert_no_task_leak()
+        .map_err(|error| RocketMQError::storage_write_failed("store", format!("{component}: {error}")))
+}
+
+fn blocking_executor() -> Result<BlockingExecutor, RocketMQError> {
+    if let Some(executor) = STORE_BLOCKING.get() {
+        return Ok(executor.clone());
+    }
+
+    let handle = tokio::runtime::Handle::try_current()
+        .map_err(|error| RocketMQError::storage_write_failed("store", format!("blocking executor: {error}")))?;
+    let group = TaskGroup::root("rocketmq-store.blocking", RuntimeHandle::new(handle));
+    let executor = BlockingExecutor::new(
+        BlockingPoolPolicy {
+            name: "rocketmq-store.blocking".to_string(),
+            ..BlockingPoolPolicy::default()
+        },
+        group.child("rocketmq-store.blocking-reaper"),
+    )
+    .map_err(|error| RocketMQError::storage_write_failed("store", format!("blocking executor: {error}")))?;
+
+    if STORE_BLOCKING.set(executor.clone()).is_err() {
+        return Ok(STORE_BLOCKING
+            .get()
+            .expect("store blocking executor must be initialized")
+            .clone());
+    }
+    Ok(executor)
+}

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -36,7 +36,6 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_common::UtilAll::is_it_time_to_do;
 use rocketmq_rust::ArcMut;
 use tokio::sync::Mutex as AsyncMutex;
-use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
@@ -252,7 +251,7 @@ pub struct TimerMessageStore {
     enqueue_suspended: AtomicBool,
     process_lock: AsyncMutex<()>,
     scheduler_shutdown: Mutex<CancellationToken>,
-    scheduler_handle: Mutex<Option<JoinHandle<()>>>,
+    scheduler_group: Mutex<Option<rocketmq_runtime::TaskGroup>>,
     enqueue_tps_counter: TpsCounter,
     dequeue_tps_counter: TpsCounter,
 }
@@ -312,8 +311,8 @@ impl TimerMessageStore {
     }
 
     pub fn start(self: &Arc<Self>) {
-        let mut scheduler_handle = self.scheduler_handle.lock();
-        if scheduler_handle.is_some() {
+        let mut scheduler_group_guard = self.scheduler_group.lock();
+        if scheduler_group_guard.is_some() {
             return;
         }
 
@@ -324,7 +323,14 @@ impl TimerMessageStore {
             .message_store_config
             .timer_precision_ms
             .max(MIN_SCHEDULER_INTERVAL_MS);
-        *scheduler_handle = Some(tokio::spawn(async move {
+        let scheduler_group = match crate::runtime::task_group("rocketmq-store.timer.scheduler") {
+            Ok(scheduler_group) => scheduler_group,
+            Err(error) => {
+                error!("TimerMessageStore scheduler not started: {error}");
+                return;
+            }
+        };
+        if let Err(error) = scheduler_group.spawn_service("timer-message-scheduler", async move {
             let mut interval = tokio::time::interval(Duration::from_millis(interval_ms));
             interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
             loop {
@@ -335,7 +341,12 @@ impl TimerMessageStore {
                     }
                 }
             }
-        }));
+        }) {
+            self.scheduler_shutdown.lock().cancel();
+            error!("failed to spawn TimerMessageStore scheduler: {error}");
+            return;
+        }
+        *scheduler_group_guard = Some(scheduler_group);
     }
 
     pub fn is_reject(&self, deliver_ms: u64) -> bool {
@@ -473,7 +484,7 @@ impl TimerMessageStore {
             enqueue_suspended: AtomicBool::new(false),
             process_lock: AsyncMutex::new(()),
             scheduler_shutdown: Mutex::new(CancellationToken::new()),
-            scheduler_handle: Mutex::new(None),
+            scheduler_group: Mutex::new(None),
             enqueue_tps_counter: TpsCounter::default(),
             dequeue_tps_counter: TpsCounter::default(),
         }
@@ -495,20 +506,19 @@ impl TimerMessageStore {
 
     pub fn shutdown(&self) {
         self.scheduler_shutdown.lock().cancel();
-        if let Some(handle) = self.scheduler_handle.lock().take() {
-            handle.abort();
+        if let Some(scheduler_group) = self.scheduler_group.lock().take() {
+            scheduler_group.cancel();
         }
         self.shutdown_storage();
     }
 
     pub async fn shutdown_gracefully(&self) {
         self.scheduler_shutdown.lock().cancel();
-        let handle = self.scheduler_handle.lock().take();
-        if let Some(handle) = handle {
-            if let Err(error) = handle.await {
-                if !error.is_cancelled() {
-                    warn!("TimerMessageStore scheduler failed during shutdown: {error}");
-                }
+        let scheduler_group = self.scheduler_group.lock().take();
+        if let Some(scheduler_group) = scheduler_group {
+            let report = scheduler_group.shutdown(Duration::from_secs(5)).await;
+            if let Err(error) = crate::runtime::shutdown_report_result("TimerMessageStore scheduler", report) {
+                warn!("TimerMessageStore scheduler failed during shutdown: {error}");
             }
         }
         self.shutdown_storage();
@@ -516,7 +526,7 @@ impl TimerMessageStore {
 
     #[cfg(test)]
     pub(crate) fn has_scheduler_handle(&self) -> bool {
-        self.scheduler_handle.lock().is_some()
+        self.scheduler_group.lock().is_some()
     }
 
     fn shutdown_storage(&self) {
@@ -1634,11 +1644,11 @@ mod tests {
 
         assert!(timer_message_store.load());
         timer_message_store.start();
-        assert!(timer_message_store.scheduler_handle.lock().is_some());
+        assert!(timer_message_store.has_scheduler_handle());
 
         timer_message_store.shutdown_gracefully().await;
 
-        assert!(timer_message_store.scheduler_handle.lock().is_none());
+        assert!(!timer_message_store.has_scheduler_handle());
     }
 
     #[test]


### PR DESCRIPTION
Closes #7496

## Summary

- Track store KV, stats, timer, reputation, HA accept, and HA connection workers with runtime task groups.
- Route store index flush, flush manager I/O, scheduled blocking tasks, and mapped-file worker joins through runtime-owned executors.
- Keep this PR to the third staged runtime-model commit for the linear merge flow.

## Validation

- Root workspace format check passed.
- Root workspace clippy passed with all targets, all features, no dependencies, and warnings denied.
- Standalone projects were not run because this PR only changes the store crate and no standalone project directly depends on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal task management for background storage services with enhanced error handling and graceful shutdown behavior.
  * Better resource cleanup and timeout-based shutdown mechanisms for increased reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->