### PR TITLE
[ISSUE #7554] ✨ Add missing repository agent skills

### DIFF
--- a/.agents/glossary/glossary-concurrency.md
+++ b/.agents/glossary/glossary-concurrency.md
@@ -1,0 +1,18 @@
+# Concurrency & Async Terminology Glossary
+
+## Terminology
+
+| English Term   | Chinese Translation | Notes         |
+|----------------|---------------------|---------------|
+| blocking       | 阻塞                  |               |
+| non-blocking   | 非阻塞                 |               |
+| asynchronous   | 异步                  |               |
+| synchronous    | 同步                  |               |
+| event loop     | 事件循环                |               |
+| reactor        | Reactor             | Pattern name  |
+| proactor       | Proactor            | Pattern name  |
+| future         | Future              | Type name     |
+| async/await    | async/await         | Keep syntax   |
+| poll           | 轮询                  | Async context |
+| waker          | Waker               | Async context |
+| context switch | 上下文切换               |               |

--- a/.agents/glossary/glossary-core.md
+++ b/.agents/glossary/glossary-core.md
@@ -1,0 +1,26 @@
+# Core IT Terminology Glossary
+
+## Rules
+
+- The following mappings MUST be respected during translation.
+- If a term appears in this glossary, its Chinese translation is fixed.
+- Do not invent alternative translations.
+
+## Terminology
+
+| English Term    | Chinese Translation | Notes       |
+|-----------------|---------------------|-------------|
+| concurrency     | 并发                  |             |
+| parallelism     | 并行                  |             |
+| throughput      | 吞吐量                 |             |
+| latency         | 延迟                  |             |
+| scalability     | 可扩展性                |             |
+| availability    | 可用性                 |             |
+| consistency     | 一致性                 | CAP context |
+| fault tolerance | 容错性                 |             |
+| backpressure    | 背压                  |             |
+| idempotent      | 幂等                  |             |
+| serialization   | 序列化                 |             |
+| deserialization | 反序列化                |             |
+| race condition  | 竞态条件                |             |
+| deadlock        | 死锁                  |             |

--- a/.agents/glossary/glossary-lang-jvm.md
+++ b/.agents/glossary/glossary-lang-jvm.md
@@ -1,0 +1,16 @@
+# JVM Language Terminology Glossary
+
+## Terminology
+
+| English Term       | Chinese Translation | Notes          |
+|--------------------|---------------------|----------------|
+| JVM                | JVM                 | Keep acronym   |
+| heap               | 堆                   |                |
+| stack              | 栈                   |                |
+| garbage collection | 垃圾回收                |                |
+| GC                 | GC                  | Keep acronym   |
+| stop-the-world     | STW                 | JVM convention |
+| classloader        | 类加载器                |                |
+| bytecode           | 字节码                 |                |
+| memory model       | 内存模型                | JMM            |
+| happens-before     | happens-before      | JMM term       |

--- a/.agents/glossary/glossary-lang-rust.md
+++ b/.agents/glossary/glossary-lang-rust.md
@@ -1,0 +1,21 @@
+# Rust Language Terminology Glossary
+
+## Terminology
+
+| English Term        | Chinese Translation | Notes         |
+|---------------------|---------------------|---------------|
+| ownership           | 所有权                 | Rust-specific |
+| borrow              | 借用                  |               |
+| borrow checker      | 借用检查器               |               |
+| lifetime            | 生命周期                |               |
+| mutable reference   | 可变引用                |               |
+| immutable reference | 不可变引用               |               |
+| move semantics      | 移动语义                |               |
+| trait               | trait               | Keep keyword  |
+| generics            | 泛型                  |               |
+| unsafe              | unsafe              | Keep keyword  |
+| Pin                 | Pin                 | Type name     |
+| Send                | Send                | Trait name    |
+| Sync                | Sync                | Trait name    |
+| zero-copy           | 零拷贝                 |               |
+| interior mutability | 内部可变性               |               |

--- a/.agents/glossary/glossary-middleware-mq.md
+++ b/.agents/glossary/glossary-middleware-mq.md
@@ -1,0 +1,19 @@
+# Message Middleware Terminology Glossary
+
+## Terminology
+
+| English Term      | Chinese Translation | Notes              |
+|-------------------|---------------------|--------------------|
+| message queue     | 消息队列                |                    |
+| topic             | 主题                  |                    |
+| partition         | 分区                  | Kafka-style        |
+| queue             | 队列                  | MQ generic         |
+| offset            | 偏移量                 |                    |
+| consumer          | 消费者                 |                    |
+| producer          | 生产者                 |                    |
+| consumer group    | 消费者组                |                    |
+| rebalance         | 再平衡                 |                    |
+| at-least-once     | 至少一次                | Delivery semantics |
+| at-most-once      | 至多一次                |                    |
+| exactly-once      | 精确一次                |                    |
+| dead letter queue | 死信队列                |                    |

--- a/.agents/glossary/glossary-network-protocol.md
+++ b/.agents/glossary/glossary-network-protocol.md
@@ -1,0 +1,20 @@
+# Network & Protocol Terminology Glossary
+
+## Terminology
+
+| English Term       | Chinese Translation | Notes            |
+|--------------------|---------------------|------------------|
+| protocol           | 协议                  |                  |
+| handshake          | 握手                  |                  |
+| frame              | 帧                   | Protocol context |
+| packet             | 数据包                 | Network layer    |
+| flow control       | 流量控制                |                  |
+| congestion control | 拥塞控制                |                  |
+| timeout            | 超时                  |                  |
+| retry              | 重试                  |                  |
+| TLS                | TLS                 | Keep acronym     |
+| TCP                | TCP                 | Keep acronym     |
+| UDP                | UDP                 | Keep acronym     |
+| MUST               | MUST                | RFC 2119         |
+| SHOULD             | SHOULD              | RFC 2119         |
+| MAY                | MAY                 | RFC 2119         |

--- a/.agents/skills/rust-doc-comment-generator/SKILL.md
+++ b/.agents/skills/rust-doc-comment-generator/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: rust-doc-comment-generator
+description: Generate idiomatic, production-grade Rust comments and documentation strictly following official Rustdoc and Rust API documentation conventions. Designed for real-world Rust projects with zero AI-identifiable markers.
+
+---
+
+# Rust Documentation & Comment Generator Skill
+
+## Overview
+
+This skill generates **standard-compliant Rust comments and documentation** for Rust source code.
+It strictly follows Rust’s official documentation guidelines and produces output suitable for
+**production-quality open-source and enterprise Rust projects**.
+
+The generated comments are:
+
+- Idiomatic and precise
+- Free of AI-identifiable artifacts
+- Fully aligned with Rustdoc conventions
+- Suitable for blocking, async, and unsafe code
+
+## Standards & References
+
+This skill MUST comply with the following authoritative sources:
+
+- Rust API Guidelines — Documentation  
+  https://rust-lang.github.io/api-guidelines/documentation.html
+- The Rustdoc Book  
+  https://doc.rust-lang.org/rustdoc/
+- Rust Style Guide  
+  https://doc.rust-lang.org/style-guide/
+
+## Supported Targets
+
+This skill applies to the following Rust items:
+
+- `struct`, `enum`, `union`
+- `trait`
+- `impl` blocks
+- `fn` / `async fn`
+- Modules (`mod`)
+- `unsafe` blocks and functions
+
+## Comment & Documentation Rules
+
+### 1. Comment Types
+
+| Context                       | Format                |
+|-------------------------------|-----------------------|
+| Public item                   | `///` Rustdoc comment |
+| Module-level documentation    | `//!`                 |
+| Private implementation detail | `//`                  |
+| Unsafe API explanation        | `/// # Safety`        |
+
+### 2. Rustdoc Section Usage
+
+Rustdoc sections MUST be included **only when semantically relevant**:
+
+- `# Examples`
+- `# Panics`
+- `# Errors`
+- `# Safety`
+- `# Performance`
+
+Empty or boilerplate sections are not allowed.
+
+### 3. Language & Tone
+
+- Use formal, neutral, technical language
+- Avoid conversational or instructional phrasing
+- Avoid marketing or subjective language
+- Describe behavior, constraints, and guarantees precisely
+
+✅ Correct:
+
+> Represents the configuration used by the message consumer.
+
+❌ Incorrect:
+
+> This struct is very useful and highly optimized.
+
+### 4. Blocking vs Async Behavior
+
+#### Blocking APIs
+
+Blocking behavior MUST be explicitly documented.
+
+```rust
+/// Blocks the current thread until a message is available.
+```
+
+#### Async / Non-Blocking APIs
+
+Async behavior MUST be explicitly documented.
+
+```rust
+/// Asynchronously waits for the next message.
+///
+/// This function does not block the calling thread.
+```
+
+### 5. Unsafe Code Documentation
+
+Any `unsafe` function or block MUST include a `# Safety` section.
+
+```rust
+/// # Safety
+///
+/// The caller must ensure that the pointer is valid and properly aligned
+/// for the duration of the call.
+```
+
+Vague or generic safety statements are forbidden.
+
+## Forbidden Content
+
+The output MUST NOT contain:
+
+- Emojis
+- Phase or workflow markers (e.g. `Phase`, `Step`, `Optimize`)
+- TODO / FIXME / NOTE meta-comments
+- AI-related indicators or explanations
+- Commentary about refactoring or future improvements
+
+## Input Expectations
+
+The user may provide:
+
+- Undocumented Rust code
+- Partially documented Rust code
+- Rust code with non-standard or low-quality comments
+
+## Output Expectations
+
+The skill MUST:
+
+1. Preserve existing correct Rustdoc comments
+2. Rewrite non-standard comments into idiomatic Rustdoc
+3. Add missing documentation where appropriate
+4. Never change code semantics
+5. Never introduce new APIs or rename identifiers
+
+## Example
+
+### Input
+
+```rust
+pub struct MessageQueue {
+    capacity: usize,
+}
+```
+
+### Output
+
+```rust
+/// Represents a bounded message queue.
+///
+/// The queue can store messages up to a fixed capacity.
+pub struct MessageQueue {
+    capacity: usize,
+}
+```
+
+## Non-Goals
+
+This skill does NOT:
+
+- Refactor code
+- Optimize performance
+- Rename symbols
+- Add logging
+- Generate tests
+
+## Compatibility
+
+This skill is designed to work alongside:
+
+- Rust API naming validation skills
+- Safety auditing skills
+- Project-specific glossary enforcement skills
+
+Each skill operates independently and does not overlap responsibilities.

--- a/.agents/skills/translate-it-doc-en-zh/SKILL.md
+++ b/.agents/skills/translate-it-doc-en-zh/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: translate-it-doc-en-zh
+description: Translate English IT and software engineering documents into professional, accurate Chinese. Use when user provides English technical documentation, API docs, README, design docs, RFCs, or source code comments and asks for Chinese translation. Prioritize correctness, standard IT terminology, and engineering-style Chinese.
+version: 1.1
+---
+
+# English to Chinese IT Documentation Translation
+
+## Role
+
+You are a professional IT and software engineering technical translator.
+
+You translate English technical documentation into **professional, precise, and standardized Chinese**, suitable for use in official documentation, design documents, and open-source projects.
+
+---
+
+## Mandatory Glossary (Strong Constraint)
+
+You MUST strictly follow terminology defined in the following glossary files:
+
+- ../glossary/glossary-core.md
+- ../glossary/glossary-concurrency.md
+- ../glossary/glossary-network-protocol.md
+- ../glossary/glossary-middleware-mq.md
+- ../glossary/glossary-lang-rust.md
+- ../glossary/glossary-lang-jvm.md
+
+### Glossary Rules
+
+- If a term exists in any glossary, you MUST use the specified Chinese translation.
+- You MUST NOT invent, localize, paraphrase, or redefine glossary terms.
+- If a term appears in multiple glossaries, apply the following priority order:
+  1. Language-specific glossary (Rust / JVM)
+  2. Domain-specific glossary (Concurrency / MQ / Network)
+  3. Core glossary
+
+---
+
+## Instructions
+
+When this skill is activated, translate the provided English IT or software engineering content into **professional Chinese** following these rules strictly:
+
+### 1. Accuracy First
+- Preserve the original technical meaning exactly.
+- Do NOT add, remove, or speculate about information.
+- Do NOT simplify technical concepts.
+
+### 2. IT Terminology Standards
+- Use widely accepted Chinese IT terminology.
+- Prefer translations used in:
+  - Official specifications
+  - Major open-source communities
+  - Industry-standard technical documentation
+- If multiple translations exist, choose the most authoritative and commonly accepted one.
+
+### 3. Keep Technical Elements Intact
+The following MUST NOT be translated:
+- Code blocks
+- Function names
+- Class names
+- Variable names
+- CLI commands
+- File paths
+- Protocol names
+- Inline code (must remain unchanged)
+
+### 4. Professional Technical Chinese Style
+- Use formal, concise, documentation-style Chinese.
+- Avoid colloquial or conversational expressions.
+- Prefer passive or neutral technical tone when appropriate.
+- Match the structure of the original text (lists, headings, paragraphs).
+
+### 5. Sentence-Level Optimization
+- Do NOT perform word-for-word translation if it reduces technical clarity.
+- Restructure sentences only when necessary to produce clear and natural technical Chinese.
+- Keep paragraph boundaries consistent with the original text.
+
+### 6. Comments & Documentation Context
+For source code comments:
+- Translate as professional developer comments.
+- Preserve intent such as explanation, warning, TODO, NOTE, or constraint.
+
+### 7. Mixed Language & Abbreviations
+- Widely used English abbreviations or terms without standard Chinese translations
+  (e.g., QPS, GC, TLS, CI/CD, linter) MUST be kept in English.
+- If appropriate and non-intrusive, a brief Chinese clarification MAY be added at first occurrence.
+- Once introduced, remain consistent throughout the document.
+
+### 8. Numbers & Units
+- Numbers and units should generally retain their original format (e.g., 10ms, 500MB).
+- Adjustments following common Chinese technical writing conventions are acceptable when clarity is improved.
+
+### 9. RFC & Specification Language
+When translating specification-style documents:
+- MUST, SHOULD, MAY MUST remain in uppercase English.
+- Do NOT weaken, strengthen, or reinterpret requirement levels.
+
+### 10. No Extra Output
+- Output only the translated Chinese content.
+- Do NOT add explanations, notes, or translation commentary.
+- Do NOT mention glossary usage in the output.
+
+---
+
+## Examples
+
+### Example 1
+
+**Input:**
+> This module is responsible for managing message offsets and ensuring at-least-once delivery semantics.
+
+**Output:**
+> 该模块负责管理消息偏移量，并确保至少一次（at-least-once）的消息投递语义。
+
+---
+
+### Example 2
+
+**Input:**
+> The producer retries sending messages when network latency exceeds the configured timeout.
+
+**Output:**
+> 当网络延迟超过配置的超时时间时，生产者会重试发送消息。
+
+---
+
+### Example 3 (Code Comment)
+
+**Input:**
+```rust
+// This function acquires a write lock and must not be called from async context.
+```
+
+**Output:**
+```rust
+// 该函数会获取写锁，且不得在异步上下文中调用。
+```
+
+---

--- a/.claude/glossary/glossary-concurrency.md
+++ b/.claude/glossary/glossary-concurrency.md
@@ -1,0 +1,18 @@
+# Concurrency & Async Terminology Glossary
+
+## Terminology
+
+| English Term   | Chinese Translation | Notes         |
+|----------------|---------------------|---------------|
+| blocking       | 阻塞                  |               |
+| non-blocking   | 非阻塞                 |               |
+| asynchronous   | 异步                  |               |
+| synchronous    | 同步                  |               |
+| event loop     | 事件循环                |               |
+| reactor        | Reactor             | Pattern name  |
+| proactor       | Proactor            | Pattern name  |
+| future         | Future              | Type name     |
+| async/await    | async/await         | Keep syntax   |
+| poll           | 轮询                  | Async context |
+| waker          | Waker               | Async context |
+| context switch | 上下文切换               |               |

--- a/.claude/glossary/glossary-core.md
+++ b/.claude/glossary/glossary-core.md
@@ -1,0 +1,26 @@
+# Core IT Terminology Glossary
+
+## Rules
+
+- The following mappings MUST be respected during translation.
+- If a term appears in this glossary, its Chinese translation is fixed.
+- Do not invent alternative translations.
+
+## Terminology
+
+| English Term    | Chinese Translation | Notes       |
+|-----------------|---------------------|-------------|
+| concurrency     | 并发                  |             |
+| parallelism     | 并行                  |             |
+| throughput      | 吞吐量                 |             |
+| latency         | 延迟                  |             |
+| scalability     | 可扩展性                |             |
+| availability    | 可用性                 |             |
+| consistency     | 一致性                 | CAP context |
+| fault tolerance | 容错性                 |             |
+| backpressure    | 背压                  |             |
+| idempotent      | 幂等                  |             |
+| serialization   | 序列化                 |             |
+| deserialization | 反序列化                |             |
+| race condition  | 竞态条件                |             |
+| deadlock        | 死锁                  |             |

--- a/.claude/glossary/glossary-lang-jvm.md
+++ b/.claude/glossary/glossary-lang-jvm.md
@@ -1,0 +1,16 @@
+# JVM Language Terminology Glossary
+
+## Terminology
+
+| English Term       | Chinese Translation | Notes          |
+|--------------------|---------------------|----------------|
+| JVM                | JVM                 | Keep acronym   |
+| heap               | 堆                   |                |
+| stack              | 栈                   |                |
+| garbage collection | 垃圾回收                |                |
+| GC                 | GC                  | Keep acronym   |
+| stop-the-world     | STW                 | JVM convention |
+| classloader        | 类加载器                |                |
+| bytecode           | 字节码                 |                |
+| memory model       | 内存模型                | JMM            |
+| happens-before     | happens-before      | JMM term       |

--- a/.claude/glossary/glossary-lang-rust.md
+++ b/.claude/glossary/glossary-lang-rust.md
@@ -1,0 +1,21 @@
+# Rust Language Terminology Glossary
+
+## Terminology
+
+| English Term        | Chinese Translation | Notes         |
+|---------------------|---------------------|---------------|
+| ownership           | 所有权                 | Rust-specific |
+| borrow              | 借用                  |               |
+| borrow checker      | 借用检查器               |               |
+| lifetime            | 生命周期                |               |
+| mutable reference   | 可变引用                |               |
+| immutable reference | 不可变引用               |               |
+| move semantics      | 移动语义                |               |
+| trait               | trait               | Keep keyword  |
+| generics            | 泛型                  |               |
+| unsafe              | unsafe              | Keep keyword  |
+| Pin                 | Pin                 | Type name     |
+| Send                | Send                | Trait name    |
+| Sync                | Sync                | Trait name    |
+| zero-copy           | 零拷贝                 |               |
+| interior mutability | 内部可变性               |               |

--- a/.claude/glossary/glossary-middleware-mq.md
+++ b/.claude/glossary/glossary-middleware-mq.md
@@ -1,0 +1,19 @@
+# Message Middleware Terminology Glossary
+
+## Terminology
+
+| English Term      | Chinese Translation | Notes              |
+|-------------------|---------------------|--------------------|
+| message queue     | 消息队列                |                    |
+| topic             | 主题                  |                    |
+| partition         | 分区                  | Kafka-style        |
+| queue             | 队列                  | MQ generic         |
+| offset            | 偏移量                 |                    |
+| consumer          | 消费者                 |                    |
+| producer          | 生产者                 |                    |
+| consumer group    | 消费者组                |                    |
+| rebalance         | 再平衡                 |                    |
+| at-least-once     | 至少一次                | Delivery semantics |
+| at-most-once      | 至多一次                |                    |
+| exactly-once      | 精确一次                |                    |
+| dead letter queue | 死信队列                |                    |

--- a/.claude/glossary/glossary-network-protocol.md
+++ b/.claude/glossary/glossary-network-protocol.md
@@ -1,0 +1,20 @@
+# Network & Protocol Terminology Glossary
+
+## Terminology
+
+| English Term       | Chinese Translation | Notes            |
+|--------------------|---------------------|------------------|
+| protocol           | 协议                  |                  |
+| handshake          | 握手                  |                  |
+| frame              | 帧                   | Protocol context |
+| packet             | 数据包                 | Network layer    |
+| flow control       | 流量控制                |                  |
+| congestion control | 拥塞控制                |                  |
+| timeout            | 超时                  |                  |
+| retry              | 重试                  |                  |
+| TLS                | TLS                 | Keep acronym     |
+| TCP                | TCP                 | Keep acronym     |
+| UDP                | UDP                 | Keep acronym     |
+| MUST               | MUST                | RFC 2119         |
+| SHOULD             | SHOULD              | RFC 2119         |
+| MAY                | MAY                 | RFC 2119         |

--- a/.claude/skills/rust-doc-comment-generator/SKILL.md
+++ b/.claude/skills/rust-doc-comment-generator/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: rust-doc-comment-generator
+description: Generate idiomatic, production-grade Rust comments and documentation strictly following official Rustdoc and Rust API documentation conventions. Designed for real-world Rust projects with zero AI-identifiable markers.
+
+---
+
+# Rust Documentation & Comment Generator Skill
+
+## Overview
+
+This skill generates **standard-compliant Rust comments and documentation** for Rust source code.
+It strictly follows Rust’s official documentation guidelines and produces output suitable for
+**production-quality open-source and enterprise Rust projects**.
+
+The generated comments are:
+
+- Idiomatic and precise
+- Free of AI-identifiable artifacts
+- Fully aligned with Rustdoc conventions
+- Suitable for blocking, async, and unsafe code
+
+## Standards & References
+
+This skill MUST comply with the following authoritative sources:
+
+- Rust API Guidelines — Documentation  
+  https://rust-lang.github.io/api-guidelines/documentation.html
+- The Rustdoc Book  
+  https://doc.rust-lang.org/rustdoc/
+- Rust Style Guide  
+  https://doc.rust-lang.org/style-guide/
+
+## Supported Targets
+
+This skill applies to the following Rust items:
+
+- `struct`, `enum`, `union`
+- `trait`
+- `impl` blocks
+- `fn` / `async fn`
+- Modules (`mod`)
+- `unsafe` blocks and functions
+
+## Comment & Documentation Rules
+
+### 1. Comment Types
+
+| Context                       | Format                |
+|-------------------------------|-----------------------|
+| Public item                   | `///` Rustdoc comment |
+| Module-level documentation    | `//!`                 |
+| Private implementation detail | `//`                  |
+| Unsafe API explanation        | `/// # Safety`        |
+
+### 2. Rustdoc Section Usage
+
+Rustdoc sections MUST be included **only when semantically relevant**:
+
+- `# Examples`
+- `# Panics`
+- `# Errors`
+- `# Safety`
+- `# Performance`
+
+Empty or boilerplate sections are not allowed.
+
+### 3. Language & Tone
+
+- Use formal, neutral, technical language
+- Avoid conversational or instructional phrasing
+- Avoid marketing or subjective language
+- Describe behavior, constraints, and guarantees precisely
+
+✅ Correct:
+
+> Represents the configuration used by the message consumer.
+
+❌ Incorrect:
+
+> This struct is very useful and highly optimized.
+
+### 4. Blocking vs Async Behavior
+
+#### Blocking APIs
+
+Blocking behavior MUST be explicitly documented.
+
+```rust
+/// Blocks the current thread until a message is available.
+```
+
+#### Async / Non-Blocking APIs
+
+Async behavior MUST be explicitly documented.
+
+```rust
+/// Asynchronously waits for the next message.
+///
+/// This function does not block the calling thread.
+```
+
+### 5. Unsafe Code Documentation
+
+Any `unsafe` function or block MUST include a `# Safety` section.
+
+```rust
+/// # Safety
+///
+/// The caller must ensure that the pointer is valid and properly aligned
+/// for the duration of the call.
+```
+
+Vague or generic safety statements are forbidden.
+
+## Forbidden Content
+
+The output MUST NOT contain:
+
+- Emojis
+- Phase or workflow markers (e.g. `Phase`, `Step`, `Optimize`)
+- TODO / FIXME / NOTE meta-comments
+- AI-related indicators or explanations
+- Commentary about refactoring or future improvements
+
+## Input Expectations
+
+The user may provide:
+
+- Undocumented Rust code
+- Partially documented Rust code
+- Rust code with non-standard or low-quality comments
+
+## Output Expectations
+
+The skill MUST:
+
+1. Preserve existing correct Rustdoc comments
+2. Rewrite non-standard comments into idiomatic Rustdoc
+3. Add missing documentation where appropriate
+4. Never change code semantics
+5. Never introduce new APIs or rename identifiers
+
+## Example
+
+### Input
+
+```rust
+pub struct MessageQueue {
+    capacity: usize,
+}
+```
+
+### Output
+
+```rust
+/// Represents a bounded message queue.
+///
+/// The queue can store messages up to a fixed capacity.
+pub struct MessageQueue {
+    capacity: usize,
+}
+```
+
+## Non-Goals
+
+This skill does NOT:
+
+- Refactor code
+- Optimize performance
+- Rename symbols
+- Add logging
+- Generate tests
+
+## Compatibility
+
+This skill is designed to work alongside:
+
+- Rust API naming validation skills
+- Safety auditing skills
+- Project-specific glossary enforcement skills
+
+Each skill operates independently and does not overlap responsibilities.

--- a/.claude/skills/translate-it-doc-en-zh/SKILL.md
+++ b/.claude/skills/translate-it-doc-en-zh/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: translate-it-doc-en-zh
+description: Translate English IT and software engineering documents into professional, accurate Chinese. Use when user provides English technical documentation, API docs, README, design docs, RFCs, or source code comments and asks for Chinese translation. Prioritize correctness, standard IT terminology, and engineering-style Chinese.
+version: 1.1
+---
+
+# English to Chinese IT Documentation Translation
+
+## Role
+
+You are a professional IT and software engineering technical translator.
+
+You translate English technical documentation into **professional, precise, and standardized Chinese**, suitable for use in official documentation, design documents, and open-source projects.
+
+---
+
+## Mandatory Glossary (Strong Constraint)
+
+You MUST strictly follow terminology defined in the following glossary files:
+
+- ../glossary/glossary-core.md
+- ../glossary/glossary-concurrency.md
+- ../glossary/glossary-network-protocol.md
+- ../glossary/glossary-middleware-mq.md
+- ../glossary/glossary-lang-rust.md
+- ../glossary/glossary-lang-jvm.md
+
+### Glossary Rules
+
+- If a term exists in any glossary, you MUST use the specified Chinese translation.
+- You MUST NOT invent, localize, paraphrase, or redefine glossary terms.
+- If a term appears in multiple glossaries, apply the following priority order:
+  1. Language-specific glossary (Rust / JVM)
+  2. Domain-specific glossary (Concurrency / MQ / Network)
+  3. Core glossary
+
+---
+
+## Instructions
+
+When this skill is activated, translate the provided English IT or software engineering content into **professional Chinese** following these rules strictly:
+
+### 1. Accuracy First
+- Preserve the original technical meaning exactly.
+- Do NOT add, remove, or speculate about information.
+- Do NOT simplify technical concepts.
+
+### 2. IT Terminology Standards
+- Use widely accepted Chinese IT terminology.
+- Prefer translations used in:
+  - Official specifications
+  - Major open-source communities
+  - Industry-standard technical documentation
+- If multiple translations exist, choose the most authoritative and commonly accepted one.
+
+### 3. Keep Technical Elements Intact
+The following MUST NOT be translated:
+- Code blocks
+- Function names
+- Class names
+- Variable names
+- CLI commands
+- File paths
+- Protocol names
+- Inline code (must remain unchanged)
+
+### 4. Professional Technical Chinese Style
+- Use formal, concise, documentation-style Chinese.
+- Avoid colloquial or conversational expressions.
+- Prefer passive or neutral technical tone when appropriate.
+- Match the structure of the original text (lists, headings, paragraphs).
+
+### 5. Sentence-Level Optimization
+- Do NOT perform word-for-word translation if it reduces technical clarity.
+- Restructure sentences only when necessary to produce clear and natural technical Chinese.
+- Keep paragraph boundaries consistent with the original text.
+
+### 6. Comments & Documentation Context
+For source code comments:
+- Translate as professional developer comments.
+- Preserve intent such as explanation, warning, TODO, NOTE, or constraint.
+
+### 7. Mixed Language & Abbreviations
+- Widely used English abbreviations or terms without standard Chinese translations
+  (e.g., QPS, GC, TLS, CI/CD, linter) MUST be kept in English.
+- If appropriate and non-intrusive, a brief Chinese clarification MAY be added at first occurrence.
+- Once introduced, remain consistent throughout the document.
+
+### 8. Numbers & Units
+- Numbers and units should generally retain their original format (e.g., 10ms, 500MB).
+- Adjustments following common Chinese technical writing conventions are acceptable when clarity is improved.
+
+### 9. RFC & Specification Language
+When translating specification-style documents:
+- MUST, SHOULD, MAY MUST remain in uppercase English.
+- Do NOT weaken, strengthen, or reinterpret requirement levels.
+
+### 10. No Extra Output
+- Output only the translated Chinese content.
+- Do NOT add explanations, notes, or translation commentary.
+- Do NOT mention glossary usage in the output.
+
+---
+
+## Examples
+
+### Example 1
+
+**Input:**
+> This module is responsible for managing message offsets and ensuring at-least-once delivery semantics.
+
+**Output:**
+> 该模块负责管理消息偏移量，并确保至少一次（at-least-once）的消息投递语义。
+
+---
+
+### Example 2
+
+**Input:**
+> The producer retries sending messages when network latency exceeds the configured timeout.
+
+**Output:**
+> 当网络延迟超过配置的超时时间时，生产者会重试发送消息。
+
+---
+
+### Example 3 (Code Comment)
+
+**Input:**
+```rust
+// This function acquires a write lock and must not be called from async context.
+```
+
+**Output:**
+```rust
+// 该函数会获取写锁，且不得在异步上下文中调用。
+```
+
+---

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ _site
 !.claude/rules/*.md
 !.claude/skills/
 !.claude/skills/**
+!.claude/glossary/**
+!.claude/glossary
 .codex
 
 # Tauri


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7554

### Brief Description

Add the `.agents` copies of repository skills that existed under `.claude/skills` but were missing from `.agents/skills`:

- `rust-doc-comment-generator`
- `translate-it-doc-en-zh`

Also add `.agents/glossary` files required by the translation skill's relative `../glossary` references, so the copied skill remains usable from the `.agents` directory.

### How Did You Test This Change?

- `python .agents\skills\rocketmq-rust-issue-generator\scripts\audit_issue_paths.py <issue-draft>` passed.
- `python .agents\skills\rocketmq-rust-pr-submitter\scripts\validate_pr_content.py --title "[ISSUE #7554] ✨ Add missing repository agent skills" --body <pr-body>` passed.
- Cargo validation not run; this PR only adds agent skill and glossary Markdown assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bilingual terminology glossaries for core IT topics, including concurrency, networking, messaging, JVM, and Rust.
  * Added guidance for generating Rust documentation comments and translating technical documents from English to Chinese.

* **Documentation**
  * Expanded terminology rules to keep translations consistent across technical content.
  * Clarified formatting, style, and required handling of code, identifiers, and safety notes in generated docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->