### PR TITLE
[ISSUE #7575]♻️Avoid commitlog UTF-8 allocation

### DIFF
--- a/rocketmq-common/src/common/message/message_decoder.rs
+++ b/rocketmq-common/src/common/message/message_decoder.rs
@@ -196,7 +196,9 @@ pub fn message_properties_to_string(properties: &HashMap<CheetahString, CheetahS
     builder.finish_string()
 }
 
-fn cheetah_from_utf8_lossy(bytes: &[u8]) -> CheetahString {
+/// Converts UTF-8 message protocol bytes into a [`CheetahString`], preserving
+/// `String::from_utf8_lossy` compatibility for invalid input.
+pub fn cheetah_from_utf8_lossy(bytes: &[u8]) -> CheetahString {
     match String::from_utf8_lossy(bytes) {
         Cow::Borrowed(value) => CheetahString::from_slice(value),
         Cow::Owned(value) => CheetahString::from_string_owned(value),

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -42,6 +42,7 @@ use rocketmq_common::utils::time_utils;
 use rocketmq_common::CRC32Utils::crc32;
 use rocketmq_common::CRC32Utils::crc32_bytes;
 use rocketmq_common::MessageDecoder;
+use rocketmq_common::MessageDecoder::cheetah_from_utf8_lossy;
 use rocketmq_common::MessageDecoder::string_to_message_properties;
 use rocketmq_common::MessageDecoder::MESSAGE_MAGIC_CODE_POSITION;
 use rocketmq_common::MessageDecoder::MESSAGE_MAGIC_CODE_V2;
@@ -102,7 +103,6 @@ pub const BLANK_MAGIC_CODE: i32 = -875286124;
 pub const CRC32_RESERVED_LEN: i32 = (MessageConst::PROPERTY_CRC32.len() + 1 + 10 + 1) as i32;
 
 // This reduces heap allocations by ~50% by reusing encoder instances
-
 fn encode_message_ext(
     message_ext: &MessageExtBrokerInner,
     message_store_config: &Arc<MessageStoreConfig>,
@@ -2010,13 +2010,12 @@ pub fn check_message_and_return_size(
     }
     let topic_len = message_version.get_topic_length(bytes);
     let topic_bytes = bytes.copy_to_bytes(topic_len);
-    let topic = CheetahString::from_string(String::from_utf8_lossy(topic_bytes.as_ref()).to_string());
+    let topic = cheetah_from_utf8_lossy(topic_bytes.as_ref());
     let properties_length = bytes.get_i16();
     let (tags_code, keys, uniq_key, properties_map) = if properties_length > 0 {
         let properties = bytes.copy_to_bytes(properties_length as usize);
-        let properties_content = String::from_utf8_lossy(properties.as_ref()).to_string();
-        //need to optimize
-        let properties_map = string_to_message_properties(Some(&CheetahString::from_string(properties_content)));
+        let properties_content = cheetah_from_utf8_lossy(properties.as_ref());
+        let properties_map = string_to_message_properties(Some(&properties_content));
         let keys = properties_map.get(MessageConst::PROPERTY_KEYS).cloned();
         let uniq_key = properties_map
             .get(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX)
@@ -2360,6 +2359,21 @@ mod tests {
 
     fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         haystack.windows(needle.len()).position(|window| window == needle)
+    }
+
+    #[test]
+    fn cheetah_from_utf8_lossy_borrows_valid_commitlog_text() {
+        let decoded = cheetah_from_utf8_lossy(b"commitlog-topic");
+
+        assert_eq!(decoded, "commitlog-topic");
+    }
+
+    #[test]
+    fn cheetah_from_utf8_lossy_preserves_invalid_commitlog_text_compatibility() {
+        let encoded = b"topic-\xff";
+        let decoded = cheetah_from_utf8_lossy(encoded);
+
+        assert_eq!(decoded.as_str(), String::from_utf8_lossy(encoded).as_ref());
     }
 
     fn build_message_with_property_crc(body: &[u8], topic: &str) -> Bytes {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7575

### Brief Description

- Promote the existing lossy UTF-8 conversion helper in `rocketmq-common` so store parsing can share the same `CheetahString` conversion path.
- Use the shared helper for commitlog topic and properties text decoding while preserving invalid UTF-8 lossy compatibility.
- Keep message body handling as `Bytes` because it is opaque payload data.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-common cheetah_from_utf8_lossy` passed.
- `cargo test -p rocketmq-store commit_log` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.