### PR TITLE
[ISSUE #7500]♻️ Track transaction check tasks

### DIFF
--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -393,6 +393,7 @@ pub(crate) struct BrokerRuntime {
     consumer_ids_change_listener: Arc<dyn ConsumerIdsChangeListener + Send + Sync + 'static>,
     scheduled_task_manager: ScheduledTaskManager,
     remoting_server_task_group: Option<TaskGroup>,
+    request_processor_task_group: Option<TaskGroup>,
 }
 
 impl Drop for BrokerRuntime {
@@ -575,6 +576,7 @@ impl BrokerRuntime {
             consumer_ids_change_listener,
             scheduled_task_manager,
             remoting_server_task_group: None,
+            request_processor_task_group: None,
         }
     }
 
@@ -647,6 +649,7 @@ impl BrokerRuntime {
         }
 
         self.shutdown_remoting_servers().await;
+        self.shutdown_request_processor_tasks().await;
 
         if let Some(auth_runtime) = self.inner.auth_runtime.take() {
             if let Err(error) = auth_runtime.shutdown().await {
@@ -715,6 +718,9 @@ impl BrokerRuntime {
         if let Some(transactional_message_check_service) = self.inner.transactional_message_check_service.as_mut() {
             transactional_message_check_service.shutdown().await;
         }
+        if let Some(transactional_message_check_listener) = self.inner.transactional_message_check_listener.as_ref() {
+            transactional_message_check_listener.shutdown().await;
+        }
         if let Some(transaction_metrics_flush_service) = self.inner.transaction_metrics_flush_service.as_mut() {
             transaction_metrics_flush_service.shutdown();
         }
@@ -780,6 +786,20 @@ impl BrokerRuntime {
             warn!(
                 report = %report.to_json(),
                 "Broker remoting server shutdown report is unhealthy"
+            );
+        }
+    }
+
+    async fn shutdown_request_processor_tasks(&mut self) {
+        let Some(task_group) = self.request_processor_task_group.take() else {
+            return;
+        };
+
+        let report = task_group.shutdown(Duration::from_secs(35)).await;
+        if !report.is_healthy() {
+            warn!(
+                report = %report.to_json(),
+                "Broker request processor shutdown report is unhealthy"
             );
         }
     }
@@ -1258,6 +1278,26 @@ impl BrokerRuntime {
         let notification_processor = NotificationProcessor::new(self.inner.clone());
         self.inner.notification_processor = Some(notification_processor.clone());
         let mut broker_request_processor = BrokerRequestProcessor::new();
+        let request_processor_task_group =
+            self.request_processor_task_group
+                .clone()
+                .or_else(|| match tokio::runtime::Handle::try_current() {
+                    Ok(handle) => Some(TaskGroup::root(
+                        "rocketmq-broker.request-processor",
+                        RuntimeHandle::new(handle),
+                    )),
+                    Err(error) => {
+                        warn!(
+                            ?error,
+                            "failed to initialize broker request processor task group outside Tokio runtime"
+                        );
+                        None
+                    }
+                });
+        if let Some(task_group) = request_processor_task_group.clone() {
+            broker_request_processor.set_request_task_group(task_group);
+        }
+        self.request_processor_task_group = request_processor_task_group;
         if let Some(auth_runtime) = &self.inner.auth_runtime {
             broker_request_processor.set_auth_runtime(auth_runtime.clone());
         }
@@ -3969,26 +4009,32 @@ impl<MS: MessageStore> BrokerRuntimeInner<MS> {
             .as_ref()
             .map(|message_store| message_store.get_confirm_offset());
 
-        for controller_address in controller_targets {
-            if self.shutdown.load(Ordering::Acquire) {
-                return;
+        let futures = controller_targets.into_iter().map(|controller_address| {
+            let cluster_name = cluster_name.clone();
+            let broker_addr = broker_addr.clone();
+            let broker_name = broker_name.clone();
+            async move {
+                if self.shutdown.load(Ordering::Acquire) {
+                    return;
+                }
+                self.broker_outer_api
+                    .send_heartbeat_to_controller(
+                        controller_address,
+                        cluster_name,
+                        broker_addr,
+                        broker_name,
+                        broker_id,
+                        self.broker_config.send_heartbeat_timeout_millis,
+                        epoch,
+                        max_offset,
+                        confirm_offset,
+                        Some(self.broker_config.controller_heartbeat_timeout_mills),
+                        Some(self.broker_config.broker_election_priority),
+                    )
+                    .await;
             }
-            self.broker_outer_api
-                .send_heartbeat_to_controller(
-                    controller_address,
-                    cluster_name.clone(),
-                    broker_addr.clone(),
-                    broker_name.clone(),
-                    broker_id,
-                    self.broker_config.send_heartbeat_timeout_millis,
-                    epoch,
-                    max_offset,
-                    confirm_offset,
-                    Some(self.broker_config.controller_heartbeat_timeout_mills),
-                    Some(self.broker_config.broker_election_priority),
-                )
-                .await;
-        }
+        });
+        futures::future::join_all(futures).await;
     }
 
     async fn send_heartbeat_to_controller_leader(

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -519,6 +519,10 @@ impl BrokerFastFailure {
         self.inner.queues.get(kind).complete(task, response);
     }
 
+    pub(crate) fn cancel(&self, kind: FastFailureQueueKind, task: &FastFailureTask, response: RemotingCommand) -> bool {
+        self.inner.queues.get(kind).cancel_pending(task, response)
+    }
+
     fn clean_expired_request(&self) {
         if !self.is_enabled() {
             return;

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -220,7 +220,7 @@ impl BrokerOuterAPI {
         compressed: bool,
         heartbeat_timeout_millis: Option<i64>,
         _broker_identity: BrokerIdentity,
-        broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
+        _broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     ) -> Vec<RegisterBrokerResult> {
         let mut name_server_address_list = self.remoting_client.get_available_name_srv_list();
         if name_server_address_list.is_empty() {
@@ -247,33 +247,22 @@ impl BrokerOuterAPI {
                 compressed,
             );
 
-            let mut handle_vec = Vec::with_capacity(name_server_address_list.len());
-            for namesrv_addr in name_server_address_list.iter() {
+            let broker_outer_api = self;
+            let futures = name_server_address_list.iter().map(|namesrv_addr| {
                 let cloned_body = register_request.body.clone();
                 let cloned_header = register_request.header.clone();
                 let addr = namesrv_addr.clone();
-                let broker_runtime_inner_ = broker_runtime_inner.clone();
-                let join_handle = tokio::spawn(async move {
-                    broker_runtime_inner_
-                        .broker_outer_api()
+                async move {
+                    broker_outer_api
                         .register_broker(&addr, oneway, timeout_mills, cloned_header, cloned_body)
                         .await
-                });
-                handle_vec.push(join_handle);
-            }
-            while let Some(handle) = handle_vec.pop() {
-                let result = tokio::join!(handle);
-                match result.0 {
-                    Ok(value) => {
-                        if let Some(v) = value {
-                            register_broker_result_list.push(v);
-                        } else {
-                            error!("Register broker to name remoting_server error");
-                        }
-                    }
-                    Err(e) => {
-                        error!("Register broker to name remoting_server error, error={}", e);
-                    }
+                }
+            });
+            for value in futures::future::join_all(futures).await {
+                if let Some(v) = value {
+                    register_broker_result_list.push(v);
+                } else {
+                    error!("Register broker to name remoting_server error");
                 }
             }
         }
@@ -351,18 +340,13 @@ impl BrokerOuterAPI {
     ) {
         let request = Self::create_request(broker_name, topic_config);
         let name_server_address_list = self.remoting_client.get_available_name_srv_list();
-        let mut handle_vec = Vec::with_capacity(name_server_address_list.len());
-        for namesrv_addr in name_server_address_list.iter() {
+        let futures = name_server_address_list.iter().map(|namesrv_addr| {
             let cloned_request = request.clone();
             let addr = namesrv_addr.clone();
             let client = self.remoting_client.clone();
-            let join_handle =
-                tokio::spawn(async move { client.invoke_request(Some(&addr), cloned_request, timeout_mills).await });
-            handle_vec.push(join_handle);
-        }
-        while let Some(handle) = handle_vec.pop() {
-            let _result = tokio::join!(handle);
-        }
+            async move { client.invoke_request(Some(&addr), cloned_request, timeout_mills).await }
+        });
+        let _ = futures::future::join_all(futures).await;
     }
 
     pub fn shutdown(&mut self) {
@@ -408,23 +392,20 @@ impl BrokerOuterAPI {
         };
 
         // Parallel heartbeat to all NameServers
-        let handles: Vec<_> = name_server_address_list
-            .iter()
-            .map(|namesrv_addr| {
-                let addr = namesrv_addr.clone();
-                let header = request_header.clone();
-                let client = self.remoting_client.clone();
+        let futures = name_server_address_list.iter().map(|namesrv_addr| {
+            let addr = namesrv_addr.clone();
+            let header = request_header.clone();
+            let client = self.remoting_client.clone();
 
-                tokio::spawn(async move {
-                    let request = RemotingCommand::create_request_command(RequestCode::BrokerHeartbeat, header);
+            async move {
+                let request = RemotingCommand::create_request_command(RequestCode::BrokerHeartbeat, header);
 
-                    client.invoke_request_oneway(&addr, request, timeout_millis).await;
-                    debug!("Send heartbeat to name server {} success", addr);
-                })
-            })
-            .collect();
+                client.invoke_request_oneway(&addr, request, timeout_millis).await;
+                debug!("Send heartbeat to name server {} success", addr);
+            }
+        });
 
-        let _ = futures::future::join_all(handles).await;
+        futures::future::join_all(futures).await;
     }
 
     /// Send heartbeat with data version to name servers
@@ -461,25 +442,22 @@ impl BrokerOuterAPI {
             }
         };
 
-        let handles: Vec<_> = name_server_address_list
-            .iter()
-            .map(|namesrv_addr| {
-                let addr = namesrv_addr.clone();
-                let header = request_header.clone();
-                let body_clone = body.clone();
-                let client = self.remoting_client.clone();
+        let futures = name_server_address_list.iter().map(|namesrv_addr| {
+            let addr = namesrv_addr.clone();
+            let header = request_header.clone();
+            let body_clone = body.clone();
+            let client = self.remoting_client.clone();
 
-                tokio::spawn(async move {
-                    let mut request = RemotingCommand::create_request_command(RequestCode::QueryDataVersion, header);
-                    request.set_body_mut_ref(bytes::Bytes::from(body_clone));
+            async move {
+                let mut request = RemotingCommand::create_request_command(RequestCode::QueryDataVersion, header);
+                request.set_body_mut_ref(bytes::Bytes::from(body_clone));
 
-                    client.invoke_request_oneway(&addr, request, timeout_millis).await;
-                    debug!("Send heartbeat via data version to {} success", addr);
-                })
-            })
-            .collect();
+                client.invoke_request_oneway(&addr, request, timeout_millis).await;
+                debug!("Send heartbeat via data version to {} success", addr);
+            }
+        });
 
-        let _ = futures::future::join_all(handles).await;
+        futures::future::join_all(futures).await;
     }
 
     /// Check if broker needs to register to name servers
@@ -521,63 +499,60 @@ impl BrokerOuterAPI {
             .data_version()
             .clone();
 
-        let handles: Vec<_> = name_server_address_list
-            .iter()
-            .map(|namesrv_addr| {
-                let addr = namesrv_addr.clone();
-                let header = QueryDataVersionRequestHeader {
-                    cluster_name: cluster_name.clone(),
-                    broker_addr: broker_addr.clone(),
-                    broker_name: broker_name.clone(),
-                    broker_id,
-                };
-                let body = data_version_body.clone();
-                let client = self.remoting_client.clone();
-                let local_version = local_data_version.clone();
+        let futures = name_server_address_list.iter().map(|namesrv_addr| {
+            let addr = namesrv_addr.clone();
+            let header = QueryDataVersionRequestHeader {
+                cluster_name: cluster_name.clone(),
+                broker_addr: broker_addr.clone(),
+                broker_name: broker_name.clone(),
+                broker_id,
+            };
+            let body = data_version_body.clone();
+            let client = self.remoting_client.clone();
+            let local_version = local_data_version.clone();
 
-                tokio::spawn(async move {
-                    let mut request = RemotingCommand::create_request_command(RequestCode::QueryDataVersion, header);
-                    request.set_body_mut_ref(bytes::Bytes::from(body));
+            async move {
+                let mut request = RemotingCommand::create_request_command(RequestCode::QueryDataVersion, header);
+                request.set_body_mut_ref(bytes::Bytes::from(body));
 
-                    match client.invoke_request(Some(&addr), request, timeout_millis).await {
-                        Ok(response) => match ResponseCode::from(response.code()) {
-                            ResponseCode::Success => {
-                                if let Ok(response_header) =
-                                    response.decode_command_custom_header::<QueryDataVersionResponseHeader>()
-                                {
-                                    // If name server explicitly indicates changed
-                                    if response_header.changed() {
-                                        return Some(true);
-                                    }
-
-                                    // Compare data versions
-                                    if let Some(body) = response.body() {
-                                        if let Ok(ns_data_version) = DataVersion::decode(body.as_ref()) {
-                                            return Some(local_version != ns_data_version);
-                                        }
-                                    }
-
-                                    Some(false)
-                                } else {
-                                    Some(true)
+                match client.invoke_request(Some(&addr), request, timeout_millis).await {
+                    Ok(response) => match ResponseCode::from(response.code()) {
+                        ResponseCode::Success => {
+                            if let Ok(response_header) =
+                                response.decode_command_custom_header::<QueryDataVersionResponseHeader>()
+                            {
+                                // If name server explicitly indicates changed
+                                if response_header.changed() {
+                                    return Some(true);
                                 }
-                            }
-                            _ => {
-                                warn!("Query data version from {} failed: {:?}", addr, response.code());
+
+                                // Compare data versions
+                                if let Some(body) = response.body() {
+                                    if let Ok(ns_data_version) = DataVersion::decode(body.as_ref()) {
+                                        return Some(local_version != ns_data_version);
+                                    }
+                                }
+
+                                Some(false)
+                            } else {
                                 Some(true)
                             }
-                        },
-                        Err(e) => {
-                            error!("Query data version from {} error: {}", addr, e);
+                        }
+                        _ => {
+                            warn!("Query data version from {} failed: {:?}", addr, response.code());
                             Some(true)
                         }
+                    },
+                    Err(e) => {
+                        error!("Query data version from {} error: {}", addr, e);
+                        Some(true)
                     }
-                })
-            })
-            .collect();
+                }
+            }
+        });
 
-        let results = futures::future::join_all(handles).await;
-        results.into_iter().filter_map(|r| r.ok().flatten()).collect()
+        let results = futures::future::join_all(futures).await;
+        results.into_iter().flatten().collect()
     }
 
     /// Get maximum offset of a message queue
@@ -1234,13 +1209,10 @@ impl BrokerOuterAPI {
             heartbeat_timeout_mills: heartbeat_timeout_millis,
             election_priority,
         };
-        let client = self.remoting_client.clone();
-        tokio::spawn(async move {
-            let request = RemotingCommand::create_request_command(RequestCode::BrokerHeartbeat, request_header);
-            client
-                .invoke_request_oneway(&controller_address, request, timeout_millis)
-                .await;
-        });
+        let request = RemotingCommand::create_request_command(RequestCode::BrokerHeartbeat, request_header);
+        self.remoting_client
+            .invoke_request_oneway(&controller_address, request, timeout_millis)
+            .await;
     }
 
     pub async fn send_heartbeat_to_controller_sync(

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -23,6 +23,8 @@ use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RejectRequestResponse;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
 use tracing::warn;
@@ -30,6 +32,7 @@ use tracing::warn;
 use self::client_manage_processor::ClientManageProcessor;
 use crate::latency::broker_fast_failure::BrokerFastFailure;
 use crate::latency::broker_fast_failure::FastFailureQueueKind;
+use crate::latency::broker_fast_failure::FastFailureTask;
 use crate::processor::ack_message_processor::AckMessageProcessor;
 use crate::processor::admin_broker_processor::AdminBrokerProcessor;
 use crate::processor::change_invisible_time_processor::ChangeInvisibleTimeProcessor;
@@ -223,6 +226,7 @@ pub struct BrokerRequestProcessor<MS: MessageStore, TS> {
     default_request_processor: Option<ArcMut<BrokerProcessorType<MS, TS>>>,
     auth_runtime: Option<Arc<AuthRuntime>>,
     broker_fast_failure: Option<BrokerFastFailure>,
+    request_task_group: Option<TaskGroup>,
 }
 
 impl<MS, TS> BrokerRequestProcessor<MS, TS>
@@ -236,6 +240,7 @@ where
             default_request_processor: None,
             auth_runtime: None,
             broker_fast_failure: None,
+            request_task_group: None,
         }
     }
 
@@ -253,6 +258,10 @@ where
 
     pub fn set_broker_fast_failure(&mut self, broker_fast_failure: BrokerFastFailure) {
         self.broker_fast_failure = Some(broker_fast_failure);
+    }
+
+    pub fn set_request_task_group(&mut self, request_task_group: TaskGroup) {
+        self.request_task_group = Some(request_task_group);
     }
 }
 
@@ -280,6 +289,7 @@ impl<MS: MessageStore, TS> Clone for BrokerRequestProcessor<MS, TS> {
             default_request_processor: self.default_request_processor.clone(),
             auth_runtime: self.auth_runtime.clone(),
             broker_fast_failure: self.broker_fast_failure.clone(),
+            request_task_group: self.request_task_group.clone(),
         }
     }
 }
@@ -383,36 +393,32 @@ where
         }
 
         let opaque = request.opaque();
-        let mut queued_request = request.clone();
+        let queued_request = request.clone();
         let (task, response_rx) = broker_fast_failure.enqueue(queue_kind, opaque);
         let broker_fast_failure = broker_fast_failure.clone();
 
-        tokio::spawn(async move {
-            let Some(_permit) = broker_fast_failure.acquire_permit(queue_kind).await else {
-                warn!("fast failure queue permit acquisition failed: queue={queue_kind:?}");
-                if broker_fast_failure.try_mark_running(queue_kind, &task) {
-                    broker_fast_failure.complete(
-                        queue_kind,
-                        &task,
-                        Some(system_error_response(
-                            opaque,
-                            "fast failure queue permit acquisition failed",
-                        )),
-                    );
-                }
-                return;
-            };
-
-            if !broker_fast_failure.try_mark_running(queue_kind, &task) {
-                return;
+        let request_task = Self::run_fast_failure_request(
+            queue_kind,
+            broker_fast_failure.clone(),
+            task.clone(),
+            processor,
+            channel,
+            ctx,
+            queued_request,
+            opaque,
+        );
+        if let Some(task_group) = &self.request_task_group {
+            if let Err(error) = task_group.spawn("broker.request.fast-failure", TaskKind::Worker, request_task) {
+                warn!(?error, "failed to spawn fast failure request task");
+                broker_fast_failure.cancel(
+                    queue_kind,
+                    &task,
+                    system_error_response(opaque, "fast failure request task spawn failed"),
+                );
             }
-
-            let response = match processor.process_request(channel, ctx, &mut queued_request).await {
-                Ok(response) => response,
-                Err(error) => Some(system_error_response(opaque, error.to_string())),
-            };
-            broker_fast_failure.complete(queue_kind, &task, response);
-        });
+        } else {
+            request_task.await;
+        }
 
         match response_rx.await {
             Ok(response) => Ok(response),
@@ -421,6 +427,42 @@ where
                 "fast failure response channel closed before request completed",
             ))),
         }
+    }
+
+    async fn run_fast_failure_request(
+        queue_kind: FastFailureQueueKind,
+        broker_fast_failure: BrokerFastFailure,
+        task: Arc<FastFailureTask>,
+        mut processor: BrokerProcessorType<MS, TS>,
+        channel: Channel,
+        ctx: ConnectionHandlerContext,
+        mut queued_request: RemotingCommand,
+        opaque: i32,
+    ) {
+        let Some(_permit) = broker_fast_failure.acquire_permit(queue_kind).await else {
+            warn!("fast failure queue permit acquisition failed: queue={queue_kind:?}");
+            if broker_fast_failure.try_mark_running(queue_kind, &task) {
+                broker_fast_failure.complete(
+                    queue_kind,
+                    &task,
+                    Some(system_error_response(
+                        opaque,
+                        "fast failure queue permit acquisition failed",
+                    )),
+                );
+            }
+            return;
+        };
+
+        if !broker_fast_failure.try_mark_running(queue_kind, &task) {
+            return;
+        }
+
+        let response = match processor.process_request(channel, ctx, &mut queued_request).await {
+            Ok(response) => response,
+            Err(error) => Some(system_error_response(opaque, error.to_string())),
+        };
+        broker_fast_failure.complete(queue_kind, &task, response);
     }
 }
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/batch_mq_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/batch_mq_handler.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -28,9 +27,8 @@ use rocketmq_remoting::protocol::RemotingDeserializable;
 use rocketmq_remoting::protocol::RemotingSerializable;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_rust::ArcMut;
-use rocketmq_rust::CountDownLatch;
 use rocketmq_store::base::message_store::MessageStore;
-use tokio::sync::Mutex;
+use tokio::time::timeout;
 use tracing::warn;
 
 use crate::broker_runtime::BrokerRuntimeInner;
@@ -76,37 +74,37 @@ impl<MS: MessageStore> BatchMqHandler<MS> {
                 addr_map.extend(self.broker_runtime_inner.broker_member_group().broker_addrs.clone());
                 addr_map.remove(&self.broker_runtime_inner.broker_config().broker_identity.broker_id);
 
-                let count_down_latch = CountDownLatch::new(addr_map.len() as u32);
                 let request_body = Bytes::from(request_body.encode().expect("lockBatchMQ encode error"));
-                let mq_lock_map_arc = Arc::new(Mutex::new(mq_lock_map.clone()));
-                for (_, broker_addr) in addr_map {
-                    let count_down_latch = count_down_latch.clone();
+                let futures = addr_map.into_values().map(|broker_addr| {
                     let broker_outer_api_ = self.broker_runtime_inner.clone();
-                    let mq_lock_map = mq_lock_map_arc.clone();
                     let request_body_cloned = request_body.clone();
-                    tokio::spawn(async move {
-                        let result = broker_outer_api_
-                            .broker_outer_api()
-                            .lock_batch_mq_async(&broker_addr, request_body_cloned, 1000)
-                            .await;
+                    async move {
+                        (
+                            broker_addr.clone(),
+                            broker_outer_api_
+                                .broker_outer_api()
+                                .lock_batch_mq_async(&broker_addr, request_body_cloned, 1000)
+                                .await,
+                        )
+                    }
+                });
+
+                if let Ok(results) = timeout(Duration::from_secs(2), futures::future::join_all(futures)).await {
+                    for (broker_addr, result) in results {
                         match result {
                             Ok(lock_ok_mqs) => {
-                                let mut mq_lock_map = mq_lock_map.lock().await;
                                 for mq in lock_ok_mqs {
                                     *mq_lock_map.entry(mq).or_insert(0) += 1;
                                 }
                             }
                             Err(e) => {
-                                warn!("lockBatchMQAsync failed: {:?}", e);
+                                warn!("lockBatchMQAsync failed on {}, {:?}", broker_addr, e);
                             }
                         }
-                        count_down_latch.count_down().await;
-                    });
+                    }
                 }
-                count_down_latch.wait_timeout(Duration::from_secs(2)).await;
 
-                let mq_lock_map = mq_lock_map_arc.lock().await;
-                for (mq, count) in &*mq_lock_map {
+                for (mq, count) in &mq_lock_map {
                     if *count >= quorum {
                         lock_ok_mqset.insert(mq.clone());
                     }

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
@@ -15,6 +15,7 @@
 use std::any::Any;
 
 use cheetah_string::CheetahString;
+use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::message::message_ext::MessageExt;
@@ -25,9 +26,13 @@ use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
 use rocketmq_remoting::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_remoting::rpc::rpc_request_header::RpcRequestHeader;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
+use std::time::Duration;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -41,6 +46,7 @@ const TCMT_QUEUE_NUMS: i32 = 1;
 pub struct DefaultTransactionalMessageCheckListener<MS: MessageStore> {
     broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>,
     broker_client: ArcMut<Broker2Client>,
+    task_group: Option<TaskGroup>,
 }
 
 impl<MS: MessageStore> Clone for DefaultTransactionalMessageCheckListener<MS> {
@@ -48,15 +54,49 @@ impl<MS: MessageStore> Clone for DefaultTransactionalMessageCheckListener<MS> {
         Self {
             broker_client: self.broker_client.clone(),
             broker_runtime_inner: self.broker_runtime_inner.clone(),
+            task_group: self.task_group.clone(),
         }
     }
 }
 
 impl<MS: MessageStore> DefaultTransactionalMessageCheckListener<MS> {
     pub fn new(broker_client: Broker2Client, broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
+        let task_group = Self::create_task_group(broker_runtime_inner.broker_config());
         Self {
             broker_runtime_inner,
             broker_client: ArcMut::new(broker_client),
+            task_group,
+        }
+    }
+
+    fn create_task_group(broker_config: &BrokerConfig) -> Option<TaskGroup> {
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                warn!(
+                    ?error,
+                    "transaction check listener initialized outside Tokio runtime; check tasks will run inline"
+                );
+                return None;
+            }
+        };
+        Some(TaskGroup::root(
+            format!("rocketmq-broker.transaction-check.{}", broker_config.broker_name()),
+            runtime,
+        ))
+    }
+
+    pub async fn shutdown(&self) {
+        let Some(task_group) = self.task_group.as_ref() else {
+            return;
+        };
+
+        let report = task_group.shutdown(Duration::from_secs(5)).await;
+        if !report.is_healthy() {
+            warn!(
+                report = %report.to_json(),
+                "DefaultTransactionalMessageCheckListener shutdown report is unhealthy"
+            );
         }
     }
 }
@@ -145,12 +185,27 @@ where
     }
 
     async fn resolve_half_msg(&self, msg_ext: MessageExt) -> rocketmq_error::RocketMQResult<()> {
+        let Some(task_group) = self.task_group.as_ref() else {
+            self.send_check_message(msg_ext).await?;
+            return Ok(());
+        };
+
         let this = self.clone();
-        tokio::spawn(async move {
-            this.send_check_message(msg_ext).await.unwrap_or_else(|e| {
-                error!("Failed to send check message: {}", e);
-            });
-        });
+        task_group
+            .spawn(
+                "broker.transaction-check.send-check-message",
+                TaskKind::Worker,
+                async move {
+                    this.send_check_message(msg_ext).await.unwrap_or_else(|e| {
+                        error!("Failed to send check message: {}", e);
+                    });
+                },
+            )
+            .map_err(|error| {
+                rocketmq_error::RocketMQError::Internal(format!(
+                    "failed to spawn transaction check message task: {error}"
+                ))
+            })?;
         Ok(())
     }
 

--- a/rocketmq-common/src/common/stats/moment_stats_item.rs
+++ b/rocketmq-common/src/common/stats/moment_stats_item.rs
@@ -18,9 +18,12 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
 
-use tokio::task;
+use parking_lot::Mutex;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use tokio::time;
 use tracing::info;
+use tracing::warn;
 
 use crate::TimeUtils::current_millis;
 use crate::UtilAll::compute_next_minutes_time_millis;
@@ -30,6 +33,7 @@ pub struct MomentStatsItem {
     value: Arc<AtomicI64>,
     stats_name: String,
     stats_key: String,
+    task_group: Arc<Mutex<Option<TaskGroup>>>,
 }
 
 impl MomentStatsItem {
@@ -38,24 +42,78 @@ impl MomentStatsItem {
             value: Arc::new(AtomicI64::new(0)),
             stats_name,
             stats_key,
+            task_group: Arc::new(Mutex::new(None)),
         }
     }
 
     pub fn init(self: Arc<Self>) {
-        let self_clone = self;
-        tokio::spawn(async move {
+        if self.task_group.lock().is_some() {
+            warn!(
+                "[{}] [{}] MomentStatsItem already initialized",
+                self.stats_name, self.stats_key
+            );
+            return;
+        }
+
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                warn!(
+                    "[{}] [{}] failed to initialize MomentStatsItem outside Tokio runtime: {}",
+                    self.stats_name, self.stats_key, error
+                );
+                return;
+            }
+        };
+        let task_group = TaskGroup::root(
+            format!("rocketmq-common.moment-stats.{}.{}", self.stats_name, self.stats_key),
+            runtime,
+        );
+        let shutdown_token = task_group.cancellation_token();
+        let self_clone = self.clone();
+        if let Err(error) = task_group.spawn_service("common.moment-stats.print", async move {
             let initial_delay = Duration::from_millis(
                 (compute_next_minutes_time_millis() as i64 - current_millis() as i64).unsigned_abs(),
             );
-            time::sleep(initial_delay).await;
-            let interval = time::interval(Duration::from_secs(300));
-            tokio::pin!(interval);
+            tokio::select! {
+                _ = shutdown_token.cancelled() => {
+                    return;
+                }
+                _ = time::sleep(initial_delay) => {}
+            }
+            let mut interval = time::interval(Duration::from_secs(300));
             loop {
-                interval.as_mut().tick().await;
+                tokio::select! {
+                    _ = shutdown_token.cancelled() => {
+                        break;
+                    }
+                    _ = interval.tick() => {}
+                }
                 self_clone.print_at_minutes();
                 self_clone.value.store(0, Ordering::Relaxed);
             }
-        });
+        }) {
+            warn!(
+                "[{}] [{}] failed to spawn MomentStatsItem task: {}",
+                self.stats_name, self.stats_key, error
+            );
+            return;
+        }
+        *self.task_group.lock() = Some(task_group);
+    }
+
+    pub fn shutdown(&self) {
+        if let Some(task_group) = self.task_group.lock().take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "[{}] [{}] MomentStatsItem shutdown report is unhealthy",
+                    self.stats_name,
+                    self.stats_key
+                );
+            }
+        }
     }
 
     pub fn print_at_minutes(&self) {

--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -59,11 +59,13 @@ use rocketmq_remoting::remoting::RemotingService;
 use rocketmq_remoting::remoting_server::rocketmq_tokio_server::RocketMQServer;
 use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::WeakArcMut;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::error;
 use tracing::info;
@@ -146,7 +148,16 @@ impl BrokerLifecycleListener for BrokerInactiveListener {
         let cluster_name = cluster_name.map(str::to_owned);
         let broker_name = CheetahString::from_string(broker_name.to_owned());
 
-        tokio::spawn(async move {
+        let Some(task_group) = controller_manager.manager_task_group() else {
+            warn!(
+                "Skip inactive broker handling because controller task group is not initialized, cluster={:?}, \
+                 broker={}, broker_id={:?}",
+                cluster_name, broker_name, broker_id
+            );
+            return;
+        };
+
+        if let Err(error) = task_group.spawn("controller.broker-inactive", TaskKind::Worker, async move {
             if !controller_manager.is_leader() {
                 warn!(
                     "Broker inactive event ignored on follower controller, cluster={:?}, broker={}, broker_id={:?}",
@@ -304,7 +315,9 @@ impl BrokerLifecycleListener for BrokerInactiveListener {
                 "Elect-master after broker inactive exhausted retries, cluster={:?}, broker={}, broker_id={:?}",
                 cluster_name, broker_name, broker_id
             );
-        });
+        }) {
+            warn!(?error, "failed to spawn inactive broker handling task");
+        }
     }
 }
 
@@ -369,8 +382,8 @@ pub struct ControllerManager {
 
     /// Remoting server for inbound RPC requests
     remoting_server: Option<RocketMQServer<ControllerRequestProcessor>>,
-    remoting_server_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
     remoting_server_shutdown_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    manager_task_group: Arc<Mutex<Option<TaskGroup>>>,
 
     /// Remoting client for outbound RPC calls
     remoting_client: ArcMut<RocketmqDefaultClient>,
@@ -386,8 +399,6 @@ pub struct ControllerManager {
     initialized: Arc<AtomicBool>,
 
     broker_housekeeping_service: Option<Arc<BrokerHousekeepingService>>,
-    leadership_watch_task: Arc<Mutex<Option<JoinHandle<()>>>>,
-    notify_worker_task: Arc<Mutex<Option<JoinHandle<()>>>>,
     notify_dispatch_tx: Arc<Mutex<Option<mpsc::UnboundedSender<NotifyTask>>>>,
     notify_cache: Arc<RwLock<HashMap<NotifyCacheKey, NotifyCacheState>>>,
     pending_notify_state: Arc<RwLock<HashMap<NotifyCacheKey, NotifyCacheState>>>,
@@ -482,21 +493,51 @@ impl ControllerManager {
             heartbeat_manager,
             processor,
             remoting_server,
-            remoting_server_handle: Arc::new(Mutex::new(None)),
             remoting_server_shutdown_tx: Arc::new(Mutex::new(None)),
+            manager_task_group: Arc::new(Mutex::new(None)),
             remoting_client,
             #[cfg(feature = "metrics")]
             metrics_manager,
             running: Arc::new(AtomicBool::new(false)),
             initialized: Arc::new(AtomicBool::new(false)),
             broker_housekeeping_service: None,
-            leadership_watch_task: Arc::new(Mutex::new(None)),
-            notify_worker_task: Arc::new(Mutex::new(None)),
             notify_dispatch_tx: Arc::new(Mutex::new(None)),
             notify_cache: Arc::new(RwLock::new(HashMap::new())),
             pending_notify_state: Arc::new(RwLock::new(HashMap::new())),
             notify_generation: Arc::new(AtomicU64::new(0)),
         })
+    }
+
+    fn ensure_manager_task_group(&self) -> Result<TaskGroup> {
+        let mut guard = self.manager_task_group.lock();
+        if let Some(task_group) = guard.as_ref() {
+            return Ok(task_group.clone());
+        }
+
+        let handle = tokio::runtime::Handle::try_current()
+            .map_err(|error| ControllerError::Internal(format!("No Tokio runtime for controller tasks: {error}")))?;
+        let task_group = TaskGroup::root("rocketmq-controller.manager", RuntimeHandle::new(handle));
+        *guard = Some(task_group.clone());
+        Ok(task_group)
+    }
+
+    fn manager_task_group(&self) -> Option<TaskGroup> {
+        self.manager_task_group.lock().clone()
+    }
+
+    async fn shutdown_manager_tasks(&self) {
+        let task_group = self.manager_task_group.lock().take();
+        let Some(task_group) = task_group else {
+            return;
+        };
+
+        let report = task_group.shutdown(Duration::from_secs(10)).await;
+        if !report.is_healthy() {
+            warn!(
+                report = %report.to_json(),
+                "Controller manager task shutdown report is unhealthy"
+            );
+        }
     }
 
     /// Initialize the controller manager
@@ -703,6 +744,8 @@ impl ControllerManager {
         }
         info!("Processor manager started");
 
+        let manager_task_group = self.ensure_manager_task_group()?;
+
         // Start remoting server (for inbound RPC requests)
         // Reference: NameServerRuntime.start() - register processors then start server
         if let Some(mut server) = self.remoting_server.take() {
@@ -714,14 +757,17 @@ impl ControllerManager {
                 .map(|service| service as Arc<dyn ChannelEventListener>);
             let (shutdown_tx, shutdown_rx) = oneshot::channel();
             *self.remoting_server_shutdown_tx.lock() = Some(shutdown_tx);
-            let handle = tokio::spawn(async move {
+            if let Err(error) = manager_task_group.spawn_service("controller.remoting-server", async move {
                 server
                     .run_with_shutdown(request_processor, broker_housekeeping_service, async move {
                         let _ = shutdown_rx.await;
                     })
                     .await;
-            });
-            *self.remoting_server_handle.lock() = Some(handle);
+            }) {
+                return Err(ControllerError::Internal(format!(
+                    "Failed to spawn controller remoting server task: {error}"
+                )));
+            }
             info!("Remoting server started with ControllerRequestProcessor");
         }
 
@@ -732,8 +778,8 @@ impl ControllerManager {
             info!("Remoting client started");
         }
 
-        self.start_notify_worker_loop().await;
-        self.start_leadership_watch_loop();
+        self.start_notify_worker_loop().await?;
+        self.start_leadership_watch_loop()?;
 
         // Metrics are already running if enabled
         #[cfg(feature = "metrics")]
@@ -772,14 +818,8 @@ impl ControllerManager {
 
         info!("Shutting down controller manager...");
 
-        if let Some(handle) = self.leadership_watch_task.lock().take() {
-            handle.abort();
-        }
         if let Some(tx) = self.notify_dispatch_tx.lock().take() {
             drop(tx);
-        }
-        if let Some(handle) = self.notify_worker_task.lock().take() {
-            handle.abort();
         }
         if let Some(shutdown_tx) = self.remoting_server_shutdown_tx.lock().take() {
             let _ = shutdown_tx.send(());
@@ -787,6 +827,7 @@ impl ControllerManager {
         if let Err(error) = self.apply_leadership_state(false).await {
             warn!("Failed to stop leader-only scheduling during shutdown: {}", error);
         }
+        self.shutdown_manager_tasks().await;
 
         // Shutdown processor first to stop accepting requests
         // Errors are logged but don't stop the shutdown process
@@ -820,20 +861,6 @@ impl ControllerManager {
             Ok(Ok(())) => info!("Raft controller shut down"),
             Ok(Err(e)) => error!("Failed to shutdown Raft: {}", e),
             Err(_) => warn!("Timed out waiting for Raft controller shutdown"),
-        }
-
-        let remoting_server_handle = { self.remoting_server_handle.lock().take() };
-        if let Some(handle) = remoting_server_handle {
-            let mut handle = handle;
-            match tokio::time::timeout(Duration::from_secs(10), &mut handle).await {
-                Ok(Ok(_)) => info!("Remoting server shut down"),
-                Ok(Err(error)) => warn!("Remoting server task exited with error: {}", error),
-                Err(_) => {
-                    warn!("Timed out waiting for remoting server shutdown");
-                    handle.abort();
-                    let _ = handle.await;
-                }
-            }
         }
 
         // Metrics manager cleanup is automatic via Drop
@@ -972,42 +999,46 @@ impl ControllerManager {
         self.raft_controller.set_runtime_elect_enabled(enabled)
     }
 
-    fn start_leadership_watch_loop(self: &ArcMut<Self>) {
-        if self.leadership_watch_task.lock().is_some() {
-            return;
-        }
-
+    fn start_leadership_watch_loop(self: &ArcMut<Self>) -> Result<()> {
         let weak_manager = ArcMut::downgrade(self);
         let interval = Duration::from_millis(self.config.heartbeat_interval_ms.max(100));
-        let handle = tokio::spawn(async move {
-            let mut was_leader = false;
-            let mut ticker = tokio::time::interval(interval);
+        let task_group = self.ensure_manager_task_group()?;
+        let shutdown_token = task_group.cancellation_token();
+        task_group
+            .spawn_service("controller.leadership-watch", async move {
+                let mut was_leader = false;
+                let mut ticker = tokio::time::interval(interval);
 
-            loop {
-                ticker.tick().await;
+                loop {
+                    tokio::select! {
+                        _ = shutdown_token.cancelled() => {
+                            break;
+                        }
+                        _ = ticker.tick() => {}
+                    }
 
-                let Some(manager) = weak_manager.upgrade() else {
-                    break;
-                };
+                    let Some(manager) = weak_manager.upgrade() else {
+                        break;
+                    };
 
-                if !manager.is_running() {
-                    break;
+                    if !manager.is_running() {
+                        break;
+                    }
+
+                    let is_leader = manager.is_leader();
+                    if is_leader == was_leader {
+                        continue;
+                    }
+
+                    if let Err(error) = manager.apply_leadership_state(is_leader).await {
+                        warn!("Failed to apply leadership state transition: {}", error);
+                    } else {
+                        was_leader = is_leader;
+                    }
                 }
-
-                let is_leader = manager.is_leader();
-                if is_leader == was_leader {
-                    continue;
-                }
-
-                if let Err(error) = manager.apply_leadership_state(is_leader).await {
-                    warn!("Failed to apply leadership state transition: {}", error);
-                } else {
-                    was_leader = is_leader;
-                }
-            }
-        });
-
-        *self.leadership_watch_task.lock() = Some(handle);
+            })
+            .map_err(|error| ControllerError::Internal(format!("Failed to spawn leadership watch task: {error}")))?;
+        Ok(())
     }
 
     async fn apply_leadership_state(&self, is_leader: bool) -> Result<()> {
@@ -1116,15 +1147,27 @@ impl ControllerManager {
         let notify_dispatch_tx = self.notify_dispatch_tx.clone();
         let notify_generation = self.notify_generation.clone();
         let delay = self.notify_retry_delay(task.attempt);
-        tokio::spawn(async move {
-            sleep(delay).await;
+        let Some(task_group) = self.manager_task_group() else {
+            warn!("Skip broker role notify retry because controller task group is not initialized");
+            return;
+        };
+        let shutdown_token = task_group.cancellation_token();
+        if let Err(error) = task_group.spawn("controller.notify-retry", TaskKind::Worker, async move {
+            tokio::select! {
+                _ = shutdown_token.cancelled() => {
+                    return;
+                }
+                _ = sleep(delay) => {}
+            }
             if notify_generation.load(Ordering::SeqCst) != task.generation {
                 return;
             }
             if let Some(sender) = notify_dispatch_tx.lock().clone() {
                 let _ = sender.send(task.retry());
             }
-        });
+        }) {
+            warn!(?error, "failed to spawn controller broker role notify retry task");
+        }
     }
 
     async fn process_notify_task(&self, task: NotifyTask) {
@@ -1169,25 +1212,33 @@ impl ControllerManager {
         }
     }
 
-    async fn start_notify_worker_loop(self: &ArcMut<Self>) {
-        if self.notify_worker_task.lock().is_some() {
-            return;
-        }
-
+    async fn start_notify_worker_loop(self: &ArcMut<Self>) -> Result<()> {
         let (sender, mut receiver) = mpsc::unbounded_channel();
         *self.notify_dispatch_tx.lock() = Some(sender);
 
         let weak_manager = ArcMut::downgrade(self);
-        let handle = tokio::spawn(async move {
-            while let Some(task) = receiver.recv().await {
-                let Some(manager) = weak_manager.upgrade() else {
-                    break;
-                };
-                manager.process_notify_task(task).await;
-            }
-        });
-
-        *self.notify_worker_task.lock() = Some(handle);
+        let task_group = self.ensure_manager_task_group()?;
+        let shutdown_token = task_group.cancellation_token();
+        task_group
+            .spawn_service("controller.notify-worker", async move {
+                loop {
+                    let task = tokio::select! {
+                        _ = shutdown_token.cancelled() => {
+                            break;
+                        }
+                        task = receiver.recv() => task,
+                    };
+                    let Some(task) = task else {
+                        break;
+                    };
+                    let Some(manager) = weak_manager.upgrade() else {
+                        break;
+                    };
+                    manager.process_notify_task(task).await;
+                }
+            })
+            .map_err(|error| ControllerError::Internal(format!("Failed to spawn notify worker task: {error}")))?;
+        Ok(())
     }
 
     pub async fn notify_broker_role_changed(&self, mut response: RemotingCommand) -> Result<()> {
@@ -1294,62 +1345,29 @@ impl Drop for ControllerManager {
         if self.running.load(Ordering::Acquire) {
             warn!("Controller manager dropped while running, attempting emergency shutdown");
 
-            // Spawn blocking emergency shutdown
-            // We use try_lock to avoid blocking the drop
-            let running = self.running.clone();
-            let processor = self.processor.clone();
-            let mut heartbeat_manager = self.heartbeat_manager.clone();
-            let metadata = self.metadata.clone();
-            let leadership_watch_task = self.leadership_watch_task.clone();
-            let notify_worker_task = self.notify_worker_task.clone();
-            let notify_dispatch_tx = self.notify_dispatch_tx.clone();
-            let notify_cache = self.notify_cache.clone();
-            let pending_notify_state = self.pending_notify_state.clone();
-            let notify_generation = self.notify_generation.clone();
-            let remoting_server_handle = self.remoting_server_handle.clone();
-            let remoting_server_shutdown_tx = self.remoting_server_shutdown_tx.clone();
-
-            // Clone remoting_client for emergency shutdown
-            let mut remoting_client = self.remoting_client.clone();
-
-            // Spawn a task to perform shutdown
-            // Note: This is best-effort; drop should not block
-            tokio::spawn(async move {
-                running.store(false, Ordering::SeqCst);
-
-                // Try to shutdown components
-                let _ = processor.shutdown().await;
-
-                BrokerHeartbeatManager::shutdown(heartbeat_manager.as_mut());
-
-                let _ = metadata.shutdown().await;
-
-                // Shutdown remoting client
-                if let Some(shutdown_tx) = remoting_server_shutdown_tx.lock().take() {
-                    let _ = shutdown_tx.send(());
+            self.running.store(false, Ordering::SeqCst);
+            if let Some(shutdown_tx) = self.remoting_server_shutdown_tx.lock().take() {
+                let _ = shutdown_tx.send(());
+            }
+            if let Some(tx) = self.notify_dispatch_tx.lock().take() {
+                drop(tx);
+            }
+            self.notify_generation.fetch_add(1, Ordering::SeqCst);
+            self.pending_notify_state.write().clear();
+            self.notify_cache.write().clear();
+            BrokerHeartbeatManager::shutdown(self.heartbeat_manager.as_mut());
+            self.remoting_client.shutdown();
+            if let Some(task_group) = self.manager_task_group.lock().take() {
+                let report = task_group.shutdown_now();
+                if !report.is_healthy() {
+                    warn!(
+                        report = %report.to_json(),
+                        "Controller manager emergency task shutdown report is unhealthy"
+                    );
                 }
+            }
 
-                remoting_client.shutdown();
-                if let Some(handle) = remoting_server_handle.lock().take() {
-                    handle.abort();
-                }
-                if let Some(handle) = leadership_watch_task.lock().take() {
-                    handle.abort();
-                }
-                if let Some(tx) = notify_dispatch_tx.lock().take() {
-                    drop(tx);
-                }
-                if let Some(handle) = notify_worker_task.lock().take() {
-                    handle.abort();
-                }
-                notify_generation.fetch_add(1, Ordering::SeqCst);
-                pending_notify_state.write().clear();
-                notify_cache.write().clear();
-
-                // Note: raft shutdown handled by Drop impl of RaftController
-
-                info!("Emergency shutdown completed");
-            });
+            info!("Emergency shutdown completed");
         }
     }
 }

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -68,10 +68,11 @@ use rocketmq_remoting::protocol::header::namesrv::broker_request::BrokerHeartbea
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::protocol::CommandCustomHeader;
 use rocketmq_remoting::protocol::RemotingDeserializable;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server;
 use tracing::info;
@@ -88,8 +89,9 @@ pub struct OpenRaftController {
     config: ArcMut<ControllerConfig>,
     /// Raft node manager
     node: Option<Arc<RaftNodeManager>>,
-    /// gRPC server task handle
-    handle: Option<JoinHandle<()>>,
+    /// gRPC server and scheduling task groups
+    task_group: Arc<Mutex<Option<TaskGroup>>>,
+    scan_task_group: Arc<Mutex<Option<TaskGroup>>>,
     /// Shutdown signal sender for gRPC server
     shutdown_tx: Option<oneshot::Sender<()>>,
 
@@ -97,7 +99,6 @@ pub struct OpenRaftController {
     lifecycle_listeners: Arc<RwLock<Vec<Arc<dyn BrokerLifecycleListener>>>>,
     scheduling: Arc<AtomicBool>,
     first_received_heartbeat_time: Arc<AtomicU64>,
-    scan_task_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 impl OpenRaftController {
@@ -113,13 +114,73 @@ impl OpenRaftController {
         Self {
             config,
             node: None,
-            handle: None,
+            task_group: Arc::new(Mutex::new(None)),
+            scan_task_group: Arc::new(Mutex::new(None)),
             shutdown_tx: None,
             heartbeat_manager,
             lifecycle_listeners: Arc::new(RwLock::new(Vec::new())),
             scheduling: Arc::new(AtomicBool::new(false)),
             first_received_heartbeat_time: Arc::new(AtomicU64::new(0)),
-            scan_task_handle: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn ensure_task_group(&self) -> RocketMQResult<TaskGroup> {
+        let mut guard = self.task_group.lock();
+        if let Some(task_group) = guard.as_ref() {
+            return Ok(task_group.clone());
+        }
+
+        let handle = tokio::runtime::Handle::try_current().map_err(|error| {
+            rocketmq_error::RocketMQError::Internal(format!("No Tokio runtime for OpenRaft controller tasks: {error}"))
+        })?;
+        let task_group = TaskGroup::root("rocketmq-controller.openraft", RuntimeHandle::new(handle));
+        *guard = Some(task_group.clone());
+        Ok(task_group)
+    }
+
+    fn start_scan_task_group(&self) -> RocketMQResult<TaskGroup> {
+        let mut guard = self.scan_task_group.lock();
+        if let Some(task_group) = guard.take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                tracing::warn!(
+                    report = %report.to_json(),
+                    "OpenRaft scan task shutdown report is unhealthy before restart"
+                );
+            }
+        }
+
+        let task_group = self
+            .ensure_task_group()?
+            .child("controller.openraft.scan-not-active-broker");
+        *guard = Some(task_group.clone());
+        Ok(task_group)
+    }
+
+    fn stop_scan_task_group(&self) {
+        if let Some(task_group) = self.scan_task_group.lock().take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                tracing::warn!(
+                    report = %report.to_json(),
+                    "OpenRaft scan task shutdown report is unhealthy"
+                );
+            }
+        }
+    }
+
+    async fn shutdown_task_group(&self) {
+        let task_group = self.task_group.lock().take();
+        let Some(task_group) = task_group else {
+            return;
+        };
+
+        let report = task_group.shutdown(Duration::from_secs(10)).await;
+        if !report.is_healthy() {
+            tracing::warn!(
+                report = %report.to_json(),
+                "OpenRaft controller task shutdown report is unhealthy"
+            );
         }
     }
 
@@ -426,27 +487,37 @@ impl Controller for OpenRaftController {
                 "Failed to bind OpenRaft gRPC server for node {node_id} on {addr}: {error}"
             ))
         })?;
+        let task_group = self.ensure_task_group()?;
+        let shutdown_token = task_group.cancellation_token();
 
-        let handle = tokio::spawn(async move {
-            info!("gRPC server starting for node {} on {}", node_id, addr);
+        task_group
+            .spawn_service("controller.openraft.grpc-server", async move {
+                info!("gRPC server starting for node {} on {}", node_id, addr);
 
-            let result = Server::builder()
-                .add_service(OpenRaftServiceServer::new(service))
-                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
-                    shutdown_rx.await.ok();
-                    info!("Shutdown signal received for node {}, stopping gRPC server", node_id);
-                })
-                .await;
+                let result = Server::builder()
+                    .add_service(OpenRaftServiceServer::new(service))
+                    .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                        tokio::select! {
+                            _ = shutdown_rx => {}
+                            _ = shutdown_token.cancelled() => {}
+                        }
+                        info!("Shutdown signal received for node {}, stopping gRPC server", node_id);
+                    })
+                    .await;
 
-            if let Err(e) = result {
-                eprintln!("gRPC server error for node {}: {}", node_id, e);
-            } else {
-                info!("gRPC server for node {} stopped gracefully", node_id);
-            }
-        });
+                if let Err(e) = result {
+                    eprintln!("gRPC server error for node {}: {}", node_id, e);
+                } else {
+                    info!("gRPC server for node {} stopped gracefully", node_id);
+                }
+            })
+            .map_err(|error| {
+                rocketmq_error::RocketMQError::Internal(format!(
+                    "Failed to spawn OpenRaft gRPC server task for node {node_id}: {error}"
+                ))
+            })?;
 
         self.node = Some(node);
-        self.handle = Some(handle);
         self.shutdown_tx = Some(shutdown_tx);
 
         info!("OpenRaft controller started successfully");
@@ -457,9 +528,7 @@ impl Controller for OpenRaftController {
         info!("Shutting down OpenRaft controller");
 
         self.scheduling.store(false, Ordering::Release);
-        if let Some(handle) = self.scan_task_handle.lock().take() {
-            handle.abort();
-        }
+        self.stop_scan_task_group();
 
         // Take and send shutdown signal to gRPC server
         if let Some(tx) = self.shutdown_tx.take() {
@@ -479,20 +548,7 @@ impl Controller for OpenRaftController {
             }
         }
 
-        // Wait for server task to complete (with timeout)
-        if let Some(handle) = self.handle.take() {
-            let timeout = tokio::time::Duration::from_secs(10);
-            let mut handle = handle;
-            match tokio::time::timeout(timeout, &mut handle).await {
-                Ok(Ok(_)) => info!("Server task completed successfully"),
-                Ok(Err(e)) => eprintln!("Server task panicked: {}", e),
-                Err(_) => {
-                    eprintln!("Timeout waiting for server task to complete");
-                    handle.abort();
-                    let _ = handle.await;
-                }
-            }
-        }
+        self.shutdown_task_group().await;
 
         info!("OpenRaft controller shutdown completed");
         Ok(())
@@ -511,58 +567,73 @@ impl Controller for OpenRaftController {
         let listeners = self.lifecycle_listeners.clone();
         let scheduling = self.scheduling.clone();
         let first_received_heartbeat_time = self.first_received_heartbeat_time.clone();
-        let handle = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(2000)).await;
-            let mut interval =
-                tokio::time::interval(Duration::from_millis(config.scan_not_active_broker_interval.max(1)));
-
-            loop {
-                interval.tick().await;
-                if !scheduling.load(Ordering::Acquire) {
-                    break;
+        let scan_task_group = self.start_scan_task_group()?;
+        let shutdown_token = scan_task_group.cancellation_token();
+        scan_task_group
+            .spawn_service("controller.openraft.scan-not-active-broker", async move {
+                tokio::select! {
+                    _ = shutdown_token.cancelled() => {
+                        return;
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(2000)) => {}
                 }
+                let mut interval =
+                    tokio::time::interval(Duration::from_millis(config.scan_not_active_broker_interval.max(1)));
 
-                use openraft::async_runtime::WatchReceiver;
-                let metrics = node.raft().metrics().borrow_watched().clone();
-                if metrics.current_leader != Some(config.node_id) {
-                    continue;
-                }
+                loop {
+                    tokio::select! {
+                        _ = shutdown_token.cancelled() => {
+                            break;
+                        }
+                        _ = interval.tick() => {}
+                    }
+                    if !scheduling.load(Ordering::Acquire) {
+                        break;
+                    }
 
-                let first_heartbeat = first_received_heartbeat_time.load(Ordering::Acquire);
-                let now_millis = current_millis();
-                if first_heartbeat == 0 || now_millis < first_heartbeat.saturating_add(config.raft_scan_wait_timeout_ms)
-                {
-                    continue;
-                }
+                    use openraft::async_runtime::WatchReceiver;
+                    let metrics = node.raft().metrics().borrow_watched().clone();
+                    if metrics.current_leader != Some(config.node_id) {
+                        continue;
+                    }
 
-                match Self::scan_not_active_broker_once(node.clone(), now_millis).await {
-                    Ok(inactive_brokers) => {
-                        for broker_identity in inactive_brokers {
-                            for listener in listeners.read().iter() {
-                                listener.on_broker_inactive(
-                                    Some(broker_identity.cluster_name.as_str()),
-                                    broker_identity.broker_name.as_str(),
-                                    broker_identity.broker_id.map(|broker_id| broker_id as i64),
-                                );
+                    let first_heartbeat = first_received_heartbeat_time.load(Ordering::Acquire);
+                    let now_millis = current_millis();
+                    if first_heartbeat == 0
+                        || now_millis < first_heartbeat.saturating_add(config.raft_scan_wait_timeout_ms)
+                    {
+                        continue;
+                    }
+
+                    match Self::scan_not_active_broker_once(node.clone(), now_millis).await {
+                        Ok(inactive_brokers) => {
+                            for broker_identity in inactive_brokers {
+                                for listener in listeners.read().iter() {
+                                    listener.on_broker_inactive(
+                                        Some(broker_identity.cluster_name.as_str()),
+                                        broker_identity.broker_name.as_str(),
+                                        broker_identity.broker_id.map(|broker_id| broker_id as i64),
+                                    );
+                                }
                             }
                         }
-                    }
-                    Err(error) => {
-                        tracing::warn!("Failed to run replicated broker inactive scan: {}", error);
+                        Err(error) => {
+                            tracing::warn!("Failed to run replicated broker inactive scan: {}", error);
+                        }
                     }
                 }
-            }
-        });
-
-        *self.scan_task_handle.lock() = Some(handle);
+            })
+            .map_err(|error| {
+                rocketmq_error::RocketMQError::Internal(format!(
+                    "Failed to spawn OpenRaft active broker scan task: {error}"
+                ))
+            })?;
         Ok(())
     }
 
     async fn stop_scheduling(&self) -> RocketMQResult<()> {
         self.scheduling.store(false, Ordering::Release);
-        if let Some(handle) = self.scan_task_handle.lock().take() {
-            handle.abort();
-        }
+        self.stop_scan_task_group();
         Ok(())
     }
 

--- a/rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs
+++ b/rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs
@@ -21,8 +21,9 @@ use std::time::Duration;
 use dashmap::DashMap;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::net::channel::Channel;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
-use tokio::task::JoinHandle;
 use tracing::info;
 use tracing::warn;
 
@@ -69,8 +70,8 @@ pub struct DefaultBrokerHeartbeatManager {
     /// Registered lifecycle listeners (initialized before start, immutable afterward)
     lifecycle_listeners: Vec<Arc<dyn BrokerLifecycleListener>>,
 
-    /// Background scan task handle
-    scan_task_handle: Option<JoinHandle<()>>,
+    /// Background scan task group
+    scan_task_group: Option<TaskGroup>,
 
     /// Scan interval in milliseconds
     scan_interval_ms: u64,
@@ -88,7 +89,7 @@ impl DefaultBrokerHeartbeatManager {
             config,
             broker_live_table: Arc::new(DashMap::with_capacity(256)),
             lifecycle_listeners: Vec::new(),
-            scan_task_handle: None,
+            scan_task_group: None,
             scan_interval_ms,
         }
     }
@@ -155,7 +156,7 @@ impl DefaultBrokerHeartbeatManager {
     }
 
     /// Notify listeners that a broker is inactive
-    async fn notify_broker_inactive(
+    fn notify_broker_inactive(
         listeners: Arc<Vec<Arc<dyn BrokerLifecycleListener>>>,
         cluster_name: &str,
         broker_name: &str,
@@ -238,28 +239,61 @@ impl BrokerHeartbeatManager for DefaultBrokerHeartbeatManager {
     }
 
     fn start(&mut self) {
+        if self.scan_task_group.is_some() {
+            warn!("DefaultBrokerHeartbeatManager background scan already started");
+            return;
+        }
+
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                warn!(
+                    ?error,
+                    "failed to start DefaultBrokerHeartbeatManager outside Tokio runtime"
+                );
+                return;
+            }
+        };
+
         let broker_live_table = self.broker_live_table.clone();
         let listeners = Arc::new(self.lifecycle_listeners.clone());
         let scan_interval_ms = self.scan_interval_ms;
+        let task_group = TaskGroup::root("rocketmq-controller.heartbeat", runtime);
+        let shutdown_token = task_group.cancellation_token();
 
-        let handle = tokio::spawn(async move {
+        if let Err(error) = task_group.spawn_service("controller.heartbeat.scan-not-active-broker", async move {
             let mut interval = tokio::time::interval(Duration::from_millis(scan_interval_ms));
             // Skip the first tick (fires immediately)
             interval.tick().await;
 
             loop {
-                interval.tick().await;
-                Self::scan_not_active_broker(broker_live_table.clone(), listeners.clone()).await;
+                tokio::select! {
+                    _ = shutdown_token.cancelled() => {
+                        return;
+                    }
+                    _ = interval.tick() => {
+                        Self::scan_not_active_broker(broker_live_table.clone(), listeners.clone()).await;
+                    }
+                }
             }
-        });
+        }) {
+            warn!(?error, "failed to spawn DefaultBrokerHeartbeatManager scan task");
+            return;
+        }
 
-        self.scan_task_handle = Some(handle);
+        self.scan_task_group = Some(task_group);
         info!("DefaultBrokerHeartbeatManager background scan started");
     }
 
     fn shutdown(&mut self) {
-        if let Some(handle) = self.scan_task_handle.take() {
-            handle.abort();
+        if let Some(task_group) = self.scan_task_group.take() {
+            let report = task_group.shutdown_now();
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "DefaultBrokerHeartbeatManager shutdown report is unhealthy"
+                );
+            }
             info!("DefaultBrokerHeartbeatManager background scan stopped");
         }
     }
@@ -301,9 +335,7 @@ impl BrokerHeartbeatManager for DefaultBrokerHeartbeatManager {
 
             if let Some((cluster_name, broker_name, broker_id)) = broker_info_for_notify {
                 let listeners = Arc::new(self.lifecycle_listeners.clone());
-                tokio::spawn(async move {
-                    Self::notify_broker_inactive(listeners, &cluster_name, &broker_name, broker_id).await;
-                });
+                Self::notify_broker_inactive(listeners, &cluster_name, &broker_name, broker_id);
             }
         }
     }

--- a/rocketmq-controller/src/metadata/broker.rs
+++ b/rocketmq-controller/src/metadata/broker.rs
@@ -18,6 +18,9 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use dashmap::DashMap;
+use parking_lot::Mutex;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use serde::Deserialize;
 use serde::Serialize;
@@ -75,6 +78,9 @@ pub struct BrokerManager {
 
     /// Heartbeat timeout duration
     heartbeat_timeout: Duration,
+
+    /// Background heartbeat checker task group
+    task_group: Mutex<Option<TaskGroup>>,
 }
 
 impl BrokerManager {
@@ -84,6 +90,7 @@ impl BrokerManager {
             brokers: Arc::new(DashMap::new()),
             config,
             heartbeat_timeout: Duration::from_secs(30),
+            task_group: Mutex::new(None),
         }
     }
 
@@ -92,15 +99,36 @@ impl BrokerManager {
         info!("Starting broker manager");
 
         // Start heartbeat checker
+        if self.task_group.lock().is_some() {
+            warn!("Broker manager heartbeat checker already started");
+            return Ok(());
+        }
+
+        let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
+            ControllerError::Internal(format!(
+                "No Tokio runtime for broker manager heartbeat checker: {error}"
+            ))
+        })?;
         let brokers = self.brokers.clone();
         let timeout = self.heartbeat_timeout;
-        tokio::spawn(async move {
-            let mut interval = time::interval(Duration::from_secs(5));
-            loop {
-                interval.tick().await;
-                Self::check_heartbeats(&brokers, timeout);
-            }
-        });
+        let task_group = TaskGroup::root("rocketmq-controller.metadata.broker", RuntimeHandle::new(runtime));
+        let shutdown_token = task_group.cancellation_token();
+        task_group
+            .spawn_service("controller.metadata.broker.heartbeat-checker", async move {
+                let mut interval = time::interval(Duration::from_secs(5));
+                loop {
+                    tokio::select! {
+                        _ = shutdown_token.cancelled() => {
+                            break;
+                        }
+                        _ = interval.tick() => {
+                            Self::check_heartbeats(&brokers, timeout);
+                        }
+                    }
+                }
+            })
+            .map_err(|error| ControllerError::Internal(format!("Failed to spawn broker heartbeat checker: {error}")))?;
+        *self.task_group.lock() = Some(task_group);
 
         Ok(())
     }
@@ -108,6 +136,16 @@ impl BrokerManager {
     /// Shutdown the broker manager
     pub async fn shutdown(&self) -> Result<()> {
         info!("Shutting down broker manager");
+        let task_group = self.task_group.lock().take();
+        if let Some(task_group) = task_group {
+            let report = task_group.shutdown(Duration::from_secs(10)).await;
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "Broker manager heartbeat checker shutdown report is unhealthy"
+                );
+            }
+        }
         self.brokers.clear();
         Ok(())
     }

--- a/rocketmq-controller/src/rpc/server.rs
+++ b/rocketmq-controller/src/rpc/server.rs
@@ -17,6 +17,10 @@ use std::sync::Arc;
 
 use futures::stream::StreamExt;
 use futures::SinkExt;
+use parking_lot::Mutex;
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskKind;
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::RwLock;
@@ -26,6 +30,7 @@ use tracing::error;
 use tracing::info;
 use tracing::warn;
 
+use crate::error::ControllerError;
 use crate::error::Result;
 use crate::processor::ProcessorManager;
 use crate::rpc::codec::RpcCodec;
@@ -46,6 +51,9 @@ pub struct RpcServer {
 
     /// Server state
     state: Arc<RwLock<ServerState>>,
+
+    /// Accept and connection task group
+    task_group: Arc<Mutex<Option<TaskGroup>>>,
 }
 
 /// Server state
@@ -68,6 +76,7 @@ impl RpcServer {
             listen_addr,
             processor_manager,
             state: Arc::new(RwLock::new(ServerState::Stopped)),
+            task_group: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -92,39 +101,60 @@ impl RpcServer {
         // Clone Arc for the task
         let processor_manager = self.processor_manager.clone();
         let state = self.state.clone();
+        let runtime = tokio::runtime::Handle::try_current()
+            .map_err(|error| ControllerError::Internal(format!("No Tokio runtime for RPC server tasks: {error}")))?;
+        let task_group = TaskGroup::root("rocketmq-controller.rpc-server", RuntimeHandle::new(runtime));
+        let shutdown_token = task_group.cancellation_token();
+        let task_group_for_accept = task_group.clone();
 
         // Spawn accept loop
-        tokio::spawn(async move {
-            loop {
-                // Check if we should stop
-                {
-                    let current_state = state.read().await;
-                    if *current_state == ServerState::ShuttingDown {
-                        info!("RPC server accept loop stopping");
-                        break;
+        task_group
+            .spawn_service("controller.rpc-server.accept", async move {
+                loop {
+                    // Check if we should stop
+                    {
+                        let current_state = state.read().await;
+                        if *current_state == ServerState::ShuttingDown {
+                            info!("RPC server accept loop stopping");
+                            break;
+                        }
                     }
-                }
 
-                // Accept new connection
-                match listener.accept().await {
-                    Ok((stream, addr)) => {
-                        debug!("Accepted connection from {}", addr);
+                    // Accept new connection
+                    let accepted = tokio::select! {
+                        _ = shutdown_token.cancelled() => {
+                            info!("RPC server accept loop stopping");
+                            break;
+                        }
+                        accepted = listener.accept() => accepted,
+                    };
+                    match accepted {
+                        Ok((stream, addr)) => {
+                            debug!("Accepted connection from {}", addr);
 
-                        // Spawn handler for this connection
-                        let processor_manager = processor_manager.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) = Self::handle_connection(stream, addr, processor_manager).await {
-                                error!("Error handling connection from {}: {}", addr, e);
+                            // Spawn handler for this connection
+                            let processor_manager = processor_manager.clone();
+                            if let Err(error) = task_group_for_accept.spawn(
+                                "controller.rpc-server.connection",
+                                TaskKind::Worker,
+                                async move {
+                                    if let Err(e) = Self::handle_connection(stream, addr, processor_manager).await {
+                                        error!("Error handling connection from {}: {}", addr, e);
+                                    }
+                                },
+                            ) {
+                                warn!(?error, "failed to spawn RPC connection handler");
                             }
-                        });
-                    }
-                    Err(e) => {
-                        error!("Failed to accept connection: {}", e);
-                        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                        }
+                        Err(e) => {
+                            error!("Failed to accept connection: {}", e);
+                            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                        }
                     }
                 }
-            }
-        });
+            })
+            .map_err(|error| ControllerError::Internal(format!("Failed to spawn RPC accept loop: {error}")))?;
+        *self.task_group.lock() = Some(task_group);
 
         Ok(())
     }
@@ -212,8 +242,16 @@ impl RpcServer {
             *state = ServerState::ShuttingDown;
         }
 
-        // Wait a bit for accept loop to stop
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        let task_group = self.task_group.lock().take();
+        if let Some(task_group) = task_group {
+            let report = task_group.shutdown(std::time::Duration::from_secs(10)).await;
+            if !report.is_healthy() {
+                warn!(
+                    report = %report.to_json(),
+                    "RPC server task shutdown report is unhealthy"
+                );
+            }
+        }
 
         // Update state
         {

--- a/rocketmq-proxy/src/grpc/server.rs
+++ b/rocketmq-proxy/src/grpc/server.rs
@@ -21,6 +21,9 @@ use tokio_stream::wrappers::TcpListenerStream;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Server;
 
+use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::TaskGroup;
+
 use crate::config::ProxyConfig;
 use crate::error::ProxyError;
 use crate::error::ProxyResult;
@@ -44,21 +47,29 @@ where
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let shutdown_signal = shutdown_tx.clone();
     let housekeeping_service = service.clone();
-    tokio::spawn(async move {
-        let mut shutdown_rx = shutdown_rx;
-        housekeeping_service
-            .run_housekeeping_until(async move {
-                loop {
-                    if *shutdown_rx.borrow() {
-                        break;
+    let runtime = tokio::runtime::Handle::try_current().map_err(|error| ProxyError::Transport {
+        message: format!("proxy gRPC server has no Tokio runtime for housekeeping task: {error}"),
+    })?;
+    let task_group = TaskGroup::root("rocketmq-proxy.grpc-server", RuntimeHandle::new(runtime));
+    task_group
+        .spawn_service("proxy.grpc.housekeeping", async move {
+            let mut shutdown_rx = shutdown_rx;
+            housekeeping_service
+                .run_housekeeping_until(async move {
+                    loop {
+                        if *shutdown_rx.borrow() {
+                            break;
+                        }
+                        if shutdown_rx.changed().await.is_err() {
+                            break;
+                        }
                     }
-                    if shutdown_rx.changed().await.is_err() {
-                        break;
-                    }
-                }
-            })
-            .await;
-    });
+                })
+                .await;
+        })
+        .map_err(|error| ProxyError::Transport {
+            message: format!("proxy gRPC server failed to spawn housekeeping task: {error}"),
+        })?;
     let service = MessagingServiceServer::new(service)
         .max_decoding_message_size(config.grpc.max_decoding_message_size)
         .max_encoding_message_size(config.grpc.max_encoding_message_size);
@@ -73,6 +84,13 @@ where
         })
         .await;
     let _ = shutdown_tx.send(true);
+    let report = task_group.shutdown(std::time::Duration::from_secs(10)).await;
+    if !report.is_healthy() {
+        tracing::warn!(
+            report = %report.to_json(),
+            "Proxy gRPC server task shutdown report is unhealthy"
+        );
+    }
 
     result.map_err(|error| ProxyError::Transport {
         message: format!("proxy gRPC server failed: {error}"),


### PR DESCRIPTION
Closes #7500

## Summary

- Track broker transaction check tasks, fast failure request tasks, controller heartbeat/manager/openraft/metadata RPC tasks, proxy gRPC housekeeping, and common moment stats work through runtime task groups.
- Structure broker outer API fanout and batch MQ lock fanout under the runtime task model.
- Keep this PR to the seventh staged runtime-model commit for the linear merge flow.

## Validation

- Root workspace format check passed.
- Root workspace clippy passed with all targets, all features, no dependencies, and warnings denied.
- Example standalone format and clippy checks passed.
- Tauri backend standalone format and all-features clippy checks passed.
- Web dashboard backend standalone format, all-features clippy, and all-features build checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Improved background task lifecycle management across broker, controller, and proxy services by adopting a centralized TaskGroup-based scheduling system, ensuring more graceful and reliable shutdown behavior.
  * Enhanced concurrent operation efficiency by replacing sequential and spawn-based task dispatch with futures-based concurrency for broker registration, heartbeat delivery, and MQ locking operations.
  * Replaced raw `tokio::spawn` patterns with structured task group spawning, providing better control and observability of background work execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->