### PR TITLE
[ISSUE #7579]🐛Fix dashboard message info metadata

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
@@ -2211,8 +2211,16 @@ fn map_message(message: &MessageExt) -> MessageView {
         tags: message.get_tags().map(|tags| tags.to_string()),
         born_timestamp: message.born_timestamp(),
         store_timestamp: message.store_timestamp(),
+        born_host: message.born_host().to_string(),
+        store_host: message.store_host().to_string(),
         queue_id: message.queue_id(),
         queue_offset: message.queue_offset(),
+        store_size: message.store_size(),
+        reconsume_times: message.reconsume_times(),
+        body_crc: message.body_crc(),
+        sys_flag: message.sys_flag(),
+        flag: message.flag(),
+        prepared_transaction_offset: message.prepared_transaction_offset(),
         body,
         properties,
     }
@@ -2336,6 +2344,7 @@ fn required_request_field<'a>(value: Option<&'a str>, label: &str) -> Result<&'a
 mod tests {
     use super::build_order_conf;
     use super::classify_topic;
+    use super::map_message;
     use super::normalize_message_type;
     use super::parse_rate_value;
     use super::select_consume_tps_value;
@@ -2343,6 +2352,9 @@ mod tests {
     use crate::model::TopicRouteBroker;
     use crate::model::TopicRouteInfo;
     use crate::model::TopicRouteQueue;
+    use cheetah_string::CheetahString;
+    use rocketmq_common::common::message::message_builder::MessageBuilder;
+    use rocketmq_common::common::message::message_ext::MessageExt;
     use std::collections::BTreeMap;
     use std::collections::HashSet;
 
@@ -2389,6 +2401,42 @@ mod tests {
         let brokers = HashSet::from(["broker-b".to_string(), "broker-a".to_string()]);
 
         assert_eq!(build_order_conf(&brokers, 8), "broker-a:8;broker-b:8");
+    }
+
+    #[test]
+    fn map_message_populates_dashboard_message_info_fields() {
+        let message = MessageBuilder::new()
+            .topic("TopicTest")
+            .body_slice(b"hello")
+            .tags("TagA")
+            .key("KeyA")
+            .flag_bits(9)
+            .build_unchecked();
+        let mut message_ext = MessageExt::default();
+        message_ext.set_message_inner(message);
+        message_ext.set_msg_id(CheetahString::from_static_str("store-msg-id"));
+        message_ext.set_born_host("172.20.48.1:61266".parse().expect("born host"));
+        message_ext.set_store_host("172.20.48.1:10911".parse().expect("store host"));
+        message_ext.set_store_size(128);
+        message_ext.set_reconsume_times(2);
+        message_ext.set_body_crc(613_185_359);
+        message_ext.set_sys_flag(7);
+        message_ext.set_prepared_transaction_offset(42);
+
+        let view = map_message(&message_ext);
+
+        assert_eq!(view.born_host, "172.20.48.1:61266");
+        assert_eq!(view.store_host, "172.20.48.1:10911");
+        assert_eq!(view.store_size, 128);
+        assert_eq!(view.reconsume_times, 2);
+        assert_eq!(view.body_crc, 613_185_359);
+        assert_eq!(view.sys_flag, 7);
+        assert_eq!(view.flag, 9);
+        assert_eq!(view.prepared_transaction_offset, 42);
+        assert_eq!(
+            serde_json::to_value(&view).expect("message view should serialize")["bodyCRC"],
+            613_185_359
+        );
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/message_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/message_model.rs
@@ -36,8 +36,17 @@ pub struct MessageView {
     pub tags: Option<String>,
     pub born_timestamp: i64,
     pub store_timestamp: i64,
+    pub born_host: String,
+    pub store_host: String,
     pub queue_id: i32,
     pub queue_offset: i64,
+    pub store_size: i32,
+    pub reconsume_times: i32,
+    #[serde(rename = "bodyCRC")]
+    pub body_crc: u32,
+    pub sys_flag: i32,
+    pub flag: i32,
+    pub prepared_transaction_offset: i64,
     pub body: String,
     pub properties: BTreeMap<String, String>,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/message.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/message.ts
@@ -5,8 +5,16 @@ export interface MessageView {
   tags?: string | null;
   bornTimestamp: number;
   storeTimestamp: number;
+  bornHost: string;
+  storeHost: string;
   queueId: number;
   queueOffset: number;
+  storeSize: number;
+  reconsumeTimes: number;
+  bodyCRC: number;
+  sysFlag: number;
+  flag: number;
+  preparedTransactionOffset: number;
   body: string;
   properties: Record<string, string>;
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7579

### Brief Description

- Add missing `MessageExt` metadata fields to the Web Dashboard backend `MessageView` response.
- Map store/born host, store size, reconsume times, body CRC, sys flag, flag, and prepared transaction offset in `map_message`.
- Align the frontend `MessageView` TypeScript contract with the backend response so Message Detail can render the values already requested by the UI.
- Add a focused backend regression test for the message info mapping and `bodyCRC` JSON field name.

### How Did You Test This Change?

- `npm run build` from `rocketmq-dashboard/rocketmq-dashboard-web/frontend`: passed; Vite reported the existing chunk size warning.
- `cargo fmt --all` from `rocketmq-dashboard/rocketmq-dashboard-web/backend`: passed.
- `cargo clippy --all-targets --all-features -- -D warnings` from `rocketmq-dashboard/rocketmq-dashboard-web/backend`: passed.
- `cargo build --all-targets --all-features` from `rocketmq-dashboard/rocketmq-dashboard-web/backend`: passed; Windows linker stdout warning was emitted.
- `cargo test map_message_populates_dashboard_message_info_fields` from `rocketmq-dashboard/rocketmq-dashboard-web/backend`: passed.
- Manual API check for `/api/messages?topic=...&messageId=...`: returned `storeHost`, `bornHost`, `storeSize`, `reconsumeTimes`, `bodyCRC`, `sysFlag`, `flag`, and `preparedTransactionOffset`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message details now show more complete metadata, including host information, size, retry count, checksum, flags, and transaction offset.
  * Added coverage to ensure these message fields are displayed correctly in both the backend response and the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->