### PR TITLE
[ISSUE #7604]✨Optimize async retry request reuse

### DIFF
--- a/rocketmq-client/benches/client_send_pipeline_benchmark.rs
+++ b/rocketmq-client/benches/client_send_pipeline_benchmark.rs
@@ -18,6 +18,7 @@
 //! network: message construction, request command construction, callback
 //! dispatch, and async backpressure permit acquisition.
 
+use std::collections::HashMap;
 use std::fs;
 use std::hint::black_box;
 use std::path::PathBuf;
@@ -105,6 +106,68 @@ fn build_send_request(mut message: Message) -> RemotingCommand {
     let header = build_send_header(&message);
     let body = message.get_body().cloned().unwrap_or_else(|| Bytes::from_static(b""));
     RemotingCommand::create_request_command(RequestCode::SendMessageV2, header).set_body(body)
+}
+
+fn build_retry_request(body_size: usize, ext_field_count: usize) -> RemotingCommand {
+    let mut request = build_send_request(build_message(body_size));
+    if ext_field_count > 0 {
+        let ext_fields = (0..ext_field_count)
+            .map(|index| {
+                (
+                    CheetahString::from_string(format!("retry-key-{index}")),
+                    CheetahString::from_string(format!("retry-value-{index}")),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        request = request.set_ext_fields(ext_fields);
+    }
+    request
+}
+
+fn observe_retry_request(request: &RemotingCommand) -> usize {
+    let body_len = request.body().map_or(0, Bytes::len);
+    let ext_field_len = request.ext_fields().map_or(0, HashMap::len);
+    body_len ^ ext_field_len ^ request.opaque() as usize
+}
+
+fn simulate_retry_clone_every_attempt(mut template: RemotingCommand, attempts: usize) -> usize {
+    let mut observed = 0usize;
+    for attempt in 0..attempts {
+        let mut request = template.clone();
+        request.make_custom_header_to_net();
+        observed ^= observe_retry_request(&request);
+        if attempt + 1 < attempts {
+            template.set_opaque_mut(RemotingCommand::create_new_request_id());
+        }
+    }
+    observed
+}
+
+fn simulate_retry_reuse_final_attempt(template: RemotingCommand, attempts: usize) -> usize {
+    let mut template = template;
+    template.materialize_custom_header_to_ext_fields();
+    let mut template = Some(template);
+    let mut observed = 0usize;
+    for attempt in 0..attempts {
+        let keep_template_for_retry = attempt + 1 < attempts;
+        let mut request = if keep_template_for_retry {
+            template
+                .as_ref()
+                .expect("retry request template should be available")
+                .clone()
+        } else {
+            template.take().expect("retry final request should be available")
+        };
+        request.make_custom_header_to_net();
+        observed ^= observe_retry_request(&request);
+        if keep_template_for_retry {
+            template
+                .as_mut()
+                .expect("retry request template should be available")
+                .set_opaque_mut(RemotingCommand::create_new_request_id());
+        }
+    }
+    observed
 }
 
 fn percentile_duration(samples: &mut [Duration], percentile: usize) -> Duration {
@@ -328,6 +391,45 @@ fn bench_callback_dispatch(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_async_retry_request_reuse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("client_send_pipeline/async_retry_request_reuse");
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(1));
+
+    for (label, body_size, ext_field_count) in [
+        ("no_body_no_ext", 0usize, 0usize),
+        ("small_body", 1024, 0),
+        ("large_body", 128 * 1024, 0),
+        ("many_ext_fields", 1024, 64),
+    ] {
+        group.throughput(Throughput::Bytes(body_size as u64));
+        for (strategy, simulate) in [
+            (
+                "clone_every_attempt",
+                simulate_retry_clone_every_attempt as fn(RemotingCommand, usize) -> usize,
+            ),
+            (
+                "reuse_final_attempt",
+                simulate_retry_reuse_final_attempt as fn(RemotingCommand, usize) -> usize,
+            ),
+        ] {
+            group.bench_with_input(
+                BenchmarkId::new(strategy, label),
+                &(body_size, ext_field_count),
+                |b, &(body_size, ext_field_count)| {
+                    b.iter_batched(
+                        || build_retry_request(body_size, ext_field_count),
+                        |request| black_box(simulate(request, 2)),
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
 fn bench_async_send_scheduling_layers(c: &mut Criterion) {
     let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime should start");
     write_async_send_scheduling_report_artifact(&runtime);
@@ -367,6 +469,7 @@ criterion_group!(
     bench_send_header_construction,
     bench_async_backpressure_envelope,
     bench_callback_dispatch,
+    bench_async_retry_request_reuse,
     bench_async_send_scheduling_layers,
 );
 criterion_main!(benches);

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -302,6 +302,45 @@ struct AsyncSendHookContext {
     trace_start_time: Option<u64>,
 }
 
+struct AsyncRetryRequest {
+    template: Option<RemotingCommand>,
+}
+
+impl AsyncRetryRequest {
+    fn new(mut request: RemotingCommand) -> Self {
+        request.materialize_custom_header_to_ext_fields();
+        Self {
+            template: Some(request),
+        }
+    }
+
+    fn next_attempt(&mut self, keep_template_for_retry: bool) -> RemotingCommand {
+        if keep_template_for_retry {
+            return self
+                .template
+                .as_ref()
+                .expect("async retry request template should be available")
+                .clone();
+        }
+
+        self.template
+            .take()
+            .expect("async retry final request should be available")
+    }
+
+    fn set_retry_opaque(&mut self, opaque: i32) {
+        self.template
+            .as_mut()
+            .expect("async retry request template should be available")
+            .set_opaque_mut(opaque);
+    }
+
+    #[cfg(test)]
+    fn is_consumed(&self) -> bool {
+        self.template.is_none()
+    }
+}
+
 pub struct MQClientAPIImpl {
     remoting_client: ArcMut<RocketmqDefaultClient<ClientRemotingProcessor>>,
     top_addressing: Arc<Box<dyn TopAddressing>>,
@@ -2547,7 +2586,7 @@ impl MQClientAPIImpl {
         msg_uniq_id: Option<CheetahString>,
         is_batch_message: bool,
         timeout_millis: u64,
-        mut current_request: RemotingCommand,
+        current_request: RemotingCommand,
         send_callback: Option<ArcSendCallback>,
         topic_publish_info: Option<TopicPublishInfo>,
         instance: Option<ArcMut<MQClientInstance>>,
@@ -2557,6 +2596,7 @@ impl MQClientAPIImpl {
     ) {
         let begin_start_time_all = Instant::now();
         let mut retry_count = 0_u32;
+        let mut retry_request = AsyncRetryRequest::new(current_request);
 
         loop {
             let elapsed = (Instant::now() - begin_start_time_all).as_millis() as u64;
@@ -2576,8 +2616,10 @@ impl MQClientAPIImpl {
 
             let remaining_timeout = timeout_millis - elapsed;
             let begin_attempt_time = Instant::now();
+            let keep_request_for_retry = retry_count < retry_times_when_send_failed;
+            let attempt_request = retry_request.next_attempt(keep_request_for_retry);
             let result = remoting_client
-                .invoke_request(Some(&current_addr), current_request.clone(), remaining_timeout)
+                .invoke_request(Some(&current_addr), attempt_request, remaining_timeout)
                 .await;
             let cost = (Instant::now() - begin_attempt_time).as_millis() as u64;
 
@@ -2712,7 +2754,7 @@ impl MQClientAPIImpl {
                             );
                             current_addr = retry_addr;
                             current_broker_name = retry_broker_name;
-                            current_request.set_opaque_mut(RemotingCommand::create_new_request_id());
+                            retry_request.set_retry_opaque(RemotingCommand::create_new_request_id());
                             continue;
                         }
                     }
@@ -7443,5 +7485,69 @@ mod tests {
         assert!(!MQClientAPIImpl::should_retry_async_send_error(
             &rocketmq_error::RocketMQError::ClientShuttingDown,
         ));
+    }
+
+    #[test]
+    fn async_retry_request_reuses_final_attempt_after_first_failure() {
+        let retry_key = CheetahString::from_static_str("retry-key");
+        let retry_value = CheetahString::from_static_str("retry-value");
+        let mut request = RemotingCommand::create_request_command(RequestCode::SendMessageV2, EmptyHeader {})
+            .set_body(bytes::Bytes::from_static(b"retry-body"))
+            .set_ext_fields(HashMap::from([(retry_key.clone(), retry_value.clone())]));
+        let initial_opaque = RemotingCommand::create_new_request_id();
+        let retry_opaque = RemotingCommand::create_new_request_id();
+        request.set_opaque_mut(initial_opaque);
+
+        let mut retry_request = AsyncRetryRequest::new(request);
+        let first_attempt = retry_request.next_attempt(true);
+
+        assert_eq!(first_attempt.opaque(), initial_opaque);
+        assert_eq!(
+            first_attempt.body().map(bytes::Bytes::as_ref),
+            Some(b"retry-body".as_slice())
+        );
+        assert_eq!(
+            first_attempt
+                .ext_fields()
+                .and_then(|fields| fields.get(&retry_key))
+                .map(CheetahString::as_str),
+            Some(retry_value.as_str())
+        );
+        assert!(!retry_request.is_consumed());
+
+        retry_request.set_retry_opaque(retry_opaque);
+        let second_attempt = retry_request.next_attempt(false);
+
+        assert_eq!(second_attempt.opaque(), retry_opaque);
+        assert_eq!(
+            second_attempt.body().map(bytes::Bytes::as_ref),
+            Some(b"retry-body".as_slice())
+        );
+        assert_eq!(
+            second_attempt
+                .ext_fields()
+                .and_then(|fields| fields.get(&retry_key))
+                .map(CheetahString::as_str),
+            Some(retry_value.as_str())
+        );
+        assert!(retry_request.is_consumed());
+    }
+
+    #[test]
+    fn async_retry_request_consumes_immediate_final_attempt_without_clone_template() {
+        let mut request = RemotingCommand::create_request_command(RequestCode::SendMessageV2, EmptyHeader {})
+            .set_body(bytes::Bytes::from_static(b"single-attempt-body"));
+        let initial_opaque = RemotingCommand::create_new_request_id();
+        request.set_opaque_mut(initial_opaque);
+
+        let mut retry_request = AsyncRetryRequest::new(request);
+        let attempt = retry_request.next_attempt(false);
+
+        assert_eq!(attempt.opaque(), initial_opaque);
+        assert_eq!(
+            attempt.body().map(bytes::Bytes::as_ref),
+            Some(b"single-attempt-body".as_slice())
+        );
+        assert!(retry_request.is_consumed());
     }
 }

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -6567,6 +6567,7 @@ mod tests {
 
     use rocketmq_common::common::lite::LiteSubscriptionAction;
     use rocketmq_remoting::protocol::command_custom_header::CommandCustomHeader;
+    use rocketmq_remoting::protocol::command_custom_header::FromMap;
     use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
 
     use super::*;
@@ -6582,6 +6583,33 @@ mod tests {
             MessageQueue::from_parts("topicA", "broker-b", 1),
         ];
         info
+    }
+
+    #[derive(Debug)]
+    struct AsyncRetryTestHeader {
+        retry_marker: CheetahString,
+    }
+
+    impl CommandCustomHeader for AsyncRetryTestHeader {
+        fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+            Some(HashMap::from([(
+                CheetahString::from_static_str("retryMarker"),
+                self.retry_marker.clone(),
+            )]))
+        }
+    }
+
+    impl FromMap for AsyncRetryTestHeader {
+        type Error = rocketmq_error::RocketMQError;
+        type Target = Self;
+
+        fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self, Self::Error> {
+            let retry_marker = map
+                .get(&CheetahString::from_static_str("retryMarker"))
+                .cloned()
+                .ok_or_else(|| rocketmq_error::RocketMQError::illegal_argument("missing retryMarker test header"))?;
+            Ok(Self { retry_marker })
+        }
     }
 
     struct DropFlag(Arc<AtomicBool>);
@@ -7548,6 +7576,49 @@ mod tests {
             attempt.body().map(bytes::Bytes::as_ref),
             Some(b"single-attempt-body".as_slice())
         );
+        assert!(retry_request.is_consumed());
+    }
+
+    #[test]
+    fn async_retry_request_materializes_custom_header_for_clone_and_final_attempt() {
+        let header_value = CheetahString::from_static_str("retry-header-value");
+        let request = RemotingCommand::create_request_command(
+            RequestCode::SendMessageV2,
+            AsyncRetryTestHeader {
+                retry_marker: header_value.clone(),
+            },
+        );
+
+        let mut retry_request = AsyncRetryRequest::new(request);
+        let first_attempt = retry_request.next_attempt(true);
+
+        assert_eq!(
+            first_attempt
+                .ext_fields()
+                .and_then(|fields| fields.get(&CheetahString::from_static_str("retryMarker")))
+                .map(CheetahString::as_str),
+            Some(header_value.as_str())
+        );
+        let decoded_first = first_attempt
+            .decode_command_custom_header::<AsyncRetryTestHeader>()
+            .expect("materialized custom header should decode from cloned retry attempt");
+        assert_eq!(decoded_first.retry_marker.as_str(), header_value.as_str());
+        assert!(!retry_request.is_consumed());
+
+        retry_request.set_retry_opaque(RemotingCommand::create_new_request_id());
+        let final_attempt = retry_request.next_attempt(false);
+
+        assert_eq!(
+            final_attempt
+                .ext_fields()
+                .and_then(|fields| fields.get(&CheetahString::from_static_str("retryMarker")))
+                .map(CheetahString::as_str),
+            Some(header_value.as_str())
+        );
+        let decoded_final = final_attempt
+            .decode_command_custom_header::<AsyncRetryTestHeader>()
+            .expect("materialized custom header should decode from final retry attempt");
+        assert_eq!(decoded_final.retry_marker.as_str(), header_value.as_str());
         assert!(retry_request.is_consumed());
     }
 }

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -919,10 +919,11 @@ impl RemotingCommand {
         }
     }
 
-    pub fn read_custom_header_mut_from_ref<T>(&self) -> Option<&mut T>
+    pub fn read_custom_header_mut_from_ref<T>(&mut self) -> Option<&mut T>
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
+        self.custom_header_to_net = false;
         match self.command_custom_header.as_ref() {
             None => None,
             Some(value) => value.mut_from_ref().as_any_mut().downcast_mut::<T>(),
@@ -1177,6 +1178,28 @@ mod tests {
         );
         let decoded = command.decode_command_custom_header::<TestCustomHeader>().unwrap();
         assert_eq!(decoded.value, 7);
+    }
+
+    #[test]
+    fn read_custom_header_mut_from_ref_invalidates_materialized_ext_fields() {
+        let mut command = RemotingCommand::create_request_command(1, TestCustomHeader { value: 7 });
+        command.materialize_custom_header_to_ext_fields();
+
+        let header = command
+            .read_custom_header_mut_from_ref::<TestCustomHeader>()
+            .expect("test header should be available");
+        header.value = 9;
+        command.make_custom_header_to_net();
+
+        assert_eq!(
+            command
+                .ext_fields()
+                .and_then(|fields| fields.get(&CheetahString::from_static_str("value")))
+                .map(CheetahString::as_str),
+            Some("9")
+        );
+        let decoded = command.decode_command_custom_header::<TestCustomHeader>().unwrap();
+        assert_eq!(decoded.value, 9);
     }
 
     #[test]

--- a/rocketmq-remoting/src/protocol/remoting_command.rs
+++ b/rocketmq-remoting/src/protocol/remoting_command.rs
@@ -93,6 +93,8 @@ pub struct RemotingCommand {
     suspended: bool,
     #[serde(skip)]
     command_custom_header: Option<ArcMut<Box<dyn CommandCustomHeader + Send + Sync + 'static>>>,
+    #[serde(skip)]
+    custom_header_to_net: bool,
     #[serde(rename = "serializeTypeCurrentRPC")]
     serialize_type: SerializeType,
 }
@@ -110,6 +112,7 @@ impl Clone for RemotingCommand {
             body: self.body.clone(),
             suspended: self.suspended,
             command_custom_header: self.command_custom_header.clone(),
+            custom_header_to_net: self.custom_header_to_net,
             serialize_type: self.serialize_type,
         }
     }
@@ -147,6 +150,7 @@ impl Default for RemotingCommand {
             body: None,
             suspended: false,
             command_custom_header: None,
+            custom_header_to_net: false,
             serialize_type: *SERIALIZE_TYPE_CONFIG_IN_THIS_SERVER,
         }
     }
@@ -209,6 +213,7 @@ impl RemotingCommand {
         T: CommandCustomHeader + Sync + Send + 'static,
     {
         self.command_custom_header = Some(ArcMut::new(Box::new(command_custom_header)));
+        self.custom_header_to_net = false;
         self
     }
 
@@ -217,6 +222,7 @@ impl RemotingCommand {
         command_custom_header: Option<ArcMut<Box<dyn CommandCustomHeader + Send + Sync + 'static>>>,
     ) -> Self {
         self.command_custom_header = command_custom_header;
+        self.custom_header_to_net = false;
         self
     }
 
@@ -225,6 +231,7 @@ impl RemotingCommand {
         T: CommandCustomHeader + Sync + Send + 'static,
     {
         self.command_custom_header = Some(ArcMut::new(Box::new(command_custom_header)));
+        self.custom_header_to_net = false;
     }
 
     pub fn set_code(mut self, code: impl Into<i32>) -> Self {
@@ -297,6 +304,7 @@ impl RemotingCommand {
     #[inline]
     pub fn set_ext_fields(mut self, ext_fields: HashMap<CheetahString, CheetahString>) -> Self {
         self.ext_fields = Some(ext_fields);
+        self.custom_header_to_net = false;
         self
     }
 
@@ -426,6 +434,10 @@ impl RemotingCommand {
     /// Convert custom header to network format (merge into ext_fields)
     #[inline]
     pub fn make_custom_header_to_net(&mut self) {
+        if self.custom_header_to_net {
+            return;
+        }
+
         if let Some(header) = &self.command_custom_header {
             if let Some(header_map) = header.to_map() {
                 match &mut self.ext_fields {
@@ -441,6 +453,12 @@ impl RemotingCommand {
                 }
             }
         }
+        self.custom_header_to_net = true;
+    }
+
+    #[inline]
+    pub fn materialize_custom_header_to_ext_fields(&mut self) {
+        self.make_custom_header_to_net();
     }
 
     #[inline]
@@ -894,6 +912,7 @@ impl RemotingCommand {
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
+        self.custom_header_to_net = false;
         match self.command_custom_header.as_mut() {
             None => None,
             Some(value) => value.as_mut().as_any_mut().downcast_mut::<T>(),
@@ -914,6 +933,7 @@ impl RemotingCommand {
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
+        self.custom_header_to_net = false;
         match self.command_custom_header.as_mut() {
             None => Err(Self::custom_header_missing_error::<T>()),
             Some(value) => value
@@ -939,6 +959,7 @@ impl RemotingCommand {
     }
 
     pub fn command_custom_header_mut(&mut self) -> Option<&mut dyn CommandCustomHeader> {
+        self.custom_header_to_net = false;
         match self.command_custom_header.as_mut() {
             None => None,
             Some(value) => Some(value.as_mut().as_mut()),
@@ -1042,7 +1063,30 @@ mod tests {
 
     impl CommandCustomHeader for TestCustomHeader {
         fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
-            Some(HashMap::new())
+            Some(HashMap::from([(
+                CheetahString::from_static_str("value"),
+                CheetahString::from_string(self.value.to_string()),
+            )]))
+        }
+    }
+
+    impl FromMap for TestCustomHeader {
+        type Error = rocketmq_error::RocketMQError;
+        type Target = Self;
+
+        fn from(map: &HashMap<CheetahString, CheetahString>) -> Result<Self, Self::Error> {
+            let value = map
+                .get(&CheetahString::from_static_str("value"))
+                .ok_or_else(|| {
+                    rocketmq_error::RocketMQError::illegal_argument("missing value test custom header field")
+                })?
+                .parse::<i32>()
+                .map_err(|error| {
+                    rocketmq_error::RocketMQError::illegal_argument(format!(
+                        "invalid value test custom header field: {error}"
+                    ))
+                })?;
+            Ok(Self { value })
         }
     }
 
@@ -1115,6 +1159,24 @@ mod tests {
 
         let header = command.try_read_custom_header_ref::<TestCustomHeader>().unwrap();
         assert_eq!(header.value, 9);
+    }
+
+    #[test]
+    fn materialize_custom_header_to_ext_fields_keeps_header_decodable_and_header_object_visible() {
+        let mut command = RemotingCommand::create_request_command(1, TestCustomHeader { value: 7 });
+
+        command.materialize_custom_header_to_ext_fields();
+
+        assert!(command.command_custom_header_ref().is_some());
+        assert_eq!(
+            command
+                .ext_fields()
+                .and_then(|fields| fields.get(&CheetahString::from_static_str("value")))
+                .map(CheetahString::as_str),
+            Some("7")
+        );
+        let decoded = command.decode_command_custom_header::<TestCustomHeader>().unwrap();
+        assert_eq!(decoded.value, 7);
     }
 
     #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7604

### Brief Description

This PR optimizes async send retry request preparation:

- Adds `AsyncRetryRequest` so async retry clones the request only while another retry may still be needed and moves the final attempt request directly.
- Adds `RemotingCommand::materialize_custom_header_to_ext_fields()` plus an internal materialization flag, preserving the custom header object for hook compatibility while avoiding repeated custom-header expansion.
- Updates async retry to refresh only the request opaque between retry attempts.
- Adds focused tests for retry request body/ext fields/opaque preservation and custom-header materialization compatibility.
- Adds Criterion coverage for async retry request preparation across no-body, small-body, large-body, and many-ext-fields cases.

Latest `client_send_pipeline/async_retry_request_reuse` Criterion mean results:

| Case | clone_every_attempt | reuse_final_attempt | Improvement |
| --- | ---: | ---: | ---: |
| `no_body_no_ext` | 1,651.59 ns | 1,103.15 ns | 33.21% |
| `small_body` | 2,169.71 ns | 1,381.33 ns | 36.34% |
| `large_body` | 2,793.57 ns | 2,295.34 ns | 17.83% |
| `many_ext_fields` | 8,456.33 ns | 7,288.05 ns | 13.82% |

### How Did You Test This Change?

Passed:

- `cargo fmt --all`
- `cargo test -p rocketmq-client-rust --lib async_retry`
- `cargo test -p rocketmq-remoting --lib materialize_custom_header_to_ext_fields`
- `cargo bench -p rocketmq-client-rust --bench client_send_pipeline_benchmark -- async_retry_request_reuse --test`
- `cargo bench -p rocketmq-client-rust --bench client_send_pipeline_benchmark`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `(rocketmq-dashboard/rocketmq-dashboard-web/backend) cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings && cargo build --all-targets --all-features`

Known pre-existing standalone validation failures:

- `(rocketmq-example) cargo fmt --all && cargo clippy --all-targets -- -D warnings` fails because `ScheduledTaskManager::new_legacy_compatibility` is not found in `rocketmq-client/src/factory/mq_client_instance.rs:302`.
- `(rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri) cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings` fails for the same `ScheduledTaskManager::new_legacy_compatibility` issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved async message retry handling to reuse request data more efficiently across retry attempts.
  * Added support for materializing request headers into fields used for transmission.

* **Bug Fixes**
  * Retry requests now preserve body and header values consistently across attempts.
  * Updated request encoding so custom header changes are reflected correctly before sending.
  * Added validation coverage for retry behavior and request field materialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->