### PR TITLE
[ISSUE #7497]♻️ Track ha client workers with task groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4324,9 +4324,11 @@ dependencies = [
  "rocketmq-error",
  "rocketmq-observability",
  "rocketmq-remoting",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "serde",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/rocketmq-client/src/runtime.rs
+++ b/rocketmq-client/src/runtime.rs
@@ -18,8 +18,11 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::Condvar;
+use std::sync::Mutex as StdMutex;
 use std::sync::OnceLock;
 use std::time::Duration;
+use std::time::Instant;
 
 use parking_lot::Mutex;
 use rocketmq_runtime::BlockingExecutor;
@@ -137,18 +140,29 @@ fn client_blocking_executor() -> io::Result<BlockingExecutor> {
 struct ClientSharedFallbackRegistry {
     state: Mutex<ClientSharedFallbackState>,
     next_generation: AtomicUsize,
+    acquire_count: AtomicUsize,
+    runtime_created: AtomicUsize,
+    runtime_reused: AtomicUsize,
     submitted_tasks: AtomicUsize,
     active_tasks: AtomicUsize,
     active_leases: AtomicUsize,
     idle_shutdowns: AtomicUsize,
     explicit_shutdowns: AtomicUsize,
-    idle_check_scheduled: AtomicBool,
+    idle_reaper_started: AtomicBool,
+    idle_reaper_starts: AtomicUsize,
+    idle_signal: Arc<(StdMutex<ClientFallbackIdleState>, Condvar)>,
 }
 
 #[derive(Default)]
 struct ClientSharedFallbackState {
     runtime: Option<Arc<ClientSharedFallbackRuntime>>,
     explicit_shutdown: bool,
+}
+
+#[derive(Default)]
+struct ClientFallbackIdleState {
+    requested_generation: Option<usize>,
+    deadline: Option<Instant>,
 }
 
 struct ClientSharedFallbackRuntime {
@@ -163,6 +177,9 @@ struct ClientSharedFallbackLease {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ClientSharedFallbackSnapshot {
+    pub acquire_count: usize,
+    pub runtime_created: usize,
+    pub runtime_reused: usize,
     pub submitted_tasks: usize,
     pub active_tasks: usize,
     pub active_leases: usize,
@@ -170,6 +187,7 @@ pub(crate) struct ClientSharedFallbackSnapshot {
     pub runtime_available: bool,
     pub idle_shutdowns: usize,
     pub explicit_shutdowns: usize,
+    pub idle_reaper_starts: usize,
 }
 
 impl ClientSharedFallbackRegistry {
@@ -177,16 +195,22 @@ impl ClientSharedFallbackRegistry {
         Self {
             state: Mutex::new(ClientSharedFallbackState::default()),
             next_generation: AtomicUsize::new(0),
+            acquire_count: AtomicUsize::new(0),
+            runtime_created: AtomicUsize::new(0),
+            runtime_reused: AtomicUsize::new(0),
             submitted_tasks: AtomicUsize::new(0),
             active_tasks: AtomicUsize::new(0),
             active_leases: AtomicUsize::new(0),
             idle_shutdowns: AtomicUsize::new(0),
             explicit_shutdowns: AtomicUsize::new(0),
-            idle_check_scheduled: AtomicBool::new(false),
+            idle_reaper_started: AtomicBool::new(false),
+            idle_reaper_starts: AtomicUsize::new(0),
+            idle_signal: Arc::new((StdMutex::new(ClientFallbackIdleState::default()), Condvar::new())),
         }
     }
 
     fn acquire(&'static self) -> io::Result<ClientSharedFallbackLease> {
+        self.acquire_count.fetch_add(1, Ordering::Relaxed);
         let runtime = {
             let mut state = self.state.lock();
             if state.explicit_shutdown {
@@ -195,18 +219,23 @@ impl ClientSharedFallbackRegistry {
                 ));
             }
 
-            match &state.runtime {
-                Some(runtime) => runtime.clone(),
+            let runtime = match &state.runtime {
+                Some(runtime) => {
+                    self.runtime_reused.fetch_add(1, Ordering::Relaxed);
+                    runtime.clone()
+                }
                 None => {
                     let generation = self.next_generation.fetch_add(1, Ordering::AcqRel) + 1;
                     let runtime = Arc::new(ClientSharedFallbackRuntime::new(generation)?);
+                    self.runtime_created.fetch_add(1, Ordering::Relaxed);
                     state.runtime = Some(runtime.clone());
                     runtime
                 }
-            }
-        };
+            };
 
-        self.active_leases.fetch_add(1, Ordering::AcqRel);
+            self.active_leases.fetch_add(1, Ordering::AcqRel);
+            runtime
+        };
         Ok(ClientSharedFallbackLease {
             registry: self,
             runtime,
@@ -222,6 +251,9 @@ impl ClientSharedFallbackRegistry {
             .unwrap_or_default();
 
         ClientSharedFallbackSnapshot {
+            acquire_count: self.acquire_count.load(Ordering::Relaxed),
+            runtime_created: self.runtime_created.load(Ordering::Relaxed),
+            runtime_reused: self.runtime_reused.load(Ordering::Relaxed),
             submitted_tasks: self.submitted_tasks.load(Ordering::Relaxed),
             active_tasks: self.active_tasks.load(Ordering::Relaxed),
             active_leases: self.active_leases.load(Ordering::Relaxed),
@@ -229,6 +261,7 @@ impl ClientSharedFallbackRegistry {
             runtime_available: state.runtime.is_some(),
             idle_shutdowns: self.idle_shutdowns.load(Ordering::Relaxed),
             explicit_shutdowns: self.explicit_shutdowns.load(Ordering::Relaxed),
+            idle_reaper_starts: self.idle_reaper_starts.load(Ordering::Relaxed),
         }
     }
 
@@ -246,8 +279,18 @@ impl ClientSharedFallbackRegistry {
     }
 
     fn schedule_idle_shutdown(&'static self, generation: usize) {
+        self.ensure_idle_reaper_started();
+
+        let (lock, condvar) = &*self.idle_signal;
+        let mut state = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.requested_generation = Some(generation);
+        state.deadline = Some(Instant::now() + fallback_idle_timeout());
+        condvar.notify_one();
+    }
+
+    fn ensure_idle_reaper_started(&'static self) {
         if self
-            .idle_check_scheduled
+            .idle_reaper_started
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
@@ -256,25 +299,59 @@ impl ClientSharedFallbackRegistry {
 
         let registry = self;
         if let Err(error) = std::thread::Builder::new()
-            .name("rocketmq-client-fallback-idle-shutdown".to_string())
+            .name("rocketmq-client-fallback-idle-reaper".to_string())
             .spawn(move || {
-                std::thread::sleep(fallback_idle_timeout());
-                registry.idle_check_scheduled.store(false, Ordering::Release);
-                registry.shutdown_idle_if_current(generation);
+                registry.run_idle_reaper();
             })
         {
-            self.idle_check_scheduled.store(false, Ordering::Release);
-            tracing::warn!(%error, "failed to schedule client fallback idle shutdown");
+            self.idle_reaper_started.store(false, Ordering::Release);
+            tracing::warn!(%error, "failed to start client fallback idle reaper");
+        } else {
+            self.idle_reaper_starts.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn run_idle_reaper(&'static self) {
+        loop {
+            let generation = self.wait_for_idle_deadline();
+            self.shutdown_idle_if_current(generation);
+        }
+    }
+
+    fn wait_for_idle_deadline(&self) -> usize {
+        let (lock, condvar) = &*self.idle_signal;
+        let mut state = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        loop {
+            let Some(deadline) = state.deadline else {
+                state = condvar.wait(state).unwrap_or_else(|poisoned| poisoned.into_inner());
+                continue;
+            };
+
+            let now = Instant::now();
+            if now >= deadline {
+                state.deadline = None;
+                return state
+                    .requested_generation
+                    .take()
+                    .expect("idle deadline requires a runtime generation");
+            }
+
+            let wait_duration = deadline.saturating_duration_since(now);
+            let (next_state, _timeout) = condvar
+                .wait_timeout(state, wait_duration)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state = next_state;
         }
     }
 
     fn shutdown_idle_if_current(&'static self, generation: usize) {
-        if self.active_leases.load(Ordering::Acquire) != 0 {
-            return;
-        }
-
         let runtime = {
             let mut state = self.state.lock();
+            if self.active_leases.load(Ordering::Acquire) != 0 {
+                return;
+            }
+
             let Some(runtime) = state.runtime.as_ref() else {
                 return;
             };
@@ -407,6 +484,9 @@ mod tests {
         let lease = registry.acquire().expect("fallback runtime should be created");
 
         let snapshot = registry.snapshot();
+        assert_eq!(snapshot.acquire_count, 1);
+        assert_eq!(snapshot.runtime_created, 1);
+        assert_eq!(snapshot.runtime_reused, 0);
         assert_eq!(snapshot.active_leases, 1);
         assert!(snapshot.runtime_available);
         assert_eq!(snapshot.runtime_generation, 1);
@@ -422,5 +502,63 @@ mod tests {
 
         assert!(error.to_string().contains("explicitly shut down"));
         assert_eq!(registry.snapshot().explicit_shutdowns, 1);
+    }
+
+    #[test]
+    fn fallback_registry_idle_reaper_shuts_down_runtime_after_idle_timeout() {
+        let registry = Box::leak(Box::new(ClientSharedFallbackRegistry::new()));
+        let lease = registry.acquire().expect("fallback runtime should be created");
+        assert!(registry.snapshot().runtime_available);
+
+        drop(lease);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let snapshot = registry.snapshot();
+            if !snapshot.runtime_available {
+                assert_eq!(snapshot.idle_shutdowns, 1);
+                assert_eq!(snapshot.idle_reaper_starts, 1);
+                break;
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "fallback runtime did not shut down after idle timeout"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn fallback_registry_reuses_single_idle_reaper_for_repeated_idle_requests() {
+        let registry = Box::leak(Box::new(ClientSharedFallbackRegistry::new()));
+        let first = registry.acquire().expect("fallback runtime should be created");
+        drop(first);
+
+        std::thread::sleep(Duration::from_millis(10));
+
+        let second = registry.acquire().expect("fallback runtime should be reused");
+        let snapshot = registry.snapshot();
+        assert_eq!(snapshot.runtime_created, 1);
+        assert_eq!(snapshot.runtime_reused, 1);
+        assert_eq!(snapshot.idle_reaper_starts, 1);
+
+        drop(second);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let snapshot = registry.snapshot();
+            if !snapshot.runtime_available {
+                assert_eq!(snapshot.idle_shutdowns, 1);
+                assert_eq!(snapshot.idle_reaper_starts, 1);
+                break;
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "fallback runtime did not shut down after second idle request"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 }

--- a/rocketmq-namesrv/Cargo.toml
+++ b/rocketmq-namesrv/Cargo.toml
@@ -39,11 +39,13 @@ rocketmq-error         = { workspace = true }
 rocketmq-client        = { version = "1.0.0", path = "../rocketmq-client", package = "rocketmq-client-rust" }
 rocketmq-controller    = { workspace = true }
 rocketmq-observability = { workspace = true }
+rocketmq-runtime       = { workspace = true }
 
 
 anyhow.workspace = true
 
 tokio.workspace = true
+tokio-util.workspace = true
 
 tracing.workspace = true
 

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -22,6 +22,7 @@ use std::net::IpAddr;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
@@ -40,6 +41,8 @@ use rocketmq_remoting::remoting::RemotingService;
 use rocketmq_remoting::remoting_server::rocketmq_tokio_server::RocketMQServer;
 use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::schedule::simple_scheduler::ScheduledTaskManager;
 use rocketmq_rust::wait_for_signal;
 use rocketmq_rust::ArcMut;
@@ -166,8 +169,8 @@ struct NameServerRuntime {
     shutdown_tx: Option<broadcast::Sender<()>>,
     shutdown_rx: Option<broadcast::Receiver<()>>,
     server_inner: Option<RocketMQServer<NameServerRequestProcessor>>,
-    /// Server task handle for graceful shutdown
-    server_task_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Server task group for graceful shutdown
+    server_task_group: Option<TaskGroup>,
     /// Runtime state machine for lifecycle management
     state: Arc<AtomicU8>,
 }
@@ -205,12 +208,23 @@ impl NameServerBootstrap {
         self.name_server_runtime.shutdown_rx = Some(shutdown_rx);
         self.name_server_runtime.initialize().await?;
 
-        let relay_handle = tokio::spawn(relay_shutdown_signal(shutdown_tx, shutdown_signal));
+        let relay_group = self
+            .name_server_runtime
+            .inner
+            .task_group()
+            .map(|task_group| task_group.child("namesrv.shutdown-relay"))
+            .ok_or_else(|| RocketMQError::Internal("NameServer task group is unavailable".to_string()))?;
+        relay_group
+            .spawn_service(
+                "namesrv.shutdown-relay",
+                relay_shutdown_signal(shutdown_tx, shutdown_signal),
+            )
+            .map_err(|error| RocketMQError::Internal(format!("failed to spawn shutdown relay: {error}")))?;
         let start_result = self.name_server_runtime.start().await;
-        if !relay_handle.is_finished() {
-            relay_handle.abort();
+        let report = relay_group.shutdown_now();
+        if let Err(error) = report.assert_no_task_leak() {
+            warn!("NameServer shutdown relay task group stopped with report: {error}");
         }
-        let _ = relay_handle.await;
         start_result?;
 
         info!("NameServer shutdown completed");
@@ -468,16 +482,23 @@ impl NameServerRuntime {
             .as_ref()
             .expect("Shutdown channel not initialized")
             .subscribe();
-        let server_handle = tokio::spawn(async move {
-            debug!("Server task started");
-            server
-                .run_with_shutdown(request_processor, channel_event_listener, async move {
-                    let _ = server_shutdown_rx.recv().await;
-                })
-                .await;
-            debug!("Server task completed");
-        });
-        self.server_task_handle = Some(server_handle);
+        let server_task_group = self
+            .inner
+            .task_group()
+            .map(|task_group| task_group.child("namesrv.server"))
+            .ok_or_else(|| RocketMQError::Internal("NameServer task group is unavailable".to_string()))?;
+        server_task_group
+            .spawn_service("namesrv.server", async move {
+                debug!("Server task started");
+                server
+                    .run_with_shutdown(request_processor, channel_event_listener, async move {
+                        let _ = server_shutdown_rx.recv().await;
+                    })
+                    .await;
+                debug!("Server task completed");
+            })
+            .map_err(|error| RocketMQError::Internal(format!("failed to spawn namesrv server task: {error}")))?;
+        self.server_task_group = Some(server_task_group);
 
         // Setup remoting client with name server address
         let local_address = NetworkUtil::get_local_address().unwrap_or_else(|| {
@@ -589,6 +610,13 @@ impl NameServerRuntime {
             warn!("Task join timeout or error: {}", e);
         }
 
+        if let Some(task_group) = self.inner.task_group.get().cloned() {
+            let report = task_group.shutdown(TASK_JOIN_TIMEOUT).await;
+            if let Err(error) = report.assert_no_task_leak() {
+                warn!("NameServer task group shutdown report is unhealthy: {error}");
+            }
+        }
+
         // Transition to Stopped state
         if let Err(e) = self.transition_to(RuntimeState::Stopped) {
             error!("Failed to transition to Stopped state: {}", e);
@@ -621,33 +649,22 @@ impl NameServerRuntime {
 
     /// Wait for server task to complete
     ///
-    /// Attempts graceful join with timeout. If timeout is exceeded,
-    /// task is aborted.
+    /// Attempts graceful task-group shutdown with timeout. If timeout is exceeded,
+    /// tracked server tasks are aborted and reported.
     #[instrument(skip(self), name = "wait_server_task")]
     async fn wait_for_server_task(&mut self, timeout: Duration) -> RocketMQResult<()> {
-        if let Some(handle) = self.server_task_handle.take() {
-            match tokio::time::timeout(timeout, handle).await {
-                Ok(Ok(())) => {
-                    debug!("Server task completed successfully");
-                    Ok(())
-                }
-                Ok(Err(e)) => {
-                    error!("Server task panicked: {}", e);
-                    Err(RocketMQError::Internal(format!("Server task panicked: {}", e)))
-                }
-                Err(_) => {
-                    warn!(
-                        "Server task join timeout ({}s), task may still be running",
-                        timeout.as_secs()
-                    );
-                    Err(RocketMQError::Timeout {
-                        operation: "server_task_join",
-                        timeout_ms: timeout.as_millis() as u64,
-                    })
-                }
+        if let Some(task_group) = self.server_task_group.take() {
+            let report = task_group.shutdown(timeout).await;
+            if let Err(error) = report.assert_no_task_leak() {
+                warn!("Server task group shutdown report is unhealthy: {error}");
+                return Err(RocketMQError::Internal(format!(
+                    "Server task group shutdown report is unhealthy: {error}"
+                )));
             }
+            debug!("Server task completed successfully");
+            Ok(())
         } else {
-            debug!("No server task handle to wait for");
+            debug!("No server task group to wait for");
             Ok(())
         }
     }
@@ -807,6 +824,7 @@ impl Builder {
             controller_config,
             controller_manager: None,
             cluster_test_route_lookup,
+            task_group: OnceLock::new(),
         });
 
         // Check configuration flag for RouteInfoManager version
@@ -838,7 +856,7 @@ impl Builder {
                 shutdown_rx: None,
                 shutdown_tx: None,
                 server_inner: None,
-                server_task_handle: None,
+                server_task_group: None,
                 state: Arc::new(AtomicU8::new(RuntimeState::Created as u8)),
             },
         }
@@ -863,6 +881,7 @@ pub(crate) struct NameServerRuntimeInner {
     broker_housekeeping_service: Option<Arc<BrokerHousekeepingService>>,
     controller_manager: Option<ArcMut<ControllerManager>>,
     cluster_test_route_lookup: Option<Arc<ClusterTestRouteLookup>>,
+    task_group: OnceLock<TaskGroup>,
 }
 
 impl NameServerRuntimeInner {
@@ -871,6 +890,23 @@ impl NameServerRuntimeInner {
     #[inline]
     pub fn name_server_config(&self) -> &NamesrvConfig {
         &self.name_server_config
+    }
+
+    pub(crate) fn task_group(&self) -> Option<TaskGroup> {
+        if let Some(task_group) = self.task_group.get() {
+            return Some(task_group.clone());
+        }
+
+        let handle = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => handle,
+            Err(error) => {
+                warn!("NameServer task group is unavailable outside Tokio runtime: {error}");
+                return None;
+            }
+        };
+        let task_group = TaskGroup::root("rocketmq-namesrv", RuntimeHandle::new(handle));
+        let _ = self.task_group.set(task_group);
+        self.task_group.get().cloned()
     }
 
     #[inline]

--- a/rocketmq-namesrv/src/route/batch_unregistration_service.rs
+++ b/rocketmq-namesrv/src/route/batch_unregistration_service.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use rocketmq_remoting::protocol::header::namesrv::broker_request::UnRegisterBrokerRequestHeader;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
-use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 use tracing::warn;
 
@@ -26,7 +25,7 @@ pub(crate) struct BatchUnregistrationService {
     name_server_runtime_inner: ArcMut<NameServerRuntimeInner>,
     tx: tokio::sync::mpsc::Sender<UnRegisterBrokerRequestHeader>,
     rx: Option<tokio::sync::mpsc::Receiver<UnRegisterBrokerRequestHeader>>,
-    shutdown_notify: Arc<Notify>,
+    task_group: parking_lot::Mutex<Option<TaskGroup>>,
 }
 
 impl BatchUnregistrationService {
@@ -40,7 +39,7 @@ impl BatchUnregistrationService {
             name_server_runtime_inner,
             tx,
             rx: Some(rx),
-            shutdown_notify: Default::default(),
+            task_group: parking_lot::Mutex::new(None),
         }
     }
 
@@ -53,48 +52,40 @@ impl BatchUnregistrationService {
     }
 
     pub fn start(&mut self) {
+        if self.task_group.lock().is_some() {
+            return;
+        }
+
+        let Some(task_group) = self
+            .name_server_runtime_inner
+            .task_group()
+            .map(|task_group| task_group.child("namesrv.batch-unregistration"))
+        else {
+            warn!("BatchUnregistrationService cannot start because NameServer task group is unavailable");
+            return;
+        };
+
         let mut name_server_runtime_inner = self.name_server_runtime_inner.clone();
         let mut rx = self.rx.take().expect("rx is None");
-        let shutdown_notify = self.shutdown_notify.clone();
-        tokio::spawn(async move {
+        let shutdown_token = task_group.cancellation_token();
+        if let Err(error) = task_group.spawn_service("namesrv.batch-unregistration", async move {
             info!("BatchUnregistrationService started");
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = shutdown_notify.notified() => {
-                        info!("BatchUnregistrationService shutdown");
-                        break;
-                    }
-                    // Wait for at least one request
-                    first_request = rx.recv() => {
-                        match first_request {
-                            Some(request) => {
-                                let mut unregistration_requests = Vec::new();
-                                unregistration_requests.push(request);
+            run_batch_unregistration_service(&mut name_server_runtime_inner, &mut rx, shutdown_token).await;
+        }) {
+            warn!("BatchUnregistrationService cannot start because task spawn failed: {error}");
+            return;
+        }
 
-                                // Drain all available requests from the channel
-                                while let Ok(req) = rx.try_recv() {
-                                    unregistration_requests.push(req);
-                                }
-
-                                name_server_runtime_inner
-                                    .route_info_manager_mut()
-                                    .un_register_broker(unregistration_requests);
-                            }
-                            None => {
-                                // Channel closed, exit the loop
-                                info!("BatchUnregistrationService channel closed");
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        });
+        *self.task_group.lock() = Some(task_group);
     }
 
     pub fn shutdown(&self) {
-        self.shutdown_notify.notify_one();
+        if let Some(task_group) = self.task_group.lock().take() {
+            let report = task_group.shutdown_now();
+            if let Err(error) = report.assert_no_task_leak() {
+                warn!("BatchUnregistrationService shutdown report is unhealthy: {error}");
+            }
+        }
     }
 
     /// Returns the number of pending unregister requests in the queue.
@@ -102,5 +93,40 @@ impl BatchUnregistrationService {
     #[allow(dead_code)]
     pub fn queue_length(&self) -> usize {
         self.tx.max_capacity() - self.tx.capacity()
+    }
+}
+
+async fn run_batch_unregistration_service(
+    name_server_runtime_inner: &mut ArcMut<NameServerRuntimeInner>,
+    rx: &mut tokio::sync::mpsc::Receiver<UnRegisterBrokerRequestHeader>,
+    shutdown_token: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown_token.cancelled() => {
+                info!("BatchUnregistrationService shutdown");
+                break;
+            }
+            first_request = rx.recv() => {
+                match first_request {
+                    Some(request) => {
+                        let mut unregistration_requests = vec![request];
+
+                        while let Ok(req) = rx.try_recv() {
+                            unregistration_requests.push(req);
+                        }
+
+                        name_server_runtime_inner
+                            .route_info_manager_mut()
+                            .un_register_broker(unregistration_requests);
+                    }
+                    None => {
+                        info!("BatchUnregistrationService channel closed");
+                        break;
+                    }
+                }
+            }
+        }
     }
 }

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -619,11 +619,16 @@ impl RouteInfoManager {
         );
 
         if let Some(broker_addrs_notify) = Self::choose_broker_addrs_to_notify(broker_addr_map, offline_broker_addr) {
+            let Some(task_group) = self.name_server_runtime_inner.task_group() else {
+                warn!("skip min broker id notification because NameServer task group is unavailable");
+                return;
+            };
             for broker_addr in broker_addrs_notify {
                 let remoting_client = self.name_server_runtime_inner.clone();
                 let requst_header = request_header.clone();
                 let broker_addr = broker_addr.clone();
-                tokio::spawn(async move {
+
+                if let Err(error) = task_group.spawn_service("namesrv.notify-min-broker-id", async move {
                     let _ = remoting_client
                         .remoting_client()
                         .invoke_request_oneway(
@@ -635,7 +640,9 @@ impl RouteInfoManager {
                             3000,
                         )
                         .await;
-                });
+                }) {
+                    warn!("failed to spawn min broker id notification task: {error}");
+                }
             }
         }
     }
@@ -1115,16 +1122,7 @@ impl RouteInfoManager {
 impl RouteInfoManager {
     //! start client connection disconnected listener
     pub fn start(&self) {
-        /* let mut inner = self.name_server_runtime_inner.clone(); */
         self.un_register_service.mut_from_ref().start();
-        /*let mut receiver = receiver;
-        tokio::spawn(async move {
-            while let Ok(socket_addr) = receiver.recv().await {
-                inner
-                    .route_info_manager_mut()
-                    .connection_disconnected(socket_addr);
-            }
-        });*/
     }
 
     pub fn shutdown(&self) {

--- a/rocketmq-namesrv/src/route/route_info_manager_v2.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager_v2.rs
@@ -819,17 +819,23 @@ impl RouteInfoManagerV2 {
         let request = RemotingCommand::create_request_command(RequestCode::NotifyMinBrokerIdChange, request_header);
 
         // Send notification to each broker asynchronously
+        let Some(task_group) = self.name_server_runtime_inner.task_group() else {
+            warn!("skip min broker id notification because NameServer task group is unavailable");
+            return;
+        };
         for broker_addr in broker_addrs_notify {
             let remoting_client = self.name_server_runtime_inner.clone();
             let request = request.clone();
             let broker_addr = broker_addr.clone();
 
-            tokio::spawn(async move {
+            if let Err(error) = task_group.spawn_service("namesrv.notify-min-broker-id", async move {
                 let _ = remoting_client
                     .remoting_client()
                     .invoke_request_oneway(&broker_addr, request, 3000)
                     .await;
-            });
+            }) {
+                warn!("failed to spawn min broker id notification task: {error}");
+            }
         }
     }
 

--- a/rocketmq-remoting/src/clients/connection_pool.rs
+++ b/rocketmq-remoting/src/clients/connection_pool.rs
@@ -86,6 +86,9 @@ use std::time::Instant;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::ShutdownReport;
+use rocketmq_runtime::TaskGroup;
 use tokio::time;
 use tracing::debug;
 use tracing::info;
@@ -291,6 +294,30 @@ pub struct ConnectionPool<PR = DefaultRemotingRequestProcessor> {
 
     /// Maximum duration a connection can be idle
     max_idle_duration: Duration,
+}
+
+/// Handle for a background connection-pool cleanup task.
+#[derive(Clone)]
+pub struct ConnectionPoolCleanupTask {
+    task_group: TaskGroup,
+}
+
+impl ConnectionPoolCleanupTask {
+    /// Stop the cleanup task immediately.
+    ///
+    /// This mirrors the previous `JoinHandle::abort()` usage while routing
+    /// the task through the runtime task accounting model.
+    pub fn abort(&self) {
+        let report = self.task_group.shutdown_now();
+        if let Err(error) = report.assert_no_task_leak() {
+            warn!("connection pool cleanup task stopped with report: {error}");
+        }
+    }
+
+    /// Stop the cleanup task gracefully and return the shutdown report.
+    pub async fn shutdown(&self, timeout: Duration) -> ShutdownReport {
+        self.task_group.shutdown(timeout).await
+    }
 }
 
 impl<PR> ConnectionPool<PR> {
@@ -513,7 +540,7 @@ impl<PR> ConnectionPool<PR> {
     ///
     /// # Returns
     ///
-    /// Task handle that can be awaited or aborted
+    /// Cleanup task handle that can be shut down or aborted
     ///
     /// # Example
     ///
@@ -529,17 +556,38 @@ impl<PR> ConnectionPool<PR> {
     /// cleanup_task.abort(); // Stop cleanup task
     /// # }
     /// ```
-    pub fn start_cleanup_task(&self, interval: Duration) -> tokio::task::JoinHandle<()>
+    pub fn start_cleanup_task(&self, interval: Duration) -> ConnectionPoolCleanupTask
+    where
+        PR: Send + Sync + 'static,
+    {
+        let handle =
+            tokio::runtime::Handle::try_current().expect("connection pool cleanup task requires a Tokio runtime");
+        let task_group = TaskGroup::root("rocketmq-remoting.connection-pool", RuntimeHandle::new(handle));
+        self.start_cleanup_task_with_group(interval, task_group)
+            .expect("connection pool cleanup task must spawn")
+    }
+
+    /// Start background cleanup task under the provided task group.
+    pub fn start_cleanup_task_with_group(
+        &self,
+        interval: Duration,
+        task_group: TaskGroup,
+    ) -> rocketmq_runtime::RuntimeResult<ConnectionPoolCleanupTask>
     where
         PR: Send + Sync + 'static,
     {
         let connections = self.connections.clone();
         let max_idle = self.max_idle_duration;
+        let cleanup_group = task_group.child("remoting.connection-pool.cleanup");
+        let cancellation_token = cleanup_group.cancellation_token();
 
-        tokio::spawn(async move {
+        cleanup_group.spawn_service("remoting.connection-pool.cleanup", async move {
             let mut ticker = time::interval(interval);
             loop {
-                ticker.tick().await;
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => break,
+                    _ = ticker.tick() => {}
+                }
 
                 // Evict idle connections
                 let mut idle_count = 0;
@@ -570,6 +618,10 @@ impl<PR> ConnectionPool<PR> {
 
                 debug!("Connection pool size: {} (after cleanup)", connections.len());
             }
+        })?;
+
+        Ok(ConnectionPoolCleanupTask {
+            task_group: cleanup_group,
         })
     }
 }
@@ -671,5 +723,15 @@ mod tests {
         assert_eq!(stats.utilization(), 0.5);
         assert_eq!(stats.error_rate(), 0.01);
         assert_eq!(stats.active(), 40);
+    }
+
+    #[tokio::test]
+    async fn cleanup_task_shutdown_reports_healthy() {
+        let pool = ConnectionPool::<()>::new(100, Duration::from_millis(10));
+        let cleanup_task = pool.start_cleanup_task(Duration::from_millis(5));
+
+        let report = cleanup_task.shutdown(Duration::from_secs(1)).await;
+
+        assert!(report.is_healthy(), "{}", report.to_json());
     }
 }

--- a/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
@@ -30,6 +30,7 @@ use tracing::warn;
 
 use crate::base::connection_net_event::ConnectionNetEvent;
 use crate::clients::connection_pool::ConnectionPool;
+use crate::clients::connection_pool::ConnectionPoolCleanupTask;
 use crate::clients::nameserver_selector::LatencyTracker;
 use crate::clients::reconnect::CircuitBreaker;
 use crate::clients::Client;
@@ -252,7 +253,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
     ///
     /// # Returns
     ///
-    /// Task handle for the cleanup background task (can be aborted)
+    /// Cleanup task handle for the background task (can be aborted)
     ///
     /// # Example
     ///
@@ -283,7 +284,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
         max_connections: usize,
         max_idle_duration: Duration,
         cleanup_interval: Duration,
-    ) -> tokio::task::JoinHandle<()> {
+    ) -> ConnectionPoolCleanupTask {
         let pool = ConnectionPool::new(max_connections, max_idle_duration);
         let cleanup_task = pool.start_cleanup_task(cleanup_interval);
         self.connection_pool = Some(pool);

--- a/rocketmq-remoting/src/connection_v2.rs
+++ b/rocketmq-remoting/src/connection_v2.rs
@@ -18,6 +18,7 @@
 //! flexible control, and lock-free concurrent writes via channel
 
 use std::io::IoSlice;
+use std::time::Duration;
 
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -26,6 +27,8 @@ use futures_util::SinkExt;
 use futures_util::StreamExt;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use tokio::io::AsyncWriteExt;
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::net::tcp::OwnedWriteHalf;
@@ -33,7 +36,6 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
-use tokio::task::JoinHandle;
 use tokio_util::codec::FramedRead;
 use tokio_util::codec::FramedWrite;
 use uuid::Uuid;
@@ -197,8 +199,8 @@ pub struct ConcurrentConnection {
     /// Connection state receiver
     state_rx: watch::Receiver<ConnectionState>,
 
-    /// Writer task handle (for graceful shutdown)
-    writer_handle: JoinHandle<()>,
+    /// Writer task group (for graceful shutdown)
+    writer_group: TaskGroup,
 
     /// Connection ID
     connection_id: CheetahString,
@@ -581,15 +583,26 @@ impl ConcurrentConnection {
         let (write_tx, write_rx) = mpsc::channel(channel_capacity);
         let (state_tx, state_rx) = watch::channel(ConnectionState::Healthy);
 
-        // Spawn dedicated writer task
-        let writer_handle = tokio::spawn(Self::writer_task(framed_writer, write_rx, state_tx));
+        let connection_id = CheetahString::from_string(format!("concurrent-{}", uuid::Uuid::new_v4()));
+        let runtime_handle =
+            tokio::runtime::Handle::try_current().expect("ConcurrentConnection writer task requires a Tokio runtime");
+        let writer_group = TaskGroup::root(
+            format!("rocketmq-remoting.connection.{connection_id}"),
+            RuntimeHandle::new(runtime_handle),
+        );
+        writer_group
+            .spawn_service(
+                "remoting.connection.writer",
+                Self::writer_task(framed_writer, write_rx, state_tx),
+            )
+            .expect("ConcurrentConnection writer task must spawn");
 
         Self {
             framed_reader,
             write_tx,
             state_rx,
-            writer_handle,
-            connection_id: CheetahString::from_string(format!("concurrent-{}", uuid::Uuid::new_v4())),
+            writer_group,
+            connection_id,
         }
     }
 
@@ -949,12 +962,13 @@ impl ConcurrentConnection {
                 "Response channel closed",
             ))
         })??;
-        self.writer_handle.await.map_err(|e| {
-            RocketMQError::Network(rocketmq_error::NetworkError::connection_failed(
+        let report = self.writer_group.shutdown(Duration::from_secs(3)).await;
+        if let Err(error) = report.assert_no_task_leak() {
+            return Err(RocketMQError::Network(rocketmq_error::NetworkError::connection_failed(
                 "connection",
-                format!("{}", e),
-            ))
-        })?;
+                format!("writer task shutdown report is unhealthy: {error}"),
+            )));
+        }
         Ok(())
     }
 }

--- a/rocketmq-remoting/src/net/channel.rs
+++ b/rocketmq-remoting/src/net/channel.rs
@@ -26,6 +26,8 @@ use cheetah_string::CheetahString;
 use flume::Receiver;
 use flume::Sender;
 use rocketmq_error::RocketMQError;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use tokio::time::timeout;
 use tracing::error;
@@ -331,6 +333,9 @@ pub struct ChannelInner {
     /// - Send task: Inserts entries when request is sent
     /// - Receive task: Removes and completes entries when response arrives
     pub(crate) response_table: ArcMut<HashMap<i32, ResponseFuture>>,
+
+    /// Tracks the outbound send task for shutdown diagnostics.
+    send_task_group: TaskGroup,
 }
 
 /// Background task that processes the outbound message queue.
@@ -437,15 +442,30 @@ impl ChannelInner {
         let (outbound_queue_tx, outbound_queue_rx) = flume::bounded(QUEUE_CAPACITY);
 
         let connection = ArcMut::new(connection);
-        tokio::spawn(handle_send(
-            connection.clone(),
-            outbound_queue_rx,
-            response_table.clone(),
-        ));
+        let task_group = TaskGroup::root(
+            "rocketmq-remoting.channel",
+            RuntimeHandle::new(tokio::runtime::Handle::current()),
+        );
+        task_group
+            .spawn_service(
+                "remoting.channel.send",
+                handle_send(connection.clone(), outbound_queue_rx, response_table.clone()),
+            )
+            .expect("channel send task must spawn");
         Self {
             outbound_queue_tx,
             connection,
             response_table,
+            send_task_group: task_group,
+        }
+    }
+}
+
+impl Drop for ChannelInner {
+    fn drop(&mut self) {
+        let report = self.send_task_group.shutdown_now();
+        if let Err(error) = report.assert_no_task_leak() {
+            tracing::warn!("channel send task stopped with report: {error}");
         }
     }
 }

--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -117,7 +117,7 @@ struct TaskGroupInner {
     cancellation_token: CancellationToken,
     tracker: TaskTracker,
     tasks: DashMap<TaskId, TaskMeta>,
-    children: DashMap<TaskGroupId, TaskGroup>,
+    children: Mutex<Vec<TaskGroup>>,
     next_task_id: AtomicU64,
     next_child_id: AtomicU64,
     completed: AtomicUsize,
@@ -193,7 +193,7 @@ impl TaskGroup {
                 self.inner.cancellation_token.child_token(),
             )),
         };
-        self.inner.children.insert(child_id, child.clone());
+        self.inner.children.lock().push(child.clone());
         child
     }
 
@@ -231,6 +231,16 @@ impl TaskGroup {
                 .clone()
         }
         .boxed()
+    }
+
+    pub fn shutdown_now(&self) -> ShutdownReport {
+        if let Some(report) = self.inner.shutdown_report.get() {
+            return report.clone();
+        }
+
+        let report = self.shutdown_now_inner();
+        let _ = self.inner.shutdown_report.set(report.clone());
+        report
     }
 
     fn spawn_inner<F>(&self, name: Arc<str>, kind: TaskKind, detached: bool, future: F) -> RuntimeResult<TaskId>
@@ -294,12 +304,7 @@ impl TaskGroup {
 
     async fn shutdown_inner(&self, timeout: Duration) -> ShutdownReport {
         let started_at = Instant::now();
-        let children = self
-            .inner
-            .children
-            .iter()
-            .map(|entry| entry.value().clone())
-            .collect::<Vec<_>>();
+        let children = self.inner.children.lock().clone();
 
         {
             let _spawn_guard = self.inner.spawn_gate.lock();
@@ -342,6 +347,54 @@ impl TaskGroup {
         if timed_out {
             report.timed_out = aborted + report.leaked;
         }
+
+        if report.detached_still_running > 0 {
+            report.annotations.push(ShutdownAnnotation::new(format!(
+                "{} detached tasks are still running",
+                report.detached_still_running
+            )));
+        }
+
+        self.inner.lifecycle.store(STATE_CLOSED, Ordering::Release);
+        report
+    }
+
+    fn shutdown_now_inner(&self) -> ShutdownReport {
+        let started_at = Instant::now();
+        let children = self.inner.children.lock().clone();
+
+        {
+            let _spawn_guard = self.inner.spawn_gate.lock();
+            self.inner.lifecycle.store(STATE_CLOSING, Ordering::Release);
+            self.inner.tracker.close();
+            self.inner.cancellation_token.cancel();
+        }
+
+        let mut child_reports = Vec::with_capacity(children.len());
+        for child in children {
+            child_reports.push(child.shutdown_now());
+        }
+
+        self.abort_tracked_tasks();
+
+        let mut report = ShutdownReport::new(self.inner.name.to_string(), started_at.elapsed());
+        report.completed = self.inner.completed.load(Ordering::Relaxed);
+        report.cancelled = self.inner.cancelled.load(Ordering::Relaxed);
+        report.panicked = self.inner.panicked.load(Ordering::Relaxed);
+        report.children = child_reports;
+
+        let aborted = self.remove_aborted_tasks();
+        report.aborted = aborted;
+        if aborted > 0 {
+            report.annotations.push(ShutdownAnnotation::new(format!(
+                "aborted {aborted} tracked tasks during immediate shutdown"
+            )));
+        }
+
+        let remaining = self.remaining_snapshots(TaskState::Leaked);
+        report.detached_still_running = remaining.iter().filter(|task| task.detached).count();
+        report.leaked = remaining.iter().filter(|task| !task.detached).count();
+        report.remaining_tasks = remaining;
 
         if report.detached_still_running > 0 {
             report.annotations.push(ShutdownAnnotation::new(format!(
@@ -406,7 +459,7 @@ impl TaskGroupInner {
             cancellation_token,
             tracker: TaskTracker::new(),
             tasks: DashMap::new(),
-            children: DashMap::new(),
+            children: Mutex::new(Vec::new()),
             next_task_id: AtomicU64::new(1),
             next_child_id: AtomicU64::new(id.as_u64() * 1_000_000 + 1),
             completed: AtomicUsize::new(0),

--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -68,6 +68,30 @@ async fn task_group_shutdown_aborts_after_timeout_without_leak() {
 }
 
 #[tokio::test]
+async fn task_group_shutdown_now_aborts_without_async_wait() {
+    let context = RuntimeContext::from_current("task-group-shutdown-now-test");
+    let group = context.root_group().child("service");
+
+    group
+        .spawn_service("pending-task", async move {
+            std::future::pending::<()>().await;
+        })
+        .unwrap();
+
+    let report = group.shutdown_now();
+    assert_eq!(report.aborted, 1, "{}", report.to_json());
+    assert_eq!(report.leaked, 0, "{}", report.to_json());
+    assert_eq!(
+        group.lifecycle_state(),
+        rocketmq_runtime::TaskGroupLifecycleState::Closed
+    );
+    assert!(group.spawn_service("late-task", async {}).is_err());
+
+    let second_report = group.shutdown(Duration::from_secs(1)).await;
+    assert_eq!(second_report.aborted, 1, "{}", second_report.to_json());
+}
+
+#[tokio::test]
 async fn scheduled_no_overlap_skips_while_previous_run_is_active() {
     let context = RuntimeContext::from_current("scheduled-test");
     let service = context.service_context("service");

--- a/rocketmq-store/src/ha/default_ha_client.rs
+++ b/rocketmq-store/src/ha/default_ha_client.rs
@@ -65,8 +65,8 @@ const READ_MAX_BUFFER_SIZE: usize = 1024 * 1024 * 4;
 /// Default HA Client implementation using bytes crate
 pub struct DefaultHAClient {
     inner: ArcMut<Inner>,
-    /// Service handle
-    service_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
+    /// Service task group
+    service_group: Arc<RwLock<Option<rocketmq_runtime::TaskGroup>>>,
 }
 
 struct Inner {
@@ -232,7 +232,7 @@ impl DefaultHAClient {
                 flow_monitor,
                 shutdown_notify: Arc::new(Notify::new()),
             }),
-            service_handle: Arc::new(RwLock::new(None)),
+            service_group: Arc::new(RwLock::new(None)),
         })
     }
 
@@ -259,9 +259,12 @@ impl DefaultHAClient {
         self.inner.shutdown_notify.notify_waiters();
 
         // Wait for service to stop
-        let mut service_handle = self.service_handle.write().await;
-        if let Some(handle) = service_handle.take() {
-            let _ = handle.await;
+        let service_group = self.service_group.write().await.take();
+        if let Some(service_group) = service_group {
+            let report = service_group.shutdown(Duration::from_secs(5)).await;
+            if let Err(error) = crate::runtime::shutdown_report_result("DefaultHAClient", report) {
+                warn!("DefaultHAClient task shutdown reported an error: {error}");
+            }
         }
 
         self.close_master().await;
@@ -301,15 +304,23 @@ impl DefaultHAClient {
 
 impl HAClient for DefaultHAClient {
     async fn start(&mut self) {
-        // Idempotent start: if a service handle already exists, do nothing
-        if self.service_handle.read().await.is_some() {
+        // Idempotent start: if a service group already exists, do nothing
+        if self.service_group.read().await.is_some() {
             warn!("HAClient service is already running");
             return;
         }
 
         self.inner.flow_monitor.start().await;
         let mut client = ArcMut::clone(&self.inner);
-        let join_handle = tokio::spawn(async move {
+        let service_group = match crate::runtime::task_group("rocketmq-store.ha.client") {
+            Ok(service_group) => service_group,
+            Err(error) => {
+                warn!("HAClient service not started: {error}");
+                return;
+            }
+        };
+        let service_loop_group = service_group.clone();
+        if let Err(error) = service_group.spawn_service("ha-client-service", async move {
             // main loop: connect -> start read/write tasks -> supervise/reconnect
             loop {
                 let read_guard = client.current_state.read().await;
@@ -335,6 +346,7 @@ impl HAClient for DefaultHAClient {
 
                             // use reader/writer to send errors back to main loop
                             let (err_tx, mut err_rx) = tokio::sync::mpsc::unbounded_channel::<anyhow::Error>();
+                            let connection_group = service_loop_group.child("ha-client-connection");
 
                             // reader task: read data from master and dispatch to message store
                             let reader_shutdown = client.shutdown_notify.clone();
@@ -345,7 +357,7 @@ impl HAClient for DefaultHAClient {
                                 buf: BytesMut::with_capacity(READ_MAX_BUFFER_SIZE),
                                 dispatch_pos: 0,
                                 offset_tx,
-                                err_tx,
+                                err_tx: err_tx.clone(),
                                 store,
                                 flow_monitor: flow,
                                 last_read_timestamp: client.last_read_timestamp.clone(),
@@ -354,12 +366,21 @@ impl HAClient for DefaultHAClient {
                                     .message_store_config_ref()
                                     .enable_controller_mode,
                             };
-                            let reader_handle = tokio::spawn(async move {
-                                tokio::select! {
+                            let reader_err_tx = reader_client.err_tx.clone();
+                            if let Err(error) = connection_group.spawn_service("ha-client-reader", async move {
+                                let result = tokio::select! {
                                     res = reader_client.run() => res,
                                     _ = reader_shutdown.notified() => Ok(()),
+                                };
+                                if let Err(error) = result {
+                                    let _ = reader_err_tx.send(error);
                                 }
-                            });
+                            }) {
+                                warn!("HAClient failed to spawn reader task: {error}");
+                                client.change_current_state(HAConnectionState::Ready).await;
+                                sleep(Duration::from_secs(5)).await;
+                                continue;
+                            }
 
                             // writer task: write data to master and report offsets
                             let writer_shutdown = client.shutdown_notify.clone();
@@ -384,12 +405,28 @@ impl HAClient for DefaultHAClient {
                                 kick_rx,
                                 report_offset: BytesMut::with_capacity(CONTROLLER_REPORT_HEADER_SIZE),
                             };
-                            let writer_handle = tokio::spawn(async move {
-                                tokio::select! {
+                            let writer_err_tx = err_tx.clone();
+                            if let Err(error) = connection_group.spawn_service("ha-client-writer", async move {
+                                let result = tokio::select! {
                                     res = writer_client.run() => res,
                                     _ = writer_shutdown.notified() => Ok(()),
+                                };
+                                if let Err(error) = result {
+                                    let _ = writer_err_tx.send(error);
                                 }
-                            });
+                            }) {
+                                warn!("HAClient failed to spawn writer task: {error}");
+                                client.shutdown_notify.notify_waiters();
+                                let report = connection_group.shutdown(Duration::from_secs(3)).await;
+                                if let Err(shutdown_error) =
+                                    crate::runtime::shutdown_report_result("DefaultHAClient connection", report)
+                                {
+                                    warn!("HAClient partial connection shutdown reported an error: {shutdown_error}");
+                                }
+                                client.change_current_state(HAConnectionState::Ready).await;
+                                sleep(Duration::from_secs(5)).await;
+                                continue;
+                            }
                             // main loop for housekeeping and monitoring
                             let mut house = interval(Duration::from_millis(
                                 client
@@ -430,8 +467,12 @@ impl HAClient for DefaultHAClient {
 
                             // stop reader/writer
                             client.shutdown_notify.notify_waiters();
-                            let _ = reader_handle.await;
-                            let _ = writer_handle.await;
+                            let report = connection_group.shutdown(Duration::from_secs(3)).await;
+                            if let Err(error) =
+                                crate::runtime::shutdown_report_result("DefaultHAClient connection", report)
+                            {
+                                warn!("HAClient connection task shutdown reported an error: {error}");
+                            }
 
                             if !exit {
                                 // need to reconnect
@@ -461,9 +502,12 @@ impl HAClient for DefaultHAClient {
             }
             client.flow_monitor.shutdown_with_interrupt(true).await;
             info!("HAClient service finished");
-        });
-        let mut service_handle = self.service_handle.write().await;
-        *service_handle = Some(join_handle);
+        }) {
+            warn!("HAClient service not started: {error}");
+            return;
+        }
+        let mut service_group_guard = self.service_group.write().await;
+        *service_group_guard = Some(service_group);
     }
 
     async fn shutdown(&self) {
@@ -471,9 +515,12 @@ impl HAClient for DefaultHAClient {
         self.inner.shutdown_notify.notify_waiters();
 
         // Wait for service to stop
-        let mut service_handle = self.service_handle.write().await;
-        if let Some(handle) = service_handle.take() {
-            let _ = handle.await;
+        let service_group = self.service_group.write().await.take();
+        if let Some(service_group) = service_group {
+            let report = service_group.shutdown(Duration::from_secs(5)).await;
+            if let Err(error) = crate::runtime::shutdown_report_result("DefaultHAClient", report) {
+                warn!("DefaultHAClient task shutdown reported an error: {error}");
+            }
         }
         self.close_master().await;
     }

--- a/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
+++ b/rocketmq-store/src/log_file/flush_manager_impl/default_flush_manager.rs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::WeakArcMut;
 use tokio::sync::Notify;
-use tokio::task::JoinHandle;
 use tokio::time;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -54,7 +55,7 @@ impl DefaultFlushManager {
                     notified: Arc::new(Notify::new()),
                     tx_in: None,
                     shutdown_token: CancellationToken::new(),
-                    worker_handle: None,
+                    worker_group: None,
                 }),
                 None,
             ),
@@ -65,7 +66,7 @@ impl DefaultFlushManager {
                     store_checkpoint: store_checkpoint.clone(),
                     notified: Arc::new(Notify::new()),
                     shutdown_token: CancellationToken::new(),
-                    worker_handle: None,
+                    worker_group: None,
                 }),
             ),
         };
@@ -77,7 +78,7 @@ impl DefaultFlushManager {
                 notified: Arc::new(Default::default()),
                 flush_manager: None,
                 shutdown_token: CancellationToken::new(),
-                worker_handle: None,
+                worker_group: None,
             })
         } else {
             None
@@ -237,7 +238,7 @@ struct GroupCommitService {
     notified: Arc<Notify>,
     tx_in: Option<tokio::sync::mpsc::Sender<GroupCommitRequest>>,
     shutdown_token: CancellationToken,
-    worker_handle: Option<JoinHandle<()>>,
+    worker_group: Option<TaskGroup>,
 }
 
 impl GroupCommitService {
@@ -256,17 +257,24 @@ impl GroupCommitService {
     }
 
     fn start(&mut self, mapped_file_queue: ArcMut<MappedFileQueue>) {
-        if self.worker_handle.is_some() {
+        if self.worker_group.is_some() {
             return;
         }
 
+        let worker_group = match crate::runtime::task_group("rocketmq-store.commit-log.group-commit") {
+            Ok(worker_group) => worker_group,
+            Err(error) => {
+                warn!("GroupCommitService cannot start because task group creation failed: {error}");
+                return;
+            }
+        };
         self.shutdown_token = CancellationToken::new();
         let (tx_in, mut rx_in) = tokio::sync::mpsc::channel::<GroupCommitRequest>(1024);
         self.tx_in = Some(tx_in);
         let shutdown_token = self.shutdown_token.clone();
         let store_checkpoint = self.store_checkpoint.clone();
         let notified = Arc::clone(&self.notified);
-        self.worker_handle = Some(tokio::spawn(async move {
+        if let Err(error) = worker_group.spawn_service("commit-log-group-commit", async move {
             loop {
                 tokio::select! {
                     _ = shutdown_token.cancelled() => {
@@ -324,7 +332,12 @@ impl GroupCommitService {
                     }
                 }
             }
-        }));
+        }) {
+            warn!("GroupCommitService cannot start because task spawn failed: {error}");
+            self.tx_in.take();
+            return;
+        }
+        self.worker_group = Some(worker_group);
     }
 
     pub fn wakeup(&self) {
@@ -334,17 +347,13 @@ impl GroupCommitService {
     pub fn shutdown(&mut self) {
         self.shutdown_token.cancel();
         self.tx_in.take();
-        if let Some(handle) = self.worker_handle.take() {
-            handle.abort();
-        }
+        shutdown_worker_now("GroupCommitService", &mut self.worker_group);
     }
 
     pub async fn shutdown_gracefully(&mut self) {
         self.shutdown_token.cancel();
         self.tx_in.take();
-        if let Some(handle) = self.worker_handle.take() {
-            await_worker("GroupCommitService", handle).await;
-        }
+        shutdown_worker_gracefully("GroupCommitService", &mut self.worker_group).await;
     }
 }
 
@@ -364,21 +373,28 @@ struct FlushRealTimeService {
     store_checkpoint: Arc<StoreCheckpoint>,
     notified: Arc<Notify>,
     shutdown_token: CancellationToken,
-    worker_handle: Option<JoinHandle<()>>,
+    worker_group: Option<TaskGroup>,
 }
 
 impl FlushRealTimeService {
     fn start(&mut self, mapped_file_queue: ArcMut<MappedFileQueue>) {
-        if self.worker_handle.is_some() {
+        if self.worker_group.is_some() {
             return;
         }
 
+        let worker_group = match crate::runtime::task_group("rocketmq-store.commit-log.flush-real-time") {
+            Ok(worker_group) => worker_group,
+            Err(error) => {
+                warn!("FlushRealTimeService cannot start because task group creation failed: {error}");
+                return;
+            }
+        };
         self.shutdown_token = CancellationToken::new();
         let message_store_config = self.message_store_config.clone();
         let store_checkpoint = self.store_checkpoint.clone();
         let notified = self.notified.clone();
         let shutdown_token = self.shutdown_token.clone();
-        self.worker_handle = Some(tokio::spawn(async move {
+        if let Err(error) = worker_group.spawn_service("commit-log-flush-real-time", async move {
             let mut last_flush_timestamp = 0;
             loop {
                 if shutdown_token.is_cancelled() {
@@ -425,7 +441,11 @@ impl FlushRealTimeService {
                     store_checkpoint.set_physic_msg_timestamp(store_timestamp);
                 }
             }
-        }));
+        }) {
+            warn!("FlushRealTimeService cannot start because task spawn failed: {error}");
+            return;
+        }
+        self.worker_group = Some(worker_group);
     }
 
     pub fn wakeup(&self) {
@@ -437,17 +457,13 @@ impl FlushRealTimeService {
     pub fn shutdown(&mut self) {
         self.shutdown_token.cancel();
         self.notified.notify_waiters();
-        if let Some(handle) = self.worker_handle.take() {
-            handle.abort();
-        }
+        shutdown_worker_now("FlushRealTimeService", &mut self.worker_group);
     }
 
     pub async fn shutdown_gracefully(&mut self) {
         self.shutdown_token.cancel();
         self.notified.notify_waiters();
-        if let Some(handle) = self.worker_handle.take() {
-            await_worker("FlushRealTimeService", handle).await;
-        }
+        shutdown_worker_gracefully("FlushRealTimeService", &mut self.worker_group).await;
     }
 }
 
@@ -457,7 +473,7 @@ pub(crate) struct CommitRealTimeService {
     notified: Arc<Notify>,
     flush_manager: Option<WeakArcMut<DefaultFlushManager>>,
     shutdown_token: CancellationToken,
-    worker_handle: Option<JoinHandle<()>>,
+    worker_group: Option<TaskGroup>,
 }
 
 impl CommitRealTimeService {
@@ -466,17 +482,24 @@ impl CommitRealTimeService {
     }
 
     fn start(&mut self, mapped_file_queue: ArcMut<MappedFileQueue>) {
-        if self.worker_handle.is_some() {
+        if self.worker_group.is_some() {
             return;
         }
 
+        let worker_group = match crate::runtime::task_group("rocketmq-store.commit-log.commit-real-time") {
+            Ok(worker_group) => worker_group,
+            Err(error) => {
+                warn!("CommitRealTimeService cannot start because task group creation failed: {error}");
+                return;
+            }
+        };
         self.shutdown_token = CancellationToken::new();
         let message_store_config = self.message_store_config.clone();
         let store_checkpoint = self.store_checkpoint.clone();
         let notified = self.notified.clone();
         let flush_manager = self.flush_manager.clone();
         let shutdown_token = self.shutdown_token.clone();
-        self.worker_handle = Some(tokio::spawn(async move {
+        if let Err(error) = worker_group.spawn_service("commit-log-commit-real-time", async move {
             let mut last_commit_timestamp = 0;
             loop {
                 if shutdown_token.is_cancelled() {
@@ -524,23 +547,23 @@ impl CommitRealTimeService {
                     }
                 }
             }
-        }));
+        }) {
+            warn!("CommitRealTimeService cannot start because task spawn failed: {error}");
+            return;
+        }
+        self.worker_group = Some(worker_group);
     }
 
     pub fn shutdown(&mut self) {
         self.shutdown_token.cancel();
         self.notified.notify_waiters();
-        if let Some(handle) = self.worker_handle.take() {
-            handle.abort();
-        }
+        shutdown_worker_now("CommitRealTimeService", &mut self.worker_group);
     }
 
     pub async fn shutdown_gracefully(&mut self) {
         self.shutdown_token.cancel();
         self.notified.notify_waiters();
-        if let Some(handle) = self.worker_handle.take() {
-            await_worker("CommitRealTimeService", handle).await;
-        }
+        shutdown_worker_gracefully("CommitRealTimeService", &mut self.worker_group).await;
     }
 
     pub fn set_flush_manager(&mut self, flush_manager: WeakArcMut<DefaultFlushManager>) {
@@ -548,10 +571,20 @@ impl CommitRealTimeService {
     }
 }
 
-async fn await_worker(service_name: &str, handle: JoinHandle<()>) {
-    if let Err(error) = handle.await {
-        if !error.is_cancelled() {
-            warn!("{service_name} task failed during shutdown: {error}");
+fn shutdown_worker_now(service_name: &'static str, worker_group: &mut Option<TaskGroup>) {
+    if let Some(worker_group) = worker_group.take() {
+        let report = worker_group.shutdown_now();
+        if let Err(error) = crate::runtime::shutdown_report_result(service_name, report) {
+            warn!("{service_name} task group failed during immediate shutdown: {error}");
+        }
+    }
+}
+
+async fn shutdown_worker_gracefully(service_name: &'static str, worker_group: &mut Option<TaskGroup>) {
+    if let Some(worker_group) = worker_group.take() {
+        let report = worker_group.shutdown(Duration::from_secs(5)).await;
+        if let Err(error) = crate::runtime::shutdown_report_result(service_name, report) {
+            warn!("{service_name} task group failed during graceful shutdown: {error}");
         }
     }
 }
@@ -720,14 +753,14 @@ mod tests {
             notified: Arc::new(Notify::new()),
             tx_in: None,
             shutdown_token: CancellationToken::new(),
-            worker_handle: None,
+            worker_group: None,
         };
         service.start(mapped_file_queue);
 
         let (request, response) = GroupCommitRequest::new(1, 0);
         assert!(service.put_request(request).await);
         service.shutdown_gracefully().await;
-        assert!(service.worker_handle.is_none());
+        assert!(service.worker_group.is_none());
 
         let status = time::timeout(time::Duration::from_secs(1), response)
             .await
@@ -749,14 +782,14 @@ mod tests {
             store_checkpoint,
             notified: Arc::new(Notify::new()),
             shutdown_token: CancellationToken::new(),
-            worker_handle: None,
+            worker_group: None,
         };
 
         service.start(mapped_file_queue);
-        assert!(service.worker_handle.is_some());
+        assert!(service.worker_group.is_some());
 
         service.shutdown_gracefully().await;
 
-        assert!(service.worker_handle.is_none());
+        assert!(service.worker_group.is_none());
     }
 }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -36,11 +36,9 @@ use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
-use std::sync::mpsc;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::sync::RwLock as StdRwLock;
-use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -95,7 +93,6 @@ use rocketmq_tieredstore::TieredMessageFetcher;
 use rocketmq_tieredstore::TieredStore;
 use tokio::sync::Mutex;
 use tokio::sync::Notify;
-use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
@@ -344,7 +341,7 @@ pub struct LocalFileMessageStore {
     flush_consume_queue_service: FlushConsumeQueueService,
     scheduled_task_shutdown: CancellationToken,
     scheduled_task_group: Option<rocketmq_runtime::TaskGroup>,
-    ha_update_master_handles: Arc<StdMutex<Vec<JoinHandle<()>>>>,
+    ha_update_master_group: Arc<StdMutex<Option<rocketmq_runtime::TaskGroup>>>,
     delay_level_table: ArcMut<BTreeMap<i32 /* level */, i64 /* delay timeMillis */>>,
     max_delay_level: i32,
 }
@@ -577,7 +574,7 @@ impl LocalFileMessageStore {
             ),
             scheduled_task_shutdown: CancellationToken::new(),
             scheduled_task_group: None,
-            ha_update_master_handles: Arc::new(StdMutex::new(Vec::new())),
+            ha_update_master_group: Arc::new(StdMutex::new(None)),
             delay_level_table: ArcMut::new(delay_level_table),
             max_delay_level,
         })
@@ -1446,24 +1443,18 @@ impl LocalFileMessageStore {
     }
 
     async fn shutdown_ha_update_master_tasks(&self) {
-        let handles = match self.ha_update_master_handles.lock() {
-            Ok(mut handles) => handles.drain(..).collect::<Vec<_>>(),
+        let task_group = match self.ha_update_master_group.lock() {
+            Ok(mut task_group) => task_group.take(),
             Err(error) => {
-                error!("failed to drain HA master address update tasks during shutdown: {error}");
+                error!("failed to take HA master address update task group during shutdown: {error}");
                 return;
             }
         };
 
-        for handle in handles {
-            match tokio::time::timeout(Duration::from_secs(3), handle).await {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) if error.is_cancelled() => {}
-                Ok(Err(error)) => {
-                    error!("HA master address update task failed during shutdown: {error}");
-                }
-                Err(_) => {
-                    warn!("Timed out waiting for HA master address update task to stop");
-                }
+        if let Some(task_group) = task_group {
+            let report = task_group.shutdown(Duration::from_secs(3)).await;
+            if let Err(error) = crate::runtime::shutdown_report_result("HA master address update tasks", report) {
+                error!("HA master address update task failed during shutdown: {error}");
             }
         }
     }
@@ -1878,7 +1869,7 @@ impl MessageStore for LocalFileMessageStore {
             if let Some(timer_message_store) = self.timer_message_store.as_ref() {
                 timer_message_store.shutdown_gracefully().await;
             }
-            self.flush_consume_queue_service.shutdown();
+            self.flush_consume_queue_service.shutdown().await;
             self.allocate_mapped_file_service.shutdown().await;
             if let Some(store_checkpoint) = self.store_checkpoint.as_ref() {
                 let _ = store_checkpoint.shutdown();
@@ -2759,22 +2750,29 @@ impl MessageStore for LocalFileMessageStore {
     fn update_master_address(&self, new_addr: &CheetahString) {
         if let Some(ha_service) = self.ha_service.as_ref().cloned() {
             let new_addr = new_addr.clone();
-            let Ok(runtime_handle) = tokio::runtime::Handle::try_current() else {
-                error!("failed to update HA master address: no Tokio runtime is available");
-                return;
-            };
-            let handle = runtime_handle.spawn(async move {
-                ha_service.update_master_address(new_addr.as_str()).await;
-            });
-            match self.ha_update_master_handles.lock() {
-                Ok(mut handles) => {
-                    handles.retain(|handle| !handle.is_finished());
-                    handles.push(handle);
+            let task_group = match self.ha_update_master_group.lock() {
+                Ok(mut task_group) => {
+                    if task_group.is_none() {
+                        match crate::runtime::task_group("rocketmq-store.local-file.ha-master-update") {
+                            Ok(group) => *task_group = Some(group),
+                            Err(error) => {
+                                error!("failed to create HA master address update task group: {error}");
+                                return;
+                            }
+                        }
+                    }
+                    task_group.as_ref().expect("task group must exist").clone()
                 }
                 Err(error) => {
-                    error!("failed to track HA master address update task: {error}");
-                    handle.abort();
+                    error!("failed to lock HA master address update task group: {error}");
+                    return;
                 }
+            };
+
+            if let Err(error) = task_group.spawn_service("ha-master-address-update", async move {
+                ha_service.update_master_address(new_addr.as_str()).await;
+            }) {
+                error!("failed to spawn HA master address update task: {error}");
             }
         }
     }
@@ -4269,8 +4267,9 @@ struct FlushConsumeQueueService {
     message_store_config: Arc<MessageStoreConfig>,
     consume_queue_store: ConsumeQueueStore,
     store_checkpoint: Arc<StoreCheckpoint>,
-    worker_handle: parking_lot::Mutex<Option<thread::JoinHandle<()>>>,
-    shutdown_tx: parking_lot::Mutex<Option<mpsc::Sender<()>>>,
+    worker_group: parking_lot::Mutex<Option<rocketmq_runtime::TaskGroup>>,
+    shutdown_token: parking_lot::Mutex<CancellationToken>,
+    wakeup: Arc<Notify>,
 }
 
 impl FlushConsumeQueueService {
@@ -4283,12 +4282,17 @@ impl FlushConsumeQueueService {
             message_store_config,
             consume_queue_store,
             store_checkpoint,
-            worker_handle: parking_lot::Mutex::new(None),
-            shutdown_tx: parking_lot::Mutex::new(None),
+            worker_group: parking_lot::Mutex::new(None),
+            shutdown_token: parking_lot::Mutex::new(CancellationToken::new()),
+            wakeup: Arc::new(Notify::new()),
         }
     }
 
-    fn flush_once(consume_queue_store: &ConsumeQueueStore, store_checkpoint: &StoreCheckpoint, flush_least_pages: i32) {
+    fn flush_once_blocking(
+        consume_queue_store: &ConsumeQueueStore,
+        store_checkpoint: &StoreCheckpoint,
+        flush_least_pages: i32,
+    ) {
         let consume_queue_table = consume_queue_store.get_consume_queue_table().lock().clone();
         for consume_queue_table in consume_queue_table.values() {
             for consume_queue in consume_queue_table.values() {
@@ -4301,65 +4305,86 @@ impl FlushConsumeQueueService {
         }
     }
 
+    async fn flush_once(
+        consume_queue_store: ConsumeQueueStore,
+        store_checkpoint: Arc<StoreCheckpoint>,
+        flush_least_pages: i32,
+    ) {
+        if let Err(error) = crate::runtime::spawn_io("flush-consume-queue", move || {
+            Self::flush_once_blocking(&consume_queue_store, &store_checkpoint, flush_least_pages);
+        })
+        .await
+        {
+            error!("flush consume queue service task failed: {error}");
+        }
+    }
+
     fn start(&self) {
-        let mut worker_handle = self.worker_handle.lock();
-        if worker_handle.is_some() {
+        let mut worker_group = self.worker_group.lock();
+        if worker_group.is_some() {
             return;
         }
 
-        let (shutdown_tx, shutdown_rx) = mpsc::channel();
-        *self.shutdown_tx.lock() = Some(shutdown_tx);
+        let group = match crate::runtime::task_group("rocketmq-store.flush-consume-queue") {
+            Ok(group) => group,
+            Err(error) => {
+                error!("failed to start flush consume queue service: {error}");
+                return;
+            }
+        };
 
         let message_store_config = self.message_store_config.clone();
         let consume_queue_store = self.consume_queue_store.clone();
         let store_checkpoint = self.store_checkpoint.clone();
+        let shutdown_token = CancellationToken::new();
+        *self.shutdown_token.lock() = shutdown_token.clone();
+        let wakeup = self.wakeup.clone();
 
-        match thread::Builder::new()
-            .name("flush-consume-queue".to_string())
-            .spawn(move || {
-                let interval = message_store_config.flush_interval_consume_queue.max(1) as u64;
-                let thorough_interval = message_store_config.flush_consume_queue_thorough_interval as u64;
-                let default_least_pages = message_store_config.flush_consume_queue_least_pages as i32;
-                let mut last_thorough_flush_timestamp = current_millis();
+        match group.spawn_service("flush-consume-queue", async move {
+            let interval = message_store_config.flush_interval_consume_queue.max(1) as u64;
+            let thorough_interval = message_store_config.flush_consume_queue_thorough_interval as u64;
+            let default_least_pages = message_store_config.flush_consume_queue_least_pages as i32;
+            let mut last_thorough_flush_timestamp = current_millis();
 
-                loop {
-                    let now = current_millis();
-                    let flush_least_pages =
-                        if thorough_interval == 0 || now >= last_thorough_flush_timestamp + thorough_interval {
-                            last_thorough_flush_timestamp = now;
-                            0
-                        } else {
-                            default_least_pages
-                        };
+            loop {
+                let now = current_millis();
+                let flush_least_pages =
+                    if thorough_interval == 0 || now >= last_thorough_flush_timestamp + thorough_interval {
+                        last_thorough_flush_timestamp = now;
+                        0
+                    } else {
+                        default_least_pages
+                    };
 
-                    Self::flush_once(&consume_queue_store, &store_checkpoint, flush_least_pages);
+                Self::flush_once(consume_queue_store.clone(), store_checkpoint.clone(), flush_least_pages).await;
 
-                    match shutdown_rx.recv_timeout(Duration::from_millis(interval)) {
-                        Ok(_) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
-                        Err(mpsc::RecvTimeoutError::Timeout) => {}
-                    }
+                tokio::select! {
+                    _ = shutdown_token.cancelled() => break,
+                    _ = wakeup.notified() => {}
+                    _ = tokio::time::sleep(Duration::from_millis(interval)) => {}
                 }
+            }
 
-                Self::flush_once(&consume_queue_store, &store_checkpoint, 0);
-            }) {
-            Ok(handle) => {
-                *worker_handle = Some(handle);
+            Self::flush_once(consume_queue_store, store_checkpoint, 0).await;
+        }) {
+            Ok(_) => {
+                *worker_group = Some(group);
             }
             Err(error) => {
-                error!("failed to start flush consume queue service thread: {error}");
-                let _ = self.shutdown_tx.lock().take();
+                error!("failed to start flush consume queue service task: {error}");
             }
         }
     }
 
-    fn shutdown(&self) {
-        if let Some(shutdown_tx) = self.shutdown_tx.lock().take() {
-            let _ = shutdown_tx.send(());
-        }
+    async fn shutdown(&self) {
+        self.shutdown_token.lock().cancel();
+        self.wakeup.notify_waiters();
 
-        if let Some(worker_handle) = self.worker_handle.lock().take() {
-            if worker_handle.join().is_err() {
-                error!("flush consume queue service thread panicked during shutdown");
+        let worker_group = self.worker_group.lock().take();
+        if let Some(worker_group) = worker_group {
+            let report = worker_group.shutdown(Duration::from_secs(5)).await;
+            if let Err(error) = crate::runtime::shutdown_report_result("FlushConsumeQueueService", report) {
+                error!("flush consume queue service task failed during shutdown: {error}");
             }
         }
     }
@@ -5717,8 +5742,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn flush_consume_queue_service_start_persists_logic_checkpoint_to_disk() {
+    #[tokio::test]
+    async fn flush_consume_queue_service_start_persists_logic_checkpoint_to_disk() {
         let temp_dir = tempdir().unwrap();
         let mut store = ArcMut::new(LocalFileMessageStore::new(
             Arc::new(MessageStoreConfig {
@@ -5768,10 +5793,10 @@ mod tests {
                 Instant::now() < deadline,
                 "flush consume queue service did not persist checkpoint in time"
             );
-            thread::sleep(Duration::from_millis(20));
+            tokio::time::sleep(Duration::from_millis(20)).await;
         }
 
-        store.flush_consume_queue_service.shutdown();
+        store.flush_consume_queue_service.shutdown().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #7497

## Summary

- Track HA client workers, HA master update tasks, consume queue flush, namesrv route/bootstrap tasks, remoting connection cleanup/writer/channel tasks through runtime task groups.
- Add immediate task group shutdown support for synchronous teardown paths.
- Move the minimal non-recursive task group child storage fix into this PR so the staged branch remains independently clippy-clean.

## Validation

- Root workspace format check passed.
- Root workspace clippy passed with all targets, all features, no dependencies, and warnings denied.
- Example standalone format and clippy checks passed.
- Tauri backend standalone format and all-features clippy checks passed.
- Web dashboard backend standalone format, all-features clippy, and all-features build checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `boot_with_shutdown()` method for deterministic NameServer shutdown coordination.
  * Added immediate shutdown capability for background task groups.

* **Improvements**
  * Optimized client idle runtime shutdown from per-request scheduling to centralized background reaper thread.
  * Unified task lifecycle management across NameServer, connection pool, and storage services for consistent shutdown behavior and resource cleanup.
  * Enhanced client runtime metrics: added acquire count, created/reused, and idle reaper start tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->