### PR TITLE
[ISSUE #7585]✨Wire namesrv into runtime model

### DIFF
--- a/rocketmq-namesrv/benches/namesrv_shutdown_drain_bench.rs
+++ b/rocketmq-namesrv/benches/namesrv_shutdown_drain_bench.rs
@@ -119,6 +119,12 @@ fn write_namesrv_shutdown_report_artifact() {
         "in_flight_timed_out": output.report.in_flight.timed_out,
         "in_flight_timeout_ms": output.report.in_flight.timeout_ms,
         "in_flight_drain_elapsed_ms": output.report.in_flight.elapsed_ms,
+        "remoting_client_present": output.report.remoting_client.is_some(),
+        "remoting_client_healthy": output
+            .report
+            .remoting_client
+            .as_ref()
+            .is_some_and(|report| report.is_healthy()),
         "shutdown_report": output.report,
     });
     let path = output_dir.join("namesrv-shutdown-drain-report.json");

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -65,15 +65,7 @@ fn main() -> Result<()> {
     match (run_result, shutdown_result) {
         (Err(error), _) => Err(error),
         (Ok(()), Err(error)) => Err(error),
-        (Ok(()), Ok(report)) => {
-            if !report.is_healthy() {
-                tracing::warn!(
-                    report = %report.to_json(),
-                    "namesrv runtime shutdown report is unhealthy"
-                );
-            }
-            Ok(())
-        }
+        (Ok(()), Ok(_)) => Ok(()),
     }
 }
 

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -65,7 +65,15 @@ fn main() -> Result<()> {
     match (run_result, shutdown_result) {
         (Err(error), _) => Err(error),
         (Ok(()), Err(error)) => Err(error),
-        (Ok(()), Ok(_)) => Ok(()),
+        (Ok(()), Ok(report)) => {
+            if !report.is_healthy() {
+                tracing::warn!(
+                    report = %report.to_json(),
+                    "namesrv runtime shutdown report is unhealthy"
+                );
+            }
+            Ok(())
+        }
     }
 }
 

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -35,6 +35,9 @@ use rocketmq_controller::ControllerConfig;
 use rocketmq_error::Result;
 use rocketmq_namesrv::bootstrap::Builder;
 use rocketmq_remoting::protocol::remoting_command;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ServiceContext;
 use serde::Deserialize;
 use tracing::error;
 use tracing::info;
@@ -51,15 +54,36 @@ const LOGO: &str = r#"
 const ENTRYPOINT_MAX_BLOCKING_THREADS: usize = 64;
 
 fn main() -> Result<()> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .max_blocking_threads(ENTRYPOINT_MAX_BLOCKING_THREADS)
-        .enable_all()
-        .build()
-        .context("failed to build namesrv Tokio runtime")?;
-    runtime.block_on(run())
+    let owner = RuntimeOwner::new(namesrv_runtime_config()).context("failed to build namesrv runtime")?;
+    let service_context = owner.context().service_context("rocketmq-namesrv-runtime");
+
+    let run_result = owner.block_on(run(service_context));
+    let shutdown_result = owner
+        .shutdown_runtime_blocking()
+        .context("failed to shutdown namesrv runtime");
+
+    match (run_result, shutdown_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(report)) => {
+            if !report.is_healthy() {
+                tracing::warn!(
+                    report = %report.to_json(),
+                    "namesrv runtime shutdown report is unhealthy"
+                );
+            }
+            Ok(())
+        }
+    }
 }
 
-async fn run() -> Result<()> {
+fn namesrv_runtime_config() -> RuntimeConfig {
+    let mut config = RuntimeConfig::namesrv_default();
+    config.max_blocking_threads = ENTRYPOINT_MAX_BLOCKING_THREADS;
+    config
+}
+
+async fn run(service_context: ServiceContext) -> Result<()> {
     // Parse command line arguments first
     let args = Args::parse();
 
@@ -105,6 +129,7 @@ async fn run() -> Result<()> {
                 .set_name_server_config(namesrv_config)
                 .set_server_config(server_config)
                 .set_controller_config_opt(controller_config)
+                .set_service_context(service_context)
                 .build()
                 .boot()
                 .await?;

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -1673,7 +1673,9 @@ mod tests {
     use rocketmq_remoting::protocol::RemotingSerializable;
     use rocketmq_remoting::runtime::processor::RequestProcessor;
     use rocketmq_runtime::RuntimeContext;
+    use tokio::net::TcpStream as TokioTcpStream;
     use tokio::sync::broadcast;
+    use tokio::sync::oneshot;
     use tokio::time::sleep;
 
     use super::*;
@@ -3332,6 +3334,51 @@ mod tests {
             .expect("namesrv report should include remoting server report");
         assert!(remoting_report.is_healthy(), "{}", remoting_report.to_json());
         assert_eq!(remoting_report.leaked, 0, "{}", remoting_report.to_json());
+    }
+
+    #[tokio::test]
+    async fn boot_shutdown_is_healthy_with_connection_waiting_for_first_byte() {
+        let server_config = namesrv_server_config();
+        let addr = format!("127.0.0.1:{}", server_config.listen_port);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let bootstrap = Builder::new().set_server_config(server_config).build();
+        let server_task = tokio::spawn(async move {
+            bootstrap
+                .boot_with_shutdown_report(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+        });
+
+        let client = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                match TokioTcpStream::connect(&addr).await {
+                    Ok(stream) => break stream,
+                    Err(_) => sleep(Duration::from_millis(10)).await,
+                }
+            }
+        })
+        .await
+        .expect("namesrv should accept TCP connections before timeout");
+        sleep(Duration::from_millis(50)).await;
+
+        let _ = shutdown_tx.send(());
+        let report = tokio::time::timeout(Duration::from_secs(5), server_task)
+            .await
+            .expect("namesrv should shut down before the server task join timeout")
+            .expect("namesrv task should not panic")
+            .expect("namesrv should return shutdown report");
+        drop(client);
+
+        assert!(report.is_healthy(), "{report:?}");
+        assert!(
+            report.server.as_ref().is_some_and(ShutdownReport::is_healthy),
+            "server shutdown report should be present and healthy: {report:?}"
+        );
+        assert!(
+            report.remoting_server.as_ref().is_some_and(ShutdownReport::is_healthy),
+            "remoting server shutdown report should be present and healthy: {report:?}"
+        );
     }
 
     #[tokio::test]

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -37,6 +37,7 @@ use rocketmq_controller::ControllerManager;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_remoting::base::channel_event_listener::ChannelEventListener;
+use rocketmq_remoting::clients::rocketmq_tokio_client::RemotingClientShutdownReport;
 use rocketmq_remoting::clients::rocketmq_tokio_client::RocketmqDefaultClient;
 use rocketmq_remoting::clients::RemotingClient;
 use rocketmq_remoting::code::request_code::RequestCode;
@@ -187,6 +188,7 @@ pub struct NameServerShutdownReport {
     pub route_unregistration: Option<ShutdownReport>,
     pub server: Option<ShutdownReport>,
     pub remoting_server: Option<ShutdownReport>,
+    pub remoting_client: Option<RemotingClientShutdownReport>,
     pub root: Option<ShutdownReport>,
 }
 
@@ -201,6 +203,10 @@ impl NameServerShutdownReport {
                 .is_none_or(ShutdownReport::is_healthy)
             && self.server.as_ref().is_none_or(ShutdownReport::is_healthy)
             && self.remoting_server.as_ref().is_none_or(ShutdownReport::is_healthy)
+            && self
+                .remoting_client
+                .as_ref()
+                .is_none_or(RemotingClientShutdownReport::is_healthy)
             && self.root.as_ref().is_none_or(ShutdownReport::is_healthy)
     }
 }
@@ -523,7 +529,11 @@ impl NameServerRuntime {
 
     /// Initialize network server for handling client requests
     fn initialize_network_components(&mut self) {
-        let server = RocketMQServer::new(Arc::new(self.inner.server_config().clone()));
+        let config = Arc::new(self.inner.server_config().clone());
+        let server = match self.inner.service_context.as_ref() {
+            Some(context) => RocketMQServer::new_with_service_context(config, context.child("namesrv.remoting-server")),
+            None => RocketMQServer::new(config),
+        };
         self.server_inner = Some(server);
         debug!(
             "Network server initialized on port {}",
@@ -767,6 +777,16 @@ impl NameServerRuntime {
         );
         shutdown_report.server = self.wait_for_server_task(TASK_JOIN_TIMEOUT).await;
         shutdown_report.remoting_server = self.wait_for_remoting_server_report(TASK_JOIN_TIMEOUT).await;
+        let remoting_client_report = self
+            .inner
+            .remoting_client
+            .mut_from_ref()
+            .shutdown_with_report(TASK_JOIN_TIMEOUT)
+            .await;
+        if !remoting_client_report.is_healthy() {
+            warn!("NameServer remoting client shutdown report is unhealthy: {remoting_client_report:?}");
+        }
+        shutdown_report.remoting_client = Some(remoting_client_report);
 
         if let Some(task_group) = self.inner.task_group.get().cloned() {
             let report = task_group.shutdown(TASK_JOIN_TIMEOUT).await;
@@ -986,11 +1006,20 @@ impl Builder {
             name_server_config.use_route_info_manager_v2
         );
 
+        let service_context = self
+            .service_context
+            .as_ref()
+            .map(|context| context.child("rocketmq-namesrv"));
+
         // Create remoting client
-        let remoting_client = ArcMut::new(RocketmqDefaultClient::new(
-            Arc::new(tokio_client_config.clone()),
-            DefaultRemotingRequestProcessor,
-        ));
+        let remoting_client = ArcMut::new(match service_context.as_ref() {
+            Some(context) => RocketmqDefaultClient::new_with_service_context(
+                Arc::new(tokio_client_config.clone()),
+                DefaultRemotingRequestProcessor,
+                context.child("namesrv.remoting-client"),
+            ),
+            None => RocketmqDefaultClient::new(Arc::new(tokio_client_config.clone()), DefaultRemotingRequestProcessor),
+        });
 
         // Create inner with empty components first
         let mut inner = ArcMut::new(NameServerRuntimeInner {
@@ -1004,7 +1033,7 @@ impl Builder {
             controller_config,
             controller_manager: None,
             cluster_test_route_lookup,
-            service_context: self.service_context,
+            service_context,
             task_group: OnceLock::new(),
             in_flight_requests: Arc::new(InFlightRequestTracker::default()),
         });
@@ -1083,8 +1112,7 @@ impl NameServerRuntimeInner {
         }
 
         if let Some(service_context) = self.service_context.as_ref() {
-            let task_group = service_context.task_group().child("rocketmq-namesrv");
-            let _ = self.task_group.set(task_group);
+            let _ = self.task_group.set(service_context.task_group().clone());
             return self.task_group.get().cloned();
         }
 
@@ -1683,6 +1711,30 @@ mod tests {
 
         let report = service.task_group().shutdown(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn service_context_shutdown_report_includes_remoting_client() {
+        let context = RuntimeContext::from_current("namesrv-runtime-owner-test");
+        let service = context.service_context("namesrv-service");
+        let bootstrap = Builder::new()
+            .set_server_config(namesrv_server_config())
+            .set_service_context(service)
+            .build();
+
+        let report = bootstrap
+            .boot_with_shutdown_report(async {})
+            .await
+            .expect("namesrv should boot and return shutdown report");
+
+        assert!(report.is_healthy(), "{report:?}");
+        assert!(
+            report
+                .remoting_client
+                .as_ref()
+                .is_some_and(RemotingClientShutdownReport::is_healthy),
+            "remoting client shutdown report should be present and healthy: {report:?}"
+        );
     }
 
     #[tokio::test]

--- a/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-remoting/src/clients/rocketmq_tokio_client.rs
@@ -30,6 +30,7 @@ use rocketmq_runtime::TaskGroupLifecycleState;
 use rocketmq_runtime::TaskId;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::WeakArcMut;
+use serde::Serialize;
 use tokio::time;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
@@ -199,13 +200,13 @@ pub struct RocketmqDefaultClient<PR = DefaultRemotingRequestProcessor> {
     tx: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct RemotingClientConnectionShutdownReport {
     pub addr: CheetahString,
     pub report: ShutdownReport,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct RemotingClientShutdownReport {
     pub background: Option<ShutdownReport>,
     pub workers: Option<ShutdownReport>,

--- a/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-remoting/src/remoting_server/rocketmq_tokio_server.rs
@@ -374,7 +374,15 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
             // Spawn dedicated task for this connection
             if let Err(error) =
                 connection_task_group.spawn("rocketmq.remoting.connection", TaskKind::Worker, async move {
-                    let Some(connection) = tls_runtime.into_connection(socket, remote_addr).await else {
+                    let mut shutdown = Shutdown::new(notify_shutdown);
+                    let connection = tokio::select! {
+                        connection = tls_runtime.into_connection(socket, remote_addr) => connection,
+                        () = shutdown.recv() => {
+                            drop(permit);
+                            return;
+                        }
+                    };
+                    let Some(connection) = connection else {
                         drop(permit);
                         return;
                     };
@@ -412,7 +420,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
                         connection_handler_context: ArcMut::new(ConnectionHandlerContextWrapper {
                             channel: channel.clone(),
                         }),
-                        shutdown: Shutdown::new(notify_shutdown),
+                        shutdown,
                         _shutdown_complete: shutdown_complete_tx,
                         conn_disconnect_notify,
                         cmd_handler,
@@ -1015,6 +1023,38 @@ mod tests {
             .expect("server should shut down before timeout")
             .expect("server task should not panic")
             .expect("server should return shutdown report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn run_shutdown_cancels_connection_before_tls_peek_completes() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let addr = listener.local_addr().expect("listener should have local addr");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let server_task = tokio::spawn(run_with_report(
+            listener,
+            async {
+                let _ = shutdown_rx.await;
+            },
+            DefaultRemotingRequestProcessor,
+            None,
+            Vec::new(),
+            None,
+        ));
+
+        let client = TcpStream::connect(addr).await.expect("client should connect");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let _ = shutdown_tx.send(());
+        let report = tokio::time::timeout(Duration::from_secs(1), server_task)
+            .await
+            .expect("server should shut down even when a connection has not sent its first byte")
+            .expect("server task should not panic")
+            .expect("server should return shutdown report");
+        drop(client);
+
         assert!(report.is_healthy(), "{}", report.to_json());
     }
 

--- a/rocketmq-runtime/src/config.rs
+++ b/rocketmq-runtime/src/config.rs
@@ -42,6 +42,10 @@ impl RuntimeConfig {
         Self::server_default("rocketmq-broker")
     }
 
+    pub fn namesrv_default() -> Self {
+        Self::server_default("rocketmq-namesrv")
+    }
+
     pub fn validate(&self) -> RuntimeResult<()> {
         if self.worker_threads == 0 {
             return Err(RuntimeError::InvalidConfig(

--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -36,14 +36,13 @@ fn production_tokio_entrypoints_set_max_blocking_threads() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("runtime crate should be inside the workspace");
-    let entrypoints = [
+    let explicit_tokio_entrypoints = [
         "rocketmq-broker/src/bin/broker_bootstrap_server.rs",
-        "rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs",
         "rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs",
         "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs",
     ];
 
-    for entrypoint in entrypoints {
+    for entrypoint in explicit_tokio_entrypoints {
         let source = fs::read_to_string(workspace_root.join(entrypoint))
             .unwrap_or_else(|error| panic!("failed to read {entrypoint}: {error}"));
         assert!(
@@ -55,6 +54,40 @@ fn production_tokio_entrypoints_set_max_blocking_threads() {
             "{entrypoint} must set max_blocking_threads explicitly"
         );
     }
+}
+
+#[test]
+fn namesrv_entrypoint_uses_runtime_owner_and_service_context() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("runtime crate should be inside the workspace");
+    let entrypoint = "rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs";
+    let source = fs::read_to_string(workspace_root.join(entrypoint))
+        .unwrap_or_else(|error| panic!("failed to read {entrypoint}: {error}"));
+
+    assert!(
+        source.contains("RuntimeOwner::new(namesrv_runtime_config())"),
+        "{entrypoint} must use RuntimeOwner as the owned runtime boundary"
+    );
+    assert!(
+        source.contains("ENTRYPOINT_MAX_BLOCKING_THREADS"),
+        "{entrypoint} must preserve the explicit blocking-thread cap"
+    );
+    assert!(
+        source.contains(".set_service_context(service_context)"),
+        "{entrypoint} must inject a ServiceContext into the namesrv bootstrap"
+    );
+}
+
+#[test]
+fn namesrv_runtime_config_uses_namesrv_thread_name() {
+    let config = RuntimeConfig::namesrv_default();
+
+    assert_eq!(config.thread_name, "rocketmq-namesrv");
+    assert!(config.worker_threads > 0);
+    assert!(config.max_blocking_threads > 0);
+    assert!(config.enable_io);
+    assert!(config.enable_time);
 }
 
 #[test]

--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -77,6 +77,10 @@ fn namesrv_entrypoint_uses_runtime_owner_and_service_context() {
         source.contains(".set_service_context(service_context)"),
         "{entrypoint} must inject a ServiceContext into the namesrv bootstrap"
     );
+    assert!(
+        !source.contains("namesrv runtime shutdown report is unhealthy"),
+        "{entrypoint} must not emit a duplicate runtime shutdown health warning"
+    );
 }
 
 #[test]

--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -78,8 +78,8 @@ fn namesrv_entrypoint_uses_runtime_owner_and_service_context() {
         "{entrypoint} must inject a ServiceContext into the namesrv bootstrap"
     );
     assert!(
-        !source.contains("namesrv runtime shutdown report is unhealthy"),
-        "{entrypoint} must not emit a duplicate runtime shutdown health warning"
+        source.contains("namesrv runtime shutdown report is unhealthy"),
+        "{entrypoint} must keep the namesrv-specific runtime shutdown health warning"
     );
 }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7585

### Brief Description

Wire `rocketmq-namesrv-rust` into the shared runtime model by creating the process runtime through `RuntimeOwner`, injecting a `ServiceContext` into the namesrv bootstrap, and parenting namesrv remoting server/client tasks under the injected task tree.

This also adds `RuntimeConfig::namesrv_default()`, extends namesrv shutdown reporting with remoting client shutdown evidence, serializes remoting client shutdown reports for benchmark artifacts, and updates runtime-model tests to guard the new entrypoint behavior.

### How Did You Test This Change?

- `cargo fmt --all` - passed
- `cargo test -p rocketmq-runtime namesrv_runtime_config_uses_namesrv_thread_name` - passed
- `cargo test -p rocketmq-runtime namesrv_entrypoint_uses_runtime_owner_and_service_context` - passed
- `cargo test -p rocketmq-namesrv --lib builder_service_context_parents_namesrv_task_group` - passed
- `cargo test -p rocketmq-namesrv --lib service_context_shutdown_report_includes_remoting_client` - passed
- `cargo test -p rocketmq-namesrv --test route_info_manager_integration namesrv_kvconfig_roundtrip_works_over_remoting` - passed
- `cargo check -p rocketmq-namesrv --bin rocketmq-namesrv-rust` - passed
- `cargo check -p rocketmq-namesrv --benches` - passed
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed
- `git diff --check` - passed with Windows line-ending normalization warnings only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NameServer shutdown reports now include remoting client status and health details.
  * NameServer startup now uses a dedicated runtime configuration with clearer thread naming.

* **Bug Fixes**
  * Improved shutdown health checks so unhealthy remoting client shutdowns are reported.
  * NameServer shutdown now logs warnings when shutdown health is not clean.

* **Tests**
  * Expanded coverage for NameServer startup, runtime settings, and shutdown reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->