### PR TITLE
[ISSUE #7546]✨Harden Tokio runtime boundaries and enforce zero action-required audit findings

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/src/topic/service.rs
@@ -67,6 +67,8 @@ use rocketmq_remoting::protocol::admin::topic_stats_table::TopicStatsTable;
 use rocketmq_remoting::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_remoting::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use rocketmq_runtime::BlockingExecutor;
+use rocketmq_runtime::BlockingPoolPolicy;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
 use std::any::Any;
@@ -76,6 +78,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::sync::OnceLock;
+use std::time::Duration;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
@@ -1122,48 +1125,61 @@ async fn send_transaction_message_with_runtime(
     request: SendTopicMessageRequest,
     normalized_message_body: String,
 ) -> TopicResult<TopicSendMessageResult> {
-    tokio::task::spawn_blocking(move || -> TopicResult<TopicSendMessageResult> {
-        let runtime = transaction_message_runtime()?;
-        let runtime = runtime
-            .lock()
-            .map_err(|error| TopicError::RocketMQ(format!("transaction message runtime lock poisoned: {error}")))?;
+    let blocking = transaction_message_blocking_executor()?;
+    blocking
+        .spawn_io(
+            "dashboard-topic-transaction-send",
+            move || -> TopicResult<TopicSendMessageResult> {
+                let runtime = transaction_message_runtime()?;
+                let runtime = runtime.lock().map_err(|error| {
+                    TopicError::RocketMQ(format!("transaction message runtime lock poisoned: {error}"))
+                })?;
 
-        runtime.block_on(async move {
-            let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
-                TopicError::Configuration(
-                    "No active NameServer is configured. Add and select a NameServer first.".into(),
-                )
-            })?;
+                runtime.block_on(async move {
+                    let current_namesrv = snapshot.current_namesrv.clone().ok_or_else(|| {
+                        TopicError::Configuration(
+                            "No active NameServer is configured. Add and select a NameServer first.".into(),
+                        )
+                    })?;
 
-            let mut client_config = ClientConfig::new();
-            client_config.set_namesrv_addr(current_namesrv.into());
-            client_config.set_vip_channel_enabled(snapshot.use_vip_channel);
-            client_config.set_use_tls(snapshot.use_tls);
+                    let mut client_config = ClientConfig::new();
+                    client_config.set_namesrv_addr(current_namesrv.into());
+                    client_config.set_vip_channel_enabled(snapshot.use_vip_channel);
+                    client_config.set_use_tls(snapshot.use_tls);
 
-            let mut producer = TransactionMQProducer::builder()
-                .producer_group(format!("dashboard-topic-tx-sender-{}", Uuid::new_v4()))
-                .client_config(client_config)
-                .transaction_listener(DashboardTransactionListener)
-                .build();
+                    let mut producer = TransactionMQProducer::builder()
+                        .producer_group(format!("dashboard-topic-tx-sender-{}", Uuid::new_v4()))
+                        .client_config(client_config)
+                        .transaction_listener(DashboardTransactionListener)
+                        .build();
 
-            producer
-                .start()
-                .await
-                .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
+                    producer
+                        .start()
+                        .await
+                        .map_err(|error| TopicError::RocketMQ(error.to_string()))?;
 
-            let message = build_send_message(&request, &normalized_message_body);
-            let tx_result = producer
-                .send_message_in_transaction::<(), _>(message, None)
-                .await
-                .map_err(|error| TopicError::RocketMQ(error.to_string()));
-            producer.shutdown().await;
-            let tx_result = tx_result?;
+                    let message = build_send_message(&request, &normalized_message_body);
+                    let tx_result = producer
+                        .send_message_in_transaction::<(), _>(message, None)
+                        .await
+                        .map_err(|error| TopicError::RocketMQ(error.to_string()));
+                    producer.shutdown().await;
+                    let tx_result = tx_result?;
 
-            map_transaction_send_result(request.topic, tx_result)
-        })
-    })
-    .await
-    .map_err(|error| TopicError::RocketMQ(error.to_string()))?
+                    map_transaction_send_result(request.topic, tx_result)
+                })
+            },
+        )
+        .await
+        .map_err(|error| TopicError::RocketMQ(error.to_string()))?
+}
+
+fn transaction_message_blocking_executor() -> TopicResult<BlockingExecutor> {
+    let runtime = transaction_message_runtime()?;
+    let runtime = runtime
+        .lock()
+        .map_err(|error| TopicError::RocketMQ(format!("transaction message runtime lock poisoned: {error}")))?;
+    Ok(runtime.context().blocking().clone())
 }
 
 fn transaction_message_runtime() -> TopicResult<&'static StdMutex<RuntimeOwner>> {
@@ -1175,6 +1191,13 @@ fn transaction_message_runtime() -> TopicResult<&'static StdMutex<RuntimeOwner>>
         worker_threads: 1,
         max_blocking_threads: 2,
         thread_name: "rocketmq-dashboard-topic-tx".to_string(),
+        blocking_pool_policy: BlockingPoolPolicy {
+            name: "rocketmq-dashboard-topic-tx-blocking".to_string(),
+            max_concurrency: 1,
+            queue_timeout: Duration::from_secs(5),
+            task_timeout: Duration::from_secs(30),
+            warn_after: Duration::from_secs(5),
+        },
         ..RuntimeConfig::default()
     })
     .map_err(|error| TopicError::RocketMQ(format!("failed to start transaction message runtime: {error}")))?;
@@ -1859,6 +1882,7 @@ mod tests {
     use super::normalize_message_type;
     use super::normalize_topic_message_body;
     use super::quote_numeric_object_keys;
+    use super::transaction_message_blocking_executor;
     use super::transaction_message_runtime;
     use cheetah_string::CheetahString;
     use rocketmq_admin_core::core::stats::StatsAllRow;
@@ -1881,6 +1905,14 @@ mod tests {
         let second = transaction_message_runtime().expect("transaction runtime should be reused") as *const _;
 
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn transaction_message_blocking_executor_uses_runtime_policy() {
+        let blocking = transaction_message_blocking_executor().expect("blocking executor should be available");
+
+        assert_eq!(blocking.policy().name, "rocketmq-dashboard-topic-tx-blocking");
+        assert_eq!(blocking.policy().max_concurrency, 1);
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/dashboard_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/dashboard_service.rs
@@ -23,7 +23,9 @@ use chrono::Utc;
 use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::Arc;
+use std::sync::Mutex;
 use tokio::sync::RwLock;
+use tokio::task::AbortHandle;
 use tokio::time::Duration;
 
 pub async fn overview(state: &AppState) -> Result<DashboardOverview, DashboardError> {
@@ -51,6 +53,45 @@ pub async fn topic_history(
 #[derive(Debug, Clone, Default)]
 pub struct DashboardHistoryStore {
     samples: Arc<RwLock<VecDeque<DashboardHistorySample>>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DashboardTaskManager {
+    inner: Arc<DashboardTaskManagerInner>,
+}
+
+#[derive(Debug, Default)]
+struct DashboardTaskManagerInner {
+    abort_handles: Mutex<Vec<AbortHandle>>,
+}
+
+impl DashboardTaskManager {
+    pub fn spawn<F>(&self, task_name: &'static str, task: F) -> anyhow::Result<()>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let mut abort_handles = self.inner.abort_handles.lock().map_err(|error| {
+            anyhow::anyhow!("dashboard task manager lock poisoned while spawning {task_name}: {error}")
+        })?;
+        let handle = tokio::task::spawn(async move {
+            tracing::debug!(task = task_name, "Dashboard background task started");
+            task.await;
+            tracing::debug!(task = task_name, "Dashboard background task stopped");
+        });
+        abort_handles.push(handle.abort_handle());
+        drop(handle);
+        Ok(())
+    }
+}
+
+impl Drop for DashboardTaskManagerInner {
+    fn drop(&mut self) {
+        if let Ok(abort_handles) = self.abort_handles.get_mut() {
+            for abort_handle in abort_handles.drain(..) {
+                abort_handle.abort();
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -145,11 +186,12 @@ impl DashboardHistoryStore {
 }
 
 pub fn spawn_dashboard_history_collector(
+    task_manager: &DashboardTaskManager,
     admin_facade: WebAdminFacade,
     history_store: DashboardHistoryStore,
     interval_secs: u64,
 ) -> anyhow::Result<()> {
-    spawn_dashboard_task("dashboard-history-collector", async move {
+    task_manager.spawn("dashboard-history-collector", async move {
         let mut interval = tokio::time::interval(Duration::from_secs(interval_secs.max(1)));
         loop {
             interval.tick().await;
@@ -161,16 +203,6 @@ pub fn spawn_dashboard_history_collector(
             }
         }
     })
-}
-
-fn spawn_dashboard_task<F>(task_name: &'static str, task: F) -> anyhow::Result<()>
-where
-    F: Future<Output = ()> + Send + 'static,
-{
-    let handle = tokio::runtime::Handle::try_current()
-        .map_err(|error| anyhow::anyhow!("{task_name} requires a Tokio runtime: {error}"))?;
-    drop(handle.spawn(task));
-    Ok(())
 }
 
 async fn collect_history_sample(
@@ -195,22 +227,48 @@ async fn collect_history_sample(
 #[cfg(test)]
 mod tests {
     use super::DashboardHistoryStore;
-    use super::spawn_dashboard_task;
+    use super::DashboardTaskManager;
     use crate::model::DashboardHistoryQuery;
     use crate::model::DashboardOverview;
     use crate::model::DashboardTopicCurrent;
     use crate::model::TopicCurrentMetric;
     use chrono::Utc;
+    use std::future;
+    use tokio::sync::oneshot;
+    use tokio::time::Duration;
+    use tokio::time::timeout;
 
-    #[test]
-    fn spawn_dashboard_task_without_tokio_runtime_returns_error() {
-        let error = spawn_dashboard_task("dashboard-test-task", async {})
-            .expect_err("dashboard task spawn should fail without a Tokio runtime");
+    struct DropSignal(Option<oneshot::Sender<()>>);
 
-        assert!(
-            error.to_string().contains("requires a Tokio runtime"),
-            "unexpected error: {error}"
-        );
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn dashboard_task_manager_drop_aborts_spawned_tasks() {
+        let manager = DashboardTaskManager::default();
+        let (started_tx, started_rx) = oneshot::channel();
+        let (dropped_tx, dropped_rx) = oneshot::channel();
+
+        manager
+            .spawn("dashboard-test-task", async move {
+                let _drop_signal = DropSignal(Some(dropped_tx));
+                let _ = started_tx.send(());
+                future::pending::<()>().await;
+            })
+            .expect("dashboard task should spawn");
+
+        started_rx.await.expect("task should start");
+        drop(manager);
+
+        timeout(Duration::from_secs(1), dropped_rx)
+            .await
+            .expect("task should be aborted when manager is dropped")
+            .expect("drop signal should be sent");
     }
 
     #[tokio::test]

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/state/app_state.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/state/app_state.rs
@@ -17,6 +17,7 @@ use crate::config::ConfigStore;
 use crate::model::DashboardConfigView;
 use crate::service::AuthState;
 use crate::service::DashboardHistoryStore;
+use crate::service::DashboardTaskManager;
 use crate::service::MonitorStore;
 use crate::service::spawn_dashboard_history_collector;
 use rocketmq_dashboard_common::DashboardAdminFacade;
@@ -31,6 +32,7 @@ pub struct AppState {
     pub auth_state: Arc<AuthState>,
     pub monitor_store: Arc<MonitorStore>,
     pub history_store: DashboardHistoryStore,
+    pub dashboard_tasks: DashboardTaskManager,
     pub dashboard_config: Arc<RwLock<DashboardConfigView>>,
     pub admin_client: DashboardAdminClient,
 }
@@ -41,11 +43,13 @@ impl AppState {
         let auth_state = Arc::new(AuthState::new(config.auth));
         let monitor_store = Arc::new(MonitorStore::new(config.monitor_store_path));
         let history_store = DashboardHistoryStore::default();
+        let dashboard_tasks = DashboardTaskManager::default();
         let dashboard_config = config_store.load_or_init(&config.initial_config)?;
         let dashboard_config = Arc::new(RwLock::new(dashboard_config));
         let admin_client = DashboardAdminClient::new(dashboard_config.clone());
         if config.dashboard_history_interval_secs > 0 {
             spawn_dashboard_history_collector(
+                &dashboard_tasks,
                 DashboardAdminFacade::new(admin_client.clone()),
                 history_store.clone(),
                 config.dashboard_history_interval_secs,
@@ -57,6 +61,7 @@ impl AppState {
             auth_state,
             monitor_store,
             history_store,
+            dashboard_tasks,
             dashboard_config,
             admin_client,
         })

--- a/scripts/runtime-audit.ps1
+++ b/scripts/runtime-audit.ps1
@@ -709,6 +709,14 @@ function Get-BoundaryDisposition {
                     -MigrationPhase $phase
             }
 
+            if ($path -eq "rocketmq-common/src/utils/http_tiny_client.rs" -and $Match.Text -match "Handle::try_current") {
+                return New-BoundaryDisposition `
+                    -Disposition "sync-runtime-guard" `
+                    -ActionRequired $false `
+                    -Reason "HttpTinyClient's deprecated blocking API checks for an active Tokio runtime only to reject nested blocking calls and direct callers to the async API." `
+                    -MigrationPhase "PR-7-store-controller-auth-blocking"
+            }
+
             if ($path -eq "rocketmq-namesrv/src/bootstrap.rs" -and $Match.Text -match "Handle::try_current") {
                 return New-BoundaryDisposition `
                     -Disposition "current-runtime-compat-adapter" `


### PR DESCRIPTION


<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #7546

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal transaction message processing path for enhanced reliability and efficiency.
  * Upgraded background task management system with automatic cleanup and safety guarantees.
  * Enhanced runtime audit scripts for better system monitoring.

These internal improvements strengthen system stability and task handling without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->