### PR TITLE
[ISSUE #7534]✨ Improving RocketMQ Rust Tokio thread model refactoring: parent-child runtime boundaries

### DIFF
--- a/rocketmq-auth/src/lib.rs
+++ b/rocketmq-auth/src/lib.rs
@@ -80,6 +80,8 @@ pub mod bench_support {
         pub shared_runtime_created: u64,
         pub shared_runtime_reused: u64,
         pub shared_runtime_available: bool,
+        pub blocking_executor_creations: u64,
+        pub blocking_executor_shutdown_requests: u64,
     }
 
     #[derive(Clone, Copy, Debug, Default, Serialize)]
@@ -91,6 +93,8 @@ pub mod bench_support {
         pub shared_runtime_acquires: u64,
         pub shared_runtime_created: u64,
         pub shared_runtime_reused: u64,
+        pub blocking_executor_creations: u64,
+        pub blocking_executor_shutdown_requests: u64,
     }
 
     #[derive(Clone, Debug, Serialize)]
@@ -312,6 +316,8 @@ accounts:
                 shared_runtime_created: snapshot.shared_runtime_created,
                 shared_runtime_reused: snapshot.shared_runtime_reused,
                 shared_runtime_available: snapshot.shared_runtime_available,
+                blocking_executor_creations: snapshot.blocking_executor_creations,
+                blocking_executor_shutdown_requests: snapshot.blocking_executor_shutdown_requests,
             }
         }
     }
@@ -336,6 +342,12 @@ accounts:
                     .shared_runtime_created
                     .saturating_sub(before.shared_runtime_created),
                 shared_runtime_reused: self.shared_runtime_reused.saturating_sub(before.shared_runtime_reused),
+                blocking_executor_creations: self
+                    .blocking_executor_creations
+                    .saturating_sub(before.blocking_executor_creations),
+                blocking_executor_shutdown_requests: self
+                    .blocking_executor_shutdown_requests
+                    .saturating_sub(before.blocking_executor_shutdown_requests),
             }
         }
     }
@@ -345,11 +357,38 @@ accounts:
 mod tests {
     #[test]
     fn auth_sync_bridge_multi_thread_probe_is_healthy() {
+        let _guard = crate::runtime_bridge::auth_runtime_bridge_test_guard();
         let probe = crate::bench_support::run_auth_sync_bridge_multi_thread_probe(8);
         assert!(probe.healthy, "{probe:?}");
         assert_eq!(probe.delta.multi_thread_block_in_place, 8);
         assert_eq!(probe.delta.current_thread_handoffs, 0);
         assert_eq!(probe.delta.shared_runtime_acquires, 0);
+    }
+
+    #[test]
+    fn auth_sync_bridge_counter_reset_clears_observable_counters() {
+        let _guard = crate::runtime_bridge::auth_runtime_bridge_test_guard();
+        crate::runtime_bridge::reset_auth_sync_bridge_counters_for_tests();
+
+        let value = crate::runtime_bridge::block_on_sync_bridge(
+            || async { Ok::<usize, String>(7) },
+            |error| error,
+            || "auth sync bridge thread panicked".to_string(),
+        )
+        .expect("auth sync bridge fallback call should complete");
+        assert_eq!(value, 7);
+        assert!(crate::runtime_bridge::auth_sync_bridge_snapshot().sync_bridge_calls > 0);
+
+        let snapshot = crate::runtime_bridge::reset_auth_sync_bridge_counters_for_tests();
+        assert_eq!(snapshot.sync_bridge_calls, 0);
+        assert_eq!(snapshot.multi_thread_block_in_place, 0);
+        assert_eq!(snapshot.current_thread_handoffs, 0);
+        assert_eq!(snapshot.fallback_runtime_calls, 0);
+        assert_eq!(snapshot.shared_runtime_acquires, 0);
+        assert_eq!(snapshot.shared_runtime_created, 0);
+        assert_eq!(snapshot.shared_runtime_reused, 0);
+        assert_eq!(snapshot.blocking_executor_creations, 0);
+        assert_eq!(snapshot.blocking_executor_shutdown_requests, 0);
     }
 }
 

--- a/rocketmq-auth/src/runtime_bridge.rs
+++ b/rocketmq-auth/src/runtime_bridge.rs
@@ -16,16 +16,20 @@ use std::future::Future;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::time::Duration;
 
 use rocketmq_runtime::BlockingExecutor;
+use rocketmq_runtime::BlockingExecutorSnapshot;
 use rocketmq_runtime::BlockingPoolPolicy;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeError;
 use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::RuntimeOwner;
 use rocketmq_runtime::RuntimeResult;
+use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 use serde::Serialize;
 
@@ -37,6 +41,17 @@ static AUTH_SYNC_BRIDGE_FALLBACK_RUNTIME_CALLS: AtomicU64 = AtomicU64::new(0);
 static AUTH_SYNC_RUNTIME_ACQUIRES: AtomicU64 = AtomicU64::new(0);
 static AUTH_SYNC_RUNTIME_CREATED: AtomicU64 = AtomicU64::new(0);
 static AUTH_SYNC_RUNTIME_REUSED: AtomicU64 = AtomicU64::new(0);
+static AUTH_BLOCKING_EXECUTOR_CREATED: AtomicU64 = AtomicU64::new(0);
+static AUTH_BLOCKING_EXECUTOR_SHUTDOWN_REQUESTS: AtomicU64 = AtomicU64::new(0);
+#[cfg(test)]
+pub(crate) static AUTH_RUNTIME_BRIDGE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(test)]
+pub(crate) fn auth_runtime_bridge_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    AUTH_RUNTIME_BRIDGE_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 #[derive(Clone, Copy, Debug, Default, Serialize)]
 pub(crate) struct AuthSyncBridgeSnapshot {
@@ -48,11 +63,19 @@ pub(crate) struct AuthSyncBridgeSnapshot {
     pub shared_runtime_created: u64,
     pub shared_runtime_reused: u64,
     pub shared_runtime_available: bool,
+    pub blocking_executor_creations: u64,
+    pub blocking_executor_shutdown_requests: u64,
 }
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct AuthBlockingExecutor {
-    inner: Arc<OnceLock<BlockingExecutor>>,
+    inner: Arc<OnceLock<AuthBlockingExecutorState>>,
+}
+
+#[derive(Clone, Debug)]
+struct AuthBlockingExecutorState {
+    executor: BlockingExecutor,
+    task_group: TaskGroup,
 }
 
 impl AuthBlockingExecutor {
@@ -64,9 +87,21 @@ impl AuthBlockingExecutor {
         self.executor()?.spawn_io(name, operation).await
     }
 
+    pub(crate) fn snapshot(&self) -> Option<BlockingExecutorSnapshot> {
+        self.inner.get().map(|state| state.executor.snapshot())
+    }
+
+    pub(crate) async fn shutdown_with_report(&self, timeout: Duration) -> Option<ShutdownReport> {
+        AUTH_BLOCKING_EXECUTOR_SHUTDOWN_REQUESTS.fetch_add(1, Ordering::Relaxed);
+        let state = self.inner.get()?.clone();
+        let mut report = state.task_group.shutdown(timeout).await;
+        report.merge_blocking(state.executor.snapshot());
+        Some(report)
+    }
+
     fn executor(&self) -> RuntimeResult<BlockingExecutor> {
-        if let Some(executor) = self.inner.get() {
-            return Ok(executor.clone());
+        if let Some(state) = self.inner.get() {
+            return Ok(state.executor.clone());
         }
 
         let handle = tokio::runtime::Handle::try_current().map_err(|_error| RuntimeError::NoCurrentRuntime)?;
@@ -78,14 +113,20 @@ impl AuthBlockingExecutor {
             },
             group.child("rocketmq-auth.blocking-reaper"),
         )?;
+        let state = AuthBlockingExecutorState {
+            executor: executor.clone(),
+            task_group: group,
+        };
 
-        if self.inner.set(executor.clone()).is_err() {
+        if self.inner.set(state).is_err() {
             return Ok(self
                 .inner
                 .get()
                 .expect("auth blocking executor must be initialized")
+                .executor
                 .clone());
         }
+        AUTH_BLOCKING_EXECUTOR_CREATED.fetch_add(1, Ordering::Relaxed);
         Ok(executor)
     }
 }
@@ -137,6 +178,25 @@ pub(crate) fn auth_sync_bridge_snapshot() -> AuthSyncBridgeSnapshot {
         shared_runtime_created: AUTH_SYNC_RUNTIME_CREATED.load(Ordering::Relaxed),
         shared_runtime_reused: AUTH_SYNC_RUNTIME_REUSED.load(Ordering::Relaxed),
         shared_runtime_available: AUTH_SYNC_RUNTIME.get().is_some(),
+        blocking_executor_creations: AUTH_BLOCKING_EXECUTOR_CREATED.load(Ordering::Relaxed),
+        blocking_executor_shutdown_requests: AUTH_BLOCKING_EXECUTOR_SHUTDOWN_REQUESTS.load(Ordering::Relaxed),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn reset_auth_sync_bridge_counters_for_tests() -> AuthSyncBridgeSnapshot {
+    AUTH_SYNC_BRIDGE_CALLS.store(0, Ordering::Relaxed);
+    AUTH_SYNC_BRIDGE_MULTI_THREAD_BLOCK_IN_PLACE.store(0, Ordering::Relaxed);
+    AUTH_SYNC_BRIDGE_CURRENT_THREAD_HANDOFFS.store(0, Ordering::Relaxed);
+    AUTH_SYNC_BRIDGE_FALLBACK_RUNTIME_CALLS.store(0, Ordering::Relaxed);
+    AUTH_SYNC_RUNTIME_ACQUIRES.store(0, Ordering::Relaxed);
+    AUTH_SYNC_RUNTIME_CREATED.store(0, Ordering::Relaxed);
+    AUTH_SYNC_RUNTIME_REUSED.store(0, Ordering::Relaxed);
+    AUTH_BLOCKING_EXECUTOR_CREATED.store(0, Ordering::Relaxed);
+    AUTH_BLOCKING_EXECUTOR_SHUTDOWN_REQUESTS.store(0, Ordering::Relaxed);
+    AuthSyncBridgeSnapshot {
+        shared_runtime_available: AUTH_SYNC_RUNTIME.get().is_some(),
+        ..AuthSyncBridgeSnapshot::default()
     }
 }
 
@@ -170,5 +230,52 @@ fn auth_sync_runtime() -> Result<&'static RuntimeOwner, String> {
             }
             Err(error.clone())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn auth_blocking_executor_snapshot_counts_creation_and_shutdown_request() {
+        let executor = AuthBlockingExecutor::default();
+        let before = auth_sync_bridge_snapshot();
+        assert!(executor.snapshot().is_none());
+
+        let value = executor
+            .spawn_io("auth.blocking.counter", || 42usize)
+            .await
+            .expect("auth blocking task should complete");
+        assert_eq!(value, 42);
+
+        let active_snapshot = executor
+            .snapshot()
+            .expect("auth blocking executor snapshot should exist after first task");
+        assert_eq!(active_snapshot.name, "rocketmq-auth.blocking");
+        assert_eq!(active_snapshot.blocking_still_running, 0);
+
+        let report = executor
+            .shutdown_with_report(Duration::from_secs(1))
+            .await
+            .expect("initialized auth blocking executor should return shutdown report");
+        assert_eq!(report.name, "rocketmq-auth.blocking");
+        assert!(report.is_healthy(), "{}", report.to_json());
+
+        let after = auth_sync_bridge_snapshot();
+        assert!(
+            after
+                .blocking_executor_creations
+                .saturating_sub(before.blocking_executor_creations)
+                >= 1
+        );
+        assert!(
+            after
+                .blocking_executor_shutdown_requests
+                .saturating_sub(before.blocking_executor_shutdown_requests)
+                >= 1
+        );
     }
 }

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -24,6 +24,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
@@ -57,6 +58,7 @@ use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::remoting_server::rocketmq_tokio_server::RocketMQServer;
 use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::ServiceContext;
 use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::schedule::simple_scheduler::ScheduledTaskManager;
@@ -426,21 +428,207 @@ impl BrokerRemotingServerShutdownReport {
                 .iter()
                 .all(|server| server.report.as_ref().is_some_and(ShutdownReport::is_healthy))
     }
+
+    pub(crate) fn has_timed_out(&self) -> bool {
+        shutdown_report_has_timed_out(&self.task_group)
+            || self
+                .server_reports
+                .iter()
+                .any(|server| server.report.as_ref().is_some_and(shutdown_report_has_timed_out))
+    }
 }
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct BrokerBasicServiceShutdownReport {
     pub(crate) remoting: Option<BrokerRemotingServerShutdownReport>,
     pub(crate) request_processor: Option<ShutdownReport>,
+    pub(crate) auth: BrokerShutdownComponentReport,
+    pub(crate) observability: BrokerShutdownComponentReport,
+    pub(crate) scheduled_tasks: BrokerShutdownComponentReport,
+    pub(crate) message_store: BrokerShutdownComponentReport,
+    pub(crate) pull_request_hold: BrokerShutdownComponentReport,
+    pub(crate) pop_services: BrokerShutdownComponentReport,
+    pub(crate) transaction_services: BrokerShutdownComponentReport,
+    pub(crate) fast_failure: BrokerShutdownComponentReport,
+    pub(crate) topic_route: BrokerShutdownComponentReport,
+    pub(crate) consumer_offset: BrokerShutdownComponentReport,
+    pub(crate) subscription_group: BrokerShutdownComponentReport,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BrokerShutdownComponentReport {
+    pub(crate) name: &'static str,
+    pub(crate) present: bool,
+    pub(crate) healthy: bool,
+    pub(crate) timed_out: bool,
+    pub(crate) elapsed: Duration,
+    pub(crate) detail: Option<String>,
+}
+
+impl Default for BrokerShutdownComponentReport {
+    fn default() -> Self {
+        Self::skipped("unknown")
+    }
+}
+
+impl BrokerShutdownComponentReport {
+    pub(crate) fn skipped(name: &'static str) -> Self {
+        Self {
+            name,
+            present: false,
+            healthy: true,
+            timed_out: false,
+            elapsed: Duration::ZERO,
+            detail: None,
+        }
+    }
+
+    pub(crate) fn completed(name: &'static str, elapsed: Duration) -> Self {
+        Self {
+            name,
+            present: true,
+            healthy: true,
+            timed_out: false,
+            elapsed,
+            detail: None,
+        }
+    }
+
+    pub(crate) fn unhealthy(name: &'static str, elapsed: Duration, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            present: true,
+            healthy: false,
+            timed_out: false,
+            elapsed,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub(crate) fn timed_out(name: &'static str, elapsed: Duration) -> Self {
+        Self {
+            name,
+            present: true,
+            healthy: false,
+            timed_out: true,
+            elapsed,
+            detail: Some("timed out".to_string()),
+        }
+    }
+
+    pub(crate) fn from_shutdown_report(name: &'static str, report: Option<&ShutdownReport>, elapsed: Duration) -> Self {
+        let Some(report) = report else {
+            return Self::skipped(name);
+        };
+        if shutdown_report_has_timed_out(report) {
+            return Self::timed_out(name, elapsed);
+        }
+        if report.is_healthy() {
+            Self::completed(name, elapsed)
+        } else {
+            Self::unhealthy(name, elapsed, report.to_json())
+        }
+    }
 }
 
 impl BrokerBasicServiceShutdownReport {
+    const COMPONENT_NAMES: [&'static str; 13] = [
+        "remoting",
+        "request_processor",
+        "auth",
+        "observability",
+        "scheduled_tasks",
+        "message_store",
+        "pull_request_hold",
+        "pop_services",
+        "transaction_services",
+        "fast_failure",
+        "topic_route",
+        "consumer_offset",
+        "subscription_group",
+    ];
+
     pub(crate) fn is_healthy(&self) -> bool {
         self.remoting
             .as_ref()
             .is_none_or(BrokerRemotingServerShutdownReport::is_healthy)
             && self.request_processor.as_ref().is_none_or(ShutdownReport::is_healthy)
+            && self.component_reports().into_iter().all(|component| component.healthy)
     }
+
+    pub(crate) fn component_names(&self) -> Vec<&'static str> {
+        Self::COMPONENT_NAMES.to_vec()
+    }
+
+    pub(crate) fn unhealthy_component_count(&self) -> usize {
+        self.unhealthy_component_names().len()
+    }
+
+    pub(crate) fn unhealthy_component_names(&self) -> Vec<&'static str> {
+        let mut names = Vec::new();
+        if self.remoting.as_ref().is_some_and(|report| !report.is_healthy()) {
+            names.push("remoting");
+        }
+        if self
+            .request_processor
+            .as_ref()
+            .is_some_and(|report| !report.is_healthy())
+        {
+            names.push("request_processor");
+        }
+        names.extend(
+            self.component_reports()
+                .into_iter()
+                .filter(|component| component.present && !component.healthy)
+                .map(|component| component.name),
+        );
+        names
+    }
+
+    pub(crate) fn timed_out_component_names(&self) -> Vec<&'static str> {
+        let mut names = Vec::new();
+        if self
+            .remoting
+            .as_ref()
+            .is_some_and(BrokerRemotingServerShutdownReport::has_timed_out)
+        {
+            names.push("remoting");
+        }
+        if self
+            .request_processor
+            .as_ref()
+            .is_some_and(shutdown_report_has_timed_out)
+        {
+            names.push("request_processor");
+        }
+        names.extend(
+            self.component_reports()
+                .into_iter()
+                .filter(|component| component.timed_out)
+                .map(|component| component.name),
+        );
+        names
+    }
+
+    fn component_reports(&self) -> Vec<&BrokerShutdownComponentReport> {
+        vec![
+            &self.auth,
+            &self.observability,
+            &self.scheduled_tasks,
+            &self.message_store,
+            &self.pull_request_hold,
+            &self.pop_services,
+            &self.transaction_services,
+            &self.fast_failure,
+            &self.topic_route,
+            &self.consumer_offset,
+            &self.subscription_group,
+        ]
+    }
+}
+
+fn shutdown_report_has_timed_out(report: &ShutdownReport) -> bool {
+    report.timed_out > 0 || report.children.iter().any(shutdown_report_has_timed_out)
 }
 
 impl Drop for BrokerRuntime {
@@ -458,12 +646,36 @@ impl BrokerRuntime {
         message_store_config: Arc<MessageStoreConfig>,
         //server_config: Arc<ServerConfig>,
     ) -> Self {
+        Self::new_with_optional_service_context(broker_config, message_store_config, None)
+    }
+
+    pub(crate) fn new_with_service_context(
+        broker_config: Arc<BrokerConfig>,
+        message_store_config: Arc<MessageStoreConfig>,
+        service_context: ServiceContext,
+    ) -> Self {
+        Self::new_with_optional_service_context(broker_config, message_store_config, Some(service_context))
+    }
+
+    fn new_with_optional_service_context(
+        broker_config: Arc<BrokerConfig>,
+        message_store_config: Arc<MessageStoreConfig>,
+        service_context: Option<ServiceContext>,
+    ) -> Self {
         let broker_address = format!("{}:{}", broker_config.broker_ip1, broker_config.listen_port);
         let store_host = broker_address.parse::<SocketAddr>().expect("parse store_host failed");
         let scheduled_task_manager = ScheduledTaskManager::default();
         let broker_outer_api = BrokerOuterAPI::new(Arc::new(TokioClientConfig::default()));
 
-        let topic_queue_mapping_manager = TopicQueueMappingManager::new(broker_config.clone());
+        let topic_queue_mapping_manager = service_context
+            .as_ref()
+            .map(|context| {
+                TopicQueueMappingManager::new_with_parent_task_group(
+                    broker_config.clone(),
+                    context.task_group().clone(),
+                )
+            })
+            .unwrap_or_else(|| TopicQueueMappingManager::new(broker_config.clone()));
         let mut broker_member_group = BrokerMemberGroup::new(
             broker_config.broker_identity.broker_cluster_name.clone(),
             broker_config.broker_identity.broker_name.clone(),
@@ -481,6 +693,12 @@ impl BrokerRuntime {
 
         let should_start_time = Arc::new(AtomicU64::new(0));
         let pop_inflight_message_counter = PopInflightMessageCounter::new(should_start_time);
+        let broker_fast_failure = service_context
+            .as_ref()
+            .map(|context| {
+                BrokerFastFailure::new_with_parent_task_group(broker_config.clone(), context.task_group().clone())
+            })
+            .unwrap_or_else(|| BrokerFastFailure::new(broker_config.clone()));
         #[cfg(feature = "rocksdb_store")]
         let rocksdb_config_managers =
             open_broker_rocksdb_config_managers(broker_config.as_ref(), message_store_config.as_ref());
@@ -538,7 +756,7 @@ impl BrokerRuntime {
             escape_bridge: None,
             pop_inflight_message_counter,
             replicas_manager: None,
-            broker_fast_failure: BrokerFastFailure::new(broker_config.clone()),
+            broker_fast_failure,
             #[cfg(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs"))]
             observability_guard: None,
             cold_data_pull_request_hold_service: Some(ColdDataPullRequestHoldService::default()),
@@ -561,6 +779,7 @@ impl BrokerRuntime {
             broker_pre_online_service: None,
             min_broker_id_in_group: AtomicU64::new(0),
             min_broker_addr_in_group: Default::default(),
+            service_context,
             lock: Default::default(),
         });
         let mut stats_manager = BrokerStatsManager::new_with_scheduler(
@@ -670,8 +889,6 @@ impl BrokerRuntime {
 
         self.inner.broker_outer_api.shutdown();
 
-        self.shutdown_scheduled_tasks().await;
-
         if let Some(client_housekeeping_service) = self.inner.client_housekeeping_service.take() {
             client_housekeeping_service.shutdown().await;
         }
@@ -706,46 +923,110 @@ impl BrokerRuntime {
         shutdown_report.remoting = self.shutdown_remoting_servers().await;
         shutdown_report.request_processor = self.shutdown_request_processor_tasks().await;
 
+        let started = Instant::now();
         if let Some(auth_runtime) = self.inner.auth_runtime.take() {
             if let Err(error) = auth_runtime.shutdown().await {
                 warn!("Failed to shutdown auth runtime: {error}");
+                shutdown_report.auth =
+                    BrokerShutdownComponentReport::unhealthy("auth", started.elapsed(), error.to_string());
+            } else {
+                shutdown_report.auth = BrokerShutdownComponentReport::completed("auth", started.elapsed());
             }
+        } else {
+            shutdown_report.auth = BrokerShutdownComponentReport::skipped("auth");
         }
 
         #[cfg(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs"))]
-        if let Some(guard) = self.inner.observability_guard.take() {
-            if let Err(error) = guard.shutdown() {
-                warn!("Failed to shutdown observability runtime: {error}");
+        {
+            let started = Instant::now();
+            if let Some(guard) = self.inner.observability_guard.take() {
+                if let Err(error) = guard.shutdown() {
+                    warn!("Failed to shutdown observability runtime: {error}");
+                    shutdown_report.observability =
+                        BrokerShutdownComponentReport::unhealthy("observability", started.elapsed(), error.to_string());
+                } else {
+                    shutdown_report.observability =
+                        BrokerShutdownComponentReport::completed("observability", started.elapsed());
+                }
+            } else {
+                shutdown_report.observability = BrokerShutdownComponentReport::skipped("observability");
             }
         }
+        #[cfg(not(any(feature = "otel-metrics", feature = "otel-traces", feature = "otel-logs")))]
+        {
+            shutdown_report.observability = BrokerShutdownComponentReport::skipped("observability");
+        }
+
+        let started = Instant::now();
+        let scheduled_report = self
+            .shutdown_scheduled_tasks_with_timeout(SCHEDULED_TASK_SHUTDOWN_TIMEOUT)
+            .await;
+        shutdown_report.scheduled_tasks = if scheduled_report.is_healthy() {
+            BrokerShutdownComponentReport::completed("scheduled_tasks", started.elapsed())
+        } else {
+            BrokerShutdownComponentReport::unhealthy(
+                "scheduled_tasks",
+                started.elapsed(),
+                format!(
+                    "task_count={}, completed={}, aborted={}, panicked={}, timed_out={}",
+                    scheduled_report.task_count,
+                    scheduled_report.completed,
+                    scheduled_report.aborted,
+                    scheduled_report.panicked,
+                    scheduled_report.timed_out
+                ),
+            )
+        };
 
         if let Some(broker_stats_manager) = self.inner.broker_stats_manager.as_ref() {
             broker_stats_manager.shutdown().await;
         }
 
+        let started = Instant::now();
+        let mut pull_request_hold_present = false;
         if let Some(pull_request_hold_service) = self.inner.pull_request_hold_service.as_mut() {
+            pull_request_hold_present = true;
             pull_request_hold_service.shutdown().await;
         }
+        shutdown_report.pull_request_hold = if pull_request_hold_present {
+            BrokerShutdownComponentReport::completed("pull_request_hold", started.elapsed())
+        } else {
+            BrokerShutdownComponentReport::skipped("pull_request_hold")
+        };
 
+        let pop_started = Instant::now();
+        let mut pop_services_present = false;
         if let Some(pop_message_processor) = self.inner.pop_message_processor.as_mut() {
+            pop_services_present = true;
             pop_message_processor.shutdown().await;
         }
 
         if let Some(pop_lite_message_processor) = self.inner.pop_lite_message_processor.as_mut() {
+            pop_services_present = true;
             pop_lite_message_processor.shutdown().await;
         }
 
         if let Some(ack_message_processor) = self.inner.ack_message_processor.as_mut() {
+            pop_services_present = true;
             ack_message_processor.shutdown().await;
         }
 
+        let transaction_started = Instant::now();
+        let mut transaction_services_present = false;
         if let Some(transactional_message_service) = self.inner.transactional_message_service.as_mut() {
+            transaction_services_present = true;
             transactional_message_service.shutdown().await;
         }
 
         if let Some(notification_processor) = self.inner.notification_processor.as_mut() {
+            pop_services_present = true;
             notification_processor.shutdown().await;
         }
+        shutdown_report.pop_services = if pop_services_present {
+            BrokerShutdownComponentReport::completed("pop_services", pop_started.elapsed())
+        } else {
+            BrokerShutdownComponentReport::skipped("pop_services")
+        };
         self.consumer_ids_change_listener.shutdown();
         if let Some(topic_queue_mapping_clean_service) = self.inner.topic_queue_mapping_clean_service.as_ref() {
             topic_queue_mapping_clean_service.shutdown().await;
@@ -757,7 +1038,13 @@ impl BrokerRuntime {
             replicas_manager.shutdown();
         }
 
-        self.inner.broker_fast_failure.shutdown().await;
+        let started = Instant::now();
+        let fast_failure_report = self.inner.broker_fast_failure.shutdown_with_report().await;
+        shutdown_report.fast_failure = BrokerShutdownComponentReport::from_shutdown_report(
+            "fast_failure",
+            fast_failure_report.as_ref(),
+            started.elapsed(),
+        );
 
         if let Some(consumer_filter_manager) = self.inner.consumer_filter_manager.as_ref() {
             consumer_filter_manager.persist();
@@ -771,20 +1058,36 @@ impl BrokerRuntime {
             schedule_message_service.shutdown().await;
         }
         if let Some(transactional_message_check_service) = self.inner.transactional_message_check_service.as_mut() {
+            transaction_services_present = true;
             transactional_message_check_service.shutdown().await;
         }
         if let Some(transactional_message_check_listener) = self.inner.transactional_message_check_listener.as_ref() {
+            transaction_services_present = true;
             transactional_message_check_listener.shutdown().await;
         }
         if let Some(transaction_metrics_flush_service) = self.inner.transaction_metrics_flush_service.as_mut() {
+            transaction_services_present = true;
             transaction_metrics_flush_service.shutdown();
         }
+        shutdown_report.transaction_services = if transaction_services_present {
+            BrokerShutdownComponentReport::completed("transaction_services", transaction_started.elapsed())
+        } else {
+            BrokerShutdownComponentReport::skipped("transaction_services")
+        };
         if let Some(escape_bridge) = self.inner.escape_bridge.as_mut() {
             escape_bridge.shutdown();
         }
+        let started = Instant::now();
+        let mut topic_route_present = false;
         if let Some(topic_route_info_manager) = self.inner.topic_route_info_manager.as_mut() {
+            topic_route_present = true;
             topic_route_info_manager.shutdown().await;
         }
+        shutdown_report.topic_route = if topic_route_present {
+            BrokerShutdownComponentReport::completed("topic_route", started.elapsed())
+        } else {
+            BrokerShutdownComponentReport::skipped("topic_route")
+        };
 
         if let Some(broker_pre_online_service) = self.inner.broker_pre_online_service.as_mut() {
             broker_pre_online_service.shutdown().await;
@@ -803,11 +1106,17 @@ impl BrokerRuntime {
             topic_config_manager.stop();
         }
 
+        let started = Instant::now();
         if let Some(mut subscription_group_manager) = self.inner.subscription_group_manager.take() {
             subscription_group_manager.persist();
             subscription_group_manager.stop();
+            shutdown_report.subscription_group =
+                BrokerShutdownComponentReport::completed("subscription_group", started.elapsed());
+        } else {
+            shutdown_report.subscription_group = BrokerShutdownComponentReport::skipped("subscription_group");
         }
 
+        let started = Instant::now();
         let mut consumer_offset_manager = ConsumerOffsetManager::new(
             self.inner.broker_config.clone(),
             self.inner.message_store_config.clone(),
@@ -816,23 +1125,27 @@ impl BrokerRuntime {
         std::mem::swap(&mut self.inner.consumer_offset_manager, &mut consumer_offset_manager);
         consumer_offset_manager.persist();
         consumer_offset_manager.stop();
+        shutdown_report.consumer_offset =
+            BrokerShutdownComponentReport::completed("consumer_offset", started.elapsed());
 
+        let started = Instant::now();
         if let Some(message_store) = self.inner.message_store.as_mut() {
             if tokio::time::timeout(Duration::from_secs(15), message_store.shutdown())
                 .await
                 .is_err()
             {
                 warn!("Timed out shutting down message store");
+                shutdown_report.message_store =
+                    BrokerShutdownComponentReport::timed_out("message_store", started.elapsed());
+            } else {
+                shutdown_report.message_store =
+                    BrokerShutdownComponentReport::completed("message_store", started.elapsed());
             }
+        } else {
+            shutdown_report.message_store = BrokerShutdownComponentReport::skipped("message_store");
         }
 
         shutdown_report
-    }
-
-    async fn shutdown_scheduled_tasks(&self) {
-        let _ = self
-            .shutdown_scheduled_tasks_with_timeout(SCHEDULED_TASK_SHUTDOWN_TIMEOUT)
-            .await;
     }
 
     pub(crate) async fn shutdown_scheduled_tasks_with_timeout(
@@ -909,17 +1222,12 @@ impl BrokerRuntime {
 
     #[doc(hidden)]
     pub(crate) fn install_remoting_server_report_probe(&mut self) -> bool {
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                warn!(
-                    ?error,
-                    "failed to install broker remoting server report probe outside Tokio runtime"
-                );
-                return false;
-            }
+        let Some(task_group) = self.broker_task_group_or_current(
+            "rocketmq-broker.remoting-server.probe",
+            "failed to install broker remoting server report probe outside Tokio runtime",
+        ) else {
+            return false;
         };
-        let task_group = TaskGroup::root("rocketmq-broker.remoting-server.probe", runtime);
         let shutdown_token = task_group.cancellation_token();
         let (report_tx, report_rx) = oneshot::channel();
         if let Err(error) = task_group.spawn_service("broker.remoting-server.probe", async move {
@@ -948,17 +1256,12 @@ impl BrokerRuntime {
             return false;
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                warn!(
-                    ?error,
-                    "failed to install broker request processor task probe outside Tokio runtime"
-                );
-                return false;
-            }
+        let Some(task_group) = self.broker_task_group_or_current(
+            "rocketmq-broker.request-processor.probe",
+            "failed to install broker request processor task probe outside Tokio runtime",
+        ) else {
+            return false;
         };
-        let task_group = TaskGroup::root("rocketmq-broker.request-processor.probe", runtime);
         let shutdown_token = task_group.cancellation_token();
         if let Err(error) = task_group.spawn_service("broker.request-processor.probe", async move {
             shutdown_token.cancelled().await;
@@ -969,6 +1272,10 @@ impl BrokerRuntime {
 
         self.request_processor_task_group = Some(task_group);
         true
+    }
+
+    fn broker_task_group_or_current(&self, name: &'static str, no_runtime_warning: &'static str) -> Option<TaskGroup> {
+        self.inner.broker_task_group_or_current(name, no_runtime_warning)
     }
 
     async fn shutdown_request_processor_tasks(&mut self) -> Option<ShutdownReport> {
@@ -1458,22 +1765,12 @@ impl BrokerRuntime {
         let notification_processor = NotificationProcessor::new(self.inner.clone());
         self.inner.notification_processor = Some(notification_processor.clone());
         let mut broker_request_processor = BrokerRequestProcessor::new();
-        let request_processor_task_group =
-            self.request_processor_task_group
-                .clone()
-                .or_else(|| match tokio::runtime::Handle::try_current() {
-                    Ok(handle) => Some(TaskGroup::root(
-                        "rocketmq-broker.request-processor",
-                        RuntimeHandle::new(handle),
-                    )),
-                    Err(error) => {
-                        warn!(
-                            ?error,
-                            "failed to initialize broker request processor task group outside Tokio runtime"
-                        );
-                        None
-                    }
-                });
+        let request_processor_task_group = self.request_processor_task_group.clone().or_else(|| {
+            self.broker_task_group_or_current(
+                "rocketmq-broker.request-processor",
+                "failed to initialize broker request processor task group outside Tokio runtime",
+            )
+        });
         if let Some(task_group) = request_processor_task_group.clone() {
             pull_message_processor
                 .mut_from_ref()
@@ -1971,14 +2268,12 @@ impl BrokerRuntime {
         let (request_processor, fast_request_processor) = self.init_processor();
         self.proxy_request_processor = Some(request_processor.clone());
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                warn!(?error, "failed to start broker remoting servers outside Tokio runtime");
-                return;
-            }
+        let Some(remoting_server_task_group) = self.broker_task_group_or_current(
+            "rocketmq-broker.remoting-server",
+            "failed to start broker remoting servers outside Tokio runtime",
+        ) else {
+            return;
         };
-        let remoting_server_task_group = TaskGroup::root("rocketmq-broker.remoting-server", runtime);
 
         let mut server = RocketMQServer::new(Arc::new(self.inner.broker_config.broker_server_config.clone()));
         //start nomarl broker remoting_server
@@ -2571,12 +2866,39 @@ pub(crate) struct BrokerRuntimeInner<MS: MessageStore> {
     broker_pre_online_service: Option<BrokerPreOnlineService<MS>>,
     min_broker_id_in_group: AtomicU64,
     min_broker_addr_in_group: Mutex<Option<CheetahString>>,
+    service_context: Option<ServiceContext>,
     lock: Mutex<()>,
 }
 
 impl<MS: MessageStore> BrokerRuntimeInner<MS> {
     pub(crate) fn auth_metrics_snapshot(&self) -> Option<AuthMetricsSnapshot> {
         self.auth_runtime.as_ref().map(|runtime| runtime.metrics_snapshot())
+    }
+
+    pub(crate) fn broker_task_group_or_current(
+        &self,
+        name: impl Into<Arc<str>>,
+        no_runtime_warning: &'static str,
+    ) -> Option<TaskGroup> {
+        let name = name.into();
+        if let Some(service_context) = self.service_context.as_ref() {
+            return Some(service_context.task_group().child(Arc::clone(&name)));
+        }
+
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                warn!(?error, "{no_runtime_warning}");
+                return None;
+            }
+        };
+        Some(TaskGroup::root(name, runtime))
+    }
+
+    pub(crate) fn broker_service_task_group(&self) -> Option<TaskGroup> {
+        self.service_context
+            .as_ref()
+            .map(|service_context| service_context.task_group().clone())
     }
 
     #[inline]
@@ -4459,6 +4781,7 @@ mod tests {
     use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
     use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
     use rocketmq_remoting::runtime::processor::RequestProcessor;
+    use rocketmq_runtime::RuntimeContext;
     use rocketmq_store::base::message_status_enum::GetMessageStatus;
     use rocketmq_store::base::message_store::MessageStore;
     use rocketmq_store::config::flush_disk_type::FlushDiskType;
@@ -4629,6 +4952,83 @@ mod tests {
         let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
 
         assert!(runtime.initial_rpc_hooks());
+    }
+
+    #[tokio::test]
+    async fn broker_runtime_service_context_parents_probe_task_groups() {
+        let context = RuntimeContext::from_current("broker-context-runtime-test");
+        let service = context.service_context("broker-service");
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut runtime = BrokerRuntime::new_with_service_context(broker_config, message_store_config, service.clone());
+
+        assert!(runtime.install_remoting_server_report_probe());
+        assert!(runtime.install_request_processor_task_probe());
+
+        let remoting_group = runtime
+            .remoting_server_task_group
+            .as_ref()
+            .expect("remoting probe task group should be installed");
+        let request_group = runtime
+            .request_processor_task_group
+            .as_ref()
+            .expect("request processor probe task group should be installed");
+        assert_eq!(remoting_group.parent_id(), Some(service.task_group().id()));
+        assert_eq!(request_group.parent_id(), Some(service.task_group().id()));
+
+        let report = runtime.shutdown_basic_service_with_report().await;
+        assert!(report.is_healthy());
+        assert!(report.remoting.is_some());
+        assert!(report.request_processor.is_some());
+        assert_eq!(report.unhealthy_component_count(), 0);
+        assert!(report.timed_out_component_names().is_empty());
+        assert!(report.component_names().contains(&"scheduled_tasks"));
+    }
+
+    #[test]
+    fn broker_basic_shutdown_report_exposes_required_component_names() {
+        let report = BrokerBasicServiceShutdownReport::default();
+
+        assert_eq!(
+            report.component_names(),
+            vec![
+                "remoting",
+                "request_processor",
+                "auth",
+                "observability",
+                "scheduled_tasks",
+                "message_store",
+                "pull_request_hold",
+                "pop_services",
+                "transaction_services",
+                "fast_failure",
+                "topic_route",
+                "consumer_offset",
+                "subscription_group",
+            ]
+        );
+    }
+
+    #[test]
+    fn broker_basic_shutdown_report_aggregates_unhealthy_and_timed_out_components() {
+        let report = BrokerBasicServiceShutdownReport {
+            auth: BrokerShutdownComponentReport::completed("auth", Duration::from_millis(1)),
+            message_store: BrokerShutdownComponentReport::timed_out("message_store", Duration::from_millis(2)),
+            fast_failure: BrokerShutdownComponentReport::unhealthy(
+                "fast_failure",
+                Duration::from_millis(3),
+                "forced unhealthy component",
+            ),
+            ..Default::default()
+        };
+
+        assert!(!report.is_healthy());
+        assert_eq!(report.unhealthy_component_count(), 2);
+        assert_eq!(
+            report.unhealthy_component_names(),
+            vec!["message_store", "fast_failure"]
+        );
+        assert_eq!(report.timed_out_component_names(), vec!["message_store"]);
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/client/client_housekeeping_service.rs
+++ b/rocketmq-broker/src/client/client_housekeeping_service.rs
@@ -20,7 +20,6 @@ use std::time::Duration;
 use parking_lot::Mutex;
 use rocketmq_remoting::base::channel_event_listener::ChannelEventListener;
 use rocketmq_remoting::net::channel::Channel;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
@@ -141,17 +140,10 @@ where
             }
         }
 
-        let handle = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => handle,
-            Err(error) => {
-                warn!(
-                    ?error,
-                    "failed to start broker client housekeeping outside Tokio runtime"
-                );
-                return None;
-            }
-        };
-        let group = TaskGroup::root("rocketmq-broker.client-housekeeping", RuntimeHandle::new(handle));
+        let group = self.broker_runtime_inner.broker_task_group_or_current(
+            "rocketmq-broker.client-housekeeping",
+            "failed to start broker client housekeeping outside Tokio runtime",
+        )?;
         *task_group = Some(group.clone());
         Some(group)
     }
@@ -233,6 +225,7 @@ mod tests {
     use std::sync::Arc;
 
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_runtime::RuntimeContext;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
 
     use crate::broker_runtime::BrokerRuntime;
@@ -258,5 +251,34 @@ mod tests {
         assert!(service.shutdown_requested.load(Ordering::Acquire));
         assert!(service.task_group.lock().is_none());
         assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn service_context_parents_task_group() {
+        let context = RuntimeContext::from_current("broker-client-housekeeping-context-test");
+        let broker_service = context.service_context("broker-service");
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut broker_runtime =
+            BrokerRuntime::new_with_service_context(broker_config, message_store_config, broker_service.clone());
+        let service = ClientHousekeepingService::new(broker_runtime.inner_for_test().clone());
+
+        service.start();
+
+        let task_group = service
+            .task_group
+            .lock()
+            .as_ref()
+            .expect("client housekeeping task group should be installed")
+            .clone();
+        assert_eq!(task_group.parent_id(), Some(broker_service.task_group().id()));
+
+        let report = service
+            .shutdown_with_report()
+            .await
+            .expect("shutdown should return a report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        let broker_report = broker_service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(broker_report.is_healthy(), "{}", broker_report.to_json());
     }
 }

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -27,7 +27,6 @@ use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
@@ -363,6 +362,7 @@ struct FastFailureLifecycle {
 
 struct BrokerFastFailureInner {
     broker_config: Arc<BrokerConfig>,
+    parent_task_group: Option<TaskGroup>,
     queues: FastFailureQueues,
     next_task_id: AtomicU64,
     running: AtomicBool,
@@ -379,9 +379,21 @@ pub(crate) struct BrokerFastFailure {
 
 impl BrokerFastFailure {
     pub(crate) fn new(broker_config: Arc<BrokerConfig>) -> Self {
+        Self::new_with_optional_parent_task_group(broker_config, None)
+    }
+
+    pub(crate) fn new_with_parent_task_group(broker_config: Arc<BrokerConfig>, parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_parent_task_group(broker_config, Some(parent_task_group))
+    }
+
+    fn new_with_optional_parent_task_group(
+        broker_config: Arc<BrokerConfig>,
+        parent_task_group: Option<TaskGroup>,
+    ) -> Self {
         Self {
             inner: Arc::new(BrokerFastFailureInner {
                 broker_config,
+                parent_task_group,
                 queues: FastFailureQueues::new(),
                 next_task_id: AtomicU64::new(0),
                 running: AtomicBool::new(false),
@@ -391,6 +403,21 @@ impl BrokerFastFailure {
                 scan_batch_limit: DEFAULT_SCAN_BATCH_LIMIT,
             }),
         }
+    }
+
+    fn task_group_or_current(&self) -> Option<TaskGroup> {
+        if let Some(parent_task_group) = self.inner.parent_task_group.as_ref() {
+            return Some(parent_task_group.child("rocketmq-broker.fast-failure"));
+        }
+
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => rocketmq_runtime::RuntimeHandle::new(handle),
+            Err(error) => {
+                warn!(?error, "failed to start BrokerFastFailure outside Tokio runtime");
+                return None;
+            }
+        };
+        Some(TaskGroup::root("rocketmq-broker.fast-failure", runtime))
     }
 
     pub(crate) fn set_page_cache_busy_checker<F>(&self, checker: F)
@@ -422,15 +449,10 @@ impl BrokerFastFailure {
             return;
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                self.inner.running.store(false, Ordering::Release);
-                warn!(?error, "failed to start BrokerFastFailure outside Tokio runtime");
-                return;
-            }
+        let Some(task_group) = self.task_group_or_current() else {
+            self.inner.running.store(false, Ordering::Release);
+            return;
         };
-        let task_group = TaskGroup::root("rocketmq-broker.fast-failure", runtime);
         let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
         let this = self.clone();
         let mut config = ScheduledTaskConfig::fixed_delay("broker.fast-failure.scan", scan_interval);
@@ -651,6 +673,7 @@ fn system_busy_response(
 mod tests {
     use std::sync::atomic::AtomicBool;
 
+    use rocketmq_runtime::RuntimeContext;
     use tokio::sync::oneshot::error::TryRecvError;
 
     use super::*;
@@ -749,6 +772,36 @@ mod tests {
         assert!(!fast_failure.is_running());
         assert_eq!(fast_failure.task_count(), 0);
         assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn parent_task_group_parents_scanner_task_group() {
+        let context = RuntimeContext::from_current("broker-fast-failure-context-test");
+        let broker_service = context.service_context("broker-service");
+        let fast_failure = BrokerFastFailure::new_with_parent_task_group(
+            config_with_fast_failure_waits(1_000),
+            broker_service.task_group().clone(),
+        );
+
+        fast_failure.start();
+
+        let task_group = fast_failure
+            .inner
+            .lifecycle
+            .lock()
+            .task_group
+            .as_ref()
+            .expect("fast failure task group should be installed")
+            .clone();
+        assert_eq!(task_group.parent_id(), Some(broker_service.task_group().id()));
+
+        let report = fast_failure
+            .shutdown_with_report()
+            .await
+            .expect("shutdown should return a report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        let broker_report = broker_service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(broker_report.is_healthy(), "{}", broker_report.to_json());
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -67,6 +67,8 @@ pub mod bench_support {
         pub remoting_shutdown_report: Option<BrokerRemotingShutdownProbe>,
         pub request_processor_shutdown_report: Option<rocketmq_runtime::ShutdownReport>,
         pub basic_shutdown_elapsed_us: u128,
+        pub basic_shutdown_healthy: bool,
+        pub basic_shutdown_report: BrokerBasicShutdownProbe,
         pub healthy: bool,
     }
 
@@ -146,6 +148,15 @@ pub mod bench_support {
         pub healthy: bool,
     }
 
+    #[derive(Debug, Clone, Serialize)]
+    pub struct BrokerBasicShutdownProbe {
+        pub component_names: Vec<&'static str>,
+        pub healthy: bool,
+        pub unhealthy_component_count: usize,
+        pub unhealthy_components: Vec<&'static str>,
+        pub timed_out_components: Vec<&'static str>,
+    }
+
     impl From<ScheduledShutdownReport> for BrokerScheduledShutdownProbe {
         fn from(report: ScheduledShutdownReport) -> Self {
             Self {
@@ -178,6 +189,18 @@ pub mod bench_support {
                 server_report_count,
                 server_reports_healthy,
                 healthy: report.is_healthy(),
+            }
+        }
+    }
+
+    impl From<&crate::broker_runtime::BrokerBasicServiceShutdownReport> for BrokerBasicShutdownProbe {
+        fn from(report: &crate::broker_runtime::BrokerBasicServiceShutdownReport) -> Self {
+            Self {
+                component_names: report.component_names(),
+                healthy: report.is_healthy(),
+                unhealthy_component_count: report.unhealthy_component_count(),
+                unhealthy_components: report.unhealthy_component_names(),
+                timed_out_components: report.timed_out_component_names(),
             }
         }
     }
@@ -281,16 +304,20 @@ pub mod bench_support {
         let remoting_probe_installed = runtime.install_remoting_server_report_probe();
         let request_processor_probe_installed = runtime.install_request_processor_task_probe();
         let basic_started_at = Instant::now();
-        let basic_shutdown_report =
+        let mut basic_shutdown_report =
             tokio::time::timeout(Duration::from_secs(5), runtime.shutdown_basic_service_with_report())
                 .await
                 .expect("broker basic service shutdown should be bounded");
         let basic_shutdown_elapsed_us = basic_started_at.elapsed().as_micros();
 
         let scheduled_shutdown_report = BrokerScheduledShutdownProbe::from(scheduled_shutdown_report);
-        let basic_shutdown_healthy = basic_shutdown_report.is_healthy();
-        let remoting_shutdown_report = basic_shutdown_report.remoting.map(BrokerRemotingShutdownProbe::from);
-        let request_processor_shutdown_report = basic_shutdown_report.request_processor;
+        let basic_shutdown_report_probe = BrokerBasicShutdownProbe::from(&basic_shutdown_report);
+        let basic_shutdown_healthy = basic_shutdown_report_probe.healthy;
+        let remoting_shutdown_report = basic_shutdown_report
+            .remoting
+            .take()
+            .map(BrokerRemotingShutdownProbe::from);
+        let request_processor_shutdown_report = basic_shutdown_report.request_processor.take();
         let remoting_shutdown_elapsed_us = basic_shutdown_elapsed_us;
         let healthy = scheduled_shutdown_report.healthy
             && basic_shutdown_healthy
@@ -318,6 +345,8 @@ pub mod bench_support {
             remoting_shutdown_report,
             request_processor_shutdown_report,
             basic_shutdown_elapsed_us,
+            basic_shutdown_healthy,
+            basic_shutdown_report: basic_shutdown_report_probe,
             healthy,
         }
     }
@@ -627,6 +656,10 @@ mod bench_support_tests {
         let probe = super::bench_support::run_broker_runtime_lifecycle_probe(root, 1).await;
 
         assert!(probe.healthy, "{probe:?}");
+        assert!(probe.basic_shutdown_healthy, "{probe:?}");
+        assert_eq!(probe.basic_shutdown_report.unhealthy_component_count, 0, "{probe:?}");
+        assert!(probe.basic_shutdown_report.timed_out_components.is_empty(), "{probe:?}");
+        assert!(probe.basic_shutdown_report.component_names.contains(&"message_store"));
         let remoting_report = probe
             .remoting_shutdown_report
             .as_ref()

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs
@@ -25,7 +25,6 @@ use parking_lot::Mutex;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
@@ -79,16 +78,12 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
             return;
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                this.running.store(false, Ordering::Release);
-                warn!(
-                    ?error,
-                    "failed to start PopLiteLongPollingService outside Tokio runtime"
-                );
-                return;
-            }
+        let Some(task_group) = this.broker_runtime_inner.broker_task_group_or_current(
+            "rocketmq-broker.long-polling.pop-lite",
+            "failed to start PopLiteLongPollingService outside Tokio runtime",
+        ) else {
+            this.running.store(false, Ordering::Release);
+            return;
         };
         let Some(mut wakeup_rx) = this.mut_from_ref().wakeup_rx.take() else {
             this.running.store(false, Ordering::Release);
@@ -96,7 +91,6 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLiteLongPolling
             return;
         };
 
-        let task_group = TaskGroup::root("rocketmq-broker.long-polling.pop-lite", runtime);
         let cancellation_token = task_group.cancellation_token();
         let service = this.clone();
 

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -32,7 +32,6 @@ use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
@@ -89,15 +88,13 @@ impl<MS: MessageStore, RP: RequestProcessor + Sync + 'static> PopLongPollingServ
             return;
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                this.running.store(false, Ordering::Release);
-                warn!(?error, "failed to start PopLongPollingService outside Tokio runtime");
-                return;
-            }
+        let Some(task_group) = this.broker_runtime_inner.broker_task_group_or_current(
+            "rocketmq-broker.long-polling.pop",
+            "failed to start PopLongPollingService outside Tokio runtime",
+        ) else {
+            this.running.store(false, Ordering::Release);
+            return;
         };
-        let task_group = TaskGroup::root("rocketmq-broker.long-polling.pop", runtime);
         let cancellation_token = task_group.cancellation_token();
         let service = this.clone();
 

--- a/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs
@@ -21,7 +21,6 @@ use std::time::Duration;
 use cheetah_string::CheetahString;
 use parking_lot::Mutex;
 use rocketmq_common::TimeUtils::current_millis;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_store::MessageStore;
@@ -80,15 +79,13 @@ where
             return;
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                self.running.store(false, Ordering::Release);
-                warn!(?error, "failed to start PullRequestHoldService outside Tokio runtime");
-                return;
-            }
+        let Some(task_group) = this.broker_task_group_or_current(
+            "rocketmq-broker.long-polling.pull-request-hold",
+            "failed to start PullRequestHoldService outside Tokio runtime",
+        ) else {
+            self.running.store(false, Ordering::Release);
+            return;
         };
-        let task_group = TaskGroup::root("rocketmq-broker.long-polling.pull-request-hold", runtime);
         let cancellation_token = task_group.cancellation_token();
 
         if let Err(error) = task_group.spawn_service("broker.long-polling.pull-request-hold.scan", async move {

--- a/rocketmq-broker/src/processor/pop_lite_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor.rs
@@ -38,6 +38,7 @@ use crate::broker_runtime::BrokerRuntimeInner;
 use crate::lite::memory_consumer_order_info_manager::MemoryConsumerOrderInfoManager;
 use crate::long_polling::long_polling_service::pop_lite_long_polling_service::PopLiteLongPollingService;
 use crate::long_polling::polling_result::PollingResult;
+use crate::processor::pop_message_processor::queue_lock_manager_for_broker;
 use crate::processor::pop_message_processor::QueueLockManager;
 
 pub(crate) struct PopLiteMessageProcessor<MS: MessageStore> {
@@ -63,7 +64,7 @@ impl<MS: MessageStore> PopLiteMessageProcessor<MS> {
         Self {
             pop_lite_long_polling_service: ArcMut::new(PopLiteLongPollingService::new(broker_runtime_inner.clone())),
             consumer_order_info_manager: MemoryConsumerOrderInfoManager::default(),
-            queue_lock_manager: QueueLockManager::new(),
+            queue_lock_manager: queue_lock_manager_for_broker(&broker_runtime_inner),
             broker_runtime_inner,
         }
     }

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -105,7 +105,7 @@ impl<MS: MessageStore> PopMessageProcessor<MS> {
                 .broker_cluster_name
                 .as_str(),
         ));
-        let queue_lock_manager = QueueLockManager::new();
+        let queue_lock_manager = queue_lock_manager_for_broker(&broker_runtime_inner);
         PopMessageProcessor {
             ck_message_number: Default::default(),
             pop_long_polling_service: ArcMut::new(PopLongPollingService::new(broker_runtime_inner.clone(), false)),
@@ -130,7 +130,7 @@ impl<MS: MessageStore> PopMessageProcessor<MS> {
                 .broker_cluster_name
                 .as_str(),
         ));
-        let queue_lock_manager = QueueLockManager::new();
+        let queue_lock_manager = queue_lock_manager_for_broker(&broker_runtime_inner);
         let processor = PopMessageProcessor {
             ck_message_number: Default::default(),
             pop_long_polling_service: ArcMut::new(PopLongPollingService::new(broker_runtime_inner.clone(), false)),
@@ -1455,6 +1455,15 @@ where
     }
 }
 
+pub(crate) fn queue_lock_manager_for_broker<MS: MessageStore>(
+    broker_runtime_inner: &ArcMut<BrokerRuntimeInner<MS>>,
+) -> QueueLockManager {
+    broker_runtime_inner
+        .broker_service_task_group()
+        .map(QueueLockManager::new_with_parent_task_group)
+        .unwrap_or_else(QueueLockManager::new)
+}
+
 impl<MS: MessageStore> PopMessageProcessor<MS> {
     pub fn gen_ack_unique_id(ack_msg: &dyn AckMessage) -> String {
         format!(
@@ -1588,16 +1597,41 @@ pub struct QueueLockManager {
     shutdown: Arc<Notify>,
     running: Arc<AtomicBool>,
     task_group: Arc<Mutex<Option<TaskGroup>>>,
+    parent_task_group: Option<TaskGroup>,
 }
 
 impl QueueLockManager {
     pub fn new() -> Self {
+        Self::new_with_optional_parent_task_group(None)
+    }
+
+    pub(crate) fn new_with_parent_task_group(parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_parent_task_group(Some(parent_task_group))
+    }
+
+    fn new_with_optional_parent_task_group(parent_task_group: Option<TaskGroup>) -> Self {
         QueueLockManager {
             expired_local_cache: Arc::new(RwLock::new(HashMap::with_capacity(4096))),
             shutdown: Arc::new(Notify::new()),
             running: Arc::new(AtomicBool::new(false)),
             task_group: Arc::new(Mutex::new(None)),
+            parent_task_group,
         }
+    }
+
+    fn task_group_or_current(&self) -> Option<TaskGroup> {
+        if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            return Some(parent_task_group.child("rocketmq-broker.pop.queue-lock"));
+        }
+
+        let runtime = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => RuntimeHandle::new(handle),
+            Err(error) => {
+                warn!(?error, "failed to start QueueLockManager outside Tokio runtime");
+                return None;
+            }
+        };
+        Some(TaskGroup::root("rocketmq-broker.pop.queue-lock", runtime))
     }
 
     #[inline]
@@ -1656,15 +1690,10 @@ impl QueueLockManager {
             return;
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                self.running.store(false, Ordering::Release);
-                warn!(?error, "failed to start QueueLockManager outside Tokio runtime");
-                return;
-            }
+        let Some(task_group) = self.task_group_or_current() else {
+            self.running.store(false, Ordering::Release);
+            return;
         };
-        let task_group = TaskGroup::root("rocketmq-broker.pop.queue-lock", runtime);
         let cancellation_token = task_group.cancellation_token();
         let this = self.clone();
         let mut lifecycle = self.task_group.lock();
@@ -1729,6 +1758,7 @@ mod tests {
     use rocketmq_remoting::net::channel::ChannelInner;
     use rocketmq_remoting::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
     use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
+    use rocketmq_runtime::RuntimeContext;
     use rocketmq_rust::ArcMut;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
     use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
@@ -1918,6 +1948,61 @@ mod tests {
 
         manager.shutdown().await;
         assert!(!manager.is_running());
+    }
+
+    #[tokio::test]
+    async fn queue_lock_manager_parent_task_group_parents_cleanup_task() {
+        let context = RuntimeContext::from_current("broker-queue-lock-context-test");
+        let broker_service = context.service_context("broker-service");
+        let manager = QueueLockManager::new_with_parent_task_group(broker_service.task_group().clone());
+
+        manager.start();
+
+        let task_group = manager
+            .task_group
+            .lock()
+            .as_ref()
+            .expect("queue lock task group should be installed")
+            .clone();
+        assert_eq!(task_group.parent_id(), Some(broker_service.task_group().id()));
+
+        manager.shutdown().await;
+        assert!(!manager.is_running());
+
+        let broker_report = broker_service
+            .task_group()
+            .shutdown(std::time::Duration::from_secs(1))
+            .await;
+        assert!(broker_report.is_healthy(), "{}", broker_report.to_json());
+    }
+
+    #[tokio::test]
+    async fn pop_message_processor_parents_queue_lock_manager_from_service_context() {
+        let context = RuntimeContext::from_current("broker-pop-processor-context-test");
+        let broker_service = context.service_context("broker-service");
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut runtime =
+            BrokerRuntime::new_with_service_context(broker_config, message_store_config, broker_service.clone());
+        let processor = PopMessageProcessor::new(runtime.inner_for_test().clone());
+
+        processor.queue_lock_manager.start();
+
+        let task_group = processor
+            .queue_lock_manager
+            .task_group
+            .lock()
+            .as_ref()
+            .expect("processor queue lock task group should be installed")
+            .clone();
+        assert_eq!(task_group.parent_id(), Some(broker_service.task_group().id()));
+
+        processor.queue_lock_manager.shutdown().await;
+        let broker_report = broker_service
+            .task_group()
+            .shutdown(std::time::Duration::from_secs(1))
+            .await;
+        assert!(broker_report.is_healthy(), "{}", broker_report.to_json());
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -42,7 +42,6 @@ use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::protocol::RemotingSerializable;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
@@ -658,15 +657,13 @@ impl<MS: MessageStore> PopBufferMergeService<MS> {
         }
 
         this.shutdown_requested.store(false, Ordering::Release);
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                this.running.store(false, Ordering::Release);
-                warn!(?error, "failed to start PopBufferMergeService outside Tokio runtime");
-                return;
-            }
+        let Some(task_group) = this.broker_runtime_inner.broker_task_group_or_current(
+            "rocketmq-broker.pop-buffer-merge",
+            "failed to start PopBufferMergeService outside Tokio runtime",
+        ) else {
+            this.running.store(false, Ordering::Release);
+            return;
         };
-        let task_group = TaskGroup::root("rocketmq-broker.pop-buffer-merge", runtime);
         let cancellation_token = task_group.cancellation_token();
         let service = this.clone();
 

--- a/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
@@ -42,7 +42,6 @@ use rocketmq_common::utils::data_converter::DataConverter;
 use rocketmq_common::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::TimeUtils::current_millis;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::get_message_result::GetMessageResult;
@@ -328,19 +327,17 @@ impl<MS: MessageStore> PopReviveService<MS> {
         }
 
         this.shutdown.store(false, Ordering::Release);
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                this.running.store(false, Ordering::Release);
-                warn!(
-                    ?error,
-                    revive_queue_id = this.queue_id,
-                    "failed to start PopReviveService outside Tokio runtime"
-                );
-                return;
-            }
+        let Some(task_group) = this.broker_runtime_inner.broker_task_group_or_current(
+            format!("rocketmq-broker.pop-revive.{}", this.queue_id),
+            "failed to start PopReviveService outside Tokio runtime",
+        ) else {
+            this.running.store(false, Ordering::Release);
+            warn!(
+                revive_queue_id = this.queue_id,
+                "failed to start PopReviveService outside Tokio runtime"
+            );
+            return;
         };
-        let task_group = TaskGroup::root(format!("rocketmq-broker.pop-revive.{}", this.queue_id), runtime);
         let cancellation_token = task_group.cancellation_token();
         let mut service = this.clone();
 

--- a/rocketmq-broker/src/schedule/schedule_message_service.rs
+++ b/rocketmq-broker/src/schedule/schedule_message_service.rs
@@ -44,7 +44,6 @@ use rocketmq_common::MessageDecoder;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::DataVersion;
 use rocketmq_remoting::protocol::RemotingSerializable;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
@@ -325,11 +324,17 @@ impl<MS: MessageStore> ScheduleMessageService<MS> {
     }
 
     fn install_task_groups(this: &ArcMut<Self>) -> Result<ScheduledTaskGroup, Box<dyn std::error::Error>> {
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => return Err(Box::new(error)),
-        };
-        let task_group = TaskGroup::root("rocketmq-broker.schedule", runtime);
+        let task_group = this
+            .broker_controller
+            .broker_task_group_or_current(
+                "rocketmq-broker.schedule",
+                "failed to start ScheduleMessageService outside Tokio runtime",
+            )
+            .ok_or_else(|| {
+                Box::<dyn std::error::Error>::from(std::io::Error::other(
+                    "failed to start ScheduleMessageService outside Tokio runtime",
+                ))
+            })?;
         let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
         *this.task_group.lock() = Some(task_group);
         *this.scheduled_tasks.lock() = Some(scheduled_tasks.clone());

--- a/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs
@@ -42,19 +42,27 @@ use tracing::warn;
 
 use crate::broker_path_config_helper::get_topic_queue_mapping_path;
 
-static TOPIC_QUEUE_MAPPING_BLOCKING: OnceLock<BlockingExecutor> = OnceLock::new();
-
 #[derive(Default)]
 pub(crate) struct TopicQueueMappingManager {
     pub(crate) data_version: Arc<parking_lot::Mutex<DataVersion>>,
     pub(crate) topic_queue_mapping_table: DashMap<CheetahString /* topic */, ArcMut<TopicQueueMappingDetail>>,
     pub(crate) broker_config: Arc<BrokerConfig>,
+    blocking_executor: OnceLock<BlockingExecutor>,
+    parent_task_group: Option<TaskGroup>,
 }
 
 impl TopicQueueMappingManager {
     pub(crate) fn new(broker_config: Arc<BrokerConfig>) -> Self {
         Self {
             broker_config,
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn new_with_parent_task_group(broker_config: Arc<BrokerConfig>, parent_task_group: TaskGroup) -> Self {
+        Self {
+            broker_config,
+            parent_task_group: Some(parent_task_group),
             ..Default::default()
         }
     }
@@ -327,7 +335,7 @@ impl TopicQueueMappingManager {
         }
 
         let file_name = self.config_file_path();
-        topic_queue_mapping_blocking_executor()?
+        self.blocking_executor()?
             .spawn_io("broker.topic_queue_mapping.persist_clean_result", move || {
                 rocketmq_common::FileUtils::string_to_file(json.as_str(), file_name.as_str())
             })
@@ -348,42 +356,53 @@ impl TopicQueueMappingManager {
             }
         }
     }
-}
+    fn blocking_executor(&self) -> RocketMQResult<BlockingExecutor> {
+        if let Some(executor) = self.blocking_executor.get() {
+            return Ok(executor.clone());
+        }
 
-fn topic_queue_mapping_blocking_executor() -> RocketMQResult<BlockingExecutor> {
-    if let Some(executor) = TOPIC_QUEUE_MAPPING_BLOCKING.get() {
-        return Ok(executor.clone());
+        let executor = self.create_blocking_executor()?;
+        if self.blocking_executor.set(executor.clone()).is_err() {
+            return Ok(self
+                .blocking_executor
+                .get()
+                .expect("topic queue mapping blocking executor must be initialized")
+                .clone());
+        }
+
+        Ok(executor)
     }
 
-    let handle = Handle::try_current().map_err(|error| {
-        RocketMQError::Internal(format!(
-            "topic queue mapping blocking executor requires a Tokio runtime: {error}"
+    fn create_blocking_executor(&self) -> RocketMQResult<BlockingExecutor> {
+        let group = self.blocking_task_group()?;
+        BlockingExecutor::new(
+            BlockingPoolPolicy {
+                name: "rocketmq-broker.topic_queue_mapping.blocking".to_string(),
+                max_concurrency: 8,
+                ..BlockingPoolPolicy::default()
+            },
+            group.child("rocketmq-broker.topic_queue_mapping.blocking-reaper"),
+        )
+        .map_err(|error| {
+            RocketMQError::Internal(format!("create topic queue mapping blocking executor failed: {error}"))
+        })
+    }
+
+    fn blocking_task_group(&self) -> RocketMQResult<TaskGroup> {
+        if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            return Ok(parent_task_group.child("rocketmq-broker.topic_queue_mapping.blocking"));
+        }
+
+        let handle = Handle::try_current().map_err(|error| {
+            RocketMQError::Internal(format!(
+                "topic queue mapping blocking executor requires a Tokio runtime: {error}"
+            ))
+        })?;
+        Ok(TaskGroup::root(
+            "rocketmq-broker.topic_queue_mapping.blocking",
+            RuntimeHandle::new(handle),
         ))
-    })?;
-    let group = TaskGroup::root(
-        "rocketmq-broker.topic_queue_mapping.blocking",
-        RuntimeHandle::new(handle),
-    );
-    let executor = BlockingExecutor::new(
-        BlockingPoolPolicy {
-            name: "rocketmq-broker.topic_queue_mapping.blocking".to_string(),
-            max_concurrency: 8,
-            ..BlockingPoolPolicy::default()
-        },
-        group.child("rocketmq-broker.topic_queue_mapping.blocking-reaper"),
-    )
-    .map_err(|error| {
-        RocketMQError::Internal(format!("create topic queue mapping blocking executor failed: {error}"))
-    })?;
-
-    if TOPIC_QUEUE_MAPPING_BLOCKING.set(executor.clone()).is_err() {
-        return Ok(TOPIC_QUEUE_MAPPING_BLOCKING
-            .get()
-            .expect("topic queue mapping blocking executor must be initialized")
-            .clone());
     }
-
-    Ok(executor)
 }
 
 //Fully implemented will be removed
@@ -426,6 +445,7 @@ mod tests {
     use std::sync::Arc;
 
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_runtime::RuntimeContext;
 
     use super::*;
 
@@ -437,6 +457,40 @@ mod tests {
         assert!(Arc::ptr_eq(&manager.broker_config, &broker_config));
         assert_eq!(manager.data_version.lock().get_state_version(), 0);
         assert_eq!(manager.topic_queue_mapping_table.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn new_with_parent_task_group_uses_service_parent_for_blocking_executor() {
+        let context = RuntimeContext::from_current("broker-topic-queue-mapping-context-test");
+        let broker_service = context.service_context("broker-service");
+        let broker_config = Arc::new(BrokerConfig::default());
+        let manager =
+            TopicQueueMappingManager::new_with_parent_task_group(broker_config, broker_service.task_group().clone());
+
+        assert_eq!(
+            manager.parent_task_group.as_ref().map(TaskGroup::id),
+            Some(broker_service.task_group().id())
+        );
+
+        let executor = manager
+            .blocking_executor()
+            .expect("blocking executor should be created");
+        assert_eq!(executor.policy().name, "rocketmq-broker.topic_queue_mapping.blocking");
+        assert_eq!(executor.policy().max_concurrency, 8);
+
+        let broker_report = broker_service
+            .task_group()
+            .shutdown(std::time::Duration::from_secs(1))
+            .await;
+        assert!(
+            broker_report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq-broker.topic_queue_mapping.blocking"),
+            "{}",
+            broker_report.to_json()
+        );
+        assert!(broker_report.is_healthy(), "{}", broker_report.to_json());
     }
 
     #[test]

--- a/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
@@ -29,7 +29,6 @@ use rocketmq_common::common::mix_all;
 use rocketmq_remoting::code::response_code::ResponseCode;
 use rocketmq_remoting::protocol::namespace_util::NamespaceUtil;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::RocketMQTokioMutex;
@@ -93,16 +92,14 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
             return;
         }
 
-        let mut task_group = self.task_group.lock();
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                self.running.store(false, Ordering::Release);
-                warn!(?error, "failed to start TopicRouteInfoManager outside Tokio runtime");
-                return;
-            }
+        let Some(group) = self.broker_runtime_inner.broker_task_group_or_current(
+            "rocketmq-broker.topic-route-info",
+            "failed to start TopicRouteInfoManager outside Tokio runtime",
+        ) else {
+            self.running.store(false, Ordering::Release);
+            return;
         };
-        let group = TaskGroup::root("rocketmq-broker.topic-route-info", runtime);
+        let mut task_group = self.task_group.lock();
         let cancellation_token = group.cancellation_token();
         let manager = self.clone();
         let load_balance_poll_name_server_interval = self
@@ -372,8 +369,10 @@ impl<MS: MessageStore> TopicRouteInfoManager<MS> {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_runtime::RuntimeContext;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
 
     use crate::broker_runtime::BrokerRuntime;
@@ -391,5 +390,30 @@ mod tests {
 
         manager.shutdown().await;
         assert!(!manager.is_running());
+    }
+
+    #[tokio::test]
+    async fn service_context_parents_task_group() {
+        let context = RuntimeContext::from_current("broker-topic-route-context-test");
+        let broker_service = context.service_context("broker-service");
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut broker_runtime =
+            BrokerRuntime::new_with_service_context(broker_config, message_store_config, broker_service.clone());
+        let mut manager = broker_runtime.inner_for_test().topic_route_info_manager().clone();
+
+        manager.start();
+
+        let task_group = manager
+            .task_group
+            .lock()
+            .as_ref()
+            .expect("topic route task group should be installed")
+            .clone();
+        assert_eq!(task_group.parent_id(), Some(broker_service.task_group().id()));
+
+        manager.shutdown().await;
+        let broker_report = broker_service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(broker_report.is_healthy(), "{}", broker_report.to_json());
     }
 }

--- a/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
+++ b/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
@@ -32,7 +32,6 @@ use rocketmq_remoting::protocol::static_topic::logic_queue_mapping_item::LogicQu
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_detail::TopicQueueMappingDetail;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_utils::TopicQueueMappingUtils;
 use rocketmq_remoting::rpc::client_metadata::ClientMetadata;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
@@ -99,18 +98,13 @@ impl<MS: MessageStore> TopicQueueMappingCleanService<MS> {
             return;
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                self.inner.running.store(false, Ordering::Release);
-                warn!(
-                    ?error,
-                    "failed to start TopicQueueMappingCleanService outside Tokio runtime"
-                );
-                return;
-            }
+        let Some(task_group) = self.inner.broker_runtime_inner.broker_task_group_or_current(
+            "rocketmq-broker.topic-queue-mapping-clean",
+            "failed to start TopicQueueMappingCleanService outside Tokio runtime",
+        ) else {
+            self.inner.running.store(false, Ordering::Release);
+            return;
         };
-        let task_group = TaskGroup::root("rocketmq-broker.topic-queue-mapping-clean", runtime);
         let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
         let this = Self {
             inner: Arc::clone(&self.inner),
@@ -529,6 +523,7 @@ mod tests {
     use std::sync::Arc;
 
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
+    use rocketmq_runtime::RuntimeContext;
     use rocketmq_store::config::message_store_config::MessageStoreConfig;
     use rocketmq_store::message_store::local_file_message_store::LocalFileMessageStore;
 
@@ -604,5 +599,39 @@ mod tests {
         assert!(!service.is_running());
         assert_eq!(service.task_count(), 0);
         assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn service_context_parents_task_group() {
+        let context = RuntimeContext::from_current("broker-topic-clean-context-test");
+        let broker_service = context.service_context("broker-service");
+        let broker_config = Arc::new(BrokerConfig::default());
+        let message_store_config = Arc::new(MessageStoreConfig::default());
+        let mut broker_runtime =
+            BrokerRuntime::new_with_service_context(broker_config, message_store_config, broker_service.clone());
+        let service = broker_runtime
+            .inner_for_test()
+            .topic_queue_mapping_clean_service_unchecked()
+            .clone();
+
+        service.start();
+
+        let task_group = service
+            .inner
+            .lifecycle
+            .lock()
+            .task_group
+            .as_ref()
+            .expect("topic queue mapping clean task group should be installed")
+            .clone();
+        assert_eq!(task_group.parent_id(), Some(broker_service.task_group().id()));
+
+        let report = service
+            .shutdown_with_report()
+            .await
+            .expect("shutdown should return a report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        let broker_report = broker_service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(broker_report.is_healthy(), "{}", broker_report.to_json());
     }
 }

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::time::Duration;
 
 use cheetah_string::CheetahString;
-use rocketmq_common::common::broker::broker_config::BrokerConfig;
 use rocketmq_common::common::config::TopicConfig;
 use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::message::message_ext::MessageExt;
@@ -26,13 +26,11 @@ use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
 use rocketmq_remoting::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_remoting::rpc::rpc_request_header::RpcRequestHeader;
-use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
 use rocketmq_store::base::message_status_enum::PutMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
-use std::time::Duration;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -61,7 +59,7 @@ impl<MS: MessageStore> Clone for DefaultTransactionalMessageCheckListener<MS> {
 
 impl<MS: MessageStore> DefaultTransactionalMessageCheckListener<MS> {
     pub fn new(broker_client: Broker2Client, broker_runtime_inner: ArcMut<BrokerRuntimeInner<MS>>) -> Self {
-        let task_group = Self::create_task_group(broker_runtime_inner.broker_config());
+        let task_group = Self::create_task_group(&broker_runtime_inner);
         Self {
             broker_runtime_inner,
             broker_client: ArcMut::new(broker_client),
@@ -69,21 +67,12 @@ impl<MS: MessageStore> DefaultTransactionalMessageCheckListener<MS> {
         }
     }
 
-    fn create_task_group(broker_config: &BrokerConfig) -> Option<TaskGroup> {
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                warn!(
-                    ?error,
-                    "transaction check listener initialized outside Tokio runtime; check tasks will run inline"
-                );
-                return None;
-            }
-        };
-        Some(TaskGroup::root(
+    fn create_task_group(broker_runtime_inner: &ArcMut<BrokerRuntimeInner<MS>>) -> Option<TaskGroup> {
+        let broker_config = broker_runtime_inner.broker_config();
+        broker_runtime_inner.broker_task_group_or_current(
             format!("rocketmq-broker.transaction-check.{}", broker_config.broker_name()),
-            runtime,
-        ))
+            "transaction check listener initialized outside Tokio runtime; check tasks will run inline",
+        )
     }
 
     pub async fn shutdown(&self) {

--- a/rocketmq-client/src/runtime.rs
+++ b/rocketmq-client/src/runtime.rs
@@ -35,6 +35,7 @@ use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskControl;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
+use rocketmq_runtime::ServiceContext;
 use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskGroupLifecycleState;
@@ -69,6 +70,18 @@ where
 {
     let (task_group, fallback_lease) = client_task_group_on(task_name, executor)?;
     spawn_client_task_in_group(task_name, task_group, fallback_lease, task)
+}
+
+pub(crate) fn spawn_client_task_with_context<F>(
+    context: &ServiceContext,
+    task_name: &'static str,
+    task: F,
+) -> io::Result<ClientRuntimeTaskHandle>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let task_group = context.task_group().child(task_name);
+    spawn_client_task_in_group(task_name, task_group, None, task)
 }
 
 pub(crate) fn spawn_detached_client_task<F>(task_name: &'static str, task: F) -> io::Result<()>
@@ -193,6 +206,29 @@ where
     })
 }
 
+pub(crate) fn spawn_client_tracked_task_with_context<F>(
+    context: &ServiceContext,
+    task_name: &'static str,
+    task: F,
+) -> io::Result<ClientTrackedTaskHandle>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let task_group = context.task_group().child(task_name);
+    let (completion_tx, completion_rx) = std_mpsc::channel();
+    task_group
+        .spawn_service(task_name, async move {
+            let _completion = ClientTrackedTaskCompletion::new(completion_tx);
+            task.await;
+        })
+        .map_err(io::Error::other)?;
+
+    Ok(ClientTrackedTaskHandle {
+        task_group,
+        completion_rx: Mutex::new(Some(completion_rx)),
+    })
+}
+
 struct ClientTrackedTaskCompletion {
     completion_tx: Option<std_mpsc::Sender<()>>,
 }
@@ -268,6 +304,34 @@ where
     })
 }
 
+pub(crate) fn schedule_client_fixed_delay_task_with_context<F, Fut>(
+    context: &ServiceContext,
+    task_name: &'static str,
+    initial_delay: Duration,
+    period: Duration,
+    shutdown_timeout: Duration,
+    task: F,
+) -> io::Result<ClientScheduledTaskHandle>
+where
+    F: FnMut() -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let task_group = context.task_group().child(task_name);
+    let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
+    let mut config = ScheduledTaskConfig::fixed_delay(task_name, period);
+    config.initial_delay = initial_delay;
+    config.shutdown_timeout = shutdown_timeout;
+    scheduled_tasks
+        .schedule_fixed_delay(config, task)
+        .map_err(io::Error::other)?;
+
+    Ok(ClientScheduledTaskHandle {
+        task_group,
+        scheduled_tasks,
+        _fallback_lease: None,
+    })
+}
+
 pub(crate) fn schedule_client_fixed_delay_controlled_task<F, Fut>(
     task_name: &'static str,
     initial_delay: Duration,
@@ -292,6 +356,34 @@ where
         task_group,
         scheduled_tasks,
         _fallback_lease: fallback_lease,
+    })
+}
+
+pub(crate) fn schedule_client_fixed_delay_controlled_task_with_context<F, Fut>(
+    context: &ServiceContext,
+    task_name: &'static str,
+    initial_delay: Duration,
+    period: Duration,
+    shutdown_timeout: Duration,
+    task: F,
+) -> io::Result<ClientScheduledTaskHandle>
+where
+    F: FnMut() -> Fut + Send + 'static,
+    Fut: Future<Output = ScheduledTaskControl> + Send + 'static,
+{
+    let task_group = context.task_group().child(task_name);
+    let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
+    let mut config = ScheduledTaskConfig::fixed_delay(task_name, period);
+    config.initial_delay = initial_delay;
+    config.shutdown_timeout = shutdown_timeout;
+    scheduled_tasks
+        .schedule_fixed_delay_controlled(config, task)
+        .map_err(io::Error::other)?;
+
+    Ok(ClientScheduledTaskHandle {
+        task_group,
+        scheduled_tasks,
+        _fallback_lease: None,
     })
 }
 
@@ -359,6 +451,22 @@ where
     R: Send + 'static,
 {
     client_blocking_executor()?
+        .spawn_io(task_name, task)
+        .await
+        .map_err(io::Error::other)
+}
+
+pub(crate) async fn spawn_client_blocking_io_with_context<F, R>(
+    context: &ServiceContext,
+    task_name: &'static str,
+    task: F,
+) -> io::Result<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    context
+        .blocking()
         .spawn_io(task_name, task)
         .await
         .map_err(io::Error::other)
@@ -818,6 +926,8 @@ mod tests {
     use std::sync::mpsc;
     use std::time::Duration;
 
+    use rocketmq_runtime::RuntimeContext;
+
     use super::*;
 
     #[test]
@@ -844,6 +954,29 @@ mod tests {
         let snapshot = shared_fallback_snapshot().expect("fallback runtime should exist");
         assert!(snapshot.submitted_tasks >= before + 8);
         assert!(snapshot.active_tasks <= snapshot.submitted_tasks);
+    }
+
+    #[tokio::test]
+    async fn context_spawned_client_task_is_parented_by_service_context() {
+        let context = RuntimeContext::from_current("client-context-runtime-test");
+        let service = context.service_context("client-service");
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        let handle = spawn_client_task_with_context(&service, "client-context-task", async move {
+            tx.send(()).expect("test receiver should be alive");
+        })
+        .expect("context client task should spawn");
+
+        tokio::time::timeout(Duration::from_secs(2), rx)
+            .await
+            .expect("context task should complete")
+            .expect("context task should complete");
+        assert!(handle.wait_finished(Duration::from_secs(2)));
+        assert_eq!(handle.task_group.parent_id(), Some(service.task_group().id()));
+        assert_eq!(handle.task_group.name(), "client-context-task");
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
     }
 
     #[test]

--- a/rocketmq-controller/src/storage/rocksdb_backend.rs
+++ b/rocketmq-controller/src/storage/rocksdb_backend.rs
@@ -50,6 +50,14 @@ pub struct RocksDBBackend {
 impl RocksDBBackend {
     /// Create a new RocksDB backend
     pub async fn new(path: PathBuf) -> Result<Self> {
+        Self::new_with_optional_parent_task_group(path, None).await
+    }
+
+    pub async fn new_with_parent_task_group(path: PathBuf, parent_task_group: TaskGroup) -> Result<Self> {
+        Self::new_with_optional_parent_task_group(path, Some(parent_task_group)).await
+    }
+
+    async fn new_with_optional_parent_task_group(path: PathBuf, parent_task_group: Option<TaskGroup>) -> Result<Self> {
         info!("Opening RocksDB at {:?}", path);
 
         // Create directory if it doesn't exist
@@ -76,7 +84,7 @@ impl RocksDBBackend {
         opts.set_max_write_buffer_number(3);
         opts.set_min_write_buffer_number_to_merge(2);
 
-        let blocking = Self::new_blocking_executor()?;
+        let blocking = Self::new_blocking_executor(parent_task_group)?;
 
         // Open the database
         let db = blocking
@@ -115,12 +123,16 @@ impl RocksDBBackend {
             .map_err(map_blocking_error)?
     }
 
-    fn new_blocking_executor() -> Result<BlockingExecutor> {
-        let runtime = RuntimeHandle::new(
-            tokio::runtime::Handle::try_current()
-                .map_err(|_error| map_blocking_error(RuntimeError::NoCurrentRuntime))?,
-        );
-        let group = TaskGroup::root("controller.rocksdb", runtime);
+    fn new_blocking_executor(parent_task_group: Option<TaskGroup>) -> Result<BlockingExecutor> {
+        let group = if let Some(parent_task_group) = parent_task_group {
+            parent_task_group.child("controller.rocksdb")
+        } else {
+            let runtime = RuntimeHandle::new(
+                tokio::runtime::Handle::try_current()
+                    .map_err(|_error| map_blocking_error(RuntimeError::NoCurrentRuntime))?,
+            );
+            TaskGroup::root("controller.rocksdb", runtime)
+        };
         BlockingExecutor::new(
             BlockingPoolPolicy {
                 name: "controller.rocksdb".to_string(),
@@ -357,16 +369,39 @@ impl StorageBackend for RocksDBBackend {
 
 #[cfg(test)]
 mod tests {
+    use rocketmq_runtime::RuntimeContext;
     use tempfile::TempDir;
 
     use super::*;
 
     #[test]
     fn blocking_executor_without_tokio_runtime_returns_error() {
-        let error = RocksDBBackend::new_blocking_executor()
+        let error = RocksDBBackend::new_blocking_executor(None)
             .expect_err("RocksDB blocking executor should require an ambient Tokio runtime");
 
         assert!(error.to_string().contains("no current Tokio runtime"));
+    }
+
+    #[tokio::test]
+    async fn new_with_parent_task_group_parents_blocking_executor() {
+        let context = RuntimeContext::from_current("controller-rocksdb-context-test");
+        let service = context.service_context("controller-service");
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("parented_db");
+
+        let backend = RocksDBBackend::new_with_parent_task_group(db_path, service.task_group().clone())
+            .await
+            .unwrap();
+        backend.put("parented_key", b"parented_value").await.unwrap();
+        drop(backend);
+
+        let report = service.task_group().shutdown(std::time::Duration::from_secs(1)).await;
+        assert!(
+            report.children.iter().any(|child| child.name == "controller.rocksdb"),
+            "{}",
+            report.to_json()
+        );
+        assert!(report.is_healthy(), "{}", report.to_json());
     }
 
     #[tokio::test]

--- a/rocketmq-namesrv/benches/namesrv_shutdown_drain_bench.rs
+++ b/rocketmq-namesrv/benches/namesrv_shutdown_drain_bench.rs
@@ -114,6 +114,11 @@ fn write_namesrv_shutdown_report_artifact() {
         "elapsed_ms": output.elapsed.as_millis(),
         "elapsed_us": output.elapsed.as_micros(),
         "healthy": output.report.is_healthy(),
+        "in_flight_completed": output.report.in_flight.completed,
+        "in_flight_remaining": output.report.in_flight.remaining,
+        "in_flight_timed_out": output.report.in_flight.timed_out,
+        "in_flight_timeout_ms": output.report.in_flight.timeout_ms,
+        "in_flight_drain_elapsed_ms": output.report.in_flight.elapsed_ms,
         "shutdown_report": output.report,
     });
     let path = output_dir.join("namesrv-shutdown-drain-report.json");

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -19,7 +19,9 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::net::IpAddr;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicU8;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -45,6 +47,7 @@ use rocketmq_remoting::runtime::config::client_config::TokioClientConfig;
 use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
+use rocketmq_runtime::ServiceContext;
 use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::wait_for_signal;
@@ -52,6 +55,7 @@ use rocketmq_rust::ArcMut;
 use serde::Serialize;
 use tokio::sync::broadcast;
 use tokio::sync::oneshot;
+use tokio::sync::Notify;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
@@ -159,8 +163,26 @@ pub struct NameServerBootstrap {
 
 #[doc(hidden)]
 #[derive(Debug, Clone, Default, Serialize)]
+pub struct NameServerInFlightDrainReport {
+    pub elapsed_ms: u64,
+    pub timeout_ms: u64,
+    pub completed: u64,
+    pub remaining: usize,
+    pub timed_out: bool,
+}
+
+impl NameServerInFlightDrainReport {
+    #[doc(hidden)]
+    pub fn is_healthy(&self) -> bool {
+        !self.timed_out && self.remaining == 0
+    }
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct NameServerShutdownReport {
     pub elapsed_ms: u64,
+    pub in_flight: NameServerInFlightDrainReport,
     pub scheduled: Option<ShutdownReport>,
     pub route_unregistration: Option<ShutdownReport>,
     pub server: Option<ShutdownReport>,
@@ -171,7 +193,8 @@ pub struct NameServerShutdownReport {
 impl NameServerShutdownReport {
     #[doc(hidden)]
     pub fn is_healthy(&self) -> bool {
-        self.scheduled.as_ref().is_none_or(ShutdownReport::is_healthy)
+        self.in_flight.is_healthy()
+            && self.scheduled.as_ref().is_none_or(ShutdownReport::is_healthy)
             && self
                 .route_unregistration
                 .as_ref()
@@ -182,12 +205,70 @@ impl NameServerShutdownReport {
     }
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct InFlightRequestTracker {
+    active: AtomicUsize,
+    completed: AtomicU64,
+    notify: Notify,
+}
+
+impl InFlightRequestTracker {
+    pub(crate) fn enter(self: &Arc<Self>) -> InFlightRequestGuard {
+        self.active.fetch_add(1, Ordering::AcqRel);
+        InFlightRequestGuard {
+            tracker: Arc::clone(self),
+        }
+    }
+
+    async fn drain(&self, timeout: Duration) -> NameServerInFlightDrainReport {
+        let started_at = Instant::now();
+        let timed_out = if self.active.load(Ordering::Acquire) == 0 {
+            false
+        } else {
+            tokio::time::timeout(timeout, async {
+                loop {
+                    let notified = self.notify.notified();
+                    if self.active.load(Ordering::Acquire) == 0 {
+                        break;
+                    }
+                    notified.await;
+                }
+            })
+            .await
+            .is_err()
+        };
+
+        NameServerInFlightDrainReport {
+            elapsed_ms: started_at.elapsed().as_millis() as u64,
+            timeout_ms: timeout.as_millis() as u64,
+            completed: self.completed.load(Ordering::Acquire),
+            remaining: self.active.load(Ordering::Acquire),
+            timed_out,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct InFlightRequestGuard {
+    tracker: Arc<InFlightRequestTracker>,
+}
+
+impl Drop for InFlightRequestGuard {
+    fn drop(&mut self) {
+        let previous = self.tracker.active.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "in-flight request counter underflow");
+        self.tracker.completed.fetch_add(1, Ordering::AcqRel);
+        self.tracker.notify.notify_waiters();
+    }
+}
+
 /// Builder for creating NameServerBootstrap with custom configuration
 pub struct Builder {
     name_server_config: Option<NamesrvConfig>,
     server_config: Option<ServerConfig>,
     controller_config: Option<ControllerConfig>,
     cluster_test_route_lookup: Option<Arc<ClusterTestRouteLookup>>,
+    service_context: Option<ServiceContext>,
 }
 
 /// Core runtime managing NameServer lifecycle and operations
@@ -649,8 +730,12 @@ impl NameServerRuntime {
             "Phase 1/5: Waiting for in-flight requests (timeout: {}s)...",
             SHUTDOWN_TIMEOUT.as_secs()
         );
-        if let Err(e) = self.wait_for_inflight_requests(SHUTDOWN_TIMEOUT).await {
-            warn!("In-flight request wait timeout or error: {}", e);
+        shutdown_report.in_flight = self.wait_for_inflight_requests(SHUTDOWN_TIMEOUT).await;
+        if !shutdown_report.in_flight.is_healthy() {
+            warn!(
+                "In-flight request drain report is unhealthy: {:?}",
+                shutdown_report.in_flight
+            );
         }
 
         info!("Phase 2/5: Stopping scheduled tasks...");
@@ -706,19 +791,8 @@ impl NameServerRuntime {
     /// This provides a grace period for ongoing requests to finish before shutdown.
     /// Returns immediately if no requests are in-flight.
     #[instrument(skip(self), name = "wait_inflight_requests")]
-    async fn wait_for_inflight_requests(&self, timeout: Duration) -> RocketMQResult<()> {
-        tokio::time::timeout(timeout, async {
-            // There is not yet an in-flight request tracker here. A fixed sleep
-            // does not prove drain and only delays shutdown; the server TaskGroup
-            // below performs the actual graceful wait.
-            tokio::task::yield_now().await;
-            debug!("No in-flight request tracker registered; skipping fixed grace wait");
-        })
-        .await
-        .map_err(|_| RocketMQError::Timeout {
-            operation: "wait_for_inflight_requests",
-            timeout_ms: timeout.as_millis() as u64,
-        })
+    async fn wait_for_inflight_requests(&self, timeout: Duration) -> NameServerInFlightDrainReport {
+        self.inner.in_flight_requests.drain(timeout).await
     }
 
     /// Wait for server task to complete
@@ -787,7 +861,8 @@ impl NameServerRuntime {
         let default_request_processor =
             crate::processor::default_request_processor::DefaultRequestProcessor::new(self.inner.clone());
 
-        let mut name_server_request_processor = NameServerRequestProcessor::new();
+        let mut name_server_request_processor =
+            NameServerRequestProcessor::new_with_in_flight_tracker(self.inner.in_flight_request_tracker());
 
         // Register topic route query processor
         name_server_request_processor.register_processor(RequestCode::GetRouteinfoByTopic, route_request_processor);
@@ -834,6 +909,7 @@ impl Builder {
             server_config: None,
             controller_config: None,
             cluster_test_route_lookup: None,
+            service_context: None,
         }
     }
 
@@ -867,6 +943,11 @@ impl Builder {
         cluster_test_route_lookup: Arc<ClusterTestRouteLookup>,
     ) -> Self {
         self.cluster_test_route_lookup = Some(cluster_test_route_lookup);
+        self
+    }
+
+    pub fn set_service_context(mut self, service_context: ServiceContext) -> Self {
+        self.service_context = Some(service_context);
         self
     }
 
@@ -923,7 +1004,9 @@ impl Builder {
             controller_config,
             controller_manager: None,
             cluster_test_route_lookup,
+            service_context: self.service_context,
             task_group: OnceLock::new(),
+            in_flight_requests: Arc::new(InFlightRequestTracker::default()),
         });
 
         // Check configuration flag for RouteInfoManager version
@@ -981,7 +1064,9 @@ pub(crate) struct NameServerRuntimeInner {
     broker_housekeeping_service: Option<Arc<BrokerHousekeepingService>>,
     controller_manager: Option<ArcMut<ControllerManager>>,
     cluster_test_route_lookup: Option<Arc<ClusterTestRouteLookup>>,
+    service_context: Option<ServiceContext>,
     task_group: OnceLock<TaskGroup>,
+    in_flight_requests: Arc<InFlightRequestTracker>,
 }
 
 impl NameServerRuntimeInner {
@@ -997,6 +1082,12 @@ impl NameServerRuntimeInner {
             return Some(task_group.clone());
         }
 
+        if let Some(service_context) = self.service_context.as_ref() {
+            let task_group = service_context.task_group().child("rocketmq-namesrv");
+            let _ = self.task_group.set(task_group);
+            return self.task_group.get().cloned();
+        }
+
         let handle = match tokio::runtime::Handle::try_current() {
             Ok(handle) => handle,
             Err(error) => {
@@ -1007,6 +1098,14 @@ impl NameServerRuntimeInner {
         let task_group = TaskGroup::root("rocketmq-namesrv", RuntimeHandle::new(handle));
         let _ = self.task_group.set(task_group);
         self.task_group.get().cloned()
+    }
+
+    pub(crate) fn in_flight_request_tracker(&self) -> Arc<InFlightRequestTracker> {
+        Arc::clone(&self.in_flight_requests)
+    }
+
+    pub(crate) fn in_flight_request_guard(&self) -> InFlightRequestGuard {
+        self.in_flight_requests.enter()
     }
 
     #[inline]
@@ -1545,6 +1644,7 @@ mod tests {
     use rocketmq_remoting::protocol::RemotingDeserializable;
     use rocketmq_remoting::protocol::RemotingSerializable;
     use rocketmq_remoting::runtime::processor::RequestProcessor;
+    use rocketmq_runtime::RuntimeContext;
     use tokio::sync::broadcast;
     use tokio::time::sleep;
 
@@ -1564,6 +1664,81 @@ mod tests {
 
     fn build_bootstrap_with_default_v2() -> NameServerBootstrap {
         build_bootstrap_with_v2_config(NamesrvConfig::default())
+    }
+
+    #[tokio::test]
+    async fn builder_service_context_parents_namesrv_task_group() {
+        let context = RuntimeContext::from_current("namesrv-context-runtime-test");
+        let service = context.service_context("namesrv-service");
+        let bootstrap = Builder::new().set_service_context(service.clone()).build();
+
+        let task_group = bootstrap
+            .name_server_runtime
+            .inner
+            .task_group()
+            .expect("service context should provide namesrv task group");
+
+        assert_eq!(task_group.parent_id(), Some(service.task_group().id()));
+        assert_eq!(task_group.name(), "rocketmq-namesrv");
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn namesrv_in_flight_drain_zero_requests_is_healthy() {
+        let bootstrap = build_bootstrap_with_default_v2();
+
+        let report = bootstrap
+            .name_server_runtime
+            .wait_for_inflight_requests(Duration::from_millis(10))
+            .await;
+
+        assert!(report.is_healthy(), "{report:?}");
+        assert_eq!(report.completed, 0);
+        assert_eq!(report.remaining, 0);
+        assert!(!report.timed_out);
+    }
+
+    #[tokio::test]
+    async fn namesrv_in_flight_drain_waits_for_controlled_request() {
+        let bootstrap = build_bootstrap_with_default_v2();
+        let guard = bootstrap.name_server_runtime.inner.in_flight_request_guard();
+        let wait = bootstrap
+            .name_server_runtime
+            .wait_for_inflight_requests(Duration::from_secs(1));
+        tokio::pin!(wait);
+
+        tokio::select! {
+            report = &mut wait => panic!("drain completed while request was still in flight: {report:?}"),
+            _ = sleep(Duration::from_millis(10)) => {}
+        }
+
+        drop(guard);
+        let report = wait.await;
+
+        assert!(report.is_healthy(), "{report:?}");
+        assert_eq!(report.completed, 1);
+        assert_eq!(report.remaining, 0);
+        assert!(!report.timed_out);
+    }
+
+    #[tokio::test]
+    async fn namesrv_in_flight_drain_timeout_reports_remaining() {
+        let bootstrap = build_bootstrap_with_default_v2();
+        let guard = bootstrap.name_server_runtime.inner.in_flight_request_guard();
+
+        let report = bootstrap
+            .name_server_runtime
+            .wait_for_inflight_requests(Duration::from_millis(1))
+            .await;
+
+        assert!(!report.is_healthy(), "{report:?}");
+        assert_eq!(report.completed, 0);
+        assert_eq!(report.remaining, 1);
+        assert!(report.timed_out);
+
+        drop(guard);
     }
 
     fn reserve_local_port() -> u16 {
@@ -1625,6 +1800,24 @@ mod tests {
             .await
             .expect("request processing should succeed")
             .expect("processor should always return a response")
+    }
+
+    #[tokio::test]
+    async fn name_server_processor_records_completed_request() {
+        let bootstrap = build_bootstrap_with_default_v2();
+        let harness = LocalRequestHarness::new().await.unwrap();
+        let mut request = RemotingCommand::create_remoting_command(999_999);
+
+        let response = process_with_name_server_processor(&bootstrap, &harness, &mut request).await;
+        assert_eq!(response.code(), ResponseCode::RequestCodeNotSupported as i32);
+
+        let report = bootstrap
+            .name_server_runtime
+            .wait_for_inflight_requests(Duration::from_millis(10))
+            .await;
+        assert!(report.is_healthy(), "{report:?}");
+        assert_eq!(report.completed, 1);
+        assert_eq!(report.remaining, 0);
     }
 
     fn topic_config_wrapper(entries: &[(&str, u32, u32)]) -> TopicConfigAndMappingSerializeWrapper {

--- a/rocketmq-namesrv/src/processor.rs
+++ b/rocketmq-namesrv/src/processor.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Instant;
 
 use rocketmq_remoting::code::request_code::RequestCode;
@@ -27,6 +28,7 @@ use rocketmq_rust::ArcMut;
 pub use self::client_request_processor::ClientRequestProcessor;
 pub use self::cluster_test_request_processor::ClusterTestRequestProcessor;
 pub(crate) use self::cluster_test_request_processor::ClusterTestRouteLookup;
+use crate::bootstrap::InFlightRequestTracker;
 use crate::processor::default_request_processor::DefaultRequestProcessor;
 
 mod client_request_processor;
@@ -83,6 +85,7 @@ pub(crate) type RequestCodeType = i32;
 pub struct NameServerRequestProcessor {
     processor_table: HashMap<RequestCodeType, NameServerRequestProcessorWrapper>,
     default_request_processor: Option<NameServerRequestProcessorWrapper>,
+    in_flight_requests: Option<Arc<InFlightRequestTracker>>,
 }
 
 impl NameServerRequestProcessor {
@@ -90,6 +93,14 @@ impl NameServerRequestProcessor {
         Self {
             processor_table: HashMap::new(),
             default_request_processor: None,
+            in_flight_requests: None,
+        }
+    }
+
+    pub(crate) fn new_with_in_flight_tracker(in_flight_requests: Arc<InFlightRequestTracker>) -> Self {
+        Self {
+            in_flight_requests: Some(in_flight_requests),
+            ..Self::new()
         }
     }
 
@@ -109,6 +120,10 @@ impl RequestProcessor for NameServerRequestProcessor {
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let _in_flight_guard = self
+            .in_flight_requests
+            .as_ref()
+            .map(|in_flight_requests| in_flight_requests.enter());
         let route_request_started = (request.code() == RequestCode::GetRouteinfoByTopic as i32).then(Instant::now);
         let response = match self.processor_table.get_mut(request.code_ref()) {
             None => match self.default_request_processor.as_mut() {

--- a/rocketmq-remoting/benches/remoting_connection_lifecycle_bench.rs
+++ b/rocketmq-remoting/benches/remoting_connection_lifecycle_bench.rs
@@ -24,8 +24,9 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-use rocketmq_remoting::remoting_server::rocketmq_tokio_server::run_with_report;
+use rocketmq_remoting::remoting_server::rocketmq_tokio_server::run_with_report_with_service_context;
 use rocketmq_remoting::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
+use rocketmq_runtime::RuntimeContext;
 use rocketmq_runtime::ShutdownReport;
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
@@ -36,6 +37,7 @@ struct RemotingLifecycleOutput {
     connection_count: usize,
     elapsed: Duration,
     report: ShutdownReport,
+    parent_report: ShutdownReport,
 }
 
 fn run_remoting_lifecycle(connection_count: usize) -> RemotingLifecycleOutput {
@@ -53,9 +55,12 @@ fn run_remoting_lifecycle(connection_count: usize) -> RemotingLifecycleOutput {
             .expect("benchmark listener should bind");
         let addr = listener.local_addr().expect("benchmark listener should expose address");
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let runtime_context = RuntimeContext::from_current("rocketmq-remoting-lifecycle-bench");
+        let service_context = runtime_context.service_context("rocketmq-remoting-lifecycle");
 
         let started_at = Instant::now();
-        let server = tokio::spawn(run_with_report(
+        let server = tokio::spawn(run_with_report_with_service_context(
+            service_context.clone(),
             listener,
             async {
                 let _ = shutdown_rx.await;
@@ -79,11 +84,22 @@ fn run_remoting_lifecycle(connection_count: usize) -> RemotingLifecycleOutput {
             .expect("remoting server task should not panic")
             .expect("remoting server should return shutdown report");
         assert!(report.is_healthy(), "{}", report.to_json());
+        let parent_report = service_context.task_group().shutdown(Duration::from_secs(5)).await;
+        assert!(parent_report.is_healthy(), "{}", parent_report.to_json());
+        assert!(
+            parent_report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq.remoting.server"),
+            "{}",
+            parent_report.to_json()
+        );
 
         RemotingLifecycleOutput {
             connection_count,
             elapsed: started_at.elapsed(),
             report,
+            parent_report,
         }
     })
 }
@@ -109,6 +125,7 @@ fn write_remoting_lifecycle_report_artifact() {
         "elapsed_us": output.elapsed.as_micros(),
         "healthy": output.report.is_healthy(),
         "shutdown_report": output.report,
+        "parent_shutdown_report": output.parent_report,
     });
     let path = output_dir.join("remoting-connection-lifecycle-report.json");
     fs::write(

--- a/rocketmq-remoting/src/clients/client.rs
+++ b/rocketmq-remoting/src/clients/client.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use rocketmq_common::common::tls_config::TlsConfig;
 use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::ServiceContext;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use tokio::net::TcpStream;
@@ -89,6 +90,12 @@ fn new_client_connection_task_group(addr: &str) -> RocketMQResult<TaskGroup> {
         format!("rocketmq-remoting.client.connection[{addr}]"),
         RuntimeHandle::new(runtime),
     ))
+}
+
+fn new_client_connection_task_group_with_service_context(context: &ServiceContext, addr: &str) -> TaskGroup {
+    context
+        .task_group()
+        .child(format!("rocketmq-remoting.client.connection[{addr}]"))
 }
 
 impl<PR> Drop for Client<PR> {
@@ -252,9 +259,30 @@ where
         tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
         tls_config: TlsConfig,
     ) -> RocketMQResult<Client<PR>> {
+        let task_group = new_client_connection_task_group(&addr)?;
+        Self::connect_with_task_group(addr, cmd_handler, tx, tls_config, task_group).await
+    }
+
+    pub(crate) async fn connect_with_service_context(
+        context: &ServiceContext,
+        addr: String,
+        cmd_handler: ArcMut<RemotingGeneralHandler<PR>>,
+        tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
+        tls_config: TlsConfig,
+    ) -> RocketMQResult<Client<PR>> {
+        let task_group = new_client_connection_task_group_with_service_context(context, &addr);
+        Self::connect_with_task_group(addr, cmd_handler, tx, tls_config, task_group).await
+    }
+
+    async fn connect_with_task_group(
+        addr: String,
+        cmd_handler: ArcMut<RemotingGeneralHandler<PR>>,
+        tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
+        tls_config: TlsConfig,
+        task_group: TaskGroup,
+    ) -> RocketMQResult<Client<PR>> {
         let (notify_shutdown, _) = broadcast::channel(1);
         let receiver = notify_shutdown.subscribe();
-        let task_group = new_client_connection_task_group(&addr)?;
         let task_lifecycle = Arc::new(ClientTaskLifecycle {
             task_group: task_group.clone(),
         });
@@ -499,6 +527,7 @@ mod lifecycle_tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
+    use rocketmq_runtime::RuntimeContext;
     use rocketmq_runtime::TaskGroupLifecycleState;
     use tokio::net::TcpListener;
     use tokio::time;
@@ -540,6 +569,37 @@ mod lifecycle_tests {
 
         drop(client);
 
+        assert!(task_group.cancellation_token().is_cancelled());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn connect_with_service_context_parents_connection_tasks() {
+        let runtime_context = RuntimeContext::from_current("remoting-client-context-test");
+        let service = runtime_context.service_context("remoting-client-service");
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.expect("accept client");
+            time::sleep(Duration::from_secs(5)).await;
+        });
+        let cmd_handler = ArcMut::new(RemotingGeneralHandler {
+            request_processor: DefaultRemotingRequestProcessor,
+            rpc_hooks: vec![],
+            response_table: ArcMut::new(HashMap::new()),
+        });
+
+        let client =
+            Client::connect_with_service_context(&service, addr.to_string(), cmd_handler, None, TlsConfig::default())
+                .await
+                .expect("connect client with context");
+        let task_group = client.task_lifecycle.task_group.clone();
+
+        assert_eq!(task_group.parent_id(), Some(service.task_group().id()));
+        assert_eq!(task_group.lifecycle_state(), TaskGroupLifecycleState::Open);
+        assert_eq!(task_group.task_count(), 2);
+
+        drop(client);
         assert!(task_group.cancellation_token().is_cancelled());
         server.abort();
     }

--- a/rocketmq-remoting/src/clients/connection_pool.rs
+++ b/rocketmq-remoting/src/clients/connection_pool.rs
@@ -92,6 +92,7 @@ use rocketmq_runtime::RuntimeResult;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
+use rocketmq_runtime::ServiceContext;
 use rocketmq_runtime::ShutdownAnnotation;
 use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
@@ -603,6 +604,24 @@ impl<PR> ConnectionPool<PR> {
         }
     }
 
+    /// Start the background cleanup task under an injected service context.
+    pub fn start_cleanup_task_with_service_context(
+        &self,
+        context: &ServiceContext,
+        interval: Duration,
+    ) -> ConnectionPoolCleanupTask
+    where
+        PR: Send + Sync + 'static,
+    {
+        match self.try_start_cleanup_task_with_service_context(context, interval) {
+            Ok(cleanup_task) => cleanup_task,
+            Err(error) => {
+                warn!(?error, "connection pool cleanup task not started from service context");
+                ConnectionPoolCleanupTask::inactive()
+            }
+        }
+    }
+
     /// Try to start the background cleanup task.
     ///
     /// Unlike [`Self::start_cleanup_task`], this method returns an error when no
@@ -613,6 +632,19 @@ impl<PR> ConnectionPool<PR> {
     {
         let handle = tokio::runtime::Handle::try_current().map_err(|_error| RuntimeError::NoCurrentRuntime)?;
         let task_group = TaskGroup::root("rocketmq-remoting.connection-pool", RuntimeHandle::new(handle));
+        self.start_cleanup_task_with_group(interval, task_group)
+    }
+
+    /// Try to start the background cleanup task under an injected service context.
+    pub fn try_start_cleanup_task_with_service_context(
+        &self,
+        context: &ServiceContext,
+        interval: Duration,
+    ) -> RuntimeResult<ConnectionPoolCleanupTask>
+    where
+        PR: Send + Sync + 'static,
+    {
+        let task_group = context.task_group().child("rocketmq-remoting.connection-pool");
         self.start_cleanup_task_with_group(interval, task_group)
     }
 
@@ -780,6 +812,34 @@ mod tests {
 
         assert!(report.is_healthy(), "{}", report.to_json());
         assert_eq!(cleanup_task.task_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_task_with_service_context_is_parented() {
+        let context = rocketmq_runtime::RuntimeContext::from_current("connection-pool-context-test");
+        let service = context.service_context("connection-pool-service");
+        let pool = ConnectionPool::<()>::new(100, Duration::from_millis(10));
+
+        let cleanup_task = pool
+            .try_start_cleanup_task_with_service_context(&service, Duration::from_millis(5))
+            .expect("cleanup task should start from service context");
+        assert!(cleanup_task.is_active());
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+        let pool_report = report
+            .children
+            .iter()
+            .find(|child| child.name == "rocketmq-remoting.connection-pool")
+            .expect("parent report should include connection-pool child");
+        assert!(
+            pool_report
+                .children
+                .iter()
+                .any(|child| child.name == "remoting.connection-pool.cleanup"),
+            "{}",
+            report.to_json()
+        );
     }
 
     #[test]

--- a/rocketmq-remoting/src/connection_v2.rs
+++ b/rocketmq-remoting/src/connection_v2.rs
@@ -28,6 +28,7 @@ use futures_util::StreamExt;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 use tokio::io::AsyncWriteExt;
 use tokio::net::tcp::OwnedReadHalf;
@@ -582,6 +583,13 @@ impl ConcurrentConnection {
         Self::try_with_channel_capacity(stream, 1024)
     }
 
+    /// Try to create a concurrent connection using a parent task group.
+    pub fn try_new_with_task_group(stream: TcpStream, parent_task_group: TaskGroup) -> RocketMQResult<Self> {
+        Self::try_with_channel_capacity_and_writer_group(stream, 1024, |connection_id| {
+            parent_task_group.child(format!("rocketmq-remoting.connection.{connection_id}"))
+        })
+    }
+
     /// Create concurrent connection with specified channel capacity
     #[deprecated(
         since = "1.0.0",
@@ -600,6 +608,19 @@ impl ConcurrentConnection {
                 format!("ConcurrentConnection writer task requires a Tokio runtime: {error}"),
             )
         })?;
+        Self::try_with_channel_capacity_and_writer_group(stream, channel_capacity, |connection_id| {
+            TaskGroup::root(
+                format!("rocketmq-remoting.connection.{connection_id}"),
+                RuntimeHandle::new(runtime_handle),
+            )
+        })
+    }
+
+    fn try_with_channel_capacity_and_writer_group(
+        stream: TcpStream,
+        channel_capacity: usize,
+        writer_group: impl FnOnce(&CheetahString) -> TaskGroup,
+    ) -> RocketMQResult<Self> {
         let (read_half, write_half) = stream.into_split();
 
         let framed_reader = FramedRead::new(read_half, CompositeCodec::default());
@@ -609,10 +630,7 @@ impl ConcurrentConnection {
         let (state_tx, state_rx) = watch::channel(ConnectionState::Healthy);
 
         let connection_id = CheetahString::from_string(format!("concurrent-{}", uuid::Uuid::new_v4()));
-        let writer_group = TaskGroup::root(
-            format!("rocketmq-remoting.connection.{connection_id}"),
-            RuntimeHandle::new(runtime_handle),
-        );
+        let writer_group = writer_group(&connection_id);
         writer_group
             .spawn_service(
                 "remoting.connection.writer",
@@ -975,8 +993,8 @@ impl ConcurrentConnection {
         self.write_tx.clone()
     }
 
-    /// Graceful shutdown
-    pub async fn close(self) -> RocketMQResult<()> {
+    /// Graceful shutdown and return the writer task shutdown report.
+    pub async fn close_with_report(self, timeout: Duration) -> RocketMQResult<ShutdownReport> {
         let (tx, rx) = oneshot::channel();
         self.write_tx.send(WriteCommand::Close(tx)).await.map_err(|_| {
             RocketMQError::Network(rocketmq_error::NetworkError::connection_failed(
@@ -990,14 +1008,19 @@ impl ConcurrentConnection {
                 "Response channel closed",
             ))
         })??;
-        let report = self.writer_group.shutdown(Duration::from_secs(3)).await;
+        let report = self.writer_group.shutdown(timeout).await;
         if let Err(error) = report.assert_no_task_leak() {
             return Err(RocketMQError::Network(rocketmq_error::NetworkError::connection_failed(
                 "connection",
                 format!("writer task shutdown report is unhealthy: {error}"),
             )));
         }
-        Ok(())
+        Ok(report)
+    }
+
+    /// Graceful shutdown
+    pub async fn close(self) -> RocketMQResult<()> {
+        self.close_with_report(Duration::from_secs(3)).await.map(|_| ())
     }
 }
 
@@ -1290,6 +1313,36 @@ mod concurrent_tests {
         assert!(error
             .to_string()
             .contains("ConcurrentConnection writer task requires a Tokio runtime"));
+    }
+
+    #[tokio::test]
+    async fn try_new_with_task_group_parents_writer_and_close_returns_report() {
+        let context = rocketmq_runtime::RuntimeContext::from_current("concurrent-connection-parent-test");
+        let service = context.service_context("concurrent-connection-service");
+        let parent_group = service.task_group().child("concurrent-connection-parent");
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _client_stream = TcpStream::connect(addr).await.unwrap();
+        let (socket, _) = listener.accept().await.unwrap();
+
+        let conn = ConcurrentConnection::try_new_with_task_group(socket, parent_group.clone()).unwrap();
+        assert_eq!(conn.writer_group.parent_id(), Some(parent_group.id()));
+        let writer_group_name = conn.writer_group.name().to_string();
+
+        let report = conn.close_with_report(Duration::from_secs(1)).await.unwrap();
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert_eq!(report.name, writer_group_name);
+
+        let parent_report = parent_group.shutdown(Duration::from_secs(1)).await;
+        assert!(parent_report.is_healthy(), "{}", parent_report.to_json());
+        assert!(
+            parent_report
+                .children
+                .iter()
+                .any(|child| child.name == writer_group_name),
+            "{}",
+            parent_report.to_json()
+        );
     }
 
     /// Test concurrent connection basic send/recv

--- a/rocketmq-remoting/src/net/channel.rs
+++ b/rocketmq-remoting/src/net/channel.rs
@@ -27,6 +27,7 @@ use flume::Receiver;
 use flume::Sender;
 use rocketmq_error::RocketMQError;
 use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_rust::ArcMut;
 use tokio::time::timeout;
@@ -443,13 +444,6 @@ impl ChannelInner {
         connection: Connection,
         response_table: ArcMut<HashMap<i32, ResponseFuture>>,
     ) -> rocketmq_error::RocketMQResult<Self> {
-        const QUEUE_CAPACITY: usize = 1024;
-
-        // Use flume bounded channel for better performance
-        // flume provides lock-free operations and better throughput than tokio::mpsc
-        let (outbound_queue_tx, outbound_queue_rx) = flume::bounded(QUEUE_CAPACITY);
-
-        let connection = ArcMut::new(connection);
         let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
             RocketMQError::network_connection_failed(
                 "channel",
@@ -457,6 +451,31 @@ impl ChannelInner {
             )
         })?;
         let task_group = TaskGroup::root("rocketmq-remoting.channel", RuntimeHandle::new(runtime));
+        Self::try_new_with_send_task_group(connection, response_table, task_group)
+    }
+
+    /// Creates a new `ChannelInner` under the provided parent task group.
+    pub fn try_new_with_task_group(
+        connection: Connection,
+        response_table: ArcMut<HashMap<i32, ResponseFuture>>,
+        parent_task_group: TaskGroup,
+    ) -> rocketmq_error::RocketMQResult<Self> {
+        let task_group = parent_task_group.child("rocketmq-remoting.channel");
+        Self::try_new_with_send_task_group(connection, response_table, task_group)
+    }
+
+    fn try_new_with_send_task_group(
+        connection: Connection,
+        response_table: ArcMut<HashMap<i32, ResponseFuture>>,
+        task_group: TaskGroup,
+    ) -> rocketmq_error::RocketMQResult<Self> {
+        const QUEUE_CAPACITY: usize = 1024;
+
+        // Use flume bounded channel for better performance
+        // flume provides lock-free operations and better throughput than tokio::mpsc
+        let (outbound_queue_tx, outbound_queue_rx) = flume::bounded(QUEUE_CAPACITY);
+
+        let connection = ArcMut::new(connection);
         task_group
             .spawn_service(
                 "remoting.channel.send",
@@ -474,6 +493,18 @@ impl ChannelInner {
             response_table,
             send_task_group: task_group,
         })
+    }
+
+    /// Closes the outbound queue and waits for the send task shutdown report.
+    pub async fn close_with_report(&mut self, timeout: Duration) -> ShutdownReport {
+        let (replacement_tx, replacement_rx) = flume::bounded(0);
+        drop(replacement_rx);
+        let outbound_queue_tx = std::mem::replace(&mut self.outbound_queue_tx, replacement_tx);
+        drop(outbound_queue_tx);
+
+        let report = self.send_task_group.shutdown(timeout).await;
+        report.log_if_unhealthy();
+        report
     }
 }
 
@@ -719,5 +750,37 @@ mod tests {
         assert!(error
             .to_string()
             .contains("ChannelInner send task requires a Tokio runtime"));
+    }
+
+    #[tokio::test]
+    async fn try_new_with_task_group_parents_send_task_and_close_returns_report() {
+        let context = rocketmq_runtime::RuntimeContext::from_current("channel-inner-parent-test");
+        let service = context.service_context("channel-inner-service");
+        let parent_group = service.task_group().child("channel-inner-parent");
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _client_stream = TcpStream::connect(addr).await.unwrap();
+        let (socket, _) = listener.accept().await.unwrap();
+
+        let mut channel_inner = ChannelInner::try_new_with_task_group(
+            Connection::new(socket),
+            ArcMut::new(HashMap::<i32, ResponseFuture>::new()),
+            parent_group.clone(),
+        )
+        .unwrap();
+        assert_eq!(channel_inner.send_task_group.parent_id(), Some(parent_group.id()));
+        let send_group_name = channel_inner.send_task_group.name().to_string();
+
+        let report = channel_inner.close_with_report(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert_eq!(report.name, send_group_name);
+
+        let parent_report = parent_group.shutdown(Duration::from_secs(1)).await;
+        assert!(parent_report.is_healthy(), "{}", parent_report.to_json());
+        assert!(
+            parent_report.children.iter().any(|child| child.name == send_group_name),
+            "{}",
+            parent_report.to_json()
+        );
     }
 }

--- a/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use rocketmq_common::common::server::config::ServerConfig;
 use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::ServiceContext;
 use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskKind;
@@ -367,74 +368,89 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
             let shutdown_complete_tx = self.shutdown_complete_tx.clone();
             let conn_disconnect_notify = self.conn_disconnect_notify.clone();
             let event_tx_clone = event_tx.clone();
-            let task_group = self.task_group.clone();
+            let connection_task_group = self.task_group.child("rocketmq.remoting.connection");
+            let handler_task_group = connection_task_group.clone();
 
             // Spawn dedicated task for this connection
-            if let Err(error) = task_group.spawn("rocketmq.remoting.connection", TaskKind::Worker, async move {
-                let Some(connection) = tls_runtime.into_connection(socket, remote_addr).await else {
-                    drop(permit);
-                    return;
-                };
-
-                // Create connection channel wrapper
-                let channel_inner = match ChannelInner::try_new(connection, cmd_handler.response_table.clone()) {
-                    Ok(channel_inner) => ArcMut::new(channel_inner),
-                    Err(error) => {
-                        error!(
-                            remote_addr = %remote_addr,
-                            error = %error,
-                            "failed to initialize remoting channel"
-                        );
+            if let Err(error) =
+                connection_task_group.spawn("rocketmq.remoting.connection", TaskKind::Worker, async move {
+                    let Some(connection) = tls_runtime.into_connection(socket, remote_addr).await else {
                         drop(permit);
                         return;
+                    };
+
+                    // Create connection channel wrapper
+                    let channel_inner = match ChannelInner::try_new_with_task_group(
+                        connection,
+                        cmd_handler.response_table.clone(),
+                        handler_task_group.clone(),
+                    ) {
+                        Ok(channel_inner) => ArcMut::new(channel_inner),
+                        Err(error) => {
+                            error!(
+                                remote_addr = %remote_addr,
+                                error = %error,
+                                "failed to initialize remoting channel"
+                            );
+                            drop(permit);
+                            return;
+                        }
+                    };
+                    let channel = Channel::new(channel_inner, local_addr, remote_addr);
+
+                    // Notify CONNECTED event after plaintext/TLS negotiation succeeds
+                    let _ = event_tx_clone.send(TokioEvent::new(
+                        ConnectionNetEvent::CONNECTED(remote_addr),
+                        remote_addr,
+                        channel.clone(),
+                    ));
+
+                    // Build connection handler
+                    let idle_timeout = Duration::from_secs(DEFAULT_CHANNEL_IDLE_TIMEOUT_SECONDS);
+                    let handler_event_tx = event_tx_clone.clone();
+                    let handler = ConnectionHandler {
+                        connection_handler_context: ArcMut::new(ConnectionHandlerContextWrapper {
+                            channel: channel.clone(),
+                        }),
+                        shutdown: Shutdown::new(notify_shutdown),
+                        _shutdown_complete: shutdown_complete_tx,
+                        conn_disconnect_notify,
+                        cmd_handler,
+                        event_tx: Some(handler_event_tx),
+                        idle_timeout,
+                    };
+                    let mut handler = handler;
+
+                    // Run handler until completion
+                    if let Err(err) = handler.handle().await {
+                        error!(
+                            remote_addr = %remote_addr,
+                            error = ?err,
+                            "Connection handler terminated with error"
+                        );
                     }
-                };
-                let channel = Channel::new(channel_inner, local_addr, remote_addr);
 
-                // Notify CONNECTED event after plaintext/TLS negotiation succeeds
-                let _ = event_tx_clone.send(TokioEvent::new(
-                    ConnectionNetEvent::CONNECTED(remote_addr),
-                    remote_addr,
-                    channel.clone(),
-                ));
+                    let channel_report = handler
+                        .connection_handler_context
+                        .channel_mut()
+                        .channel_inner_mut()
+                        .close_with_report(Duration::from_secs(3))
+                        .await;
+                    channel_report.log_if_unhealthy();
 
-                // Build connection handler
-                let idle_timeout = Duration::from_secs(DEFAULT_CHANNEL_IDLE_TIMEOUT_SECONDS);
-                let handler_event_tx = event_tx_clone.clone();
-                let handler = ConnectionHandler {
-                    connection_handler_context: ArcMut::new(ConnectionHandlerContextWrapper {
-                        channel: channel.clone(),
-                    }),
-                    shutdown: Shutdown::new(notify_shutdown),
-                    _shutdown_complete: shutdown_complete_tx,
-                    conn_disconnect_notify,
-                    cmd_handler,
-                    event_tx: Some(handler_event_tx),
-                    idle_timeout,
-                };
-                let mut handler = handler;
+                    // Notify DISCONNECTED event
+                    let _ = event_tx_clone.send(TokioEvent::new(
+                        ConnectionNetEvent::DISCONNECTED,
+                        remote_addr,
+                        handler.connection_handler_context.channel.clone(),
+                    ));
 
-                // Run handler until completion
-                if let Err(err) = handler.handle().await {
-                    error!(
-                        remote_addr = %remote_addr,
-                        error = ?err,
-                        "Connection handler terminated with error"
-                    );
-                }
+                    info!("Client {} disconnected", remote_addr);
 
-                // Notify DISCONNECTED event
-                let _ = event_tx_clone.send(TokioEvent::new(
-                    ConnectionNetEvent::DISCONNECTED,
-                    remote_addr,
-                    handler.connection_handler_context.channel.clone(),
-                ));
-
-                info!("Client {} disconnected", remote_addr);
-
-                // IMPORTANT: Permit released when `permit` drops here
-                drop(permit);
-            }) {
+                    // IMPORTANT: Permit released when `permit` drops here
+                    drop(permit);
+                })
+            {
                 error!(remote_addr = %remote_addr, error = %error, "failed to spawn remoting connection task");
             }
         }
@@ -503,6 +519,7 @@ async fn acquire_connection_permit(limit_connections: &Arc<Semaphore>) -> anyhow
 pub struct RocketMQServer<RP> {
     config: Arc<ServerConfig>,
     rpc_hooks: Option<Vec<Arc<dyn RPCHook>>>,
+    service_context: Option<ServiceContext>,
     _phantom_data: std::marker::PhantomData<RP>,
 }
 
@@ -511,6 +528,16 @@ impl<RP> RocketMQServer<RP> {
         Self {
             config,
             rpc_hooks: Some(vec![]),
+            service_context: None,
+            _phantom_data: std::marker::PhantomData,
+        }
+    }
+
+    pub fn new_with_service_context(config: Arc<ServerConfig>, service_context: ServiceContext) -> Self {
+        Self {
+            config,
+            rpc_hooks: Some(vec![]),
+            service_context: Some(service_context),
             _phantom_data: std::marker::PhantomData,
         }
     }
@@ -562,7 +589,12 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> RocketMQServer<RP> {
             }
         };
         let rpc_hooks = self.rpc_hooks.take().unwrap_or_default();
-        let tls_runtime = TlsServerRuntime::new(self.config.tls_config.clone());
+        let remoting_context = self.service_context.as_ref().map(new_remoting_server_context);
+        let task_group = remoting_context.as_ref().map(|context| context.task_group().clone());
+        let tls_runtime = remoting_context.as_ref().map_or_else(
+            || TlsServerRuntime::new(self.config.tls_config.clone()),
+            |context| TlsServerRuntime::new_with_service_context(self.config.tls_config.clone(), context),
+        );
         info!("Starting remoting_server at: {}", addr);
         let (notify_conn_disconnect, _) = broadcast::channel::<SocketAddr>(100);
         run_with_tls_config_report(
@@ -573,6 +605,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> RocketMQServer<RP> {
             rpc_hooks,
             channel_event_listener,
             tls_runtime,
+            task_group,
         )
         .await
     }
@@ -614,6 +647,32 @@ pub async fn run_with_report<RP: RequestProcessor + Sync + 'static + Clone>(
         rpc_hooks,
         channel_event_listener,
         TlsServerRuntime::new(Default::default()),
+        None,
+    )
+    .await
+}
+
+#[doc(hidden)]
+pub async fn run_with_report_with_service_context<RP: RequestProcessor + Sync + 'static + Clone>(
+    service_context: ServiceContext,
+    listener: TcpListener,
+    shutdown: impl Future,
+    request_processor: RP,
+    conn_disconnect_notify: Option<broadcast::Sender<SocketAddr>>,
+    rpc_hooks: Vec<Arc<dyn RPCHook>>,
+    channel_event_listener: Option<Arc<dyn ChannelEventListener>>,
+) -> Option<ShutdownReport> {
+    let remoting_context = new_remoting_server_context(&service_context);
+    let tls_runtime = TlsServerRuntime::new_with_service_context(Default::default(), &remoting_context);
+    run_with_tls_config_report(
+        listener,
+        shutdown,
+        request_processor,
+        conn_disconnect_notify,
+        rpc_hooks,
+        channel_event_listener,
+        tls_runtime,
+        Some(remoting_context.task_group().clone()),
     )
     .await
 }
@@ -635,6 +694,7 @@ async fn run_with_tls_config<RP: RequestProcessor + Sync + 'static + Clone>(
         rpc_hooks,
         channel_event_listener,
         tls_runtime,
+        None,
     )
     .await;
 }
@@ -647,14 +707,19 @@ async fn run_with_tls_config_report<RP: RequestProcessor + Sync + 'static + Clon
     rpc_hooks: Vec<Arc<dyn RPCHook>>,
     channel_event_listener: Option<Arc<dyn ChannelEventListener>>,
     tls_runtime: TlsServerRuntime,
+    parented_task_group: Option<TaskGroup>,
 ) -> Option<ShutdownReport> {
     let (notify_shutdown, _) = broadcast::channel(1);
     let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel(1);
-    let task_group = match new_remoting_server_task_group() {
-        Ok(task_group) => task_group,
-        Err(error) => {
-            error!(%error, "failed to start remoting server task group");
-            return None;
+    let task_group = if let Some(parented_task_group) = parented_task_group {
+        parented_task_group
+    } else {
+        match new_remoting_server_task_group() {
+            Ok(task_group) => task_group,
+            Err(error) => {
+                error!(%error, "failed to start remoting server task group");
+                return None;
+            }
         }
     };
     // Initialize the connection listener state
@@ -725,6 +790,14 @@ fn new_remoting_server_task_group() -> rocketmq_error::RocketMQResult<TaskGroup>
     Ok(TaskGroup::root("rocketmq.remoting.server", RuntimeHandle::new(runtime)))
 }
 
+fn new_remoting_server_context(context: &ServiceContext) -> ServiceContext {
+    context.child("rocketmq.remoting.server")
+}
+
+fn new_remoting_server_task_group_with_service_context(context: &ServiceContext) -> TaskGroup {
+    new_remoting_server_context(context).task_group().clone()
+}
+
 #[derive(Debug)]
 pub(crate) struct Shutdown {
     /// `true` if the shutdown signal has been received
@@ -776,11 +849,33 @@ mod tests {
     use rocketmq_common::common::tls_config::TlsMode;
     #[cfg(feature = "tls")]
     use rocketmq_common::common::tls_config::TlsServerConfig;
+    use rocketmq_runtime::RuntimeContext;
+    use tokio::io::AsyncWriteExt;
     use tokio::net::TcpStream;
     use tokio::sync::oneshot;
 
     use super::*;
     use crate::request_processor::default_request_processor::DefaultRemotingRequestProcessor;
+
+    struct ConnectSignalListener {
+        connected: std::sync::Mutex<Option<oneshot::Sender<()>>>,
+    }
+
+    impl ChannelEventListener for ConnectSignalListener {
+        fn on_channel_connect(&self, _remote_addr: &str, _channel: &Channel) {
+            if let Some(sender) = self.connected.lock().expect("connect signal lock").take() {
+                let _ = sender.send(());
+            }
+        }
+
+        fn on_channel_close(&self, _remote_addr: &str, _channel: &Channel) {}
+
+        fn on_channel_exception(&self, _remote_addr: &str, _channel: &Channel) {}
+
+        fn on_channel_idle(&self, _remote_addr: &str, _channel: &Channel) {}
+
+        fn on_channel_active(&self, _remote_addr: &str, _channel: &Channel) {}
+    }
 
     #[test]
     fn remoting_server_task_group_without_tokio_runtime_returns_error() {
@@ -790,6 +885,61 @@ mod tests {
         assert!(error
             .to_string()
             .contains("remoting server task group requires a Tokio runtime"));
+    }
+
+    #[tokio::test]
+    async fn remoting_server_task_group_from_service_context_is_parented() {
+        let context = RuntimeContext::from_current("remoting-server-context-test");
+        let service = context.service_context("remoting-server-service");
+
+        let task_group = new_remoting_server_task_group_with_service_context(&service);
+
+        assert_eq!(task_group.parent_id(), Some(service.task_group().id()));
+        assert_eq!(task_group.name(), "rocketmq.remoting.server");
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn run_with_report_with_service_context_adds_remoting_child_to_parent_report() {
+        let context = RuntimeContext::from_current("remoting-server-parent-report-test");
+        let service = context.service_context("remoting-server-parent");
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let server_task = tokio::spawn(run_with_report_with_service_context(
+            service.clone(),
+            listener,
+            async {
+                let _ = shutdown_rx.await;
+            },
+            DefaultRemotingRequestProcessor,
+            None,
+            Vec::new(),
+            None,
+        ));
+
+        let _ = shutdown_tx.send(());
+        let report = tokio::time::timeout(Duration::from_secs(3), server_task)
+            .await
+            .expect("server should shut down before timeout")
+            .expect("server task should not panic")
+            .expect("server should return shutdown report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert_eq!(report.name, "rocketmq.remoting.server");
+
+        let parent_report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(
+            parent_report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq.remoting.server"),
+            "{}",
+            parent_report.to_json()
+        );
     }
 
     #[tokio::test]
@@ -868,6 +1018,64 @@ mod tests {
         assert!(report.is_healthy(), "{}", report.to_json());
     }
 
+    #[tokio::test]
+    async fn run_shutdown_report_includes_channel_send_task_child() {
+        let context = RuntimeContext::from_current("remoting-server-channel-report-test");
+        let service = context.service_context("remoting-server-channel-report");
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let addr = listener.local_addr().expect("listener should have local addr");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let (connected_tx, connected_rx) = oneshot::channel::<()>();
+        let channel_listener = std::sync::Arc::new(ConnectSignalListener {
+            connected: std::sync::Mutex::new(Some(connected_tx)),
+        });
+        let server_task = tokio::spawn(run_with_report_with_service_context(
+            service,
+            listener,
+            async {
+                let _ = shutdown_rx.await;
+            },
+            DefaultRemotingRequestProcessor,
+            None,
+            Vec::new(),
+            Some(channel_listener),
+        ));
+
+        let mut client = TcpStream::connect(addr).await.expect("client should connect");
+        client
+            .write_all(&[0])
+            .await
+            .expect("client should send first byte for TLS/plaintext detection");
+        tokio::time::timeout(Duration::from_secs(3), connected_rx)
+            .await
+            .expect("server should accept connection before timeout")
+            .expect("connect signal should be sent");
+        let _ = shutdown_tx.send(());
+        let report = tokio::time::timeout(Duration::from_secs(3), server_task)
+            .await
+            .expect("server should shut down before timeout")
+            .expect("server task should not panic")
+            .expect("server should return shutdown report");
+        drop(client);
+
+        assert!(report.is_healthy(), "{}", report.to_json());
+        let connection_report = report
+            .children
+            .iter()
+            .find(|child| child.name == "rocketmq.remoting.connection")
+            .expect("remoting report should include connection child group");
+        assert!(
+            connection_report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq-remoting.channel"),
+            "{}",
+            report.to_json()
+        );
+    }
+
     #[cfg(feature = "tls")]
     #[tokio::test]
     async fn run_shutdown_report_includes_tls_reload_task() {
@@ -894,6 +1102,7 @@ mod tests {
             Vec::new(),
             None,
             tls_runtime,
+            None,
         );
         let server_task = tokio::spawn(report);
 

--- a/rocketmq-remoting/src/tls.rs
+++ b/rocketmq-remoting/src/tls.rs
@@ -33,6 +33,7 @@ use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 #[cfg(feature = "tls")]
 use rocketmq_runtime::RuntimeHandle;
+use rocketmq_runtime::ServiceContext;
 use rocketmq_runtime::ShutdownReport;
 #[cfg(feature = "tls")]
 use rocketmq_runtime::TaskGroup;
@@ -71,6 +72,38 @@ impl TlsServerRuntime {
     pub fn new(base_config: TlsConfig) -> Self {
         #[cfg(feature = "tls")]
         {
+            Self::new_with_reload_task_group(base_config, None)
+        }
+
+        #[cfg(not(feature = "tls"))]
+        {
+            Self {
+                mode: base_config.server.mode,
+            }
+        }
+    }
+
+    pub fn new_with_service_context(base_config: TlsConfig, service_context: &ServiceContext) -> Self {
+        #[cfg(feature = "tls")]
+        {
+            Self::new_with_reload_task_group(
+                base_config,
+                Some(service_context.task_group().child("rocketmq-remoting.tls")),
+            )
+        }
+
+        #[cfg(not(feature = "tls"))]
+        {
+            let _ = service_context;
+            Self {
+                mode: base_config.server.mode,
+            }
+        }
+    }
+
+    #[cfg(feature = "tls")]
+    fn new_with_reload_task_group(base_config: TlsConfig, reload_task_group: Option<TaskGroup>) -> Self {
+        {
             let effective_config = effective_tls_config(&base_config);
             let acceptor = StdArc::new(TlsAcceptorSlot::empty());
             let mode = base_config.server.mode;
@@ -90,15 +123,8 @@ impl TlsServerRuntime {
                 base_config: StdArc::new(base_config),
                 reload_task_group: StdArc::new(Mutex::new(None)),
             };
-            runtime.spawn_reload_task();
+            runtime.spawn_reload_task(reload_task_group);
             runtime
-        }
-
-        #[cfg(not(feature = "tls"))]
-        {
-            Self {
-                mode: base_config.server.mode,
-            }
         }
     }
 
@@ -183,21 +209,26 @@ impl TlsServerRuntime {
     }
 
     #[cfg(feature = "tls")]
-    fn spawn_reload_task(&self) {
+    fn spawn_reload_task(&self, task_group: Option<TaskGroup>) {
         if self.mode == TlsMode::Disabled {
             return;
         }
 
         let base_config = self.base_config.clone();
         let acceptor = self.acceptor.clone();
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                warn!(?error, "failed to start TLS reload task outside Tokio runtime");
-                return;
+        let task_group = match task_group {
+            Some(task_group) => task_group,
+            None => {
+                let runtime = match tokio::runtime::Handle::try_current() {
+                    Ok(handle) => RuntimeHandle::new(handle),
+                    Err(error) => {
+                        warn!(?error, "failed to start TLS reload task outside Tokio runtime");
+                        return;
+                    }
+                };
+                TaskGroup::root("rocketmq-remoting.tls", runtime)
             }
         };
-        let task_group = TaskGroup::root("rocketmq-remoting.tls", runtime);
         let cancellation_token = task_group.cancellation_token();
         *self.reload_task_group.lock() = Some(task_group.clone());
 
@@ -686,6 +717,37 @@ fn config_error(key: &'static str, value: impl Into<String>, reason: impl Into<S
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "tls")]
+    #[tokio::test]
+    async fn tls_reload_task_with_service_context_is_parented() {
+        let context = rocketmq_runtime::RuntimeContext::from_current("tls-context-runtime-test");
+        let service = context.service_context("tls-service");
+        let config = TlsConfig {
+            test_mode_enable: true,
+            server: rocketmq_common::common::tls_config::TlsServerConfig {
+                mode: TlsMode::Permissive,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let runtime = TlsServerRuntime::new_with_service_context(config, &service);
+        let task_group = runtime
+            .reload_task_group
+            .lock()
+            .as_ref()
+            .cloned()
+            .expect("reload task group");
+
+        assert_eq!(task_group.parent_id(), Some(service.task_group().id()));
+
+        let report = runtime
+            .shutdown_gracefully(Duration::from_secs(1))
+            .await
+            .expect("reload task should be running");
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
 
     #[cfg(feature = "tls")]
     #[test]

--- a/rocketmq-runtime/Cargo.toml
+++ b/rocketmq-runtime/Cargo.toml
@@ -41,6 +41,10 @@ tracing.workspace = true
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }
 
+[[test]]
+name = "task_group_concurrency_model"
+path = "tests/task_group_concurrency_model.rs"
+
 [[bench]]
 name    = "task_group_lifecycle_bench"
 harness = false

--- a/rocketmq-runtime/README.md
+++ b/rocketmq-runtime/README.md
@@ -89,6 +89,15 @@ Use `RuntimeContext::from_current` in applications that already run inside
 can shut down tracked RocketMQ tasks, but it does not own or close the Tokio
 runtime itself.
 
+### Legacy Compatibility Boundary
+
+`RocketMQRuntime` is retained only for legacy synchronous APIs that still need
+to pass around an owned Tokio runtime. New code should use `RuntimeOwner` for
+owned runtime lifecycle and `RuntimeContext` / `ServiceContext` for borrowed
+runtime integration. Runtime audit classifies remaining `RocketMQRuntime`
+references as either runtime primitives or explicit compatibility adapters so
+new unclassified legacy runtime use cannot grow unnoticed.
+
 `RuntimeOwner` intentionally separates two phases:
 
 1. `shutdown_tasks().await`: cancel, close, wait, abort, and report tracked
@@ -194,6 +203,8 @@ New RocketMQ code should follow these rules:
   through `BlockingExecutor`;
 - keep long-running blocking loops outside Tokio blocking pools;
 - return or log `ShutdownReport` during component shutdown;
+- do not rely on `Drop` for graceful shutdown; `Drop` may only cancel or abort
+  work as an emergency cleanup path;
 - keep diagnostics and benchmark tooling as validation artifacts rather than
   production-critical runtime dependencies.
 
@@ -216,6 +227,7 @@ hard-coded performance claims. The expected validation loop is:
 Useful local checks:
 
 ```bash
+cargo test -p rocketmq-runtime --test task_group_concurrency_model
 cargo test -p rocketmq-runtime --all-targets --all-features
 cargo clippy -p rocketmq-runtime --all-targets --all-features -- -D warnings
 ```

--- a/rocketmq-runtime/src/context.rs
+++ b/rocketmq-runtime/src/context.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use crate::blocking::BlockingExecutor;
 use crate::blocking::BlockingPoolPolicy;
 use crate::diagnostics::RuntimeDiagnostics;
+use crate::diagnostics::RuntimeDiagnosticsSnapshot;
 use crate::error::RuntimeError;
 use crate::error::RuntimeResult;
 use crate::handle::RuntimeHandle;
@@ -77,6 +78,10 @@ impl RuntimeContext {
 
     pub fn diagnostics(&self) -> &RuntimeDiagnostics {
         &self.diagnostics
+    }
+
+    pub fn diagnostics_snapshot(&self) -> RuntimeDiagnosticsSnapshot {
+        self.diagnostics.snapshot(&self.root_group, &self.blocking)
     }
 
     pub fn service_context(&self, name: impl Into<Arc<str>>) -> ServiceContext {

--- a/rocketmq-runtime/src/diagnostics.rs
+++ b/rocketmq-runtime/src/diagnostics.rs
@@ -12,19 +12,54 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::blocking::BlockingExecutor;
+use crate::blocking::BlockingExecutorSnapshot;
 use crate::handle::RuntimeHandle;
+use crate::task_group::TaskGroup;
+
+static NEXT_RUNTIME_DIAGNOSTICS_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Clone)]
 pub struct RuntimeDiagnostics {
     runtime: RuntimeHandle,
+    runtime_id: Arc<str>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeDiagnosticsSnapshot {
+    pub runtime_id: String,
+    pub root_name: String,
+    pub blocking: BlockingExecutorSnapshot,
 }
 
 impl RuntimeDiagnostics {
     pub fn new(runtime: RuntimeHandle) -> Self {
-        Self { runtime }
+        let runtime_id = NEXT_RUNTIME_DIAGNOSTICS_ID.fetch_add(1, Ordering::Relaxed);
+        Self {
+            runtime,
+            runtime_id: Arc::from(format!("rocketmq-runtime-{runtime_id}")),
+        }
     }
 
     pub fn runtime(&self) -> &RuntimeHandle {
         &self.runtime
+    }
+
+    pub fn runtime_id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    pub fn snapshot(&self, root: &TaskGroup, blocking: &BlockingExecutor) -> RuntimeDiagnosticsSnapshot {
+        RuntimeDiagnosticsSnapshot {
+            runtime_id: self.runtime_id.to_string(),
+            root_name: root.name().to_string(),
+            blocking: blocking.snapshot(),
+        }
     }
 }

--- a/rocketmq-runtime/src/legacy.rs
+++ b/rocketmq-runtime/src/legacy.rs
@@ -14,6 +14,14 @@
 
 use std::time::Duration;
 
+/// Legacy compatibility wrapper around a directly owned Tokio runtime.
+///
+/// New RocketMQ code should prefer [`RuntimeOwner`](crate::RuntimeOwner) when
+/// it owns the runtime, or [`RuntimeContext`](crate::RuntimeContext) /
+/// [`ServiceContext`](crate::ServiceContext) when it is borrowing an existing
+/// Tokio runtime. `RocketMQRuntime` remains available for older synchronous
+/// builder and scheduler APIs while those call sites are migrated behind
+/// explicit compatibility adapters.
 pub enum RocketMQRuntime {
     Multi(tokio::runtime::Runtime),
 }

--- a/rocketmq-runtime/src/lib.rs
+++ b/rocketmq-runtime/src/lib.rs
@@ -35,6 +35,7 @@ pub use blocking::BlockingTaskSnapshot;
 pub use config::RuntimeConfig;
 pub use context::RuntimeContext;
 pub use diagnostics::RuntimeDiagnostics;
+pub use diagnostics::RuntimeDiagnosticsSnapshot;
 pub use error::RuntimeError;
 pub use error::RuntimeResult;
 pub use handle::RuntimeHandle;

--- a/rocketmq-runtime/src/service_context.rs
+++ b/rocketmq-runtime/src/service_context.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use crate::blocking::BlockingExecutor;
 use crate::diagnostics::RuntimeDiagnostics;
+use crate::diagnostics::RuntimeDiagnosticsSnapshot;
 use crate::error::RuntimeResult;
 use crate::handle::RuntimeHandle;
 use crate::scheduled::ScheduledTaskGroup;
@@ -68,6 +69,10 @@ impl ServiceContext {
 
     pub fn diagnostics(&self) -> &RuntimeDiagnostics {
         &self.diagnostics
+    }
+
+    pub fn diagnostics_snapshot(&self) -> RuntimeDiagnosticsSnapshot {
+        self.diagnostics.snapshot(&self.task_group, &self.blocking)
     }
 
     pub fn child(&self, name: impl Into<Arc<str>>) -> Self {

--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -124,8 +124,8 @@ struct TaskGroupInner {
     tracker: TaskTracker,
     tasks: DashMap<TaskId, TaskMeta>,
     children: Mutex<Vec<TaskGroup>>,
+    next_group_id: Arc<AtomicU64>,
     next_task_id: AtomicU64,
-    next_child_id: AtomicU64,
     completed: AtomicUsize,
     cancelled: AtomicUsize,
     aborted: AtomicUsize,
@@ -197,6 +197,7 @@ impl Drop for TaskCompletionGuard {
 
 impl TaskGroup {
     pub fn root(name: impl Into<Arc<str>>, runtime: RuntimeHandle) -> Self {
+        let next_group_id = Arc::new(AtomicU64::new(2));
         Self {
             inner: Arc::new(TaskGroupInner::new(
                 TaskGroupId(1),
@@ -204,6 +205,7 @@ impl TaskGroup {
                 name.into(),
                 runtime,
                 CancellationToken::new(),
+                next_group_id,
             )),
         }
     }
@@ -262,7 +264,7 @@ impl TaskGroup {
     }
 
     fn open_child(&self, name: Arc<str>) -> Self {
-        let child_id = TaskGroupId(self.inner.next_child_id.fetch_add(1, Ordering::Relaxed));
+        let child_id = TaskGroupId(self.inner.next_group_id.fetch_add(1, Ordering::Relaxed));
         Self {
             inner: Arc::new(TaskGroupInner::new(
                 child_id,
@@ -270,6 +272,7 @@ impl TaskGroup {
                 name,
                 self.inner.runtime.clone(),
                 self.inner.cancellation_token.child_token(),
+                self.inner.next_group_id.clone(),
             )),
         }
     }
@@ -677,6 +680,7 @@ impl TaskGroupInner {
         name: Arc<str>,
         runtime: RuntimeHandle,
         cancellation_token: CancellationToken,
+        next_group_id: Arc<AtomicU64>,
     ) -> Self {
         Self {
             id,
@@ -687,8 +691,8 @@ impl TaskGroupInner {
             tracker: TaskTracker::new(),
             tasks: DashMap::new(),
             children: Mutex::new(Vec::new()),
+            next_group_id,
             next_task_id: AtomicU64::new(1),
-            next_child_id: AtomicU64::new(id.as_u64() * 1_000_000 + 1),
             completed: AtomicUsize::new(0),
             cancelled: AtomicUsize::new(0),
             aborted: AtomicUsize::new(0),

--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -29,6 +29,62 @@ impl Drop for DropCounter {
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn diagnostics_snapshot_reports_runtime_state() {
+    let context = RuntimeContext::from_current("diagnostics-root");
+    let service = context.service_context("diagnostics-service");
+    let scheduled = service.scheduled_tasks("diagnostics-scheduled");
+
+    assert_eq!(scheduled.group().name(), "diagnostics-scheduled");
+
+    service
+        .spawn_service("diagnostics-service-task", async move {})
+        .expect("diagnostics service task should spawn");
+    context
+        .blocking()
+        .spawn_io("diagnostics-blocking-io", || 42)
+        .await
+        .expect("diagnostics blocking task should complete");
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let context_snapshot = context.diagnostics_snapshot();
+    let service_snapshot = service.diagnostics_snapshot();
+
+    assert!(!context_snapshot.runtime_id.is_empty(), "{context_snapshot:?}");
+    assert_eq!(context_snapshot.runtime_id, service_snapshot.runtime_id);
+    assert_eq!(context_snapshot.root_name, "diagnostics-root");
+    assert_eq!(service_snapshot.root_name, "diagnostics-service");
+    assert_eq!(context_snapshot.blocking.name, "rocketmq-blocking");
+    assert_eq!(
+        context_snapshot.blocking.max_concurrency,
+        BlockingPoolPolicy::default().max_concurrency
+    );
+    assert_eq!(context_snapshot.blocking.blocking_still_running, 0);
+    assert!(context_snapshot.blocking.tasks.is_empty(), "{context_snapshot:?}");
+
+    let report = context.shutdown_tasks(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
+#[tokio::test]
+async fn service_context_child_preserves_parent_runtime_and_blocking_executor() {
+    let context = RuntimeContext::from_current("service-context-parent-test");
+    let parent = context.service_context("parent-service");
+    let child = parent.child("child-service");
+
+    assert_eq!(child.name(), "child-service");
+    assert_eq!(child.task_group().parent_id(), Some(parent.task_group().id()));
+    assert_eq!(child.blocking().snapshot().name, parent.blocking().snapshot().name);
+    assert_eq!(
+        child.diagnostics_snapshot().runtime_id,
+        parent.diagnostics_snapshot().runtime_id
+    );
+
+    let report = context.shutdown_tasks(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
 #[tokio::test]
 async fn task_group_shutdown_waits_for_completed_tasks() {
     let context = RuntimeContext::from_current("task-group-complete-test");

--- a/rocketmq-runtime/tests/task_group_concurrency_model.rs
+++ b/rocketmq-runtime/tests/task_group_concurrency_model.rs
@@ -1,0 +1,213 @@
+use std::collections::HashSet;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_runtime::RuntimeError;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskGroupLifecycleState;
+use tokio::sync::Barrier;
+use tokio::sync::Notify;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn task_group_concurrency_model_covers_spawn_shutdown_races() {
+    let context = RuntimeContext::from_current("task-group-concurrency-model");
+    let group = context.root_group().child("service");
+
+    run_task_group_concurrency_model(group).await;
+}
+
+async fn run_task_group_concurrency_model(group: TaskGroup) {
+    deep_child_creation_does_not_overflow(group.child("deep-child-id"));
+    child_creation_racing_with_shutdown_rejects_late_children(group.child("child-race")).await;
+    spawn_metadata_is_registered_before_task_can_finish(group.child("metadata-before-finish")).await;
+    shutdown_after_spawn_leaves_no_running_metadata_for_completed_tasks(group.child("completed-cleanup")).await;
+    duplicate_child_names_keep_distinct_identity(group.child("duplicate-children")).await;
+
+    let report = group.shutdown(Duration::from_secs(5)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
+fn deep_child_creation_does_not_overflow(group: TaskGroup) {
+    let mut current = group;
+    for depth in 0..16 {
+        let parent = current.clone();
+        let child = parent.child(format!("deep-child-{depth}"));
+        assert_eq!(child.parent_id(), Some(parent.id()));
+        assert_ne!(child.id(), parent.id());
+        current = child;
+    }
+}
+
+async fn child_creation_racing_with_shutdown_rejects_late_children(group: TaskGroup) {
+    const PRODUCERS: usize = 8;
+    const LATE_CHILDREN_PER_PRODUCER: usize = 64;
+
+    let ready = Arc::new(AtomicUsize::new(0));
+    let ready_notify = Arc::new(Notify::new());
+    let late_start = Arc::new(Notify::new());
+    let rejected = Arc::new(AtomicUsize::new(0));
+    let accepted_late = Arc::new(AtomicUsize::new(0));
+    let mut producers = Vec::with_capacity(PRODUCERS);
+
+    for producer_id in 0..PRODUCERS {
+        let group = group.clone();
+        let ready = ready.clone();
+        let ready_notify = ready_notify.clone();
+        let late_start = late_start.clone();
+        let rejected = rejected.clone();
+        let accepted_late = accepted_late.clone();
+
+        producers.push(tokio::spawn(async move {
+            let warmup_child = group
+                .try_child(format!("warmup-child-{producer_id}"))
+                .expect("warmup child should be created before shutdown starts");
+            assert_eq!(warmup_child.parent_id(), Some(group.id()));
+
+            if ready.fetch_add(1, Ordering::AcqRel) + 1 == PRODUCERS {
+                ready_notify.notify_one();
+            }
+
+            late_start.notified().await;
+
+            for child_index in 0..LATE_CHILDREN_PER_PRODUCER {
+                match group.try_child(format!("late-child-{producer_id}-{child_index}")) {
+                    Ok(_child) => {
+                        accepted_late.fetch_add(1, Ordering::AcqRel);
+                    }
+                    Err(RuntimeError::TaskGroupClosing { .. }) => {
+                        rejected.fetch_add(1, Ordering::AcqRel);
+                    }
+                    Err(error) => panic!("unexpected child creation error: {error}"),
+                }
+                tokio::task::yield_now().await;
+            }
+        }));
+    }
+
+    wait_until(Duration::from_secs(1), || ready.load(Ordering::Acquire) == PRODUCERS)
+        .await
+        .expect("all child producers should reach the late-child gate");
+
+    let shutdown_group = group.clone();
+    let shutdown = tokio::spawn(async move { shutdown_group.shutdown(Duration::from_secs(5)).await });
+
+    wait_until(Duration::from_secs(1), || {
+        group.lifecycle_state() != TaskGroupLifecycleState::Open
+    })
+    .await
+    .expect("shutdown should close child creation before late attempts");
+    late_start.notify_waiters();
+
+    for producer in producers {
+        producer.await.expect("child producer should not panic");
+    }
+
+    let report = shutdown.await.expect("shutdown task should not panic");
+    assert!(report.is_healthy(), "{}", report.to_json());
+    assert_eq!(rejected.load(Ordering::Acquire), PRODUCERS * LATE_CHILDREN_PER_PRODUCER);
+    assert_eq!(accepted_late.load(Ordering::Acquire), 0);
+    assert!(matches!(
+        group
+            .try_child("post-shutdown-child")
+            .expect_err("late child creation should be rejected after shutdown"),
+        RuntimeError::TaskGroupClosing { .. }
+    ));
+}
+
+async fn spawn_metadata_is_registered_before_task_can_finish(group: TaskGroup) {
+    let release = Arc::new(Notify::new());
+    let release_task = release.clone();
+
+    let (task_id, handle) = group
+        .spawn_service_with_handle("metadata-visible-task", async move {
+            release_task.notified().await;
+        })
+        .expect("tracked task should spawn");
+
+    assert!(group.contains_task(task_id));
+    assert_eq!(group.task_count(), 1);
+
+    release.notify_one();
+    handle.await.expect("tracked task should join");
+    assert!(group.wait_task(task_id, Duration::from_secs(1)).await);
+
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+    assert_eq!(report.completed, 1, "{}", report.to_json());
+    assert_eq!(group.task_count(), 0, "{}", report.to_json());
+}
+
+async fn shutdown_after_spawn_leaves_no_running_metadata_for_completed_tasks(group: TaskGroup) {
+    const TASKS: usize = 512;
+
+    let mut handles = Vec::with_capacity(TASKS);
+    for task_index in 0..TASKS {
+        let (_task_id, handle) = group
+            .spawn_service_with_handle(format!("completed-task-{task_index}"), async move {})
+            .expect("short tracked task should spawn");
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.await.expect("short tracked task should join");
+    }
+
+    wait_until(Duration::from_secs(1), || group.task_count() == 0)
+        .await
+        .expect("completed tasks should remove task metadata before shutdown");
+
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+    assert_eq!(report.completed, TASKS, "{}", report.to_json());
+    assert_eq!(report.leaked, 0, "{}", report.to_json());
+    assert!(report.remaining_tasks.is_empty(), "{}", report.to_json());
+}
+
+async fn duplicate_child_names_keep_distinct_identity(group: TaskGroup) {
+    const CHILDREN: usize = 64;
+
+    let start = Arc::new(Barrier::new(CHILDREN));
+    let mut creators = Vec::with_capacity(CHILDREN);
+    for _ in 0..CHILDREN {
+        let group = group.clone();
+        let start = start.clone();
+        creators.push(tokio::spawn(async move {
+            start.wait().await;
+            let child = group
+                .try_child("duplicate-model-child")
+                .expect("duplicate child name should still create a distinct child");
+            assert_eq!(child.parent_id(), Some(group.id()));
+            child.id()
+        }));
+    }
+
+    let mut child_ids = HashSet::with_capacity(CHILDREN);
+    for creator in creators {
+        let child_id = creator.await.expect("child creator should not panic");
+        assert!(child_ids.insert(child_id), "duplicate TaskGroupId: {child_id:?}");
+    }
+    assert_eq!(child_ids.len(), CHILDREN);
+
+    let report = group.shutdown(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+    assert_eq!(report.children.len(), CHILDREN, "{}", report.to_json());
+    assert!(report
+        .children
+        .iter()
+        .all(|child| child.name == "duplicate-model-child"));
+}
+
+async fn wait_until(timeout: Duration, condition: impl Fn() -> bool) -> Result<(), tokio::time::error::Elapsed> {
+    tokio::time::timeout(timeout, async {
+        loop {
+            if condition() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+}

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -181,7 +181,7 @@ pub mod bench_support {
             queue_waits.push(result.expect("store blocking benchmark task should complete"));
         }
         let elapsed_us = started_at.elapsed().as_micros();
-        let snapshot = crate::runtime::blocking_snapshot().expect("store blocking snapshot should be available");
+        let snapshot = wait_for_store_blocking_idle().await;
         assert_eq!(snapshot.blocking_still_running, 0, "{snapshot:?}");
         assert!(snapshot.tasks.is_empty(), "{snapshot:?}");
 
@@ -202,6 +202,22 @@ pub mod bench_support {
             shutdown_report,
             healthy,
         }
+    }
+
+    async fn wait_for_store_blocking_idle() -> BlockingExecutorSnapshot {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+        let mut snapshot = crate::runtime::blocking_snapshot().expect("store blocking snapshot should be available");
+
+        while snapshot.blocking_still_running != 0 || !snapshot.tasks.is_empty() {
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            snapshot = crate::runtime::blocking_snapshot().expect("store blocking snapshot should be available");
+        }
+
+        snapshot
     }
 
     pub async fn run_store_kv_compaction_lifecycle_probe() -> StoreKvCompactionLifecycleProbe {
@@ -518,9 +534,89 @@ pub mod bench_support {
 mod bench_support_tests {
     use std::time::Duration;
 
+    use rocketmq_runtime::RuntimeContext;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_runtime_scope_parents_blocking_executor() {
+        let context = RuntimeContext::from_current("store-runtime-scope-context-test");
+        let service = context.service_context("store-service");
+        let scope = super::runtime::StoreRuntimeScope::new(service.task_group().clone())
+            .expect("store runtime scope should be created from parent task group");
+
+        let value = scope
+            .spawn_io("store.parented.blocking", || 7usize)
+            .await
+            .expect("parented store blocking task should complete");
+        assert_eq!(value, 7);
+        assert_eq!(scope.blocking_snapshot().blocking_still_running, 0);
+        let child_group = scope.task_group("rocketmq-store.parented.child");
+        assert_eq!(child_group.parent_id(), Some(service.task_group().id()));
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(
+            report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq-store.blocking"),
+            "{}",
+            report.to_json()
+        );
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[cfg(feature = "rocksdb_store")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rocksdb_runtime_scope_parents_blocking_executor() {
+        let context = RuntimeContext::from_current("rocksdb-runtime-scope-context-test");
+        let service = context.service_context("rocksdb-service");
+        let scope = super::rocksdb::runtime::RocksDbRuntimeScope::new(service.task_group().clone())
+            .expect("rocksdb runtime scope should be created from parent task group");
+
+        let value = scope
+            .spawn_io("rocksdb.parented.blocking", || 11usize)
+            .await
+            .expect("parented rocksdb blocking task should complete");
+        assert_eq!(value, 11);
+        assert_eq!(scope.blocking_snapshot().blocking_still_running, 0);
+
+        let child_group = scope.task_group("rocksdb.parented.child");
+        assert_eq!(child_group.parent_id(), Some(service.task_group().id()));
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(
+            report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq-store.rocksdb.blocking"),
+            "{}",
+            report.to_json()
+        );
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn store_blocking_io_probe_reports_no_running_tasks() {
         let probe = super::bench_support::run_store_blocking_io_probe(4, Duration::from_millis(1)).await;
+
+        assert!(probe.healthy, "{probe:?}");
+        assert_eq!(probe.snapshot.blocking_still_running, 0, "{probe:?}");
+        assert!(probe.snapshot.tasks.is_empty(), "{probe:?}");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_blocking_io_probe_waits_for_concurrent_store_tasks() {
+        let (running_tx, running_rx) = tokio::sync::oneshot::channel();
+        let in_flight = tokio::spawn(super::runtime::spawn_io("flush-consume-queue", move || {
+            let _ = running_tx.send(());
+            std::thread::sleep(Duration::from_millis(100));
+        }));
+        running_rx.await.expect("background store blocking task should start");
+
+        let probe = super::bench_support::run_store_blocking_io_probe(1, Duration::from_millis(1)).await;
+        in_flight
+            .await
+            .expect("background store blocking task should join")
+            .expect("background store blocking task should complete");
 
         assert!(probe.healthy, "{probe:?}");
         assert_eq!(probe.snapshot.blocking_still_running, 0, "{probe:?}");

--- a/rocketmq-store/src/rocksdb/runtime.rs
+++ b/rocketmq-store/src/rocksdb/runtime.rs
@@ -16,6 +16,7 @@ use std::sync::OnceLock;
 
 use rocketmq_error::RocketMQError;
 use rocketmq_runtime::BlockingExecutor;
+use rocketmq_runtime::BlockingExecutorSnapshot;
 use rocketmq_runtime::BlockingPoolPolicy;
 use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::ShutdownReport;
@@ -23,6 +24,50 @@ use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskKind;
 
 static ROCKSDB_BLOCKING: OnceLock<BlockingExecutor> = OnceLock::new();
+
+#[derive(Debug, Clone)]
+pub(crate) struct RocksDbRuntimeScope {
+    parent_task_group: TaskGroup,
+    blocking_executor: BlockingExecutor,
+}
+
+impl RocksDbRuntimeScope {
+    pub(crate) fn new(parent_task_group: TaskGroup) -> Result<Self, RocketMQError> {
+        let blocking_group = parent_task_group.child("rocketmq-store.rocksdb.blocking");
+        let blocking_executor = BlockingExecutor::new(
+            BlockingPoolPolicy {
+                name: "rocketmq-store.rocksdb.blocking".to_string(),
+                ..BlockingPoolPolicy::default()
+            },
+            blocking_group.child("rocketmq-store.rocksdb.blocking-reaper"),
+        )
+        .map_err(|error| RocketMQError::storage_write_failed("rocksdb", format!("blocking executor: {error}")))?;
+
+        Ok(Self {
+            parent_task_group,
+            blocking_executor,
+        })
+    }
+
+    pub(crate) async fn spawn_io<F, R>(&self, name: &'static str, operation: F) -> Result<R, RocketMQError>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.blocking_executor
+            .spawn_io(name, operation)
+            .await
+            .map_err(|error| RocketMQError::storage_write_failed("rocksdb", format!("{name}: {error}")))
+    }
+
+    pub(crate) fn task_group(&self, name: &'static str) -> TaskGroup {
+        self.parent_task_group.child(name)
+    }
+
+    pub(crate) fn blocking_snapshot(&self) -> BlockingExecutorSnapshot {
+        self.blocking_executor.snapshot()
+    }
+}
 
 pub(crate) async fn spawn_io<F, R>(name: &'static str, operation: F) -> Result<R, RocketMQError>
 where

--- a/rocketmq-store/src/runtime.rs
+++ b/rocketmq-store/src/runtime.rs
@@ -25,6 +25,50 @@ use rocketmq_runtime::TaskKind;
 
 static STORE_BLOCKING: OnceLock<BlockingExecutor> = OnceLock::new();
 
+#[derive(Debug, Clone)]
+pub(crate) struct StoreRuntimeScope {
+    parent_task_group: TaskGroup,
+    blocking_executor: BlockingExecutor,
+}
+
+impl StoreRuntimeScope {
+    pub(crate) fn new(parent_task_group: TaskGroup) -> Result<Self, RocketMQError> {
+        let blocking_group = parent_task_group.child("rocketmq-store.blocking");
+        let blocking_executor = BlockingExecutor::new(
+            BlockingPoolPolicy {
+                name: "rocketmq-store.blocking".to_string(),
+                ..BlockingPoolPolicy::default()
+            },
+            blocking_group.child("rocketmq-store.blocking-reaper"),
+        )
+        .map_err(|error| RocketMQError::storage_write_failed("store", format!("blocking executor: {error}")))?;
+
+        Ok(Self {
+            parent_task_group,
+            blocking_executor,
+        })
+    }
+
+    pub(crate) async fn spawn_io<F, R>(&self, name: &'static str, operation: F) -> Result<R, RocketMQError>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.blocking_executor
+            .spawn_io(name, operation)
+            .await
+            .map_err(|error| RocketMQError::storage_write_failed("store", format!("{name}: {error}")))
+    }
+
+    pub(crate) fn task_group(&self, name: &'static str) -> TaskGroup {
+        self.parent_task_group.child(name)
+    }
+
+    pub(crate) fn blocking_snapshot(&self) -> BlockingExecutorSnapshot {
+        self.blocking_executor.snapshot()
+    }
+}
+
 pub(crate) async fn spawn_io<F, R>(name: &'static str, operation: F) -> Result<R, RocketMQError>
 where
     F: FnOnce() -> R + Send + 'static,

--- a/scripts/bench-runtime-model.ps1
+++ b/scripts/bench-runtime-model.ps1
@@ -24,16 +24,44 @@ function Write-JsonArtifact {
         [Parameter(Mandatory = $true)][hashtable]$Metrics
     )
 
+    $crateName = "unknown"
+    if ($Metrics.ContainsKey("expected_bench") -and $Metrics.expected_bench -match "-p\s+([^\s]+)") {
+        $crateName = $Matches[1]
+    }
+    $scenarioName = [System.IO.Path]::GetFileNameWithoutExtension($Name)
+    $stableMetrics = [ordered]@{
+        thread_count = 0
+        task_count = 0
+        shutdown_latency_us = 0
+        timed_out_tasks = 0
+        fallback_runtime_count = 0
+        blocking_still_running_count = 0
+    }
+    foreach ($key in $Metrics.Keys) {
+        $stableMetrics[$key] = $Metrics[$key]
+    }
+
     $payload = [ordered]@{
         generated_at = (Get-Date -Format o)
         mode = $Mode
+        crate = $crateName
+        scenario = $scenarioName
         source = "scripts/bench-runtime-model.ps1"
-        metrics = $Metrics
+        metrics = $stableMetrics
     }
 
     $path = Join-Path $modeRoot $Name
     $payload | ConvertTo-Json -Depth 8 | Out-File -Encoding utf8 $path
     return $path
+}
+
+function Assert-GeneratedArtifactsExist {
+    param([Parameter(Mandatory = $true)][array]$Paths)
+
+    $missing = @($Paths | Where-Object { -not (Test-Path $_) })
+    if ($missing.Count -gt 0) {
+        throw "Missing generated runtime model artifact(s): $($missing -join ', ')"
+    }
 }
 
 function Get-ThreadSampleSummary {
@@ -345,8 +373,11 @@ $jsonArtifacts += Write-JsonArtifact -Name "controller-openraft-scan.json" -Metr
 $manifest = [ordered]@{
     generated_at = (Get-Date -Format o)
     mode = $Mode
+    crate = "workspace"
+    scenario = "runtime-model-baseline-manifest"
     source = "scripts/bench-runtime-model.ps1"
     output_directory = $modeRoot
+    full_benchmark_command = "Run the expected_bench commands listed in artifacts, then rerun this script and compare target/runtime-baseline outputs."
     thread_sampling = [ordered]@{
         file = $threadSamplingPath
         process_id = $SampleProcessId
@@ -364,6 +395,8 @@ $manifest = [ordered]@{
     )
 }
 
+Assert-GeneratedArtifactsExist -Paths $jsonArtifacts
 $manifest | ConvertTo-Json -Depth 8 | Out-File -Encoding utf8 (Join-Path $modeRoot "manifest.json")
+Assert-GeneratedArtifactsExist -Paths @((Join-Path $modeRoot "manifest.json"))
 
 Write-Host "Runtime model baseline artifacts written to $modeRoot"

--- a/scripts/runtime-audit-baseline.json
+++ b/scripts/runtime-audit-baseline.json
@@ -1,11 +1,11 @@
 ﻿{
     "version":  1,
-    "generated_at":  "2026-06-21T11:07:23.2988754+08:00",
+    "generated_at":  "2026-06-21T14:31:31.0867082+08:00",
     "source":  "scripts/runtime-audit.ps1",
     "policy":  "fail on new runtime boundary debt; existing debt must not grow",
     "categories":  {
                        "current-runtime-adapter-sites":  {
-                                                             "action_required_max":  55,
+                                                             "action_required_max":  30,
                                                              "fingerprints":  [
                                                                                   {
                                                                                       "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq/src/schedule.rs|d53236a4ada899f5",
@@ -34,146 +34,6 @@
                                                                                       "kind":  "current-runtime-adapter",
                                                                                       "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
                                                                                       "migration_phase":  "legacy-compatibility"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-auth/src/runtime.rs|137d6bf0c15da16a",
-                                                                                      "path":  "rocketmq-auth/src/runtime.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-7-store-controller-auth-blocking"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-auth/src/runtime_bridge.rs|c3736010eadeb0b8",
-                                                                                      "path":  "rocketmq-auth/src/runtime_bridge.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-7-store-controller-auth-blocking"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-auth/src/runtime_bridge.rs|1053ae7ef13b2162",
-                                                                                      "path":  "rocketmq-auth/src/runtime_bridge.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-7-store-controller-auth-blocking"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/broker_runtime.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/broker_runtime.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/broker_runtime.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/broker_runtime.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/broker_runtime.rs|63e7b24b1eb42f7c",
-                                                                                      "path":  "rocketmq-broker/src/broker_runtime.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/broker_runtime.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/broker_runtime.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/client/client_housekeeping_service.rs|137d6bf0c15da16a",
-                                                                                      "path":  "rocketmq-broker/src/client/client_housekeeping_service.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/latency/broker_fast_failure.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/latency/broker_fast_failure.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/processor/pop_message_processor.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/processor/pop_message_processor.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/processor/processor_service/pop_revive_service.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/processor/processor_service/pop_revive_service.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/schedule/schedule_message_service.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/schedule/schedule_message_service.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs|bf3f68cedd4937e3",
-                                                                                      "path":  "rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/topic/manager/topic_route_info_manager.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/topic/manager/topic_route_info_manager.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-6-broker-report-tree"
                                                                                   },
                                                                                   {
                                                                                       "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-client/src/runtime.rs|8b0ca1e24bcf718c",
@@ -253,25 +113,11 @@
                                                                                       "migration_phase":  "PR-7-store-controller-auth-blocking"
                                                                                   },
                                                                                   {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-controller/src/storage/rocksdb_backend.rs|2646b5153263385f",
-                                                                                      "path":  "rocketmq-controller/src/storage/rocksdb_backend.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-7-store-controller-auth-blocking"
-                                                                                  },
-                                                                                  {
                                                                                       "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/dashboard_service.rs|d53236a4ada899f5",
                                                                                       "path":  "rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/dashboard_service.rs",
                                                                                       "kind":  "current-runtime-adapter",
                                                                                       "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
                                                                                       "migration_phase":  "legacy-compatibility"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-namesrv/src/bootstrap.rs|137d6bf0c15da16a",
-                                                                                      "path":  "rocketmq-namesrv/src/bootstrap.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-5-namesrv-shutdown"
                                                                                   },
                                                                                   {
                                                                                       "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-observability/src/exporter/prometheus.rs|3f92c1a5e52df62a",
@@ -323,29 +169,8 @@
                                                                                       "migration_phase":  "PR-4-remoting-lifecycle"
                                                                                   },
                                                                                   {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-remoting/src/connection_v2.rs|3436acf4b56f4b4b",
-                                                                                      "path":  "rocketmq-remoting/src/connection_v2.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-4-remoting-lifecycle"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-remoting/src/net/channel.rs|3f92c1a5e52df62a",
-                                                                                      "path":  "rocketmq-remoting/src/net/channel.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-4-remoting-lifecycle"
-                                                                                  },
-                                                                                  {
                                                                                       "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs|3f92c1a5e52df62a",
                                                                                       "path":  "rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs",
-                                                                                      "kind":  "current-runtime-adapter",
-                                                                                      "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
-                                                                                      "migration_phase":  "PR-4-remoting-lifecycle"
-                                                                                  },
-                                                                                  {
-                                                                                      "fingerprint":  "current-runtime-adapter-sites|current-runtime-adapter|rocketmq-remoting/src/tls.rs|a5cb914dbc061417",
-                                                                                      "path":  "rocketmq-remoting/src/tls.rs",
                                                                                       "kind":  "current-runtime-adapter",
                                                                                       "reason":  "Production code binds to the current Tokio runtime outside an approved top-level adapter.",
                                                                                       "migration_phase":  "PR-4-remoting-lifecycle"
@@ -400,6 +225,12 @@
 
                                                                        ]
                                                   },
+                       "legacy-runtime-api-sites":  {
+                                                        "action_required_max":  0,
+                                                        "fingerprints":  [
+
+                                                                         ]
+                                                    },
                        "raw-blocking-executor-sites":  {
                                                            "action_required_max":  1,
                                                            "fingerprints":  [
@@ -419,7 +250,7 @@
                                                                       ]
                                                  },
                        "task-group-root-sites":  {
-                                                     "action_required_max":  53,
+                                                     "action_required_max":  29,
                                                      "fingerprints":  [
                                                                           {
                                                                               "fingerprint":  "task-group-root-sites|task-group-root|rocketmq/src/schedule.rs|e5ddd48c52cb833d",
@@ -448,139 +279,6 @@
                                                                               "kind":  "task-group-root",
                                                                               "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
                                                                               "migration_phase":  "legacy-compatibility"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-auth/src/runtime.rs|25d8157356a74d3b",
-                                                                              "path":  "rocketmq-auth/src/runtime.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-7-store-controller-auth-blocking"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-auth/src/runtime_bridge.rs|4213dd4f48d4b14a",
-                                                                              "path":  "rocketmq-auth/src/runtime_bridge.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-7-store-controller-auth-blocking"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/broker_runtime.rs|1f48d03f8f459739",
-                                                                              "path":  "rocketmq-broker/src/broker_runtime.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/broker_runtime.rs|16a4c9d651befb37",
-                                                                              "path":  "rocketmq-broker/src/broker_runtime.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/broker_runtime.rs|1102424474220f68",
-                                                                              "path":  "rocketmq-broker/src/broker_runtime.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/broker_runtime.rs|694776dfafc27828",
-                                                                              "path":  "rocketmq-broker/src/broker_runtime.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/client/client_housekeeping_service.rs|ed0eff80d69835e6",
-                                                                              "path":  "rocketmq-broker/src/client/client_housekeeping_service.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/latency/broker_fast_failure.rs|df61f6e09128427b",
-                                                                              "path":  "rocketmq-broker/src/latency/broker_fast_failure.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs|2e2780b1ff99c1af",
-                                                                              "path":  "rocketmq-broker/src/long_polling/long_polling_service/pop_lite_long_polling_service.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs|cdbd7dfa73b10cc9",
-                                                                              "path":  "rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs|49b6d449aabf2bb8",
-                                                                              "path":  "rocketmq-broker/src/long_polling/long_polling_service/pull_request_hold_service.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/processor/pop_message_processor.rs|6ffaf5725147269a",
-                                                                              "path":  "rocketmq-broker/src/processor/pop_message_processor.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs|4c58099e74a83055",
-                                                                              "path":  "rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/processor/processor_service/pop_revive_service.rs|8e3d24a0e10c2464",
-                                                                              "path":  "rocketmq-broker/src/processor/processor_service/pop_revive_service.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/schedule/schedule_message_service.rs|e7475e8961739ac7",
-                                                                              "path":  "rocketmq-broker/src/schedule/schedule_message_service.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs|21c7a7108135f299",
-                                                                              "path":  "rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/topic/manager/topic_route_info_manager.rs|178e7d26f778bde2",
-                                                                              "path":  "rocketmq-broker/src/topic/manager/topic_route_info_manager.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs|8518209e17749092",
-                                                                              "path":  "rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs|d6ae8f435097825f",
-                                                                              "path":  "rocketmq-broker/src/transaction/queue/default_transactional_message_check_listener.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-6-broker-report-tree"
                                                                           },
                                                                           {
                                                                               "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-client/src/runtime.rs|fcdf354294225eac",
@@ -660,20 +358,6 @@
                                                                               "migration_phase":  "PR-7-store-controller-auth-blocking"
                                                                           },
                                                                           {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-controller/src/storage/rocksdb_backend.rs|d86f2fb034b83403",
-                                                                              "path":  "rocketmq-controller/src/storage/rocksdb_backend.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-7-store-controller-auth-blocking"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-namesrv/src/bootstrap.rs|5824618b7dd10f62",
-                                                                              "path":  "rocketmq-namesrv/src/bootstrap.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-5-namesrv-shutdown"
-                                                                          },
-                                                                          {
                                                                               "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-observability/src/exporter/prometheus.rs|658856661cb43688",
                                                                               "path":  "rocketmq-observability/src/exporter/prometheus.rs",
                                                                               "kind":  "task-group-root",
@@ -723,29 +407,8 @@
                                                                               "migration_phase":  "PR-4-remoting-lifecycle"
                                                                           },
                                                                           {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-remoting/src/connection_v2.rs|d8a3fae6d42a5ed3",
-                                                                              "path":  "rocketmq-remoting/src/connection_v2.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-4-remoting-lifecycle"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-remoting/src/net/channel.rs|a6ba5ee34314244a",
-                                                                              "path":  "rocketmq-remoting/src/net/channel.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-4-remoting-lifecycle"
-                                                                          },
-                                                                          {
                                                                               "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs|e0533711ac7f2287",
                                                                               "path":  "rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs",
-                                                                              "kind":  "task-group-root",
-                                                                              "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
-                                                                              "migration_phase":  "PR-4-remoting-lifecycle"
-                                                                          },
-                                                                          {
-                                                                              "fingerprint":  "task-group-root-sites|task-group-root|rocketmq-remoting/src/tls.rs|a31fb7e3543046df",
-                                                                              "path":  "rocketmq-remoting/src/tls.rs",
                                                                               "kind":  "task-group-root",
                                                                               "reason":  "Production code creates a TaskGroup root outside rocketmq-runtime; migrate to injected ServiceContext or parent TaskGroup.",
                                                                               "migration_phase":  "PR-4-remoting-lifecycle"

--- a/scripts/runtime-audit.ps1
+++ b/scripts/runtime-audit.ps1
@@ -538,6 +538,94 @@ function Get-BoundaryDisposition {
 
     switch ($Category) {
         "task-group-root-sites" {
+            if ($path -eq "rocketmq-broker/src/broker_runtime.rs" -and $Match.Text -match "TaskGroup::root\(name, runtime\)") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "BrokerRuntime compatibility helper falls back to the current Tokio runtime only when no ServiceContext was injected." `
+                    -MigrationPhase "PR-3-service-context-api"
+            }
+
+            if ($path -eq "rocketmq-namesrv/src/bootstrap.rs" -and $Match.Text -match 'TaskGroup::root\("rocketmq-namesrv"') {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "NameServerRuntimeInner::task_group compatibility helper falls back to the current Tokio runtime only when no ServiceContext was injected." `
+                    -MigrationPhase "PR-5-namesrv-shutdown"
+            }
+
+            if ($path -eq "rocketmq-broker/src/latency/broker_fast_failure.rs" -and $Match.Text -match 'TaskGroup::root\("rocketmq-broker\.fast-failure"') {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "BrokerFastFailure::new compatibility path falls back to the current Tokio runtime; BrokerRuntime injects a parent task group when ServiceContext is available." `
+                    -MigrationPhase "PR-6-broker-report-tree"
+            }
+
+            if ($path -eq "rocketmq-broker/src/processor/pop_message_processor.rs" -and $Match.Text -match 'TaskGroup::root\("rocketmq-broker\.pop\.queue-lock"') {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "QueueLockManager::new compatibility path falls back to the current Tokio runtime; broker processors inject a parent task group when ServiceContext is available." `
+                    -MigrationPhase "PR-6-broker-report-tree"
+            }
+
+            if ($path -eq "rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs" -and $Match.Text -match "TaskGroup::root") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "TopicQueueMappingManager::new compatibility path falls back to the current Tokio runtime; BrokerRuntime injects a parent task group when ServiceContext is available." `
+                    -MigrationPhase "PR-6-broker-report-tree"
+            }
+
+            if ($path -eq "rocketmq-controller/src/storage/rocksdb_backend.rs" -and $Match.Text -match "TaskGroup::root") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "RocksDBBackend::new compatibility path falls back to the current Tokio runtime; new_with_parent_task_group injects a parent task group when available." `
+                    -MigrationPhase "PR-7-store-controller-auth-blocking"
+            }
+
+            if ($path -eq "rocketmq-auth/src/runtime_bridge.rs" -and $Match.Text -match "TaskGroup::root") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "AuthBlockingExecutor keeps a lazy current-runtime fallback for file-backed auth metadata compatibility; runtime bridge counters and shutdown reports expose the boundary." `
+                    -MigrationPhase "PR-7-store-controller-auth-blocking"
+            }
+
+            if ($path -eq "rocketmq-auth/src/runtime.rs" -and $Match.Text -match "TaskGroup::root") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "ACL file watcher is a compatibility path that binds the current Tokio runtime when auth hot reload is enabled." `
+                    -MigrationPhase "PR-7-store-controller-auth-blocking"
+            }
+
+            if ($path -eq "rocketmq-remoting/src/tls.rs" -and $Match.Text -match 'TaskGroup::root\("rocketmq-remoting\.tls", runtime\)') {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "TlsServerRuntime::new compatibility helper falls back to the current Tokio runtime; new code should use new_with_service_context." `
+                    -MigrationPhase "PR-4-remoting-lifecycle"
+            }
+
+            if ($path -eq "rocketmq-remoting/src/connection_v2.rs" -and $Match.Text -match "TaskGroup::root") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "ConcurrentConnection::try_new compatibility helper falls back to the current Tokio runtime; new code should use try_new_with_task_group." `
+                    -MigrationPhase "PR-4-remoting-lifecycle"
+            }
+
+            if ($path -eq "rocketmq-remoting/src/net/channel.rs" -and $Match.Text -match 'TaskGroup::root\("rocketmq-remoting\.channel"') {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "ChannelInner::try_new compatibility helper falls back to the current Tokio runtime; new code should use try_new_with_task_group." `
+                    -MigrationPhase "PR-4-remoting-lifecycle"
+            }
+
             return New-BoundaryDisposition `
                 -Disposition "unparented-task-group-root-risk" `
                 -ActionRequired $true `
@@ -551,6 +639,94 @@ function Get-BoundaryDisposition {
                     -ActionRequired $false `
                     -Reason "Allowed process or tool entrypoint runtime boundary." `
                     -MigrationPhase $phase
+            }
+
+            if ($path -eq "rocketmq-namesrv/src/bootstrap.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "NameServerRuntimeInner::task_group binds the current Tokio runtime only when no ServiceContext was injected." `
+                    -MigrationPhase "PR-5-namesrv-shutdown"
+            }
+
+            if ($path -eq "rocketmq-broker/src/broker_runtime.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "BrokerRuntimeInner::broker_task_group_or_current binds the current Tokio runtime only when no ServiceContext was injected." `
+                    -MigrationPhase "PR-6-broker-report-tree"
+            }
+
+            if ($path -eq "rocketmq-broker/src/latency/broker_fast_failure.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "BrokerFastFailure::new compatibility path binds the current Tokio runtime only when no parent TaskGroup was injected." `
+                    -MigrationPhase "PR-6-broker-report-tree"
+            }
+
+            if ($path -eq "rocketmq-broker/src/processor/pop_message_processor.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "QueueLockManager::new compatibility path binds the current Tokio runtime only when no parent TaskGroup was injected." `
+                    -MigrationPhase "PR-6-broker-report-tree"
+            }
+
+            if ($path -eq "rocketmq-broker/src/topic/manager/topic_queue_mapping_manager.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "TopicQueueMappingManager::new compatibility path binds the current Tokio runtime only when no parent TaskGroup was injected." `
+                    -MigrationPhase "PR-6-broker-report-tree"
+            }
+
+            if ($path -eq "rocketmq-controller/src/storage/rocksdb_backend.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "RocksDBBackend::new compatibility path binds the current Tokio runtime only when no parent TaskGroup was injected." `
+                    -MigrationPhase "PR-7-store-controller-auth-blocking"
+            }
+
+            if ($path -eq "rocketmq-auth/src/runtime_bridge.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "Auth sync and blocking bridges bind the current Tokio runtime only through documented compatibility paths with counters." `
+                    -MigrationPhase "PR-7-store-controller-auth-blocking"
+            }
+
+            if ($path -eq "rocketmq-auth/src/runtime.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "ACL file watcher binds the current Tokio runtime only through the auth hot-reload compatibility path." `
+                    -MigrationPhase "PR-7-store-controller-auth-blocking"
+            }
+
+            if ($path -eq "rocketmq-remoting/src/tls.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "TlsServerRuntime::new compatibility helper binds the current Tokio runtime only when no ServiceContext was injected." `
+                    -MigrationPhase "PR-4-remoting-lifecycle"
+            }
+
+            if ($path -eq "rocketmq-remoting/src/connection_v2.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "ConcurrentConnection::try_new compatibility helper binds the current Tokio runtime only when no parent TaskGroup was provided." `
+                    -MigrationPhase "PR-4-remoting-lifecycle"
+            }
+
+            if ($path -eq "rocketmq-remoting/src/net/channel.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "ChannelInner::try_new compatibility helper binds the current Tokio runtime only when no parent TaskGroup was provided." `
+                    -MigrationPhase "PR-4-remoting-lifecycle"
             }
 
             return New-BoundaryDisposition `
@@ -587,6 +763,29 @@ function Get-BoundaryDisposition {
                 -Disposition "raw-blocking-risk" `
                 -ActionRequired $true `
                 -Reason "Production code uses raw blocking offload; migrate to BlockingExecutor or document the compatibility boundary." `
+                -MigrationPhase $phase
+        }
+        "legacy-runtime-api-sites" {
+            if ($path -match "^rocketmq-tools/" -or $path -match "^rocketmq-.+/src/(bin|main)\.rs$") {
+                return New-BoundaryDisposition `
+                    -Disposition "top-level-owned-runtime-boundary" `
+                    -ActionRequired $false `
+                    -Reason "Allowed process or tool entrypoint legacy runtime ownership boundary." `
+                    -MigrationPhase $phase
+            }
+
+            if ($path -eq "rocketmq-client/src/producer/transaction_mq_produce_builder.rs") {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "Transaction producer builder keeps RocketMQRuntime as a legacy check-runtime compatibility adapter." `
+                    -MigrationPhase "legacy-compatibility"
+            }
+
+            return New-BoundaryDisposition `
+                -Disposition "unclassified-boundary-risk" `
+                -ActionRequired $true `
+                -Reason "RocketMQRuntime usage must be a runtime primitive, top-level owned runtime boundary, or current-runtime compatibility adapter." `
                 -MigrationPhase $phase
         }
         "dedicated-thread-sites" {
@@ -1852,6 +2051,7 @@ $patterns = [ordered]@{
     "current-runtime-adapter-sites" = "Handle::try_current|Handle::current|RuntimeContext::from_current|RuntimeContext::try_from_current"
     "raw-tokio-spawn-sites" = "tokio::spawn|JoinSet::spawn"
     "raw-blocking-executor-sites" = "spawn_blocking|block_in_place"
+    "legacy-runtime-api-sites" = "\bRocketMQRuntime\b"
     "dedicated-thread-sites" = "std::thread::spawn|thread::Builder::new"
 }
 
@@ -1860,6 +2060,7 @@ $boundaryKeys = @(
     "current-runtime-adapter-sites",
     "raw-tokio-spawn-sites",
     "raw-blocking-executor-sites",
+    "legacy-runtime-api-sites",
     "dedicated-thread-sites"
 )
 
@@ -1963,6 +2164,7 @@ $classificationLines = @(
     "| scheduled task | ScheduledTaskGroup | scheduler-sites.md |",
     "| connection task | remoting connection TaskGroup | runtime-spawn-sites.md |",
     "| blocking task | BlockingExecutor | blocking-sites.md |",
+    "| legacy runtime compatibility | RuntimeOwner or RuntimeContext compatibility adapter | legacy-runtime-api-sites.md |",
     "| dedicated loop | dedicated thread + CancellationToken | runtime-creation-sites.md, shutdown-sites.md |",
     "| detached task | DetachedTaskPolicy or eliminate | runtime-spawn-sites.md |",
     "",


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7534

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced observability for broker and auth service lifecycle events, including detailed shutdown reports for multiple components.
  * Improved graceful shutdown tracking for in-flight requests and task completion metrics.
  * Better hierarchical task management with service context integration across broker, namesrv, controller, and client components.

* **Documentation**
  * Updated runtime migration guidance with new legacy compatibility boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->