### PR TITLE
[ISSUE #7610]✨Consolidate pull delayed scheduler

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -152,6 +152,10 @@ name    = "pull_message_service_lifecycle_bench"
 harness = false
 
 [[bench]]
+name    = "client_pull_scheduler_benchmark"
+harness = false
+
+[[bench]]
 name    = "rebalance_service_lifecycle_bench"
 harness = false
 

--- a/rocketmq-client/benches/client_pull_scheduler_benchmark.rs
+++ b/rocketmq-client/benches/client_pull_scheduler_benchmark.rs
@@ -1,0 +1,194 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use rocketmq_client_rust::consumer::consumer_impl::pull_message_service::PullMessageService;
+use serde::Serialize;
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc;
+use tokio::time::Instant as TokioInstant;
+
+#[derive(Debug, Serialize)]
+struct PullSchedulerBenchOutput {
+    request_count: usize,
+    submitted_tasks: usize,
+    p99_late_us: u128,
+}
+
+fn p99(mut values: Vec<u128>) -> u128 {
+    values.sort_unstable();
+    let index = values.len().saturating_mul(99).div_ceil(100).saturating_sub(1);
+    values[index]
+}
+
+async fn run_one_shot_sleep_tasks(request_count: usize, delay: Duration) -> PullSchedulerBenchOutput {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    for _ in 0..request_count {
+        let tx = tx.clone();
+        let deadline = TokioInstant::now() + delay;
+        tokio::spawn(async move {
+            tokio::time::sleep_until(deadline).await;
+            let late_us = TokioInstant::now()
+                .checked_duration_since(deadline)
+                .unwrap_or_default()
+                .as_micros();
+            let _ = tx.send(late_us);
+        });
+    }
+    drop(tx);
+
+    let mut late_us = Vec::with_capacity(request_count);
+    while let Some(value) = rx.recv().await {
+        late_us.push(value);
+        if late_us.len() == request_count {
+            break;
+        }
+    }
+
+    PullSchedulerBenchOutput {
+        request_count,
+        submitted_tasks: request_count,
+        p99_late_us: p99(late_us),
+    }
+}
+
+async fn run_shared_scheduler_tasks(request_count: usize, delay: Duration) -> PullSchedulerBenchOutput {
+    let service = PullMessageService::new();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    for _ in 0..request_count {
+        let tx = tx.clone();
+        let deadline = TokioInstant::now() + delay;
+        service.execute_task_later(
+            move || {
+                let late_us = TokioInstant::now()
+                    .checked_duration_since(deadline)
+                    .unwrap_or_default()
+                    .as_micros();
+                let _ = tx.send(late_us);
+            },
+            delay.as_millis() as u64,
+        );
+    }
+    drop(tx);
+
+    let mut late_us = Vec::with_capacity(request_count);
+    while let Some(value) = rx.recv().await {
+        late_us.push(value);
+        if late_us.len() == request_count {
+            break;
+        }
+    }
+
+    let snapshot = service.delayed_scheduler_snapshot();
+    service
+        .shutdown(1_000)
+        .await
+        .expect("shared scheduler benchmark service should shutdown");
+
+    PullSchedulerBenchOutput {
+        request_count,
+        submitted_tasks: snapshot.scheduler_task_count,
+        p99_late_us: p99(late_us),
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("rocketmq-client should live below workspace root")
+        .to_path_buf()
+}
+
+fn benchmark_artifact_dir() -> PathBuf {
+    workspace_root().join("target/runtime-baseline/prototype")
+}
+
+fn write_pull_scheduler_report_artifact(runtime: &Runtime) {
+    let request_count = 1000usize;
+    let delay = Duration::from_millis(20);
+    let one_shot = runtime.block_on(run_one_shot_sleep_tasks(request_count, delay));
+    let shared_scheduler = runtime.block_on(run_shared_scheduler_tasks(request_count, delay));
+    let output_dir = benchmark_artifact_dir();
+    std::fs::create_dir_all(&output_dir).expect("pull scheduler benchmark artifact directory should be created");
+
+    let generated_at_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_millis();
+    let payload = serde_json::json!({
+        "case": "client_pull_scheduler_delayed_1000",
+        "generated_at_unix_ms": generated_at_unix_ms,
+        "one_shot_sleep_tasks": one_shot,
+        "shared_scheduler": shared_scheduler,
+    });
+    let path = output_dir.join("client-pull-scheduler-report.json");
+    std::fs::write(
+        path,
+        serde_json::to_vec_pretty(&payload).expect("pull scheduler artifact should serialize"),
+    )
+    .expect("pull scheduler artifact should be written");
+}
+
+fn bench_pull_scheduler(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("pull scheduler benchmark runtime should start");
+    write_pull_scheduler_report_artifact(&runtime);
+
+    let mut group = c.benchmark_group("client_pull_scheduler/delayed_1000");
+    let request_count = 1000usize;
+    let delay = Duration::from_millis(20);
+    group.throughput(Throughput::Elements(request_count as u64));
+
+    for (label, shared_scheduler) in [("OneShotSleepTasks", false), ("SharedScheduler", true)] {
+        group.bench_with_input(
+            BenchmarkId::new(label, request_count),
+            &(request_count, shared_scheduler),
+            |bencher, &(request_count, shared_scheduler)| {
+                bencher.to_async(&runtime).iter(|| async move {
+                    let output = if shared_scheduler {
+                        run_shared_scheduler_tasks(request_count, delay).await
+                    } else {
+                        run_one_shot_sleep_tasks(request_count, delay).await
+                    };
+                    assert_eq!(output.request_count, request_count);
+                    black_box(output.submitted_tasks);
+                    black_box(output.p99_late_us);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(1));
+    targets = bench_pull_scheduler
+}
+criterion_main!(benches);

--- a/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BinaryHeap;
 use std::future::Future;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -24,6 +28,8 @@ use rocketmq_error::RocketMQError;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::Shutdown;
 use serde::Serialize;
+use tokio::sync::mpsc;
+use tokio::time::Instant as TokioInstant;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::error;
@@ -44,6 +50,9 @@ const DEFAULT_QUEUE_CAPACITY: usize = 4096;
 
 /// Default shutdown timeout in milliseconds
 const DEFAULT_SHUTDOWN_TIMEOUT_MS: u64 = 1000;
+
+type BoxedMessageRequest = Box<dyn MessageRequest + Send + 'static>;
+type MessageRequestSender = tokio::sync::mpsc::Sender<BoxedMessageRequest>;
 
 /// RocketMQ Consumer Pull Message Service
 ///
@@ -77,11 +86,17 @@ pub struct PullMessageService {
     /// Main service loop task handle
     main_task_handle: Arc<tokio::sync::Mutex<Option<ClientTrackedTaskHandle>>>,
 
-    /// Tracks delayed one-shot tasks submitted by execute_*_later APIs.
+    /// Tracks the shared delayed scheduler and immediate generic tasks.
     scheduled_task_tracker: TaskTracker,
 
-    /// Cancels delayed one-shot tasks during shutdown.
+    /// Cancels delayed scheduler and tracked generic tasks during shutdown.
     scheduled_task_shutdown: CancellationToken,
+
+    /// Shared delayed scheduler command channel.
+    delayed_scheduler_tx: Arc<StdMutex<Option<mpsc::UnboundedSender<DelayedScheduleCommand>>>>,
+
+    /// Shared delayed scheduler metrics.
+    delayed_scheduler_metrics: Arc<DelayedSchedulerMetrics>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -90,6 +105,251 @@ pub struct PullMessageServiceLifecycleProbe {
     pub task_count_before_shutdown: usize,
     pub task_count_after_shutdown: usize,
     pub shutdown_elapsed_us: u128,
+    pub delayed_scheduler: PullMessageServiceDelayedSchedulerSnapshot,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct PullMessageServiceDelayedSchedulerSnapshot {
+    pub queue_depth: usize,
+    pub submitted_count: u64,
+    pub expired_count: u64,
+    pub cancelled_count: u64,
+    pub scheduler_task_count: usize,
+}
+
+#[derive(Default)]
+struct DelayedSchedulerMetrics {
+    queue_depth: AtomicUsize,
+    submitted_count: AtomicU64,
+    expired_count: AtomicU64,
+    cancelled_count: AtomicU64,
+    scheduler_running: AtomicBool,
+}
+
+impl DelayedSchedulerMetrics {
+    fn record_submitted(&self) {
+        self.submitted_count.fetch_add(1, Ordering::Relaxed);
+        self.queue_depth.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_expired(&self) {
+        self.expired_count.fetch_add(1, Ordering::Relaxed);
+        self.decrement_depth(1);
+    }
+
+    fn record_cancelled(&self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        self.cancelled_count.fetch_add(count as u64, Ordering::Relaxed);
+        self.decrement_depth(count);
+    }
+
+    fn decrement_depth(&self, count: usize) {
+        let _ = self
+            .queue_depth
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                Some(current.saturating_sub(count))
+            });
+    }
+
+    fn snapshot(&self) -> PullMessageServiceDelayedSchedulerSnapshot {
+        PullMessageServiceDelayedSchedulerSnapshot {
+            queue_depth: self.queue_depth.load(Ordering::Relaxed),
+            submitted_count: self.submitted_count.load(Ordering::Relaxed),
+            expired_count: self.expired_count.load(Ordering::Relaxed),
+            cancelled_count: self.cancelled_count.load(Ordering::Relaxed),
+            scheduler_task_count: usize::from(self.scheduler_running.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+struct DelayedScheduleCommand {
+    deadline: TokioInstant,
+    payload: DelayedSchedulePayload,
+}
+
+enum DelayedSchedulePayload {
+    Pull {
+        request: PullRequest,
+        tx: Option<MessageRequestSender>,
+    },
+    Pop {
+        request: PopRequest,
+        tx: Option<MessageRequestSender>,
+    },
+    Task(Box<dyn FnOnce() + Send + 'static>),
+}
+
+impl DelayedSchedulePayload {
+    async fn execute(self, stopped: &AtomicBool) {
+        if stopped.load(Ordering::Acquire) {
+            return;
+        }
+
+        match self {
+            Self::Pull { request, tx } => {
+                if let Some(tx) = tx {
+                    if let Err(error) = tx.send(Box::new(request)).await {
+                        warn!("Failed to send pull request: {:?}", error);
+                    }
+                }
+            }
+            Self::Pop { request, tx } => {
+                if let Some(tx) = tx {
+                    if let Err(error) = tx.send(Box::new(request)).await {
+                        warn!("Failed to send pop request: {:?}", error);
+                    }
+                }
+            }
+            Self::Task(task) => task(),
+        }
+    }
+}
+
+struct DelayedQueueEntry {
+    deadline: TokioInstant,
+    sequence: u64,
+    payload: DelayedSchedulePayload,
+}
+
+impl PartialEq for DelayedQueueEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.deadline == other.deadline && self.sequence == other.sequence
+    }
+}
+
+impl Eq for DelayedQueueEntry {}
+
+impl Ord for DelayedQueueEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        other
+            .deadline
+            .cmp(&self.deadline)
+            .then_with(|| other.sequence.cmp(&self.sequence))
+    }
+}
+
+impl PartialOrd for DelayedQueueEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+struct DelayedSchedulerRunningGuard {
+    metrics: Arc<DelayedSchedulerMetrics>,
+}
+
+impl DelayedSchedulerRunningGuard {
+    fn new(metrics: Arc<DelayedSchedulerMetrics>) -> Self {
+        metrics.scheduler_running.store(true, Ordering::Release);
+        Self { metrics }
+    }
+}
+
+impl Drop for DelayedSchedulerRunningGuard {
+    fn drop(&mut self) {
+        self.metrics.scheduler_running.store(false, Ordering::Release);
+    }
+}
+
+async fn run_delayed_scheduler(
+    mut rx: mpsc::UnboundedReceiver<DelayedScheduleCommand>,
+    shutdown_token: CancellationToken,
+    stopped: Arc<AtomicBool>,
+    metrics: Arc<DelayedSchedulerMetrics>,
+) {
+    let _running = DelayedSchedulerRunningGuard::new(metrics.clone());
+    let mut delayed_queue = BinaryHeap::new();
+    let mut sequence = 0u64;
+
+    loop {
+        if shutdown_token.is_cancelled() {
+            cancel_delayed_queue(&mut delayed_queue, &mut rx, &metrics);
+            break;
+        }
+
+        match delayed_queue.peek().map(|entry: &DelayedQueueEntry| entry.deadline) {
+            Some(deadline) if deadline <= TokioInstant::now() => {
+                drain_expired_delayed_requests(&mut delayed_queue, &stopped, &metrics).await;
+            }
+            Some(deadline) => {
+                tokio::select! {
+                    biased;
+                    _ = tokio::time::sleep_until(deadline) => {
+                        drain_expired_delayed_requests(&mut delayed_queue, &stopped, &metrics).await;
+                    }
+                    command = rx.recv() => {
+                        if let Some(command) = command {
+                            push_delayed_command(&mut delayed_queue, command, &mut sequence);
+                        } else {
+                            cancel_delayed_queue(&mut delayed_queue, &mut rx, &metrics);
+                            break;
+                        }
+                    }
+                    _ = shutdown_token.cancelled() => {
+                        cancel_delayed_queue(&mut delayed_queue, &mut rx, &metrics);
+                        break;
+                    }
+                }
+            }
+            None => {
+                tokio::select! {
+                    command = rx.recv() => {
+                        if let Some(command) = command {
+                            push_delayed_command(&mut delayed_queue, command, &mut sequence);
+                        } else {
+                            cancel_delayed_queue(&mut delayed_queue, &mut rx, &metrics);
+                            break;
+                        }
+                    }
+                    _ = shutdown_token.cancelled() => {
+                        cancel_delayed_queue(&mut delayed_queue, &mut rx, &metrics);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn push_delayed_command(
+    delayed_queue: &mut BinaryHeap<DelayedQueueEntry>,
+    command: DelayedScheduleCommand,
+    sequence: &mut u64,
+) {
+    delayed_queue.push(DelayedQueueEntry {
+        deadline: command.deadline,
+        sequence: *sequence,
+        payload: command.payload,
+    });
+    *sequence = sequence.wrapping_add(1);
+}
+
+async fn drain_expired_delayed_requests(
+    delayed_queue: &mut BinaryHeap<DelayedQueueEntry>,
+    stopped: &AtomicBool,
+    metrics: &DelayedSchedulerMetrics,
+) {
+    let now = TokioInstant::now();
+    while delayed_queue.peek().is_some_and(|entry| entry.deadline <= now) {
+        let entry = delayed_queue.pop().expect("entry should exist after peek");
+        metrics.record_expired();
+        entry.payload.execute(stopped).await;
+    }
+}
+
+fn cancel_delayed_queue(
+    delayed_queue: &mut BinaryHeap<DelayedQueueEntry>,
+    rx: &mut mpsc::UnboundedReceiver<DelayedScheduleCommand>,
+    metrics: &DelayedSchedulerMetrics,
+) {
+    let mut cancelled = delayed_queue.len();
+    delayed_queue.clear();
+    while rx.try_recv().is_ok() {
+        cancelled += 1;
+    }
+    metrics.record_cancelled(cancelled);
 }
 
 impl PullMessageService {
@@ -108,6 +368,8 @@ impl PullMessageService {
             main_task_handle: Arc::new(tokio::sync::Mutex::new(None)),
             scheduled_task_tracker: TaskTracker::new(),
             scheduled_task_shutdown: CancellationToken::new(),
+            delayed_scheduler_tx: Arc::new(StdMutex::new(None)),
+            delayed_scheduler_metrics: Arc::new(DelayedSchedulerMetrics::default()),
         }
     }
 
@@ -178,6 +440,61 @@ impl PullMessageService {
             .unwrap_or_default()
     }
 
+    pub fn delayed_scheduler_snapshot(&self) -> PullMessageServiceDelayedSchedulerSnapshot {
+        self.delayed_scheduler_metrics.snapshot()
+    }
+
+    fn submit_delayed(&self, payload: DelayedSchedulePayload, time_delay: u64) {
+        self.delayed_scheduler_metrics.record_submitted();
+        let Some(tx) = self.ensure_delayed_scheduler_started() else {
+            self.delayed_scheduler_metrics.record_cancelled(1);
+            return;
+        };
+
+        if tx
+            .send(DelayedScheduleCommand {
+                deadline: TokioInstant::now() + Duration::from_millis(time_delay),
+                payload,
+            })
+            .is_err()
+        {
+            self.delayed_scheduler_metrics.record_cancelled(1);
+        }
+    }
+
+    fn ensure_delayed_scheduler_started(&self) -> Option<mpsc::UnboundedSender<DelayedScheduleCommand>> {
+        if self.scheduled_task_shutdown.is_cancelled() {
+            return None;
+        }
+
+        let mut guard = self
+            .delayed_scheduler_tx
+            .lock()
+            .expect("delayed scheduler sender lock should not be poisoned");
+        if let Some(tx) = guard.as_ref() {
+            return Some(tx.clone());
+        }
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        let tracked_task = self.scheduled_task_tracker.track_future(run_delayed_scheduler(
+            rx,
+            self.scheduled_task_shutdown.clone(),
+            self.stopped.clone(),
+            self.delayed_scheduler_metrics.clone(),
+        ));
+
+        match spawn_client_task("rocketmq-client-pull-delayed-scheduler", tracked_task) {
+            Ok(_) => {
+                *guard = Some(tx.clone());
+                Some(tx)
+            }
+            Err(error) => {
+                error!("Failed to spawn PullMessageService delayed scheduler: {}", error);
+                None
+            }
+        }
+    }
+
     /// Processes a message request (Pull or Pop)
     ///
     /// # Arguments
@@ -244,26 +561,12 @@ impl PullMessageService {
             return;
         }
 
-        let this = self.clone();
-        let request = pull_request.clone();
-
-        spawn_scheduled_pull_message_task(
-            "rocketmq-client-pull-request-delay",
-            &self.scheduled_task_tracker,
-            &self.scheduled_task_shutdown,
-            async move {
-                tokio::time::sleep(Duration::from_millis(time_delay)).await;
-
-                if this.is_stopped() {
-                    return;
-                }
-
-                if let Some(tx) = &this.tx {
-                    if let Err(e) = tx.send(Box::new(request)).await {
-                        warn!("Failed to send pull request: {:?}", e);
-                    }
-                }
+        self.submit_delayed(
+            DelayedSchedulePayload::Pull {
+                request: pull_request,
+                tx: self.tx.clone(),
             },
+            time_delay,
         );
     }
 
@@ -296,26 +599,12 @@ impl PullMessageService {
             return;
         }
 
-        let this = self.clone();
-        let request = pop_request.clone();
-
-        spawn_scheduled_pull_message_task(
-            "rocketmq-client-pop-request-delay",
-            &self.scheduled_task_tracker,
-            &self.scheduled_task_shutdown,
-            async move {
-                tokio::time::sleep(Duration::from_millis(time_delay)).await;
-
-                if this.is_stopped() {
-                    return;
-                }
-
-                if let Some(tx) = &this.tx {
-                    if let Err(e) = tx.send(Box::new(request)).await {
-                        warn!("Failed to send pop request: {:?}", e);
-                    }
-                }
+        self.submit_delayed(
+            DelayedSchedulePayload::Pop {
+                request: pop_request,
+                tx: self.tx.clone(),
             },
+            time_delay,
         );
     }
 
@@ -352,19 +641,7 @@ impl PullMessageService {
             return;
         }
 
-        let stopped = self.stopped.clone();
-        spawn_scheduled_pull_message_task(
-            "rocketmq-client-pull-task-delay",
-            &self.scheduled_task_tracker,
-            &self.scheduled_task_shutdown,
-            async move {
-                tokio::time::sleep(Duration::from_millis(time_delay)).await;
-                if stopped.load(Ordering::Acquire) {
-                    return;
-                }
-                task();
-            },
-        );
+        self.submit_delayed(DelayedSchedulePayload::Task(Box::new(task)), time_delay);
     }
 
     /// Executes a generic task immediately (equivalent to Java's executeTask)
@@ -408,6 +685,10 @@ impl PullMessageService {
         // 1. Set stopped flag
         self.stopped.store(true, Ordering::Release);
         self.scheduled_task_shutdown.cancel();
+        self.delayed_scheduler_tx
+            .lock()
+            .expect("delayed scheduler sender lock should not be poisoned")
+            .take();
 
         // 2. Send shutdown signal
         if let Some(tx_shutdown) = &self.tx_shutdown {
@@ -470,6 +751,7 @@ pub async fn run_pull_message_service_lifecycle_probe() -> PullMessageServiceLif
     let shutdown_result = service.shutdown(1_000).await;
     let shutdown_elapsed_us = shutdown_started.elapsed().as_micros();
     let task_count_after_shutdown = service.main_task_count().await;
+    let delayed_scheduler = service.delayed_scheduler_snapshot();
 
     instance.shutdown().await;
 
@@ -481,6 +763,7 @@ pub async fn run_pull_message_service_lifecycle_probe() -> PullMessageServiceLif
         task_count_before_shutdown,
         task_count_after_shutdown,
         shutdown_elapsed_us,
+        delayed_scheduler,
     }
 }
 

--- a/rocketmq-client/tests/pull_message_service_test.rs
+++ b/rocketmq-client/tests/pull_message_service_test.rs
@@ -24,6 +24,7 @@
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
@@ -175,6 +176,36 @@ async fn test_delayed_task_cancelled_after_shutdown() {
 }
 
 #[tokio::test]
+async fn test_delayed_requests_use_single_scheduler_task() {
+    let mut service = PullMessageService::new();
+    let instance = create_mock_client_instance();
+    service.start(instance).await.unwrap();
+
+    for i in 0..1000 {
+        let pull_request = create_test_pull_request(&format!("group_{}", i % 10), &format!("topic_{}", i % 5));
+        service.execute_pull_request_later(pull_request, 60_000);
+    }
+
+    let mut snapshot = service.delayed_scheduler_snapshot();
+    for _ in 0..100 {
+        if snapshot.scheduler_task_count == 1 && snapshot.queue_depth == 1000 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        snapshot = service.delayed_scheduler_snapshot();
+    }
+
+    assert_eq!(snapshot.submitted_count, 1000);
+    assert_eq!(snapshot.queue_depth, 1000);
+    assert_eq!(snapshot.scheduler_task_count, 1);
+
+    service.shutdown(1000).await.unwrap();
+    let snapshot = service.delayed_scheduler_snapshot();
+    assert_eq!(snapshot.queue_depth, 0);
+    assert_eq!(snapshot.cancelled_count, 1000);
+}
+
+#[tokio::test]
 async fn test_execute_task() {
     let mut service = PullMessageService::new();
     let instance = create_mock_client_instance();
@@ -217,6 +248,47 @@ async fn test_execute_task_later() {
     // Wait for delayed execution
     tokio::time::sleep(Duration::from_millis(150)).await;
     assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+    service.shutdown(1000).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_delayed_tasks_with_same_deadline_keep_insert_order() {
+    let service = PullMessageService::new();
+    let observed = Arc::new(StdMutex::new(Vec::new()));
+
+    for index in 0..8 {
+        let observed = observed.clone();
+        service.execute_task_later(
+            move || {
+                observed
+                    .lock()
+                    .expect("observed order lock should not be poisoned")
+                    .push(index);
+            },
+            20,
+        );
+    }
+
+    for _ in 0..100 {
+        if observed
+            .lock()
+            .expect("observed order lock should not be poisoned")
+            .len()
+            == 8
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    assert_eq!(
+        *observed.lock().expect("observed order lock should not be poisoned"),
+        (0..8).collect::<Vec<_>>()
+    );
+    let snapshot = service.delayed_scheduler_snapshot();
+    assert_eq!(snapshot.queue_depth, 0);
+    assert_eq!(snapshot.expired_count, 8);
 
     service.shutdown(1000).await.unwrap();
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7610

### Brief Description

Replaces per-request delayed sleep tasks in `PullMessageService` with a shared delayed scheduler. Delayed pull, pop, and generic task submissions now enqueue `deadline + sequence + payload` into a single scheduler task, which waits for the nearest deadline and dispatches expired work into the existing main request path.

The change keeps immediate pull/pop APIs on the direct channel path, preserves insertion order for equal-priority delayed work, clears pending delayed work on shutdown, and exposes delayed scheduler metrics: queue depth, submitted count, expired count, cancelled count, and scheduler task count.

This PR also adds regression coverage for 1000 delayed requests and a new `client_pull_scheduler_benchmark` target comparing the old one-shot sleep model against the shared scheduler.

Latest local scheduler benchmark data for 1000 delayed tasks with 20ms delay:

| Case | Mean | p99 late | Submitted tasks |
| --- | ---: | ---: | ---: |
| One-shot sleep tasks | 31.301 ms | 16,272 us | 1000 |
| Shared scheduler | 31.094 ms | 11,092 us | 1 |

The shared scheduler reduces submitted sleeping task count by 99.9% and improves p99 late dispatch by 31.83% in this local run.

### How Did You Test This Change?

- `cargo fmt --all` - passed
- `cargo test -p rocketmq-client-rust --test pull_message_service_test` - passed, 25 tests
- `cargo test -p rocketmq-client-rust --lib pull_message_service` - passed, 5 tests
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed
- `cargo bench -p rocketmq-client-rust --bench pull_message_service_lifecycle_bench` - passed, lifecycle mean 3.565 ms and no performance change detected
- `cargo bench -p rocketmq-client-rust --bench client_pull_scheduler_benchmark` - passed, shared scheduler mean 31.094 ms vs one-shot 31.301 ms
- `cargo fmt --all` from `rocketmq-example` - passed
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example` - failed on existing shared-client compile error: `ScheduledTaskManager::new_legacy_compatibility` is missing in `rocketmq-client/src/factory/mq_client_instance.rs`
- `cargo fmt --all` from `rocketmq-dashboard/rocketmq-dashboard-web/backend` - first attempt timed out without diagnostics, rerun passed
- `cargo clippy --all-targets --all-features -- -D warnings` from `rocketmq-dashboard/rocketmq-dashboard-web/backend` - passed
- `cargo build --all-targets --all-features` from `rocketmq-dashboard/rocketmq-dashboard-web/backend` - passed
- `cargo fmt --all` from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri` - passed
- `cargo clippy --all-targets --all-features -- -D warnings` from `rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri` - failed on the same existing shared-client `ScheduledTaskManager::new_legacy_compatibility` compile error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more efficient delayed task scheduling mechanism for consumer requests, improving how delayed work is handled under load.
  * Exposed scheduler status in service diagnostics so timing and queue activity can be inspected more easily.

* **Tests**
  * Added coverage for high-volume delayed requests and same-deadline execution order to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->