### PR TITLE
[ISSUE #7596]✨Establish client performance baseline benchmarks

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -96,6 +96,14 @@ name    = "client_hot_path_benchmark"
 harness = false
 
 [[bench]]
+name    = "client_send_pipeline_benchmark"
+harness = false
+
+[[bench]]
+name    = "client_consume_pipeline_benchmark"
+harness = false
+
+[[bench]]
 name    = "client_runtime_spawn_benchmark"
 harness = false
 

--- a/rocketmq-client/benches/client_consume_pipeline_benchmark.rs
+++ b/rocketmq-client/benches/client_consume_pipeline_benchmark.rs
@@ -1,0 +1,154 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Broker-free consumer cache pipeline baselines.
+//!
+//! These benchmarks exercise ProcessQueue hot operations through hidden probe
+//! functions so later storage and lock optimizations have a stable baseline.
+
+use std::hint::black_box;
+use std::time::Duration;
+use std::time::Instant;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use rocketmq_client_rust::consumer::consumer_impl::process_queue::run_process_queue_max_span_probe;
+use rocketmq_client_rust::consumer::consumer_impl::process_queue::run_process_queue_put_probe;
+use rocketmq_client_rust::consumer::consumer_impl::process_queue::run_process_queue_remove_probe;
+use rocketmq_client_rust::consumer::consumer_impl::process_queue::run_process_queue_take_probe;
+use rocketmq_client_rust::consumer::consumer_impl::process_queue::ProcessQueueOperationFixture;
+
+fn bench_process_queue_put(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime should start");
+    let mut group = c.benchmark_group("client_consume_pipeline/process_queue_put");
+
+    for message_count in [32usize, 256, 1024] {
+        group.throughput(Throughput::Elements(message_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(message_count),
+            &message_count,
+            |b, &message_count| {
+                b.to_async(&runtime).iter_custom(|iters| async move {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iters {
+                        let fixture = ProcessQueueOperationFixture::new(message_count, 1024);
+                        let started_at = Instant::now();
+                        black_box(run_process_queue_put_probe(fixture).await);
+                        elapsed += started_at.elapsed();
+                    }
+                    elapsed
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_process_queue_take(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime should start");
+    let mut group = c.benchmark_group("client_consume_pipeline/process_queue_take");
+
+    for message_count in [32usize, 256, 1024] {
+        group.throughput(Throughput::Elements(message_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(message_count),
+            &message_count,
+            |b, &message_count| {
+                b.to_async(&runtime).iter_custom(|iters| async move {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iters {
+                        let fixture = ProcessQueueOperationFixture::seeded(message_count, 1024).await;
+                        let started_at = Instant::now();
+                        black_box(run_process_queue_take_probe(fixture).await);
+                        elapsed += started_at.elapsed();
+                    }
+                    elapsed
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_process_queue_remove(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime should start");
+    let mut group = c.benchmark_group("client_consume_pipeline/process_queue_remove");
+
+    for message_count in [32usize, 256, 1024] {
+        group.throughput(Throughput::Elements(message_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(message_count),
+            &message_count,
+            |b, &message_count| {
+                b.to_async(&runtime).iter_custom(|iters| async move {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iters {
+                        let fixture = ProcessQueueOperationFixture::seeded(message_count, 1024).await;
+                        let started_at = Instant::now();
+                        black_box(run_process_queue_remove_probe(fixture).await);
+                        elapsed += started_at.elapsed();
+                    }
+                    elapsed
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_process_queue_max_span(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime should start");
+    let mut group = c.benchmark_group("client_consume_pipeline/process_queue_max_span");
+
+    for message_count in [32usize, 256, 1024] {
+        group.throughput(Throughput::Elements(message_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(message_count),
+            &message_count,
+            |b, &message_count| {
+                b.to_async(&runtime).iter_custom(|iters| async move {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iters {
+                        let fixture = ProcessQueueOperationFixture::seeded(message_count, 1024).await;
+                        let started_at = Instant::now();
+                        black_box(run_process_queue_max_span_probe(fixture).await);
+                        elapsed += started_at.elapsed();
+                    }
+                    elapsed
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(1));
+    targets = bench_process_queue_put,
+        bench_process_queue_take,
+        bench_process_queue_remove,
+        bench_process_queue_max_span
+}
+criterion_main!(benches);

--- a/rocketmq-client/benches/client_send_pipeline_benchmark.rs
+++ b/rocketmq-client/benches/client_send_pipeline_benchmark.rs
@@ -1,0 +1,189 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Broker-free producer send pipeline baselines.
+//!
+//! These benchmarks measure local work performed before a request reaches the
+//! network: message construction, request command construction, callback
+//! dispatch, and async backpressure permit acquisition.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BatchSize;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use rocketmq_client_rust::producer::send_callback::ArcSendCallback;
+use rocketmq_client_rust::producer::send_result::SendResult;
+use rocketmq_common::common::message::message_client_id_setter::MessageClientIDSetter;
+use rocketmq_common::common::message::message_single::Message;
+use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::MessageDecoder;
+use rocketmq_common::TimeUtils::current_millis;
+use rocketmq_remoting::code::request_code::RequestCode;
+use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
+use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use tokio::sync::Semaphore;
+
+fn build_message(body_size: usize) -> Message {
+    Message::builder()
+        .topic("BenchmarkTopic")
+        .tags("BenchmarkTag")
+        .keys(vec!["benchmark-key".to_string()])
+        .body(vec![b'x'; body_size])
+        .build()
+        .expect("benchmark message should be valid")
+}
+
+fn build_send_header(message: &Message) -> SendMessageRequestHeader {
+    SendMessageRequestHeader {
+        producer_group: CheetahString::from_static_str("benchmark-producer-group"),
+        topic: message.topic().clone(),
+        default_topic: CheetahString::from_static_str("TBW102"),
+        default_topic_queue_nums: 4,
+        queue_id: 0,
+        sys_flag: 0,
+        born_timestamp: current_millis() as i64,
+        flag: message.get_flag(),
+        properties: Some(MessageDecoder::message_properties_to_string(message.get_properties())),
+        reconsume_times: Some(0),
+        unit_mode: Some(false),
+        batch: Some(false),
+        ..Default::default()
+    }
+}
+
+fn build_send_request(mut message: Message) -> RemotingCommand {
+    MessageClientIDSetter::set_uniq_id(&mut message);
+    let header = build_send_header(&message);
+    let body = message.get_body().cloned().unwrap_or_else(|| Bytes::from_static(b""));
+    RemotingCommand::create_request_command(RequestCode::SendMessageV2, header).set_body(body)
+}
+
+fn bench_message_construction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("client_send_pipeline/message_construction");
+
+    for body_size in [128usize, 1024, 16 * 1024, 128 * 1024] {
+        group.throughput(Throughput::Bytes(body_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(body_size), &body_size, |b, &body_size| {
+            b.iter(|| black_box(build_message(body_size)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_request_construction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("client_send_pipeline/request_construction");
+
+    for body_size in [128usize, 1024, 16 * 1024, 128 * 1024] {
+        group.throughput(Throughput::Bytes(body_size as u64));
+        let message = build_message(body_size);
+        group.bench_with_input(BenchmarkId::from_parameter(body_size), &message, |b, message| {
+            b.iter_batched(
+                || message.clone(),
+                |message| black_box(build_send_request(message)),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_async_backpressure_envelope(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime should start");
+    let mut group = c.benchmark_group("client_send_pipeline/async_backpressure_envelope");
+
+    for body_size in [128usize, 1024, 16 * 1024, 128 * 1024] {
+        group.throughput(Throughput::Bytes(body_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(body_size), &body_size, |b, &body_size| {
+            let send_num = Arc::new(Semaphore::new(1024));
+            let send_size = Arc::new(Semaphore::new(1024 * 1024));
+            b.to_async(&runtime).iter(|| {
+                let send_num = send_num.clone();
+                let send_size = send_size.clone();
+                async move {
+                    let num_permit = send_num
+                        .acquire_owned()
+                        .await
+                        .expect("benchmark semaphore should be open");
+                    let size_permit = send_size
+                        .acquire_many_owned(body_size as u32)
+                        .await
+                        .expect("benchmark semaphore should have capacity");
+                    black_box((&num_permit, &size_permit));
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_callback_dispatch(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime should start");
+    let send_result = SendResult::default();
+    let callback: ArcSendCallback = Arc::new(|result: Option<&SendResult>, error: Option<&dyn std::error::Error>| {
+        black_box(result.is_some());
+        black_box(error.is_some());
+    });
+
+    let mut group = c.benchmark_group("client_send_pipeline/callback_dispatch");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("no_callback", |b| {
+        b.iter(|| {
+            let callback: Option<ArcSendCallback> = None;
+            if let Some(callback) = callback {
+                callback.on_success(black_box(&send_result));
+            }
+        });
+    });
+
+    group.bench_function("direct_callback", |b| {
+        b.iter(|| {
+            callback.on_success(black_box(&send_result));
+        });
+    });
+
+    group.bench_function("executor_callback", |b| {
+        b.to_async(&runtime).iter(|| {
+            let callback = callback.clone();
+            let send_result = send_result.clone();
+            async move {
+                let handle = tokio::spawn(async move {
+                    callback.on_success(&send_result);
+                });
+                handle.await.expect("callback task should complete");
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_message_construction,
+    bench_request_construction,
+    bench_async_backpressure_envelope,
+    bench_callback_dispatch,
+);
+criterion_main!(benches);

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -22,12 +22,14 @@ use std::sync::LazyLock;
 
 use cheetah_string::CheetahString;
 use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::common::message::MessageTrait;
 use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::protocol::body::process_queue_info::ProcessQueueInfo;
 use rocketmq_rust::ArcMut;
+use serde::Serialize;
 use tokio::sync::RwLock;
 use tracing::info;
 
@@ -80,6 +82,46 @@ pub struct ProcessQueue {
     last_pull_timestamp: AtomicU64,
     last_consume_timestamp: AtomicU64,
     last_lock_timestamp: AtomicU64,
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Serialize)]
+pub struct ProcessQueueOperationProbe {
+    pub message_count: usize,
+    pub body_size: usize,
+    pub dispatch_to_consume: bool,
+    pub max_span: u64,
+    pub taken_count: usize,
+    pub next_offset: i64,
+    pub final_msg_count: u64,
+    pub final_msg_size: u64,
+}
+
+#[doc(hidden)]
+pub struct ProcessQueueOperationFixture {
+    process_queue: ProcessQueue,
+    messages: Vec<ArcMut<MessageExt>>,
+    message_count: usize,
+    body_size: usize,
+    dispatch_to_consume: bool,
+}
+
+impl ProcessQueueOperationFixture {
+    pub fn new(message_count: usize, body_size: usize) -> Self {
+        Self {
+            process_queue: ProcessQueue::new(),
+            messages: benchmark_messages(message_count, body_size),
+            message_count,
+            body_size,
+            dispatch_to_consume: false,
+        }
+    }
+
+    pub async fn seeded(message_count: usize, body_size: usize) -> Self {
+        let mut fixture = Self::new(message_count, body_size);
+        fixture.dispatch_to_consume = fixture.process_queue.put_message(&fixture.messages).await;
+        fixture
+    }
 }
 
 impl Default for ProcessQueue {
@@ -476,6 +518,116 @@ impl ProcessQueue {
     }
 }
 
+fn benchmark_messages(message_count: usize, body_size: usize) -> Vec<ArcMut<MessageExt>> {
+    (0..message_count)
+        .map(|index| {
+            let message = Message::builder()
+                .topic("BenchmarkTopic")
+                .body(vec![b'x'; body_size])
+                .build()
+                .expect("benchmark message should be valid");
+            let mut message_ext = MessageExt::default();
+            message_ext.set_message_inner(message);
+            message_ext.set_broker_name(CheetahString::from_static_str("benchmark-broker"));
+            message_ext.set_queue_id(0);
+            message_ext.set_queue_offset(index as i64);
+            ArcMut::new(message_ext)
+        })
+        .collect()
+}
+
+#[doc(hidden)]
+pub async fn run_process_queue_put_probe(fixture: ProcessQueueOperationFixture) -> ProcessQueueOperationProbe {
+    let ProcessQueueOperationFixture {
+        process_queue,
+        messages,
+        message_count,
+        body_size,
+        ..
+    } = fixture;
+    let dispatch_to_consume = process_queue.put_message(&messages).await;
+
+    ProcessQueueOperationProbe {
+        message_count,
+        body_size,
+        dispatch_to_consume,
+        max_span: process_queue.get_max_span().await,
+        taken_count: 0,
+        next_offset: -1,
+        final_msg_count: process_queue.msg_count(),
+        final_msg_size: process_queue.msg_size(),
+    }
+}
+
+#[doc(hidden)]
+pub async fn run_process_queue_take_probe(fixture: ProcessQueueOperationFixture) -> ProcessQueueOperationProbe {
+    let ProcessQueueOperationFixture {
+        process_queue,
+        message_count,
+        body_size,
+        dispatch_to_consume,
+        ..
+    } = fixture;
+    let taken = process_queue.take_messages(message_count as u32).await;
+
+    ProcessQueueOperationProbe {
+        message_count,
+        body_size,
+        dispatch_to_consume,
+        max_span: process_queue.get_max_span().await,
+        taken_count: taken.len(),
+        next_offset: -1,
+        final_msg_count: process_queue.msg_count(),
+        final_msg_size: process_queue.msg_size(),
+    }
+}
+
+#[doc(hidden)]
+pub async fn run_process_queue_remove_probe(fixture: ProcessQueueOperationFixture) -> ProcessQueueOperationProbe {
+    let ProcessQueueOperationFixture {
+        process_queue,
+        messages,
+        message_count,
+        body_size,
+        dispatch_to_consume,
+    } = fixture;
+    let next_offset = process_queue.remove_message(&messages).await;
+
+    ProcessQueueOperationProbe {
+        message_count,
+        body_size,
+        dispatch_to_consume,
+        max_span: process_queue.get_max_span().await,
+        taken_count: 0,
+        next_offset,
+        final_msg_count: process_queue.msg_count(),
+        final_msg_size: process_queue.msg_size(),
+    }
+}
+
+#[doc(hidden)]
+pub async fn run_process_queue_max_span_probe(fixture: ProcessQueueOperationFixture) -> ProcessQueueOperationProbe {
+    let ProcessQueueOperationFixture {
+        process_queue,
+        message_count,
+        body_size,
+        dispatch_to_consume,
+        ..
+    } = fixture;
+    let max_span = process_queue.get_max_span().await;
+
+    ProcessQueueOperationProbe {
+        message_count,
+        body_size,
+        dispatch_to_consume,
+        max_span,
+        taken_count: 0,
+        next_offset: -1,
+        final_msg_count: process_queue.msg_count(),
+        final_msg_size: process_queue.msg_size(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -495,6 +647,30 @@ mod tests {
             messages.push(ArcMut::new(msg));
         }
         messages
+    }
+
+    #[tokio::test]
+    async fn test_process_queue_operation_probes_report_expected_metrics() {
+        let put = run_process_queue_put_probe(ProcessQueueOperationFixture::new(4, 64)).await;
+        assert_eq!(put.message_count, 4);
+        assert_eq!(put.body_size, 64);
+        assert!(put.dispatch_to_consume);
+        assert_eq!(put.max_span, 3);
+        assert_eq!(put.final_msg_count, 4);
+        assert_eq!(put.final_msg_size, 256);
+
+        let taken = run_process_queue_take_probe(ProcessQueueOperationFixture::seeded(4, 64).await).await;
+        assert_eq!(taken.taken_count, 4);
+        assert_eq!(taken.final_msg_count, 4);
+
+        let removed = run_process_queue_remove_probe(ProcessQueueOperationFixture::seeded(4, 64).await).await;
+        assert_eq!(removed.next_offset, 4);
+        assert_eq!(removed.final_msg_count, 0);
+        assert_eq!(removed.final_msg_size, 0);
+
+        let max_span = run_process_queue_max_span_probe(ProcessQueueOperationFixture::seeded(4, 64).await).await;
+        assert_eq!(max_span.max_span, 3);
+        assert_eq!(max_span.final_msg_count, 4);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7596

### Brief Description

Adds Task 0 client performance baseline benchmark assets without changing runtime behavior:

- Registers broker-free producer and consumer pipeline benchmarks.
- Adds producer send pipeline benchmarks for message construction, request construction, async backpressure envelope, and callback dispatch.
- Adds hidden ProcessQueue pipeline probes and consumer cache pipeline benchmarks for put/take/remove/max-span paths.
- Adds a focused probe regression test so the benchmark support API keeps reporting expected metrics.

Benchmark results are generated locally under `target/criterion` and `target/runtime-baseline`; docs and generated reports are intentionally not included in this PR.

### How Did You Test This Change?

- `cargo fmt --all` - passed
- `cargo check -p rocketmq-client-rust --benches` - passed
- `cargo test -p rocketmq-client-rust --lib process_queue --quiet` - passed
- `cargo bench -p rocketmq-client-rust --bench client_send_pipeline_benchmark -- --test` - passed
- `cargo bench -p rocketmq-client-rust --bench client_consume_pipeline_benchmark -- --test` - passed
- `cargo bench -p rocketmq-client-rust --bench client_hot_path_benchmark` - passed
- `cargo bench -p rocketmq-client-rust --bench client_send_pipeline_benchmark` - passed
- `cargo bench -p rocketmq-client-rust --bench client_consume_pipeline_benchmark` - passed
- `cargo bench -p rocketmq-client-rust --bench produce_accumulator_benchmark` - passed
- `cargo bench -p rocketmq-client-rust --bench client_runtime_spawn_benchmark` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed
