### PR TITLE
[ISSUE #7600]✨Optimize producer request properties

### DIFF
--- a/rocketmq-client/benches/client_send_pipeline_benchmark.rs
+++ b/rocketmq-client/benches/client_send_pipeline_benchmark.rs
@@ -34,6 +34,7 @@ use rocketmq_client_rust::producer::send_result::SendResult;
 use rocketmq_common::common::message::message_client_id_setter::MessageClientIDSetter;
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageTrait;
+use rocketmq_common::MessageAccessor::MessageAccessor;
 use rocketmq_common::MessageDecoder;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_remoting::code::request_code::RequestCode;
@@ -49,6 +50,22 @@ fn build_message(body_size: usize) -> Message {
         .body(vec![b'x'; body_size])
         .build()
         .expect("benchmark message should be valid")
+}
+
+fn build_message_with_properties(body_size: usize, property_count: usize) -> Message {
+    let mut message = Message::builder()
+        .topic("BenchmarkTopic")
+        .body(vec![b'x'; body_size])
+        .build()
+        .expect("benchmark message should be valid");
+    for index in 0..property_count {
+        MessageAccessor::put_property(
+            &mut message,
+            CheetahString::from_string(format!("property-key-{index}")),
+            CheetahString::from_string(format!("property-value-{index}")),
+        );
+    }
+    message
 }
 
 fn build_send_header(message: &Message) -> SendMessageRequestHeader {
@@ -101,6 +118,20 @@ fn bench_request_construction(c: &mut Criterion) {
                 |message| black_box(build_send_request(message)),
                 BatchSize::SmallInput,
             );
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_send_header_construction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("client_send_pipeline/send_header_construction");
+    group.throughput(Throughput::Elements(1));
+
+    for property_count in [0usize, 1, 4, 16] {
+        let message = build_message_with_properties(128, property_count);
+        group.bench_with_input(BenchmarkId::from_parameter(property_count), &message, |b, message| {
+            b.iter(|| black_box(build_send_header(black_box(message))));
         });
     }
 
@@ -183,6 +214,7 @@ criterion_group!(
     benches,
     bench_message_construction,
     bench_request_construction,
+    bench_send_header_construction,
     bench_async_backpressure_envelope,
     bench_callback_dispatch,
 );

--- a/rocketmq-client/benches/message_util_bench.rs
+++ b/rocketmq-client/benches/message_util_bench.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::hint::black_box;
 
+use cheetah_string::CheetahBuilder;
 use cheetah_string::CheetahString;
 use criterion::criterion_group;
 use criterion::criterion_main;
@@ -21,9 +23,12 @@ use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
 use rocketmq_client_rust::utils::message_util::MessageUtil;
+use rocketmq_common::common::message::message_decoder::NAME_VALUE_SEPARATOR;
+use rocketmq_common::common::message::message_decoder::PROPERTY_SEPARATOR;
 use rocketmq_common::common::message::message_single::Message;
 use rocketmq_common::common::message::MessageConst;
 use rocketmq_common::MessageAccessor::MessageAccessor;
+use rocketmq_common::MessageDecoder;
 
 // ============================================================================
 // Helper functions to create test messages
@@ -72,6 +77,35 @@ fn create_test_message_minimal() -> Message {
         CheetahString::from_static_str("DefaultCluster"),
     );
     msg
+}
+
+fn create_properties(count: usize) -> HashMap<CheetahString, CheetahString> {
+    (0..count)
+        .map(|index| {
+            (
+                CheetahString::from_string(format!("property-key-{index}")),
+                CheetahString::from_string(format!("property-value-{index}")),
+            )
+        })
+        .collect()
+}
+
+fn legacy_message_properties_to_string(properties: &HashMap<CheetahString, CheetahString>) -> CheetahString {
+    let mut len = 0;
+    for (name, value) in properties.iter() {
+        len += name.len();
+        len += value.len();
+        len += 2;
+    }
+
+    let mut builder = CheetahBuilder::with_capacity(len);
+    for (name, value) in properties.iter() {
+        builder.push_str(name.as_str());
+        builder.push(NAME_VALUE_SEPARATOR);
+        builder.push_str(value.as_str());
+        builder.push(PROPERTY_SEPARATOR);
+    }
+    builder.finish_string()
 }
 
 // ============================================================================
@@ -247,6 +281,35 @@ fn bench_static_cache_effectiveness(c: &mut Criterion) {
 }
 
 // ============================================================================
+// Benchmark: message_properties_to_string
+// ============================================================================
+
+fn bench_message_properties_to_string(c: &mut Criterion) {
+    let mut group = c.benchmark_group("message_properties_to_string");
+
+    for property_count in [0usize, 1, 4, 16] {
+        group.throughput(Throughput::Elements(property_count.max(1) as u64));
+        let properties = create_properties(property_count);
+        group.bench_with_input(
+            BenchmarkId::new("legacy", property_count),
+            &properties,
+            |b, properties| {
+                b.iter(|| black_box(legacy_message_properties_to_string(black_box(properties))));
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("optimized", property_count),
+            &properties,
+            |b, properties| {
+                b.iter(|| black_box(MessageDecoder::message_properties_to_string(black_box(properties))));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ============================================================================
 // Register all benchmarks
 // ============================================================================
 
@@ -259,6 +322,7 @@ criterion_group!(
     bench_high_throughput,
     bench_memory_pattern,
     bench_static_cache_effectiveness,
+    bench_message_properties_to_string,
 );
 
 criterion_main!(benches);

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -16,6 +16,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -28,6 +29,8 @@ use cheetah_string::CheetahString;
 use dashmap::DashMap;
 use rand::random;
 use rocketmq_common::common::base::service_state::ServiceState;
+use rocketmq_common::common::compression::compression_type::CompressionType;
+use rocketmq_common::common::compression::compressor::Compressor;
 use rocketmq_common::common::message::message_batch::MessageBatch;
 use rocketmq_common::common::message::message_client_id_setter::MessageClientIDSetter;
 use rocketmq_common::common::message::message_enum::MessageType;
@@ -102,6 +105,34 @@ use crate::runtime::spawn_client_task_on;
 
 type Topic = CheetahString;
 type TopicPublishInfoSnapshot = Arc<TopicPublishInfo>;
+
+#[derive(Clone)]
+struct ProducerSendConfigSnapshot {
+    producer_group: CheetahString,
+    create_topic_key: CheetahString,
+    default_topic_queue_nums: i32,
+    compress_msg_body_over_howmuch: usize,
+    compress_level: i32,
+    compress_type: CompressionType,
+    compressor: Option<&'static (dyn Compressor + Send + Sync)>,
+    unit_mode: bool,
+}
+
+impl ProducerSendConfigSnapshot {
+    fn new(client_config: &ClientConfig, producer_config: &ProducerConfig) -> Self {
+        Self {
+            producer_group: producer_config.producer_group().clone(),
+            create_topic_key: producer_config.create_topic_key().clone(),
+            default_topic_queue_nums: producer_config.default_topic_queue_nums() as i32,
+            compress_msg_body_over_howmuch: producer_config.compress_msg_body_over_howmuch() as usize,
+            compress_level: producer_config.compress_level(),
+            compress_type: producer_config.compress_type(),
+            compressor: producer_config.compressor(),
+            unit_mode: client_config.unit_mode,
+        }
+    }
+}
+
 const QUERY_UNIQ_KEY_LOOKBACK_MILLIS: u64 = 3 * 24 * 60 * 60 * 1000;
 const PRODUCER_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const PRODUCER_TASK_FORCE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
@@ -271,6 +302,7 @@ pub struct DefaultMQProducerImpl {
     // ===== Immutable configuration =====
     client_config: ClientConfig,
     producer_config: Arc<ProducerConfig>,
+    send_config: ProducerSendConfigSnapshot,
 
     // ===== Atomic state machine =====
     state: AtomicU8, // ProducerState
@@ -302,6 +334,7 @@ pub struct DefaultMQProducerImpl {
     transaction_check_env: Option<TransactionCheckEnv>,
     producer_task_tracker: TaskTracker,
     producer_task_shutdown: CancellationToken,
+    compressor_missing_logged: AtomicBool,
 }
 
 #[allow(unused_must_use)]
@@ -324,9 +357,11 @@ impl DefaultMQProducerImpl {
         );
         let topic_publish_info_table = Arc::new(DashMap::new());
         let (state_changes, _) = watch::channel(ProducerState::Created);
+        let send_config = ProducerSendConfigSnapshot::new(&client_config, &producer_config);
         DefaultMQProducerImpl {
             client_config: client_config.clone(),
             producer_config: Arc::new(producer_config),
+            send_config,
             state: AtomicU8::new(ProducerState::Created as u8),
             state_changes,
             service_state: ServiceState::CreateJust,
@@ -348,6 +383,7 @@ impl DefaultMQProducerImpl {
             transaction_check_env: None,
             producer_task_tracker: TaskTracker::new(),
             producer_task_shutdown: CancellationToken::new(),
+            compressor_missing_logged: AtomicBool::new(false),
         }
     }
 
@@ -507,6 +543,8 @@ impl DefaultMQProducerImpl {
             .back_pressure_for_async_send_size()
             .max(MIN_BACK_PRESSURE_FOR_ASYNC_SEND_SIZE) as usize;
 
+        self.send_config = ProducerSendConfigSnapshot::new(&self.client_config, &producer_config);
+        self.compressor_missing_logged.store(false, Ordering::Relaxed);
         self.producer_config = Arc::new(producer_config);
         Self::resize_available_permits(&self.semaphore_async_send_num, old_num_total, new_num_total);
         Self::resize_available_permits(&self.semaphore_async_send_size, old_size_total, new_size_total);
@@ -741,7 +779,7 @@ impl DefaultMQProducerImpl {
             tracing::debug!("Oneway batch send skipped: MQClientInstance is not available");
             return;
         };
-        let producer_config = self.producer_config.clone();
+        let send_config = self.send_config.clone();
         let client_config = self.client_config.clone();
 
         let task = async move {
@@ -762,7 +800,7 @@ impl DefaultMQProducerImpl {
                 &mut msg,
                 &mq,
                 &broker_name,
-                &producer_config,
+                &send_config,
                 client_config.namespace.as_deref(),
             ) {
                 Ok(req) => req,
@@ -1483,7 +1521,7 @@ impl DefaultMQProducerImpl {
         let mut msg_body_compressed = false;
         if self.try_to_compress_message(msg) {
             sys_flag |= MessageSysFlag::COMPRESSED_FLAG;
-            sys_flag |= self.producer_config.compress_type().get_compression_flag();
+            sys_flag |= self.send_config.compress_type.get_compression_flag();
             msg_body_compressed = true;
         }
 
@@ -1499,12 +1537,12 @@ impl DefaultMQProducerImpl {
         if self.has_check_forbidden_hook() {
             let check_forbidden_context = CheckForbiddenContext {
                 name_srv_addr: self.client_config.get_namesrv_addr(),
-                group: Some(self.producer_config.producer_group().clone()),
+                group: Some(self.send_config.producer_group.clone()),
                 communication_mode: Some(communication_mode),
                 broker_addr: Some(broker_addr.clone()),
                 message: Some(msg),
                 mq: Some(mq),
-                unit_mode: self.is_unit_mode(),
+                unit_mode: self.send_config.unit_mode,
                 ..Default::default()
             };
             self.execute_check_forbidden_hook(&check_forbidden_context)?;
@@ -1514,22 +1552,22 @@ impl DefaultMQProducerImpl {
         #[cfg(feature = "observability")]
         rocketmq_observability::propagation::inject_current_context_into_message(msg);
 
-        let producer_group = self.producer_config.producer_group();
+        let producer_group = &self.send_config.producer_group;
         let topic = msg.topic();
-        let create_topic_key = self.producer_config.create_topic_key();
+        let create_topic_key = &self.send_config.create_topic_key;
 
         let mut request_header = SendMessageRequestHeader {
             producer_group: producer_group.clone(),
             topic: topic.clone(),
             default_topic: create_topic_key.clone(),
-            default_topic_queue_nums: self.producer_config.default_topic_queue_nums() as i32,
+            default_topic_queue_nums: self.send_config.default_topic_queue_nums,
             queue_id: mq.queue_id(),
             sys_flag,
             born_timestamp: current_millis() as i64,
             flag: msg.get_flag(),
             properties: Some(MessageDecoder::message_properties_to_string(msg.get_properties())),
             reconsume_times: Some(0),
-            unit_mode: Some(self.is_unit_mode()),
+            unit_mode: Some(self.send_config.unit_mode),
             batch: Some(batch),
             topic_request_header: Some(TopicRequestHeader {
                 rpc_request_header: Some(RpcRequestHeader {
@@ -1757,23 +1795,33 @@ impl DefaultMQProducerImpl {
 
         if let Some(message) = msg.as_any_mut().downcast_mut::<Message>() {
             let body_len = message.body_slice().len();
-            if body_len >= self.producer_config.compress_msg_body_over_howmuch() as usize {
-                let Some(compressor) = self.producer_config.compressor() else {
-                    tracing::error!("tryToCompressMessage exception: compressor is not configured");
-                    return false;
-                };
-                match compressor.compress(message.body_slice(), self.producer_config.compress_level()) {
-                    Ok(data) => {
-                        // Store the compressed data to compressed_body field
-                        // (Rust design: preserve original body + store compressed separately)
-                        msg.set_compressed_body_mut(data);
-                        return true;
-                    }
-                    Err(e) => {
-                        tracing::error!("tryToCompressMessage exception: {:?}", e);
-                        if tracing::enabled!(tracing::Level::DEBUG) {
-                            tracing::debug!("Message: {:?}", msg);
-                        }
+            if body_len < self.send_config.compress_msg_body_over_howmuch {
+                return false;
+            }
+
+            let Some(compressor) = self.send_config.compressor else {
+                if self
+                    .compressor_missing_logged
+                    .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    tracing::warn!("tryToCompressMessage skipped: compressor is not configured");
+                } else {
+                    tracing::debug!("tryToCompressMessage skipped: compressor is not configured");
+                }
+                return false;
+            };
+            match compressor.compress(message.body_slice(), self.send_config.compress_level) {
+                Ok(data) => {
+                    // Store the compressed data to compressed_body field
+                    // (Rust design: preserve original body + store compressed separately)
+                    msg.set_compressed_body_mut(data);
+                    return true;
+                }
+                Err(e) => {
+                    tracing::error!("tryToCompressMessage exception: {:?}", e);
+                    if tracing::enabled!(tracing::Level::DEBUG) {
+                        tracing::debug!("Message: {:?}", msg);
                     }
                 }
             }
@@ -2919,7 +2967,7 @@ impl MQProducerInner for DefaultMQProducerImpl {
     }
 
     fn is_unit_mode(&self) -> bool {
-        self.client_config.unit_mode
+        self.send_config.unit_mode
     }
 }
 
@@ -3486,7 +3534,7 @@ fn build_oneway_request_internal<T>(
     msg: &mut T,
     mq: &MessageQueue,
     broker_name: &CheetahString,
-    producer_config: &ProducerConfig,
+    send_config: &ProducerSendConfigSnapshot,
     namespace: Option<&str>,
 ) -> rocketmq_error::RocketMQResult<RemotingCommand>
 where
@@ -3501,17 +3549,17 @@ where
 
     // Build request header (simplified for oneway)
     let request_header = SendMessageRequestHeader {
-        producer_group: CheetahString::from_string(producer_config.producer_group().to_string()),
-        topic: CheetahString::from_string(msg.topic().to_string()),
-        default_topic: CheetahString::from_string(producer_config.create_topic_key().to_string()),
-        default_topic_queue_nums: producer_config.default_topic_queue_nums() as i32,
+        producer_group: send_config.producer_group.clone(),
+        topic: msg.topic().clone(),
+        default_topic: send_config.create_topic_key.clone(),
+        default_topic_queue_nums: send_config.default_topic_queue_nums,
         queue_id: mq.queue_id(),
         sys_flag: 0,
         born_timestamp: current_millis() as i64,
         flag: msg.get_flag(),
         properties: Some(MessageDecoder::message_properties_to_string(msg.get_properties())),
         reconsume_times: Some(0),
-        unit_mode: Some(false),
+        unit_mode: Some(send_config.unit_mode),
         batch: Some(false),
         topic_request_header: Some(TopicRequestHeader {
             rpc_request_header: Some(RpcRequestHeader {
@@ -3551,9 +3599,30 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicUsize;
 
+    use bytes::Bytes;
+
     use super::*;
     use crate::producer::default_mq_producer::DefaultMQProducer;
     use crate::producer::transaction_listener::TransactionListener;
+
+    struct CountingCompressor {
+        calls: AtomicUsize,
+    }
+
+    impl Compressor for CountingCompressor {
+        fn compress(&self, src: &[u8], _level: i32) -> rocketmq_error::RocketMQResult<Bytes> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(Bytes::copy_from_slice(src))
+        }
+
+        fn decompress(&self, src: &[u8]) -> rocketmq_error::RocketMQResult<Bytes> {
+            Ok(Bytes::copy_from_slice(src))
+        }
+    }
+
+    static COUNTING_COMPRESSOR: CountingCompressor = CountingCompressor {
+        calls: AtomicUsize::new(0),
+    };
 
     fn running_producer_without_client() -> DefaultMQProducerImpl {
         let mut producer = DefaultMQProducerImpl::new(ClientConfig::default(), ProducerConfig::default(), None);
@@ -4121,6 +4190,44 @@ mod tests {
         assert!(Arc::ptr_eq(&cached, &info));
         assert_eq!(cached.message_queue_list.len(), 256);
         assert!(producer.select_one_message_queue(&cached, None, false).is_some());
+    }
+
+    #[test]
+    fn replace_producer_config_refreshes_send_config_snapshot() {
+        let mut producer = DefaultMQProducerImpl::new(ClientConfig::default(), ProducerConfig::default(), None);
+        let configured = DefaultMQProducer::builder()
+            .producer_group("snapshot-group")
+            .create_topic_key("SnapshotTopic")
+            .default_topic_queue_nums(12)
+            .compress_msg_body_over_howmuch(8192)
+            .compressor(&COUNTING_COMPRESSOR)
+            .build();
+
+        producer.replace_producer_config(configured.producer_config().clone());
+
+        assert_eq!(producer.send_config.producer_group, "snapshot-group");
+        assert_eq!(producer.send_config.create_topic_key, "SnapshotTopic");
+        assert_eq!(producer.send_config.default_topic_queue_nums, 12);
+        assert_eq!(producer.send_config.compress_msg_body_over_howmuch, 8192);
+        assert!(producer.send_config.compressor.is_some());
+    }
+
+    #[test]
+    fn compression_below_threshold_does_not_access_compressor() {
+        COUNTING_COMPRESSOR.calls.store(0, Ordering::Relaxed);
+        let configured = DefaultMQProducer::builder()
+            .producer_group("compress-threshold-group")
+            .compress_msg_body_over_howmuch(1024)
+            .compressor(&COUNTING_COMPRESSOR)
+            .build();
+        let producer = DefaultMQProducerImpl::new(ClientConfig::default(), configured.producer_config().clone(), None);
+        let mut msg = Message::builder()
+            .topic("TopicTest")
+            .body(vec![b'a'; 128])
+            .build_unchecked();
+
+        assert!(!producer.try_to_compress_message(&mut msg));
+        assert_eq!(COUNTING_COMPRESSOR.calls.load(Ordering::Relaxed), 0);
     }
 
     #[tokio::test]

--- a/rocketmq-common/src/common/message/message_decoder.rs
+++ b/rocketmq-common/src/common/message/message_decoder.rs
@@ -63,6 +63,9 @@ pub const QUEUE_OFFSET_POSITION: usize = 4 + 4 + 4 + 4 + 4;
 pub const SYSFLAG_POSITION: usize = 4 + 4 + 4 + 4 + 4 + 8 + 8;
 pub const BORN_TIMESTAMP_POSITION: usize = 4 + 4 + 4 + 4 + 4 + 8 + 8 + 4 + 8;
 
+const SMALL_PROPERTIES_PREALLOC_THRESHOLD: usize = 16;
+const SMALL_PROPERTY_PREALLOC_BYTES: usize = 34;
+
 fn get_i16_checked(buffer: &mut Bytes) -> Option<i16> {
     if buffer.remaining() < 2 {
         None
@@ -176,16 +179,28 @@ pub fn str_to_message_properties(properties: Option<&str>) -> HashMap<CheetahStr
     map
 }
 
+/// Encodes message properties with RocketMQ's name/value and property
+/// separators.
+#[inline]
 pub fn message_properties_to_string(properties: &HashMap<CheetahString, CheetahString>) -> CheetahString {
-    let mut len = 0;
-    for (name, value) in properties.iter() {
-        len += name.len();
-
-        len += value.len();
-        len += 2; // separator
+    if properties.is_empty() {
+        return CheetahString::empty();
     }
 
-    let mut builder = CheetahBuilder::with_capacity(len);
+    let property_count = properties.len();
+    let capacity = if property_count <= SMALL_PROPERTIES_PREALLOC_THRESHOLD {
+        property_count * SMALL_PROPERTY_PREALLOC_BYTES
+    } else {
+        let mut len = 0;
+        for (name, value) in properties.iter() {
+            len += name.len();
+            len += value.len();
+            len += 2; // separator
+        }
+        len
+    };
+
+    let mut builder = CheetahBuilder::with_capacity(capacity);
     for (name, value) in properties.iter() {
         builder.push_str(name.as_str());
         builder.push(NAME_VALUE_SEPARATOR);
@@ -980,6 +995,38 @@ mod tests {
         let encoded = message_properties_to_string(&properties);
 
         assert_eq!(encoded, "key\u{0001}value\u{0002}");
+    }
+
+    #[test]
+    fn message_properties_to_string_empty_properties_returns_empty_string() {
+        let properties = HashMap::new();
+
+        let encoded = message_properties_to_string(&properties);
+
+        assert!(encoded.is_empty());
+    }
+
+    #[test]
+    fn message_properties_to_string_round_trips_small_property_map() {
+        let properties = [
+            ("topic", "benchmark-topic"),
+            ("keys", "key-a"),
+            ("tags", "tag-a"),
+            ("trace", "trace-001"),
+        ]
+        .into_iter()
+        .map(|(key, value)| {
+            (
+                CheetahString::from_static_str(key),
+                CheetahString::from_static_str(value),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+        let encoded = message_properties_to_string(&properties);
+        let decoded = string_to_message_properties(Some(&encoded));
+
+        assert_eq!(decoded, properties);
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7600

### Brief Description

- Add an empty-properties fast path in `MessageDecoder::message_properties_to_string`.
- Add small-property preallocation in `MessageDecoder::message_properties_to_string` for maps up to 16 entries, avoiding an extra sizing pass on the common send path while preserving exact sizing for larger maps.
- Cache producer send hot-path fields in a `ProducerSendConfigSnapshot` and refresh it when producer config is replaced.
- Read compression threshold, compression type, compressor, producer group, default topic, default queue nums, and unit mode from the send snapshot during request construction.
- Skip compressor access before the body-size threshold and rate-limit missing-compressor diagnostics to one warning per producer config generation.
- Add benchmark coverage for legacy vs optimized properties encoding and send header construction by property count.

### How Did You Test This Change?

- `cargo test -p rocketmq-common --lib message_properties_to_string` - passed
- `cargo test -p rocketmq-client-rust --lib replace_producer_config_refreshes_send_config_snapshot` - passed
- `cargo test -p rocketmq-client-rust --lib compression_below_threshold_does_not_access_compressor` - passed
- `cargo test -p rocketmq-client-rust --lib send_message` - passed
- `cargo test -p rocketmq-client-rust --test send_oneway_tests` - passed
- `cargo bench -p rocketmq-client-rust --bench message_util_bench -- --test` - passed
- `cargo bench -p rocketmq-client-rust --bench client_send_pipeline_benchmark -- --test` - passed
- `cargo bench -p rocketmq-client-rust --bench message_util_bench message_properties_to_string` - passed; latest medians: 0 props legacy 13.020 ns vs optimized 8.4837 ns, 1 prop legacy 48.467 ns vs optimized 48.520 ns, 4 props legacy 63.061 ns vs optimized 58.997 ns, 16 props legacy 160.24 ns vs optimized 138.18 ns
- `cargo bench -p rocketmq-client-rust --bench message_util_bench` - passed; earlier full run before the small-property preallocation follow-up completed successfully
- `cargo bench -p rocketmq-client-rust --bench client_send_pipeline_benchmark` - passed
- `cargo fmt --all` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed
- `git diff --check` - passed
- `cargo fmt --all -- --check; cargo clippy --all-targets -- -D warnings` from `rocketmq-example/` - failed before project checks with existing standalone dependency resolution error: `ScheduledTaskManager::new_legacy_compatibility` not found while compiling `rocketmq-client-rust`
- `cargo fmt --all -- --check; cargo clippy --all-targets --all-features -- -D warnings` from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/` - failed with the same existing standalone dependency resolution error
- `cargo fmt --all -- --check; cargo clippy --all-targets --all-features -- -D warnings; cargo build --all-targets --all-features` from `rocketmq-dashboard/rocketmq-dashboard-web/backend/` - passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark coverage for message send header construction and message property serialization with different property sizes.

* **Performance Improvements**
  * Improved message property string handling for empty and small maps, reducing unnecessary work.
  * Optimized producer send-path behavior by reusing cached send settings and avoiding repeated warning logs when compression isn’t available.

* **Bug Fixes**
  * Updated producer configuration refresh behavior so send-related settings are applied consistently after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->