### PR TITLE
[ISSUE #7530]Fix store sync flush dispatch and tieredstore metadata races

### DIFF
--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -3518,6 +3518,14 @@ impl ReputMessageService {
                         loop {
                             // Check if there are messages to process
                             if !inner.is_commit_log_available() {
+                                if inner.has_unconfirmed_commit_log() {
+                                    dispatch_progress_notify.notify_waiters();
+                                    tokio::select! {
+                                        _ = shutdown_reader.cancelled() => return,
+                                        _ = tokio::time::sleep(Duration::from_millis(1)) => {}
+                                    }
+                                    continue;
+                                }
                                 break;
                             }
 
@@ -3542,6 +3550,13 @@ impl ReputMessageService {
                                 None => {
                                     // No more messages available at this offset
                                     dispatch_progress_notify.notify_waiters();
+                                    if inner.has_unconfirmed_commit_log() {
+                                        tokio::select! {
+                                            _ = shutdown_reader.cancelled() => return,
+                                            _ = tokio::time::sleep(Duration::from_millis(1)) => {}
+                                        }
+                                        continue;
+                                    }
                                     break;
                                 }
                             }
@@ -3846,6 +3861,12 @@ impl ReputMessageServiceInner {
 
     fn is_commit_log_available(&self) -> bool {
         self.reput_from_offset.load(Ordering::Relaxed) < self.get_reput_end_offset()
+    }
+
+    fn has_unconfirmed_commit_log(&self) -> bool {
+        !self.message_store_config.read_uncommitted
+            && self.reput_from_offset.load(Ordering::Relaxed) < self.commit_log.get_max_offset()
+            && !self.is_commit_log_available()
     }
 
     fn get_reput_end_offset(&self) -> i64 {

--- a/rocketmq-tieredstore/src/metadata/metadata_store.rs
+++ b/rocketmq-tieredstore/src/metadata/metadata_store.rs
@@ -77,6 +77,7 @@ struct MetadataState {
 pub struct JsonMetadataStore {
     path: PathBuf,
     state: RwLock<MetadataState>,
+    persist_lock: tokio::sync::Mutex<()>,
 }
 
 impl JsonMetadataStore {
@@ -87,6 +88,7 @@ impl JsonMetadataStore {
                 .join("config")
                 .join("tieredStoreMetadata.json"),
             state: RwLock::new(MetadataState::default()),
+            persist_lock: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -123,6 +125,7 @@ impl TieredMetadataStore for JsonMetadataStore {
     }
 
     async fn persist(&self) -> Result<(), RocketMQError> {
+        let _persist_guard = self.persist_lock.lock().await;
         let Some(parent) = self.path.parent() else {
             return Err(error::storage_write_failed(
                 path_to_string(&self.path),


### PR DESCRIPTION
Fixes #7530

## Summary

- keep the local file store reput reader alive while sync flush has written commit log data that is still waiting for confirm offset advancement
- serialize JSON tieredstore metadata persistence so concurrent upserts cannot race on the shared temporary metadata file

## Root Cause

- `wait_store_msg_ok=false` sync flush messages could wake reput before the flush thread advanced the confirm offset; with `read_uncommitted=false`, reput observed no dispatchable data and exited without another wakeup
- tieredstore metadata persistence used one fixed `.json.tmp` path, so concurrent upserts could write and rename the same temp file

## Validation

- `cargo test -p rocketmq-store --lib message_store::local_file_message_store::tests::sync_flush_store_dispatches_wait_false_schedule_topic_messages -- --exact --nocapture`
- `cargo test -p rocketmq-store --lib tieredstore::tests::dispatcher_adapter_writes_commitlog_and_consumequeue_to_tieredstore --all-features -- --exact --nocapture`
- `cargo test -p rocketmq-store --lib bench_support_tests::store_blocking_io_probe_reports_no_running_tasks -- --exact --nocapture`
- `cargo test -p rocketmq-store --lib --all-features`
- `cargo test -p rocketmq-tieredstore metadata::metadata_store::tests -- --nocapture`
- `cargo fmt --all`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message reader handling when uncommitted data is present; now correctly waits for data availability instead of exiting prematurely
  * Serialized concurrent metadata persistence operations to ensure data integrity and prevent potential corruption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->