### PR TITLE
[ISSUE #7598]✨Optimize producer route snapshot cloning

### DIFF
--- a/rocketmq-client/benches/client_hot_path_benchmark.rs
+++ b/rocketmq-client/benches/client_hot_path_benchmark.rs
@@ -23,6 +23,7 @@
 use std::collections::HashSet;
 use std::hint::black_box;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use cheetah_string::CheetahString;
@@ -36,15 +37,19 @@ use rocketmq_client_rust::common::session_credentials::SessionCredentials;
 use rocketmq_client_rust::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 use rocketmq_client_rust::consumer::rebalance_strategy::allocate_message_queue_consistent_hash::AllocateMessageQueueConsistentHash;
 use rocketmq_client_rust::producer::message_queue_selector::MessageQueueSelector;
+use rocketmq_client_rust::producer::producer_impl::topic_publish_info::TopicPublishInfo;
 use rocketmq_client_rust::producer::queue_selector::SelectMessageQueueByHash;
 use rocketmq_client_rust::producer::queue_selector::SelectMessageQueueByMachineRoom;
 use rocketmq_client_rust::producer::queue_selector::SelectMessageQueueByRandom;
 use rocketmq_client_rust::AclClientRPCHook;
+use rocketmq_common::common::constant::PermName;
 use rocketmq_common::common::message::message_batch::MessageBatch;
 use rocketmq_common::common::message::message_ext::MessageExt;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
+use rocketmq_remoting::protocol::route::route_data_view::QueueData;
+use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_remoting::runtime::RPCHook;
 use rocketmq_rust::ArcMut;
 
@@ -132,6 +137,60 @@ fn bench_queue_selectors(c: &mut Criterion) {
     group.bench_function("machine_room_selector", |b| {
         b.iter(|| black_box(machine_room_selector.select(&queues, &msg, &())))
     });
+
+    group.finish();
+}
+
+fn build_topic_publish_info(queue_count: i32) -> TopicPublishInfo {
+    let mut info = TopicPublishInfo::new();
+    info.have_topic_router_info = true;
+    info.message_queue_list = build_queues(queue_count);
+    info.topic_route_data = Some(TopicRouteData {
+        queue_datas: (0..queue_count)
+            .map(|queue_id| {
+                QueueData::new(
+                    CheetahString::from_string(format!("broker-{queue_id}")),
+                    1,
+                    1,
+                    PermName::PERM_READ | PermName::PERM_WRITE,
+                    0,
+                )
+            })
+            .collect(),
+        ..Default::default()
+    });
+    info
+}
+
+fn bench_producer_route_snapshot(c: &mut Criterion) {
+    let mut group = c.benchmark_group("producer_route_snapshot");
+    group.throughput(Throughput::Elements(1));
+
+    for queue_count in [4i32, 64, 256, 1024] {
+        let owned_info = build_topic_publish_info(queue_count);
+        group.bench_with_input(
+            BenchmarkId::new("owned_clone_and_select", queue_count),
+            &owned_info,
+            |b, info| {
+                b.iter(|| {
+                    let info = black_box(info).clone();
+                    black_box(info.select_one_message_queue())
+                })
+            },
+        );
+
+        let shared_info = Arc::new(build_topic_publish_info(queue_count));
+        group.bench_with_input(
+            BenchmarkId::new("arc_snapshot_clone_and_select", queue_count),
+            &shared_info,
+            |b, info| {
+                b.iter(|| {
+                    let info = Arc::clone(black_box(info));
+                    black_box(info.select_one_message_queue())
+                })
+            },
+        );
+    }
 
     group.finish();
 }
@@ -245,6 +304,7 @@ criterion_group!(
     benches,
     bench_acl_signing,
     bench_queue_selectors,
+    bench_producer_route_snapshot,
     bench_consistent_hash_rebalance,
     bench_producer_batch_encode,
     bench_lite_pull_batch_clone,

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -101,6 +101,7 @@ use crate::runtime::spawn_client_blocking_io;
 use crate::runtime::spawn_client_task_on;
 
 type Topic = CheetahString;
+type TopicPublishInfoSnapshot = Arc<TopicPublishInfo>;
 const QUERY_UNIQ_KEY_LOOKBACK_MILLIS: u64 = 3 * 24 * 60 * 60 * 1000;
 const PRODUCER_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const PRODUCER_TASK_FORCE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
@@ -286,7 +287,7 @@ pub struct DefaultMQProducerImpl {
     pending_end_transaction_hooks: parking_lot::Mutex<Option<Vec<Arc<dyn EndTransactionHook>>>>,
     pending_forbidden_hooks: parking_lot::Mutex<Option<Vec<Arc<dyn CheckForbiddenHook>>>>,
 
-    topic_publish_info_table: Arc<DashMap<Topic, TopicPublishInfo>>,
+    topic_publish_info_table: Arc<DashMap<Topic, TopicPublishInfoSnapshot>>,
 
     rpc_hook: Option<Arc<dyn RPCHook>>,
     client_instance: Option<ArcMut<MQClientInstance>>,
@@ -719,7 +720,7 @@ impl DefaultMQProducerImpl {
                 if info.ok() {
                     if let Some(mq) = self.select_one_message_queue(&info, None, false) {
                         // Spawn background task for each message
-                        self.spawn_oneway_send(msg, mq, info, timeout);
+                        self.spawn_oneway_send(msg, mq, timeout);
                         sent_count += 1;
                     }
                 }
@@ -732,7 +733,7 @@ impl DefaultMQProducerImpl {
     /// Spawn a background task for oneway message sending.
     ///
     /// This is a helper method for send_oneway_batch to avoid code duplication.
-    fn spawn_oneway_send<T>(&self, msg: T, mq: MessageQueue, topic_publish_info: TopicPublishInfo, timeout: u64)
+    fn spawn_oneway_send<T>(&self, msg: T, mq: MessageQueue, timeout: u64)
     where
         T: MessageTrait + Send + Sync + 'static,
     {
@@ -742,7 +743,6 @@ impl DefaultMQProducerImpl {
         };
         let producer_config = self.producer_config.clone();
         let client_config = self.client_config.clone();
-        let topic_publish_info = Arc::new(topic_publish_info);
 
         let task = async move {
             // Prepare message in background task
@@ -1808,23 +1808,32 @@ impl DefaultMQProducerImpl {
         Ok(())
     }
 
-    async fn try_to_find_topic_publish_info(&self, topic: &Topic) -> Option<TopicPublishInfo> {
-        let mut topic_publish_info = self.topic_publish_info_table.get(topic).map(|v| v.clone());
-        if !topic_publish_info.as_ref().is_some_and(TopicPublishInfo::ok) {
+    async fn try_to_find_topic_publish_info(&self, topic: &Topic) -> Option<TopicPublishInfoSnapshot> {
+        let mut topic_publish_info = self
+            .topic_publish_info_table
+            .get(topic)
+            .map(|entry| Arc::clone(entry.value()));
+        if !topic_publish_info.as_ref().is_some_and(|info| info.ok()) {
             self.topic_publish_info_table
-                .insert(topic.clone(), TopicPublishInfo::new());
+                .insert(topic.clone(), Arc::new(TopicPublishInfo::new()));
             let Ok(client_instance) = self.client_instance() else {
                 tracing::debug!(
                     "Skip topic route refresh for {} because MQClientInstance is not available",
                     topic
                 );
-                return self.topic_publish_info_table.get(topic).map(|v| v.clone());
+                return self
+                    .topic_publish_info_table
+                    .get(topic)
+                    .map(|entry| Arc::clone(entry.value()));
             };
             client_instance
                 .mut_from_ref()
                 .update_topic_route_info_from_name_server_topic(topic)
                 .await;
-            topic_publish_info = self.topic_publish_info_table.get(topic).map(|v| v.clone());
+            topic_publish_info = self
+                .topic_publish_info_table
+                .get(topic)
+                .map(|entry| Arc::clone(entry.value()));
         }
 
         let topic_publish_info_ref = topic_publish_info.as_ref()?;
@@ -1843,7 +1852,9 @@ impl DefaultMQProducerImpl {
             .mut_from_ref()
             .update_topic_route_info_from_name_server_default(topic, true, Some(&self.producer_config))
             .await;
-        self.topic_publish_info_table.get(topic).map(|v| v.clone())
+        self.topic_publish_info_table
+            .get(topic)
+            .map(|entry| Arc::clone(entry.value()))
     }
 
     fn make_sure_state_ok(&self) -> rocketmq_error::RocketMQResult<()> {
@@ -2904,7 +2915,7 @@ impl MQProducerInner for DefaultMQProducerImpl {
         let Some(info) = info else {
             return;
         };
-        self.topic_publish_info_table.insert(topic, info);
+        self.topic_publish_info_table.insert(topic, Arc::new(info));
     }
 
     fn is_unit_mode(&self) -> bool {
@@ -3225,7 +3236,7 @@ impl DefaultMQProducerImpl {
             let new_topic =
                 NamespaceUtil::wrap_namespace(self.client_config.get_namespace().unwrap_or_default().as_str(), topic);
             let topic_publish_info = self.try_to_find_topic_publish_info(&new_topic).await;
-            if !topic_publish_info.as_ref().is_some_and(TopicPublishInfo::ok) {
+            if !topic_publish_info.as_ref().is_some_and(|info| info.ok()) {
                 warn!(
                     "No route info of this topic: {} {}",
                     new_topic,
@@ -3438,7 +3449,7 @@ impl DefaultMQProducerImpl {
 
 pub(crate) struct DefaultServiceDetector {
     client_instance: ArcMut<MQClientInstance>,
-    topic_publish_info_table: Arc<DashMap<CheetahString /* topic */, TopicPublishInfo>>,
+    topic_publish_info_table: Arc<DashMap<CheetahString /* topic */, TopicPublishInfoSnapshot>>,
 }
 
 impl ServiceDetector for DefaultServiceDetector {
@@ -4052,11 +4063,11 @@ mod tests {
         producer.client_instance = Some(client_instance);
         producer.topic_publish_info_table.insert(
             CheetahString::from_static_str("ns-a%TopicTest"),
-            TopicPublishInfo {
+            Arc::new(TopicPublishInfo {
                 have_topic_router_info: true,
                 message_queue_list: vec![MessageQueue::from_parts("ns-a%TopicTest", "broker-a", 0)],
                 ..Default::default()
-            },
+            }),
         );
         let mut msg = Message::builder()
             .topic("ns-a%TopicTest")
@@ -4084,6 +4095,32 @@ mod tests {
         assert_eq!(seen.1.as_deref(), Some("TopicTest"));
         assert_eq!(msg.topic(), "ns-a%TopicTest");
         assert_eq!(selected.topic(), "ns-a%TopicTest");
+    }
+
+    #[tokio::test]
+    async fn cached_topic_publish_info_is_returned_as_shared_snapshot() {
+        let topic = CheetahString::from_static_str("TopicTest");
+        let producer = DefaultMQProducerImpl::new(ClientConfig::default(), ProducerConfig::default(), None);
+        let info = Arc::new(TopicPublishInfo {
+            have_topic_router_info: true,
+            message_queue_list: (0..256)
+                .map(|queue_id| MessageQueue::from_parts("TopicTest", "broker-a", queue_id))
+                .collect(),
+            ..Default::default()
+        });
+
+        producer
+            .topic_publish_info_table
+            .insert(topic.clone(), Arc::clone(&info));
+
+        let cached = producer
+            .try_to_find_topic_publish_info(&topic)
+            .await
+            .expect("cached route should be returned");
+
+        assert!(Arc::ptr_eq(&cached, &info));
+        assert_eq!(cached.message_queue_list.len(), 256);
+        assert!(producer.select_one_message_queue(&cached, None, false).is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7598

### Brief Description

- Store producer topic publish info cache entries as shared `Arc<TopicPublishInfo>` snapshots so send hot paths clone only the snapshot handle instead of deep-cloning route data and message queues.
- Keep route refresh as replace-on-update and preserve `TopicPublishInfo` public fields and queue selection behavior.
- Add `producer_route_snapshot` benchmarks for 4, 64, 256, and 1024 queues comparing owned clone+select with Arc snapshot clone+select.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust --lib cached_topic_publish_info_is_returned_as_shared_snapshot` - passed
- `cargo test -p rocketmq-client-rust --lib topic_publish_info` - passed
- `cargo test -p rocketmq-client-rust --test integration_tests` - passed
- `cargo bench -p rocketmq-client-rust --bench client_hot_path_benchmark -- --test` - passed
- `cargo bench -p rocketmq-client-rust --bench client_hot_path_benchmark` - passed; `producer_route_snapshot` median improved from 2.9567 us to 18.963 ns at 256 queues and from 12.183 us to 18.990 ns at 1024 queues
- `cargo fmt --all` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed
- `git diff --check` - passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved producer route handling by using shared route snapshots for faster reuse.
  * Added benchmark coverage for producer route selection under different queue counts.

* **Performance**
  * Reduced repeated copying of route information by sharing cached snapshots across send operations.

* **Tests**
  * Updated tests for the new shared-cache behavior.
  * Added a test to verify cached route data is reused as the same shared instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->