### PR TITLE
[ISSUE #7569]✨Standardize compact PR skill title format

### DIFF
--- a/.agents/skills/rocketmq-rust-pr-submitter/SKILL.md
+++ b/.agents/skills/rocketmq-rust-pr-submitter/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: rocketmq-rust-pr-submitter
-description: Use when the user asks to prepare, submit, publish, or optimize a pull request for the rocketmq-rust project, especially when the PR must follow the `[ISSUE #issue_id] <emoji> <summary>` title convention, the `.github/PULL_REQUEST_TEMPLATE.md` body format (Fixes, Brief Description, How Did You Test This Change), and must not be created as a draft PR unless the user explicitly requests one.
+description: Use when the user asks to prepare, submit, publish, or optimize a pull request for the rocketmq-rust project, especially when the PR title or commit message must follow the `[ISSUE #issue_id]<emoji><summary>` convention, the `.github/PULL_REQUEST_TEMPLATE.md` body format, and the PR must not be draft unless explicitly requested.
 ---
 
 # RocketMQ Rust PR Submitter
 
-Prepare RocketMQ Rust PR titles and bodies from `.github/PULL_REQUEST_TEMPLATE.md`. Connects PR to issue via `[ISSUE #id]` title prefix and `Fixes #id` body line.
+Prepare RocketMQ Rust PR titles, commit messages, and bodies from `.github/PULL_REQUEST_TEMPLATE.md`. Connects PR to issue via `[ISSUE #id]` title/commit prefix and `Fixes #id` body line.
 
 ## When to Use
 
 - User asks to create, prepare, or publish a PR for rocketmq-rust
-- PR title must follow `[ISSUE #issue_id] <emoji> <summary>` format
+- PR title or commit message must follow `[ISSUE #issue_id]<emoji><summary>` format
 - PR body must follow the repository's real PR template (not a custom format)
 - Issue id is available from user request, branch name, or commit history
 
@@ -42,9 +42,15 @@ Priority order: user request → branch name (`issue-7544`, `fix-7544`) → comm
 
 ### 3. Write Title
 ```
-[ISSUE #issue_id] <emoji> <summary>
+[ISSUE #issue_id]<emoji><summary>
 ```
-Exactly one space after `]` and after emoji. No extra prefixes (conventional commit, branch name). Keep summary short and action-oriented.
+Do not put spaces between `]`, the emoji, and the summary. No extra prefixes (conventional commit, branch name). Keep the summary short and action-oriented.
+
+If creating a commit as part of the PR workflow, use the exact same compact format for the commit message:
+
+```
+[ISSUE #issue_id]<emoji><summary>
+```
 
 ### 4. Write Body
 ```markdown
@@ -79,7 +85,7 @@ Preserve template headings exactly. Keep paths repository-relative. In the test 
 | Leaving `#issue_id` placeholder | Replace with numeric id in both title and body |
 | Creating draft PR by default | Normal ready-for-review PR unless user says "draft PR" |
 | Claiming unrun validation passed | State "validation not run" honestly in test section |
-| Adding extra prefixes (conventional commit, branch name) | Only `[ISSUE #id] <emoji> <summary>` |
+| Adding spaces or extra prefixes | Only `[ISSUE #id]<emoji><summary>` for PR titles and commit messages |
 | Wrong emoji for change type | Match to linked issue type; default to ✨ |
 
 ## Output Format
@@ -87,7 +93,7 @@ Preserve template headings exactly. Keep paths repository-relative. In the test 
 **Full prepare request:**
 ```
 Title:
-[ISSUE #issue_id] <emoji> <summary>
+[ISSUE #issue_id]<emoji><summary>
 
 Body:
 ### Which Issue(s) This PR Fixes(Closes)
@@ -99,7 +105,8 @@ Body:
 
 ## Final Check
 
-- Title matches `[ISSUE #number] <emoji> <summary>`
+- Title matches `[ISSUE #number]<emoji><summary>`
+- Commit message, when created, matches `[ISSUE #number]<emoji><summary>`
 - Body includes three PR template headings in order with `- Fixes #number`
 - Test section doesn't claim unrun commands passed
 - No local absolute paths or machine-specific roots

--- a/.agents/skills/rocketmq-rust-pr-submitter/evals/evals.json
+++ b/.agents/skills/rocketmq-rust-pr-submitter/evals/evals.json
@@ -4,19 +4,19 @@
     {
       "id": 1,
       "prompt": "Create a PR title and body for issue 7544. The change adds runtime audit CI enforcement for RocketMQ Rust. Validation run: .\\scripts\\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline passed.",
-      "expected_output": "Uses title format `[ISSUE #7544] ✨ ...`, includes the three PULL_REQUEST_TEMPLATE headings in order, uses `- Fixes #7544`, describes runtime audit CI enforcement, and lists the audit command as passed.",
+      "expected_output": "Uses title and commit-message format `[ISSUE #7544]✨...`, includes the three PULL_REQUEST_TEMPLATE headings in order, uses `- Fixes #7544`, describes runtime audit CI enforcement, and lists the audit command as passed.",
       "files": []
     },
     {
       "id": 2,
       "prompt": "Generate only a PR title for issue 8123. This is a broker auth bug fix.",
-      "expected_output": "Returns only title candidates, each matching `[ISSUE #8123] 🐛 <summary>`, with no PR body.",
+      "expected_output": "Returns only title candidates, each matching `[ISSUE #8123]🐛<summary>`, with no PR body.",
       "files": []
     },
     {
       "id": 3,
       "prompt": "Prepare ready-to-submit PR title and body for issue 8201 adding consume queue recovery regression tests. I have not run tests yet.",
-      "expected_output": "Uses title format `[ISSUE #8201] 🧪 ...`, uses the PR template body, and honestly states that validation was not run instead of claiming tests passed.",
+      "expected_output": "Uses title and commit-message format `[ISSUE #8201]🧪...`, uses the PR template body, and honestly states that validation was not run instead of claiming tests passed.",
       "files": []
     },
     {

--- a/.agents/skills/rocketmq-rust-pr-submitter/scripts/validate_pr_content.py
+++ b/.agents/skills/rocketmq-rust-pr-submitter/scripts/validate_pr_content.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 TITLE_RE = re.compile(
-    r"^\[ISSUE #(?P<issue>\d+)\] (?P<emoji>🐛|📝|✨|🚀|♻️|🧪) (?P<summary>.+\S)$",
+    r"^\[ISSUE #(?P<issue>\d+)\](?P<emoji>🐛|📝|✨|🚀|♻️|🧪)(?P<summary>\S(?:.*\S)?)$",
 )
 
 LOCAL_PATH_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
@@ -93,7 +93,7 @@ def main() -> int:
 
     title_match = TITLE_RE.match(args.title)
     if title_match is None:
-        errors.append("title must match: [ISSUE #issue_id] <emoji> <summary>")
+        errors.append("title must match: [ISSUE #issue_id]<emoji><summary>")
         title_issue = None
     else:
         title_issue = title_match.group("issue")

--- a/.claude/skills/rocketmq-rust-pr-submitter/SKILL.md
+++ b/.claude/skills/rocketmq-rust-pr-submitter/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: rocketmq-rust-pr-submitter
-description: Use when the user asks to prepare, submit, publish, or optimize a pull request for the rocketmq-rust project, especially when the PR must follow the `[ISSUE #issue_id] <emoji> <summary>` title convention, the `.github/PULL_REQUEST_TEMPLATE.md` body format (Fixes, Brief Description, How Did You Test This Change), and must not be created as a draft PR unless the user explicitly requests one.
+description: Use when the user asks to prepare, submit, publish, or optimize a pull request for the rocketmq-rust project, especially when the PR title or commit message must follow the `[ISSUE #issue_id]<emoji><summary>` convention, the `.github/PULL_REQUEST_TEMPLATE.md` body format, and the PR must not be draft unless explicitly requested.
 ---
 
 # RocketMQ Rust PR Submitter
 
-Prepare RocketMQ Rust PR titles and bodies from `.github/PULL_REQUEST_TEMPLATE.md`. Connects PR to issue via `[ISSUE #id]` title prefix and `Fixes #id` body line.
+Prepare RocketMQ Rust PR titles, commit messages, and bodies from `.github/PULL_REQUEST_TEMPLATE.md`. Connects PR to issue via `[ISSUE #id]` title/commit prefix and `Fixes #id` body line.
 
 ## When to Use
 
 - User asks to create, prepare, or publish a PR for rocketmq-rust
-- PR title must follow `[ISSUE #issue_id] <emoji> <summary>` format
+- PR title or commit message must follow `[ISSUE #issue_id]<emoji><summary>` format
 - PR body must follow the repository's real PR template (not a custom format)
 - Issue id is available from user request, branch name, or commit history
 
@@ -42,9 +42,15 @@ Priority order: user request → branch name (`issue-7544`, `fix-7544`) → comm
 
 ### 3. Write Title
 ```
-[ISSUE #issue_id] <emoji> <summary>
+[ISSUE #issue_id]<emoji><summary>
 ```
-Exactly one space after `]` and after emoji. No extra prefixes (conventional commit, branch name). Keep summary short and action-oriented.
+Do not put spaces between `]`, the emoji, and the summary. No extra prefixes (conventional commit, branch name). Keep the summary short and action-oriented.
+
+If creating a commit as part of the PR workflow, use the exact same compact format for the commit message:
+
+```
+[ISSUE #issue_id]<emoji><summary>
+```
 
 ### 4. Write Body
 ```markdown
@@ -79,7 +85,7 @@ Preserve template headings exactly. Keep paths repository-relative. In the test 
 | Leaving `#issue_id` placeholder | Replace with numeric id in both title and body |
 | Creating draft PR by default | Normal ready-for-review PR unless user says "draft PR" |
 | Claiming unrun validation passed | State "validation not run" honestly in test section |
-| Adding extra prefixes (conventional commit, branch name) | Only `[ISSUE #id] <emoji> <summary>` |
+| Adding spaces or extra prefixes | Only `[ISSUE #id]<emoji><summary>` for PR titles and commit messages |
 | Wrong emoji for change type | Match to linked issue type; default to ✨ |
 
 ## Output Format
@@ -87,7 +93,7 @@ Preserve template headings exactly. Keep paths repository-relative. In the test 
 **Full prepare request:**
 ```
 Title:
-[ISSUE #issue_id] <emoji> <summary>
+[ISSUE #issue_id]<emoji><summary>
 
 Body:
 ### Which Issue(s) This PR Fixes(Closes)
@@ -99,7 +105,8 @@ Body:
 
 ## Final Check
 
-- Title matches `[ISSUE #number] <emoji> <summary>`
+- Title matches `[ISSUE #number]<emoji><summary>`
+- Commit message, when created, matches `[ISSUE #number]<emoji><summary>`
 - Body includes three PR template headings in order with `- Fixes #number`
 - Test section doesn't claim unrun commands passed
 - No local absolute paths or machine-specific roots

--- a/.claude/skills/rocketmq-rust-pr-submitter/evals/evals.json
+++ b/.claude/skills/rocketmq-rust-pr-submitter/evals/evals.json
@@ -4,19 +4,19 @@
     {
       "id": 1,
       "prompt": "Create a PR title and body for issue 7544. The change adds runtime audit CI enforcement for RocketMQ Rust. Validation run: .\\scripts\\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline passed.",
-      "expected_output": "Uses title format `[ISSUE #7544] ✨ ...`, includes the three PULL_REQUEST_TEMPLATE headings in order, uses `- Fixes #7544`, describes runtime audit CI enforcement, and lists the audit command as passed.",
+      "expected_output": "Uses title and commit-message format `[ISSUE #7544]✨...`, includes the three PULL_REQUEST_TEMPLATE headings in order, uses `- Fixes #7544`, describes runtime audit CI enforcement, and lists the audit command as passed.",
       "files": []
     },
     {
       "id": 2,
       "prompt": "Generate only a PR title for issue 8123. This is a broker auth bug fix.",
-      "expected_output": "Returns only title candidates, each matching `[ISSUE #8123] 🐛 <summary>`, with no PR body.",
+      "expected_output": "Returns only title candidates, each matching `[ISSUE #8123]🐛<summary>`, with no PR body.",
       "files": []
     },
     {
       "id": 3,
       "prompt": "Prepare ready-to-submit PR title and body for issue 8201 adding consume queue recovery regression tests. I have not run tests yet.",
-      "expected_output": "Uses title format `[ISSUE #8201] 🧪 ...`, uses the PR template body, and honestly states that validation was not run instead of claiming tests passed.",
+      "expected_output": "Uses title and commit-message format `[ISSUE #8201]🧪...`, uses the PR template body, and honestly states that validation was not run instead of claiming tests passed.",
       "files": []
     },
     {

--- a/.claude/skills/rocketmq-rust-pr-submitter/scripts/validate_pr_content.py
+++ b/.claude/skills/rocketmq-rust-pr-submitter/scripts/validate_pr_content.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 TITLE_RE = re.compile(
-    r"^\[ISSUE #(?P<issue>\d+)\] (?P<emoji>🐛|📝|✨|🚀|♻️|🧪) (?P<summary>.+\S)$",
+    r"^\[ISSUE #(?P<issue>\d+)\](?P<emoji>🐛|📝|✨|🚀|♻️|🧪)(?P<summary>\S(?:.*\S)?)$",
 )
 
 LOCAL_PATH_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
@@ -93,7 +93,7 @@ def main() -> int:
 
     title_match = TITLE_RE.match(args.title)
     if title_match is None:
-        errors.append("title must match: [ISSUE #issue_id] <emoji> <summary>")
+        errors.append("title must match: [ISSUE #issue_id]<emoji><summary>")
         title_issue = None
     else:
         title_issue = title_match.group("issue")


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #7569

### Brief Description

- Updated the `.agents` PR submitter skill to require compact PR title and commit-message format.
- Updated the `.claude` PR submitter skill to keep Claude Code behavior aligned.
- Updated the PR content validator so `[ISSUE #id]<emoji><summary>` is accepted and the previous spaced format is rejected.
- Updated eval examples to document the compact title and commit-message convention.

### How Did You Test This Change?

- `python -m json.tool .agents\skills\rocketmq-rust-pr-submitter\evals\evals.json`
- `python -m json.tool .claude\skills\rocketmq-rust-pr-submitter\evals\evals.json`
- `python .agents\skills\rocketmq-rust-pr-submitter\scripts\validate_pr_content.py --title "[ISSUE #7569]✨Standardize compact PR skill title format" --body <temp-pr-body>`
- `python .claude\skills\rocketmq-rust-pr-submitter\scripts\validate_pr_content.py --title "[ISSUE #7569]✨Standardize compact PR skill title format" --body <temp-pr-body>`
- Verified the old spaced title format is rejected by both validators.
- `git diff --check`

Rust validation was not run because this change only updates repository skill documentation, eval JSON, and Python validation scripts; no Rust source or Cargo configuration changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened PR title checks to require the exact compact format: `[ISSUE `#id`]<emoji><summary>` with no spaces.
  * Updated validation messages to clearly show the expected format.

* **Documentation**
  * Aligned guidance and examples with the new title/commit-message format.
  * Clarified the checklist used to verify PR formatting before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->