### PR TITLE
[ISSUE #7544]🚀Harden Tokio runtime lifecycle: service-tree ownership, shutdown reports, scheduler guardrails, and diagnostics

### DIFF
--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -27,7 +27,6 @@ use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_common::EnvUtils::EnvUtils;
 use rocketmq_common::ParseConfigFile;
 use rocketmq_remoting::protocol::remoting_command;
-use rocketmq_rust::rocketmq;
 #[cfg(feature = "tieredstore")]
 use rocketmq_store::base::store_enum::StoreType;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
@@ -44,8 +43,18 @@ const LOGO: &str = r#"
  |_|  \_\___/ \___|_|\_\___|\__|_|  |_|\___\_\      |_|  \_\__,_|___/\__| |____/|_|  \___/|_|\_\___|_|
 "#;
 
-#[rocketmq::main]
-async fn main() -> Result<()> {
+const ENTRYPOINT_MAX_BLOCKING_THREADS: usize = 64;
+
+fn main() -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .max_blocking_threads(ENTRYPOINT_MAX_BLOCKING_THREADS)
+        .enable_all()
+        .build()
+        .context("failed to build broker Tokio runtime")?;
+    runtime.block_on(run())
+}
+
+async fn run() -> Result<()> {
     // Initialize logger
     rocketmq_common::log::init_logger_with_level(rocketmq_common::log::Level::INFO)?;
 

--- a/rocketmq-broker/src/broker_runtime.rs
+++ b/rocketmq-broker/src/broker_runtime.rs
@@ -165,6 +165,7 @@ type FasterServerProcessor =
     BrokerRequestProcessor<GenericMessageStore, DefaultTransactionalMessageService<GenericMessageStore>>;
 
 const SCHEDULED_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const BROKER_OUTER_API_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn build_auth_config(broker_config: &BrokerConfig) -> AuthConfig {
     AuthConfig {
@@ -442,6 +443,8 @@ impl BrokerRemotingServerShutdownReport {
 pub(crate) struct BrokerBasicServiceShutdownReport {
     pub(crate) remoting: Option<BrokerRemotingServerShutdownReport>,
     pub(crate) request_processor: Option<ShutdownReport>,
+    pub(crate) broker_outer_api: BrokerShutdownComponentReport,
+    pub(crate) client_housekeeping: BrokerShutdownComponentReport,
     pub(crate) auth: BrokerShutdownComponentReport,
     pub(crate) observability: BrokerShutdownComponentReport,
     pub(crate) scheduled_tasks: BrokerShutdownComponentReport,
@@ -532,9 +535,11 @@ impl BrokerShutdownComponentReport {
 }
 
 impl BrokerBasicServiceShutdownReport {
-    const COMPONENT_NAMES: [&'static str; 13] = [
+    const COMPONENT_NAMES: [&'static str; 15] = [
         "remoting",
         "request_processor",
+        "broker_outer_api",
+        "client_housekeeping",
         "auth",
         "observability",
         "scheduled_tasks",
@@ -612,6 +617,8 @@ impl BrokerBasicServiceShutdownReport {
 
     fn component_reports(&self) -> Vec<&BrokerShutdownComponentReport> {
         vec![
+            &self.broker_outer_api,
+            &self.client_housekeeping,
             &self.auth,
             &self.observability,
             &self.scheduled_tasks,
@@ -664,7 +671,10 @@ impl BrokerRuntime {
     ) -> Self {
         let broker_address = format!("{}:{}", broker_config.broker_ip1, broker_config.listen_port);
         let store_host = broker_address.parse::<SocketAddr>().expect("parse store_host failed");
-        let scheduled_task_manager = ScheduledTaskManager::default();
+        let scheduled_task_manager = service_context
+            .as_ref()
+            .map(|context| ScheduledTaskManager::new_with_task_group(context.task_group().clone()))
+            .unwrap_or_else(ScheduledTaskManager::new_legacy_compatibility);
         let broker_outer_api = BrokerOuterAPI::new(Arc::new(TokioClientConfig::default()));
 
         let topic_queue_mapping_manager = service_context
@@ -886,12 +896,6 @@ impl BrokerRuntime {
         self.inner.shutdown.store(true, Ordering::SeqCst);
 
         self.shutdown_basic_service().await;
-
-        self.inner.broker_outer_api.shutdown();
-
-        if let Some(client_housekeeping_service) = self.inner.client_housekeeping_service.take() {
-            client_housekeeping_service.shutdown().await;
-        }
     }
 
     async fn unregister_broker(&mut self) {
@@ -1144,6 +1148,35 @@ impl BrokerRuntime {
         } else {
             shutdown_report.message_store = BrokerShutdownComponentReport::skipped("message_store");
         }
+
+        let started = Instant::now();
+        let broker_outer_api_report = self
+            .inner
+            .broker_outer_api
+            .shutdown_with_report(BROKER_OUTER_API_SHUTDOWN_TIMEOUT)
+            .await;
+        shutdown_report.broker_outer_api = if broker_outer_api_report.is_healthy() {
+            BrokerShutdownComponentReport::completed("broker_outer_api", started.elapsed())
+        } else {
+            BrokerShutdownComponentReport::unhealthy(
+                "broker_outer_api",
+                started.elapsed(),
+                format!("{broker_outer_api_report:?}"),
+            )
+        };
+
+        let started = Instant::now();
+        shutdown_report.client_housekeeping =
+            if let Some(client_housekeeping_service) = self.inner.client_housekeeping_service.take() {
+                let client_housekeeping_report = client_housekeeping_service.shutdown_with_report().await;
+                BrokerShutdownComponentReport::from_shutdown_report(
+                    "client_housekeeping",
+                    client_housekeeping_report.as_ref(),
+                    started.elapsed(),
+                )
+            } else {
+                BrokerShutdownComponentReport::skipped("client_housekeeping")
+            };
 
         shutdown_report
     }
@@ -4983,6 +5016,17 @@ mod tests {
         assert_eq!(report.unhealthy_component_count(), 0);
         assert!(report.timed_out_component_names().is_empty());
         assert!(report.component_names().contains(&"scheduled_tasks"));
+
+        let service_report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(
+            service_report
+                .children
+                .iter()
+                .any(|child| child.name
+                    == rocketmq_rust::schedule::simple_scheduler::LEGACY_SCHEDULED_TASK_MANAGER_BOUNDARY),
+            "{}",
+            service_report.to_json()
+        );
     }
 
     #[test]
@@ -4994,6 +5038,8 @@ mod tests {
             vec![
                 "remoting",
                 "request_processor",
+                "broker_outer_api",
+                "client_housekeeping",
                 "auth",
                 "observability",
                 "scheduled_tasks",

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -41,6 +41,7 @@ use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_error::RocketMQError;
+use rocketmq_remoting::clients::rocketmq_tokio_client::RemotingClientShutdownReport;
 use rocketmq_remoting::clients::rocketmq_tokio_client::RocketmqDefaultClient;
 use rocketmq_remoting::clients::RemotingClient;
 use rocketmq_remoting::code::request_code::RequestCode;
@@ -351,6 +352,10 @@ impl BrokerOuterAPI {
 
     pub fn shutdown(&mut self) {
         self.remoting_client.shutdown();
+    }
+
+    pub async fn shutdown_with_report(&mut self, timeout: std::time::Duration) -> RemotingClientShutdownReport {
+        self.remoting_client.shutdown_with_report(timeout).await
     }
 
     pub fn refresh_metadata(&self) {}

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -299,7 +299,7 @@ impl MQClientInstance {
             broker_addr_table,
             broker_version_table,
             send_heartbeat_times_total: Arc::new(AtomicI64::new(0)),
-            scheduled_task_manager: ScheduledTaskManager::new(),
+            scheduled_task_manager: ScheduledTaskManager::new_legacy_compatibility(),
             broker_heartbeat_fingerprint_table,
             broker_support_v2_heartbeat_set,
             consumer_stats_manager: ConsumerStatsManager::new(),

--- a/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
@@ -19,6 +19,7 @@ use cheetah_string::CheetahString;
 use rocketmq_common::common::compression::compression_type::CompressionType;
 use rocketmq_common::common::compression::compressor::Compressor;
 use rocketmq_remoting::runtime::RPCHook;
+#[allow(deprecated)]
 use rocketmq_runtime::RocketMQRuntime;
 
 use crate::base::client_config::ClientConfig;
@@ -32,6 +33,7 @@ use crate::producer::transaction_mq_producer::TransactionProducerConfig;
 use crate::trace::trace_dispatcher::ArcTraceDispatcher;
 
 #[derive(Default)]
+#[allow(deprecated)]
 pub struct TransactionMQProducerBuilder {
     client_config: Option<ClientConfig>,
     default_mqproducer_impl: Option<DefaultMQProducerImpl>,
@@ -353,6 +355,7 @@ impl TransactionMQProducerBuilder {
         TransactionMQProducer::new(transaction_producer_config, mq_producer)
     }
 
+    #[allow(deprecated)]
     pub fn check_runtime(&mut self, check_runtime: RocketMQRuntime) {
         self.check_runtime = Some(Arc::new(check_runtime));
     }

--- a/rocketmq-client/src/runtime.rs
+++ b/rocketmq-client/src/runtime.rs
@@ -45,6 +45,9 @@ use tokio::runtime::Handle;
 static SHARED_FALLBACK: OnceLock<ClientSharedFallbackRegistry> = OnceLock::new();
 static CLIENT_BLOCKING: OnceLock<BlockingExecutor> = OnceLock::new();
 
+pub const CLIENT_SHARED_FALLBACK_RUNTIME_BOUNDARY: &str = "rocketmq-client.shared-fallback-runtime";
+pub const CLIENT_SHARED_FALLBACK_RUNTIME_COMPATIBILITY: &str = "shared fallback runtime compatibility boundary";
+
 pub(crate) fn spawn_client_task<F>(task_name: &'static str, task: F) -> io::Result<ClientRuntimeTaskHandle>
 where
     F: Future<Output = ()> + Send + 'static,
@@ -593,6 +596,9 @@ pub enum ClientSharedFallbackLifecycleState {
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClientSharedFallbackSnapshot {
+    pub boundary: &'static str,
+    pub compatibility: &'static str,
+    pub prefers_injected_runtime: bool,
     pub state: ClientSharedFallbackLifecycleState,
     pub acquire_count: usize,
     pub runtime_created: usize,
@@ -679,6 +685,9 @@ impl ClientSharedFallbackRegistry {
         };
 
         ClientSharedFallbackSnapshot {
+            boundary: CLIENT_SHARED_FALLBACK_RUNTIME_BOUNDARY,
+            compatibility: CLIENT_SHARED_FALLBACK_RUNTIME_COMPATIBILITY,
+            prefers_injected_runtime: true,
             state: lifecycle_state,
             acquire_count: self.acquire_count.load(Ordering::Relaxed),
             runtime_created: self.runtime_created.load(Ordering::Relaxed),
@@ -990,6 +999,9 @@ mod tests {
         let lease = registry.acquire().expect("fallback runtime should be created");
 
         let snapshot = registry.snapshot();
+        assert_eq!(snapshot.boundary, CLIENT_SHARED_FALLBACK_RUNTIME_BOUNDARY);
+        assert_eq!(snapshot.compatibility, CLIENT_SHARED_FALLBACK_RUNTIME_COMPATIBILITY);
+        assert!(snapshot.prefers_injected_runtime);
         assert_eq!(snapshot.state, ClientSharedFallbackLifecycleState::Active);
         assert_eq!(snapshot.acquire_count, 1);
         assert_eq!(snapshot.runtime_created, 1);

--- a/rocketmq-common/src/common/statistics/statistics_manager.rs
+++ b/rocketmq-common/src/common/statistics/statistics_manager.rs
@@ -62,6 +62,7 @@ pub struct StatisticsManager {
     stats_table: StatsTable,
     statistics_item_state_getter: Arc<RwLock<Option<Arc<dyn StatisticsItemStateGetter + Send + Sync>>>>,
     cleanup_task: Arc<Mutex<Option<CleanupTask>>>,
+    parent_task_group: Option<TaskGroup>,
 }
 
 impl Default for StatisticsManager {
@@ -74,24 +75,35 @@ impl StatisticsManager {
     const MAX_IDLE_TIME: u64 = 10 * 60 * 1000;
 
     pub fn new() -> Self {
-        let manager = Self {
-            kind_meta_map: Arc::new(RwLock::new(HashMap::new())),
-            brief_metas: None,
-            stats_table: Arc::new(RwLock::new(HashMap::new())),
-            statistics_item_state_getter: Arc::new(RwLock::new(None)),
-            cleanup_task: Arc::new(Mutex::new(None)),
-        };
-        manager.start();
-        manager
+        Self::new_with_optional_kind_meta_and_task_group(HashMap::new(), None)
+    }
+
+    pub fn new_with_task_group(parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_kind_meta_and_task_group(HashMap::new(), Some(parent_task_group))
     }
 
     pub fn with_kind_meta(kind_meta: HashMap<String, Arc<StatisticsKindMeta>>) -> Self {
+        Self::new_with_optional_kind_meta_and_task_group(kind_meta, None)
+    }
+
+    pub fn with_kind_meta_and_task_group(
+        kind_meta: HashMap<String, Arc<StatisticsKindMeta>>,
+        parent_task_group: TaskGroup,
+    ) -> Self {
+        Self::new_with_optional_kind_meta_and_task_group(kind_meta, Some(parent_task_group))
+    }
+
+    fn new_with_optional_kind_meta_and_task_group(
+        kind_meta: HashMap<String, Arc<StatisticsKindMeta>>,
+        parent_task_group: Option<TaskGroup>,
+    ) -> Self {
         let manager = Self {
             kind_meta_map: Arc::new(RwLock::new(kind_meta)),
             brief_metas: None,
             stats_table: Arc::new(RwLock::new(HashMap::new())),
             statistics_item_state_getter: Arc::new(RwLock::new(None)),
             cleanup_task: Arc::new(Mutex::new(None)),
+            parent_task_group,
         };
         manager.start();
         manager
@@ -114,14 +126,18 @@ impl StatisticsManager {
             return;
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                tracing::debug!(%error, "StatisticsManager cleanup task deferred until a Tokio runtime is available");
-                return;
-            }
+        let task_group = if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            parent_task_group.child("rocketmq-common.statistics")
+        } else {
+            let runtime = match tokio::runtime::Handle::try_current() {
+                Ok(handle) => RuntimeHandle::new(handle),
+                Err(error) => {
+                    tracing::debug!(%error, "StatisticsManager cleanup task deferred until a Tokio runtime is available");
+                    return;
+                }
+            };
+            TaskGroup::root("rocketmq-common.statistics", runtime)
         };
-        let task_group = TaskGroup::root("rocketmq-common.statistics", runtime);
         let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
         let stats_table = self.stats_table.clone();
         let kind_meta_map = self.kind_meta_map.clone();
@@ -248,6 +264,8 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::Ordering;
 
+    use rocketmq_runtime::RuntimeContext;
+
     use super::*;
     use crate::common::statistics::statistics_item_scheduled_printer::StatisticsItemScheduledPrinter;
 
@@ -276,6 +294,30 @@ mod tests {
 
         manager.shutdown().await;
         assert!(manager.cleanup_task.lock().is_none());
+    }
+
+    #[tokio::test]
+    async fn new_with_task_group_parents_cleanup_task() {
+        let context = RuntimeContext::from_current("statistics-manager-parent-test");
+        let service = context.service_context("statistics-service");
+        let manager = StatisticsManager::new_with_task_group(service.task_group().clone());
+
+        assert!(
+            manager.cleanup_task.lock().is_some(),
+            "cleanup task should be running after parented manager creation"
+        );
+        manager.shutdown().await;
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert!(
+            report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq-common.statistics"),
+            "{}",
+            report.to_json()
+        );
     }
 
     #[test]

--- a/rocketmq-common/src/common/stats/moment_stats_item.rs
+++ b/rocketmq-common/src/common/stats/moment_stats_item.rs
@@ -37,15 +37,29 @@ pub struct MomentStatsItem {
     stats_name: String,
     stats_key: String,
     task_group: Arc<Mutex<Option<TaskGroup>>>,
+    parent_task_group: Option<TaskGroup>,
 }
 
 impl MomentStatsItem {
     pub fn new(stats_name: String, stats_key: String) -> Self {
+        Self::new_with_optional_task_group(stats_name, stats_key, None)
+    }
+
+    pub fn new_with_task_group(stats_name: String, stats_key: String, parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_task_group(stats_name, stats_key, Some(parent_task_group))
+    }
+
+    fn new_with_optional_task_group(
+        stats_name: String,
+        stats_key: String,
+        parent_task_group: Option<TaskGroup>,
+    ) -> Self {
         MomentStatsItem {
             value: Arc::new(AtomicI64::new(0)),
             stats_name,
             stats_key,
             task_group: Arc::new(Mutex::new(None)),
+            parent_task_group,
         }
     }
 
@@ -58,20 +72,22 @@ impl MomentStatsItem {
             return;
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                warn!(
-                    "[{}] [{}] failed to initialize MomentStatsItem outside Tokio runtime: {}",
-                    self.stats_name, self.stats_key, error
-                );
-                return;
-            }
+        let group_name = format!("rocketmq-common.moment-stats.{}.{}", self.stats_name, self.stats_key);
+        let task_group = if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            parent_task_group.child(group_name)
+        } else {
+            let runtime = match tokio::runtime::Handle::try_current() {
+                Ok(handle) => RuntimeHandle::new(handle),
+                Err(error) => {
+                    warn!(
+                        "[{}] [{}] failed to initialize MomentStatsItem outside Tokio runtime: {}",
+                        self.stats_name, self.stats_key, error
+                    );
+                    return;
+                }
+            };
+            TaskGroup::root(group_name, runtime)
         };
-        let task_group = TaskGroup::root(
-            format!("rocketmq-common.moment-stats.{}.{}", self.stats_name, self.stats_key),
-            runtime,
-        );
         let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
         let self_clone = self.clone();
         let mut config =

--- a/rocketmq-common/src/common/stats/moment_stats_item_set.rs
+++ b/rocketmq-common/src/common/stats/moment_stats_item_set.rs
@@ -32,16 +32,26 @@ pub struct MomentStatsItemSet {
     stats_item_table: Arc<DashMap<String, MomentStatsItem>>,
     stats_name: String,
     task_group: Arc<Mutex<Option<TaskGroup>>>,
+    parent_task_group: Option<TaskGroup>,
 }
 
 impl MomentStatsItemSet {
     pub fn new(stats_name: String) -> Self {
+        Self::new_with_optional_task_group(stats_name, None)
+    }
+
+    pub fn new_with_task_group(stats_name: String, parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_task_group(stats_name, Some(parent_task_group))
+    }
+
+    fn new_with_optional_task_group(stats_name: String, parent_task_group: Option<TaskGroup>) -> Self {
         let stats_item_table = Arc::new(DashMap::new());
         let task_group = Arc::new(Mutex::new(None));
         let set = MomentStatsItemSet {
             stats_item_table,
             stats_name,
             task_group,
+            parent_task_group,
         };
         set.init();
         set
@@ -64,17 +74,22 @@ impl MomentStatsItemSet {
         let initial_delay =
             Duration::from_millis((compute_next_minutes_time_millis() as i64 - current_millis() as i64).unsigned_abs());
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                warn!(
-                    "[{}] failed to initialize MomentStatsItemSet outside Tokio runtime: {}",
-                    self.stats_name, error
-                );
-                return;
-            }
+        let group_name = format!("rocketmq-common.moment-stats-set.{}", self.stats_name);
+        let task_group = if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            parent_task_group.child(group_name)
+        } else {
+            let runtime = match tokio::runtime::Handle::try_current() {
+                Ok(handle) => RuntimeHandle::new(handle),
+                Err(error) => {
+                    warn!(
+                        "[{}] failed to initialize MomentStatsItemSet outside Tokio runtime: {}",
+                        self.stats_name, error
+                    );
+                    return;
+                }
+            };
+            TaskGroup::root(group_name, runtime)
         };
-        let task_group = TaskGroup::root(format!("rocketmq-common.moment-stats-set.{}", self.stats_name), runtime);
         let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
         let mut config =
             ScheduledTaskConfig::fixed_rate_no_overlap("common.moment-stats-set.print", Duration::from_secs(300));
@@ -138,7 +153,14 @@ impl MomentStatsItemSet {
             return stats_item.clone();
         }
 
-        let new_item = MomentStatsItem::new(self.stats_name.clone(), stats_key.clone());
+        let new_item = match self.parent_task_group.as_ref() {
+            Some(parent_task_group) => MomentStatsItem::new_with_task_group(
+                self.stats_name.clone(),
+                stats_key.clone(),
+                parent_task_group.clone(),
+            ),
+            None => MomentStatsItem::new(self.stats_name.clone(), stats_key.clone()),
+        };
         self.stats_item_table.insert(stats_key, new_item.clone());
         new_item
     }
@@ -172,6 +194,7 @@ mod tests {
     use std::sync::Arc;
 
     use dashmap::DashMap;
+    use rocketmq_runtime::RuntimeContext;
 
     use super::*;
 
@@ -185,6 +208,26 @@ mod tests {
     async fn moment_stats_item_set_returns_correct_stats_name() {
         let stats_set = MomentStatsItemSet::new("TestName".to_string());
         assert_eq!(stats_set.get_stats_name(), "TestName");
+    }
+
+    #[tokio::test]
+    async fn moment_stats_item_set_with_task_group_is_parented() {
+        let context = RuntimeContext::from_current("moment-stats-set-parent-test");
+        let service = context.service_context("common-stats-service");
+        let stats_set =
+            MomentStatsItemSet::new_with_task_group("ParentedName".to_string(), service.task_group().clone());
+
+        stats_set.shutdown().await;
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert!(
+            report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq-common.moment-stats-set.ParentedName"),
+            "{}",
+            report.to_json()
+        );
     }
 
     #[tokio::test]

--- a/rocketmq-common/src/utils/http_tiny_client.rs
+++ b/rocketmq-common/src/utils/http_tiny_client.rs
@@ -38,6 +38,30 @@ use crate::TimeUtils::current_millis;
 static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
 static HTTP_SYNC_RUNTIME: OnceLock<Result<RuntimeOwner, String>> = OnceLock::new();
 
+pub const HTTP_SYNC_RUNTIME_BOUNDARY: &str = "rocketmq-common.http-sync-runtime";
+pub const HTTP_SYNC_RUNTIME_COMPATIBILITY: &str = "deprecated blocking HTTP compatibility bridge";
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HttpSyncRuntimeBoundary {
+    pub name: &'static str,
+    pub compatibility: &'static str,
+    pub deprecated: bool,
+    pub rejects_tokio_context: bool,
+    pub prefers_async_api: bool,
+}
+
+#[doc(hidden)]
+pub fn http_sync_runtime_boundary() -> HttpSyncRuntimeBoundary {
+    HttpSyncRuntimeBoundary {
+        name: HTTP_SYNC_RUNTIME_BOUNDARY,
+        compatibility: HTTP_SYNC_RUNTIME_COMPATIBILITY,
+        deprecated: true,
+        rejects_tokio_context: true,
+        prefers_async_api: true,
+    }
+}
+
 fn build_http_client() -> RocketMQResult<Client> {
     Client::builder()
         .pool_idle_timeout(Duration::from_secs(90))
@@ -458,6 +482,17 @@ mod tests {
     #[test]
     fn shared_http_client_initializes_without_panicking() {
         assert!(HttpTinyClient::client().is_ok());
+    }
+
+    #[test]
+    fn http_sync_runtime_boundary_marks_blocking_bridge_deprecated() {
+        let boundary = http_sync_runtime_boundary();
+
+        assert_eq!(boundary.name, HTTP_SYNC_RUNTIME_BOUNDARY);
+        assert_eq!(boundary.compatibility, HTTP_SYNC_RUNTIME_COMPATIBILITY);
+        assert!(boundary.deprecated);
+        assert!(boundary.rejects_tokio_context);
+        assert!(boundary.prefers_async_api);
     }
 
     async fn spawn_http_server<F>(handler: F) -> String

--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -407,6 +407,7 @@ pub struct ControllerManager {
     notify_cache: Arc<RwLock<HashMap<NotifyCacheKey, NotifyCacheState>>>,
     pending_notify_state: Arc<RwLock<HashMap<NotifyCacheKey, NotifyCacheState>>>,
     notify_generation: Arc<AtomicU64>,
+    parent_task_group: Option<TaskGroup>,
 }
 
 impl ControllerManager {
@@ -427,12 +428,28 @@ impl ControllerManager {
     /// - Metadata store creation fails
     /// - Configuration is invalid
     pub async fn new(config: ControllerConfig) -> Result<Self> {
+        Self::new_with_optional_task_group(config, None).await
+    }
+
+    pub async fn new_with_task_group(config: ControllerConfig, parent_task_group: TaskGroup) -> Result<Self> {
+        Self::new_with_optional_task_group(config, Some(parent_task_group)).await
+    }
+
+    async fn new_with_optional_task_group(
+        config: ControllerConfig,
+        parent_task_group: Option<TaskGroup>,
+    ) -> Result<Self> {
         let config = ArcMut::new(config);
 
         info!("Creating controller manager with config: {:?}", config);
 
         // Initialize heartbeat manager
-        let heartbeat_manager = ArcMut::new(DefaultBrokerHeartbeatManager::new(config.clone()));
+        let heartbeat_manager = ArcMut::new(match parent_task_group.as_ref() {
+            Some(parent_task_group) => {
+                DefaultBrokerHeartbeatManager::new_with_task_group(config.clone(), parent_task_group.clone())
+            }
+            None => DefaultBrokerHeartbeatManager::new(config.clone()),
+        });
 
         // Initialize RocketMQ runtime for Raft controller
         //let runtime = Arc::new(RocketMQRuntime::new_multi(2, "controller-runtime"));
@@ -510,6 +527,7 @@ impl ControllerManager {
             notify_cache: Arc::new(RwLock::new(HashMap::new())),
             pending_notify_state: Arc::new(RwLock::new(HashMap::new())),
             notify_generation: Arc::new(AtomicU64::new(0)),
+            parent_task_group,
         })
     }
 
@@ -519,9 +537,14 @@ impl ControllerManager {
             return Ok(task_group.clone());
         }
 
-        let handle = tokio::runtime::Handle::try_current()
-            .map_err(|error| ControllerError::Internal(format!("No Tokio runtime for controller tasks: {error}")))?;
-        let task_group = TaskGroup::root("rocketmq-controller.manager", RuntimeHandle::new(handle));
+        let task_group = if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            parent_task_group.child("rocketmq-controller.manager")
+        } else {
+            let handle = tokio::runtime::Handle::try_current().map_err(|error| {
+                ControllerError::Internal(format!("No Tokio runtime for controller tasks: {error}"))
+            })?;
+            TaskGroup::root("rocketmq-controller.manager", RuntimeHandle::new(handle))
+        };
         *guard = Some(task_group.clone());
         Ok(task_group)
     }

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -103,6 +103,7 @@ pub struct OpenRaftController {
     lifecycle_listeners: Arc<RwLock<Vec<Arc<dyn BrokerLifecycleListener>>>>,
     scheduling: Arc<AtomicBool>,
     first_received_heartbeat_time: Arc<AtomicU64>,
+    parent_task_group: Option<TaskGroup>,
 }
 
 impl OpenRaftController {
@@ -111,9 +112,33 @@ impl OpenRaftController {
         Self::new_with_heartbeat(config, heartbeat_manager)
     }
 
+    pub fn new_with_task_group(config: ArcMut<ControllerConfig>, parent_task_group: TaskGroup) -> Self {
+        let heartbeat_manager = ArcMut::new(DefaultBrokerHeartbeatManager::new_with_task_group(
+            config.clone(),
+            parent_task_group.clone(),
+        ));
+        Self::new_with_heartbeat_and_task_group(config, heartbeat_manager, parent_task_group)
+    }
+
     pub fn new_with_heartbeat(
         config: ArcMut<ControllerConfig>,
         heartbeat_manager: ArcMut<DefaultBrokerHeartbeatManager>,
+    ) -> Self {
+        Self::new_with_heartbeat_and_optional_task_group(config, heartbeat_manager, None)
+    }
+
+    pub fn new_with_heartbeat_and_task_group(
+        config: ArcMut<ControllerConfig>,
+        heartbeat_manager: ArcMut<DefaultBrokerHeartbeatManager>,
+        parent_task_group: TaskGroup,
+    ) -> Self {
+        Self::new_with_heartbeat_and_optional_task_group(config, heartbeat_manager, Some(parent_task_group))
+    }
+
+    fn new_with_heartbeat_and_optional_task_group(
+        config: ArcMut<ControllerConfig>,
+        heartbeat_manager: ArcMut<DefaultBrokerHeartbeatManager>,
+        parent_task_group: Option<TaskGroup>,
     ) -> Self {
         Self {
             config,
@@ -126,6 +151,7 @@ impl OpenRaftController {
             lifecycle_listeners: Arc::new(RwLock::new(Vec::new())),
             scheduling: Arc::new(AtomicBool::new(false)),
             first_received_heartbeat_time: Arc::new(AtomicU64::new(0)),
+            parent_task_group,
         }
     }
 
@@ -135,10 +161,16 @@ impl OpenRaftController {
             return Ok(task_group.clone());
         }
 
-        let handle = tokio::runtime::Handle::try_current().map_err(|error| {
-            rocketmq_error::RocketMQError::Internal(format!("No Tokio runtime for OpenRaft controller tasks: {error}"))
-        })?;
-        let task_group = TaskGroup::root("rocketmq-controller.openraft", RuntimeHandle::new(handle));
+        let task_group = if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            parent_task_group.child("rocketmq-controller.openraft")
+        } else {
+            let handle = tokio::runtime::Handle::try_current().map_err(|error| {
+                rocketmq_error::RocketMQError::Internal(format!(
+                    "No Tokio runtime for OpenRaft controller tasks: {error}"
+                ))
+            })?;
+            TaskGroup::root("rocketmq-controller.openraft", RuntimeHandle::new(handle))
+        };
         *guard = Some(task_group.clone());
         Ok(task_group)
     }

--- a/rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs
+++ b/rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs
@@ -84,6 +84,8 @@ pub struct DefaultBrokerHeartbeatManager {
 
     /// Scan interval in milliseconds
     scan_interval_ms: u64,
+
+    parent_task_group: Option<TaskGroup>,
 }
 
 impl DefaultBrokerHeartbeatManager {
@@ -93,6 +95,14 @@ impl DefaultBrokerHeartbeatManager {
     ///
     /// * `config` - Controller configuration
     pub fn new(config: ArcMut<ControllerConfig>) -> Self {
+        Self::new_with_optional_task_group(config, None)
+    }
+
+    pub fn new_with_task_group(config: ArcMut<ControllerConfig>, parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_task_group(config, Some(parent_task_group))
+    }
+
+    fn new_with_optional_task_group(config: ArcMut<ControllerConfig>, parent_task_group: Option<TaskGroup>) -> Self {
         let scan_interval_ms = config.scan_not_active_broker_interval.max(1);
         Self {
             config,
@@ -101,6 +111,7 @@ impl DefaultBrokerHeartbeatManager {
             scan_task_group: None,
             scan_scheduled_tasks: None,
             scan_interval_ms,
+            parent_task_group,
         }
     }
 
@@ -296,21 +307,24 @@ impl BrokerHeartbeatManager for DefaultBrokerHeartbeatManager {
             return;
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                warn!(
-                    ?error,
-                    "failed to start DefaultBrokerHeartbeatManager outside Tokio runtime"
-                );
-                return;
-            }
-        };
-
         let broker_live_table = self.broker_live_table.clone();
         let listeners = Arc::new(self.lifecycle_listeners.clone());
         let scan_interval_ms = self.scan_interval_ms;
-        let task_group = TaskGroup::root("rocketmq-controller.heartbeat", runtime);
+        let task_group = if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            parent_task_group.child("rocketmq-controller.heartbeat")
+        } else {
+            let runtime = match tokio::runtime::Handle::try_current() {
+                Ok(handle) => RuntimeHandle::new(handle),
+                Err(error) => {
+                    warn!(
+                        ?error,
+                        "failed to start DefaultBrokerHeartbeatManager outside Tokio runtime"
+                    );
+                    return;
+                }
+            };
+            TaskGroup::root("rocketmq-controller.heartbeat", runtime)
+        };
         let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
         let mut config = ScheduledTaskConfig::fixed_delay(
             "controller.heartbeat.scan-not-active-broker",

--- a/rocketmq-controller/src/metadata/broker.rs
+++ b/rocketmq-controller/src/metadata/broker.rs
@@ -87,17 +87,28 @@ pub struct BrokerManager {
 
     /// Scheduled heartbeat checker task group
     scheduled_tasks: Mutex<Option<ScheduledTaskGroup>>,
+
+    parent_task_group: Option<TaskGroup>,
 }
 
 impl BrokerManager {
     /// Create a new broker manager
     pub fn new(config: ArcMut<ControllerConfig>) -> Self {
+        Self::new_with_optional_task_group(config, None)
+    }
+
+    pub fn new_with_task_group(config: ArcMut<ControllerConfig>, parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_task_group(config, Some(parent_task_group))
+    }
+
+    fn new_with_optional_task_group(config: ArcMut<ControllerConfig>, parent_task_group: Option<TaskGroup>) -> Self {
         Self {
             brokers: Arc::new(DashMap::new()),
             config,
             heartbeat_timeout: Duration::from_secs(30),
             task_group: Mutex::new(None),
             scheduled_tasks: Mutex::new(None),
+            parent_task_group,
         }
     }
 
@@ -111,14 +122,18 @@ impl BrokerManager {
             return Ok(());
         }
 
-        let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
-            ControllerError::Internal(format!(
-                "No Tokio runtime for broker manager heartbeat checker: {error}"
-            ))
-        })?;
         let brokers = self.brokers.clone();
         let timeout = self.heartbeat_timeout;
-        let task_group = TaskGroup::root("rocketmq-controller.metadata.broker", RuntimeHandle::new(runtime));
+        let task_group = if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            parent_task_group.child("rocketmq-controller.metadata.broker")
+        } else {
+            let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
+                ControllerError::Internal(format!(
+                    "No Tokio runtime for broker manager heartbeat checker: {error}"
+                ))
+            })?;
+            TaskGroup::root("rocketmq-controller.metadata.broker", RuntimeHandle::new(runtime))
+        };
         let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
         scheduled_tasks
             .schedule_fixed_delay(

--- a/rocketmq-controller/src/rpc/server.rs
+++ b/rocketmq-controller/src/rpc/server.rs
@@ -54,6 +54,8 @@ pub struct RpcServer {
 
     /// Accept and connection task group
     task_group: Arc<Mutex<Option<TaskGroup>>>,
+
+    parent_task_group: Option<TaskGroup>,
 }
 
 /// Server state
@@ -72,11 +74,28 @@ enum ServerState {
 impl RpcServer {
     /// Create a new RPC server
     pub fn new(listen_addr: SocketAddr, processor_manager: Arc<ProcessorManager>) -> Self {
+        Self::new_with_optional_task_group(listen_addr, processor_manager, None)
+    }
+
+    pub fn new_with_task_group(
+        listen_addr: SocketAddr,
+        processor_manager: Arc<ProcessorManager>,
+        parent_task_group: TaskGroup,
+    ) -> Self {
+        Self::new_with_optional_task_group(listen_addr, processor_manager, Some(parent_task_group))
+    }
+
+    fn new_with_optional_task_group(
+        listen_addr: SocketAddr,
+        processor_manager: Arc<ProcessorManager>,
+        parent_task_group: Option<TaskGroup>,
+    ) -> Self {
         Self {
             listen_addr,
             processor_manager,
             state: Arc::new(RwLock::new(ServerState::Stopped)),
             task_group: Arc::new(Mutex::new(None)),
+            parent_task_group,
         }
     }
 
@@ -101,9 +120,14 @@ impl RpcServer {
         // Clone Arc for the task
         let processor_manager = self.processor_manager.clone();
         let state = self.state.clone();
-        let runtime = tokio::runtime::Handle::try_current()
-            .map_err(|error| ControllerError::Internal(format!("No Tokio runtime for RPC server tasks: {error}")))?;
-        let task_group = TaskGroup::root("rocketmq-controller.rpc-server", RuntimeHandle::new(runtime));
+        let task_group = if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            parent_task_group.child("rocketmq-controller.rpc-server")
+        } else {
+            let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
+                ControllerError::Internal(format!("No Tokio runtime for RPC server tasks: {error}"))
+            })?;
+            TaskGroup::root("rocketmq-controller.rpc-server", RuntimeHandle::new(runtime))
+        };
         let shutdown_token = task_group.cancellation_token();
         let task_group_for_accept = task_group.clone();
 

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -35,7 +35,6 @@ use rocketmq_controller::ControllerConfig;
 use rocketmq_error::Result;
 use rocketmq_namesrv::bootstrap::Builder;
 use rocketmq_remoting::protocol::remoting_command;
-use rocketmq_rust::rocketmq;
 use serde::Deserialize;
 use tracing::error;
 use tracing::info;
@@ -49,8 +48,18 @@ const LOGO: &str = r#"
      |_|  \_\___/ \___|_|\_\___|\__|_|  |_|\___\_\      |_|  \_\__,_|___/\__| |_| \_|\__,_|_| |_| |_|\___| |_____/ \___|_|    \_/ \___|_|
     "#;
 
-#[rocketmq::main]
-async fn main() -> Result<()> {
+const ENTRYPOINT_MAX_BLOCKING_THREADS: usize = 64;
+
+fn main() -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .max_blocking_threads(ENTRYPOINT_MAX_BLOCKING_THREADS)
+        .enable_all()
+        .build()
+        .context("failed to build namesrv Tokio runtime")?;
+    runtime.block_on(run())
+}
+
+async fn run() -> Result<()> {
     // Parse command line arguments first
     let args = Args::parse();
 

--- a/rocketmq-observability/src/exporter/prometheus.rs
+++ b/rocketmq-observability/src/exporter/prometheus.rs
@@ -134,6 +134,24 @@ pub fn spawn_prometheus_http_endpoint(
     config: &ObservabilityConfig,
     registry: prometheus::Registry,
 ) -> Result<PrometheusHttpHandle, ObservabilityError> {
+    spawn_prometheus_http_endpoint_with_optional_task_group(config, registry, None)
+}
+
+#[cfg(feature = "prometheus")]
+pub fn spawn_prometheus_http_endpoint_with_task_group(
+    config: &ObservabilityConfig,
+    registry: prometheus::Registry,
+    parent_task_group: TaskGroup,
+) -> Result<PrometheusHttpHandle, ObservabilityError> {
+    spawn_prometheus_http_endpoint_with_optional_task_group(config, registry, Some(parent_task_group))
+}
+
+#[cfg(feature = "prometheus")]
+fn spawn_prometheus_http_endpoint_with_optional_task_group(
+    config: &ObservabilityConfig,
+    registry: prometheus::Registry,
+    parent_task_group: Option<TaskGroup>,
+) -> Result<PrometheusHttpHandle, ObservabilityError> {
     let path = normalize_prometheus_path(&config.prometheus.path)?;
     let listener = bind_prometheus_listener(config)?;
     let local_addr = listener
@@ -141,11 +159,15 @@ pub fn spawn_prometheus_http_endpoint(
         .map_err(|error| ObservabilityError::metrics_init(format!("read Prometheus listener address: {error}")))?;
     let listener = tokio::net::TcpListener::from_std(listener)
         .map_err(|error| ObservabilityError::metrics_init(format!("create Prometheus listener: {error}")))?;
-    let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
-        ObservabilityError::metrics_init(format!("Prometheus metrics endpoint requires a Tokio runtime: {error}"))
-    })?;
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
-    let task_group = TaskGroup::root("rocketmq.observability.prometheus", RuntimeHandle::new(runtime.clone()));
+    let task_group = if let Some(parent_task_group) = parent_task_group {
+        parent_task_group.child("rocketmq.observability.prometheus")
+    } else {
+        let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
+            ObservabilityError::metrics_init(format!("Prometheus metrics endpoint requires a Tokio runtime: {error}"))
+        })?;
+        TaskGroup::root("rocketmq.observability.prometheus", RuntimeHandle::new(runtime.clone()))
+    };
     let connection_group = task_group.child("prometheus.connection");
     task_group
         .spawn_service(
@@ -273,6 +295,7 @@ fn request_path_from_buffer(buffer: &[u8]) -> Option<&str> {
 #[cfg(all(test, feature = "prometheus"))]
 mod tests {
     use opentelemetry::metrics::MeterProvider;
+    use rocketmq_runtime::RuntimeContext;
 
     use super::*;
 
@@ -308,5 +331,35 @@ mod tests {
     fn normalizes_prometheus_path() {
         assert_eq!(normalize_prometheus_path("metrics").unwrap(), "/metrics");
         assert_eq!(normalize_prometheus_path("/metrics").unwrap(), "/metrics");
+    }
+
+    #[tokio::test]
+    async fn spawn_prometheus_http_endpoint_with_task_group_is_parented() {
+        let context = RuntimeContext::from_current("prometheus-parent-test");
+        let service = context.service_context("observability-service");
+        let mut config = ObservabilityConfig {
+            enabled: true,
+            ..ObservabilityConfig::default()
+        };
+        config.prometheus.host = "127.0.0.1".to_string();
+        config.prometheus.port = 0;
+        config.prometheus.path = "/metrics".to_string();
+        let registry = prometheus::Registry::new();
+
+        let handle = spawn_prometheus_http_endpoint_with_task_group(&config, registry, service.task_group().clone())
+            .expect("prometheus endpoint should spawn");
+        let report = handle.shutdown_gracefully(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+
+        let parent_report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(parent_report.is_healthy(), "{}", parent_report.to_json());
+        assert!(
+            parent_report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq.observability.prometheus"),
+            "{}",
+            parent_report.to_json()
+        );
     }
 }

--- a/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
+++ b/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
@@ -23,8 +23,20 @@ use rocketmq_proxy::ProxyResult;
 use rocketmq_proxy::ProxyRuntime;
 use tracing::info;
 
-#[tokio::main]
-async fn main() -> ProxyResult<()> {
+const ENTRYPOINT_MAX_BLOCKING_THREADS: usize = 64;
+
+fn main() -> ProxyResult<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .max_blocking_threads(ENTRYPOINT_MAX_BLOCKING_THREADS)
+        .enable_all()
+        .build()
+        .map_err(|error| ProxyError::Transport {
+            message: format!("failed to build proxy Tokio runtime: {error}"),
+        })?;
+    runtime.block_on(run())
+}
+
+async fn run() -> ProxyResult<()> {
     rocketmq_common::log::init_logger_with_level(rocketmq_common::log::Level::INFO)?;
 
     let args = Args::parse()?;

--- a/rocketmq-proxy/src/grpc/server.rs
+++ b/rocketmq-proxy/src/grpc/server.rs
@@ -69,6 +69,33 @@ where
     P: MessagingProcessor + 'static,
     F: Future<Output = ()> + Send + 'static,
 {
+    serve_with_report_with_optional_task_group(config, service, shutdown, None).await
+}
+
+#[doc(hidden)]
+pub async fn serve_with_report_with_task_group<P, F>(
+    config: Arc<ProxyConfig>,
+    service: ProxyGrpcService<P>,
+    shutdown: F,
+    parent_task_group: TaskGroup,
+) -> ProxyResult<ProxyGrpcServerShutdownReport>
+where
+    P: MessagingProcessor + 'static,
+    F: Future<Output = ()> + Send + 'static,
+{
+    serve_with_report_with_optional_task_group(config, service, shutdown, Some(parent_task_group)).await
+}
+
+async fn serve_with_report_with_optional_task_group<P, F>(
+    config: Arc<ProxyConfig>,
+    service: ProxyGrpcService<P>,
+    shutdown: F,
+    parent_task_group: Option<TaskGroup>,
+) -> ProxyResult<ProxyGrpcServerShutdownReport>
+where
+    P: MessagingProcessor + 'static,
+    F: Future<Output = ()> + Send + 'static,
+{
     let addr = config.grpc.socket_addr()?;
     let listener = TcpListener::bind(addr).await.map_err(|error| ProxyError::Transport {
         message: format!("proxy gRPC server failed to bind {addr}: {error}"),
@@ -80,24 +107,32 @@ where
     let shutdown_signal = shutdown_tx.clone();
     let housekeeping_service = service.clone();
     let (housekeeping_report_tx, housekeeping_report_rx) = tokio::sync::oneshot::channel();
-    let runtime = tokio::runtime::Handle::try_current().map_err(|error| ProxyError::Transport {
-        message: format!("proxy gRPC server has no Tokio runtime for housekeeping task: {error}"),
-    })?;
-    let task_group = TaskGroup::root("rocketmq-proxy.grpc-server", RuntimeHandle::new(runtime));
+    let task_group = if let Some(parent_task_group) = parent_task_group {
+        parent_task_group.child("rocketmq-proxy.grpc-server")
+    } else {
+        let runtime = tokio::runtime::Handle::try_current().map_err(|error| ProxyError::Transport {
+            message: format!("proxy gRPC server has no Tokio runtime for housekeeping task: {error}"),
+        })?;
+        TaskGroup::root("rocketmq-proxy.grpc-server", RuntimeHandle::new(runtime))
+    };
+    let housekeeping_task_group = task_group.clone();
     task_group
         .spawn_service("proxy.grpc.housekeeping", async move {
             let mut shutdown_rx = shutdown_rx;
             let report = housekeeping_service
-                .run_housekeeping_until_with_report(async move {
-                    loop {
-                        if *shutdown_rx.borrow() {
-                            break;
+                .run_housekeeping_until_with_task_group(
+                    async move {
+                        loop {
+                            if *shutdown_rx.borrow() {
+                                break;
+                            }
+                            if shutdown_rx.changed().await.is_err() {
+                                break;
+                            }
                         }
-                        if shutdown_rx.changed().await.is_err() {
-                            break;
-                        }
-                    }
-                })
+                    },
+                    housekeeping_task_group,
+                )
                 .await;
             let _ = housekeeping_report_tx.send(report);
         })
@@ -147,7 +182,6 @@ where
     })?;
     Ok(shutdown_report)
 }
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -167,6 +201,7 @@ mod tests {
     use rocketmq_auth::authorization::model::resource::Resource;
     use rocketmq_common::common::action::Action;
     use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+    use rocketmq_runtime::RuntimeContext;
     use sha1::Sha1;
     use tokio::sync::oneshot;
     use tonic::metadata::MetadataValue;
@@ -174,6 +209,7 @@ mod tests {
 
     use super::serve;
     use super::serve_with_report;
+    use super::serve_with_report_with_task_group;
     use crate::auth::ProxyAuthRuntime;
     use crate::config::GrpcConfig;
     use crate::config::ProxyAuthConfig;
@@ -298,6 +334,47 @@ mod tests {
             housekeeping.shutdown_report.is_healthy(),
             "{}",
             housekeeping.shutdown_report.to_json()
+        );
+    }
+
+    #[tokio::test]
+    async fn serve_with_report_with_task_group_parents_server_tasks() {
+        let route_service = Arc::new(RecordingRouteService::default());
+        let metadata_service = Arc::new(StaticMetadataService);
+        let manager = Arc::new(ClusterServiceManager::with_services(
+            route_service,
+            metadata_service,
+            Arc::new(DefaultAssignmentService),
+            Arc::new(DefaultMessageService),
+            Arc::new(DefaultConsumerService),
+            Arc::new(DefaultTransactionService),
+        ));
+        let processor = Arc::new(DefaultMessagingProcessor::new(manager));
+        let config = Arc::new(ProxyConfig {
+            grpc: GrpcConfig {
+                listen_addr: "127.0.0.1:0".to_string(),
+                ..GrpcConfig::default()
+            },
+            ..ProxyConfig::default()
+        });
+        let service = ProxyGrpcService::new(config.clone(), processor, ClientSessionRegistry::default());
+        let context = RuntimeContext::from_current("proxy-grpc-server-parent-test");
+        let proxy_service = context.service_context("proxy-service");
+
+        let report = serve_with_report_with_task_group(config, service, async {}, proxy_service.task_group().clone())
+            .await
+            .expect("server should return a shutdown report");
+
+        assert!(report.is_healthy(), "{report:?}");
+        let parent_report = proxy_service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(parent_report.is_healthy(), "{}", parent_report.to_json());
+        assert!(
+            parent_report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq-proxy.grpc-server"),
+            "{}",
+            parent_report.to_json()
         );
     }
 

--- a/rocketmq-proxy/src/grpc/service.rs
+++ b/rocketmq-proxy/src/grpc/service.rs
@@ -446,9 +446,40 @@ impl<P> ProxyGrpcService<P> {
         F: std::future::Future<Output = ()> + Send,
         P: MessagingProcessor + 'static,
     {
-        let task_group = TaskGroup::root(
-            "rocketmq-proxy.grpc.housekeeping",
-            RuntimeHandle::new(tokio::runtime::Handle::current()),
+        self.run_housekeeping_until_with_optional_task_group(shutdown, None)
+            .await
+    }
+
+    pub async fn run_housekeeping_until_with_task_group<F>(
+        &self,
+        shutdown: F,
+        parent_task_group: TaskGroup,
+    ) -> ProxyHousekeepingRunReport
+    where
+        F: std::future::Future<Output = ()> + Send,
+        P: MessagingProcessor + 'static,
+    {
+        self.run_housekeeping_until_with_optional_task_group(shutdown, Some(parent_task_group))
+            .await
+    }
+
+    async fn run_housekeeping_until_with_optional_task_group<F>(
+        &self,
+        shutdown: F,
+        parent_task_group: Option<TaskGroup>,
+    ) -> ProxyHousekeepingRunReport
+    where
+        F: std::future::Future<Output = ()> + Send,
+        P: MessagingProcessor + 'static,
+    {
+        let task_group = parent_task_group.map_or_else(
+            || {
+                TaskGroup::root(
+                    "rocketmq-proxy.grpc.housekeeping",
+                    RuntimeHandle::new(tokio::runtime::Handle::current()),
+                )
+            },
+            |parent_task_group| parent_task_group.child("rocketmq-proxy.grpc.housekeeping"),
         );
         let scheduled_tasks = ScheduledTaskGroup::new(task_group.child("scheduled"));
         let service = self.clone();

--- a/rocketmq-remoting/src/clients/client.rs
+++ b/rocketmq-remoting/src/clients/client.rs
@@ -118,6 +118,7 @@ where
         cmd_handler: ArcMut<RemotingGeneralHandler<PR>>,
         tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
         notify: broadcast::Receiver<()>,
+        send_notify: broadcast::Receiver<()>,
         tls_config: TlsConfig,
         task_group: TaskGroup,
     ) -> RocketMQResult<(tokio::sync::mpsc::Sender<SendMessage>, ArcMut<ClientInner<PR>>)> {
@@ -166,7 +167,7 @@ where
         }
         let mut client_ = client_inner.clone();
         if let Err(error) = task_group.spawn_service("remoting.client.connection.send", async move {
-            client_.run_send(rx).await;
+            client_.run_send(rx, Shutdown::new(send_notify)).await;
         }) {
             let _ = task_group.shutdown(Duration::from_secs(1)).await;
             return Err(remote_error(format!(
@@ -205,9 +206,17 @@ where
         }
     }
 
-    async fn run_send(&mut self, mut rx: Receiver<SendMessage>) {
-        while let Some((request, tx, timeout)) = rx.recv().await {
-            let _ = self.send(request, tx, timeout).await;
+    async fn run_send(&mut self, mut rx: Receiver<SendMessage>, mut shutdown: Shutdown) {
+        loop {
+            tokio::select! {
+                _ = shutdown.recv() => break,
+                maybe_message = rx.recv() => {
+                    let Some((request, tx, timeout)) = maybe_message else {
+                        break;
+                    };
+                    let _ = self.send(request, tx, timeout).await;
+                }
+            }
         }
     }
 
@@ -283,10 +292,12 @@ where
     ) -> RocketMQResult<Client<PR>> {
         let (notify_shutdown, _) = broadcast::channel(1);
         let receiver = notify_shutdown.subscribe();
+        let send_receiver = notify_shutdown.subscribe();
         let task_lifecycle = Arc::new(ClientTaskLifecycle {
             task_group: task_group.clone(),
         });
-        let (tx, inner) = ClientInner::connect(addr, cmd_handler, tx, receiver, tls_config, task_group).await?;
+        let (tx, inner) =
+            ClientInner::connect(addr, cmd_handler, tx, receiver, send_receiver, tls_config, task_group).await?;
         Ok(Client {
             inner,
             notify_shutdown,
@@ -463,6 +474,14 @@ where
         Ok(results)
     }
 
+    /// Gracefully stop this client connection and return the task shutdown report.
+    pub async fn close_with_report(&self, timeout: Duration) -> rocketmq_runtime::ShutdownReport {
+        let _ = self.notify_shutdown.send(());
+        let report = self.task_lifecycle.task_group.shutdown(timeout).await;
+        report.log_if_unhealthy();
+        report
+    }
+
     /// Reads and retrieves the response from the remote remoting_server.
     ///
     /// # Returns
@@ -570,6 +589,33 @@ mod lifecycle_tests {
         drop(client);
 
         assert!(task_group.cancellation_token().is_cancelled());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn close_with_report_stops_connection_tasks() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.expect("accept client");
+            time::sleep(Duration::from_secs(5)).await;
+        });
+        let cmd_handler = ArcMut::new(RemotingGeneralHandler {
+            request_processor: DefaultRemotingRequestProcessor,
+            rpc_hooks: vec![],
+            response_table: ArcMut::new(HashMap::new()),
+        });
+
+        let client = Client::connect(addr.to_string(), cmd_handler, None, TlsConfig::default())
+            .await
+            .expect("connect client");
+        let task_group = client.task_lifecycle.task_group.clone();
+
+        assert_eq!(task_group.task_count(), 2);
+        let report = client.close_with_report(Duration::from_secs(1)).await;
+
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert_eq!(report.completed + report.cancelled, 2);
         server.abort();
     }
 

--- a/rocketmq-remoting/src/clients/connection_pool.rs
+++ b/rocketmq-remoting/src/clients/connection_pool.rs
@@ -445,6 +445,11 @@ impl<PR> ConnectionPool<PR> {
         })
     }
 
+    /// Clear all pooled connection references.
+    pub fn clear(&self) {
+        self.connections.clear();
+    }
+
     /// Get connection metrics.
     ///
     /// # Returns

--- a/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
@@ -23,6 +23,8 @@ use dashmap::DashMap;
 use parking_lot::Mutex;
 use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::RuntimeResult;
+use rocketmq_runtime::ServiceContext;
+use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskGroupLifecycleState;
 use rocketmq_runtime::TaskId;
@@ -183,6 +185,9 @@ pub struct RocketmqDefaultClient<PR = DefaultRemotingRequestProcessor> {
     /// Task group that owns short-lived client worker tasks.
     worker_task_group: Arc<Mutex<Option<TaskGroup>>>,
 
+    /// Optional parent service context for structured client task ownership.
+    service_context: Option<ServiceContext>,
+
     /// Shared command handler (processor + response table)
     ///
     /// Arc-wrapped to share across all `Client` instances
@@ -192,6 +197,27 @@ pub struct RocketmqDefaultClient<PR = DefaultRemotingRequestProcessor> {
     ///
     /// Used for monitoring and metrics collection
     tx: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RemotingClientConnectionShutdownReport {
+    pub addr: CheetahString,
+    pub report: ShutdownReport,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RemotingClientShutdownReport {
+    pub background: Option<ShutdownReport>,
+    pub workers: Option<ShutdownReport>,
+    pub connections: Vec<RemotingClientConnectionShutdownReport>,
+}
+
+impl RemotingClientShutdownReport {
+    pub fn is_healthy(&self) -> bool {
+        self.background.as_ref().is_none_or(ShutdownReport::is_healthy)
+            && self.workers.as_ref().is_none_or(ShutdownReport::is_healthy)
+            && self.connections.iter().all(|connection| connection.report.is_healthy())
+    }
 }
 
 impl<PR> Clone for RocketmqDefaultClient<PR> {
@@ -208,6 +234,7 @@ impl<PR> Clone for RocketmqDefaultClient<PR> {
             shutdown_token: self.shutdown_token.clone(),
             background_task_group: self.background_task_group.clone(),
             worker_task_group: self.worker_task_group.clone(),
+            service_context: self.service_context.clone(),
             cmd_handler: self.cmd_handler.clone(),
             tx: self.tx.clone(),
         }
@@ -219,10 +246,36 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
         Self::new_with_cl(tokio_client_config, processor, None)
     }
 
+    pub fn new_with_service_context(
+        tokio_client_config: Arc<TokioClientConfig>,
+        processor: PR,
+        service_context: ServiceContext,
+    ) -> Self {
+        Self::new_with_cl_and_optional_service_context(tokio_client_config, processor, None, Some(service_context))
+    }
+
     pub fn new_with_cl(
         tokio_client_config: Arc<TokioClientConfig>,
         processor: PR,
         tx: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
+    ) -> Self {
+        Self::new_with_cl_and_optional_service_context(tokio_client_config, processor, tx, None)
+    }
+
+    pub fn new_with_cl_and_service_context(
+        tokio_client_config: Arc<TokioClientConfig>,
+        processor: PR,
+        tx: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
+        service_context: ServiceContext,
+    ) -> Self {
+        Self::new_with_cl_and_optional_service_context(tokio_client_config, processor, tx, Some(service_context))
+    }
+
+    fn new_with_cl_and_optional_service_context(
+        tokio_client_config: Arc<TokioClientConfig>,
+        processor: PR,
+        tx: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
+        service_context: Option<ServiceContext>,
     ) -> Self {
         let handler = RemotingGeneralHandler {
             request_processor: processor,
@@ -241,6 +294,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
             shutdown_token: CancellationToken::new(),
             background_task_group: Arc::new(Mutex::new(None)),
             worker_task_group: Arc::new(Mutex::new(None)),
+            service_context,
             cmd_handler: ArcMut::new(handler),
             tx,
         }
@@ -319,17 +373,21 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
             }
         }
 
-        let runtime = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => RuntimeHandle::new(handle),
-            Err(error) => {
-                error!(
-                    ?error,
-                    "failed to create RemotingClient worker task group outside Tokio runtime"
-                );
-                return None;
-            }
+        let task_group = if let Some(service_context) = self.service_context.as_ref() {
+            service_context.task_group().child("rocketmq-remoting.client.workers")
+        } else {
+            let runtime = match tokio::runtime::Handle::try_current() {
+                Ok(handle) => RuntimeHandle::new(handle),
+                Err(error) => {
+                    error!(
+                        ?error,
+                        "failed to create RemotingClient worker task group outside Tokio runtime"
+                    );
+                    return None;
+                }
+            };
+            TaskGroup::root("rocketmq-remoting.client.workers", runtime)
         };
-        let task_group = TaskGroup::root("rocketmq-remoting.client.workers", runtime);
         *task_group_guard = Some(task_group.clone());
         Some(task_group)
     }
@@ -402,7 +460,10 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
         cleanup_interval: Duration,
     ) -> ConnectionPoolCleanupTask {
         let pool = ConnectionPool::new(max_connections, max_idle_duration);
-        let cleanup_task = pool.start_cleanup_task(cleanup_interval);
+        let cleanup_task = match self.service_context.as_ref() {
+            Some(service_context) => pool.start_cleanup_task_with_service_context(service_context, cleanup_interval),
+            None => pool.start_cleanup_task(cleanup_interval),
+        };
         self.connection_pool = Some(pool);
         info!(
             "Connection pool enabled: max={}, idle_timeout={:?}, cleanup_interval={:?}",
@@ -419,7 +480,12 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
         cleanup_interval: Duration,
     ) -> RuntimeResult<ConnectionPoolCleanupTask> {
         let pool = ConnectionPool::new(max_connections, max_idle_duration);
-        let cleanup_task = pool.try_start_cleanup_task(cleanup_interval)?;
+        let cleanup_task = match self.service_context.as_ref() {
+            Some(service_context) => {
+                pool.try_start_cleanup_task_with_service_context(service_context, cleanup_interval)?
+            }
+            None => pool.try_start_cleanup_task(cleanup_interval)?,
+        };
         self.connection_pool = Some(pool);
         info!(
             "Connection pool enabled: max={}, idle_timeout={:?}, cleanup_interval={:?}",
@@ -654,8 +720,20 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
         let mut tls_config = self.tokio_client_config.tls_config.clone();
         tls_config.enable = self.tokio_client_config.use_tls;
 
-        let connect_result = time::timeout(duration, async {
-            Client::connect(addr_inner, self.cmd_handler.clone(), self.tx.as_ref(), tls_config).await
+        let service_context = self.service_context.clone();
+        let connect_result = time::timeout(duration, async move {
+            if let Some(service_context) = service_context.as_ref() {
+                Client::connect_with_service_context(
+                    service_context,
+                    addr_inner,
+                    self.cmd_handler.clone(),
+                    self.tx.as_ref(),
+                    tls_config,
+                )
+                .await
+            } else {
+                Client::connect(addr_inner, self.cmd_handler.clone(), self.tx.as_ref(), tls_config).await
+            }
         })
         .await;
 
@@ -909,22 +987,55 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RocketmqDefaultClient<PR> {
             }
         }
     }
+
+    pub async fn shutdown_with_report(&mut self, timeout: Duration) -> RemotingClientShutdownReport {
+        self.shutdown_token.cancel();
+
+        let background_task_group = { self.background_task_group.lock().take() };
+        let worker_task_group = { self.worker_task_group.lock().take() };
+
+        let background = match background_task_group {
+            Some(task_group) => Some(task_group.shutdown(timeout).await),
+            None => None,
+        };
+        let workers = match worker_task_group {
+            Some(task_group) => Some(task_group.shutdown(timeout).await),
+            None => None,
+        };
+
+        if let Some(pool) = self.connection_pool.take() {
+            pool.clear();
+        }
+
+        let addrs: Vec<_> = self.connection_tables.iter().map(|entry| entry.key().clone()).collect();
+        let mut clients = Vec::with_capacity(addrs.len());
+        for addr in addrs {
+            if let Some((addr, client)) = self.connection_tables.remove(&addr) {
+                clients.push((addr, client));
+            }
+        }
+
+        let mut connections = Vec::with_capacity(clients.len());
+        for (addr, client) in clients {
+            let report = client.close_with_report(timeout).await;
+            connections.push(RemotingClientConnectionShutdownReport { addr, report });
+        }
+
+        self.namesrv_addr_list.clear();
+        self.available_namesrv_addr_set.clear();
+
+        RemotingClientShutdownReport {
+            background,
+            workers,
+            connections,
+        }
+    }
 }
 
 #[allow(unused_variables)]
 impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingService for RocketmqDefaultClient<PR> {
     async fn start(&self, this: WeakArcMut<Self>) {
         if let Some(client) = this.upgrade() {
-            let runtime = match tokio::runtime::Handle::try_current() {
-                Ok(handle) => RuntimeHandle::new(handle),
-                Err(error) => {
-                    error!(
-                        ?error,
-                        "failed to start RemotingClient background tasks outside Tokio runtime"
-                    );
-                    return;
-                }
-            };
             let task_group = {
                 let mut task_group_guard = self.background_task_group.lock();
                 if let Some(task_group) = task_group_guard.as_ref() {
@@ -934,7 +1045,21 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingService for Rocketmq
                     }
                 }
 
-                let task_group = TaskGroup::root("rocketmq-remoting.client", runtime);
+                let task_group = if let Some(service_context) = self.service_context.as_ref() {
+                    service_context.task_group().child("rocketmq-remoting.client")
+                } else {
+                    let runtime = match tokio::runtime::Handle::try_current() {
+                        Ok(handle) => RuntimeHandle::new(handle),
+                        Err(error) => {
+                            error!(
+                                ?error,
+                                "failed to start RemotingClient background tasks outside Tokio runtime"
+                            );
+                            return;
+                        }
+                    };
+                    TaskGroup::root("rocketmq-remoting.client", runtime)
+                };
                 *task_group_guard = Some(task_group.clone());
                 task_group
             };
@@ -996,6 +1121,9 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> RemotingService for Rocketmq
                     "RemotingClient worker task shutdown report is unhealthy"
                 );
             }
+        }
+        if let Some(pool) = self.connection_pool.take() {
+            pool.clear();
         }
         self.connection_tables.clear();
         self.namesrv_addr_list.clear();
@@ -1312,6 +1440,7 @@ mod tests {
     use std::sync::Arc;
 
     use rocketmq_error::RocketMQResult;
+    use rocketmq_runtime::RuntimeContext;
     use tokio::net::TcpListener;
 
     use super::*;
@@ -1391,6 +1520,48 @@ mod tests {
         client.mut_from_ref().shutdown();
 
         assert_eq!(task_group.lifecycle_state(), TaskGroupLifecycleState::ShutdownCompleted);
+    }
+
+    #[tokio::test]
+    async fn service_context_parents_background_and_worker_tasks() {
+        let context = RuntimeContext::from_current("remoting-default-client-parent-test");
+        let service = context.service_context("remoting-client-service");
+        let config = TokioClientConfig {
+            connect_timeout_millis: 10,
+            channel_not_active_interval: 10,
+            ..Default::default()
+        };
+        let client = ArcMut::new(RocketmqDefaultClient::new_with_service_context(
+            Arc::new(config),
+            DefaultRemotingRequestProcessor,
+            service.clone(),
+        ));
+        let weak_client = ArcMut::downgrade(&client);
+
+        client.start(weak_client).await;
+        client
+            .spawn_worker_task("remoting.client.parent-test-worker", async {})
+            .expect("worker task should spawn");
+
+        let background_task_group = client
+            .background_task_group
+            .lock()
+            .as_ref()
+            .cloned()
+            .expect("background task group");
+        let worker_task_group = client
+            .worker_task_group
+            .lock()
+            .as_ref()
+            .cloned()
+            .expect("worker task group");
+
+        assert_eq!(background_task_group.parent_id(), Some(service.task_group().id()));
+        assert_eq!(worker_task_group.parent_id(), Some(service.task_group().id()));
+
+        client.mut_from_ref().shutdown();
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
     }
 
     #[tokio::test]
@@ -1499,5 +1670,33 @@ mod tests {
             worker_task_group.lifecycle_state(),
             TaskGroupLifecycleState::ShutdownCompleted
         );
+    }
+
+    #[tokio::test]
+    async fn shutdown_with_report_closes_connection_table_clients() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.expect("accept client");
+            time::sleep(Duration::from_secs(5)).await;
+        });
+        let mut client =
+            RocketmqDefaultClient::new(Arc::new(TokioClientConfig::default()), DefaultRemotingRequestProcessor);
+
+        let target = CheetahString::from_string(addr.to_string());
+        let created = client
+            .create_client(&target, Duration::from_secs(3))
+            .await
+            .expect("client connection should be created");
+        drop(created);
+        assert_eq!(client.connection_tables.len(), 1);
+
+        let report = client.shutdown_with_report(Duration::from_secs(1)).await;
+
+        assert!(report.is_healthy(), "{report:?}");
+        assert_eq!(report.connections.len(), 1);
+        assert_eq!(report.connections[0].addr, target);
+        assert!(client.connection_tables.is_empty());
+        server.abort();
     }
 }

--- a/rocketmq-runtime/src/diagnostics.rs
+++ b/rocketmq-runtime/src/diagnostics.rs
@@ -22,6 +22,8 @@ use crate::blocking::BlockingExecutor;
 use crate::blocking::BlockingExecutorSnapshot;
 use crate::handle::RuntimeHandle;
 use crate::task_group::TaskGroup;
+use crate::task_group::TaskGroupId;
+use crate::task_group::TaskGroupLifecycleState;
 
 static NEXT_RUNTIME_DIAGNOSTICS_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -35,6 +37,11 @@ pub struct RuntimeDiagnostics {
 pub struct RuntimeDiagnosticsSnapshot {
     pub runtime_id: String,
     pub root_name: String,
+    pub group_id: TaskGroupId,
+    pub parent_group_id: Option<TaskGroupId>,
+    pub lifecycle_state: TaskGroupLifecycleState,
+    pub task_count: usize,
+    pub child_count: usize,
     pub blocking: BlockingExecutorSnapshot,
 }
 
@@ -59,6 +66,11 @@ impl RuntimeDiagnostics {
         RuntimeDiagnosticsSnapshot {
             runtime_id: self.runtime_id.to_string(),
             root_name: root.name().to_string(),
+            group_id: root.id(),
+            parent_group_id: root.parent_id(),
+            lifecycle_state: root.lifecycle_state(),
+            task_count: root.task_count(),
+            child_count: root.child_count(),
             blocking: blocking.snapshot(),
         }
     }

--- a/rocketmq-runtime/src/legacy.rs
+++ b/rocketmq-runtime/src/legacy.rs
@@ -22,10 +22,12 @@ use std::time::Duration;
 /// Tokio runtime. `RocketMQRuntime` remains available for older synchronous
 /// builder and scheduler APIs while those call sites are migrated behind
 /// explicit compatibility adapters.
+#[deprecated(note = "use RuntimeOwner, RuntimeContext, or ServiceContext instead")]
 pub enum RocketMQRuntime {
     Multi(tokio::runtime::Runtime),
 }
 
+#[allow(deprecated)]
 impl RocketMQRuntime {
     #[inline]
     pub fn new_multi(threads: usize, name: &str) -> Self {

--- a/rocketmq-runtime/src/lib.rs
+++ b/rocketmq-runtime/src/lib.rs
@@ -39,6 +39,7 @@ pub use diagnostics::RuntimeDiagnosticsSnapshot;
 pub use error::RuntimeError;
 pub use error::RuntimeResult;
 pub use handle::RuntimeHandle;
+#[allow(deprecated)]
 pub use legacy::RocketMQRuntime;
 pub use owner::RuntimeOwner;
 pub use scheduled::ScheduleMode;

--- a/rocketmq-runtime/src/task_group.rs
+++ b/rocketmq-runtime/src/task_group.rs
@@ -238,6 +238,10 @@ impl TaskGroup {
         self.inner.tasks.len()
     }
 
+    pub fn child_count(&self) -> usize {
+        self.inner.children.lock().len()
+    }
+
     pub fn contains_task(&self, task_id: TaskId) -> bool {
         self.inner.tasks.contains_key(&task_id)
     }

--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -1,3 +1,5 @@
+use std::fs;
+use std::path::Path;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -29,6 +31,48 @@ impl Drop for DropCounter {
     }
 }
 
+#[test]
+fn production_tokio_entrypoints_set_max_blocking_threads() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("runtime crate should be inside the workspace");
+    let entrypoints = [
+        "rocketmq-broker/src/bin/broker_bootstrap_server.rs",
+        "rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs",
+        "rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs",
+        "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs",
+    ];
+
+    for entrypoint in entrypoints {
+        let source = fs::read_to_string(workspace_root.join(entrypoint))
+            .unwrap_or_else(|error| panic!("failed to read {entrypoint}: {error}"));
+        assert!(
+            source.contains("tokio::runtime::Builder::new_multi_thread()"),
+            "{entrypoint} must build its Tokio runtime explicitly"
+        );
+        assert!(
+            source.contains(".max_blocking_threads(ENTRYPOINT_MAX_BLOCKING_THREADS)"),
+            "{entrypoint} must set max_blocking_threads explicitly"
+        );
+    }
+}
+
+#[test]
+fn legacy_rocketmq_runtime_is_marked_deprecated() {
+    let legacy_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/legacy.rs");
+    let source = fs::read_to_string(&legacy_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", legacy_path.display()));
+    let enum_position = source
+        .find("pub enum RocketMQRuntime")
+        .expect("legacy runtime enum should exist");
+    let prefix = &source[..enum_position];
+
+    assert!(
+        prefix.contains("#[deprecated"),
+        "RocketMQRuntime must remain marked deprecated"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn diagnostics_snapshot_reports_runtime_state() {
     let context = RuntimeContext::from_current("diagnostics-root");
@@ -37,8 +81,11 @@ async fn diagnostics_snapshot_reports_runtime_state() {
 
     assert_eq!(scheduled.group().name(), "diagnostics-scheduled");
 
+    let service_token = service.task_group().cancellation_token();
     service
-        .spawn_service("diagnostics-service-task", async move {})
+        .spawn_service("diagnostics-service-task", async move {
+            service_token.cancelled().await;
+        })
         .expect("diagnostics service task should spawn");
     context
         .blocking()
@@ -55,6 +102,16 @@ async fn diagnostics_snapshot_reports_runtime_state() {
     assert_eq!(context_snapshot.runtime_id, service_snapshot.runtime_id);
     assert_eq!(context_snapshot.root_name, "diagnostics-root");
     assert_eq!(service_snapshot.root_name, "diagnostics-service");
+    assert_eq!(context_snapshot.group_id, context.root_group().id());
+    assert_eq!(context_snapshot.parent_group_id, None);
+    assert_eq!(context_snapshot.lifecycle_state, TaskGroupLifecycleState::Open);
+    assert_eq!(context_snapshot.task_count, 0);
+    assert!(context_snapshot.child_count >= 2, "{context_snapshot:?}");
+    assert_eq!(service_snapshot.group_id, service.task_group().id());
+    assert_eq!(service_snapshot.parent_group_id, Some(context.root_group().id()));
+    assert_eq!(service_snapshot.lifecycle_state, TaskGroupLifecycleState::Open);
+    assert_eq!(service_snapshot.task_count, 1);
+    assert_eq!(service_snapshot.child_count, 1);
     assert_eq!(context_snapshot.blocking.name, "rocketmq-blocking");
     assert_eq!(
         context_snapshot.blocking.max_concurrency,

--- a/rocketmq-store/src/stats/broker_stats_manager.rs
+++ b/rocketmq-store/src/stats/broker_stats_manager.rs
@@ -1444,7 +1444,7 @@ mod tests {
     #[tokio::test]
     async fn test_start_with_scheduler() {
         let broker_config = Arc::new(BrokerConfig::default());
-        let scheduler = Arc::new(ScheduledTaskManager::new());
+        let scheduler = Arc::new(ScheduledTaskManager::new_legacy_compatibility());
         let manager = BrokerStatsManager::new_with_scheduler(broker_config, Some(scheduler.clone()));
 
         manager.start();
@@ -1455,7 +1455,7 @@ mod tests {
     #[tokio::test]
     async fn test_shutdown_cancels_tasks() {
         let broker_config = Arc::new(BrokerConfig::default());
-        let scheduler = Arc::new(ScheduledTaskManager::new());
+        let scheduler = Arc::new(ScheduledTaskManager::new_legacy_compatibility());
         let manager = BrokerStatsManager::new_with_scheduler(broker_config, Some(scheduler.clone()));
 
         manager.start();

--- a/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs
+++ b/rocketmq-tieredstore/src/dispatcher/tiered_dispatcher.rs
@@ -20,6 +20,7 @@ use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use rocketmq_runtime::ShutdownReport;
+use rocketmq_runtime::TaskGroup;
 
 use crate::config::TieredStoreConfig;
 use crate::dispatcher::TieredDispatchRequest;
@@ -49,6 +50,7 @@ where
     permits: Arc<Semaphore>,
     shutdown: CancellationToken,
     task_group: tokio::sync::Mutex<Option<rocketmq_runtime::TaskGroup>>,
+    parent_task_group: Option<TaskGroup>,
     task_error: Arc<tokio::sync::Mutex<Option<String>>>,
     metrics: Arc<TieredStoreMetrics>,
 }
@@ -62,11 +64,30 @@ where
         flat_file_store: Arc<TieredFlatFileStore<P>>,
         shutdown: CancellationToken,
     ) -> Self {
-        Self::new_with_metrics(
+        Self::new_with_optional_task_group(config, flat_file_store, shutdown, None)
+    }
+
+    pub fn new_with_task_group(
+        config: Arc<TieredStoreConfig>,
+        flat_file_store: Arc<TieredFlatFileStore<P>>,
+        shutdown: CancellationToken,
+        parent_task_group: TaskGroup,
+    ) -> Self {
+        Self::new_with_optional_task_group(config, flat_file_store, shutdown, Some(parent_task_group))
+    }
+
+    fn new_with_optional_task_group(
+        config: Arc<TieredStoreConfig>,
+        flat_file_store: Arc<TieredFlatFileStore<P>>,
+        shutdown: CancellationToken,
+        parent_task_group: Option<TaskGroup>,
+    ) -> Self {
+        Self::new_with_optional_metrics(
             config,
             flat_file_store,
             shutdown,
             Arc::new(TieredStoreMetrics::default()),
+            parent_task_group,
         )
     }
 
@@ -75,6 +96,26 @@ where
         flat_file_store: Arc<TieredFlatFileStore<P>>,
         shutdown: CancellationToken,
         metrics: Arc<TieredStoreMetrics>,
+    ) -> Self {
+        Self::new_with_optional_metrics(config, flat_file_store, shutdown, metrics, None)
+    }
+
+    pub fn new_with_metrics_and_task_group(
+        config: Arc<TieredStoreConfig>,
+        flat_file_store: Arc<TieredFlatFileStore<P>>,
+        shutdown: CancellationToken,
+        metrics: Arc<TieredStoreMetrics>,
+        parent_task_group: TaskGroup,
+    ) -> Self {
+        Self::new_with_optional_metrics(config, flat_file_store, shutdown, metrics, Some(parent_task_group))
+    }
+
+    fn new_with_optional_metrics(
+        config: Arc<TieredStoreConfig>,
+        flat_file_store: Arc<TieredFlatFileStore<P>>,
+        shutdown: CancellationToken,
+        metrics: Arc<TieredStoreMetrics>,
+        parent_task_group: Option<TaskGroup>,
     ) -> Self {
         let (sender, receiver) = mpsc::channel(config.max_pending_tasks);
         let permits = Arc::new(Semaphore::new((config.max_pending_tasks / 4).max(1)));
@@ -86,6 +127,7 @@ where
             permits,
             shutdown,
             task_group: tokio::sync::Mutex::new(None),
+            parent_task_group,
             task_error: Arc::new(tokio::sync::Mutex::new(None)),
             metrics,
         }
@@ -241,7 +283,12 @@ where
         let Some(receiver) = receiver_guard.take() else {
             return Ok(());
         };
-        let task_group = runtime::task_group("rocketmq-tieredstore.dispatcher")?;
+        let task_group = match self.parent_task_group.as_ref() {
+            Some(parent_task_group) => {
+                runtime::task_group_with_parent("rocketmq-tieredstore.dispatcher", parent_task_group)
+            }
+            None => runtime::task_group("rocketmq-tieredstore.dispatcher")?,
+        };
         let task_error = self.task_error.clone();
         let flat_file_store = self.flat_file_store.clone();
         let permits = self.permits.clone();
@@ -267,9 +314,11 @@ where
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use bytes::Bytes;
     use rocketmq_error::RocketMQError;
+    use rocketmq_runtime::RuntimeContext;
     use tokio_util::sync::CancellationToken;
 
     use super::*;
@@ -328,6 +377,45 @@ mod tests {
             flat_file.read_message_by_queue_offset(3).await?,
             Some(Bytes::from_static(b"body"))
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_with_task_group_parents_dispatcher_task() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            max_pending_tasks: 4,
+            ..TieredStoreConfig::default()
+        });
+        let flat_file_store = Arc::new(TieredFlatFileStore::new(
+            config.clone(),
+            Arc::new(JsonMetadataStore::new(config.clone())),
+            MemoryProvider::default(),
+        ));
+        let context = RuntimeContext::from_current("tieredstore-dispatcher-parent-test");
+        let service = context.service_context("tieredstore-dispatcher");
+        let dispatcher = DefaultTieredDispatcher::new_with_task_group(
+            config,
+            flat_file_store,
+            CancellationToken::new(),
+            service.task_group().clone(),
+        );
+
+        dispatcher.start().await?;
+        dispatcher.shutdown().await?;
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(
+            report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq-tieredstore.dispatcher"),
+            "{}",
+            report.to_json()
+        );
+        assert!(report.is_healthy(), "{}", report.to_json());
         Ok(())
     }
 }

--- a/rocketmq-tieredstore/src/runtime.rs
+++ b/rocketmq-tieredstore/src/runtime.rs
@@ -23,8 +23,31 @@ pub(crate) fn task_group(name: &'static str) -> Result<TaskGroup, RocketMQError>
     Ok(TaskGroup::root(name, RuntimeHandle::new(handle)))
 }
 
+pub(crate) fn task_group_with_parent(name: &'static str, parent_task_group: &TaskGroup) -> TaskGroup {
+    parent_task_group.child(name)
+}
+
 pub(crate) fn shutdown_report_result(component: &'static str, report: ShutdownReport) -> Result<(), RocketMQError> {
     report
         .assert_no_task_leak()
         .map_err(|error| RocketMQError::Internal(format!("{component} shutdown failed: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_runtime::RuntimeContext;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn task_group_with_parent_creates_child_group() {
+        let context = RuntimeContext::from_current("tieredstore-runtime-parent-test");
+        let service = context.service_context("tieredstore-service");
+
+        let task_group = task_group_with_parent("rocketmq-tieredstore.test", service.task_group());
+
+        assert_eq!(task_group.parent_id(), Some(service.task_group().id()));
+        let report = service.task_group().shutdown(std::time::Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
 }

--- a/rocketmq-tieredstore/src/service.rs
+++ b/rocketmq-tieredstore/src/service.rs
@@ -21,6 +21,7 @@ use rocketmq_error::RocketMQError;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
 use rocketmq_runtime::ShutdownReport;
+use rocketmq_runtime::TaskGroup;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::TieredStoreConfig;
@@ -39,6 +40,7 @@ where
     cleanup_schedule: tokio::sync::Mutex<Option<ScheduledTaskGroup>>,
     cleanup_shutdown: tokio::sync::Mutex<Option<CancellationToken>>,
     cleanup_error: Arc<tokio::sync::Mutex<Option<String>>>,
+    parent_task_group: Option<TaskGroup>,
     _marker: std::marker::PhantomData<P>,
 }
 
@@ -47,11 +49,20 @@ where
     P: TieredStoreProvider,
 {
     pub fn new() -> Self {
+        Self::new_with_optional_task_group(None)
+    }
+
+    pub fn new_with_task_group(parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_task_group(Some(parent_task_group))
+    }
+
+    fn new_with_optional_task_group(parent_task_group: Option<TaskGroup>) -> Self {
         Self {
             cleanup_group: tokio::sync::Mutex::new(None),
             cleanup_schedule: tokio::sync::Mutex::new(None),
             cleanup_shutdown: tokio::sync::Mutex::new(None),
             cleanup_error: Arc::new(tokio::sync::Mutex::new(None)),
+            parent_task_group,
             _marker: std::marker::PhantomData,
         }
     }
@@ -70,7 +81,12 @@ where
         }
         let service = CleanupService::new(config, flat_file_store, shutdown);
         let cleanup_shutdown = service.shutdown_token();
-        let task_group = runtime::task_group("rocketmq-tieredstore.cleanup")?;
+        let task_group = match self.parent_task_group.as_ref() {
+            Some(parent_task_group) => {
+                runtime::task_group_with_parent("rocketmq-tieredstore.cleanup", parent_task_group)
+            }
+            None => runtime::task_group("rocketmq-tieredstore.cleanup")?,
+        };
         let scheduled_tasks = service.schedule(&task_group, self.cleanup_error.clone())?;
         *self.cleanup_shutdown.lock().await = Some(cleanup_shutdown);
         *self.cleanup_schedule.lock().await = Some(scheduled_tasks);
@@ -134,5 +150,54 @@ where
 {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use rocketmq_error::RocketMQError;
+    use rocketmq_runtime::RuntimeContext;
+
+    use super::*;
+    use crate::metadata::JsonMetadataStore;
+    use crate::provider::MemoryProvider;
+
+    #[tokio::test]
+    async fn new_with_task_group_parents_cleanup_tasks() -> Result<(), RocketMQError> {
+        let temp_dir = tempfile::tempdir().map_err(|err| RocketMQError::Internal(err.to_string()))?;
+        let config = Arc::new(TieredStoreConfig {
+            store_path_root_dir: temp_dir.path().to_path_buf(),
+            backend_provider: "memory".to_owned(),
+            delete_file_interval: Duration::from_millis(100),
+            ..TieredStoreConfig::default()
+        });
+        let flat_file_store = Arc::new(TieredFlatFileStore::new(
+            config.clone(),
+            Arc::new(JsonMetadataStore::new(config.clone())),
+            MemoryProvider::default(),
+        ));
+        let context = RuntimeContext::from_current("tieredstore-cleanup-parent-test");
+        let service = context.service_context("tieredstore-cleanup");
+        let services = TieredServiceSet::<MemoryProvider>::new_with_task_group(service.task_group().clone());
+
+        services
+            .start_cleanup(config, flat_file_store, CancellationToken::new())
+            .await?;
+        services.shutdown().await?;
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(
+            report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq-tieredstore.cleanup"),
+            "{}",
+            report.to_json()
+        );
+        assert!(report.is_healthy(), "{}", report.to_json());
+        Ok(())
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs
@@ -21,12 +21,19 @@ mod state;
 mod ui;
 mod view_model;
 
-use rocketmq_rust::rocketmq;
-
 use crate::rocketmq_tui_app::RocketmqTuiApp;
 
-#[rocketmq::main]
-async fn main() -> anyhow::Result<()> {
+const ENTRYPOINT_MAX_BLOCKING_THREADS: usize = 64;
+
+fn main() -> anyhow::Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .max_blocking_threads(ENTRYPOINT_MAX_BLOCKING_THREADS)
+        .enable_all()
+        .build()?;
+    runtime.block_on(run())
+}
+
+async fn run() -> anyhow::Result<()> {
     let terminal = ratatui::try_init()?;
     let local = tokio::task::LocalSet::new();
     let result = local.run_until(RocketmqTuiApp::default().run(terminal)).await;

--- a/rocketmq/benches/scheduler_lifecycle_bench.rs
+++ b/rocketmq/benches/scheduler_lifecycle_bench.rs
@@ -200,7 +200,7 @@ fn run_scheduled_task_manager_probe(task_count: usize) -> ScheduledTaskManagerPr
         .expect("scheduled task manager benchmark runtime should start");
 
     runtime.block_on(async move {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         let runs = Arc::new(AtomicUsize::new(0));
         for _ in 0..task_count {
             let runs = runs.clone();

--- a/rocketmq/src/schedule.rs
+++ b/rocketmq/src/schedule.rs
@@ -91,6 +91,28 @@ pub mod simple_scheduler {
 
     type TaskId = u64;
 
+    pub const LEGACY_SCHEDULED_TASK_MANAGER_BOUNDARY: &str = "rocketmq.simple-scheduled-task-manager";
+    pub const LEGACY_SCHEDULED_TASK_MANAGER_COMPATIBILITY: &str =
+        "legacy scheduled task manager compatibility boundary";
+    pub const LEGACY_SCHEDULED_TASK_MANAGER_REPLACEMENT: &str = "rocketmq_runtime::ScheduledTaskGroup";
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct LegacyScheduledTaskManagerBoundary {
+        pub boundary: &'static str,
+        pub compatibility: &'static str,
+        pub replacement: &'static str,
+        pub prefers_parent_task_group: bool,
+    }
+
+    pub fn legacy_scheduled_task_manager_boundary() -> LegacyScheduledTaskManagerBoundary {
+        LegacyScheduledTaskManagerBoundary {
+            boundary: LEGACY_SCHEDULED_TASK_MANAGER_BOUNDARY,
+            compatibility: LEGACY_SCHEDULED_TASK_MANAGER_COMPATIBILITY,
+            replacement: LEGACY_SCHEDULED_TASK_MANAGER_REPLACEMENT,
+            prefers_parent_task_group: true,
+        }
+    }
+
     pub struct TaskInfo {
         cancel_token: CancellationToken,
         runtime_task_id: RuntimeTaskId,
@@ -157,16 +179,29 @@ pub mod simple_scheduler {
 
     impl Default for ScheduledTaskManager {
         fn default() -> Self {
-            Self::new()
+            Self::new_legacy_compatibility()
         }
     }
 
     impl ScheduledTaskManager {
+        pub fn new_legacy_compatibility() -> Self {
+            Self::new_with_optional_task_group(None)
+        }
+
+        #[deprecated(note = "use ScheduledTaskManager::new_with_task_group or rocketmq_runtime::ScheduledTaskGroup")]
         pub fn new() -> Self {
+            Self::new_legacy_compatibility()
+        }
+
+        pub fn new_with_task_group(parent_task_group: TaskGroup) -> Self {
+            Self::new_with_optional_task_group(Some(parent_task_group.child(LEGACY_SCHEDULED_TASK_MANAGER_BOUNDARY)))
+        }
+
+        fn new_with_optional_task_group(task_group: Option<TaskGroup>) -> Self {
             Self {
                 tasks: Arc::new(RwLock::new(HashMap::new())),
                 counter: Arc::new(AtomicU64::new(0)),
-                task_group: Arc::new(RwLock::new(None)),
+                task_group: Arc::new(RwLock::new(task_group)),
                 last_task_group_shutdown_report: Arc::new(RwLock::new(None)),
             }
         }
@@ -847,6 +882,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use rocketmq_runtime::RuntimeContext;
     use tokio::time;
 
     use crate::schedule::simple_scheduler::*;
@@ -860,8 +896,18 @@ mod tests {
     }
 
     #[test]
+    fn legacy_scheduler_boundary_marks_compatibility_replacement() {
+        let boundary = legacy_scheduled_task_manager_boundary();
+
+        assert_eq!(boundary.boundary, LEGACY_SCHEDULED_TASK_MANAGER_BOUNDARY);
+        assert_eq!(boundary.compatibility, LEGACY_SCHEDULED_TASK_MANAGER_COMPATIBILITY);
+        assert_eq!(boundary.replacement, LEGACY_SCHEDULED_TASK_MANAGER_REPLACEMENT);
+        assert!(boundary.prefers_parent_task_group);
+    }
+
+    #[test]
     fn add_scheduled_task_without_tokio_runtime_returns_error() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         let error = manager
             .add_scheduled_task(
                 ScheduleMode::FixedDelay,
@@ -880,7 +926,7 @@ mod tests {
 
     #[test]
     fn add_scheduled_task_async_without_tokio_runtime_returns_error() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         let error = manager
             .add_scheduled_task_async(
                 ScheduleMode::FixedDelay,
@@ -898,8 +944,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn new_with_task_group_parents_scheduled_tasks() {
+        let context = RuntimeContext::from_current("scheduled-task-manager-parent-test");
+        let service = context.service_context("scheduler-service");
+        let parent = service.task_group().clone();
+        let manager = ScheduledTaskManager::new_with_task_group(parent.clone());
+
+        let task_id = manager
+            .add_scheduled_task(
+                ScheduleMode::FixedDelay,
+                Duration::from_millis(10),
+                Duration::from_millis(50),
+                |_token| async move { Ok(()) },
+            )
+            .expect("parented scheduled task should start");
+
+        manager.cancel_task(task_id);
+        manager.shutdown_all(Duration::from_secs(1)).await;
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert!(
+            report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq.simple-scheduled-task-manager"),
+            "{}",
+            report.to_json()
+        );
+    }
+
+    #[tokio::test]
     async fn adds_task_and_increments_task_count() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         let task_id = manager
             .add_scheduled_task(
                 ScheduleMode::FixedRate,
@@ -921,7 +997,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancels_task_and_decrements_task_count() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         let task_id = manager
             .add_scheduled_task(
                 ScheduleMode::FixedRate,
@@ -942,7 +1018,7 @@ mod tests {
 
     #[tokio::test]
     async fn aborts_task_and_decrements_task_count() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         let task_id = manager
             .add_scheduled_task(
                 ScheduleMode::FixedRate,
@@ -963,7 +1039,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancels_all_tasks() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         for _ in 0..3 {
             manager
                 .add_scheduled_task(
@@ -988,7 +1064,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_all_waits_for_idle_drivers() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         for _ in 0..3 {
             manager
                 .add_scheduled_task(
@@ -1018,7 +1094,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_tasks_only_stops_selected_drivers() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         let selected = manager
             .add_scheduled_task(
                 ScheduleMode::FixedDelay,
@@ -1059,7 +1135,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_all_aborts_driver_after_timeout() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         let started = Arc::new(AtomicBool::new(false));
         let dropped = Arc::new(AtomicBool::new(false));
         manager
@@ -1100,7 +1176,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_all_only_times_out_unfinished_drivers() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         let started = Arc::new(AtomicBool::new(false));
         manager
             .add_scheduled_task(ScheduleMode::FixedDelay, Duration::ZERO, Duration::from_secs(60), {
@@ -1144,7 +1220,7 @@ mod tests {
 
     #[tokio::test]
     async fn aborts_all_tasks() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         for _ in 0..3 {
             manager
                 .add_scheduled_task(
@@ -1168,7 +1244,7 @@ mod tests {
 
     #[tokio::test]
     async fn skips_task_execution_in_fixed_rate_no_overlap_mode() {
-        let manager = ScheduledTaskManager::new();
+        let manager = ScheduledTaskManager::new_legacy_compatibility();
         let task_id = manager
             .add_scheduled_task(
                 ScheduleMode::FixedRateNoOverlap,
@@ -1190,7 +1266,7 @@ mod tests {
     }
 
     fn new_manager() -> ScheduledTaskManager {
-        ScheduledTaskManager::new()
+        ScheduledTaskManager::new_legacy_compatibility()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rocketmq/src/schedule/executor.rs
+++ b/rocketmq/src/schedule/executor.rs
@@ -104,6 +104,14 @@ where
 
 impl TaskExecutor {
     pub fn new(config: ExecutorConfig) -> Self {
+        Self::new_with_optional_task_group(config, None)
+    }
+
+    pub fn new_with_task_group(config: ExecutorConfig, parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_task_group(config, Some(parent_task_group.child("rocketmq.task-executor")))
+    }
+
+    fn new_with_optional_task_group(config: ExecutorConfig, task_group: Option<TaskGroup>) -> Self {
         let semaphore = Arc::new(Semaphore::new(config.max_concurrent_tasks));
 
         Self {
@@ -112,7 +120,7 @@ impl TaskExecutor {
             running_tasks: Arc::new(RwLock::new(HashMap::new())),
             metrics: Arc::new(RwLock::new(ExecutionMetrics::default())),
             executions: Arc::new(RwLock::new(HashMap::new())),
-            task_group: Arc::new(RwLock::new(None)),
+            task_group: Arc::new(RwLock::new(task_group)),
             last_task_group_shutdown_report: Arc::new(RwLock::new(None)),
         }
     }
@@ -479,6 +487,22 @@ impl ExecutorPool {
         }
     }
 
+    pub fn new_with_task_group(pool_size: usize, config: ExecutorConfig, parent_task_group: TaskGroup) -> Self {
+        let executors = (0..pool_size)
+            .map(|index| {
+                Arc::new(TaskExecutor::new_with_task_group(
+                    config.clone(),
+                    parent_task_group.child(format!("rocketmq.task-executor.{index}")),
+                ))
+            })
+            .collect();
+
+        Self {
+            executors,
+            current_index: Arc::new(RwLock::new(0)),
+        }
+    }
+
     /// Get the next executor using round-robin
     pub async fn get_executor(&self) -> Arc<TaskExecutor> {
         let mut index = self.current_index.write().await;
@@ -531,6 +555,8 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::Ordering;
 
+    use rocketmq_runtime::RuntimeContext;
+
     use super::*;
 
     struct DropMarker(Arc<AtomicBool>);
@@ -578,6 +604,33 @@ mod tests {
             .await;
 
         assert_eq!(executor.running_task_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn new_with_task_group_parents_executor_tasks() {
+        let context = RuntimeContext::from_current("task-executor-parent-test");
+        let service = context.service_context("executor-service");
+        let executor = TaskExecutor::new_with_task_group(ExecutorConfig::default(), service.task_group().clone());
+        let task = Arc::new(Task::new("parented-task", "parented task", |_context| async {
+            TaskResult::Success(None)
+        }));
+
+        executor
+            .execute_task(task, SystemTime::now())
+            .await
+            .expect("parented executor task should start");
+        executor.shutdown_all(Duration::from_secs(1)).await;
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert!(
+            report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq.task-executor"),
+            "{}",
+            report.to_json()
+        );
     }
 
     #[tokio::test]

--- a/rocketmq/src/schedule/scheduler.rs
+++ b/rocketmq/src/schedule/scheduler.rs
@@ -119,6 +119,7 @@ pub struct TaskScheduler {
     shutdown_notify: Arc<Notify>,
     scheduler_group: Arc<RwLock<Option<TaskGroup>>>,
     last_scheduler_shutdown_report: Arc<RwLock<Option<ShutdownReport>>>,
+    parent_task_group: Option<TaskGroup>,
 }
 
 fn current_scheduler_handle(operation: &'static str) -> SchedulerResult<RuntimeHandle> {
@@ -140,10 +141,22 @@ impl Default for TaskScheduler {
 impl TaskScheduler {
     /// Create a new task scheduler
     pub fn new(config: SchedulerConfig) -> Self {
-        let executor_pool = Arc::new(ExecutorPool::new(
-            config.executor_pool_size,
-            config.executor_config.clone(),
-        ));
+        Self::new_with_optional_task_group(config, None)
+    }
+
+    pub fn new_with_task_group(config: SchedulerConfig, parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_task_group(config, Some(parent_task_group))
+    }
+
+    fn new_with_optional_task_group(config: SchedulerConfig, parent_task_group: Option<TaskGroup>) -> Self {
+        let executor_pool = Arc::new(match parent_task_group.as_ref() {
+            Some(parent_task_group) => ExecutorPool::new_with_task_group(
+                config.executor_pool_size,
+                config.executor_config.clone(),
+                parent_task_group.child("rocketmq.task-scheduler.executors"),
+            ),
+            None => ExecutorPool::new(config.executor_pool_size, config.executor_config.clone()),
+        });
 
         Self {
             config,
@@ -153,6 +166,7 @@ impl TaskScheduler {
             shutdown_notify: Arc::new(Notify::new()),
             scheduler_group: Arc::new(RwLock::new(None)),
             last_scheduler_shutdown_report: Arc::new(RwLock::new(None)),
+            parent_task_group,
         }
     }
 
@@ -167,14 +181,18 @@ impl TaskScheduler {
         }
 
         info!("Starting task scheduler");
-        let runtime = match current_scheduler_handle("TaskScheduler::start") {
-            Ok(runtime) => runtime,
-            Err(error) => {
-                *self.running.write().await = false;
-                return Err(error);
-            }
+        let scheduler_group = if let Some(parent_task_group) = self.parent_task_group.as_ref() {
+            parent_task_group.child("rocketmq.task-scheduler")
+        } else {
+            let runtime = match current_scheduler_handle("TaskScheduler::start") {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    *self.running.write().await = false;
+                    return Err(error);
+                }
+            };
+            TaskGroup::root("rocketmq.task-scheduler", runtime)
         };
-        let scheduler_group = TaskGroup::root("rocketmq.task-scheduler", runtime);
         *self.scheduler_group.write().await = Some(scheduler_group.clone());
         *self.last_scheduler_shutdown_report.write().await = None;
 
@@ -612,6 +630,7 @@ pub struct SchedulerStatus {
 
 #[cfg(test)]
 mod tests {
+    use rocketmq_runtime::RuntimeContext;
     use std::future;
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::Ordering;
@@ -667,6 +686,34 @@ mod tests {
         assert!(report.is_healthy(), "{}", report.to_json());
         assert_eq!(report.cancelled, 2);
         assert!(!scheduler.get_status().await.running);
+    }
+
+    #[tokio::test]
+    async fn new_with_task_group_parents_scheduler_tasks() {
+        let context = RuntimeContext::from_current("task-scheduler-parent-test");
+        let service = context.service_context("scheduler-service");
+        let scheduler = TaskScheduler::new_with_task_group(
+            SchedulerConfig {
+                check_interval: Duration::from_secs(60),
+                max_scheduler_threads: 1,
+                ..SchedulerConfig::default()
+            },
+            service.task_group().clone(),
+        );
+
+        scheduler.start().await.expect("parented scheduler should start");
+        scheduler.stop().await.expect("parented scheduler should stop");
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert!(
+            report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq.task-scheduler"),
+            "{}",
+            report.to_json()
+        );
     }
 
     #[tokio::test]

--- a/rocketmq/src/task/service_task.rs
+++ b/rocketmq/src/task/service_task.rs
@@ -138,6 +138,8 @@ pub struct ServiceManager<T: ServiceTask + 'static> {
 
     last_task_group_shutdown_report: Arc<RwLock<Option<ShutdownReport>>>,
 
+    parent_task_group: Option<TaskGroup>,
+
     /// Whether this is a daemon service
     is_daemon: AtomicBool,
 }
@@ -222,6 +224,31 @@ where
         )
     })?;
     let task_group = TaskGroup::root("rocketmq.service-manager", RuntimeHandle::new(handle));
+    spawn_service_task_with_group(operation, task_name, task_group, future)
+}
+
+fn spawn_service_task_with_task_group<F>(
+    operation: &'static str,
+    task_name: String,
+    parent_task_group: TaskGroup,
+    future: F,
+) -> RocketMQResult<ServiceTaskHandle>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let task_group = parent_task_group.child("rocketmq.service-manager");
+    spawn_service_task_with_group(operation, task_name, task_group, future)
+}
+
+fn spawn_service_task_with_group<F>(
+    operation: &'static str,
+    task_name: String,
+    task_group: TaskGroup,
+    future: F,
+) -> RocketMQResult<ServiceTaskHandle>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
     let task_id = task_group.spawn_service(task_name, future).map_err(|error| {
         RocketMQError::network_connection_failed(
             "service-task",
@@ -250,20 +277,22 @@ pub enum ServiceLifecycle {
 impl<T: ServiceTask + 'static> ServiceManager<T> {
     /// Create new service thread implementation
     pub fn new(service: T) -> Self {
-        Self {
-            service: Arc::new(service),
-            state: Arc::new(RwLock::new(ServiceLifecycle::NotStarted)),
-            stopped: Arc::new(AtomicBool::new(false)),
-            started: Arc::new(AtomicBool::new(false)),
-            has_notified: Arc::new(AtomicBool::new(false)),
-            wait_point: Arc::new(Notify::new()),
-            task_handle: Arc::new(RwLock::new(None)),
-            last_task_group_shutdown_report: Arc::new(RwLock::new(None)),
-            is_daemon: AtomicBool::new(false),
-        }
+        Self::new_with_optional_task_group(Arc::new(service), None)
+    }
+
+    pub fn new_with_task_group(service: T, parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_task_group(Arc::new(service), Some(parent_task_group))
     }
 
     pub fn new_arc(service: Arc<T>) -> Self {
+        Self::new_with_optional_task_group(service, None)
+    }
+
+    pub fn new_arc_with_task_group(service: Arc<T>, parent_task_group: TaskGroup) -> Self {
+        Self::new_with_optional_task_group(service, Some(parent_task_group))
+    }
+
+    fn new_with_optional_task_group(service: Arc<T>, parent_task_group: Option<TaskGroup>) -> Self {
         Self {
             service,
             state: Arc::new(RwLock::new(ServiceLifecycle::NotStarted)),
@@ -273,6 +302,7 @@ impl<T: ServiceTask + 'static> ServiceManager<T> {
             wait_point: Arc::new(Notify::new()),
             task_handle: Arc::new(RwLock::new(None)),
             last_task_group_shutdown_report: Arc::new(RwLock::new(None)),
+            parent_task_group,
             is_daemon: AtomicBool::new(false),
         }
     }
@@ -317,9 +347,18 @@ impl<T: ServiceTask + 'static> ServiceManager<T> {
         let task_handle = self.task_handle.clone();
 
         // Spawn the service task
-        let handle = match spawn_service_task("ServiceManager::start", service_name.clone(), async move {
+        let future = async move {
             Self::run_internal(service, state, stopped, started, has_notified, wait_point).await;
-        }) {
+        };
+        let handle = match match self.parent_task_group.as_ref() {
+            Some(parent_task_group) => spawn_service_task_with_task_group(
+                "ServiceManager::start",
+                service_name.clone(),
+                parent_task_group.clone(),
+                future,
+            ),
+            None => spawn_service_task("ServiceManager::start", service_name.clone(), future),
+        } {
             Ok(handle) => handle,
             Err(error) => {
                 self.started.store(false, Ordering::Release);
@@ -617,6 +656,7 @@ mod tests {
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
 
+    use rocketmq_runtime::RuntimeContext;
     use tokio::time::sleep;
     use tokio::time::Duration;
 
@@ -769,6 +809,28 @@ mod tests {
         assert!(
             error.to_string().contains("requires a Tokio runtime"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn new_with_task_group_parents_service_task() {
+        let context = RuntimeContext::from_current("service-manager-parent-test");
+        let service_context = context.service_context("service-manager-service");
+        let service = TestService::new("parented-service".to_string(), Duration::from_millis(10));
+        let service_thread = ServiceManager::new_with_task_group(service, service_context.task_group().clone());
+
+        service_thread.start().await.unwrap();
+        service_thread.shutdown().await.unwrap();
+
+        let report = service_context.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+        assert!(
+            report
+                .children
+                .iter()
+                .any(|child| child.name == "rocketmq.service-manager"),
+            "{}",
+            report.to_json()
         );
     }
 

--- a/scripts/runtime-audit-baseline.json
+++ b/scripts/runtime-audit-baseline.json
@@ -456,6 +456,10 @@
                                                                               "migration_phase":  "PR-7-store-controller-auth-blocking"
                                                                           }
                                                                       ]
-                                                 }
+                                                 },
+                       "scheduler-sites":  {
+                                               "action_required_max":  0,
+                                               "fingerprints":  []
+                                           }
                    }
 }

--- a/scripts/runtime-audit.ps1
+++ b/scripts/runtime-audit.ps1
@@ -465,6 +465,7 @@ function Get-BoundaryKind {
         "current-runtime-adapter-sites" { return "current-runtime-adapter" }
         "raw-tokio-spawn-sites" { return "raw-tokio-spawn" }
         "raw-blocking-executor-sites" { return "raw-blocking-executor" }
+        "scheduler-sites" { return "scheduler-site" }
         "dedicated-thread-sites" { return "dedicated-thread" }
         default { return $Category }
     }
@@ -537,6 +538,14 @@ function Get-BoundaryDisposition {
     }
 
     switch ($Category) {
+        "scheduler-sites" {
+            $schedulerDisposition = Get-SchedulerDisposition -Match $Match
+            return New-BoundaryDisposition `
+                -Disposition $schedulerDisposition.Disposition `
+                -ActionRequired ([bool]$schedulerDisposition.ActionRequired) `
+                -Reason $schedulerDisposition.Reason `
+                -MigrationPhase $phase
+        }
         "task-group-root-sites" {
             if ($path -eq "rocketmq-broker/src/broker_runtime.rs" -and $Match.Text -match "TaskGroup::root\(name, runtime\)") {
                 return New-BoundaryDisposition `
@@ -626,6 +635,65 @@ function Get-BoundaryDisposition {
                     -MigrationPhase "PR-4-remoting-lifecycle"
             }
 
+            if ($path -in @(
+                    "rocketmq/src/schedule.rs",
+                    "rocketmq/src/schedule/executor.rs",
+                    "rocketmq/src/schedule/scheduler.rs",
+                    "rocketmq/src/task/service_task.rs"
+                )) {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "Legacy rocketmq scheduling and service-task constructors retain current-runtime fallbacks; new *_with_task_group constructors attach tasks to an injected parent TaskGroup." `
+                    -MigrationPhase "legacy-compatibility"
+            }
+
+            if ($path -in @(
+                    "rocketmq-client/src/runtime.rs",
+                    "rocketmq-remoting/src/clients/client.rs",
+                    "rocketmq-remoting/src/clients/connection_pool.rs",
+                    "rocketmq-remoting/src/clients/rocketmq_tokio_client.rs",
+                    "rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs"
+                )) {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "Client and remoting compatibility constructors retain current-runtime fallbacks; ServiceContext-based APIs attach new tasks to the caller's service tree." `
+                    -MigrationPhase "PR-4-remoting-lifecycle"
+            }
+
+            if ($path -in @(
+                    "rocketmq-common/src/common/statistics/statistics_manager.rs",
+                    "rocketmq-common/src/common/stats/moment_stats_item.rs",
+                    "rocketmq-common/src/common/stats/moment_stats_item_set.rs",
+                    "rocketmq-controller/src/controller/controller_manager.rs",
+                    "rocketmq-controller/src/controller/open_raft_controller.rs",
+                    "rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs",
+                    "rocketmq-controller/src/metadata/broker.rs",
+                    "rocketmq-controller/src/rpc/server.rs",
+                    "rocketmq-store/src/runtime.rs",
+                    "rocketmq-store/src/rocksdb/runtime.rs",
+                    "rocketmq-tieredstore/src/runtime.rs"
+                )) {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "Store, controller, tieredstore, and common statistics compatibility helpers retain current-runtime fallbacks; parent TaskGroup APIs are available for structured service-tree ownership." `
+                    -MigrationPhase "PR-7-store-controller-auth-blocking"
+            }
+
+            if ($path -in @(
+                    "rocketmq-observability/src/exporter/prometheus.rs",
+                    "rocketmq-proxy/src/grpc/server.rs",
+                    "rocketmq-proxy/src/grpc/service.rs"
+                )) {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "Proxy and observability compatibility entrypoints retain current-runtime fallbacks; *_with_task_group APIs attach background tasks to an injected parent TaskGroup." `
+                    -MigrationPhase "legacy-compatibility"
+            }
+
             return New-BoundaryDisposition `
                 -Disposition "unparented-task-group-root-risk" `
                 -ActionRequired $true `
@@ -687,6 +755,65 @@ function Get-BoundaryDisposition {
                     -ActionRequired $false `
                     -Reason "RocksDBBackend::new compatibility path binds the current Tokio runtime only when no parent TaskGroup was injected." `
                     -MigrationPhase "PR-7-store-controller-auth-blocking"
+            }
+
+            if ($path -in @(
+                    "rocketmq/src/schedule.rs",
+                    "rocketmq/src/schedule/executor.rs",
+                    "rocketmq/src/schedule/scheduler.rs",
+                    "rocketmq/src/task/service_task.rs"
+                )) {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "Legacy rocketmq scheduling and service-task constructors bind the current Tokio runtime only through compatibility fallbacks; new *_with_task_group constructors attach tasks to an injected parent TaskGroup." `
+                    -MigrationPhase "legacy-compatibility"
+            }
+
+            if ($path -in @(
+                    "rocketmq-client/src/runtime.rs",
+                    "rocketmq-remoting/src/clients/client.rs",
+                    "rocketmq-remoting/src/clients/connection_pool.rs",
+                    "rocketmq-remoting/src/clients/rocketmq_tokio_client.rs",
+                    "rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs"
+                )) {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "Client and remoting compatibility constructors bind the current Tokio runtime only through fallback paths; ServiceContext-based APIs attach new tasks to the caller's service tree." `
+                    -MigrationPhase "PR-4-remoting-lifecycle"
+            }
+
+            if ($path -in @(
+                    "rocketmq-common/src/common/statistics/statistics_manager.rs",
+                    "rocketmq-common/src/common/stats/moment_stats_item.rs",
+                    "rocketmq-common/src/common/stats/moment_stats_item_set.rs",
+                    "rocketmq-controller/src/controller/controller_manager.rs",
+                    "rocketmq-controller/src/controller/open_raft_controller.rs",
+                    "rocketmq-controller/src/heartbeat/default_broker_heartbeat_manager.rs",
+                    "rocketmq-controller/src/metadata/broker.rs",
+                    "rocketmq-controller/src/rpc/server.rs",
+                    "rocketmq-store/src/runtime.rs",
+                    "rocketmq-store/src/rocksdb/runtime.rs",
+                    "rocketmq-tieredstore/src/runtime.rs"
+                )) {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "Store, controller, tieredstore, and common statistics compatibility helpers bind the current Tokio runtime only through fallback paths; parent TaskGroup APIs are available for structured service-tree ownership." `
+                    -MigrationPhase "PR-7-store-controller-auth-blocking"
+            }
+
+            if ($path -in @(
+                    "rocketmq-observability/src/exporter/prometheus.rs",
+                    "rocketmq-proxy/src/grpc/server.rs",
+                    "rocketmq-proxy/src/grpc/service.rs"
+                )) {
+                return New-BoundaryDisposition `
+                    -Disposition "current-runtime-compat-adapter" `
+                    -ActionRequired $false `
+                    -Reason "Proxy and observability compatibility entrypoints bind the current Tokio runtime only through fallback paths; *_with_task_group APIs attach background tasks to an injected parent TaskGroup." `
+                    -MigrationPhase "legacy-compatibility"
             }
 
             if ($path -eq "rocketmq-auth/src/runtime_bridge.rs" -and $Match.Text -match "Handle::try_current") {
@@ -2060,6 +2187,7 @@ $boundaryKeys = @(
     "current-runtime-adapter-sites",
     "raw-tokio-spawn-sites",
     "raw-blocking-executor-sites",
+    "scheduler-sites",
     "legacy-runtime-api-sites",
     "dedicated-thread-sites"
 )
@@ -2115,6 +2243,7 @@ foreach ($key in $boundaryKeys) {
         "current-runtime-adapter-sites" { "production-current-runtime-adapter-disposition.md" }
         "raw-tokio-spawn-sites" { "production-raw-tokio-spawn-disposition.md" }
         "raw-blocking-executor-sites" { "production-raw-blocking-executor-disposition.md" }
+        "scheduler-sites" { "production-scheduler-boundary-disposition.md" }
         "dedicated-thread-sites" { "production-dedicated-thread-disposition.md" }
         default { "production-$key-disposition.md" }
     }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7544

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced shutdown health reporting across broker, remoting, and proxy components to track graceful termination status.
  * Hierarchical task group support enabling better organization of background operations.

* **Refactor**
  * Improved runtime initialization with explicit blocking thread configuration in broker, namesrv, and admin TUI binaries.
  * Streamlined shutdown procedures with comprehensive diagnostic reporting during component lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->