### PR TITLE
[ISSUE #7573]♻️Use immutable namesrv route keys

### DIFF
--- a/rocketmq-namesrv/src/route/tables/broker_table.rs
+++ b/rocketmq-namesrv/src/route/tables/broker_table.rs
@@ -23,7 +23,10 @@ use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
 
+use crate::route::types::public_name_from_route;
+use crate::route::types::route_broker_name;
 use crate::route::types::BrokerName;
+use crate::route::types::RouteBrokerName;
 
 /// Broker address table: BrokerName -> BrokerData
 ///
@@ -45,7 +48,7 @@ use crate::route::types::BrokerName;
 /// ```
 #[derive(Clone)]
 pub struct BrokerAddrTable {
-    inner: DashMap<BrokerName, Arc<BrokerData>>,
+    inner: DashMap<RouteBrokerName, Arc<BrokerData>>,
 }
 
 impl BrokerAddrTable {
@@ -67,13 +70,13 @@ impl BrokerAddrTable {
     /// Insert or update broker data
     ///
     /// # Arguments
-    /// * `broker_name` - Broker name (zero-copy Arc<str>)
+    /// * `broker_name` - Broker name
     /// * `broker_data` - Broker configuration including addresses
     ///
     /// # Returns
     /// Previous broker data if existed
     pub fn insert(&self, broker_name: BrokerName, broker_data: BrokerData) -> Option<Arc<BrokerData>> {
-        self.inner.insert(broker_name, Arc::new(broker_data))
+        self.inner.insert(route_broker_name(broker_name), Arc::new(broker_data))
     }
 
     /// Get broker data by name
@@ -106,9 +109,12 @@ impl BrokerAddrTable {
     /// Get all broker names
     ///
     /// # Returns
-    /// Vector of broker names (CheetahString for zero-copy)
+    /// Vector of public broker names.
     pub fn get_all_broker_names(&self) -> Vec<BrokerName> {
-        self.inner.iter().map(|entry| entry.key().clone()).collect()
+        self.inner
+            .iter()
+            .map(|entry| public_name_from_route(entry.key()))
+            .collect()
     }
 
     /// Get all broker data entries
@@ -118,7 +124,7 @@ impl BrokerAddrTable {
     pub fn get_all_brokers(&self) -> Vec<(BrokerName, Arc<BrokerData>)> {
         self.inner
             .iter()
-            .map(|entry| (entry.key().clone(), Arc::clone(entry.value())))
+            .map(|entry| (public_name_from_route(entry.key()), Arc::clone(entry.value())))
             .collect()
     }
 
@@ -129,7 +135,7 @@ impl BrokerAddrTable {
         for entry in self.inner.iter() {
             for (broker_id, addr) in entry.value().broker_addrs() {
                 if addr.as_str() == broker_addr {
-                    return Some((entry.key().clone(), *broker_id));
+                    return Some((public_name_from_route(entry.key()), *broker_id));
                 }
             }
         }
@@ -145,7 +151,7 @@ impl BrokerAddrTable {
 
             for (broker_id, addr) in entry.value().broker_addrs() {
                 if addr.as_str() == broker_addr {
-                    return Some((entry.key().clone(), *broker_id));
+                    return Some((public_name_from_route(entry.key()), *broker_id));
                 }
             }
         }
@@ -166,7 +172,7 @@ impl BrokerAddrTable {
     pub fn snapshot(&self) -> HashMap<BrokerName, BrokerData> {
         let mut snapshot = HashMap::with_capacity(self.inner.len());
         for entry in self.inner.iter() {
-            snapshot.insert(entry.key().clone(), entry.value().as_ref().clone());
+            snapshot.insert(public_name_from_route(entry.key()), entry.value().as_ref().clone());
         }
         snapshot
     }
@@ -182,7 +188,7 @@ impl BrokerAddrTable {
         self.inner
             .iter()
             .filter(|entry| entry.value().cluster() == cluster_name)
-            .map(|entry| entry.key().clone())
+            .map(|entry| public_name_from_route(entry.key()))
             .collect()
     }
 

--- a/rocketmq-namesrv/src/route/tables/cluster_table.rs
+++ b/rocketmq-namesrv/src/route/tables/cluster_table.rs
@@ -23,8 +23,13 @@ use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use dashmap::DashSet;
 
+use crate::route::types::public_name_from_route;
+use crate::route::types::route_broker_name;
+use crate::route::types::route_cluster_name;
 use crate::route::types::BrokerName;
 use crate::route::types::ClusterName;
+use crate::route::types::RouteBrokerName;
+use crate::route::types::RouteClusterName;
 
 /// Cluster address table: ClusterName -> Set<BrokerName>
 ///
@@ -47,7 +52,7 @@ use crate::route::types::ClusterName;
 /// ```
 #[derive(Clone)]
 pub struct ClusterAddrTable {
-    inner: DashMap<ClusterName, DashSet<BrokerName>>,
+    inner: DashMap<RouteClusterName, DashSet<RouteBrokerName>>,
 }
 
 impl ClusterAddrTable {
@@ -69,13 +74,16 @@ impl ClusterAddrTable {
     /// Add a broker to a cluster
     ///
     /// # Arguments
-    /// * `cluster_name` - Cluster name (zero-copy Arc<str>)
-    /// * `broker_name` - Broker name to add (zero-copy Arc<str>)
+    /// * `cluster_name` - Cluster name
+    /// * `broker_name` - Broker name to add
     ///
     /// # Returns
     /// true if broker was newly added, false if already existed
     pub fn add_broker(&self, cluster_name: ClusterName, broker_name: BrokerName) -> bool {
-        self.inner.entry(cluster_name).or_default().insert(broker_name)
+        self.inner
+            .entry(route_cluster_name(cluster_name))
+            .or_default()
+            .insert(route_broker_name(broker_name))
     }
 
     /// Remove a broker from a cluster
@@ -113,11 +121,16 @@ impl ClusterAddrTable {
     /// * `cluster_name` - Cluster name
     ///
     /// # Returns
-    /// Vector of broker names (CheetahString for zero-copy)
+    /// Vector of public broker names.
     pub fn get_brokers(&self, cluster_name: &str) -> Vec<BrokerName> {
         self.inner
             .get(cluster_name)
-            .map(|brokers| brokers.iter().map(|broker| broker.key().clone()).collect())
+            .map(|brokers| {
+                brokers
+                    .iter()
+                    .map(|broker| public_name_from_route(broker.key()))
+                    .collect()
+            })
             .unwrap_or_default()
     }
 
@@ -141,9 +154,12 @@ impl ClusterAddrTable {
     /// Get all cluster names
     ///
     /// # Returns
-    /// Vector of cluster names (CheetahString for zero-copy)
+    /// Vector of public cluster names.
     pub fn get_all_clusters(&self) -> Vec<ClusterName> {
-        self.inner.iter().map(|entry| entry.key().clone()).collect()
+        self.inner
+            .iter()
+            .map(|entry| public_name_from_route(entry.key()))
+            .collect()
     }
 
     /// Get all clusters with their brokers
@@ -154,8 +170,8 @@ impl ClusterAddrTable {
         self.inner
             .iter()
             .map(|entry| {
-                let cluster = entry.key().clone();
-                let brokers = entry.value().iter().map(|b| b.key().clone()).collect();
+                let cluster = public_name_from_route(entry.key());
+                let brokers = entry.value().iter().map(|b| public_name_from_route(b.key())).collect();
                 (cluster, brokers)
             })
             .collect()
@@ -164,8 +180,8 @@ impl ClusterAddrTable {
     /// Append cluster names and broker names to an output topic list.
     pub fn append_cluster_and_broker_names(&self, topic_list: &mut Vec<CheetahString>) {
         for entry in self.inner.iter() {
-            topic_list.push(entry.key().clone());
-            topic_list.extend(entry.value().iter().map(|broker| broker.key().clone()));
+            topic_list.push(public_name_from_route(entry.key()));
+            topic_list.extend(entry.value().iter().map(|broker| public_name_from_route(broker.key())));
         }
     }
 
@@ -173,8 +189,12 @@ impl ClusterAddrTable {
     pub fn snapshot(&self) -> HashMap<ClusterName, HashSet<BrokerName>> {
         let mut snapshot = HashMap::with_capacity(self.inner.len());
         for entry in self.inner.iter() {
-            let brokers = entry.value().iter().map(|broker| broker.key().clone()).collect();
-            snapshot.insert(entry.key().clone(), brokers);
+            let brokers = entry
+                .value()
+                .iter()
+                .map(|broker| public_name_from_route(broker.key()))
+                .collect();
+            snapshot.insert(public_name_from_route(entry.key()), brokers);
         }
         snapshot
     }

--- a/rocketmq-namesrv/src/route/tables/topic_queue_mapping_table.rs
+++ b/rocketmq-namesrv/src/route/tables/topic_queue_mapping_table.rs
@@ -23,7 +23,12 @@ use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQueueMappingInfo;
 
+use crate::route::types::public_name_from_route;
+use crate::route::types::route_broker_name;
+use crate::route::types::route_topic_name;
 use crate::route::types::BrokerName;
+use crate::route::types::RouteBrokerName;
+use crate::route::types::RouteTopicName;
 use crate::route::types::TopicName;
 
 /// Topic queue mapping info table: Topic -> (BrokerName -> TopicQueueMappingInfo)
@@ -52,7 +57,7 @@ use crate::route::types::TopicName;
 pub struct TopicQueueMappingInfoTable {
     // Outer map: Topic -> Inner map
     // Inner map: BrokerName -> TopicQueueMappingInfo
-    inner: DashMap<TopicName, DashMap<BrokerName, Arc<TopicQueueMappingInfo>>>,
+    inner: DashMap<RouteTopicName, DashMap<RouteBrokerName, Arc<TopicQueueMappingInfo>>>,
 }
 
 impl Default for TopicQueueMappingInfoTable {
@@ -92,7 +97,10 @@ impl TopicQueueMappingInfoTable {
         broker_name: BrokerName,
         mapping_info: Arc<TopicQueueMappingInfo>,
     ) -> Option<Arc<TopicQueueMappingInfo>> {
-        self.inner.entry(topic).or_default().insert(broker_name, mapping_info)
+        self.inner
+            .entry(route_topic_name(topic))
+            .or_default()
+            .insert(route_broker_name(broker_name), mapping_info)
     }
 
     /// Get topic queue mapping info for a specific broker
@@ -120,7 +128,7 @@ impl TopicQueueMappingInfoTable {
         self.inner.get(topic).map(|broker_map| {
             broker_map
                 .iter()
-                .map(|entry| (entry.key().clone(), (**entry.value()).clone()))
+                .map(|entry| (public_name_from_route(entry.key()), (**entry.value()).clone()))
                 .collect()
         })
     }
@@ -146,8 +154,13 @@ impl TopicQueueMappingInfoTable {
     ///
     /// # Returns
     /// Removed broker map if existed
-    pub fn remove_topic(&self, topic: &str) -> Option<DashMap<BrokerName, Arc<TopicQueueMappingInfo>>> {
-        self.inner.remove(topic).map(|(_, v)| v)
+    pub fn remove_topic(&self, topic: &str) -> Option<HashMap<BrokerName, Arc<TopicQueueMappingInfo>>> {
+        self.inner.remove(topic).map(|(_, broker_map)| {
+            broker_map
+                .into_iter()
+                .map(|(broker_name, mapping_info)| (public_name_from_route(&broker_name), mapping_info))
+                .collect()
+        })
     }
 
     /// Check if topic has any mapping info
@@ -189,7 +202,10 @@ impl TopicQueueMappingInfoTable {
     /// # Returns
     /// Vector of topic names
     pub fn get_all_topics(&self) -> Vec<TopicName> {
-        self.inner.iter().map(|entry| entry.key().clone()).collect()
+        self.inner
+            .iter()
+            .map(|entry| public_name_from_route(entry.key()))
+            .collect()
     }
 
     /// Get all broker names for a topic
@@ -200,9 +216,12 @@ impl TopicQueueMappingInfoTable {
     /// # Returns
     /// Vector of broker names if topic exists
     pub fn get_brokers_for_topic(&self, topic: &str) -> Option<Vec<BrokerName>> {
-        self.inner
-            .get(topic)
-            .map(|broker_map| broker_map.iter().map(|entry| entry.key().clone()).collect())
+        self.inner.get(topic).map(|broker_map| {
+            broker_map
+                .iter()
+                .map(|entry| public_name_from_route(entry.key()))
+                .collect()
+        })
     }
 
     /// Cleanup empty topics (topics with no broker mappings)
@@ -233,9 +252,9 @@ impl TopicQueueMappingInfoTable {
                 let broker_map: HashMap<BrokerName, Arc<TopicQueueMappingInfo>> = entry
                     .value()
                     .iter()
-                    .map(|broker_entry| (broker_entry.key().clone(), broker_entry.value().clone()))
+                    .map(|broker_entry| (public_name_from_route(broker_entry.key()), broker_entry.value().clone()))
                     .collect();
-                (entry.key().clone(), broker_map)
+                (public_name_from_route(entry.key()), broker_map)
             })
             .collect()
     }

--- a/rocketmq-namesrv/src/route/tables/topic_table.rs
+++ b/rocketmq-namesrv/src/route/tables/topic_table.rs
@@ -16,13 +16,19 @@
 //!
 //! Manages topic -> broker -> queue data mappings using nested DashMap.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
 use dashmap::DashMap;
 use rocketmq_remoting::protocol::route::route_data_view::QueueData;
 
+use crate::route::types::public_name_from_route;
+use crate::route::types::route_broker_name;
+use crate::route::types::route_topic_name;
 use crate::route::types::BrokerName;
+use crate::route::types::RouteBrokerName;
+use crate::route::types::RouteTopicName;
 use crate::route::types::TopicName;
 
 /// Topic queue table: Topic -> (Broker -> QueueData)
@@ -48,9 +54,9 @@ use crate::route::types::TopicName;
 pub struct TopicQueueTable {
     /// Outer map: Topic name -> Broker map
     /// Inner map: Broker name -> Queue data
-    inner: DashMap<TopicName, DashMap<BrokerName, Arc<QueueData>>>,
+    inner: DashMap<RouteTopicName, DashMap<RouteBrokerName, Arc<QueueData>>>,
     /// Reverse index: Broker name -> topic set
-    broker_topics: DashMap<BrokerName, HashSet<TopicName>>,
+    broker_topics: DashMap<RouteBrokerName, HashSet<RouteTopicName>>,
 }
 
 impl TopicQueueTable {
@@ -78,20 +84,22 @@ impl TopicQueueTable {
     /// Insert or update queue data for a topic-broker pair
     ///
     /// # Arguments
-    /// * `topic` - Topic name (zero-copy Arc<str>)
-    /// * `broker` - Broker name (zero-copy Arc<str>)
+    /// * `topic` - Topic name
+    /// * `broker` - Broker name
     /// * `queue_data` - Queue configuration
     ///
     /// # Returns
     /// Previous queue data if existed
     pub fn insert(&self, topic: TopicName, broker: BrokerName, queue_data: QueueData) -> Option<Arc<QueueData>> {
-        let index_topic = topic.clone();
+        let route_topic = route_topic_name(topic);
+        let route_broker = route_broker_name(broker);
+        let index_topic = route_topic.clone();
         let previous = self
             .inner
-            .entry(topic)
+            .entry(route_topic)
             .or_default()
-            .insert(broker.clone(), Arc::new(queue_data));
-        self.broker_topics.entry(broker).or_default().insert(index_topic);
+            .insert(route_broker.clone(), Arc::new(queue_data));
+        self.broker_topics.entry(route_broker).or_default().insert(index_topic);
         previous
     }
 
@@ -122,7 +130,7 @@ impl TopicQueueTable {
             .map(|brokers| {
                 brokers
                     .iter()
-                    .map(|entry| (entry.key().clone(), Arc::clone(entry.value())))
+                    .map(|entry| (public_name_from_route(entry.key()), Arc::clone(entry.value())))
                     .collect()
             })
             .unwrap_or_default()
@@ -138,9 +146,9 @@ impl TopicQueueTable {
     /// * `topic` - A string slice representing the name of the topic to look up.
     ///
     /// # Returns
-    /// * `Option<dashmap::mapref::one::Ref<'_, TopicName, DashMap<BrokerName, Arc<QueueData>>>>`
-    ///   - `Some` if the topic exists, containing a reference to the `DashMap` of brokers and their
-    ///     queue data.
+    /// * `Option<HashMap<BrokerName, Arc<QueueData>>>`
+    ///   - `Some` if the topic exists, containing a public snapshot of brokers and their queue
+    ///     data.
     ///   - `None` if the topic does not exist.
     ///
     /// # Example
@@ -149,11 +157,13 @@ impl TopicQueueTable {
     /// if let Some(broker_map) = topic_map {
     ///     // Access broker-specific queue data
     /// }
-    pub fn get_topic_queues_map(
-        &self,
-        topic: &str,
-    ) -> Option<dashmap::mapref::one::Ref<'_, TopicName, DashMap<BrokerName, Arc<QueueData>>>> {
-        self.inner.get(topic)
+    pub fn get_topic_queues_map(&self, topic: &str) -> Option<HashMap<BrokerName, Arc<QueueData>>> {
+        self.inner.get(topic).map(|brokers| {
+            brokers
+                .iter()
+                .map(|entry| (public_name_from_route(entry.key()), Arc::clone(entry.value())))
+                .collect()
+        })
     }
 
     /// Remove a broker from a topic
@@ -201,9 +211,12 @@ impl TopicQueueTable {
     /// Get all topic names
     ///
     /// # Returns
-    /// Vector of topic names (CheetahString for zero-copy)
+    /// Vector of public topic names.
     pub fn get_all_topics(&self) -> Vec<TopicName> {
-        self.inner.iter().map(|entry| entry.key().clone()).collect()
+        self.inner
+            .iter()
+            .map(|entry| public_name_from_route(entry.key()))
+            .collect()
     }
 
     /// Get number of topics
@@ -297,7 +310,7 @@ impl TopicQueueTable {
             .iter()
             .filter_map(|entry| {
                 let first_queue = entry.value().iter().next()?;
-                predicate(first_queue.value().as_ref()).then(|| entry.key().clone())
+                predicate(first_queue.value().as_ref()).then(|| public_name_from_route(entry.key()))
             })
             .collect()
     }
@@ -310,7 +323,7 @@ impl TopicQueueTable {
                 topics
                     .iter()
                     .filter(|topic| self.get(topic.as_str(), broker_name).is_some())
-                    .cloned()
+                    .map(public_name_from_route)
                     .collect()
             })
             .unwrap_or_default()
@@ -327,7 +340,7 @@ impl TopicQueueTable {
             if let Some(broker_topics) = self.broker_topics.get(broker_name.as_str()) {
                 for topic in broker_topics.iter() {
                     if self.get(topic.as_str(), broker_name.as_str()).is_some() {
-                        topics.push(topic.clone());
+                        topics.push(public_name_from_route(topic));
                     }
                 }
             }
@@ -347,7 +360,7 @@ impl TopicQueueTable {
             if let Some(broker_topics) = self.broker_topics.get(broker_name.as_str()) {
                 for topic in broker_topics.iter() {
                     if self.get(topic.as_str(), broker_name.as_str()).is_some() {
-                        pairs.push((topic.clone(), broker_name.clone()));
+                        pairs.push((public_name_from_route(topic), broker_name.clone()));
                     }
                 }
             }
@@ -365,7 +378,7 @@ impl TopicQueueTable {
                     .iter()
                     .filter_map(|topic| {
                         self.get(topic.as_str(), broker_name)
-                            .map(|queue_data| (topic.clone(), queue_data))
+                            .map(|queue_data| (public_name_from_route(topic), queue_data))
                     })
                     .collect()
             })

--- a/rocketmq-namesrv/src/route/types.rs
+++ b/rocketmq-namesrv/src/route/types.rs
@@ -15,12 +15,14 @@
 //! Type definitions for route management system
 //!
 //! This module contains optimized type definitions using:
-//! - `CheetahString` instead of `String` for zero-copy sharing and consistency
+//! - `CheetahString` instead of `String` for public route names
+//! - `CheetahStr` for immutable internal route table keys
 //! - `Arc<T>` for immutable shared data
 //! - Strong typing for better API safety
 
 use std::sync::Arc;
 
+use cheetah_string::CheetahStr;
 use cheetah_string::CheetahString;
 use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
 use rocketmq_remoting::protocol::route::route_data_view::QueueData;
@@ -29,7 +31,7 @@ use rocketmq_remoting::protocol::static_topic::topic_queue_mapping_info::TopicQu
 use crate::route::tables::BrokerLiveInfo;
 use crate::route_info::broker_addr_info::BrokerAddrInfo;
 
-/// Topic name type - uses CheetahString for zero-copy sharing
+/// Public topic name type.
 pub type TopicName = CheetahString;
 
 /// Broker name type
@@ -37,6 +39,35 @@ pub type BrokerName = CheetahString;
 
 /// Cluster name type
 pub type ClusterName = CheetahString;
+
+/// Internal route topic key type.
+pub(crate) type RouteTopicName = CheetahStr;
+
+/// Internal route broker key type.
+pub(crate) type RouteBrokerName = CheetahStr;
+
+/// Internal route cluster key type.
+pub(crate) type RouteClusterName = CheetahStr;
+
+#[inline]
+pub(crate) fn route_topic_name(topic: TopicName) -> RouteTopicName {
+    CheetahStr::from(topic)
+}
+
+#[inline]
+pub(crate) fn route_broker_name(broker_name: BrokerName) -> RouteBrokerName {
+    CheetahStr::from(broker_name)
+}
+
+#[inline]
+pub(crate) fn route_cluster_name(cluster_name: ClusterName) -> RouteClusterName {
+    CheetahStr::from(cluster_name)
+}
+
+#[inline]
+pub(crate) fn public_name_from_route(route_name: &CheetahStr) -> CheetahString {
+    CheetahString::from_slice(route_name.as_str())
+}
 
 /// Broker address string
 pub type BrokerAddr = CheetahString;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7573

### Brief Description

- Add crate-private `CheetahStr` aliases for immutable namesrv route table keys while preserving the existing public `CheetahString` aliases.
- Store topic, broker, and cluster keys as immutable route keys inside namesrv topic, broker, cluster, and static-topic mapping tables.
- Convert route keys back to public `CheetahString` values at snapshot and public-return boundaries.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo check -p rocketmq-namesrv` passed.
- `cargo test -p rocketmq-namesrv topic_table` passed.
- `cargo test -p rocketmq-namesrv --test topic_table_index_equivalence` passed.
- `cargo bench -p rocketmq-namesrv --bench topic_table_hot_path_bench -- --sample-size 10` passed.
- `cargo test -p rocketmq-namesrv --lib` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how route information is stored and returned, making broker, cluster, and topic lookups more consistent.
  * Fixed several read paths so results now use the expected public names when listing topics, brokers, clusters, and queue mappings.
  * Updated topic removal and snapshot-style views to return cleaner, more reliable data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->