### PR TITLE
[ISSUE #7602]✨Optimize async send scheduling

### DIFF
--- a/rocketmq-client/benches/client_runtime_spawn_benchmark.rs
+++ b/rocketmq-client/benches/client_runtime_spawn_benchmark.rs
@@ -127,6 +127,14 @@ fn wait_for_tasks_finished(task_handles: &[ClientRuntimeTaskHandle]) {
     }
 }
 
+fn percentile_duration_micros(samples: &[Duration], percentile: usize) -> u128 {
+    assert!(!samples.is_empty(), "percentile requires at least one sample");
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let index = ((sorted.len() - 1) * percentile) / 100;
+    sorted[index].as_micros()
+}
+
 fn snapshot_json(snapshot: ClientSharedFallbackSnapshot) -> serde_json::Value {
     serde_json::json!({
         "state": format!("{:?}", snapshot.state),
@@ -145,7 +153,10 @@ fn snapshot_json(snapshot: ClientSharedFallbackSnapshot) -> serde_json::Value {
 }
 
 fn write_client_runtime_report_artifact() {
-    let output = run_fallback_spawn(128);
+    let sample_count = 10;
+    let outputs = (0..sample_count).map(|_| run_fallback_spawn(128)).collect::<Vec<_>>();
+    let elapsed_samples = outputs.iter().map(|output| output.elapsed).collect::<Vec<_>>();
+    let output = outputs.last().expect("runtime report should have at least one sample");
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("rocketmq-client should live below workspace root")
@@ -162,8 +173,12 @@ fn write_client_runtime_report_artifact() {
         "generated_at_unix_ms": generated_at_unix_ms,
         "fallback_spawn": {
             "task_count": output.task_count,
+            "sample_count": sample_count,
             "elapsed_ms": output.elapsed.as_millis(),
             "elapsed_us": output.elapsed.as_micros(),
+            "elapsed_p50_us": percentile_duration_micros(&elapsed_samples, 50),
+            "elapsed_p95_us": percentile_duration_micros(&elapsed_samples, 95),
+            "elapsed_p99_us": percentile_duration_micros(&elapsed_samples, 99),
             "acquire_count_delta": output.acquire_count_delta,
             "runtime_created_delta": output.runtime_created_delta,
             "runtime_reused_delta": output.runtime_reused_delta,

--- a/rocketmq-client/benches/client_runtime_spawn_benchmark.rs
+++ b/rocketmq-client/benches/client_runtime_spawn_benchmark.rs
@@ -129,9 +129,11 @@ fn wait_for_tasks_finished(task_handles: &[ClientRuntimeTaskHandle]) {
 
 fn percentile_duration_micros(samples: &[Duration], percentile: usize) -> u128 {
     assert!(!samples.is_empty(), "percentile requires at least one sample");
+    assert!(percentile <= 100, "percentile must be between 0 and 100");
     let mut sorted = samples.to_vec();
     sorted.sort_unstable();
-    let index = ((sorted.len() - 1) * percentile) / 100;
+    let rank = (sorted.len() * percentile).div_ceil(100);
+    let index = rank.saturating_sub(1);
     sorted[index].as_micros()
 }
 

--- a/rocketmq-client/benches/client_send_pipeline_benchmark.rs
+++ b/rocketmq-client/benches/client_send_pipeline_benchmark.rs
@@ -109,8 +109,11 @@ fn build_send_request(mut message: Message) -> RemotingCommand {
 
 fn percentile_duration(samples: &mut [Duration], percentile: usize) -> Duration {
     assert!(!samples.is_empty(), "percentile requires at least one sample");
+    assert!(percentile <= 100, "percentile must be between 0 and 100");
     samples.sort_unstable();
-    samples[((samples.len() - 1) * percentile) / 100]
+    let rank = (samples.len() * percentile).div_ceil(100);
+    let index = rank.saturating_sub(1);
+    samples[index]
 }
 
 fn run_async_send_scheduling(
@@ -124,15 +127,16 @@ fn run_async_send_scheduling(
 
         for _ in 0..task_count {
             let tx = tx.clone();
+            let submitted_at = Instant::now();
             if nested_api_spawn {
                 tokio::spawn(async move {
                     tokio::spawn(async move {
-                        let _ = tx.send(started_at.elapsed());
+                        let _ = tx.send(submitted_at.elapsed());
                     });
                 });
             } else {
                 tokio::spawn(async move {
-                    let _ = tx.send(started_at.elapsed());
+                    let _ = tx.send(submitted_at.elapsed());
                 });
             }
         }

--- a/rocketmq-client/benches/client_send_pipeline_benchmark.rs
+++ b/rocketmq-client/benches/client_send_pipeline_benchmark.rs
@@ -18,8 +18,14 @@
 //! network: message construction, request command construction, callback
 //! dispatch, and async backpressure permit acquisition.
 
+use std::fs;
 use std::hint::black_box;
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use bytes::Bytes;
 use cheetah_string::CheetahString;
@@ -41,6 +47,14 @@ use rocketmq_remoting::code::request_code::RequestCode;
 use rocketmq_remoting::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
 use rocketmq_remoting::protocol::remoting_command::RemotingCommand;
 use tokio::sync::Semaphore;
+
+#[derive(Debug)]
+struct AsyncSchedulingOutput {
+    task_count: usize,
+    elapsed: Duration,
+    p99_latency: Duration,
+    submitted_tasks: usize,
+}
 
 fn build_message(body_size: usize) -> Message {
     Message::builder()
@@ -91,6 +105,106 @@ fn build_send_request(mut message: Message) -> RemotingCommand {
     let header = build_send_header(&message);
     let body = message.get_body().cloned().unwrap_or_else(|| Bytes::from_static(b""));
     RemotingCommand::create_request_command(RequestCode::SendMessageV2, header).set_body(body)
+}
+
+fn percentile_duration(samples: &mut [Duration], percentile: usize) -> Duration {
+    assert!(!samples.is_empty(), "percentile requires at least one sample");
+    samples.sort_unstable();
+    samples[((samples.len() - 1) * percentile) / 100]
+}
+
+fn run_async_send_scheduling(
+    runtime: &tokio::runtime::Runtime,
+    task_count: usize,
+    nested_api_spawn: bool,
+) -> AsyncSchedulingOutput {
+    runtime.block_on(async move {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let started_at = Instant::now();
+
+        for _ in 0..task_count {
+            let tx = tx.clone();
+            if nested_api_spawn {
+                tokio::spawn(async move {
+                    tokio::spawn(async move {
+                        let _ = tx.send(started_at.elapsed());
+                    });
+                });
+            } else {
+                tokio::spawn(async move {
+                    let _ = tx.send(started_at.elapsed());
+                });
+            }
+        }
+        drop(tx);
+
+        let mut latencies = Vec::with_capacity(task_count);
+        while let Some(latency) = rx.recv().await {
+            latencies.push(latency);
+            if latencies.len() == task_count {
+                break;
+            }
+        }
+
+        assert_eq!(latencies.len(), task_count);
+        let elapsed = started_at.elapsed();
+        let p99_latency = percentile_duration(&mut latencies, 99);
+        AsyncSchedulingOutput {
+            task_count,
+            elapsed,
+            p99_latency,
+            submitted_tasks: if nested_api_spawn { task_count * 2 } else { task_count },
+        }
+    })
+}
+
+fn scheduling_output_json(output: &AsyncSchedulingOutput) -> serde_json::Value {
+    serde_json::json!({
+        "task_count": output.task_count,
+        "submitted_tasks": output.submitted_tasks,
+        "elapsed_us": output.elapsed.as_micros(),
+        "p99_latency_us": output.p99_latency.as_micros(),
+    })
+}
+
+fn write_async_send_scheduling_report_artifact(runtime: &tokio::runtime::Runtime) {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("rocketmq-client should live below workspace root")
+        .to_path_buf();
+    let output_dir = workspace_root.join("target/runtime-baseline/prototype");
+    fs::create_dir_all(&output_dir).expect("runtime benchmark artifact directory should be created");
+
+    let generated_at_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_millis();
+    let cases = [10_000usize, 100_000]
+        .into_iter()
+        .map(|task_count| {
+            let single = run_async_send_scheduling(runtime, task_count, false);
+            let nested = run_async_send_scheduling(runtime, task_count, true);
+            let submitted_task_reduction_percent =
+                100.0 * (nested.submitted_tasks - single.submitted_tasks) as f64 / nested.submitted_tasks as f64;
+            serde_json::json!({
+                "task_count": task_count,
+                "single_spawn": scheduling_output_json(&single),
+                "nested_spawn": scheduling_output_json(&nested),
+                "submitted_task_reduction_percent": submitted_task_reduction_percent,
+            })
+        })
+        .collect::<Vec<_>>();
+    let payload = serde_json::json!({
+        "case": "client_send_pipeline.async_send_scheduling_layers",
+        "generated_at_unix_ms": generated_at_unix_ms,
+        "cases": cases,
+    });
+    let path = output_dir.join("client-async-send-scheduling-report.json");
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&payload).expect("async send scheduling artifact should serialize"),
+    )
+    .expect("async send scheduling artifact should be written");
 }
 
 fn bench_message_construction(c: &mut Criterion) {
@@ -210,6 +324,38 @@ fn bench_callback_dispatch(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_async_send_scheduling_layers(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime should start");
+    write_async_send_scheduling_report_artifact(&runtime);
+
+    let mut group = c.benchmark_group("client_send_pipeline/async_send_scheduling_layers");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(1));
+
+    for task_count in [10_000usize, 100_000] {
+        group.throughput(Throughput::Elements(task_count as u64));
+        for (label, nested_api_spawn) in [("single_spawn", false), ("nested_spawn", true)] {
+            group.bench_with_input(
+                BenchmarkId::new(label, task_count),
+                &(task_count, nested_api_spawn),
+                |b, &(task_count, nested_api_spawn)| {
+                    b.iter(|| {
+                        let output = run_async_send_scheduling(&runtime, task_count, nested_api_spawn);
+                        black_box((
+                            output.task_count,
+                            output.elapsed,
+                            output.p99_latency,
+                            output.submitted_tasks,
+                        ));
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_message_construction,
@@ -217,5 +363,6 @@ criterion_group!(
     bench_send_header_construction,
     bench_async_backpressure_envelope,
     bench_callback_dispatch,
+    bench_async_send_scheduling_layers,
 );
 criterion_main!(benches);

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -48,7 +48,6 @@ use crate::producer::send_result::SendResult;
 use crate::producer::send_status::SendStatus;
 use crate::runtime::spawn_client_blocking_io;
 use crate::runtime::spawn_client_task;
-use crate::runtime::spawn_client_task_on;
 use cheetah_string::CheetahString;
 
 use crate::base::validators::Validators;
@@ -2352,7 +2351,8 @@ impl MQClientAPIImpl {
                     retry_times_when_send_failed,
                     context,
                     producer,
-                );
+                )
+                .await;
                 Ok(None)
             }
             CommunicationMode::Oneway => {
@@ -2445,7 +2445,7 @@ impl MQClientAPIImpl {
         self.process_send_response(broker_name, msg, &response, addr)
     }
 
-    fn send_message_async<T: MessageTrait>(
+    async fn send_message_async<T: MessageTrait>(
         &mut self,
         addr: &CheetahString,
         broker_name: &CheetahString,
@@ -2497,7 +2497,6 @@ impl MQClientAPIImpl {
         let instance_cloned = instance.clone();
         let mq_fault_strategy = producer.mq_fault_strategy.clone();
         let callback_executor = producer.producer_config().callback_executor().cloned();
-        let async_sender_executor = producer.producer_config().async_sender_executor().cloned();
 
         // Clone the context data that we need for hook execution
         // We'll use the execute_send_message_hook_after method which requires a context
@@ -2515,28 +2514,25 @@ impl MQClientAPIImpl {
             trace_start_time: c.trace_start_time,
         });
 
-        let async_send_task = async move {
-            Self::send_message_async_impl(
-                remoting_client,
-                client_config,
-                mq_fault_strategy,
-                current_addr,
-                current_broker_name,
-                msg_topic,
-                msg_uniq_id,
-                is_batch_message,
-                timeout_millis,
-                current_request,
-                send_callback,
-                topic_publish_info_cloned,
-                instance_cloned,
-                retry_times_when_send_failed,
-                context_data,
-                callback_executor,
-            )
-            .await;
-        };
-        Self::spawn_async_send_task(async_sender_executor, async_send_task);
+        Self::send_message_async_impl(
+            remoting_client,
+            client_config,
+            mq_fault_strategy,
+            current_addr,
+            current_broker_name,
+            msg_topic,
+            msg_uniq_id,
+            is_batch_message,
+            timeout_millis,
+            current_request,
+            send_callback,
+            topic_publish_info_cloned,
+            instance_cloned,
+            retry_times_when_send_failed,
+            context_data,
+            callback_executor,
+        )
+        .await;
     }
 
     /// Background task implementation for async message sending.
@@ -2812,15 +2808,6 @@ impl MQClientAPIImpl {
 
     fn boxed_context_error(message: String) -> Arc<Box<dyn StdError + Send + Sync>> {
         Arc::new(Box::new(std::io::Error::other(message)))
-    }
-
-    fn spawn_async_send_task<F>(async_sender_executor: Option<tokio::runtime::Handle>, task: F)
-    where
-        F: Future<Output = ()> + Send + 'static,
-    {
-        if let Err(error) = spawn_client_task_on("rocketmq-client-async-send", async_sender_executor.as_ref(), task) {
-            warn!("Failed to spawn rocketmq-client-async-send task: {}", error);
-        }
     }
 
     fn spawn_api_background_task<F>(
@@ -7111,42 +7098,6 @@ mod tests {
         assert_eq!(thread_name, "rocketmq-callback-error");
         assert!(!has_result);
         assert_eq!(error.as_deref(), Some("callback failure"));
-    }
-
-    #[test]
-    fn async_send_task_uses_configured_async_sender_executor_like_java() {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .thread_name("rocketmq-async-sender")
-            .enable_all()
-            .build()
-            .expect("async sender runtime should build");
-        let (tx, rx) = std::sync::mpsc::channel();
-
-        MQClientAPIImpl::spawn_async_send_task(Some(runtime.handle().clone()), async move {
-            tx.send(std::thread::current().name().unwrap_or_default().to_string())
-                .expect("test receiver should be alive");
-        });
-
-        let thread_name = rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("async send task should run on configured runtime");
-        assert_eq!(thread_name, "rocketmq-async-sender");
-    }
-
-    #[test]
-    fn async_send_task_without_tokio_runtime_runs_on_fallback_thread() {
-        let (tx, rx) = std::sync::mpsc::channel();
-
-        MQClientAPIImpl::spawn_async_send_task(None, async move {
-            tx.send(std::thread::current().name().unwrap_or_default().to_string())
-                .expect("test receiver should be alive");
-        });
-
-        let thread_name = rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("async send task should run on fallback runtime");
-        assert_eq!(thread_name, "rocketmq-client-fallback");
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -3665,13 +3665,52 @@ mod tests {
     }
 
     #[test]
-    fn spawn_producer_task_uses_configured_async_sender_executor() {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
+    fn execute_async_message_send_uses_configured_async_sender_executor() {
+        let async_sender_runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .thread_name("rocketmq-producer-async-sender")
             .enable_all()
             .build()
             .expect("async sender runtime should build");
+        let caller_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("caller runtime should build");
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut producer = running_producer_without_client();
+        producer.set_async_sender_executor(async_sender_runtime.handle().clone());
+
+        caller_runtime.block_on(async {
+            producer
+                .execute_async_message_send(
+                    async move {
+                        let current_thread = std::thread::current();
+                        let thread_name = current_thread.name().unwrap_or_default().to_string();
+                        tx.send(thread_name).expect("test receiver should still be open");
+                    },
+                    None,
+                    1000,
+                    Instant::now(),
+                    1,
+                )
+                .await
+                .expect("async send should spawn on configured runtime");
+        });
+
+        let thread_name = rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("configured producer task should complete");
+        assert_eq!(thread_name, "rocketmq-producer-async-sender");
+    }
+
+    #[test]
+    fn spawn_producer_task_uses_explicit_executor() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("rocketmq-producer-explicit-executor")
+            .enable_all()
+            .build()
+            .expect("producer task runtime should build");
         let (tx, rx) = std::sync::mpsc::channel();
         let tracker = TaskTracker::new();
         let shutdown_token = CancellationToken::new();
@@ -3692,7 +3731,7 @@ mod tests {
         let thread_name = rx
             .recv_timeout(Duration::from_secs(1))
             .expect("configured producer task should complete");
-        assert_eq!(thread_name, "rocketmq-producer-async-sender");
+        assert_eq!(thread_name, "rocketmq-producer-explicit-executor");
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -3664,6 +3664,37 @@ mod tests {
         assert_eq!(thread_name, "rocketmq-client-fallback");
     }
 
+    #[test]
+    fn spawn_producer_task_uses_configured_async_sender_executor() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("rocketmq-producer-async-sender")
+            .enable_all()
+            .build()
+            .expect("async sender runtime should build");
+        let (tx, rx) = std::sync::mpsc::channel();
+        let tracker = TaskTracker::new();
+        let shutdown_token = CancellationToken::new();
+
+        spawn_producer_task(
+            Some(runtime.handle()),
+            "rocketmq-client-producer-test",
+            &tracker,
+            &shutdown_token,
+            async move {
+                let current_thread = std::thread::current();
+                let thread_name = current_thread.name().unwrap_or_default().to_string();
+                tx.send(thread_name).expect("test receiver should still be open");
+            },
+        )
+        .expect("producer task should spawn on configured runtime");
+
+        let thread_name = rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("configured producer task should complete");
+        assert_eq!(thread_name, "rocketmq-producer-async-sender");
+    }
+
     #[tokio::test]
     async fn tracked_producer_task_cancellation_stops_pending_task() {
         struct DropFlag(Arc<AtomicBool>);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7602

### Brief Description

- Remove the API-layer async send spawn from `MQClientAPIImpl::send_message_async` and await `send_message_async_impl` inside the producer-owned async send task.
- Keep `DefaultMQProducerImpl::execute_async_message_send` as the single main send-path spawn point for async producer sends.
- Preserve callback isolation through the configured callback executor and move async sender executor coverage to the producer spawn helper.
- Keep async backpressure permits held until the producer async send future completes.
- Extend runtime/send pipeline benchmarks with p99 and submitted-task evidence for single-spawn vs nested-spawn scheduling at 10k and 100k logical async sends.
- Address review feedback by using ceil-based percentile selection, measuring scheduling latency from each task submission point, and testing the producer config executor wiring through `execute_async_message_send`.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust --test client_runtime_fallback_test` - passed
- `cargo test -p rocketmq-client-rust --lib async_send` - passed
- `cargo test -p rocketmq-client-rust --lib spawn_producer_task` - passed
- `cargo test -p rocketmq-client-rust --lib execute_async_message_send_uses_configured_async_sender_executor` - passed
- `cargo test -p rocketmq-client-rust --lib tracked_producer_task_cancellation_stops_pending_task` - passed
- `cargo bench -p rocketmq-client-rust --bench client_runtime_spawn_benchmark -- --test` - passed
- `cargo bench -p rocketmq-client-rust --bench client_send_pipeline_benchmark -- --test` - passed
- `cargo bench -p rocketmq-client-rust --bench client_runtime_spawn_benchmark` - passed; fallback spawn report records p50 717 us, p95 971 us, and p99 971 us
- `cargo bench -p rocketmq-client-rust --bench client_send_pipeline_benchmark` - passed; async send scheduling medians: 10k single-spawn 4.3088 ms vs nested-spawn 5.2460 ms, 100k single-spawn 43.854 ms vs nested-spawn 52.931 ms
- `target/runtime-baseline/prototype/client-async-send-scheduling-report.json` - generated; 10k submitted tasks drop from 20,000 to 10,000 and per-spawn p99 drops from 23 us to 17 us; 100k submitted tasks drop from 200,000 to 100,000 and per-spawn p99 drops from 23 us to 15 us
- `cargo test -p rocketmq-client-rust --lib` - passed, 930 tests
- `cargo test -p rocketmq-client-rust --test integration_tests` - passed
- `cargo test -p rocketmq-client-rust --test pull_message_service_test` - passed
- `cargo test -p rocketmq-client-rust --test rebalance_concurrent_safety_test` - passed
- `cargo fmt --all` - passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed
- `git diff --check` - passed with LF/CRLF working-copy warnings only
- `cargo fmt --all -- --check; cargo clippy --all-targets -- -D warnings` from `rocketmq-example/` - failed before project checks with existing standalone dependency resolution error: `ScheduledTaskManager::new_legacy_compatibility` not found while compiling `rocketmq-client-rust`
- `cargo fmt --all -- --check; cargo clippy --all-targets --all-features -- -D warnings` from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri/` - failed with the same existing standalone dependency resolution error
- `cargo fmt --all -- --check; cargo clippy --all-targets --all-features -- -D warnings; cargo build --all-targets --all-features` from `rocketmq-dashboard/rocketmq-dashboard-web/backend/` - passed
