### PR TITLE
[ISSUE #7499]♻️ Track topic route polling task

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[target.'cfg(all(windows, target_env = "msvc"))']
+# MSVC emits import-library status lines on stdout; nightly rustc reports them
+# through `linker_messages`, which obscures otherwise clean validation output.
+rustflags = ["-A", "linker_messages"]

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -56,6 +56,8 @@ use rocketmq_remoting::protocol::subscription::subscription_group_config::Subscr
 use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::remoting_server::rocketmq_tokio_server::RocketMQServer;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::schedule::simple_scheduler::ScheduledTaskManager;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::commit_log_dispatcher::CommitLogDispatcher;
@@ -390,6 +392,7 @@ pub(crate) struct BrokerRuntime {
     proxy_request_processor: Option<DefaultServerProcessor>,
     consumer_ids_change_listener: Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static>,
     scheduled_task_manager: ScheduledTaskManager,
+    remoting_server_task_group: Option<TaskGroup>,
 }
 
 impl Drop for BrokerRuntime {
@@ -571,6 +574,7 @@ impl BrokerRuntime {
             proxy_request_processor: None,
             consumer_ids_change_listener,
             scheduled_task_manager,
+            remoting_server_task_group: None,
         }
     }
 
@@ -642,6 +646,8 @@ impl BrokerRuntime {
             hook.before_shutdown();
         }
 
+        self.shutdown_remoting_servers().await;
+
         if let Some(auth_runtime) = self.inner.auth_runtime.take() {
             if let Err(error) = auth_runtime.shutdown().await {
                 warn!("Failed to shutdown auth runtime: {error}");
@@ -664,15 +670,15 @@ impl BrokerRuntime {
         }
 
         if let Some(pop_message_processor) = self.inner.pop_message_processor.as_mut() {
-            pop_message_processor.shutdown();
+            pop_message_processor.shutdown().await;
         }
 
         if let Some(pop_lite_message_processor) = self.inner.pop_lite_message_processor.as_mut() {
-            pop_lite_message_processor.shutdown();
+            pop_lite_message_processor.shutdown().await;
         }
 
         if let Some(ack_message_processor) = self.inner.ack_message_processor.as_mut() {
-            ack_message_processor.shutdown();
+            ack_message_processor.shutdown().await;
         }
 
         if let Some(transactional_message_service) = self.inner.transactional_message_service.as_mut() {
@@ -680,7 +686,7 @@ impl BrokerRuntime {
         }
 
         if let Some(notification_processor) = self.inner.notification_processor.as_mut() {
-            notification_processor.shutdown();
+            notification_processor.shutdown().await;
         }
         self.consumer_ids_change_listener.shutdown();
         if let Some(topic_queue_mapping_clean_service) = self.inner.topic_queue_mapping_clean_service.as_ref() {
@@ -761,6 +767,20 @@ impl BrokerRuntime {
             {
                 warn!("Timed out shutting down message store");
             }
+        }
+    }
+
+    async fn shutdown_remoting_servers(&mut self) {
+        let Some(task_group) = self.remoting_server_task_group.take() else {
+            return;
+        };
+
+        let report = task_group.shutdown(Duration::from_secs(35)).await;
+        if !report.is_healthy() {
+            warn!(
+                report = %report.to_json(),
+                "Broker remoting server shutdown report is unhealthy"
+            );
         }
     }
 }
@@ -1696,6 +1716,15 @@ impl BrokerRuntime {
         let (request_processor, fast_request_processor) = self.init_processor();
         self.proxy_request_processor = Some(request_processor.clone());
 
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                warn!(?error, "failed to start broker remoting servers outside Tokio runtime");
+                return;
+            }
+        };
+        let remoting_server_task_group = TaskGroup::root("rocketmq-broker.remoting-server", runtime);
+
         let mut server = RocketMQServer::new(Arc::new(self.inner.broker_config.broker_server_config.clone()));
         //start nomarl broker remoting_server
         let client_housekeeping_service_main = self
@@ -1704,16 +1733,31 @@ impl BrokerRuntime {
             .clone()
             .map(|item| item as Arc<dyn ChannelEventListener>);
         let client_housekeeping_service_fast = client_housekeeping_service_main.clone();
-        tokio::spawn(async move { server.run(request_processor, client_housekeeping_service_main).await });
+        let shutdown_token = remoting_server_task_group.cancellation_token();
+        if let Err(error) = remoting_server_task_group.spawn_service("broker.remoting-server.normal", async move {
+            server
+                .run_with_shutdown(request_processor, client_housekeeping_service_main, async move {
+                    shutdown_token.cancelled().await;
+                })
+                .await
+        }) {
+            warn!(?error, "failed to spawn broker normal remoting server task");
+        }
         //start fast broker remoting_server
         let mut fast_server_config = self.inner.broker_config.broker_server_config.clone();
         fast_server_config.listen_port = self.inner.broker_config.broker_server_config.listen_port - 2;
         let mut fast_server = RocketMQServer::new(Arc::new(fast_server_config));
-        tokio::spawn(async move {
+        let shutdown_token = remoting_server_task_group.cancellation_token();
+        if let Err(error) = remoting_server_task_group.spawn_service("broker.remoting-server.fast", async move {
             fast_server
-                .run(fast_request_processor, client_housekeeping_service_fast)
+                .run_with_shutdown(fast_request_processor, client_housekeeping_service_fast, async move {
+                    shutdown_token.cancelled().await;
+                })
                 .await
-        });
+        }) {
+            warn!(?error, "failed to spawn broker fast remoting server task");
+        }
+        self.remoting_server_task_group = Some(remoting_server_task_group);
 
         if let Some(pop_message_processor) = self.inner.pop_message_processor.as_mut() {
             pop_message_processor.start();
@@ -7424,7 +7468,8 @@ accounts:
             .pop_lite_message_processor
             .as_mut()
             .expect("pop lite processor should be initialized")
-            .shutdown();
+            .shutdown()
+            .await;
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 
@@ -7521,7 +7566,8 @@ accounts:
             .pop_lite_message_processor
             .as_mut()
             .expect("pop lite processor should be initialized")
-            .shutdown();
+            .shutdown()
+            .await;
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use crossbeam_skiplist::SkipSet;
 use dashmap::DashMap;
+use parking_lot::Mutex;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use tokio::select;
@@ -29,7 +35,9 @@ use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::Notify;
+use tokio::task::JoinHandle;
 use tracing::error;
+use tracing::warn;
 
 use crate::broker_runtime::BrokerRuntimeInner;
 use crate::long_polling::polling_result::PollingResult;
@@ -43,6 +51,9 @@ pub(crate) struct PopLiteLongPollingService<MS: MessageStore, RP> {
     notify: Notify,
     wakeup_tx: UnboundedSender<CheetahString>,
     wakeup_rx: Option<UnboundedReceiver<CheetahString>>,
+    running: AtomicBool,
+    task_group: Mutex<Option<TaskGroup>>,
+    main_task: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPollingService<MS, RP> {
@@ -56,23 +67,51 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
             notify: Notify::new(),
             wakeup_tx,
             wakeup_rx: Some(wakeup_rx),
+            running: AtomicBool::new(false),
+            task_group: Mutex::new(None),
+            main_task: Mutex::new(None),
         }
     }
 
     pub(crate) fn start(this: ArcMut<Self>) {
-        let mut wakeup_rx = this
-            .mut_from_ref()
-            .wakeup_rx
-            .take()
-            .expect("pop-lite long polling receiver should only be taken once");
-        tokio::spawn(async move {
+        if this
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                this.running.store(false, Ordering::Release);
+                warn!(
+                    ?error,
+                    "failed to start PopLiteLongPollingService outside Tokio runtime"
+                );
+                return;
+            }
+        };
+        let Some(mut wakeup_rx) = this.mut_from_ref().wakeup_rx.take() else {
+            this.running.store(false, Ordering::Release);
+            warn!("PopLiteLongPollingService receiver has already been taken");
+            return;
+        };
+
+        let task_group = TaskGroup::root("rocketmq-broker.long-polling.pop-lite", runtime);
+        let cancellation_token = task_group.cancellation_token();
+        let service = this.clone();
+
+        let spawn_result = task_group.spawn_service_with_handle("broker.long-polling.pop-lite.scan", async move {
             loop {
                 select! {
-                    _ = this.notify.notified() => { break; }
+                    _ = cancellation_token.cancelled() => { break; }
+                    _ = service.notify.notified() => { break; }
                     wakeup = wakeup_rx.recv() => {
                         match wakeup {
                             Some(client_id) => {
-                                this.wake_up_client(&client_id);
+                                service.wake_up_client(&client_id);
                             }
                             None => break,
                         }
@@ -80,10 +119,10 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
                     _ = tokio::time::sleep(tokio::time::Duration::from_millis(20)) => {}
                 }
 
-                if this.polling_map.is_empty() {
+                if service.polling_map.is_empty() {
                     continue;
                 }
-                for entry in this.polling_map.iter() {
+                for entry in service.polling_map.iter() {
                     let queue = entry.value();
                     if queue.is_empty() {
                         continue;
@@ -97,24 +136,63 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
                             queue.insert(first);
                             break;
                         }
-                        this.total_polling_num.fetch_sub(1, Ordering::AcqRel);
-                        this.wake_up(first);
+                        service.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+                        service.wake_up(first);
                     }
                 }
             }
 
-            for entry in this.polling_map.iter() {
+            for entry in service.polling_map.iter() {
                 let queue = entry.value();
                 while let Some(first) = queue.pop_front() {
-                    this.total_polling_num.fetch_sub(1, Ordering::AcqRel);
-                    this.wake_up(first.value().clone());
+                    service.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+                    service.wake_up(first.value().clone());
                 }
             }
+            service.running.store(false, Ordering::Release);
         });
+
+        let (_task_id, main_task) = match spawn_result {
+            Ok(result) => result,
+            Err(error) => {
+                this.running.store(false, Ordering::Release);
+                warn!(?error, "failed to spawn PopLiteLongPollingService scan task");
+                return;
+            }
+        };
+
+        *this.task_group.lock() = Some(task_group);
+        *this.main_task.lock() = Some(main_task);
     }
 
-    pub(crate) fn shutdown(&mut self) {
+    pub(crate) async fn shutdown(&mut self) {
         self.notify.notify_waiters();
+        let main_task = self.main_task.lock().take();
+        if let Some(mut main_task) = main_task {
+            match tokio::time::timeout(Duration::from_secs(5), &mut main_task).await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    warn!(?error, "PopLiteLongPollingService scan task failed during shutdown");
+                }
+                Err(_) => {
+                    warn!("PopLiteLongPollingService scan task did not stop before shutdown timeout");
+                    main_task.abort();
+                    let _ = main_task.await;
+                }
+            }
+        }
+
+        let task_group = self.task_group.lock().take();
+        if let Some(task_group) = task_group {
+            let report = task_group.shutdown(Duration::from_secs(5)).await;
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "PopLiteLongPollingService shutdown report is unhealthy"
+                );
+            }
+        }
+        self.running.store(false, Ordering::Release);
     }
 
     pub(crate) fn wakeup_sender(&self) -> UnboundedSender<CheetahString> {
@@ -180,26 +258,37 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
         match self.processor.clone() {
             None => false,
             Some(mut processor) => {
-                tokio::spawn(async move {
-                    let channel = pop_request.get_channel().clone();
-                    let ctx = pop_request.get_ctx().clone();
-                    let opaque = pop_request.get_remoting_command().opaque();
-                    let response = processor
-                        .process_request(channel, ctx, &mut pop_request.get_remoting_command().clone())
-                        .await;
-                    match response {
-                        Ok(result) => {
-                            if let Some(mut response) = result {
-                                let channel = pop_request.get_channel();
-                                response.set_opaque_mut(opaque);
-                                let _ = channel.channel_inner().send_oneway(response, 1000).await;
+                let task_group = self.task_group.lock().as_ref().cloned();
+                let Some(task_group) = task_group else {
+                    warn!("PopLiteLongPollingService wake-up skipped because task group is not running");
+                    return false;
+                };
+
+                let spawn_result =
+                    task_group.spawn("broker.long-polling.pop-lite.wake-up", TaskKind::Worker, async move {
+                        let channel = pop_request.get_channel().clone();
+                        let ctx = pop_request.get_ctx().clone();
+                        let opaque = pop_request.get_remoting_command().opaque();
+                        let response = processor
+                            .process_request(channel, ctx, &mut pop_request.get_remoting_command().clone())
+                            .await;
+                        match response {
+                            Ok(result) => {
+                                if let Some(mut response) = result {
+                                    let channel = pop_request.get_channel();
+                                    response.set_opaque_mut(opaque);
+                                    let _ = channel.channel_inner().send_oneway(response, 1000).await;
+                                }
+                            }
+                            Err(error) => {
+                                error!("Execute pop-lite request when wakeup run {}", error);
                             }
                         }
-                        Err(error) => {
-                            error!("Execute pop-lite request when wakeup run {}", error);
-                        }
-                    }
-                });
+                    });
+                if let Err(error) = spawn_result {
+                    warn!(?error, "failed to spawn PopLiteLongPollingService wake-up task");
+                    return false;
+                }
                 true
             }
         }

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -15,13 +15,16 @@
 #![allow(unused_variables)]
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use crossbeam_skiplist::SkipSet;
 use dashmap::DashMap;
+use parking_lot::Mutex;
 use rocketmq_common::common::key_builder::KeyBuilder;
 use rocketmq_common::common::pop_ack_constants::PopAckConstants;
 use rocketmq_common::TimeUtils::current_millis;
@@ -29,14 +32,19 @@ use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::consume_queue::cq_ext_unit::CqExtUnit;
 use rocketmq_store::filter::ArcMessageFilter;
 use tokio::select;
 use tokio::sync::Notify;
+use tokio::task::JoinHandle;
 use tracing::error;
 use tracing::info;
+use tracing::warn;
 
 use crate::broker_runtime::BrokerRuntimeInner;
 use crate::long_polling::polling_header::PollingHeader;
@@ -52,6 +60,9 @@ pub(crate) struct PopLongPollingService<MS: MessageStore, RP> {
     notify_last: bool,
     processor: Option<ArcMut<RP>>,
     notify: Notify,
+    running: AtomicBool,
+    task_group: Mutex<Option<TaskGroup>>,
+    main_task: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingService<MS, RP> {
@@ -66,21 +77,45 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
             broker_runtime_inner,
             processor: None,
             notify: Default::default(),
+            running: AtomicBool::new(false),
+            task_group: Mutex::new(None),
+            main_task: Mutex::new(None),
         }
     }
 
     pub fn start(this: ArcMut<Self>) {
-        tokio::spawn(async move {
+        if this
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                this.running.store(false, Ordering::Release);
+                warn!(?error, "failed to start PopLongPollingService outside Tokio runtime");
+                return;
+            }
+        };
+        let task_group = TaskGroup::root("rocketmq-broker.long-polling.pop", runtime);
+        let cancellation_token = task_group.cancellation_token();
+        let service = this.clone();
+
+        let spawn_result = task_group.spawn_service_with_handle("broker.long-polling.pop.scan", async move {
             loop {
                 select! {
-                    _ = this.notify.notified() => {break;}
+                    _ = cancellation_token.cancelled() => {break;}
+                    _ = service.notify.notified() => {break;}
                     _ = tokio::time::sleep(tokio::time::Duration::from_millis(20)) => {}
                 }
 
-                if this.polling_map.is_empty() {
+                if service.polling_map.is_empty() {
                     continue;
                 }
-                for entry in this.polling_map.iter() {
+                for entry in service.polling_map.iter() {
                     let key = entry.key();
                     let value = entry.value();
                     if value.is_empty() {
@@ -96,28 +131,67 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
                             value.insert(first);
                             break;
                         }
-                        this.total_polling_num.fetch_sub(1, Ordering::AcqRel);
-                        this.wake_up(first);
+                        service.total_polling_num.fetch_sub(1, Ordering::AcqRel);
+                        service.wake_up(first);
                     }
                 }
 
-                if this.last_clean_time == 0 || current_millis() - this.last_clean_time > 5 * 60 * 1000 {
-                    this.mut_from_ref().clean_unused_resource();
+                if service.last_clean_time == 0 || current_millis() - service.last_clean_time > 5 * 60 * 1000 {
+                    service.mut_from_ref().clean_unused_resource();
                 }
             }
 
             //clean all
-            for entry in this.polling_map.iter() {
+            for entry in service.polling_map.iter() {
                 let value = entry.value();
                 while let Some(first) = value.pop_front() {
-                    this.wake_up(first.value().clone());
+                    service.wake_up(first.value().clone());
                 }
             }
+            service.running.store(false, Ordering::Release);
         });
+
+        let (_task_id, main_task) = match spawn_result {
+            Ok(result) => result,
+            Err(error) => {
+                this.running.store(false, Ordering::Release);
+                warn!(?error, "failed to spawn PopLongPollingService scan task");
+                return;
+            }
+        };
+
+        *this.task_group.lock() = Some(task_group);
+        *this.main_task.lock() = Some(main_task);
     }
 
-    pub fn shutdown(&mut self) {
+    pub async fn shutdown(&mut self) {
         self.notify.notify_waiters();
+        let main_task = self.main_task.lock().take();
+        if let Some(mut main_task) = main_task {
+            match tokio::time::timeout(Duration::from_secs(5), &mut main_task).await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    warn!(?error, "PopLongPollingService scan task failed during shutdown");
+                }
+                Err(_) => {
+                    warn!("PopLongPollingService scan task did not stop before shutdown timeout");
+                    main_task.abort();
+                    let _ = main_task.await;
+                }
+            }
+        }
+
+        let task_group = self.task_group.lock().take();
+        if let Some(task_group) = task_group {
+            let report = task_group.shutdown(Duration::from_secs(5)).await;
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "PopLongPollingService shutdown report is unhealthy"
+                );
+            }
+        }
+        self.running.store(false, Ordering::Release);
     }
 
     fn clean_unused_resource(&mut self) {
@@ -433,7 +507,13 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
         match self.processor.clone() {
             None => false,
             Some(mut processor) => {
-                tokio::spawn(async move {
+                let task_group = self.task_group.lock().as_ref().cloned();
+                let Some(task_group) = task_group else {
+                    warn!("PopLongPollingService wake-up skipped because task group is not running");
+                    return false;
+                };
+
+                let spawn_result = task_group.spawn("broker.long-polling.pop.wake-up", TaskKind::Worker, async move {
                     let channel = pop_request.get_channel().clone();
                     let ctx = pop_request.get_ctx().clone();
                     let opaque = pop_request.get_remoting_command().opaque();
@@ -453,6 +533,10 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
                         }
                     }
                 });
+                if let Err(error) = spawn_result {
+                    warn!(?error, "failed to spawn PopLongPollingService wake-up task");
+                    return false;
+                }
                 true
             }
         }

--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -13,10 +13,15 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use cheetah_string::CheetahString;
+use parking_lot::Mutex;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use rocketmq_store::consume_queue::cq_ext_unit::CqExtUnit;
@@ -37,6 +42,8 @@ pub struct PullRequestHoldService<MS: MessageStore> {
     pull_message_processor: ArcMut<PullMessageProcessor<MS>>,
     shutdown: Arc<Notify>,
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+    running: AtomicBool,
+    task_group: Mutex<Option<TaskGroup>>,
 }
 
 impl<MS> PullRequestHoldService<MS>
@@ -52,6 +59,8 @@ where
             pull_message_processor,
             shutdown: Arc::new(Default::default()),
             broker_runtime_inner,
+            running: AtomicBool::new(false),
+            task_group: Mutex::new(None),
         }
     }
 }
@@ -62,7 +71,26 @@ where
     MS: MessageStore + Send + Sync,
 {
     pub fn start(&mut self, this: ArcMut<BrokerRuntimeInner<MS>>) {
-        tokio::spawn(async move {
+        if self
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                self.running.store(false, Ordering::Release);
+                warn!(?error, "failed to start PullRequestHoldService outside Tokio runtime");
+                return;
+            }
+        };
+        let task_group = TaskGroup::root("rocketmq-broker.long-polling.pull-request-hold", runtime);
+        let cancellation_token = task_group.cancellation_token();
+
+        if let Err(error) = task_group.spawn_service("broker.long-polling.pull-request-hold.scan", async move {
             loop {
                 let handle_future = if this.broker_config().long_polling_enable {
                     tokio::time::sleep(tokio::time::Duration::from_secs(5))
@@ -72,8 +100,18 @@ where
                     ))
                 };
                 tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        if let Some(service) = this.pull_request_hold_service() {
+                            service.running.store(false, Ordering::Release);
+                        }
+                        info!("PullRequestHoldService: shutdown..........");
+                        break;
+                    }
                     _ = handle_future => {}
                     _ = this.pull_request_hold_service().as_ref().unwrap().shutdown.notified() => {
+                        if let Some(service) = this.pull_request_hold_service() {
+                            service.running.store(false, Ordering::Release);
+                        }
                         info!("PullRequestHoldService: shutdown..........");
                         break;
                     }
@@ -85,12 +123,33 @@ where
                     warn!("PullRequestHoldService: check hold pull request cost {}ms", elapsed);
                 }
             }
-        });
+        }) {
+            self.running.store(false, Ordering::Release);
+            warn!(?error, "failed to spawn PullRequestHoldService scan task");
+            return;
+        }
+
+        *self.task_group.lock() = Some(task_group);
     }
 
     pub fn shutdown(&mut self) {
+        self.running.store(false, Ordering::Release);
         self.shutdown.notify_waiters();
+        if let Some(task_group) = self.task_group.lock().take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "PullRequestHoldService shutdown report is unhealthy"
+                );
+            }
+        }
     }
+
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::Acquire)
+    }
+
     pub fn suspend_pull_request(&self, topic: &str, queue_id: i32, mut pull_request: PullRequest) {
         let key = build_key(topic, queue_id);
         let mut table = self.pull_request_table.write();
@@ -226,4 +285,37 @@ where
 
 fn build_key(topic: &str, queue_id: i32) -> String {
     format!("{topic}{TOPIC_QUEUE_ID_SEPARATOR}{queue_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+
+    use super::*;
+    use crate::broker_runtime::BrokerRuntime;
+    use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
+
+    #[tokio::test]
+    async fn start_is_idempotent_and_shutdown_stops_background_task() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut broker_runtime = BrokerRuntime::new(broker_config, message_store_config);
+        let inner = broker_runtime.inner_for_test().clone();
+        let result_handler = ArcMut::new(DefaultPullMessageResultHandler::new(
+            Arc::new(Default::default()),
+            inner.clone(),
+        ));
+        let pull_message_processor = ArcMut::new(PullMessageProcessor::new(result_handler, inner.clone()));
+        let mut service = PullRequestHoldService::new(pull_message_processor, inner.clone());
+
+        service.start(inner.clone());
+        service.start(inner);
+        assert!(service.is_running());
+
+        service.shutdown();
+        assert!(!service.is_running());
+    }
 }

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -15,6 +15,7 @@
 use std::cmp::Ordering;
 
 use cheetah_string::CheetahString;
+use futures::future::join_all;
 use rocketmq_common::common::key_builder::POP_ORDER_REVIVE_QUEUE;
 use rocketmq_common::common::message::message_decoder;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
@@ -565,9 +566,12 @@ where
             .decrement_in_flight_message_num(&topic, &consume_group, pop_time, q_id, 1);
     }
 
-    pub fn shutdown(&mut self) {
-        for pop_revive_service in self.pop_revive_services.iter_mut() {
-            pop_revive_service.shutdown();
-        }
+    pub async fn shutdown(&mut self) {
+        join_all(
+            self.pop_revive_services
+                .iter_mut()
+                .map(|pop_revive_service| pop_revive_service.shutdown()),
+        )
+        .await;
     }
 }

--- a/rocketmq-broker/src/processor/notification_processor.rs
+++ b/rocketmq-broker/src/processor/notification_processor.rs
@@ -59,8 +59,8 @@ impl<MS: MessageStore> NotificationProcessor<MS> {
         PopLongPollingService::start(self.pop_long_polling_service.clone())
     }
 
-    pub fn shutdown(&mut self) {
-        self.pop_long_polling_service.shutdown();
+    pub async fn shutdown(&mut self) {
+        self.pop_long_polling_service.shutdown().await;
     }
 
     pub fn notify_message_arriving_simple(&self, topic: &CheetahString, queue_id: i32) {

--- a/rocketmq-broker/src/processor/pop_lite_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor.rs
@@ -85,8 +85,8 @@ impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
         self.queue_lock_manager.start();
     }
 
-    pub(crate) fn shutdown(&mut self) {
-        self.pop_lite_long_polling_service.shutdown();
+    pub(crate) async fn shutdown(&mut self) {
+        self.pop_lite_long_polling_service.shutdown().await;
         self.queue_lock_manager.shutdown();
     }
 

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -21,10 +21,12 @@ use std::sync::atomic::AtomicI64;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
+use parking_lot::Mutex;
 use rand::RngExt;
 use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::constant::consume_init_mode::ConsumeInitMode;
@@ -54,6 +56,8 @@ use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::get_message_result::GetMessageResult;
 use rocketmq_store::base::message_status_enum::GetMessageStatus;
@@ -1436,8 +1440,16 @@ where
         Some(bytes_mut.freeze())
     }
 
-    pub fn shutdown(&mut self) {
-        self.pop_long_polling_service.shutdown();
+    pub async fn shutdown(&mut self) {
+        self.pop_long_polling_service.shutdown().await;
+        self.pop_buffer_merge_service.shutdown();
+        if let Err(error) = self
+            .pop_buffer_merge_service
+            .wait_for_shutdown(Duration::from_secs(5))
+            .await
+        {
+            warn!(?error, "failed to gracefully shutdown PopBufferMergeService");
+        }
         self.queue_lock_manager.shutdown();
     }
 }
@@ -1573,6 +1585,8 @@ impl TimedLock {
 pub struct QueueLockManager {
     expired_local_cache: Arc<RwLock<HashMap<CheetahString, TimedLock>>>,
     shutdown: Arc<Notify>,
+    running: Arc<AtomicBool>,
+    task_group: Arc<Mutex<Option<TaskGroup>>>,
 }
 
 impl QueueLockManager {
@@ -1580,6 +1594,8 @@ impl QueueLockManager {
         QueueLockManager {
             expired_local_cache: Arc::new(RwLock::new(HashMap::with_capacity(4096))),
             shutdown: Arc::new(Notify::new()),
+            running: Arc::new(AtomicBool::new(false)),
+            task_group: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -1631,11 +1647,36 @@ impl QueueLockManager {
     }
 
     pub fn start(&self) {
+        if self
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                self.running.store(false, Ordering::Release);
+                warn!(?error, "failed to start QueueLockManager outside Tokio runtime");
+                return;
+            }
+        };
+        let task_group = TaskGroup::root("rocketmq-broker.pop.queue-lock", runtime);
+        let cancellation_token = task_group.cancellation_token();
         let this = self.clone();
-        tokio::spawn(async move {
+        let mut lifecycle = self.task_group.lock();
+
+        if let Err(error) = task_group.spawn_service("broker.pop.queue-lock.clean-unused", async move {
             loop {
                 select! {
+                    _ = cancellation_token.cancelled() => {
+                        this.running.store(false, Ordering::Release);
+                        break;
+                    }
                     _ = this.shutdown.notified() => {
+                        this.running.store(false, Ordering::Release);
                         break;
                     }
                     _ = tokio::time::sleep(tokio::time::Duration::from_secs(60)) => {}
@@ -1643,11 +1684,31 @@ impl QueueLockManager {
                 let count = this.clean_unused_locks(60000).await;
                 info!("QueueLockSize={}", count);
             }
-        });
+        }) {
+            self.running.store(false, Ordering::Release);
+            warn!(?error, "failed to spawn QueueLockManager cleanup task");
+            return;
+        }
+
+        *lifecycle = Some(task_group);
     }
 
     pub fn shutdown(&self) {
+        self.running.store(false, Ordering::Release);
         self.shutdown.notify_waiters();
+        if let Some(task_group) = self.task_group.lock().take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "QueueLockManager shutdown report is unhealthy"
+                );
+            }
+        }
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::Acquire)
     }
 }
 
@@ -1843,6 +1904,18 @@ mod tests {
         let manager = QueueLockManager::new();
         let cache = manager.expired_local_cache.read().await;
         assert!(cache.is_empty());
+    }
+
+    #[tokio::test]
+    async fn queue_lock_manager_start_is_idempotent_and_shutdown_stops_task() {
+        let manager = QueueLockManager::new();
+
+        manager.start();
+        manager.start();
+        assert!(manager.is_running());
+
+        manager.shutdown();
+        assert!(!manager.is_running());
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -21,11 +21,13 @@ use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 
 use bytes::Bytes;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
+use parking_lot::Mutex;
 use rocketmq_common::common::broker::broker_role::BrokerRole;
 use rocketmq_common::common::key_builder::KeyBuilder;
 use rocketmq_common::common::message::message_decoder;
@@ -40,6 +42,8 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::RemotingSerializable;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
@@ -79,6 +83,9 @@ pub(crate) struct PopBufferMergeService<MS: MessageStore> {
     batch_ack_index_list: Vec<u8>,
     master: AtomicBool,
     shutdown: Arc<Notify>,
+    shutdown_requested: AtomicBool,
+    running: AtomicBool,
+    task_group: Mutex<Option<TaskGroup>>,
     start_time: Instant,
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     #[cfg(feature = "rocksdb_store")]
@@ -109,6 +116,9 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
             batch_ack_index_list: Vec::with_capacity(32),
             master: AtomicBool::new(false),
             shutdown: Arc::new(Notify::new()),
+            shutdown_requested: AtomicBool::new(false),
+            running: AtomicBool::new(false),
+            task_group: Mutex::new(None),
             start_time: Instant::now(),
             broker_runtime_inner,
             #[cfg(feature = "rocksdb_store")]
@@ -639,51 +649,100 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
     }
 
     pub fn start(this: ArcMut<Self>) {
-        tokio::spawn(async move {
-            let interval = this.interval * 200 * 5;
+        if this
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        this.shutdown_requested.store(false, Ordering::Release);
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                this.running.store(false, Ordering::Release);
+                warn!(?error, "failed to start PopBufferMergeService outside Tokio runtime");
+                return;
+            }
+        };
+        let task_group = TaskGroup::root("rocketmq-broker.pop-buffer-merge", runtime);
+        let cancellation_token = task_group.cancellation_token();
+        let service = this.clone();
+
+        if let Err(error) = task_group.spawn_service("broker.pop-buffer-merge.scan", async move {
+            service.serving.store(true, Ordering::Release);
+            let interval = service.interval * 200 * 5;
 
             loop {
+                if service.shutdown_requested.load(Ordering::Acquire) {
+                    info!("[PopBuffer]Shutdown requested, processing remaining data");
+                    Self::drain_remaining_for_shutdown(&service, true).await;
+                    info!("[PopBuffer]All data processed, shutting down");
+                    break;
+                }
+
                 select! {
-                    _ = this.shutdown.notified() => {
+                    _ = cancellation_token.cancelled() => {
+                        info!("[PopBuffer]Cancellation signal received, processing remaining data");
+                        Self::drain_remaining_for_shutdown(&service, true).await;
+                        info!("[PopBuffer]All data processed, shutting down");
+                        break;
+                    }
+                    _ = service.shutdown.notified() => {
                         info!("[PopBuffer]Shutdown signal received, processing remaining data");
-
-                        while !this.buffer.is_empty() || this.get_offset_total_size().await > 0 {
-                            this.mut_from_ref().scan().await;
-                            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-                        }
-
+                        Self::drain_remaining_for_shutdown(&service, true).await;
                         info!("[PopBuffer]All data processed, shutting down");
                         break;
                     }
                     _ = async {
-                        if !this.is_should_running() {
+                        if !service.is_should_running() {
                             //slave
                             tokio::time::sleep(tokio::time::Duration::from_millis(interval)).await;
-                            this.buffer.clear();
-                            this.commit_offsets.clear();
+                            service.buffer.clear();
+                            service.commit_offsets.clear();
                             return;
                         }
-                        this.mut_from_ref().scan().await;
-                        if this.scan_times % this.count_of_second30 == 0 {
-                            this.mut_from_ref().scan_garbage();
+                        service.mut_from_ref().scan().await;
+                        if service.scan_times % service.count_of_second30 == 0 {
+                            service.mut_from_ref().scan_garbage();
                         }
-                        tokio::time::sleep(tokio::time::Duration::from_millis(this.interval)).await;
-                        if !this.serving.load(Ordering::Acquire) && this.buffer.is_empty()  && this.get_offset_total_size().await == 0 {
-                            this.serving.store(true,Ordering::Release);
+                        tokio::time::sleep(tokio::time::Duration::from_millis(service.interval)).await;
+                        if !service.shutdown_requested.load(Ordering::Acquire)
+                            && !service.serving.load(Ordering::Acquire)
+                            && service.buffer.is_empty()
+                            && service.get_offset_total_size().await == 0 {
+                            service.serving.store(true,Ordering::Release);
                         }
                     } =>{}
 
                 }
             }
-            this.serving.store(false, Ordering::Release);
-            tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
-            if !this.is_should_running() {
-                return;
+            service.serving.store(false, Ordering::Release);
+            select! {
+                _ = cancellation_token.cancelled() => {}
+                _ = tokio::time::sleep(tokio::time::Duration::from_millis(2000)) => {}
             }
-            while !this.buffer.is_empty() || this.get_offset_total_size().await > 0 {
-                this.mut_from_ref().scan().await;
+            if service.is_should_running() {
+                Self::drain_remaining_for_shutdown(&service, false).await;
             }
-        });
+            service.running.store(false, Ordering::Release);
+        }) {
+            this.running.store(false, Ordering::Release);
+            warn!(?error, "failed to spawn PopBufferMergeService scan task");
+            return;
+        }
+
+        *this.task_group.lock() = Some(task_group);
+    }
+
+    async fn drain_remaining_for_shutdown(this: &ArcMut<Self>, pause_between_scans: bool) {
+        while !this.buffer.is_empty() || this.get_offset_total_size().await > 0 {
+            this.mut_from_ref().scan().await;
+            if pause_between_scans {
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            }
+        }
     }
 
     async fn scan_commit_offset(&self) -> usize {
@@ -863,12 +922,12 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
 
     pub fn shutdown(&self) {
         info!("[PopBuffer]Initiating graceful shutdown");
+        self.shutdown_requested.store(true, Ordering::Release);
+        self.serving.store(false, Ordering::Release);
         self.shutdown.notify_waiters();
     }
 
-    pub async fn wait_for_shutdown(&self, timeout: std::time::Duration) -> RocketMQResult<()> {
-        use std::time::Instant;
-
+    pub async fn wait_for_shutdown(&self, timeout: Duration) -> RocketMQResult<()> {
         let start = Instant::now();
 
         info!(
@@ -894,6 +953,25 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
 
+        let task_group = self.task_group.lock().take();
+        if let Some(task_group) = task_group {
+            let remaining = timeout
+                .checked_sub(start.elapsed())
+                .unwrap_or_else(|| Duration::from_millis(1));
+            let report = task_group.shutdown(remaining).await;
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "[PopBuffer]Shutdown task group report is unhealthy"
+                );
+                return Err(RocketMQError::Internal(format!(
+                    "PopBufferMergeService shutdown report is unhealthy: {}",
+                    report.to_json()
+                )));
+            }
+        }
+
+        self.running.store(false, Ordering::Release);
         info!("[PopBuffer]Shutdown completed, all buffers cleared");
         Ok(())
     }

--- a/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
@@ -19,11 +19,13 @@ use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use cheetah_string::CheetahString;
 use futures::future::join_all;
 use futures::FutureExt;
+use parking_lot::Mutex;
 use rocketmq_client_rust::consumer::pull_result::PullResult;
 use rocketmq_client_rust::consumer::pull_status::PullStatus;
 use rocketmq_common::common::config::TopicConfig;
@@ -40,6 +42,8 @@ use rocketmq_common::utils::data_converter::DataConverter;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::get_message_result::GetMessageResult;
 use rocketmq_store::base::message_status_enum::AppendMessageStatus;
@@ -76,6 +80,8 @@ pub struct PopReviveService<MS: MessageStore> {
     inflight_revive_request_map: Arc<tokio::sync::Mutex<BTreeMap<PopCheckPoint, (i64, bool)>>>,
     revive_offset: Arc<AtomicI64>,
     shutdown: Arc<AtomicBool>,
+    running: AtomicBool,
+    task_group: Mutex<Option<TaskGroup>>,
 }
 impl<MS: MessageStore> PopReviveService<MS> {
     pub fn new(
@@ -100,6 +106,8 @@ impl<MS: MessageStore> PopReviveService<MS> {
                 10, 20, 30, 60, 120, 180, 240, 300, 360, 420, 480, 540, 600, 1200, 1800, 3600, 7200,
             ],
             shutdown: Arc::new(AtomicBool::new(false)),
+            running: AtomicBool::new(false),
+            task_group: Mutex::new(None),
         }
     }
 
@@ -310,30 +318,60 @@ impl<MS: MessageStore> PopReviveService<MS> {
         }
     }
 
-    pub fn start(mut this: ArcMut<Self>) {
-        tokio::spawn(async move {
+    pub fn start(this: ArcMut<Self>) {
+        if this
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        this.shutdown.store(false, Ordering::Release);
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                this.running.store(false, Ordering::Release);
+                warn!(
+                    ?error,
+                    revive_queue_id = this.queue_id,
+                    "failed to start PopReviveService outside Tokio runtime"
+                );
+                return;
+            }
+        };
+        let task_group = TaskGroup::root(format!("rocketmq-broker.pop-revive.{}", this.queue_id), runtime);
+        let cancellation_token = task_group.cancellation_token();
+        let mut service = this.clone();
+
+        if let Err(error) = task_group.spawn_service("broker.pop-revive.scan", async move {
             let mut slow = 1;
             loop {
-                if this.shutdown.load(Relaxed) {
+                if service.shutdown.load(Ordering::Acquire) || cancellation_token.is_cancelled() {
                     break;
                 }
 
-                if current_millis() < this.broker_runtime_inner.should_start_time().load(Relaxed) {
+                if current_millis() < service.broker_runtime_inner.should_start_time().load(Relaxed) {
                     info!(
                         "PopReviveService Ready to run after {}",
-                        this.broker_runtime_inner.should_start_time().load(Relaxed)
+                        service.broker_runtime_inner.should_start_time().load(Relaxed)
                     );
-                    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                    tokio::select! {
+                        _ = cancellation_token.cancelled() => break,
+                        _ = tokio::time::sleep(tokio::time::Duration::from_secs(1)) => {}
+                    }
                     continue;
                 }
-                tokio::time::sleep(tokio::time::Duration::from_millis(
-                    this.broker_runtime_inner.broker_config().revive_interval,
-                ))
-                .await;
-                if !this.should_run_pop_revive.load(Ordering::Acquire) {
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => break,
+                    _ = tokio::time::sleep(tokio::time::Duration::from_millis(
+                        service.broker_runtime_inner.broker_config().revive_interval,
+                    )) => {}
+                }
+                if !service.should_run_pop_revive.load(Ordering::Acquire) {
                     continue;
                 }
-                if !this
+                if !service
                     .broker_runtime_inner
                     .message_store()
                     .unwrap()
@@ -343,58 +381,83 @@ impl<MS: MessageStore> PopReviveService<MS> {
                     info!("skip revive topic because timerWheelEnable is false");
                     continue;
                 }
-                if this.broker_runtime_inner.broker_config().enable_pop_log {
+                if service.broker_runtime_inner.broker_config().enable_pop_log {
                     info!(
                         "start revive topic={}, reviveQueueId={}",
-                        this.revive_topic, this.queue_id
+                        service.revive_topic, service.queue_id
                     );
                 }
                 let mut consume_revive_obj = ConsumeReviveObj::new();
-                this.consume_revive_message(&mut consume_revive_obj).await;
-                if !this.should_run_pop_revive.load(Ordering::Acquire) {
+                service.consume_revive_message(&mut consume_revive_obj).await;
+                if !service.should_run_pop_revive.load(Ordering::Acquire) || cancellation_token.is_cancelled() {
                     info!(
                         "slave skip scan, revive topic={}, reviveQueueId={}",
-                        this.revive_topic, this.queue_id
+                        service.revive_topic, service.queue_id
                     );
                     continue;
                 }
 
-                if let Err(e) = Self::merge_and_revive(this.clone(), &mut consume_revive_obj).await {
-                    error!("reviveQueueId={}, revive error:{}", this.queue_id, e);
+                if let Err(e) = Self::merge_and_revive(service.clone(), &mut consume_revive_obj).await {
+                    error!("reviveQueueId={}, revive error:{}", service.queue_id, e);
                     continue;
                 }
                 let mut delay = 0;
                 if let Some(ref sort_list) = consume_revive_obj.sort_list {
                     if !sort_list.is_empty() {
                         delay = (current_millis() - (sort_list[0].get_revive_time() as u64)) / 1000;
-                        this.current_revive_message_timestamp = sort_list[0].get_revive_time();
+                        service.current_revive_message_timestamp = sort_list[0].get_revive_time();
                         slow = 1;
                     }
                 } else {
-                    this.current_revive_message_timestamp = current_millis() as i64;
+                    service.current_revive_message_timestamp = current_millis() as i64;
                 }
-                if this.broker_runtime_inner.broker_config().enable_pop_log {
+                if service.broker_runtime_inner.broker_config().enable_pop_log {
                     info!(
                         "reviveQueueId={}, revive finish,old offset is {}, new offset is {}, ckDelay={}  ",
-                        this.queue_id, consume_revive_obj.old_offset, consume_revive_obj.new_offset, delay
+                        service.queue_id, consume_revive_obj.old_offset, consume_revive_obj.new_offset, delay
                     );
                 }
 
                 if consume_revive_obj.sort_list.is_none() || consume_revive_obj.sort_list.as_ref().unwrap().is_empty() {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(
-                        slow * this.broker_runtime_inner.broker_config().revive_interval,
-                    ))
-                    .await;
-                    if slow < this.broker_runtime_inner.broker_config().revive_max_slow {
+                    tokio::select! {
+                        _ = cancellation_token.cancelled() => break,
+                        _ = tokio::time::sleep(tokio::time::Duration::from_millis(
+                            slow * service.broker_runtime_inner.broker_config().revive_interval,
+                        )) => {}
+                    }
+                    if slow < service.broker_runtime_inner.broker_config().revive_max_slow {
                         slow += 1;
                     }
                 }
             }
-        });
+            service.running.store(false, Ordering::Release);
+        }) {
+            this.running.store(false, Ordering::Release);
+            warn!(
+                ?error,
+                revive_queue_id = this.queue_id,
+                "failed to spawn PopReviveService scan task"
+            );
+            return;
+        }
+
+        *this.task_group.lock() = Some(task_group);
     }
 
-    pub fn shutdown(&mut self) {
-        self.shutdown.store(true, Ordering::Relaxed);
+    pub async fn shutdown(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        let task_group = self.task_group.lock().take();
+        if let Some(task_group) = task_group {
+            let report = task_group.shutdown(Duration::from_secs(5)).await;
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    revive_queue_id = self.queue_id,
+                    "PopReviveService shutdown report is unhealthy"
+                );
+            }
+        }
+        self.running.store(false, Ordering::Release);
     }
 
     async fn consume_revive_message(&self, consume_revive_obj: &mut ConsumeReviveObj) {

--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -18,6 +18,7 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::future::Future;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicI64;
@@ -27,6 +28,7 @@ use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
+use parking_lot::Mutex as ParkingMutex;
 use rocketmq_common::common::config_manager::ConfigManager;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBrokerInner;
@@ -42,6 +44,8 @@ use rocketmq_common::MessageDecoder;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::protocol::RemotingSerializable;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_result::PutMessageResult;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
@@ -130,8 +134,8 @@ pub struct ScheduleMessageService<MS: MessageStore> {
     deliver_pending_table: DeliverPendingTable<MS>,
     broker_controller: ArcMut<BrokerRuntimeInner<MS>>,
     version_change_counter: AtomicI64,
-    /// Handles for all spawned tasks to support graceful shutdown
-    task_handles: Option<Vec<tokio::task::JoinHandle<()>>>,
+    /// Tracks all scheduled delivery and persistence tasks for graceful shutdown.
+    task_group: ParkingMutex<Option<TaskGroup>>,
 }
 
 impl<MS: MessageStore> ScheduleMessageService<MS> {
@@ -149,7 +153,7 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
             deliver_pending_table: Arc::new(DashMap::new()),
             broker_controller,
             version_change_counter: AtomicI64::new(0),
-            task_handles: None,
+            task_group: ParkingMutex::new(None),
         }
     }
 
@@ -229,7 +233,7 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
     /// # Returns
     ///
     /// `Ok(())` on successful start, error otherwise
-    pub fn start(mut this: ArcMut<Self>) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn start(this: ArcMut<Self>) -> Result<(), Box<dyn std::error::Error>> {
         if this
             .started
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
@@ -238,8 +242,14 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
             info!("Starting ScheduleMessageService...");
             this.load();
 
-            // Pre-allocate task_handles vector for all delay levels + persist task
-            let mut task_handles = Vec::with_capacity(this.delay_level_table.len() * 2 + 1);
+            let runtime = match tokio::runtime::Handle::try_current() {
+                Ok(handle) => RuntimeHandle::new(handle),
+                Err(error) => {
+                    this.started.store(false, Ordering::SeqCst);
+                    return Err(Box::new(error));
+                }
+            };
+            *this.task_group.lock() = Some(TaskGroup::root("rocketmq-broker.schedule", runtime));
 
             for level in this.delay_level_table.keys() {
                 let offset = { this.offset_table.get(level).map_or(0, |key_value| *key_value.value()) };
@@ -250,12 +260,11 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
                     let service = this.clone();
                     let shutdown_flag = Arc::clone(&this.shutdown_requested);
 
-                    let handle = tokio::spawn(async move {
+                    this.spawn_schedule_task("broker.schedule.handle-put-result", async move {
                         tokio::time::sleep(Duration::from_millis(FIRST_DELAY_TIME)).await;
                         let task = HandlePutResultTask::new(level_copy, service, shutdown_flag);
                         task.run().await;
                     });
-                    task_handles.push(handle);
                 }
 
                 // Spawn delivery timer task
@@ -264,19 +273,18 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
                 let service = this.clone();
                 let shutdown_flag = Arc::clone(&this.shutdown_requested);
 
-                let handle = tokio::spawn(async move {
+                this.spawn_schedule_task("broker.schedule.deliver-delayed-message", async move {
                     let task = DeliverDelayedMessageTimerTask::new(level_copy, offset_copy, service, shutdown_flag);
                     tokio::time::sleep(Duration::from_millis(FIRST_DELAY_TIME)).await;
                     task.run().await;
                 });
-                task_handles.push(handle);
             }
 
             // Spawn periodic persist task
             let service = this.clone();
             let shutdown_flag = Arc::clone(&this.shutdown_requested);
 
-            let persist_handle = tokio::spawn(async move {
+            this.spawn_schedule_task("broker.schedule.persist-delay-offset", async move {
                 let mut interval = tokio::time::interval(Duration::from_millis(
                     service
                         .broker_controller
@@ -318,10 +326,6 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
                     }
                 }
             });
-            task_handles.push(persist_handle);
-
-            // Store all task handles (one-time assignment at startup)
-            this.task_handles = Some(task_handles);
 
             info!(
                 "ScheduleMessageService started successfully with {} delay levels",
@@ -342,36 +346,18 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
         self.shutdown_requested.store(true, Ordering::SeqCst);
         self.stop();
 
-        // Take out all task handles (one-time consumption at shutdown)
-        let Some(mut handles) = self.task_handles.take() else {
-            warn!("No task handles found during shutdown");
+        let task_group = self.task_group.lock().take();
+        let Some(task_group) = task_group else {
+            warn!("No schedule task group found during shutdown");
             return;
         };
 
-        let task_count = handles.len();
-
-        info!("Waiting for {} tasks to complete...", task_count);
-
-        for (idx, handle) in handles.drain(..).enumerate() {
-            let mut handle = handle;
-            match tokio::time::timeout(Duration::from_millis(WAIT_FOR_SHUTDOWN), &mut handle).await {
-                Ok(Ok(())) => {
-                    info!("Task {}/{} completed successfully", idx + 1, task_count);
-                }
-                Ok(Err(e)) => {
-                    warn!("Task {}/{} panicked: {:?}", idx + 1, task_count, e);
-                }
-                Err(_) => {
-                    warn!(
-                        "Task {}/{} timed out after {}ms",
-                        idx + 1,
-                        task_count,
-                        WAIT_FOR_SHUTDOWN
-                    );
-                    handle.abort();
-                    let _ = handle.await;
-                }
-            }
+        let report = task_group.shutdown(Duration::from_millis(WAIT_FOR_SHUTDOWN)).await;
+        if !report.is_healthy() {
+            warn!(
+                report = %report.to_json(),
+                "ScheduleMessageService shutdown report is unhealthy"
+            );
         }
 
         info!("ScheduleMessageService shutdown complete");
@@ -393,6 +379,21 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
 
     pub fn is_started(&self) -> bool {
         self.started.load(Ordering::Relaxed)
+    }
+
+    fn spawn_schedule_task<F>(&self, task_name: &'static str, future: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let task_group = self.task_group.lock().as_ref().cloned();
+        let Some(task_group) = task_group else {
+            warn!(task = task_name, "ScheduleMessageService task group is not initialized");
+            return;
+        };
+
+        if let Err(error) = task_group.spawn_service(task_name, future) {
+            warn!(?error, task = task_name, "failed to spawn ScheduleMessageService task");
+        }
     }
 
     pub fn get_max_delay_level(&self) -> i32 {
@@ -987,12 +988,17 @@ impl<MS: MessageStore> DeliverDelayedMessageTimerTask<MS> {
 
     /// Schedule the next timer task
     fn schedule_next_timer_task(&self, offset: i64, delay: u64) {
+        if self.shutdown_flag.load(Ordering::Relaxed) || !self.schedule_service.is_started() {
+            return;
+        }
+
         let schedule_service = self.schedule_service.clone();
         let delay_level = self.delay_level;
         let shutdown_flag = Arc::clone(&self.shutdown_flag);
+        let spawner = self.schedule_service.clone();
 
         // Schedule the next task after the specified delay
-        tokio::spawn(async move {
+        spawner.spawn_schedule_task("broker.schedule.deliver-delayed-message", async move {
             tokio::time::sleep(Duration::from_millis(delay)).await;
             let task = DeliverDelayedMessageTimerTask::new(delay_level, offset, schedule_service, shutdown_flag);
             task.run().await;
@@ -1617,9 +1623,10 @@ impl<MS: MessageStore> HandlePutResultTask<MS> {
             let delay_level = self.delay_level;
             let schedule_service = ArcMut::clone(&self.schedule_service);
             let shutdown_flag = Arc::clone(&self.shutdown_flag);
+            let spawner = ArcMut::clone(&self.schedule_service);
 
             // Schedule after a short delay
-            tokio::spawn(async move {
+            spawner.spawn_schedule_task("broker.schedule.handle-put-result", async move {
                 tokio::time::sleep(Duration::from_millis(DELAY_FOR_A_SLEEP)).await;
                 let task = HandlePutResultTask::new(delay_level, schedule_service, shutdown_flag);
                 task.run().await;

--- a/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
@@ -14,10 +14,13 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
+use parking_lot::Mutex;
 use rocketmq_client_rust::factory::mq_client_instance::topic_route_data2topic_publish_info;
 use rocketmq_client_rust::factory::mq_client_instance::topic_route_data2topic_subscribe_info;
 use rocketmq_client_rust::producer::producer_impl::topic_publish_info::TopicPublishInfo;
@@ -26,6 +29,8 @@ use rocketmq_common::common::mix_all;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::RocketMQTokioMutex;
 use rocketmq_store::base::message_store::MessageStore;
@@ -37,7 +42,6 @@ use crate::broker_runtime::BrokerRuntimeInner;
 const GET_TOPIC_ROUTE_TIMEOUT: u64 = 3000;
 const LOCK_TIMEOUT_MILLIS: u64 = 3000;
 
-#[derive(Clone)]
 pub(crate) struct TopicRouteInfoManager<MS: MessageStore> {
     pub(crate) lock: Arc<RocketMQTokioMutex<()>>,
     pub(crate) topic_route_table: ArcMut<HashMap<CheetahString /* Topic */, TopicRouteData>>,
@@ -46,6 +50,23 @@ pub(crate) struct TopicRouteInfoManager<MS: MessageStore> {
     pub(crate) topic_publish_info_table: ArcMut<HashMap<CheetahString /* topic */, TopicPublishInfo>>,
     pub(crate) topic_subscribe_info_table: ArcMut<HashMap<CheetahString /* topic */, HashSet<MessageQueue>>>,
     pub(crate) broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+    running: Arc<AtomicBool>,
+    task_group: Arc<Mutex<Option<TaskGroup>>>,
+}
+
+impl<MS: MessageStore> Clone for TopicRouteInfoManager<MS> {
+    fn clone(&self) -> Self {
+        Self {
+            lock: self.lock.clone(),
+            topic_route_table: self.topic_route_table.clone(),
+            broker_addr_table: self.broker_addr_table.clone(),
+            topic_publish_info_table: self.topic_publish_info_table.clone(),
+            topic_subscribe_info_table: self.topic_subscribe_info_table.clone(),
+            broker_runtime_inner: self.broker_runtime_inner.clone(),
+            running: self.running.clone(),
+            task_group: self.task_group.clone(),
+        }
+    }
 }
 
 impl<MS: MessageStore> TopicRouteInfoManager<MS> {
@@ -57,32 +78,84 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
             topic_publish_info_table: ArcMut::new(HashMap::new()),
             topic_subscribe_info_table: ArcMut::new(HashMap::new()),
             broker_runtime_inner,
+            running: Arc::new(AtomicBool::new(false)),
+            task_group: Arc::new(Mutex::new(None)),
         }
     }
 
     pub fn start(&self) {
-        let this = self.broker_runtime_inner.clone();
+        if self
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let mut task_group = self.task_group.lock();
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                self.running.store(false, Ordering::Release);
+                warn!(?error, "failed to start TopicRouteInfoManager outside Tokio runtime");
+                return;
+            }
+        };
+        let group = TaskGroup::root("rocketmq-broker.topic-route-info", runtime);
+        let cancellation_token = group.cancellation_token();
+        let manager = self.clone();
         let load_balance_poll_name_server_interval = self
             .broker_runtime_inner
             .broker_config()
             .load_balance_poll_name_server_interval;
-        tokio::spawn(async move {
-            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-            loop {
-                this.topic_route_info_manager()
-                    .update_topic_route_info_from_name_server()
-                    .await;
-                tokio::time::sleep(tokio::time::Duration::from_millis(
-                    load_balance_poll_name_server_interval,
-                ))
-                .await;
+
+        if let Err(error) = group.spawn_service("broker.topic-route-info.poll-namesrv", async move {
+            tokio::select! {
+                _ = cancellation_token.cancelled() => {
+                    manager.running.store(false, Ordering::Release);
+                    return;
+                }
+                _ = tokio::time::sleep(tokio::time::Duration::from_secs(1)) => {}
             }
-        });
+
+            loop {
+                manager.update_topic_route_info_from_name_server().await;
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {
+                        manager.running.store(false, Ordering::Release);
+                        return;
+                    }
+                    _ = tokio::time::sleep(tokio::time::Duration::from_millis(
+                        load_balance_poll_name_server_interval,
+                    )) => {}
+                }
+            }
+        }) {
+            self.running.store(false, Ordering::Release);
+            warn!(?error, "failed to spawn TopicRouteInfoManager namesrv polling task");
+            return;
+        }
+
+        *task_group = Some(group);
     }
 
     pub fn shutdown(&mut self) {
-        warn!("TopicRouteInfoManager shutdown not implemented");
+        self.running.store(false, Ordering::Release);
+        if let Some(task_group) = self.task_group.lock().take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "TopicRouteInfoManager shutdown report is unhealthy"
+                );
+            }
+        }
     }
+
+    pub(crate) fn is_running(&self) -> bool {
+        self.running.load(Ordering::Acquire)
+    }
+
     async fn update_topic_route_info_from_name_server(&self) {
         let topic_set_for_pop_assignment = self
             .topic_subscribe_info_table
@@ -291,5 +364,30 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
             queues = self.topic_subscribe_info_table.get(topic).cloned();
         }
         queues
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_store::config::message_store_config::MessageStoreConfig;
+
+    use crate::broker_runtime::BrokerRuntime;
+
+    #[tokio::test]
+    async fn start_is_idempotent_and_shutdown_stops_background_task() {
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut broker_runtime = BrokerRuntime::new(broker_config, message_store_config);
+        let mut manager = broker_runtime.inner_for_test().topic_route_info_manager().clone();
+
+        manager.start();
+        manager.start();
+        assert!(manager.is_running());
+
+        manager.shutdown();
+        assert!(!manager.is_running());
     }
 }


### PR DESCRIPTION
Closes #7499

## Summary

- Track broker topic route polling, pop queue lock cleanup, pull request hold, schedule message, pop buffer merge, pop revive, pop long polling, pop lite long polling, and remoting server tasks through runtime task groups.
- Add root cargo config to suppress MSVC linker informational output during warning-denied checks.
- Keep this PR to the sixth staged runtime-model commit for the linear merge flow.

## Validation

- Root workspace format check passed.
- Root workspace clippy passed with all targets, all features, no dependencies, and warnings denied.
- Example standalone format and clippy checks passed.
- Tauri backend standalone format and all-features clippy checks passed.
- Web dashboard backend standalone format, all-features clippy, and all-features build checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved graceful shutdown behavior across long-polling and message processing services
  * Enhanced lifecycle management for background service tasks
  * Better resource cleanup during broker shutdown
* **Chores**
  * Optimized Windows MSVC linker configuration to reduce build warnings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->