### PR TITLE
[ISSUE #7581]🐛Fix message body preview overflow

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.tsx
@@ -1,6 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { Clock3, Copy, DatabaseZap, Eye, GitBranch, Hash, KeyRound, RefreshCw, RotateCcw, Search, Send, X } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type FocusEvent, type MouseEvent } from 'react';
 import { messageApi } from '../api/message_api';
 import { topicApi } from '../api/topic_api';
 import ConfirmDialog from '../components/ConfirmDialog';
@@ -14,6 +14,8 @@ import type { MutationResult } from '../types/topic';
 
 type QueryMode = 'topic' | 'key' | 'id';
 type NoticeTone = 'success' | 'warning' | 'danger';
+type BodyToast = { body: string; x: number; y: number };
+type BodyToastPoint = { clientX: number; clientY: number };
 
 const queryModes: Array<{ key: QueryMode; label: string; description: string }> = [
   {
@@ -52,6 +54,7 @@ export default function MessageQueryPage() {
   const [trace, setTrace] = useState<MessageTraceView | null>(null);
   const [traceLoading, setTraceLoading] = useState(false);
   const [resending, setResending] = useState(false);
+  const [bodyToast, setBodyToast] = useState<BodyToast | null>(null);
 
   const activeMode = queryModes.find((item) => item.key === mode) ?? queryModes[0];
 
@@ -185,6 +188,14 @@ export default function MessageQueryPage() {
     setNotice({ tone: 'success', message: `Copied message ID ${truncateMiddle(messageId, 26)}.` });
   };
 
+  const showBodyToast = (body: string, point: BodyToastPoint) => {
+    if (!body) {
+      setBodyToast(null);
+      return;
+    }
+    setBodyToast({ body, ...bodyToastPosition(point) });
+  };
+
   const columns: DataTableColumn<MessageView>[] = [
     {
       header: 'Message ID',
@@ -215,7 +226,7 @@ export default function MessageQueryPage() {
     {
       header: 'Body',
       width: '260px',
-      render: (row) => <span className="message-body-preview" title={row.body}>{row.body || '-'}</span>
+      render: (row) => <MessageBodyPreview body={row.body} onShow={showBodyToast} onHide={() => setBodyToast(null)} />
     },
     {
       header: 'Operation',
@@ -256,6 +267,11 @@ export default function MessageQueryPage() {
       />
 
       {notice ? <div className={`notice notice-${notice.tone}`}>{notice.message}</div> : null}
+      {bodyToast ? (
+        <div className="message-body-hover-toast" role="tooltip" style={{ left: bodyToast.x, top: bodyToast.y }}>
+          {bodyToast.body}
+        </div>
+      ) : null}
 
       <section className="message-query-panel">
         <div className="message-mode-row">
@@ -396,6 +412,40 @@ function MessageMetric({ label, value, detail, icon }: MessageMetricProps) {
       </div>
       <div className="message-metric-icon">{icon}</div>
     </article>
+  );
+}
+
+interface MessageBodyPreviewProps {
+  body: string;
+  onShow: (body: string, point: BodyToastPoint) => void;
+  onHide: () => void;
+}
+
+function MessageBodyPreview({ body, onShow, onHide }: MessageBodyPreviewProps) {
+  if (!body) {
+    return <span className="message-body-preview message-body-preview-empty">-</span>;
+  }
+
+  const showFromMouse = (event: MouseEvent<HTMLElement>) => {
+    onShow(body, { clientX: event.clientX, clientY: event.clientY });
+  };
+  const showFromFocus = (event: FocusEvent<HTMLElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    onShow(body, { clientX: rect.left, clientY: rect.bottom });
+  };
+
+  return (
+    <span
+      className="message-body-preview"
+      tabIndex={0}
+      onMouseEnter={showFromMouse}
+      onMouseMove={showFromMouse}
+      onMouseLeave={onHide}
+      onFocus={showFromFocus}
+      onBlur={onHide}
+    >
+      {body}
+    </span>
   );
 }
 
@@ -654,6 +704,19 @@ function truncateMiddle(value: string, maxLength: number) {
   if (value.length <= maxLength) return value;
   const edge = Math.floor((maxLength - 3) / 2);
   return `${value.slice(0, edge)}...${value.slice(-edge)}`;
+}
+
+function bodyToastPosition(point: BodyToastPoint) {
+  const offset = 14;
+  const toastMaxWidth = 760;
+  const toastMaxHeight = 320;
+  const viewportPadding = 16;
+  const maxLeft = Math.max(viewportPadding, window.innerWidth - toastMaxWidth - viewportPadding);
+  const maxTop = Math.max(viewportPadding, window.innerHeight - toastMaxHeight - viewportPadding);
+  return {
+    x: Math.min(Math.max(point.clientX + offset, viewportPadding), maxLeft),
+    y: Math.min(Math.max(point.clientY + offset, viewportPadding), maxTop)
+  };
 }
 
 function pad2(value: number) {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/globals.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/globals.css
@@ -2528,6 +2528,7 @@ td code,
 
 .message-results-wide table {
   min-width: 1890px;
+  table-layout: fixed;
 }
 
 .message-results-wide th,
@@ -2538,6 +2539,11 @@ td code,
 
 .message-results-wide tbody tr:nth-child(even) td {
   background: color-mix(in srgb, var(--surface-2) 32%, transparent);
+}
+
+.message-results-wide th:nth-child(6),
+.message-results-wide td:nth-child(6) {
+  overflow: hidden;
 }
 
 .message-id-cell {
@@ -2591,12 +2597,42 @@ td code,
 }
 
 .message-body-preview {
-  display: inline-block;
+  display: block;
   max-width: 100%;
   overflow: hidden;
   color: var(--muted);
+  cursor: help;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.message-body-preview:focus {
+  outline: 2px solid color-mix(in srgb, var(--primary) 45%, transparent);
+  outline-offset: 2px;
+}
+
+.message-body-preview-empty {
+  cursor: default;
+}
+
+.message-body-hover-toast {
+  position: fixed;
+  z-index: 1200;
+  max-width: min(760px, calc(100vw - 32px));
+  max-height: min(320px, calc(100vh - 32px));
+  overflow: auto;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--primary) 36%, var(--border));
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--surface-2) 94%, var(--primary));
+  box-shadow: 0 18px 52px color-mix(in srgb, #000 42%, transparent);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  pointer-events: none;
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 
 .message-table-actions {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7581

### Brief Description

- Add a compact `MessageBodyPreview` renderer for the Message page result table.
- Keep long body values truncated in the list row while showing the full body in a hover/focus popup.
- Switch the Message result table to fixed layout so long body text cannot expand the table horizontally.
- Preserve the full message body in the existing detail drawer.

### How Did You Test This Change?

- `npm run build` from `rocketmq-dashboard/rocketmq-dashboard-web/frontend`: passed; Vite reported the existing chunk size warning.
- Manual browser check at `/messages`: queried 2,000 messages, confirmed the `Body` column is truncated and the hover popup shows the full body without being clipped by the table scroll container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message body values now show a hover/focus preview tooltip, making long message content easier to inspect without leaving the table.
  * The preview works with both mouse and keyboard focus for better usability.

* **Bug Fixes**
  * Improved message table display so wide content truncates more consistently.
  * Added clearer focus and empty-state styling for message body cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->