### PR TITLE
[ISSUE #7590]✨Introduce unified thread model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4031,6 +4031,7 @@ dependencies = [
  "rocketmq-common",
  "rocketmq-error",
  "rocketmq-remoting",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "serde",
  "serde_json",
@@ -4070,12 +4071,14 @@ dependencies = [
  "rocketmq-admin-core",
  "rocketmq-common",
  "rocketmq-remoting",
+ "rocketmq-runtime",
  "rocketmq-rust",
  "serde",
  "serde_json",
  "strum",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]

--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -27,6 +27,9 @@ use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_common::EnvUtils::EnvUtils;
 use rocketmq_common::ParseConfigFile;
 use rocketmq_remoting::protocol::remoting_command;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ServiceContext;
 #[cfg(feature = "tieredstore")]
 use rocketmq_store::base::store_enum::StoreType;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
@@ -46,15 +49,36 @@ const LOGO: &str = r#"
 const ENTRYPOINT_MAX_BLOCKING_THREADS: usize = 64;
 
 fn main() -> Result<()> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .max_blocking_threads(ENTRYPOINT_MAX_BLOCKING_THREADS)
-        .enable_all()
-        .build()
-        .context("failed to build broker Tokio runtime")?;
-    runtime.block_on(run())
+    let owner = RuntimeOwner::new(broker_runtime_config()).context("failed to build broker runtime")?;
+    let service_context = owner.context().service_context("rocketmq-broker-runtime");
+
+    let run_result = owner.block_on(run(service_context));
+    let shutdown_result = owner
+        .shutdown_runtime_blocking()
+        .context("failed to shutdown broker runtime");
+
+    match (run_result, shutdown_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(report)) => {
+            if !report.is_healthy() {
+                tracing::warn!(
+                    report = %report.to_json(),
+                    "broker runtime shutdown report is unhealthy"
+                );
+            }
+            Ok(())
+        }
+    }
 }
 
-async fn run() -> Result<()> {
+fn broker_runtime_config() -> RuntimeConfig {
+    let mut config = RuntimeConfig::broker_default();
+    config.max_blocking_threads = ENTRYPOINT_MAX_BLOCKING_THREADS;
+    config
+}
+
+async fn run(service_context: ServiceContext) -> Result<()> {
     // Initialize logger
     rocketmq_common::log::init_logger_with_level(rocketmq_common::log::Level::INFO)?;
 
@@ -115,6 +139,7 @@ async fn run() -> Result<()> {
     Builder::new()
         .set_broker_config(broker_config)
         .set_message_store_config(message_store_config)
+        .set_service_context(service_context)
         .build()
         .boot()
         .await;

--- a/rocketmq-broker/src/broker_bootstrap.rs
+++ b/rocketmq-broker/src/broker_bootstrap.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use rocketmq_common::common::broker::broker_config::BrokerConfig;
+use rocketmq_runtime::ServiceContext;
 use rocketmq_rust::wait_for_signal;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
 use tracing::error;
@@ -64,6 +65,7 @@ impl BrokerBootstrap {
 pub struct Builder {
     broker_config: BrokerConfig,
     message_store_config: MessageStoreConfig,
+    service_context: Option<ServiceContext>,
 }
 
 impl Builder {
@@ -72,6 +74,7 @@ impl Builder {
         Builder {
             broker_config: Default::default(),
             message_store_config: MessageStoreConfig::default(),
+            service_context: None,
         }
     }
     #[inline]
@@ -85,15 +88,50 @@ impl Builder {
         self
     }
     #[inline]
+    pub fn set_service_context(mut self, service_context: ServiceContext) -> Self {
+        self.service_context = Some(service_context);
+        self
+    }
+    #[inline]
     pub fn build(self) -> BrokerBootstrap {
-        BrokerBootstrap {
-            broker_runtime: BrokerRuntime::new(Arc::new(self.broker_config), Arc::new(self.message_store_config)),
-        }
+        let broker_config = Arc::new(self.broker_config);
+        let message_store_config = Arc::new(self.message_store_config);
+        let broker_runtime = match self.service_context {
+            Some(service_context) => {
+                BrokerRuntime::new_with_service_context(broker_config, message_store_config, service_context)
+            }
+            None => BrokerRuntime::new(broker_config, message_store_config),
+        };
+
+        BrokerBootstrap { broker_runtime }
     }
 }
 
 impl Default for Builder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(all(test, feature = "local_file_store"))]
+mod tests {
+    use rocketmq_runtime::RuntimeContext;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn builder_passes_service_context_to_broker_runtime() {
+        let context = RuntimeContext::from_current("broker-bootstrap-context-test");
+        let service_context = context.service_context("broker-bootstrap-service");
+
+        let mut bootstrap = Builder::new().set_service_context(service_context.clone()).build();
+
+        let broker_task_group = bootstrap
+            .broker_runtime
+            .inner_for_test()
+            .broker_service_task_group()
+            .expect("broker service task group should come from service context");
+
+        assert_eq!(broker_task_group.id(), service_context.task_group().id());
     }
 }

--- a/rocketmq-client/tests/client_lifecycle_probes_test.rs
+++ b/rocketmq-client/tests/client_lifecycle_probes_test.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_client_rust::run_concurrent_clean_expire_lifecycle_probe;
+use rocketmq_client_rust::run_connection_event_listener_lifecycle_probe;
+use rocketmq_client_rust::run_consumer_stats_manager_lifecycle_probe;
+use rocketmq_client_rust::run_latency_fault_detector_lifecycle_probe;
+use rocketmq_client_rust::run_lite_pull_task_lifecycle_probe;
+use rocketmq_client_rust::run_local_file_offset_store_lifecycle_probe;
+use rocketmq_client_rust::run_namesrv_refresh_lifecycle_probe;
+use rocketmq_client_rust::run_orderly_lock_periodic_lifecycle_probe;
+use rocketmq_client_rust::run_pop_orderly_lock_refresh_lifecycle_probe;
+use rocketmq_client_rust::run_produce_accumulator_guard_lifecycle_probe;
+use rocketmq_client_rust::run_pull_message_service_lifecycle_probe;
+use rocketmq_client_rust::run_rebalance_service_lifecycle_probe;
+use rocketmq_client_rust::run_request_future_holder_lifecycle_probe;
+use rocketmq_client_rust::run_trace_worker_lifecycle_probe;
+
+#[tokio::test]
+async fn client_service_lifecycle_probes_report_clean_shutdown() {
+    let connection_events = run_connection_event_listener_lifecycle_probe().await;
+    assert!(connection_events.healthy, "{connection_events:?}");
+    assert_eq!(connection_events.task_count_after_shutdown, 0);
+
+    let namesrv_refresh = run_namesrv_refresh_lifecycle_probe().await;
+    assert!(namesrv_refresh.healthy, "{namesrv_refresh:?}");
+    assert_eq!(namesrv_refresh.task_count_after_shutdown, 0);
+
+    let consumer_stats = run_consumer_stats_manager_lifecycle_probe().await;
+    assert!(consumer_stats.healthy, "{consumer_stats:?}");
+    assert_eq!(consumer_stats.task_count_after_shutdown, 0);
+
+    let latency_fault_detector = run_latency_fault_detector_lifecycle_probe().await;
+    assert!(latency_fault_detector.healthy, "{latency_fault_detector:?}");
+    assert_eq!(latency_fault_detector.task_count_after_shutdown, 0);
+    assert_eq!(latency_fault_detector.scheduled_failures, 0);
+
+    let concurrent_clean_expire = run_concurrent_clean_expire_lifecycle_probe().await;
+    assert!(concurrent_clean_expire.healthy, "{concurrent_clean_expire:?}");
+    assert_eq!(concurrent_clean_expire.task_count_after_shutdown, 0);
+
+    let orderly_lock = run_orderly_lock_periodic_lifecycle_probe().await;
+    assert!(orderly_lock.healthy, "{orderly_lock:?}");
+    assert_eq!(orderly_lock.task_count_after_shutdown, 0);
+    assert_eq!(orderly_lock.scheduled_failures, 0);
+
+    let pop_orderly_lock = run_pop_orderly_lock_refresh_lifecycle_probe().await;
+    assert!(pop_orderly_lock.healthy, "{pop_orderly_lock:?}");
+    assert_eq!(pop_orderly_lock.task_count_after_shutdown, 0);
+    assert_eq!(pop_orderly_lock.scheduled_failures, 0);
+
+    let lite_pull = run_lite_pull_task_lifecycle_probe().await;
+    assert!(lite_pull.healthy, "{lite_pull:?}");
+    assert_eq!(lite_pull.task_count_after_shutdown, 0);
+
+    let pull_message = run_pull_message_service_lifecycle_probe().await;
+    assert!(pull_message.healthy, "{pull_message:?}");
+    assert_eq!(pull_message.task_count_after_shutdown, 0);
+
+    let rebalance = run_rebalance_service_lifecycle_probe().await;
+    assert!(rebalance.healthy, "{rebalance:?}");
+    assert_eq!(rebalance.task_count_after_shutdown, 0);
+
+    let local_offset_store = run_local_file_offset_store_lifecycle_probe().await;
+    assert!(local_offset_store.healthy, "{local_offset_store:?}");
+    assert_eq!(local_offset_store.task_count_after_shutdown, 0);
+    assert_eq!(local_offset_store.scheduled_failures, 0);
+
+    let produce_accumulator = run_produce_accumulator_guard_lifecycle_probe().await;
+    assert!(produce_accumulator.healthy, "{produce_accumulator:?}");
+    assert_eq!(produce_accumulator.task_count_after_shutdown, 0);
+
+    let request_future_holder = run_request_future_holder_lifecycle_probe().await;
+    assert!(request_future_holder.healthy, "{request_future_holder:?}");
+    assert_eq!(request_future_holder.task_count_after_shutdown, 0);
+    assert_eq!(request_future_holder.scheduled_failures, 0);
+
+    let trace_worker = run_trace_worker_lifecycle_probe().await;
+    assert!(trace_worker.healthy, "{trace_worker:?}");
+    assert_eq!(trace_worker.remaining_tasks_after_shutdown, 0);
+    assert_eq!(trace_worker.timed_out, 0);
+}

--- a/rocketmq-client/tests/client_runtime_fallback_test.rs
+++ b/rocketmq-client/tests/client_runtime_fallback_test.rs
@@ -1,0 +1,88 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use rocketmq_client_rust::client_runtime_fallback_snapshot;
+use rocketmq_client_rust::reset_client_runtime_fallback_for_diagnostics;
+use rocketmq_client_rust::spawn_client_runtime_probe_task;
+use rocketmq_client_rust::ClientSharedFallbackLifecycleState;
+
+#[test]
+fn fallback_runtime_supports_no_ambient_callers_and_reset_diagnostics() {
+    let _ = reset_client_runtime_fallback_for_diagnostics(Duration::from_secs(1))
+        .expect("initial fallback reset should not fail");
+
+    let (started_tx, started_rx) = mpsc::channel();
+    let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+
+    let handle = spawn_client_runtime_probe_task("client-fallback-compat-test", async move {
+        let thread_name = std::thread::current().name().unwrap_or_default().to_string();
+        started_tx.send(thread_name).expect("started receiver should be alive");
+        let _ = finish_rx.await;
+    })
+    .expect("fallback task should spawn without an ambient Tokio runtime");
+
+    let thread_name = started_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("fallback task should start");
+    assert_eq!(thread_name, "rocketmq-client-fallback");
+
+    let active = client_runtime_fallback_snapshot().expect("fallback snapshot should exist");
+    assert_eq!(active.boundary, "rocketmq-client.shared-fallback-runtime");
+    assert_eq!(active.compatibility, "shared fallback runtime compatibility boundary");
+    assert!(active.prefers_injected_runtime);
+    assert_eq!(active.state, ClientSharedFallbackLifecycleState::Active);
+    assert!(active.runtime_available);
+    assert!(active.active_tasks >= 1);
+    let first_generation = active.runtime_generation;
+
+    let reset_error = reset_client_runtime_fallback_for_diagnostics(Duration::from_millis(20))
+        .expect_err("reset must reject an active fallback lease");
+    assert!(reset_error.to_string().contains("leases are active"));
+
+    finish_tx.send(()).expect("fallback task should still be waiting");
+    assert!(handle.wait_finished(Duration::from_secs(2)));
+
+    let report = reset_client_runtime_fallback_for_diagnostics(Duration::from_secs(1))
+        .expect("fallback reset should complete")
+        .expect("reset should return a shutdown report for the active fallback runtime");
+    assert!(report.is_healthy(), "{}", report.to_json());
+
+    let reset = client_runtime_fallback_snapshot().expect("fallback snapshot should exist after reset");
+    assert_eq!(reset.state, ClientSharedFallbackLifecycleState::Uninitialized);
+    assert!(!reset.runtime_available);
+
+    let (recreated_tx, recreated_rx) = mpsc::channel();
+    let recreated_handle = spawn_client_runtime_probe_task("client-fallback-recreate-test", async move {
+        recreated_tx.send(()).expect("recreated receiver should be alive");
+    })
+    .expect("reset fallback runtime should accept no-ambient callers again");
+
+    recreated_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("recreated fallback task should run");
+    assert!(recreated_handle.wait_finished(Duration::from_secs(2)));
+
+    let recreated = client_runtime_fallback_snapshot().expect("fallback snapshot should exist after recreate");
+    assert!(recreated.runtime_available);
+    assert!(
+        recreated.runtime_generation > first_generation,
+        "reset should force a new fallback runtime generation"
+    );
+
+    let _ = reset_client_runtime_fallback_for_diagnostics(Duration::from_secs(1))
+        .expect("cleanup fallback reset should complete");
+}

--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -23,6 +23,9 @@ use rocketmq_controller::ControllerManager;
 use rocketmq_error::ControllerError;
 use rocketmq_error::Result;
 use rocketmq_remoting::protocol::remoting_command;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ServiceContext;
 use rocketmq_rust::ArcMut;
 use tracing::info;
 
@@ -46,8 +49,40 @@ use tracing::info;
 /// # Print configuration and exit
 /// rocketmq-controller-rust --print-config-item
 /// ```
-#[rocketmq_rust::main]
-pub async fn main() -> Result<()> {
+const ENTRYPOINT_MAX_BLOCKING_THREADS: usize = 64;
+
+pub fn main() -> Result<()> {
+    let owner = RuntimeOwner::new(controller_runtime_config())
+        .map_err(|error| ControllerError::Internal(format!("failed to build controller runtime: {error}")))?;
+    let service_context = owner.context().service_context("rocketmq-controller-runtime");
+
+    let run_result = owner.block_on(run(service_context));
+    let shutdown_result = owner
+        .shutdown_runtime_blocking()
+        .map_err(|error| ControllerError::Internal(format!("failed to shutdown controller runtime: {error}")));
+
+    match (run_result, shutdown_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error.into()),
+        (Ok(()), Ok(report)) => {
+            if !report.is_healthy() {
+                tracing::warn!(
+                    report = %report.to_json(),
+                    "controller runtime shutdown report is unhealthy"
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
+fn controller_runtime_config() -> RuntimeConfig {
+    let mut config = RuntimeConfig::controller_default();
+    config.max_blocking_threads = ENTRYPOINT_MAX_BLOCKING_THREADS;
+    config
+}
+
+async fn run(service_context: ServiceContext) -> Result<()> {
     // Initialize logger
     rocketmq_common::log::init_logger_with_level(rocketmq_common::log::Level::INFO)?;
 
@@ -86,7 +121,7 @@ pub async fn main() -> Result<()> {
 
     // Create controller manager
     info!("Creating Controller Manager...");
-    let controller_manager = ControllerManager::new(config).await?;
+    let controller_manager = ControllerManager::new_with_service_context(config, service_context).await?;
     let controller_manager = ArcMut::new(controller_manager);
     // Initialize controller
     info!("Initializing Controller...");

--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -63,6 +63,7 @@ use rocketmq_runtime::RuntimeHandle;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
+use rocketmq_runtime::ServiceContext;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskKind;
 use rocketmq_rust::ArcMut;
@@ -428,18 +429,27 @@ impl ControllerManager {
     /// - Metadata store creation fails
     /// - Configuration is invalid
     pub async fn new(config: ControllerConfig) -> Result<Self> {
-        Self::new_with_optional_task_group(config, None).await
+        Self::new_with_optional_runtime_context(config, None, None).await
     }
 
     pub async fn new_with_task_group(config: ControllerConfig, parent_task_group: TaskGroup) -> Result<Self> {
-        Self::new_with_optional_task_group(config, Some(parent_task_group)).await
+        Self::new_with_optional_runtime_context(config, None, Some(parent_task_group)).await
     }
 
-    async fn new_with_optional_task_group(
+    pub async fn new_with_service_context(config: ControllerConfig, service_context: ServiceContext) -> Result<Self> {
+        Self::new_with_optional_runtime_context(config, Some(service_context), None).await
+    }
+
+    async fn new_with_optional_runtime_context(
         config: ControllerConfig,
+        service_context: Option<ServiceContext>,
         parent_task_group: Option<TaskGroup>,
     ) -> Result<Self> {
         let config = ArcMut::new(config);
+        let parent_task_group = service_context
+            .as_ref()
+            .map(|context| context.task_group().clone())
+            .or(parent_task_group);
 
         info!("Creating controller manager with config: {:?}", config);
 
@@ -484,7 +494,13 @@ impl ControllerManager {
             listen_port,
             ..Default::default()
         };
-        let remoting_server = Some(RocketMQServer::new(Arc::new(server_config)));
+        let remoting_server = Some(match service_context.as_ref() {
+            Some(service_context) => RocketMQServer::new_with_service_context(
+                Arc::new(server_config),
+                service_context.child("controller.remoting-server"),
+            ),
+            None => RocketMQServer::new(Arc::new(server_config)),
+        });
         info!("Remoting server created on port {}", listen_port);
 
         // Initialize remoting client for outbound RPC
@@ -787,11 +803,21 @@ impl ControllerManager {
             let (shutdown_tx, shutdown_rx) = oneshot::channel();
             *self.remoting_server_shutdown_tx.lock() = Some(shutdown_tx);
             if let Err(error) = manager_task_group.spawn_service("controller.remoting-server", async move {
-                server
-                    .run_with_shutdown(request_processor, broker_housekeeping_service, async move {
+                let report = server
+                    .run_with_shutdown_report(request_processor, broker_housekeeping_service, async move {
                         let _ = shutdown_rx.await;
                     })
                     .await;
+                match report.as_ref() {
+                    Some(report) if !report.is_healthy() => {
+                        warn!(
+                            report = %report.to_json(),
+                            "Controller remoting server shutdown report is unhealthy"
+                        );
+                    }
+                    None => warn!("Controller remoting server stopped without a shutdown report"),
+                    _ => {}
+                }
             }) {
                 return Err(ControllerError::Internal(format!(
                     "Failed to spawn controller remoting server task: {error}"

--- a/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
+++ b/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
@@ -21,22 +21,50 @@ use rocketmq_proxy::ProxyError;
 use rocketmq_proxy::ProxyMode;
 use rocketmq_proxy::ProxyResult;
 use rocketmq_proxy::ProxyRuntime;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ServiceContext;
 use tracing::info;
 
 const ENTRYPOINT_MAX_BLOCKING_THREADS: usize = 64;
 
 fn main() -> ProxyResult<()> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .max_blocking_threads(ENTRYPOINT_MAX_BLOCKING_THREADS)
-        .enable_all()
-        .build()
-        .map_err(|error| ProxyError::Transport {
-            message: format!("failed to build proxy Tokio runtime: {error}"),
-        })?;
-    runtime.block_on(run())
+    let owner = RuntimeOwner::new(proxy_runtime_config()).map_err(proxy_runtime_error("build proxy runtime"))?;
+    let service_context = owner.context().service_context("rocketmq-proxy-runtime");
+
+    let run_result = owner.block_on(run(service_context));
+    let shutdown_result = owner
+        .shutdown_runtime_blocking()
+        .map_err(proxy_runtime_error("shutdown proxy runtime"));
+
+    match (run_result, shutdown_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(report)) => {
+            if !report.is_healthy() {
+                tracing::warn!(
+                    report = %report.to_json(),
+                    "proxy runtime shutdown report is unhealthy"
+                );
+            }
+            Ok(())
+        }
+    }
 }
 
-async fn run() -> ProxyResult<()> {
+fn proxy_runtime_config() -> RuntimeConfig {
+    let mut config = RuntimeConfig::proxy_default();
+    config.max_blocking_threads = ENTRYPOINT_MAX_BLOCKING_THREADS;
+    config
+}
+
+fn proxy_runtime_error(action: &'static str) -> impl FnOnce(rocketmq_runtime::RuntimeError) -> ProxyError {
+    move |error| ProxyError::Transport {
+        message: format!("failed to {action}: {error}"),
+    }
+}
+
+async fn run(service_context: ServiceContext) -> ProxyResult<()> {
     rocketmq_common::log::init_logger_with_level(rocketmq_common::log::Level::INFO)?;
 
     let args = Args::parse()?;
@@ -56,7 +84,9 @@ async fn run() -> ProxyResult<()> {
         config.mode, config.grpc.listen_addr, config.remoting.enabled, config.remoting.listen_addr
     );
 
-    ProxyRuntime::new(config)
+    ProxyRuntime::builder(config)
+        .with_service_context(service_context)
+        .build()
         .serve_with_shutdown(async {
             if let Err(error) = tokio::signal::ctrl_c().await {
                 eprintln!("failed to listen for ctrl-c: {error}");

--- a/rocketmq-proxy/src/bootstrap.rs
+++ b/rocketmq-proxy/src/bootstrap.rs
@@ -17,6 +17,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use futures::FutureExt;
+use rocketmq_runtime::ServiceContext;
 
 use crate::auth::build_cluster_acl_rpc_hook;
 use crate::auth::ProxyAuthRuntime;
@@ -46,6 +47,7 @@ pub struct ProxyRuntimeBuilder {
     hooks: Option<ProxyHookChain>,
     metrics: Option<ProxyMetrics>,
     remoting_backend: Option<Arc<dyn ProxyRemotingBackend>>,
+    service_context: Option<ServiceContext>,
 }
 
 impl ProxyRuntimeBuilder {
@@ -79,6 +81,11 @@ impl ProxyRuntimeBuilder {
         self
     }
 
+    pub fn with_service_context(mut self, service_context: ServiceContext) -> Self {
+        self.service_context = Some(service_context);
+        self
+    }
+
     pub fn build(self) -> ProxyRuntime<DefaultMessagingProcessor> {
         let local_mode_supported = true;
         let (service_manager, remoting_backend) = match self.service_manager {
@@ -98,6 +105,7 @@ impl ProxyRuntimeBuilder {
             self.hooks.unwrap_or_default(),
             self.metrics.unwrap_or_default(),
             remoting_backend,
+            self.service_context,
         )
     }
 }
@@ -111,6 +119,7 @@ pub struct ProxyRuntime<P = DefaultMessagingProcessor> {
     auth_runtime: Option<ProxyAuthRuntime>,
     auth_metadata_service: Option<Arc<dyn MetadataService>>,
     remoting_backend: Option<Arc<dyn ProxyRemotingBackend>>,
+    service_context: Option<ServiceContext>,
 }
 
 impl ProxyRuntime<DefaultMessagingProcessor> {
@@ -123,6 +132,7 @@ impl ProxyRuntime<DefaultMessagingProcessor> {
             hooks: None,
             metrics: None,
             remoting_backend: None,
+            service_context: None,
         }
     }
 
@@ -146,6 +156,7 @@ where
             ProxyHookChain::default(),
             ProxyMetrics::default(),
             None,
+            None,
         )
     }
 
@@ -159,6 +170,7 @@ where
         hooks: ProxyHookChain,
         metrics: ProxyMetrics,
         remoting_backend: Option<Arc<dyn ProxyRemotingBackend>>,
+        service_context: Option<ServiceContext>,
     ) -> Self {
         #[cfg(feature = "observability")]
         crate::observability::init_observability_metrics(&config);
@@ -178,6 +190,7 @@ where
             auth_runtime,
             auth_metadata_service,
             remoting_backend,
+            service_context,
         }
     }
 
@@ -202,6 +215,7 @@ where
             auth_runtime,
             auth_metadata_service,
             remoting_backend,
+            service_context,
         } = self;
         if matches!(config.mode, ProxyMode::Local) && !local_mode_supported {
             return Err(crate::error::ProxyError::not_implemented(
@@ -217,7 +231,14 @@ where
         let auth_runtime_for_shutdown = auth_runtime.clone();
         let grpc_service = grpc_service.with_auth_runtime(auth_runtime.clone());
         if !config.remoting.enabled {
-            let result = server::serve(config, grpc_service, shutdown).await;
+            let result = match service_context.as_ref().map(|context| context.task_group().clone()) {
+                Some(parent_task_group) => {
+                    server::serve_with_report_with_task_group(config, grpc_service, shutdown, parent_task_group)
+                        .await
+                        .map(|_| ())
+                }
+                None => server::serve(config, grpc_service, shutdown).await,
+            };
             let shutdown_result = match auth_runtime_for_shutdown {
                 Some(auth_runtime) => Some(auth_runtime.shutdown().await),
                 None => None,
@@ -239,15 +260,49 @@ where
         let remoting_shutdown = async move {
             shared_shutdown.await;
         };
-        let grpc_future = server::serve(config.clone(), grpc_service, grpc_shutdown);
-        let remoting_future = remoting::serve(
-            config,
-            processor,
-            sessions,
-            auth_runtime,
-            remoting_backend,
-            remoting_shutdown,
-        );
+        let grpc_parent_task_group = service_context.as_ref().map(|context| context.task_group().clone());
+        let remoting_service_context = service_context.map(|context| context.child("rocketmq-proxy.remoting"));
+        let grpc_config = config.clone();
+        let remoting_config = config;
+        let grpc_future = async move {
+            match grpc_parent_task_group {
+                Some(parent_task_group) => server::serve_with_report_with_task_group(
+                    grpc_config,
+                    grpc_service,
+                    grpc_shutdown,
+                    parent_task_group,
+                )
+                .await
+                .map(|_| ()),
+                None => server::serve(grpc_config, grpc_service, grpc_shutdown).await,
+            }
+        };
+        let remoting_future = async move {
+            match remoting_service_context {
+                Some(service_context) => remoting::serve_with_service_context(
+                    service_context,
+                    remoting_config,
+                    processor,
+                    sessions,
+                    auth_runtime,
+                    remoting_backend,
+                    remoting_shutdown,
+                )
+                .await
+                .map(|_| ()),
+                None => {
+                    remoting::serve(
+                        remoting_config,
+                        processor,
+                        sessions,
+                        auth_runtime,
+                        remoting_backend,
+                        remoting_shutdown,
+                    )
+                    .await
+                }
+            }
+        };
         let (grpc_result, remoting_result) = tokio::join!(grpc_future, remoting_future);
         let shutdown_result = match auth_runtime_for_shutdown {
             Some(auth_runtime) => Some(auth_runtime.shutdown().await),

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -82,7 +82,10 @@ use rocketmq_remoting::remoting_server::rocketmq_tokio_server;
 use rocketmq_remoting::runtime::connection_handler_context::ConnectionHandlerContext;
 use rocketmq_remoting::runtime::processor::RejectRequestResponse;
 use rocketmq_remoting::runtime::processor::RequestProcessor;
+use rocketmq_runtime::ServiceContext;
+use rocketmq_runtime::ShutdownReport;
 use tokio::net::TcpListener;
+use tracing::warn;
 
 use crate::auth::build_cluster_acl_rpc_hook;
 use crate::auth::is_auth_error;
@@ -196,20 +199,92 @@ where
     P: MessagingProcessor + 'static,
     F: Future<Output = ()> + Send + 'static,
 {
+    serve_with_optional_service_context(
+        None,
+        config,
+        processor,
+        sessions,
+        auth_runtime,
+        remoting_backend,
+        shutdown,
+    )
+    .await
+    .map(|_| ())
+}
+
+#[doc(hidden)]
+pub async fn serve_with_service_context<P, F>(
+    service_context: ServiceContext,
+    config: Arc<ProxyConfig>,
+    processor: Arc<P>,
+    sessions: ClientSessionRegistry,
+    auth_runtime: Option<ProxyAuthRuntime>,
+    remoting_backend: Option<Arc<dyn ProxyRemotingBackend>>,
+    shutdown: F,
+) -> ProxyResult<Option<ShutdownReport>>
+where
+    P: MessagingProcessor + 'static,
+    F: Future<Output = ()> + Send + 'static,
+{
+    serve_with_optional_service_context(
+        Some(service_context),
+        config,
+        processor,
+        sessions,
+        auth_runtime,
+        remoting_backend,
+        shutdown,
+    )
+    .await
+}
+
+async fn serve_with_optional_service_context<P, F>(
+    service_context: Option<ServiceContext>,
+    config: Arc<ProxyConfig>,
+    processor: Arc<P>,
+    sessions: ClientSessionRegistry,
+    auth_runtime: Option<ProxyAuthRuntime>,
+    remoting_backend: Option<Arc<dyn ProxyRemotingBackend>>,
+    shutdown: F,
+) -> ProxyResult<Option<ShutdownReport>>
+where
+    P: MessagingProcessor + 'static,
+    F: Future<Output = ()> + Send + 'static,
+{
     let addr = config.remoting.socket_addr()?;
     let listener = TcpListener::bind(addr).await.map_err(|error| ProxyError::Transport {
         message: format!("proxy remoting server failed to bind {addr}: {error}"),
     })?;
-    rocketmq_tokio_server::run(
-        listener,
-        shutdown,
-        ProxyRemotingRequestProcessor::new(config, processor, sessions, auth_runtime, remoting_backend),
-        None,
-        Vec::new(),
-        None,
-    )
-    .await;
-    Ok(())
+    let request_processor =
+        ProxyRemotingRequestProcessor::new(config, processor, sessions, auth_runtime, remoting_backend);
+    let report = match service_context {
+        Some(service_context) => {
+            rocketmq_tokio_server::run_with_report_with_service_context(
+                service_context,
+                listener,
+                shutdown,
+                request_processor,
+                None,
+                Vec::new(),
+                None,
+            )
+            .await
+        }
+        None => {
+            rocketmq_tokio_server::run_with_report(listener, shutdown, request_processor, None, Vec::new(), None).await
+        }
+    };
+    match report.as_ref() {
+        Some(report) if !report.is_healthy() => {
+            warn!(
+                report = %report.to_json(),
+                "Proxy remoting server task shutdown report is unhealthy"
+            );
+        }
+        None => warn!("Proxy remoting server stopped without a shutdown report"),
+        _ => {}
+    }
+    Ok(report)
 }
 
 pub struct ProxyRemotingDispatcher<P> {

--- a/rocketmq-runtime/README-zh_cn.md
+++ b/rocketmq-runtime/README-zh_cn.md
@@ -3,140 +3,158 @@
 [![Crates.io](https://img.shields.io/crates/v/rocketmq-runtime.svg)](https://crates.io/crates/rocketmq-runtime)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](../LICENSE-APACHE)
 
-`rocketmq-runtime` 是
-[rocketmq-rust](https://github.com/mxsm/rocketmq-rust) 工作区内部使用的轻量级运行时适配 crate。
-当某个组件需要独立持有 Tokio 多线程运行时时，它提供统一的运行时创建、线程命名、句柄访问、固定频率后台任务调度以及关闭控制能力。
-
-这个 crate 的定位很克制：它不会替代 Tokio，不实现完整任务管理器，也不负责组件生命周期策略。
-它只为 broker、client 以及后续工作区组件提供一致的运行时所有权原语，让线程命名、Tokio 句柄访问和关闭语义保持统一。
+`rocketmq-runtime` 是 [rocketmq-rust](https://github.com/mxsm/rocketmq-rust)
+工作区共享的 Tokio 运行时基座。它不替代 Tokio，而是统一 RocketMQ 组件如何拥有或借用
+Tokio runtime、如何追踪长期任务、如何调度周期任务、如何隔离短时阻塞工作，以及如何用
+`ShutdownReport` 验证关闭结果。
 
 [English](README.md)
 
-## 架构
+## 目标线程模型
 
-![rocketmq-runtime architecture](../resources/runtime-architecture.svg)
+RocketMQ Rust 只使用 Tokio 作为异步 runtime。runtime 所有权和任务生命周期必须显式：
 
-`rocketmq-runtime` 位于 RocketMQ 组件和 Tokio 之间：
+- 应用入口使用 `RuntimeOwner`，或在已有 Tokio runtime 中绑定 `RuntimeContext`。
+- broker、namesrv、proxy、controller 和 admin 工具入口从 owner 派生组件级 `ServiceContext`。
+- 长期服务任务通过 `TaskGroup` 注册和关闭。
+- 周期任务通过 `ScheduledTaskGroup` 管理。
+- 文件 IO、RocksDB、DNS、压缩等短时阻塞工作通过 `BlockingExecutor` 执行。
+- 不适合 Tokio blocking pool 的长期循环保留为 dedicated OS thread，但必须有 owner、线程名、stop signal 和 bounded join。
+- 关闭路径必须返回或记录 `ShutdownReport`。
 
-- 工作区组件通过 `RocketMQRuntime` 请求一个具名运行时。
-- `RocketMQRuntime::new_multi` 创建启用 IO、timer 等 Tokio driver 的多线程运行时。
-- 组件在需要直接访问 Tokio 时，通过 `get_handle()` 或 `get_runtime()` 获取借用。
-- 固定频率调度方法会把同步闭包作为重复任务提交到当前持有的运行时。
-- 关闭 API 会消费包装对象，并委托 Tokio 执行后台关闭或带超时关闭。
-
-## 能力
-
-- 使用显式 worker 线程数创建具名 Tokio 多线程运行时。
-- 借用底层 `tokio::runtime::Handle` 以提交异步任务。
-- 借用底层 `tokio::runtime::Runtime` 以支持更底层的集成场景。
-- 使用可选初始延迟运行固定频率后台任务。
-- 同时支持不可变 `Fn` 和可变 `FnMut` 调度闭包。
-- 支持后台关闭和带超时关闭两种运行时释放方式。
-- 保持极小依赖面：当前只依赖 Tokio。
-
-## 快速开始
-
-```toml
-[dependencies]
-rocketmq-runtime = { path = "../rocketmq-runtime" }
+```mermaid
+flowchart TD
+    Entry["应用入口"] --> Owner["RuntimeOwner"]
+    Entry --> Current["RuntimeContext::from_current"]
+    Owner --> Context["RuntimeContext"]
+    Current --> Context
+    Context --> Root["根 TaskGroup"]
+    Context --> Blocking["BlockingExecutor"]
+    Context --> Diagnostics["RuntimeDiagnostics"]
+    Context --> Service["ServiceContext"]
+    Service --> Group["服务 TaskGroup"]
+    Group --> Scheduled["ScheduledTaskGroup"]
+    Group --> Workers["service / worker / IO tasks"]
+    Blocking --> Reaper["blocking reaper task group"]
+    Root --> Report["ShutdownReport"]
+    Blocking --> Report
 ```
 
-创建运行时、提交异步任务、调度周期性维护任务，并在所有者结束时关闭运行时：
+## 核心类型
 
-```rust
-use std::time::Duration;
-
-use rocketmq_runtime::RocketMQRuntime;
-
-let runtime = RocketMQRuntime::new_multi(4, "rocketmq-worker");
-
-runtime.get_handle().spawn(async {
-    // 执行组件自己的异步任务。
-});
-
-runtime.schedule_at_fixed_rate(
-    || {
-        // 执行轻量级周期任务。
-    },
-    Some(Duration::from_secs(1)),
-    Duration::from_secs(5),
-);
-
-runtime.shutdown_timeout(Duration::from_secs(3));
-```
-
-如果周期任务需要持有可变状态，可以使用 `schedule_at_fixed_rate_mut`：
-
-```rust
-use std::time::Duration;
-
-use rocketmq_runtime::RocketMQRuntime;
-
-let runtime = RocketMQRuntime::new_multi(2, "rocketmq-scheduler");
-let mut runs = 0_u64;
-
-runtime.schedule_at_fixed_rate_mut(
-    move || {
-        runs += 1;
-    },
-    None,
-    Duration::from_secs(10),
-);
-```
-
-## 运行时模型
-
-| API | 作用 |
+| 类型 | 作用 |
 | --- | --- |
-| `RocketMQRuntime::new_multi(threads, name)` | 使用指定 worker 线程数和线程名创建 Tokio 多线程运行时。 |
-| `get_handle()` | 返回借用的 Tokio `Handle`，用于提交异步任务。 |
-| `get_runtime()` | 返回借用的 Tokio `Runtime`，用于更底层的集成场景。 |
-| `schedule_at_fixed_rate(task, initial_delay, period)` | 在运行时上重复执行不可变同步闭包。 |
-| `schedule_at_fixed_rate_mut(task, initial_delay, period)` | 在运行时上重复执行可变同步闭包。 |
-| `shutdown()` | 消费包装对象，并执行 Tokio 后台关闭。 |
-| `shutdown_timeout(timeout)` | 消费包装对象，并在指定超时时间内等待关闭完成。 |
+| `RuntimeConfig` | 配置 Tokio worker 线程数、blocking 线程上限、线程名、可选 worker stack、keep-alive、关闭超时、IO/time driver 和 blocking policy。 |
+| `RuntimeOwner` | 持有专用 Tokio 多线程 runtime，并暴露 `RuntimeContext`；关闭时区分任务关闭和 runtime 释放。 |
+| `RuntimeContext` | 绑定当前 runtime handle、根 `TaskGroup`、`BlockingExecutor` 和 diagnostics；可来自 owned runtime 或当前 Tokio runtime。 |
+| `ServiceContext` | 组件级运行时视图，包含 runtime handle、服务 `TaskGroup`、blocking executor 和 diagnostics。 |
+| `TaskGroup` | 结构化任务作用域，支持任务元数据、取消、关闭、abort、child group 和健康报告。 |
+| `ScheduledTaskGroup` | 在 `TaskGroup` 下运行 fixed-delay / fixed-rate 周期任务，并记录调度指标。 |
+| `BlockingExecutor` | 有界 `spawn_blocking` 网关，提供排队超时、任务超时和仍在运行任务的 reaper 跟踪。 |
+| `ShutdownReport` | 可序列化的关闭证据，记录任务完成、取消、abort、泄漏、panic、timeout、detached task 和 blocking task。 |
+| `RocketMQRuntime` | 旧兼容 wrapper。新代码应使用 `RuntimeOwner`、`RuntimeContext` 或 `ServiceContext`。 |
 
-调度器会基于上一次开始执行的时间计算下一次执行时间。
-如果任务耗时超过配置的周期，下一次延迟会饱和为零，并在当前任务结束后立即继续执行。
+## 使用方式
 
-## 工作区使用方式
+组件拥有独立 runtime 时使用 `RuntimeOwner`：
 
-当前工作区中的使用场景包括：
+```rust
+use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
 
-- `rocketmq-broker` 持有 broker 级别后台运行时，并在 `BrokerRuntime::drop` 中关闭。
-- `rocketmq-broker` 的 pull-message processor 会为写消息路径创建独立运行时。
-- `rocketmq-client` 为事务生产者检查任务暴露运行时注入能力。
-- `rocketmq-controller`、`rocketmq-observability` 和 `rocketmq-tieredstore`
-  将该 crate 作为工作区共享运行时能力的一部分。
+fn main() -> rocketmq_runtime::RuntimeResult<()> {
+    let owner = RuntimeOwner::new(RuntimeConfig::broker_default())?;
+    let broker = owner.context().service_context("broker");
 
-## 设计边界
+    broker.spawn_service("heartbeat", async move {
+        // tracked service loop
+    })?;
 
-- 当前只实现了 Tokio 多线程运行时变体。
-- `new_multi` 会直接 unwrap Tokio 运行时创建结果。调用方应传入有效线程数，并只在运行时创建失败属于致命错误的上下文中使用。
-- 调度闭包是同步闭包。应保持轻量；如果需要执行异步工作，应捕获 clone 后的 Tokio `Handle`，再在闭包内调用 `spawn`。
-- 调度循环会持续运行，直到运行时关闭。需要显式取消能力的组件应自行持有 task handle，或在本 crate 之上使用更高层任务管理器。
-- 本 crate 不负责组件级 metrics、tracing 或错误处理策略。
+    let report = owner.shutdown_runtime_blocking()?;
+    assert!(report.is_healthy(), "{}", report.to_json());
+    Ok(())
+}
+```
+
+组件运行在已有 Tokio runtime 内时使用 `RuntimeContext::from_current`。这种 context
+可以关闭 RocketMQ 自己登记的任务，但不会拥有或关闭宿主 Tokio runtime。
+
+## 工作区接入状态
+
+当前统一模型已经覆盖：
+
+- `rocketmq-broker`：bootstrap、broker runtime、housekeeping、scheduled services、processor、auth、store/remoting integration 和 shutdown report。
+- `rocketmq-namesrv`：bootstrap、route services、batch unregister、segmented lock、remoting server/client 和 shutdown report。
+- `rocketmq-client`：producer、consumer、admin、trace、rebalance、pull、offset、delayed action、fallback runtime 和 blocking helpers。
+- `rocketmq-remoting`：client/server、connection pool、reconnect、writer task、request processing、TLS/network lifecycle。
+- `rocketmq-store` 与 `rocketmq-tieredstore`：store runtime scope、RocksDB、timer、HA、consume queue、index、compaction、dispatcher、cleanup、recovery 和 blocking IO。
+- `rocketmq-proxy`：`RuntimeOwner::new(RuntimeConfig::proxy_default())`、gRPC/remoting ingress、session/auth shutdown。
+- `rocketmq-controller`：`RuntimeOwner::new(RuntimeConfig::controller_default())`、RPC/remoting server、heartbeat、metadata/openraft scan、leadership watch。
+- `rocketmq-common`、`rocketmq-observability`、`rocketmq` 和 `rocketmq-tools/*`：helper、observability lifecycle、foundation service task/scheduler、admin CLI/TUI/store-inspect 均已分类为统一模型接入或显式兼容边界。
+
+Standalone dashboard 应用保留宿主 runtime 边界：Tauri/Web backend、GPUI 和 frontend 只有在 runtime owner、admin session、diagnostics API、TypeScript type 或 UI contract 改动时，才从各自 standalone root 做额外验证。
+
+## 兼容边界
+
+以下边界被保留并已文档化：
+
+- deprecated `RocketMQRuntime`：兼容旧同步 API 和历史调用点。
+- client shared fallback runtime：支持无 ambient runtime 的 client 调用方。
+- store static blocking executor：迁移期间支持未注入 `StoreRuntimeScope` 的调用点。
+- foundation service task helper：旧 `ServiceThread` 抽象内部已接入 `TaskGroup` 和 shutdown report。
+- dedicated OS threads：用于不适合 Tokio blocking pool 的长期循环，必须提供 stop signal 和 bounded join。
+
+新增代码不得扩大未分类 legacy runtime、raw `tokio::spawn` 或隐藏 runtime owner 的使用范围。
+
+## 关闭语义
+
+正常关闭顺序：
+
+1. 关闭 task group，拒绝新任务。
+2. 广播 cancellation。
+3. 关闭 child groups。
+4. 在超时内等待 tracked tasks。
+5. abort 剩余 tracked tasks。
+6. 合并 `BlockingExecutor` snapshot。
+7. 返回 `ShutdownReport`。
+
+`ShutdownReport::is_healthy()` 是主要正确性门槛。存在 leaked task、panic、timeout、仍在运行的 blocking task、仍在运行的 detached task 或不健康 child report 时，report 为 unhealthy。
+
+## 验证
+
+修改 runtime 行为后至少运行：
+
+```bash
+cargo test -p rocketmq-runtime --test runtime_model
+cargo test -p rocketmq-runtime --all-targets --all-features
+cargo clippy -p rocketmq-runtime --all-targets --all-features -- -D warnings
+```
+
+影响 workspace runtime 行为时继续运行：
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+```
+
+模块级迁移需要补跑对应 crate 的 `--all-targets --all-features` 测试，并在审计文档中记录无法运行的本地环境限制。
 
 ## Crate 结构
 
 ```text
 rocketmq-runtime/
-  Cargo.toml        crate 元数据和 Tokio 依赖
-  src/lib.rs        RocketMQRuntime 包装、句柄访问、关闭控制和调度逻辑
+  src/config.rs           runtime 与 blocking policy 配置
+  src/owner.rs            owned Tokio runtime 生命周期
+  src/context.rs          borrowed runtime context 与 service context factory
+  src/service_context.rs  组件级 runtime 视图
+  src/handle.rs           Tokio handle wrapper
+  src/task_group.rs       结构化任务跟踪与关闭
+  src/scheduled.rs        周期任务 group 与调度指标
+  src/blocking.rs         有界 blocking executor 与 reaper 跟踪
+  src/diagnostics.rs      runtime diagnostics facade
+  src/shutdown_report.rs  可序列化关闭证据
+  src/legacy.rs           legacy RocketMQRuntime 兼容 wrapper
 ```
-
-## 验证
-
-修改该 crate 后可运行：
-
-```bash
-cargo test -p rocketmq-runtime --lib
-cargo clippy -p rocketmq-runtime --all-targets --all-features -- -D warnings
-```
-
-如果运行时行为变更会影响其他 RocketMQ 组件，应继续运行更大范围的工作区检查。
 
 ## 许可证
 
-本项目使用 Apache License 2.0 许可证。详情请参见
-[`LICENSE-APACHE`](../LICENSE-APACHE)。
+本项目使用 Apache License 2.0 许可证。详情请参见 [`LICENSE-APACHE`](../LICENSE-APACHE)。

--- a/rocketmq-runtime/README.md
+++ b/rocketmq-runtime/README.md
@@ -23,6 +23,8 @@ lifecycle are explicit:
 
 - application entrypoints create a `RuntimeOwner` or bind a `RuntimeContext`
   to the current Tokio runtime;
+- broker, namesrv, proxy, controller, and admin tool entrypoints derive their
+  component `ServiceContext` from the runtime owner;
 - every service receives a `ServiceContext`;
 - every long-running task is spawned through a `TaskGroup`;
 - every periodic task is registered through a `ScheduledTaskGroup`;
@@ -52,7 +54,7 @@ flowchart TD
 
 | Type | Responsibility |
 | --- | --- |
-| `RuntimeConfig` | Configures Tokio worker threads, blocking-thread limit, thread name, keep-alive, shutdown timeout, IO/time drivers, and blocking policy. |
+| `RuntimeConfig` | Configures Tokio worker threads, blocking-thread limit, thread name, optional worker stack size, keep-alive, shutdown timeout, IO/time drivers, and blocking policy. |
 | `RuntimeOwner` | Owns a dedicated Tokio multi-thread runtime and exposes `RuntimeContext`. It separates async task shutdown from blocking runtime shutdown. |
 | `RuntimeContext` | Binds runtime handle, root `TaskGroup`, `BlockingExecutor`, and diagnostics. It can be created from an owned runtime or the current Tokio runtime. |
 | `RuntimeHandle` | Lightweight wrapper around `tokio::runtime::Handle`; it is handle access, not lifecycle ownership. |
@@ -207,6 +209,19 @@ New RocketMQ code should follow these rules:
   work as an emergency cleanup path;
 - keep diagnostics and benchmark tooling as validation artifacts rather than
   production-critical runtime dependencies.
+
+## Workspace Integration
+
+The unified model is the production entrypoint for broker, namesrv, proxy,
+controller, client fallback runtime, remoting, store, tieredstore, common
+statistics helpers, observability lifecycle, and admin tools. Standalone
+dashboard applications keep their host runtime boundary documented unless
+their runtime owner, admin session, diagnostics API, or UI contract changes.
+
+Compatibility adapters that intentionally remain include the deprecated
+`RocketMQRuntime`, client fallback runtime, store static blocking executor,
+foundation service task helper, and dedicated OS-thread services with explicit
+stop and join behavior.
 
 ## Diagnostics And Benchmarks
 

--- a/rocketmq-runtime/src/config.rs
+++ b/rocketmq-runtime/src/config.rs
@@ -23,6 +23,7 @@ pub struct RuntimeConfig {
     pub worker_threads: usize,
     pub max_blocking_threads: usize,
     pub thread_name: String,
+    pub thread_stack_size: Option<usize>,
     pub thread_keep_alive: Duration,
     pub shutdown_timeout: Duration,
     pub blocking_pool_policy: BlockingPoolPolicy,
@@ -46,6 +47,14 @@ impl RuntimeConfig {
         Self::server_default("rocketmq-namesrv")
     }
 
+    pub fn proxy_default() -> Self {
+        Self::server_default("rocketmq-proxy")
+    }
+
+    pub fn controller_default() -> Self {
+        Self::server_default("rocketmq-controller")
+    }
+
     pub fn validate(&self) -> RuntimeResult<()> {
         if self.worker_threads == 0 {
             return Err(RuntimeError::InvalidConfig(
@@ -60,6 +69,11 @@ impl RuntimeConfig {
         if self.thread_name.trim().is_empty() {
             return Err(RuntimeError::InvalidConfig("thread_name must not be empty".to_string()));
         }
+        if matches!(self.thread_stack_size, Some(0)) {
+            return Err(RuntimeError::InvalidConfig(
+                "thread_stack_size must be greater than zero when set".to_string(),
+            ));
+        }
         self.blocking_pool_policy.validate()?;
         Ok(())
     }
@@ -73,6 +87,7 @@ impl Default for RuntimeConfig {
             worker_threads: parallelism,
             max_blocking_threads: parallelism * 4,
             thread_name: "rocketmq-runtime".to_string(),
+            thread_stack_size: None,
             thread_keep_alive: Duration::from_secs(30),
             shutdown_timeout: Duration::from_secs(30),
             blocking_pool_policy: BlockingPoolPolicy {

--- a/rocketmq-runtime/src/lib.rs
+++ b/rocketmq-runtime/src/lib.rs
@@ -12,6 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Runtime substrate for the RocketMQ Rust unified thread model.
+//!
+//! This crate standardizes how components own or borrow a Tokio runtime, how
+//! they derive service-level task scopes through [`ServiceContext`], how
+//! [`TaskGroup`] and [`ScheduledTaskGroup`] track long-running and periodic
+//! tasks, how [`BlockingExecutor`] isolates short blocking work, and how
+//! [`ShutdownReport`] records verifiable shutdown evidence.
+//!
+//! New production code should prefer [`RuntimeOwner`], [`RuntimeContext`], and
+//! [`ServiceContext`]. [`RocketMQRuntime`] remains only as a deprecated
+//! compatibility boundary.
+
 pub mod actor;
 pub mod blocking;
 pub mod config;

--- a/rocketmq-runtime/src/owner.rs
+++ b/rocketmq-runtime/src/owner.rs
@@ -38,6 +38,9 @@ impl RuntimeOwner {
             .max_blocking_threads(config.max_blocking_threads)
             .thread_name(config.thread_name.clone())
             .thread_keep_alive(config.thread_keep_alive);
+        if let Some(thread_stack_size) = config.thread_stack_size {
+            builder.thread_stack_size(thread_stack_size);
+        }
         if config.enable_io {
             builder.enable_io();
         }

--- a/rocketmq-runtime/tests/runtime_model.rs
+++ b/rocketmq-runtime/tests/runtime_model.rs
@@ -32,28 +32,82 @@ impl Drop for DropCounter {
 }
 
 #[test]
-fn production_tokio_entrypoints_set_max_blocking_threads() {
+fn owned_runtime_entrypoints_use_runtime_owner() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("runtime crate should be inside the workspace");
-    let explicit_tokio_entrypoints = [
-        "rocketmq-broker/src/bin/broker_bootstrap_server.rs",
-        "rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs",
-        "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs",
+    let runtime_owner_entrypoints = [
+        (
+            "rocketmq-broker/src/bin/broker_bootstrap_server.rs",
+            "RuntimeOwner::new(broker_runtime_config())",
+            "broker runtime shutdown report is unhealthy",
+        ),
+        (
+            "rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs",
+            "RuntimeOwner::new(namesrv_runtime_config())",
+            "namesrv runtime shutdown report is unhealthy",
+        ),
+        (
+            "rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs",
+            "RuntimeOwner::new(proxy_runtime_config())",
+            "proxy runtime shutdown report is unhealthy",
+        ),
+        (
+            "rocketmq-controller/src/bin/controller_bootstrap.rs",
+            "RuntimeOwner::new(controller_runtime_config())",
+            "controller runtime shutdown report is unhealthy",
+        ),
+        (
+            "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs",
+            "RuntimeOwner::new(admin_tui_runtime_config())",
+            "rocketmq-admin-tui runtime shutdown report is unhealthy",
+        ),
+        (
+            "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs",
+            "RuntimeOwner::new(admin_cli_runtime_config())",
+            "rocketmq-admin-cli runtime shutdown report is unhealthy",
+        ),
     ];
 
-    for entrypoint in explicit_tokio_entrypoints {
+    for (entrypoint, runtime_owner_call, shutdown_warning) in runtime_owner_entrypoints {
         let source = fs::read_to_string(workspace_root.join(entrypoint))
             .unwrap_or_else(|error| panic!("failed to read {entrypoint}: {error}"));
         assert!(
-            source.contains("tokio::runtime::Builder::new_multi_thread()"),
-            "{entrypoint} must build its Tokio runtime explicitly"
+            source.contains(runtime_owner_call),
+            "{entrypoint} must use RuntimeOwner as the owned runtime boundary"
         );
         assert!(
-            source.contains(".max_blocking_threads(ENTRYPOINT_MAX_BLOCKING_THREADS)"),
-            "{entrypoint} must set max_blocking_threads explicitly"
+            source.contains(shutdown_warning),
+            "{entrypoint} must keep the runtime shutdown health warning"
         );
     }
+}
+
+#[test]
+fn broker_entrypoint_uses_runtime_owner_and_service_context() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("runtime crate should be inside the workspace");
+    let entrypoint = "rocketmq-broker/src/bin/broker_bootstrap_server.rs";
+    let source = fs::read_to_string(workspace_root.join(entrypoint))
+        .unwrap_or_else(|error| panic!("failed to read {entrypoint}: {error}"));
+
+    assert!(
+        source.contains("RuntimeOwner::new(broker_runtime_config())"),
+        "{entrypoint} must use RuntimeOwner as the owned runtime boundary"
+    );
+    assert!(
+        source.contains("ENTRYPOINT_MAX_BLOCKING_THREADS"),
+        "{entrypoint} must preserve the explicit blocking-thread cap"
+    );
+    assert!(
+        source.contains(".set_service_context(service_context)"),
+        "{entrypoint} must inject a ServiceContext into the broker bootstrap"
+    );
+    assert!(
+        source.contains("broker runtime shutdown report is unhealthy"),
+        "{entrypoint} must keep the broker-specific runtime shutdown health warning"
+    );
 }
 
 #[test]
@@ -92,6 +146,25 @@ fn namesrv_runtime_config_uses_namesrv_thread_name() {
     assert!(config.max_blocking_threads > 0);
     assert!(config.enable_io);
     assert!(config.enable_time);
+}
+
+#[test]
+fn server_runtime_config_supports_optional_thread_stack_size() {
+    let mut config = RuntimeConfig::server_default("rocketmq-admin-cli");
+    assert_eq!(config.thread_stack_size, None);
+
+    config.thread_stack_size = Some(16 * 1024 * 1024);
+    RuntimeOwner::new(config)
+        .expect("runtime owner should accept a positive thread stack size")
+        .shutdown_runtime_blocking()
+        .expect("runtime owner should shutdown outside Tokio runtime");
+
+    let mut invalid = RuntimeConfig::server_default("invalid-stack-runtime");
+    invalid.thread_stack_size = Some(0);
+    assert!(matches!(
+        RuntimeOwner::new(invalid),
+        Err(RuntimeError::InvalidConfig(message)) if message.contains("thread_stack_size")
+    ));
 }
 
 #[test]

--- a/rocketmq-store/benches/zerocopy_performance.rs
+++ b/rocketmq-store/benches/zerocopy_performance.rs
@@ -39,6 +39,7 @@ use rocketmq_common::common::message::message_ext_broker_inner::MessageExtBroker
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_store::base::append_message_callback::AppendMessageCallback;
 use rocketmq_store::base::append_message_callback::DefaultAppendMessageCallback;
+use rocketmq_store::base::message_encoder_pool::encode_message_with_pool;
 use rocketmq_store::base::put_message_context::PutMessageContext;
 use rocketmq_store::config::message_store_config::MessageStoreConfig;
 use rocketmq_store::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
@@ -47,7 +48,7 @@ use tempfile::TempDir;
 /// Setup: Create a test MappedFile and message
 fn setup_test_environment(file_size: u64) -> (Arc<DefaultMappedFile>, TempDir, DefaultAppendMessageCallback) {
     let temp_dir = TempDir::new().unwrap();
-    let file_path = temp_dir.path().join("test_commitlog");
+    let file_path = temp_dir.path().join("00000000000000000000");
 
     let mapped_file = Arc::new(DefaultMappedFile::new(
         CheetahString::from_string(file_path.to_string_lossy().to_string()),
@@ -87,8 +88,11 @@ fn create_test_message_with_encoding(body_size: usize) -> MessageExtBrokerInner 
             .as_millis() as i64,
     );
 
-    // Pre-encode the message (simulating the encoding phase)
-    // Note: In real implementation, this would call the encoder
+    let config = Arc::new(MessageStoreConfig::default());
+    let (encode_result, encoded_buff) = encode_message_with_pool(&msg_inner, &config);
+    assert!(encode_result.is_none());
+    msg_inner.encoded_buff = Some(encoded_buff);
+
     msg_inner
 }
 
@@ -107,10 +111,10 @@ fn bench_zerocopy_vs_standard(c: &mut Criterion) {
         // Benchmark standard path
         group.bench_with_input(BenchmarkId::new("standard_append", size), &size, |b, &size| {
             let (mapped_file, _temp, callback) = setup_test_environment(10 * 1024 * 1024);
-            let mut message = create_test_message_with_encoding(size);
             let context = PutMessageContext::default();
 
             b.iter(|| {
+                let mut message = create_test_message_with_encoding(size);
                 let result = callback.do_append(
                     std::hint::black_box(0),
                     std::hint::black_box(mapped_file.as_ref()),
@@ -125,10 +129,10 @@ fn bench_zerocopy_vs_standard(c: &mut Criterion) {
         // Benchmark zero-copy path
         group.bench_with_input(BenchmarkId::new("zerocopy_append", size), &size, |b, &size| {
             let (mapped_file, _temp, callback) = setup_test_environment(10 * 1024 * 1024);
-            let mut message = create_test_message_with_encoding(size);
             let context = PutMessageContext::default();
 
             b.iter(|| {
+                let mut message = create_test_message_with_encoding(size);
                 let result = callback.do_append_zerocopy(
                     std::hint::black_box(0),
                     std::hint::black_box(mapped_file.as_ref()),
@@ -156,10 +160,10 @@ fn bench_memory_allocation(c: &mut Criterion) {
 
     group.bench_function("standard_allocations", |b| {
         let (mapped_file, _temp, callback) = setup_test_environment(10 * 1024 * 1024);
-        let mut message = create_test_message_with_encoding(msg_size);
         let context = PutMessageContext::default();
 
         b.iter(|| {
+            let mut message = create_test_message_with_encoding(msg_size);
             // Standard path creates intermediate BytesMut buffer
             let result = callback.do_append(
                 std::hint::black_box(0),
@@ -174,10 +178,10 @@ fn bench_memory_allocation(c: &mut Criterion) {
 
     group.bench_function("zerocopy_allocations", |b| {
         let (mapped_file, _temp, callback) = setup_test_environment(10 * 1024 * 1024);
-        let mut message = create_test_message_with_encoding(msg_size);
         let context = PutMessageContext::default();
 
         b.iter(|| {
+            let mut message = create_test_message_with_encoding(msg_size);
             // Zero-copy directly writes to mmap, no intermediate buffer
             let result = callback.do_append_zerocopy(
                 std::hint::black_box(0),
@@ -207,10 +211,10 @@ fn bench_zerocopy_throughput_by_size(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
             let (mapped_file, _temp, callback) = setup_test_environment(100 * 1024 * 1024);
-            let mut message = create_test_message_with_encoding(size);
             let context = PutMessageContext::default();
 
             b.iter(|| {
+                let mut message = create_test_message_with_encoding(size);
                 let result = callback.do_append_zerocopy(
                     std::hint::black_box(0),
                     std::hint::black_box(mapped_file.as_ref()),
@@ -251,10 +255,10 @@ fn bench_concurrent_zerocopy(c: &mut Criterion) {
                         let iter_count = iters / thread_count as u64;
 
                         std::thread::spawn(move || {
-                            let mut message = create_test_message_with_encoding(1024);
                             let context = PutMessageContext::default();
 
                             for _ in 0..iter_count {
+                                let mut message = create_test_message_with_encoding(1024);
                                 let result = callback.do_append_zerocopy(
                                     0,
                                     mapped_file.as_ref(),
@@ -295,11 +299,11 @@ fn bench_cache_efficiency(c: &mut Criterion) {
         let (mapped_file, _temp, callback) = setup_test_environment(100 * 1024 * 1024);
 
         b.iter(|| {
-            let mut message = create_test_message_with_encoding(msg_size);
             let context = PutMessageContext::default();
 
             // Sequential writes (good cache locality)
             for _ in 0..batch_size {
+                let mut message = create_test_message_with_encoding(msg_size);
                 let result = callback.do_append_zerocopy(
                     std::hint::black_box(0),
                     std::hint::black_box(mapped_file.as_ref()),
@@ -325,10 +329,10 @@ fn bench_latency_percentiles(c: &mut Criterion) {
 
     group.bench_function("zerocopy_latency", |b| {
         let (mapped_file, _temp, callback) = setup_test_environment(100 * 1024 * 1024);
-        let mut message = create_test_message_with_encoding(1024);
         let context = PutMessageContext::default();
 
         b.iter(|| {
+            let mut message = create_test_message_with_encoding(1024);
             let start = Instant::now();
             let result = callback.do_append_zerocopy(
                 std::hint::black_box(0),

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/Cargo.toml
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/Cargo.toml
@@ -32,6 +32,7 @@ rocketmq-admin-core = { version = "1.0.0", path = "../rocketmq-admin-core", feat
 rocketmq-common     = { workspace = true }
 rocketmq-error      = { workspace = true }
 rocketmq-remoting   = { workspace = true }
+rocketmq-runtime    = { workspace = true }
 rocketmq-rust       = { workspace = true }
 
 bytes = { workspace = true }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
@@ -16,6 +16,8 @@ use rocketmq_admin_cli::rocketmq_cli::RocketMQCli;
 use rocketmq_common::EnvUtils::EnvUtils;
 use rocketmq_common::common::mq_version::CURRENT_VERSION;
 use rocketmq_remoting::protocol::remoting_command;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
 
 const CLI_RUNTIME_STACK_SIZE: usize = 16 * 1024 * 1024;
 
@@ -24,18 +26,30 @@ fn main() {
         .name("rocketmq-admin-cli-main".to_string())
         .stack_size(CLI_RUNTIME_STACK_SIZE)
         .spawn(|| {
-            let runtime = tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .thread_stack_size(CLI_RUNTIME_STACK_SIZE)
-                .build()
-                .expect("failed to build rocketmq-admin-cli runtime");
-            runtime.block_on(async_main());
+            let owner =
+                RuntimeOwner::new(admin_cli_runtime_config()).expect("failed to build rocketmq-admin-cli runtime");
+            owner.block_on(async_main());
+            let report = owner
+                .shutdown_runtime_blocking()
+                .expect("failed to shutdown rocketmq-admin-cli runtime");
+            if !report.is_healthy() {
+                tracing::warn!(
+                    report = %report.to_json(),
+                    "rocketmq-admin-cli runtime shutdown report is unhealthy"
+                );
+            }
         })
         .expect("failed to spawn rocketmq-admin-cli main thread");
 
     if let Err(payload) = handle.join() {
         std::panic::resume_unwind(payload);
     }
+}
+
+fn admin_cli_runtime_config() -> RuntimeConfig {
+    let mut config = RuntimeConfig::server_default("rocketmq-admin-cli");
+    config.thread_stack_size = Some(CLI_RUNTIME_STACK_SIZE);
+    config
 }
 
 async fn async_main() {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/Cargo.toml
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/Cargo.toml
@@ -31,14 +31,16 @@ rust-version.workspace = true
 rocketmq-admin-core = { version = "1.0.0", path = "../rocketmq-admin-core" }
 rocketmq-common     = { workspace = true }
 rocketmq-remoting   = { workspace = true }
-rocketmq-rust = { workspace = true }
-ratatui       = { version = "0.30.1" }
-crossterm     = { version = "0.29", features = ["event-stream"] }
+rocketmq-runtime    = { workspace = true }
+rocketmq-rust       = { workspace = true }
+ratatui             = { version = "0.30.1" }
+crossterm           = { version = "0.29", features = ["event-stream"] }
 
 tokio.workspace = true
 tokio-stream    = { workspace = true }
+tracing         = { workspace = true }
 
-anyhow = { workspace = true }
-serde  = { workspace = true, features = ["derive"] }
+anyhow     = { workspace = true }
+serde      = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-strum  = { workspace = true, features = ["derive"] }
+strum      = { workspace = true, features = ["derive"] }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-tui/src/main.rs
@@ -23,14 +23,38 @@ mod view_model;
 
 use crate::rocketmq_tui_app::RocketmqTuiApp;
 
+use anyhow::Context;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+
 const ENTRYPOINT_MAX_BLOCKING_THREADS: usize = 64;
 
 fn main() -> anyhow::Result<()> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .max_blocking_threads(ENTRYPOINT_MAX_BLOCKING_THREADS)
-        .enable_all()
-        .build()?;
-    runtime.block_on(run())
+    let owner = RuntimeOwner::new(admin_tui_runtime_config()).context("failed to build rocketmq-admin-tui runtime")?;
+    let run_result = owner.block_on(run());
+    let shutdown_result = owner
+        .shutdown_runtime_blocking()
+        .context("failed to shutdown rocketmq-admin-tui runtime");
+
+    match (run_result, shutdown_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(report)) => {
+            if !report.is_healthy() {
+                tracing::warn!(
+                    report = %report.to_json(),
+                    "rocketmq-admin-tui runtime shutdown report is unhealthy"
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
+fn admin_tui_runtime_config() -> RuntimeConfig {
+    let mut config = RuntimeConfig::server_default("rocketmq-admin-tui");
+    config.max_blocking_threads = ENTRYPOINT_MAX_BLOCKING_THREADS;
+    config
 }
 
 async fn run() -> anyhow::Result<()> {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7590

### Brief Description

Introduce the unified thread model across RocketMQ Rust modules and complete the module-level acceptance work:

- Route broker, proxy, controller, and admin CLI/TUI entrypoints through `RuntimeOwner` / `ServiceContext`; proxy gRPC/remoting and controller remoting server now preserve shutdown report evidence.
- Extend `rocketmq-runtime` configuration with proxy/controller defaults and optional worker stack size; keep the admin CLI explicit main OS-thread boundary documented.
- Complete runtime coverage for client fallback/lifecycle, store/tieredstore, common helpers, observability, foundation helpers, tools, and standalone dashboard/example boundaries.
- Update runtime README files and crate-level runtime docs.

### How Did You Test This Change?

- `cargo fmt --all`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `git diff --check`: passed, with Windows LF/CRLF normalization warnings only.
- `openspec validate introduce-unified-thread-model --type change --strict`: passed.
- `openspec validate --all --strict`: passed.
- `cargo test -p rocketmq-runtime --test runtime_model`: 32 passed.
- `cargo test -p rocketmq-runtime --test task_group_concurrency_model`: 1 passed.
- `cargo test -p rocketmq-runtime --all-targets --all-features`: passed.
- `cargo test -p rocketmq-broker --all-targets --all-features`: passed.
- `cargo test -p rocketmq-namesrv --all-targets --all-features`: passed.
- `cargo test -p rocketmq-client-rust --test client_runtime_fallback_test --all-features`: passed.
- `cargo test -p rocketmq-client-rust --test client_lifecycle_probes_test --all-features`: passed.
- `cargo test -p rocketmq-client-rust --all-targets --all-features`: passed.
- `cargo test -p rocketmq-remoting --lib --tests --all-features`: passed.
- `cargo test -p rocketmq-remoting --all-targets --all-features`: passed.
- `cargo test -p rocketmq-store --all-targets --all-features`: passed.
- `cargo test -p rocketmq-tieredstore --all-targets --all-features`: passed.
- `cargo test -p rocketmq-proxy --all-targets --all-features`: passed.
- `cargo test -p rocketmq-controller --all-targets --all-features`: passed.
- `cargo test -p rocketmq-common --all-targets --all-features`: passed.
- `cargo test -p rocketmq-rust --all-targets --all-features`: passed.
- `cargo test -p rocketmq-observability --all-targets --all-features`: passed.
- `cargo test -p rocketmq-admin-cli --all-targets --all-features`: passed.
- `cargo test -p rocketmq-admin-tui --all-targets --all-features`: passed.
- `cargo test -p rocketmq-store-inspect --all-targets --all-features`: passed.
- `cargo test -p rocketmq-admin-core --all-targets --all-features`: most tests passed, but the current Windows session could not start the `topic_update_list_core_models` test binary because the process requires elevation (`os error 740`). The related `producer_core_models`, `static_topic_core_models`, and `stats_core_models` tests were rerun individually and passed.