### PR TITLE
[ISSUE #7498]♻️ Avoid recursive task group child map

### DIFF
--- a/rocketmq-broker/src/client/client_housekeeping_service.rs
+++ b/rocketmq-broker/src/client/client_housekeeping_service.rs
@@ -12,20 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use parking_lot::Mutex;
 use rocketmq_remoting::base::channel_event_listener::ChannelEventListener;
 use rocketmq_remoting::net::channel::Channel;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskGroupLifecycleState;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use tokio::select;
 use tokio::sync::Notify;
+use tracing::debug;
+use tracing::warn;
 
 use crate::broker_runtime::BrokerRuntimeInner;
 
 pub struct ClientHousekeepingService<MS: MessageStore> {
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     shutdown: Arc<Notify>,
+    shutdown_requested: Arc<AtomicBool>,
+    task_group: Arc<Mutex<Option<TaskGroup>>>,
 }
 
 impl<MS: MessageStore> Clone for ClientHousekeepingService<MS> {
@@ -33,6 +43,8 @@ impl<MS: MessageStore> Clone for ClientHousekeepingService<MS> {
         Self {
             broker_runtime_inner: self.broker_runtime_inner.clone(),
             shutdown: self.shutdown.clone(),
+            shutdown_requested: self.shutdown_requested.clone(),
+            task_group: self.task_group.clone(),
         }
     }
 }
@@ -45,16 +57,36 @@ where
         Self {
             broker_runtime_inner,
             shutdown: Arc::new(Notify::new()),
+            shutdown_requested: Arc::new(AtomicBool::new(false)),
+            task_group: Arc::new(Mutex::new(None)),
         }
     }
 
     pub fn start(&self) {
+        if self.shutdown_requested.load(Ordering::Acquire) {
+            debug!("Broker client housekeeping service is already shutting down");
+            return;
+        }
+
+        let Some(task_group) = self.task_group() else {
+            return;
+        };
+
+        if task_group.task_count() > 0 {
+            debug!("Broker client housekeeping service is already running");
+            return;
+        }
+
         let broker_runtime_inner = self.clone();
         let shutdown = self.shutdown.clone();
-        tokio::spawn(async move {
+        let cancellation_token = task_group.cancellation_token();
+        if let Err(error) = task_group.spawn_service("broker.client-housekeeping.scan", async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(10_000));
             loop {
                 select! {
+                    _ = cancellation_token.cancelled() => {
+                        break;
+                    }
                     _ = interval.tick() => {
                         broker_runtime_inner.scan_exception_channel();
                     }
@@ -63,16 +95,51 @@ where
                     }
                 }
             }
-        });
+        }) {
+            warn!(?error, "failed to spawn broker client housekeeping task");
+        }
     }
 
     pub fn shutdown(&self) {
+        self.shutdown_requested.store(true, Ordering::Release);
         self.shutdown.notify_waiters();
+        if let Some(task_group) = self.task_group.lock().take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "Broker client housekeeping task shutdown report is unhealthy"
+                );
+            }
+        }
     }
 
     fn scan_exception_channel(&self) {
         self.broker_runtime_inner.producer_manager().scan_not_active_channel();
         self.broker_runtime_inner.consumer_manager().scan_not_active_channel();
+    }
+
+    fn task_group(&self) -> Option<TaskGroup> {
+        let mut task_group = self.task_group.lock();
+        if let Some(group) = task_group.as_ref() {
+            if group.lifecycle_state() == TaskGroupLifecycleState::Open {
+                return Some(group.clone());
+            }
+        }
+
+        let handle = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => handle,
+            Err(error) => {
+                warn!(
+                    ?error,
+                    "failed to start broker client housekeeping outside Tokio runtime"
+                );
+                return None;
+            }
+        };
+        let group = TaskGroup::root("rocketmq-broker.client-housekeeping", RuntimeHandle::new(handle));
+        *task_group = Some(group.clone());
+        Some(group)
     }
 }
 

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -27,12 +27,12 @@ use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use tokio::sync::oneshot;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
-use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
-use tokio_util::sync::CancellationToken;
 use tracing::info;
 use tracing::warn;
 
@@ -353,8 +353,7 @@ impl FastFailureQueues {
 
 #[derive(Default)]
 struct FastFailureLifecycle {
-    cancel: Option<CancellationToken>,
-    handle: Option<JoinHandle<()>>,
+    task_group: Option<TaskGroup>,
 }
 
 struct BrokerFastFailureInner {
@@ -414,10 +413,20 @@ impl BrokerFastFailure {
             return;
         }
 
-        let cancel = CancellationToken::new();
-        let cancel_for_task = cancel.clone();
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                self.inner.running.store(false, Ordering::Release);
+                warn!(?error, "failed to start BrokerFastFailure outside Tokio runtime");
+                return;
+            }
+        };
+        let task_group = TaskGroup::root("rocketmq-broker.fast-failure", runtime);
+        let cancel_for_task = task_group.cancellation_token();
         let this = self.clone();
-        let handle = tokio::spawn(async move {
+        let mut lifecycle = self.inner.lifecycle.lock();
+
+        if let Err(error) = task_group.spawn_service("broker.fast-failure.scan", async move {
             tokio::select! {
                 _ = cancel_for_task.cancelled() => {
                     this.inner.running.store(false, Ordering::Release);
@@ -442,22 +451,27 @@ impl BrokerFastFailure {
                     }
                 }
             }
-        });
+        }) {
+            self.inner.running.store(false, Ordering::Release);
+            warn!(?error, "failed to spawn BrokerFastFailure scan task");
+            return;
+        }
 
-        let mut lifecycle = self.inner.lifecycle.lock();
-        lifecycle.cancel = Some(cancel);
-        lifecycle.handle = Some(handle);
+        lifecycle.task_group = Some(task_group);
         info!("BrokerFastFailure started");
     }
 
     pub(crate) fn shutdown(&self) {
         self.inner.running.store(false, Ordering::Release);
         let mut lifecycle = self.inner.lifecycle.lock();
-        if let Some(cancel) = lifecycle.cancel.take() {
-            cancel.cancel();
-        }
-        if let Some(handle) = lifecycle.handle.take() {
-            handle.abort();
+        if let Some(task_group) = lifecycle.task_group.take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "BrokerFastFailure shutdown report is unhealthy"
+                );
+            }
         }
         info!("BrokerFastFailure shutdown");
     }

--- a/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
+++ b/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
@@ -32,11 +32,11 @@ use rocketmq_remoting::protocol::static_topic::logic_queue_mapping_item::LogicQu
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_utils::TopicQueueMappingUtils;
 use rocketmq_remoting::rpc::client_metadata::ClientMetadata;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
-use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
-use tokio_util::sync::CancellationToken;
 use tracing::info;
 use tracing::warn;
 
@@ -48,8 +48,7 @@ const TOPIC_SCAN_YIELD_DELAY: Duration = Duration::from_millis(10);
 
 #[derive(Default)]
 struct CleanServiceLifecycle {
-    cancel: Option<CancellationToken>,
-    handle: Option<JoinHandle<()>>,
+    task_group: Option<TaskGroup>,
 }
 
 struct TopicQueueMappingCleanServiceInner<MS: MessageStore> {
@@ -91,12 +90,25 @@ impl<MS: MessageStore> TopicQueueMappingCleanService<MS> {
             return;
         }
 
-        let cancel = CancellationToken::new();
-        let cancel_for_task = cancel.clone();
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                self.inner.running.store(false, Ordering::Release);
+                warn!(
+                    ?error,
+                    "failed to start TopicQueueMappingCleanService outside Tokio runtime"
+                );
+                return;
+            }
+        };
+        let task_group = TaskGroup::root("rocketmq-broker.topic-queue-mapping-clean", runtime);
+        let cancel_for_task = task_group.cancellation_token();
         let this = Self {
             inner: Arc::clone(&self.inner),
         };
-        let handle = tokio::spawn(async move {
+        let mut lifecycle = self.inner.lifecycle.lock();
+
+        if let Err(error) = task_group.spawn_service("broker.topic-queue-mapping-clean.scan", async move {
             tokio::select! {
                 _ = cancel_for_task.cancelled() => {
                     this.inner.running.store(false, Ordering::Release);
@@ -121,22 +133,27 @@ impl<MS: MessageStore> TopicQueueMappingCleanService<MS> {
                     }
                 }
             }
-        });
+        }) {
+            self.inner.running.store(false, Ordering::Release);
+            warn!(?error, "failed to spawn TopicQueueMappingCleanService scan task");
+            return;
+        }
 
-        let mut lifecycle = self.inner.lifecycle.lock();
-        lifecycle.cancel = Some(cancel);
-        lifecycle.handle = Some(handle);
+        lifecycle.task_group = Some(task_group);
         info!("TopicQueueMappingCleanService started");
     }
 
     pub fn shutdown(&self) {
         self.inner.running.store(false, Ordering::Release);
         let mut lifecycle = self.inner.lifecycle.lock();
-        if let Some(cancel) = lifecycle.cancel.take() {
-            cancel.cancel();
-        }
-        if let Some(handle) = lifecycle.handle.take() {
-            handle.abort();
+        if let Some(task_group) = lifecycle.task_group.take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "TopicQueueMappingCleanService shutdown report is unhealthy"
+                );
+            }
         }
         info!("TopicQueueMappingCleanService shutdown");
     }

--- a/rocketmq-remoting/src/clients/client.rs
+++ b/rocketmq-remoting/src/clients/client.rs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use rocketmq_common::common::tls_config::TlsConfig;
 use rocketmq_error::RocketMQResult;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use tokio::net::TcpStream;
 use tokio::sync::broadcast;
@@ -56,6 +59,7 @@ pub struct Client<PR> {
     inner: ArcMut<ClientInner<PR>>,
     notify_shutdown: broadcast::Sender<()>,
     tx: tokio::sync::mpsc::Sender<SendMessage>,
+    task_lifecycle: Arc<ClientTaskLifecycle>,
 }
 
 type SendMessage = (
@@ -70,6 +74,27 @@ struct ClientInner<PR> {
     shutdown: Shutdown,
 }
 
+struct ClientTaskLifecycle {
+    task_group: TaskGroup,
+}
+
+impl<PR> Drop for Client<PR> {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.task_lifecycle) != 1 {
+            return;
+        }
+
+        let _ = self.notify_shutdown.send(());
+        let report = self.task_lifecycle.task_group.shutdown_now();
+        if !report.is_healthy() {
+            tracing::warn!(
+                report = %report.to_json(),
+                "Remoting client connection task shutdown report is unhealthy"
+            );
+        }
+    }
+}
+
 impl<PR> ClientInner<PR>
 where
     PR: RequestProcessor + Sync + 'static,
@@ -80,6 +105,7 @@ where
         tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
         notify: broadcast::Receiver<()>,
         tls_config: TlsConfig,
+        task_group: TaskGroup,
     ) -> RocketMQResult<(tokio::sync::mpsc::Sender<SendMessage>, ArcMut<ClientInner<PR>>)> {
         let stream = TcpStream::connect(addr.as_str()).await.map_err(io_error)?;
         let local_addr = stream.local_addr()?;
@@ -116,13 +142,23 @@ where
         };
         let client_inner = ArcMut::new(client);
         let mut client_ = client_inner.clone();
-        tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("remoting.client.connection.recv", async move {
             let _ = client_.run_recv().await;
-        });
+        }) {
+            let _ = task_group.shutdown_now();
+            return Err(remote_error(format!(
+                "failed to spawn remoting client receive task: {error}"
+            )));
+        }
         let mut client_ = client_inner.clone();
-        tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("remoting.client.connection.send", async move {
             client_.run_send(rx).await;
-        });
+        }) {
+            let _ = task_group.shutdown_now();
+            return Err(remote_error(format!(
+                "failed to spawn remoting client send task: {error}"
+            )));
+        }
 
         if let Some(tx) = tx {
             let _ = tx.send(ConnectionNetEvent::CONNECTED(client_inner.ctx.channel.remote_address()));
@@ -211,11 +247,19 @@ where
     ) -> RocketMQResult<Client<PR>> {
         let (notify_shutdown, _) = broadcast::channel(1);
         let receiver = notify_shutdown.subscribe();
-        let (tx, inner) = ClientInner::connect(addr, cmd_handler, tx, receiver, tls_config).await?;
+        let task_group = TaskGroup::root(
+            format!("rocketmq-remoting.client.connection[{addr}]"),
+            RuntimeHandle::new(tokio::runtime::Handle::current()),
+        );
+        let task_lifecycle = Arc::new(ClientTaskLifecycle {
+            task_group: task_group.clone(),
+        });
+        let (tx, inner) = ClientInner::connect(addr, cmd_handler, tx, receiver, tls_config, task_group).await?;
         Ok(Client {
             inner,
             notify_shutdown,
             tx,
+            task_lifecycle,
         })
     }
 
@@ -443,5 +487,46 @@ mod tls_tests {
         assert_eq!(server_name_from_addr("127.0.0.1:10911"), "127.0.0.1");
         assert_eq!(server_name_from_addr("[::1]:10911"), "::1");
         assert_eq!(server_name_from_addr("::1"), "::1");
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    use rocketmq_runtime::TaskGroupLifecycleState;
+    use tokio::net::TcpListener;
+    use tokio::time;
+
+    use super::*;
+    use crate::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
+
+    #[tokio::test]
+    async fn drop_last_client_closes_connection_task_group() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.expect("accept client");
+            time::sleep(Duration::from_secs(5)).await;
+        });
+        let cmd_handler = ArcMut::new(RemotingGeneralHandler {
+            request_processor: DefaultRemotingRequestProcessor,
+            rpc_hooks: vec![],
+            response_table: ArcMut::new(HashMap::new()),
+        });
+
+        let client = Client::connect(addr.to_string(), cmd_handler, None, TlsConfig::default())
+            .await
+            .expect("connect client");
+        let task_group = client.task_lifecycle.task_group.clone();
+
+        assert_eq!(task_group.lifecycle_state(), TaskGroupLifecycleState::Open);
+        assert_eq!(task_group.task_count(), 2);
+
+        drop(client);
+
+        assert_eq!(task_group.lifecycle_state(), TaskGroupLifecycleState::Closed);
+        server.abort();
     }
 }

--- a/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
@@ -14,11 +14,16 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
+use parking_lot::Mutex;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskGroupLifecycleState;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::WeakArcMut;
 use tokio::time;
@@ -170,6 +175,12 @@ pub struct RocketmqDefaultClient<PR = DefaultRemotingRequestProcessor> {
     /// scan loops spawned in [`start()`].
     shutdown_token: CancellationToken,
 
+    /// Task group that owns long-lived background maintenance tasks.
+    background_task_group: Arc<Mutex<Option<TaskGroup>>>,
+
+    /// Task group that owns short-lived client worker tasks.
+    worker_task_group: Arc<Mutex<Option<TaskGroup>>>,
+
     /// Shared command handler (processor + response table)
     ///
     /// Arc-wrapped to share across all `Client` instances
@@ -193,6 +204,8 @@ impl<PR> Clone for RocketmqDefaultClient<PR> {
             circuit_breakers: self.circuit_breakers.clone(),
             connection_pool: self.connection_pool.clone(),
             shutdown_token: self.shutdown_token.clone(),
+            background_task_group: self.background_task_group.clone(),
+            worker_task_group: self.worker_task_group.clone(),
             cmd_handler: self.cmd_handler.clone(),
             tx: self.tx.clone(),
         }
@@ -224,6 +237,8 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
             circuit_breakers: Arc::new(DashMap::with_capacity(64)),
             connection_pool: None,
             shutdown_token: CancellationToken::new(),
+            background_task_group: Arc::new(Mutex::new(None)),
+            worker_task_group: Arc::new(Mutex::new(None)),
             cmd_handler: ArcMut::new(handler),
             tx,
         }
@@ -239,6 +254,60 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
     #[inline]
     pub fn tls_config(&self) -> &TlsConfig {
         &self.tokio_client_config.tls_config
+    }
+
+    fn get_or_create_worker_task_group(&self) -> Option<TaskGroup> {
+        if self.shutdown_token.is_cancelled() {
+            return None;
+        }
+
+        let mut task_group_guard = self.worker_task_group.lock();
+        if let Some(task_group) = task_group_guard.as_ref() {
+            if task_group.lifecycle_state() == TaskGroupLifecycleState::Open {
+                return Some(task_group.clone());
+            }
+        }
+
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                error!(
+                    ?error,
+                    "failed to create RemotingClient worker task group outside Tokio runtime"
+                );
+                return None;
+            }
+        };
+        let task_group = TaskGroup::root("rocketmq-remoting.client.workers", runtime);
+        *task_group_guard = Some(task_group.clone());
+        Some(task_group)
+    }
+
+    pub(crate) fn worker_task_group(&self) -> Option<TaskGroup> {
+        self.worker_task_group.lock().as_ref().cloned()
+    }
+
+    pub(crate) fn spawn_worker_task_with_handle<F>(
+        &self,
+        name: impl Into<Arc<str>>,
+        future: F,
+    ) -> Option<tokio::task::JoinHandle<()>>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let name = name.into();
+        let task_group = self.get_or_create_worker_task_group()?;
+        match task_group.spawn_service_with_handle(name.clone(), future) {
+            Ok((_task_id, join_handle)) => Some(join_handle),
+            Err(error) => {
+                warn!(
+                    ?error,
+                    task = %name,
+                    "failed to spawn RemotingClient worker task"
+                );
+                None
+            }
+        }
     }
 }
 
@@ -782,12 +851,36 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
 impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingService for RocketmqDefaultClient<PR> {
     async fn start(&self, this: WeakArcMut<Self>) {
         if let Some(client) = this.upgrade() {
+            let runtime = match tokio::runtime::Handle::try_current() {
+                Ok(handle) => RuntimeHandle::new(handle),
+                Err(error) => {
+                    error!(
+                        ?error,
+                        "failed to start RemotingClient background tasks outside Tokio runtime"
+                    );
+                    return;
+                }
+            };
+            let task_group = {
+                let mut task_group_guard = self.background_task_group.lock();
+                if let Some(task_group) = task_group_guard.as_ref() {
+                    if task_group.lifecycle_state() == TaskGroupLifecycleState::Open {
+                        debug!("RemotingClient background tasks are already running");
+                        return;
+                    }
+                }
+
+                let task_group = TaskGroup::root("rocketmq-remoting.client", runtime);
+                *task_group_guard = Some(task_group.clone());
+                task_group
+            };
+
             let connect_timeout_millis = self.tokio_client_config.connect_timeout_millis as u64;
             let token = self.shutdown_token.clone();
 
             let client_for_scan = client.clone();
             let scan_token = token.clone();
-            tokio::spawn(async move {
+            if let Err(error) = task_group.spawn_service("remoting.client.namesrv-scan", async move {
                 loop {
                     tokio::select! {
                         () = scan_token.cancelled() => break,
@@ -797,12 +890,14 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingService for Rocketmq
                         } => {}
                     }
                 }
-            });
+            }) {
+                error!(?error, "failed to spawn RemotingClient nameserver scan task");
+            }
 
             let channel_not_active_interval = self.tokio_client_config.channel_not_active_interval as u64;
             if channel_not_active_interval > 0 {
                 let idle_token = token.clone();
-                tokio::spawn(async move {
+                if let Err(error) = task_group.spawn_service("remoting.client.idle-scan", async move {
                     loop {
                         tokio::select! {
                             () = idle_token.cancelled() => break,
@@ -811,13 +906,33 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingService for Rocketmq
                             }
                         }
                     }
-                });
+                }) {
+                    error!(?error, "failed to spawn RemotingClient idle connection scan task");
+                }
             }
         }
     }
 
     fn shutdown(&mut self) {
         self.shutdown_token.cancel();
+        if let Some(task_group) = self.background_task_group.lock().take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "RemotingClient background task shutdown report is unhealthy"
+                );
+            }
+        }
+        if let Some(task_group) = self.worker_task_group.lock().take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "RemotingClient worker task shutdown report is unhealthy"
+                );
+            }
+        }
         self.connection_tables.clear();
         self.namesrv_addr_list.clear();
         self.available_namesrv_addr_set.clear();
@@ -1058,7 +1173,11 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
                     }
                 }
                 let addr_clone = addr.clone();
-                tokio::spawn(async move {
+                let Some(task_group) = self.get_or_create_worker_task_group() else {
+                    warn!("invokeOneway: client is shut down, skipping send to {}", addr);
+                    return;
+                };
+                if let Err(error) = task_group.spawn_service("remoting.client.oneway-send", async move {
                     match time::timeout(Duration::from_millis(timeout_millis), async move {
                         let mut request = request;
                         request.mark_oneway_rpc_ref();
@@ -1077,15 +1196,25 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
                             );
                         }
                     }
-                });
+                }) {
+                    warn!("invokeOneway: failed to spawn send task for {}: {:?}", addr, error);
+                }
             }
         }
     }
 
     fn invoke_oneway_unbounded(&self, addr: CheetahString, request: RemotingCommand) {
         let client_owner = self.clone();
+        let addr_for_spawn_error = addr.clone();
+        let Some(task_group) = self.get_or_create_worker_task_group() else {
+            tracing::debug!(
+                "invoke_oneway_unbounded: client is shut down, skipping send to {}",
+                addr
+            );
+            return;
+        };
 
-        tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("remoting.client.oneway-unbounded", async move {
             if client_owner.shutdown_token.is_cancelled() {
                 tracing::debug!(
                     "invoke_oneway_unbounded: client is shut down, skipping send to {}",
@@ -1120,7 +1249,13 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingClient for RocketmqD
             if let Err(error) = client.send(request).await {
                 tracing::warn!("invoke_oneway_unbounded: send request to {} failed: {:?}", addr, error);
             }
-        });
+        }) {
+            tracing::warn!(
+                "invoke_oneway_unbounded: failed to spawn send task for {}: {:?}",
+                addr_for_spawn_error,
+                error
+            );
+        }
     }
 
     fn is_address_reachable(&mut self, addr: &CheetahString) {
@@ -1213,6 +1348,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn start_tracks_background_tasks_with_task_group() {
+        let config = TokioClientConfig {
+            connect_timeout_millis: 10,
+            channel_not_active_interval: 10,
+            ..Default::default()
+        };
+        let client = ArcMut::new(RocketmqDefaultClient::new(
+            Arc::new(config),
+            DefaultRemotingRequestProcessor,
+        ));
+        let weak_client = ArcMut::downgrade(&client);
+
+        client.start(weak_client).await;
+
+        let task_group = client
+            .background_task_group
+            .lock()
+            .as_ref()
+            .cloned()
+            .expect("background task group");
+        assert_eq!(task_group.lifecycle_state(), TaskGroupLifecycleState::Open);
+        assert_eq!(task_group.task_count(), 2);
+
+        client.mut_from_ref().shutdown();
+
+        assert_eq!(task_group.lifecycle_state(), TaskGroupLifecycleState::Closed);
+    }
+
+    #[tokio::test]
     async fn invoke_request_runs_outbound_rpc_hooks() {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
         let addr = listener.local_addr().expect("listener addr");
@@ -1293,6 +1457,13 @@ mod tests {
         let target = CheetahString::from_string(addr.to_string());
         let request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo);
         client.invoke_oneway_unbounded(target, request);
+        let worker_task_group = client
+            .worker_task_group
+            .lock()
+            .as_ref()
+            .cloned()
+            .expect("worker task group");
+        assert_eq!(worker_task_group.lifecycle_state(), TaskGroupLifecycleState::Open);
 
         let (code, is_oneway, hooked) = time::timeout(Duration::from_secs(3), received_rx)
             .await
@@ -1307,5 +1478,6 @@ mod tests {
 
         server.await.expect("server task");
         client.shutdown();
+        assert_eq!(worker_task_group.lifecycle_state(), TaskGroupLifecycleState::Closed);
     }
 }

--- a/rocketmq-remoting/src/local.rs
+++ b/rocketmq-remoting/src/local.rs
@@ -36,11 +36,8 @@ impl LocalRequestHarness {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let server_addr = listener.local_addr()?;
 
-        let client_task = tokio::spawn(async move { tokio::net::TcpStream::connect(server_addr).await });
-        let (server_stream, _) = listener.accept().await?;
-        let client_stream = client_task.await.map_err(|error| {
-            rocketmq_error::RocketMQError::Internal(format!("failed to join local remoting client task: {error}"))
-        })??;
+        let (client_stream, (server_stream, _)) =
+            tokio::try_join!(tokio::net::TcpStream::connect(server_addr), listener.accept())?;
 
         let local_address = server_stream.local_addr()?;
         let remote_address = server_stream.peer_addr()?;

--- a/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
@@ -625,8 +625,10 @@ async fn run_with_tls_config<RP: RequestProcessor + Sync + 'static + Clone>(
     let ConnectionListener {
         shutdown_complete_tx,
         notify_shutdown,
+        tls_runtime,
         ..
     } = listener;
+    tls_runtime.shutdown();
     drop(notify_shutdown);
     drop(shutdown_complete_tx);
 

--- a/rocketmq-remoting/src/rpc/rpc_client_impl.rs
+++ b/rocketmq-remoting/src/rpc/rpc_client_impl.rs
@@ -504,19 +504,22 @@ impl RpcClientImpl {
     {
         let client_metadata = self.client_metadata.clone();
         let remoting_client = self.remoting_client.clone();
+        let remoting_client_for_task = remoting_client.clone();
         let hooks = self.client_hook_list.clone();
 
-        tokio::spawn(async move {
-            // Create a temporary client instance for the async task
-            let temp_client = RpcClientImpl {
-                client_metadata,
-                remoting_client,
-                client_hook_list: hooks,
-            };
+        remoting_client
+            .spawn_worker_task_with_handle("remoting.rpc.callback", async move {
+                // Create a temporary client instance for the async task
+                let temp_client = RpcClientImpl {
+                    client_metadata,
+                    remoting_client: remoting_client_for_task,
+                    client_hook_list: hooks,
+                };
 
-            let result = temp_client.invoke(request, timeout_millis).await;
-            callback(result);
-        })
+                let result = temp_client.invoke(request, timeout_millis).await;
+                callback(result);
+            })
+            .expect("RPC callback task should be spawned on the remoting worker task group")
     }
 }
 
@@ -526,6 +529,7 @@ mod tests {
 
     use super::*;
     use crate::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader;
+    use crate::remoting::RemotingService;
     use crate::runtime::config::client_config::TokioClientConfig;
 
     #[test]
@@ -568,5 +572,46 @@ mod tests {
             error,
             rocketmq_error::RocketMQError::Rpc(RpcClientError::BrokerNotFound { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn invoke_with_callback_uses_remoting_worker_task_group() {
+        let client_metadata = Arc::new(ClientMetadata::new());
+        let remoting_client = ArcMut::new(RocketmqDefaultClient::new(
+            Arc::new(TokioClientConfig::default()),
+            DefaultRemotingRequestProcessor,
+        ));
+        let rpc_client = RpcClientImpl::new(client_metadata, remoting_client.clone());
+        let request = RpcRequest::new(
+            RequestCode::GetMinOffset.into(),
+            GetMinOffsetRequestHeader {
+                topic: CheetahString::from_static_str("TopicA"),
+                queue_id: 0,
+                topic_request_header: None,
+            },
+            None,
+        );
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        let handle = rpc_client.invoke_with_callback(request, 3000, move |result| {
+            let _ = tx.send(result.is_err());
+        });
+
+        handle.await.expect("callback task should join");
+        assert!(rx.await.expect("callback result should be sent"));
+
+        let worker_task_group = remoting_client.worker_task_group().expect("worker task group");
+        assert_eq!(
+            worker_task_group.lifecycle_state(),
+            rocketmq_runtime::TaskGroupLifecycleState::Open
+        );
+        assert_eq!(worker_task_group.task_count(), 0);
+
+        remoting_client.mut_from_ref().shutdown();
+
+        assert_eq!(
+            worker_task_group.lifecycle_state(),
+            rocketmq_runtime::TaskGroupLifecycleState::Closed
+        );
     }
 }

--- a/rocketmq-remoting/src/tls.rs
+++ b/rocketmq-remoting/src/tls.rs
@@ -24,11 +24,17 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 #[cfg(feature = "tls")]
+use parking_lot::Mutex;
+#[cfg(feature = "tls")]
 use rocketmq_common::common::tls_config::TlsClientAuth;
 pub use rocketmq_common::common::tls_config::TlsConfig;
 pub use rocketmq_common::common::tls_config::TlsMode;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+#[cfg(feature = "tls")]
+use rocketmq_runtime::RuntimeHandle;
+#[cfg(feature = "tls")]
+use rocketmq_runtime::TaskGroup;
 use tokio::net::TcpStream;
 #[cfg(feature = "tls")]
 use tokio::time;
@@ -51,6 +57,7 @@ pub struct TlsServerRuntime {
     mode: TlsMode,
     acceptor: StdArc<TlsAcceptorSlot>,
     base_config: StdArc<TlsConfig>,
+    reload_task_group: StdArc<Mutex<Option<TaskGroup>>>,
 }
 
 #[cfg(not(feature = "tls"))]
@@ -80,6 +87,7 @@ impl TlsServerRuntime {
                 mode,
                 acceptor,
                 base_config: StdArc::new(base_config),
+                reload_task_group: StdArc::new(Mutex::new(None)),
             };
             runtime.spawn_reload_task();
             runtime
@@ -129,6 +137,21 @@ impl TlsServerRuntime {
         }
     }
 
+    pub fn shutdown(&self) {
+        #[cfg(feature = "tls")]
+        {
+            if let Some(task_group) = self.reload_task_group.lock().take() {
+                let report = task_group.shutdown_now();
+                if !report.is_healthy() {
+                    warn!(
+                        report = %report.to_json(),
+                        "TLS reload task shutdown report is unhealthy"
+                    );
+                }
+            }
+        }
+    }
+
     #[cfg(feature = "tls")]
     async fn accept_tls(&self, stream: TcpStream, remote_addr: SocketAddr) -> Option<Connection> {
         let Some(acceptor) = self.acceptor.load_full() else {
@@ -159,10 +182,24 @@ impl TlsServerRuntime {
 
         let base_config = self.base_config.clone();
         let acceptor = self.acceptor.clone();
-        tokio::spawn(async move {
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                warn!(?error, "failed to start TLS reload task outside Tokio runtime");
+                return;
+            }
+        };
+        let task_group = TaskGroup::root("rocketmq-remoting.tls", runtime);
+        let cancellation_token = task_group.cancellation_token();
+        *self.reload_task_group.lock() = Some(task_group.clone());
+
+        if let Err(error) = task_group.spawn_service("remoting.tls.reload", async move {
             let mut previous_snapshot = file_snapshot(&effective_tls_config(&base_config).watched_server_paths());
             loop {
-                time::sleep(TLS_RELOAD_POLL_INTERVAL).await;
+                tokio::select! {
+                    () = cancellation_token.cancelled() => break,
+                    () = time::sleep(TLS_RELOAD_POLL_INTERVAL) => {}
+                }
 
                 let effective_config = effective_tls_config(&base_config);
                 let paths = effective_config.watched_server_paths();
@@ -182,7 +219,9 @@ impl TlsServerRuntime {
                     }
                 }
             }
-        });
+        }) {
+            warn!(?error, "failed to spawn TLS reload task");
+        }
     }
 }
 
@@ -727,6 +766,39 @@ mod tests {
         config.protocols = Some("TLSv1.1".to_string());
         let error = configured_protocol_versions(&config).expect_err("unsupported protocols should fail");
         assert!(error.to_string().contains("tls.protocols"));
+    }
+
+    #[cfg(feature = "tls")]
+    #[tokio::test]
+    async fn tls_reload_task_shutdown_closes_task_group() {
+        let config = TlsConfig {
+            test_mode_enable: true,
+            server: rocketmq_common::common::tls_config::TlsServerConfig {
+                mode: TlsMode::Permissive,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let runtime = TlsServerRuntime::new(config);
+        let task_group = runtime
+            .reload_task_group
+            .lock()
+            .as_ref()
+            .cloned()
+            .expect("reload task group");
+
+        assert_eq!(
+            task_group.lifecycle_state(),
+            rocketmq_runtime::TaskGroupLifecycleState::Open
+        );
+        assert_eq!(task_group.task_count(), 1);
+
+        runtime.shutdown();
+
+        assert_eq!(
+            task_group.lifecycle_state(),
+            rocketmq_runtime::TaskGroupLifecycleState::Closed
+        );
     }
 
     #[cfg(feature = "tls")]

--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -211,6 +211,29 @@ impl TaskGroup {
         self.spawn(name, TaskKind::Service, future)
     }
 
+    pub fn spawn_with_handle<F>(
+        &self,
+        name: impl Into<Arc<str>>,
+        kind: TaskKind,
+        future: F,
+    ) -> RuntimeResult<(TaskId, tokio::task::JoinHandle<()>)>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.spawn_inner_with_handle(name.into(), kind, false, true, future)
+    }
+
+    pub fn spawn_service_with_handle<F>(
+        &self,
+        name: impl Into<Arc<str>>,
+        future: F,
+    ) -> RuntimeResult<(TaskId, tokio::task::JoinHandle<()>)>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.spawn_with_handle(name, TaskKind::Service, future)
+    }
+
     pub fn spawn_detached<F>(&self, name: impl Into<Arc<str>>, kind: TaskKind, future: F) -> RuntimeResult<TaskId>
     where
         F: Future<Output = ()> + Send + 'static,
@@ -247,6 +270,22 @@ impl TaskGroup {
     where
         F: Future<Output = ()> + Send + 'static,
     {
+        let (task_id, join_handle) = self.spawn_inner_with_handle(name, kind, detached, false, future)?;
+        drop(join_handle);
+        Ok(task_id)
+    }
+
+    fn spawn_inner_with_handle<F>(
+        &self,
+        name: Arc<str>,
+        kind: TaskKind,
+        detached: bool,
+        propagate_panic: bool,
+        future: F,
+    ) -> RuntimeResult<(TaskId, tokio::task::JoinHandle<()>)>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
         let _spawn_guard = self.inner.spawn_gate.lock();
         if self.inner.lifecycle_state() != TaskGroupLifecycleState::Open {
             return Err(RuntimeError::TaskGroupClosing {
@@ -275,15 +314,21 @@ impl TaskGroup {
         let token = inner.cancellation_token.clone();
         let wrapped = async move {
             let result = AssertUnwindSafe(future).catch_unwind().await;
-            let task_result = match result {
-                Ok(()) if token.is_cancelled() => TaskResult::Cancelled,
-                Ok(()) => TaskResult::Completed,
+            match result {
+                Ok(()) if token.is_cancelled() => {
+                    inner.finish_task(task_id, TaskResult::Cancelled);
+                }
+                Ok(()) => {
+                    inner.finish_task(task_id, TaskResult::Completed);
+                }
                 Err(error) => {
                     tracing::error!(task_id = task_id.as_u64(), ?error, "task panicked");
-                    TaskResult::Panicked
+                    inner.finish_task(task_id, TaskResult::Panicked);
+                    if propagate_panic {
+                        std::panic::resume_unwind(error);
+                    }
                 }
-            };
-            inner.finish_task(task_id, task_result);
+            }
         };
 
         let join_handle = if detached {
@@ -292,14 +337,13 @@ impl TaskGroup {
             self.inner.tracker.spawn_on(wrapped, self.inner.runtime.inner())
         };
         let abort_handle = join_handle.abort_handle();
-        drop(join_handle);
 
         if let Some(mut meta) = self.inner.tasks.get_mut(&task_id) {
             meta.abort_handle = Some(abort_handle);
             meta.state = TaskState::Running;
         }
 
-        Ok(task_id)
+        Ok((task_id, join_handle))
     }
 
     async fn shutdown_inner(&self, timeout: Duration) -> ShutdownReport {

--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -51,6 +51,20 @@ async fn task_group_shutdown_reports_panics() {
 }
 
 #[tokio::test]
+async fn task_group_spawn_service_with_handle_remains_tracked() {
+    let context = RuntimeContext::from_current("task-group-handle-test");
+    let group = context.root_group().child("service");
+
+    let (_task_id, handle) = group.spawn_service_with_handle("handled-task", async move {}).unwrap();
+
+    handle.await.expect("tracked task should join");
+
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+    assert_eq!(report.completed, 1);
+}
+
+#[tokio::test]
 async fn task_group_shutdown_aborts_after_timeout_without_leak() {
     let context = RuntimeContext::from_current("task-group-abort-test");
     let group = context.root_group().child("service");


### PR DESCRIPTION
Closes #7498

## Summary

- Track remoting client background scans, TLS reload, outbound connection tasks, oneway worker tasks, RPC callbacks, and related broker housekeeping tasks through runtime task groups.
- Add task group spawn-with-handle support used by remoting task ownership paths.
- Keep this PR to the remaining staged changes after the minimal non-recursive child storage fix was moved into the previous PR for independent validation.

## Validation

- Root workspace format check passed.
- Root workspace clippy passed with all targets, all features, no dependencies, and warnings denied.
- Example standalone format and clippy checks passed.
- Tauri backend standalone format and all-features clippy checks passed.
- Web dashboard backend standalone format, all-features clippy, and all-features build checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced lifecycle management for background services (broker housekeeping, fast failure detection, topic queue mapping cleanup) with improved error handling and shutdown diagnostics.
  * Better RPC callback task execution and TLS reload service reliability.
  * Improved shutdown behavior with explicit cleanup and warning logging for better observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->