### PR TITLE
[ISSUE #7571]♻️Optimize remoting header key construction

### DIFF
--- a/rocketmq-macros/src/request_header_custom.rs
+++ b/rocketmq-macros/src/request_header_custom.rs
@@ -92,7 +92,7 @@ pub(super) fn request_header_codec_inner(input: proc_macro::TokenStream) -> proc
                                    if let Some(ref value) = self.#field_name {
                                       map.insert (
                                            cheetah_string::CheetahString::from_static_str(Self::#static_name),
-                                           cheetah_string::CheetahString::from_string(value.clone())
+                                           cheetah_string::CheetahString::from_string_owned(value.clone())
                                       );
                                     }
                                }
@@ -109,7 +109,7 @@ pub(super) fn request_header_codec_inner(input: proc_macro::TokenStream) -> proc
                                    if let Some(ref value) = self.#field_name {
                                       map.insert (
                                           cheetah_string::CheetahString::from_static_str(Self::#static_name),
-                                          cheetah_string::CheetahString::from_string(value.to_string())
+                                          cheetah_string::CheetahString::from_string_owned(value.to_string())
                                       );
                                     }
                                }
@@ -125,7 +125,7 @@ pub(super) fn request_header_codec_inner(input: proc_macro::TokenStream) -> proc
                         quote! {
                              map.insert (
                                  cheetah_string::CheetahString::from_static_str(Self::#static_name),
-                                 cheetah_string::CheetahString::from_string(self.#field_name.clone())
+                                 cheetah_string::CheetahString::from_string_owned(self.#field_name.clone())
                              );
                          }
                     } else if is_struct_type && has_serde_flatten_attribute {
@@ -140,7 +140,7 @@ pub(super) fn request_header_codec_inner(input: proc_macro::TokenStream) -> proc
                         quote! {
                              map.insert (
                                  cheetah_string::CheetahString::from_static_str(Self::#static_name),
-                                 cheetah_string::CheetahString::from_string(self.#field_name.to_string())
+                                 cheetah_string::CheetahString::from_string_owned(self.#field_name.to_string())
                              );
                          }
                     },
@@ -420,28 +420,28 @@ impl FieldMetadata {
                 if let Some(ref value) = self.#field_ident {
                     map.insert(
                         cheetah_string::CheetahString::from_static_str(Self::#const_ident),
-                        cheetah_string::CheetahString::from_string(value.clone())
+                        cheetah_string::CheetahString::from_string_owned(value.clone())
                     );
                 }
             },
             (TypeCategory::String, false) => quote! {
                 map.insert(
                     cheetah_string::CheetahString::from_static_str(Self::#const_ident),
-                    cheetah_string::CheetahString::from_string(self.#field_ident.clone())
+                    cheetah_string::CheetahString::from_string_owned(self.#field_ident.clone())
                 );
             },
             (TypeCategory::Primitive, true) => quote! {
                 if let Some(ref value) = self.#field_ident {
                     map.insert(
                         cheetah_string::CheetahString::from_static_str(Self::#const_ident),
-                        cheetah_string::CheetahString::from_string(value.to_string())
+                        cheetah_string::CheetahString::from_string_owned(value.to_string())
                     );
                 }
             },
             (TypeCategory::Primitive, false) => quote! {
                 map.insert(
                     cheetah_string::CheetahString::from_static_str(Self::#const_ident),
-                    cheetah_string::CheetahString::from_string(self.#field_ident.to_string())
+                    cheetah_string::CheetahString::from_string_owned(self.#field_ident.to_string())
                 );
             },
             _ => quote! {},

--- a/rocketmq-remoting/src/protocol/command_custom_header.rs
+++ b/rocketmq-remoting/src/protocol/command_custom_header.rs
@@ -115,6 +115,24 @@ pub trait CommandCustomHeader: AsAny {
             )),
         }
     }
+
+    /// Retrieves a borrowed value associated with the specified field from the provided map.
+    #[inline(always)]
+    fn get_and_check_not_none_ref<'a>(
+        &self,
+        map: &'a HashMap<CheetahString, CheetahString>,
+        field: &CheetahString,
+    ) -> rocketmq_error::RocketMQResult<&'a CheetahString> {
+        match map.get(field) {
+            Some(value) => Ok(value),
+            None => Err(rocketmq_error::RocketMQError::Serialization(
+                rocketmq_error::SerializationError::DecodeFailed {
+                    format: "header",
+                    message: format!("The field {field} is required."),
+                },
+            )),
+        }
+    }
 }
 
 pub trait AsAny: Any {

--- a/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
+++ b/rocketmq-remoting/src/protocol/header/message_operation_header/send_message_request_header_v2.rs
@@ -88,58 +88,31 @@ pub struct SendMessageRequestHeaderV2 {
 impl CommandCustomHeader for SendMessageRequestHeaderV2 {
     fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
         let mut map = HashMap::with_capacity(14);
-        map.insert(CheetahString::from_static_str(FIELD_A), self.a.clone());
-        map.insert(CheetahString::from_static_str(FIELD_B), self.b.clone());
-        map.insert(CheetahString::from_static_str(FIELD_C), self.c.clone());
-        map.insert(
-            CheetahString::from_static_str(FIELD_D),
-            CheetahString::from_string(self.d.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(FIELD_E),
-            CheetahString::from_string(self.e.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(FIELD_F),
-            CheetahString::from_string(self.f.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(FIELD_G),
-            CheetahString::from_string(self.g.to_string()),
-        );
-        map.insert(
-            CheetahString::from_static_str(FIELD_H),
-            CheetahString::from_string(self.h.to_string()),
-        );
+        map.insert(KEY_A.clone(), self.a.clone());
+        map.insert(KEY_B.clone(), self.b.clone());
+        map.insert(KEY_C.clone(), self.c.clone());
+        map.insert(KEY_D.clone(), CheetahString::from_string_owned(self.d.to_string()));
+        map.insert(KEY_E.clone(), CheetahString::from_string_owned(self.e.to_string()));
+        map.insert(KEY_F.clone(), CheetahString::from_string_owned(self.f.to_string()));
+        map.insert(KEY_G.clone(), CheetahString::from_string_owned(self.g.to_string()));
+        map.insert(KEY_H.clone(), CheetahString::from_string_owned(self.h.to_string()));
         if let Some(ref value) = self.i {
-            map.insert(CheetahString::from_static_str(FIELD_I), value.clone());
+            map.insert(KEY_I.clone(), value.clone());
         }
         if let Some(value) = self.j {
-            map.insert(
-                CheetahString::from_static_str(FIELD_J),
-                CheetahString::from_string(value.to_string()),
-            );
+            map.insert(KEY_J.clone(), CheetahString::from_string_owned(value.to_string()));
         }
         if let Some(value) = self.k {
-            map.insert(
-                CheetahString::from_static_str(FIELD_K),
-                CheetahString::from_string(value.to_string()),
-            );
+            map.insert(KEY_K.clone(), CheetahString::from_string_owned(value.to_string()));
         }
         if let Some(value) = self.l {
-            map.insert(
-                CheetahString::from_static_str(FIELD_L),
-                CheetahString::from_string(value.to_string()),
-            );
+            map.insert(KEY_L.clone(), CheetahString::from_string_owned(value.to_string()));
         }
         if let Some(value) = self.m {
-            map.insert(
-                CheetahString::from_static_str(FIELD_M),
-                CheetahString::from_string(value.to_string()),
-            );
+            map.insert(KEY_M.clone(), CheetahString::from_string_owned(value.to_string()));
         }
         if let Some(ref value) = self.n {
-            map.insert(CheetahString::from_static_str(FIELD_N), value.clone());
+            map.insert(KEY_N.clone(), value.clone());
         }
         if let Some(ref value) = self.topic_request_header {
             if let Some(value) = value.to_map() {
@@ -210,45 +183,45 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
     fn decode_fast(&mut self, fields: &HashMap<CheetahString, CheetahString>) -> rocketmq_error::RocketMQResult<()> {
         // Use static keys to avoid repeated allocations
 
-        self.a = self.get_and_check_not_none(fields, &KEY_A)?; //producerGroup
-        self.b = self.get_and_check_not_none(fields, &KEY_B)?; //topic
-        self.c = self.get_and_check_not_none(fields, &KEY_C)?; //defaultTopic
-        self.d = self.get_and_check_not_none(fields, &KEY_D)?.parse().map_err(|_| {
+        self.a = self.get_and_check_not_none_ref(fields, &KEY_A)?.clone(); //producerGroup
+        self.b = self.get_and_check_not_none_ref(fields, &KEY_B)?.clone(); //topic
+        self.c = self.get_and_check_not_none_ref(fields, &KEY_C)?.clone(); //defaultTopic
+        self.d = self.get_and_check_not_none_ref(fields, &KEY_D)?.parse().map_err(|_| {
             rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
                 format: "header",
                 message: "Parse field d error".to_string(),
             })
         })?; //defaultTopicQueueNums
-        self.e = self.get_and_check_not_none(fields, &KEY_E)?.parse().map_err(|_| {
+        self.e = self.get_and_check_not_none_ref(fields, &KEY_E)?.parse().map_err(|_| {
             rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
                 format: "header",
                 message: "Parse field e error".to_string(),
             })
         })?; //queueId
-        self.f = self.get_and_check_not_none(fields, &KEY_F)?.parse().map_err(|_| {
+        self.f = self.get_and_check_not_none_ref(fields, &KEY_F)?.parse().map_err(|_| {
             rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
                 format: "header",
                 message: "Parse field f error".to_string(),
             })
         })?; //sysFlag
-        self.g = self.get_and_check_not_none(fields, &KEY_G)?.parse().map_err(|_| {
+        self.g = self.get_and_check_not_none_ref(fields, &KEY_G)?.parse().map_err(|_| {
             rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
                 format: "header",
                 message: "Parse field g error".to_string(),
             })
         })?; //bornTimestamp
-        self.h = self.get_and_check_not_none(fields, &KEY_H)?.parse().map_err(|_| {
+        self.h = self.get_and_check_not_none_ref(fields, &KEY_H)?.parse().map_err(|_| {
             rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
                 format: "header",
                 message: "Parse field h error".to_string(),
             })
         })?; //flag
 
-        if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_I)) {
+        if let Some(v) = fields.get(&KEY_I) {
             self.i = Some(v.clone());
         }
 
-        if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_J)) {
+        if let Some(v) = fields.get(&KEY_J) {
             self.j = Some(v.parse().map_err(|_| {
                 rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
                     format: "header",
@@ -257,7 +230,7 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
             })?);
         }
 
-        if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_K)) {
+        if let Some(v) = fields.get(&KEY_K) {
             self.k = Some(v.parse().map_err(|_| {
                 rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
                     format: "header",
@@ -266,7 +239,7 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
             })?);
         }
 
-        if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_L)) {
+        if let Some(v) = fields.get(&KEY_L) {
             self.l = Some(v.parse().map_err(|_| {
                 rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
                     format: "header",
@@ -275,7 +248,7 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
             })?);
         }
 
-        if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_M)) {
+        if let Some(v) = fields.get(&KEY_M) {
             self.m = Some(v.parse().map_err(|_| {
                 rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
                     format: "header",
@@ -284,7 +257,7 @@ impl CommandCustomHeader for SendMessageRequestHeaderV2 {
             })?);
         }
 
-        if let Some(v) = fields.get(&CheetahString::from_static_str(FIELD_N)) {
+        if let Some(v) = fields.get(&KEY_N) {
             self.n = Some(v.clone());
         }
         Ok(())


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7571

### Brief Description

- Add a borrowed `CommandCustomHeader::get_and_check_not_none_ref` helper for required header field lookups.
- Reuse existing static `KEY_*` constants in `SendMessageRequestHeaderV2::to_map` and optional `decode_fast` lookups.
- Use `CheetahString::from_string_owned` for owned `String` and primitive `to_string()` values in handwritten and macro-generated header maps.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-remoting send_message_request_header_v2` passed.
- `cargo test -p rocketmq-remoting --lib` passed.
- `cargo test -p rocketmq-macros` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request header encoding and decoding for message requests, including more reliable handling of required and optional fields.
  * Added safer lookup behavior for missing header values, with consistent error reporting.
  * Updated header value conversion to better support string and numeric fields during serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->