### PR TITLE
[ISSUE #7628]✨Optimize client route refresh sharding

### DIFF
--- a/rocketmq-client/benches/namesrv_refresh_lifecycle_bench.rs
+++ b/rocketmq-client/benches/namesrv_refresh_lifecycle_bench.rs
@@ -23,7 +23,9 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
 use rocketmq_client_rust::run_namesrv_refresh_lifecycle_probe;
+use rocketmq_client_rust::run_route_refresh_shard_probe;
 use rocketmq_client_rust::NamesrvRefreshLifecycleProbe;
+use rocketmq_client_rust::RouteRefreshShardProbe;
 
 fn run_lifecycle_probe() -> NamesrvRefreshLifecycleProbe {
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -35,6 +37,10 @@ fn run_lifecycle_probe() -> NamesrvRefreshLifecycleProbe {
         .expect("namesrv refresh benchmark runtime should start");
 
     runtime.block_on(run_namesrv_refresh_lifecycle_probe())
+}
+
+fn run_route_refresh_probe(topic_count: usize) -> RouteRefreshShardProbe {
+    run_route_refresh_shard_probe(topic_count)
 }
 
 fn workspace_root() -> PathBuf {
@@ -51,6 +57,10 @@ fn benchmark_artifact_dir() -> PathBuf {
 fn write_namesrv_refresh_report_artifact() {
     let output = run_lifecycle_probe();
     assert!(output.healthy, "{output:?}");
+    let route_refresh_profiles = [10, 100, 1_000]
+        .into_iter()
+        .map(run_route_refresh_probe)
+        .collect::<Vec<_>>();
     let output_dir = benchmark_artifact_dir();
     fs::create_dir_all(&output_dir).expect("runtime benchmark artifact directory should be created");
 
@@ -62,6 +72,7 @@ fn write_namesrv_refresh_report_artifact() {
         "case": "client_namesrv_refresh_lifecycle",
         "generated_at_unix_ms": generated_at_unix_ms,
         "probe": output,
+        "route_refresh_profiles": route_refresh_profiles,
     });
     let path = output_dir.join("client-namesrv-refresh-lifecycle-report.json");
     fs::write(
@@ -83,6 +94,20 @@ fn bench_namesrv_refresh_lifecycle(criterion: &mut Criterion) {
             black_box(output.shutdown_elapsed_us);
         });
     });
+
+    for topic_count in [10, 100, 1_000] {
+        let bench_name = format!("client_route_refresh_shard/{topic_count}_topics");
+        criterion.bench_function(&bench_name, |bencher| {
+            bencher.iter(|| {
+                let output = run_route_refresh_probe(topic_count);
+                assert_eq!(output.topic_count, topic_count);
+                assert!(output.selected_topics <= output.batch_size);
+                black_box(output.selected_topics);
+                black_box(output.skipped_topics);
+                black_box(output.peak_topic_reduction_percent);
+            });
+        });
+    }
 }
 
 criterion_group! {

--- a/rocketmq-client/src/factory/client_tables.rs
+++ b/rocketmq-client/src/factory/client_tables.rs
@@ -21,11 +21,15 @@
 //! are defined in the `crate::types` module.
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use dashmap::DashMap;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_remoting::protocol::route::topic_route_data::TopicRouteData;
+use serde::Serialize;
 
 use crate::admin::mq_admin_ext_async_inner::MQAdminExtInnerImpl;
 use crate::consumer::mq_consumer_inner::MQConsumerInnerImpl;
@@ -52,6 +56,9 @@ pub type AdminExtTable = Arc<DashMap<AdminGroupName, MQAdminExtInnerImpl>>;
 /// Maps topic name to its routing data (broker addresses, queue configuration, etc.).
 pub type TopicRouteTable = Arc<DashMap<TopicName, TopicRouteData>>;
 
+/// Monotonic route snapshot versions, indexed by topic name.
+pub type TopicRouteVersionTable = Arc<DashMap<TopicName, u64>>;
+
 /// Topic endpoint mapping table for static topics.
 /// Maps topic name to a mapping of message queues to their broker names.
 pub type TopicEndPointsTable = Arc<DashMap<TopicName, HashMap<MessageQueue, BrokerName>>>;
@@ -73,3 +80,135 @@ pub type BrokerHeartbeatFingerprintTable = Arc<DashMap<BrokerAddr, i32>>;
 /// Set of brokers that support HeartbeatV2 protocol.
 /// Maps broker address to unit value (used as a set).
 pub type BrokerSupportV2HeartbeatSet = Arc<DashMap<BrokerAddr, ()>>;
+
+/// Shared route-refresh state used to shard periodic refreshes and expose counters.
+pub struct TopicRouteRefreshState {
+    pub periodic_cursor: AtomicUsize,
+    pub versions: TopicRouteVersionTable,
+    pub metrics: TopicRouteRefreshMetrics,
+}
+
+impl Default for TopicRouteRefreshState {
+    fn default() -> Self {
+        Self {
+            periodic_cursor: AtomicUsize::new(0),
+            versions: Arc::new(DashMap::default()),
+            metrics: TopicRouteRefreshMetrics::default(),
+        }
+    }
+}
+
+/// Atomic route refresh counters. The snapshot type below is the stable observable shape.
+pub struct TopicRouteRefreshMetrics {
+    refresh_attempts_total: AtomicU64,
+    refresh_success_total: AtomicU64,
+    refresh_skipped_total: AtomicU64,
+    refresh_failed_total: AtomicU64,
+    periodic_batches_total: AtomicU64,
+    periodic_topics_total: AtomicU64,
+    periodic_skipped_topics_total: AtomicU64,
+    last_periodic_total_topics: AtomicU64,
+    last_periodic_batch_topics: AtomicU64,
+    last_periodic_skipped_topics: AtomicU64,
+    last_periodic_elapsed_us: AtomicU64,
+    last_route_miss_elapsed_us: AtomicU64,
+}
+
+impl Default for TopicRouteRefreshMetrics {
+    fn default() -> Self {
+        Self {
+            refresh_attempts_total: AtomicU64::new(0),
+            refresh_success_total: AtomicU64::new(0),
+            refresh_skipped_total: AtomicU64::new(0),
+            refresh_failed_total: AtomicU64::new(0),
+            periodic_batches_total: AtomicU64::new(0),
+            periodic_topics_total: AtomicU64::new(0),
+            periodic_skipped_topics_total: AtomicU64::new(0),
+            last_periodic_total_topics: AtomicU64::new(0),
+            last_periodic_batch_topics: AtomicU64::new(0),
+            last_periodic_skipped_topics: AtomicU64::new(0),
+            last_periodic_elapsed_us: AtomicU64::new(0),
+            last_route_miss_elapsed_us: AtomicU64::new(0),
+        }
+    }
+}
+
+impl TopicRouteRefreshMetrics {
+    #[inline]
+    pub fn record_attempt(&self) {
+        self.refresh_attempts_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn record_success(&self) {
+        self.refresh_success_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn record_skip(&self) {
+        self.refresh_skipped_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn record_failure(&self) {
+        self.refresh_failed_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_periodic_batch(
+        &self,
+        total_topics: u64,
+        refreshed_topics: u64,
+        skipped_topics: u64,
+        elapsed_us: u64,
+    ) {
+        self.periodic_batches_total.fetch_add(1, Ordering::Relaxed);
+        self.periodic_topics_total
+            .fetch_add(refreshed_topics, Ordering::Relaxed);
+        self.periodic_skipped_topics_total
+            .fetch_add(skipped_topics, Ordering::Relaxed);
+        self.last_periodic_total_topics.store(total_topics, Ordering::Relaxed);
+        self.last_periodic_batch_topics
+            .store(refreshed_topics, Ordering::Relaxed);
+        self.last_periodic_skipped_topics
+            .store(skipped_topics, Ordering::Relaxed);
+        self.last_periodic_elapsed_us.store(elapsed_us, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn record_route_miss_elapsed(&self, elapsed_us: u64) {
+        self.last_route_miss_elapsed_us.store(elapsed_us, Ordering::Relaxed);
+    }
+
+    pub fn snapshot(&self) -> TopicRouteRefreshMetricsSnapshot {
+        TopicRouteRefreshMetricsSnapshot {
+            refresh_attempts_total: self.refresh_attempts_total.load(Ordering::Relaxed),
+            refresh_success_total: self.refresh_success_total.load(Ordering::Relaxed),
+            refresh_skipped_total: self.refresh_skipped_total.load(Ordering::Relaxed),
+            refresh_failed_total: self.refresh_failed_total.load(Ordering::Relaxed),
+            periodic_batches_total: self.periodic_batches_total.load(Ordering::Relaxed),
+            periodic_topics_total: self.periodic_topics_total.load(Ordering::Relaxed),
+            periodic_skipped_topics_total: self.periodic_skipped_topics_total.load(Ordering::Relaxed),
+            last_periodic_total_topics: self.last_periodic_total_topics.load(Ordering::Relaxed),
+            last_periodic_batch_topics: self.last_periodic_batch_topics.load(Ordering::Relaxed),
+            last_periodic_skipped_topics: self.last_periodic_skipped_topics.load(Ordering::Relaxed),
+            last_periodic_elapsed_us: self.last_periodic_elapsed_us.load(Ordering::Relaxed),
+            last_route_miss_elapsed_us: self.last_route_miss_elapsed_us.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TopicRouteRefreshMetricsSnapshot {
+    pub refresh_attempts_total: u64,
+    pub refresh_success_total: u64,
+    pub refresh_skipped_total: u64,
+    pub refresh_failed_total: u64,
+    pub periodic_batches_total: u64,
+    pub periodic_topics_total: u64,
+    pub periodic_skipped_topics_total: u64,
+    pub last_periodic_total_topics: u64,
+    pub last_periodic_batch_topics: u64,
+    pub last_periodic_skipped_topics: u64,
+    pub last_periodic_elapsed_us: u64,
+    pub last_route_miss_elapsed_us: u64,
+}

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -94,6 +94,7 @@ use crate::stat::consumer_stats_manager::ConsumerStatsManager;
 
 const LOCK_TIMEOUT_MILLIS: u64 = 3000;
 const SCHEDULED_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const ROUTE_REFRESH_MAX_TOPICS_PER_ROUND: usize = 64;
 
 fn get_topic_config_request_header(topic: CheetahString) -> GetTopicConfigRequestHeader {
     let mut request_header = GetTopicConfigRequestHeader {
@@ -238,6 +239,7 @@ pub struct MQClientInstance {
     broker_heartbeat_fingerprint_table: BrokerHeartbeatFingerprintTable,
     /// HeartbeatV2: Set of brokers that support V2 protocol
     broker_support_v2_heartbeat_set: BrokerSupportV2HeartbeatSet,
+    route_refresh_state: TopicRouteRefreshState,
     consumer_stats_manager: ConsumerStatsManager,
     connection_event_shutdown: CancellationToken,
     connection_event_task_handle: Option<ClientTrackedTaskHandle>,
@@ -251,6 +253,37 @@ pub struct ConnectionEventListenerLifecycleProbe {
     pub task_count_before_shutdown: usize,
     pub task_count_after_shutdown: usize,
     pub shutdown_elapsed_us: u128,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RouteRefreshShardProbe {
+    pub topic_count: usize,
+    pub batch_size: usize,
+    pub selected_topics: usize,
+    pub skipped_topics: usize,
+    pub peak_topic_reduction_percent: f64,
+    pub elapsed_us: u128,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RouteRefreshConcurrentProbe {
+    pub healthy: bool,
+    pub stale_skipped: bool,
+    pub final_order_topic_conf: Option<CheetahString>,
+    pub route_version: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TopicRouteRefreshKind {
+    Periodic,
+    RouteMiss,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TopicRouteApplyOutcome {
+    Applied,
+    Unchanged,
+    Stale,
 }
 
 impl MQClientInstance {
@@ -302,6 +335,7 @@ impl MQClientInstance {
             scheduled_task_manager: ScheduledTaskManager::new_legacy_compatibility(),
             broker_heartbeat_fingerprint_table,
             broker_support_v2_heartbeat_set,
+            route_refresh_state: TopicRouteRefreshState::default(),
             consumer_stats_manager: ConsumerStatsManager::new(),
             connection_event_shutdown: CancellationToken::new(),
             connection_event_task_handle: None,
@@ -548,6 +582,7 @@ impl MQClientInstance {
         self.admin_ext_table.clear();
 
         self.topic_route_table.clear();
+        self.route_refresh_state.versions.clear();
         self.topic_end_points_table.clear();
         self.broker_addr_table.clear();
         self.broker_version_table.clear();
@@ -733,21 +768,27 @@ impl MQClientInstance {
     }
 
     pub async fn update_topic_route_info_from_name_server(&mut self) {
-        let mut topic_list = HashSet::new();
+        let topic_list = self.collect_registered_route_topics();
+        let total_topics = topic_list.len();
+        let (refresh_topics, skipped_topics) = self.select_periodic_route_refresh_batch(&topic_list);
+        let started = Instant::now();
 
-        for entry in self.producer_table.iter() {
-            topic_list.extend(entry.value().get_publish_topic_list());
+        for topic in refresh_topics.iter() {
+            self.update_topic_route_info_from_name_server_default_with_kind(
+                topic,
+                false,
+                None,
+                TopicRouteRefreshKind::Periodic,
+            )
+            .await;
         }
 
-        for entry in self.consumer_table.iter() {
-            entry.value().subscriptions().iter().for_each(|sub| {
-                topic_list.insert(sub.topic.clone());
-            });
-        }
-
-        for topic in topic_list.iter() {
-            self.update_topic_route_info_from_name_server_topic(topic).await;
-        }
+        self.route_refresh_state.metrics.record_periodic_batch(
+            total_topics as u64,
+            refresh_topics.len() as u64,
+            skipped_topics as u64,
+            started.elapsed().as_micros() as u64,
+        );
     }
 
     #[inline]
@@ -826,15 +867,36 @@ impl MQClientInstance {
         is_default: bool,
         producer_config: Option<&Arc<ProducerConfig>>,
     ) -> bool {
-        let lock = self.lock_namesrv.lock().await;
-        let Some(mq_client_api_impl) = self.mq_client_api_impl.as_mut() else {
+        self.update_topic_route_info_from_name_server_default_with_kind(
+            topic,
+            is_default,
+            producer_config,
+            TopicRouteRefreshKind::RouteMiss,
+        )
+        .await
+    }
+
+    async fn update_topic_route_info_from_name_server_default_with_kind(
+        &mut self,
+        topic: &CheetahString,
+        is_default: bool,
+        producer_config: Option<&Arc<ProducerConfig>>,
+        refresh_kind: TopicRouteRefreshKind,
+    ) -> bool {
+        self.route_refresh_state.metrics.record_attempt();
+        let started = Instant::now();
+        let request_version = self.topic_route_version(topic);
+
+        let Some(mq_client_api_impl) = self.mq_client_api_impl.as_ref() else {
             error!(
                 "updateTopicRouteInfoFromNameServer skipped because mq_client_api_impl is None, Topic: {}. [{}]",
                 topic, self.client_id
             );
-            drop(lock);
+            self.record_topic_route_refresh_finish(refresh_kind, started, TopicRouteApplyOutcome::Unchanged);
+            self.route_refresh_state.metrics.record_failure();
             return false;
         };
+
         let topic_route_data = if let (true, Some(producer_config)) = (is_default, producer_config) {
             let mut result = match mq_client_api_impl
                 .get_default_topic_route_info_from_name_server(self.client_config.mq_client_api_timeout)
@@ -854,75 +916,181 @@ impl MQClientInstance {
             }
             result
         } else {
-            mq_client_api_impl
+            match mq_client_api_impl
                 .get_topic_route_info_from_name_server(topic, self.client_config.mq_client_api_timeout)
                 .await
-                .unwrap_or(None)
+            {
+                Ok(value) => value,
+                Err(error) => {
+                    warn!(
+                        "getTopicRouteInfoFromNameServer failed, topic: {}, error: {}",
+                        topic, error
+                    );
+                    None
+                }
+            }
         };
         if let Some(mut topic_route_data) = topic_route_data {
-            let old = self.topic_route_table.get(topic).map(|entry| entry.value().clone());
-            let mut changed = topic_route_data.topic_route_data_changed(old.as_ref());
-            if !changed {
-                changed = self.is_need_update_topic_route_info(topic).await;
-            } else {
-                info!(
-                    "the topic[{}] route info changed, old[{:?}] ,new[{:?}]",
-                    topic, old, topic_route_data
-                )
-            }
-            if changed {
-                for bd in topic_route_data.broker_datas.iter() {
-                    self.broker_addr_table
-                        .insert(bd.broker_name().clone(), bd.broker_addrs().clone());
+            let outcome = self
+                .apply_topic_route_data_if_fresh(topic, &mut topic_route_data, request_version)
+                .await;
+            self.record_topic_route_refresh_finish(refresh_kind, started, outcome);
+            match outcome {
+                TopicRouteApplyOutcome::Applied => {
+                    self.route_refresh_state.metrics.record_success();
+                    return true;
                 }
-
-                // Update endpoint map
-                {
-                    let mq_end_points =
-                        ClientMetadata::topic_route_data2endpoints_for_static_topic(topic, &topic_route_data);
-                    if let Some(mq_end_points) = mq_end_points {
-                        if !mq_end_points.is_empty() {
-                            self.topic_end_points_table.insert(topic.into(), mq_end_points);
-                        }
-                    }
+                TopicRouteApplyOutcome::Unchanged | TopicRouteApplyOutcome::Stale => {
+                    self.route_refresh_state.metrics.record_skip();
+                    return false;
                 }
-
-                // Update Pub info
-                {
-                    let mut publish_info = topic_route_data2topic_publish_info(topic, &mut topic_route_data);
-                    publish_info.have_topic_router_info = true;
-                    for mut entry in self.producer_table.iter_mut() {
-                        entry
-                            .value_mut()
-                            .update_topic_publish_info(topic.to_string(), Some(publish_info.clone()));
-                    }
-                }
-
-                // Update sub info
-                if !self.consumer_table.is_empty() {
-                    let subscribe_info = topic_route_data2topic_subscribe_info(topic, &topic_route_data);
-
-                    let consumers: Vec<_> = self.consumer_table.iter().map(|entry| entry.value().clone()).collect();
-
-                    for consumer in consumers {
-                        consumer
-                            .update_topic_subscribe_info(topic.clone(), &subscribe_info)
-                            .await;
-                    }
-                }
-                let clone_topic_route_data = TopicRouteData::from_existing(&topic_route_data);
-                self.topic_route_table.insert(topic.clone(), clone_topic_route_data);
-                return true;
             }
         } else {
             warn!(
                 "updateTopicRouteInfoFromNameServer, getTopicRouteInfoFromNameServer return null, Topic: {}. [{}]",
                 topic, self.client_id
             );
+            self.route_refresh_state.metrics.record_failure();
         }
 
-        drop(lock);
+        self.record_topic_route_refresh_finish(refresh_kind, started, TopicRouteApplyOutcome::Unchanged);
         false
+    }
+
+    fn collect_registered_route_topics(&self) -> Vec<CheetahString> {
+        let mut topic_list = HashSet::new();
+
+        for entry in self.producer_table.iter() {
+            topic_list.extend(entry.value().get_publish_topic_list());
+        }
+
+        for entry in self.consumer_table.iter() {
+            entry.value().subscriptions().iter().for_each(|sub| {
+                topic_list.insert(sub.topic.clone());
+            });
+        }
+
+        let mut topics = topic_list.into_iter().collect::<Vec<_>>();
+        topics.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        topics
+    }
+
+    fn select_periodic_route_refresh_batch(&self, topics: &[CheetahString]) -> (Vec<CheetahString>, usize) {
+        let total_topics = topics.len();
+        if total_topics <= ROUTE_REFRESH_MAX_TOPICS_PER_ROUND {
+            return (topics.to_vec(), 0);
+        }
+
+        let start = self
+            .route_refresh_state
+            .periodic_cursor
+            .fetch_add(ROUTE_REFRESH_MAX_TOPICS_PER_ROUND, std::sync::atomic::Ordering::Relaxed)
+            % total_topics;
+        let selected = (0..ROUTE_REFRESH_MAX_TOPICS_PER_ROUND)
+            .map(|offset| topics[(start + offset) % total_topics].clone())
+            .collect::<Vec<_>>();
+        let skipped = total_topics.saturating_sub(selected.len());
+        (selected, skipped)
+    }
+
+    fn topic_route_version(&self, topic: &CheetahString) -> u64 {
+        self.route_refresh_state
+            .versions
+            .get(topic)
+            .map(|entry| *entry.value())
+            .unwrap_or_default()
+    }
+
+    fn bump_topic_route_version(&self, topic: &CheetahString, current_version: u64) {
+        self.route_refresh_state
+            .versions
+            .insert(topic.clone(), current_version.saturating_add(1));
+    }
+
+    fn record_topic_route_refresh_finish(
+        &self,
+        refresh_kind: TopicRouteRefreshKind,
+        started: Instant,
+        _outcome: TopicRouteApplyOutcome,
+    ) {
+        if matches!(refresh_kind, TopicRouteRefreshKind::RouteMiss) {
+            self.route_refresh_state
+                .metrics
+                .record_route_miss_elapsed(started.elapsed().as_micros() as u64);
+        }
+    }
+
+    async fn apply_topic_route_data_if_fresh(
+        &mut self,
+        topic: &CheetahString,
+        topic_route_data: &mut TopicRouteData,
+        request_version: u64,
+    ) -> TopicRouteApplyOutcome {
+        let _lock = self.lock_namesrv.lock().await;
+        let current_version = self.topic_route_version(topic);
+        if current_version != request_version {
+            warn!(
+                "updateTopicRouteInfoFromNameServer skipped stale route snapshot, Topic: {}, requestVersion: {}, \
+                 currentVersion: {}",
+                topic, request_version, current_version
+            );
+            return TopicRouteApplyOutcome::Stale;
+        }
+
+        let old = self.topic_route_table.get(topic).map(|entry| entry.value().clone());
+        let mut changed = topic_route_data.topic_route_data_changed(old.as_ref());
+        if !changed {
+            changed = self.is_need_update_topic_route_info(topic).await;
+        } else {
+            info!(
+                "the topic[{}] route info changed, old[{:?}] ,new[{:?}]",
+                topic, old, topic_route_data
+            )
+        }
+        if !changed {
+            return TopicRouteApplyOutcome::Unchanged;
+        }
+
+        for bd in topic_route_data.broker_datas.iter() {
+            self.broker_addr_table
+                .insert(bd.broker_name().clone(), bd.broker_addrs().clone());
+        }
+
+        if let Some(mq_end_points) =
+            ClientMetadata::topic_route_data2endpoints_for_static_topic(topic, topic_route_data)
+        {
+            if !mq_end_points.is_empty() {
+                self.topic_end_points_table.insert(topic.into(), mq_end_points);
+            }
+        }
+
+        let mut publish_info = topic_route_data2topic_publish_info(topic, topic_route_data);
+        publish_info.have_topic_router_info = true;
+        for mut entry in self.producer_table.iter_mut() {
+            entry
+                .value_mut()
+                .update_topic_publish_info(topic.to_string(), Some(publish_info.clone()));
+        }
+
+        if !self.consumer_table.is_empty() {
+            let subscribe_info = topic_route_data2topic_subscribe_info(topic, topic_route_data);
+            let consumers: Vec<_> = self.consumer_table.iter().map(|entry| entry.value().clone()).collect();
+
+            for consumer in consumers {
+                consumer
+                    .update_topic_subscribe_info(topic.clone(), &subscribe_info)
+                    .await;
+            }
+        }
+
+        let clone_topic_route_data = TopicRouteData::from_existing(topic_route_data);
+        self.topic_route_table.insert(topic.clone(), clone_topic_route_data);
+        self.bump_topic_route_version(topic, current_version);
+        TopicRouteApplyOutcome::Applied
+    }
+
+    pub fn route_refresh_metrics_snapshot(&self) -> TopicRouteRefreshMetricsSnapshot {
+        self.route_refresh_state.metrics.snapshot()
     }
 
     async fn is_need_update_topic_route_info(&self, topic: &CheetahString) -> bool {
@@ -2272,11 +2440,93 @@ pub async fn run_connection_event_listener_lifecycle_probe() -> ConnectionEventL
     }
 }
 
+fn route_refresh_probe_topics(topic_count: usize) -> Vec<CheetahString> {
+    (0..topic_count)
+        .map(|index| CheetahString::from_string(format!("route-refresh-topic-{index:04}")))
+        .collect()
+}
+
+#[doc(hidden)]
+pub fn run_route_refresh_shard_probe(topic_count: usize) -> RouteRefreshShardProbe {
+    let client_config = ClientConfig {
+        namesrv_addr: None,
+        ..Default::default()
+    };
+    let instance = MQClientInstance::new_arc(client_config, 0, "route-refresh-shard-probe", None);
+    let topics = route_refresh_probe_topics(topic_count);
+    let started = Instant::now();
+    let (selected, skipped_topics) = instance.select_periodic_route_refresh_batch(&topics);
+    let elapsed_us = started.elapsed().as_micros();
+    let peak_topic_reduction_percent = if topic_count == 0 {
+        0.0
+    } else {
+        ((topic_count - selected.len()) as f64 / topic_count as f64) * 100.0
+    };
+
+    RouteRefreshShardProbe {
+        topic_count,
+        batch_size: ROUTE_REFRESH_MAX_TOPICS_PER_ROUND,
+        selected_topics: selected.len(),
+        skipped_topics,
+        peak_topic_reduction_percent,
+        elapsed_us,
+    }
+}
+
+#[doc(hidden)]
+pub async fn run_route_refresh_concurrent_stale_guard_probe() -> RouteRefreshConcurrentProbe {
+    let client_config = ClientConfig {
+        namesrv_addr: None,
+        ..Default::default()
+    };
+    let mut instance = MQClientInstance::new_arc(client_config, 0, "route-refresh-concurrent-probe", None);
+    let topic = CheetahString::from_static_str("route-refresh-concurrent-topic");
+    let current_route = TopicRouteData {
+        order_topic_conf: Some(CheetahString::from_static_str("broker-new:1")),
+        ..Default::default()
+    };
+    instance.topic_route_table.insert(topic.clone(), current_route);
+    instance.route_refresh_state.versions.insert(topic.clone(), 1);
+
+    let mut stale_route = TopicRouteData {
+        order_topic_conf: Some(CheetahString::from_static_str("broker-stale:1")),
+        ..Default::default()
+    };
+    let outcome = instance
+        .apply_topic_route_data_if_fresh(&topic, &mut stale_route, 0)
+        .await;
+
+    let final_order_topic_conf = instance
+        .topic_route_table
+        .get(&topic)
+        .and_then(|entry| entry.value().order_topic_conf.clone());
+    let route_version = instance.topic_route_version(&topic);
+    let stale_skipped = matches!(outcome, TopicRouteApplyOutcome::Stale);
+    let kept_current_route = final_order_topic_conf
+        .as_ref()
+        .is_some_and(|value| value.as_str() == "broker-new:1");
+
+    RouteRefreshConcurrentProbe {
+        healthy: stale_skipped && kept_current_route && route_version == 1,
+        stale_skipped,
+        final_order_topic_conf,
+        route_version,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rocketmq_error::RocketMQError;
+    use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
+    use rocketmq_remoting::protocol::route::route_data_view::BrokerData;
+    use rocketmq_remoting::protocol::route::route_data_view::QueueData;
 
     use super::*;
+    use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
+    use crate::consumer::default_mq_push_consumer::ConsumerConfig;
+    use crate::consumer::mq_consumer_inner::MQConsumerInnerImpl;
+    use crate::producer::producer_impl::default_mq_producer_impl::DefaultMQProducerImpl;
+    use crate::producer::producer_impl::mq_producer_inner::MQProducerInner;
 
     #[tokio::test]
     async fn get_mq_client_api_impl_returns_client_not_started_instead_of_panicking() {
@@ -2418,6 +2668,122 @@ mod tests {
         assert!(probe.healthy, "{probe:?}");
         assert_eq!(probe.task_count_before_shutdown, 1);
         assert_eq!(probe.task_count_after_shutdown, 0);
+    }
+
+    #[test]
+    fn periodic_route_refresh_batches_large_topic_sets() {
+        let client_config = ClientConfig {
+            namesrv_addr: None,
+            ..Default::default()
+        };
+        let instance = MQClientInstance::new_arc(client_config, 0, "route-refresh-batch-test", None);
+        let topics = route_refresh_probe_topics(1_000);
+
+        let (first_batch, first_skipped) = instance.select_periodic_route_refresh_batch(&topics);
+        let (second_batch, second_skipped) = instance.select_periodic_route_refresh_batch(&topics);
+
+        assert_eq!(first_batch.len(), ROUTE_REFRESH_MAX_TOPICS_PER_ROUND);
+        assert_eq!(second_batch.len(), ROUTE_REFRESH_MAX_TOPICS_PER_ROUND);
+        assert_eq!(first_skipped, 1_000 - ROUTE_REFRESH_MAX_TOPICS_PER_ROUND);
+        assert_eq!(second_skipped, 1_000 - ROUTE_REFRESH_MAX_TOPICS_PER_ROUND);
+        assert_ne!(first_batch[0], second_batch[0]);
+
+        let small_topics = route_refresh_probe_topics(10);
+        let (small_batch, small_skipped) = instance.select_periodic_route_refresh_batch(&small_topics);
+        assert_eq!(small_batch.len(), 10);
+        assert_eq!(small_skipped, 0);
+    }
+
+    #[test]
+    fn route_refresh_shard_probe_reports_peak_topic_reduction() {
+        let probe = run_route_refresh_shard_probe(1_000);
+
+        assert_eq!(probe.batch_size, ROUTE_REFRESH_MAX_TOPICS_PER_ROUND);
+        assert_eq!(probe.selected_topics, ROUTE_REFRESH_MAX_TOPICS_PER_ROUND);
+        assert!(probe.peak_topic_reduction_percent > 90.0, "{probe:?}");
+    }
+
+    #[tokio::test]
+    async fn stale_route_snapshot_does_not_overwrite_current_route() {
+        let probe = run_route_refresh_concurrent_stale_guard_probe().await;
+
+        assert!(probe.healthy, "{probe:?}");
+        assert!(probe.stale_skipped);
+        assert_eq!(probe.route_version, 1);
+    }
+
+    #[tokio::test]
+    async fn apply_route_refresh_updates_producer_and_consumer_views() {
+        let client_config = ClientConfig {
+            namesrv_addr: None,
+            ..Default::default()
+        };
+        let mut instance = MQClientInstance::new_arc(client_config, 0, "route-refresh-apply-test", None);
+        let topic = CheetahString::from_static_str("route-refresh-topic");
+
+        let producer = ArcMut::new(DefaultMQProducerImpl::new(
+            ClientConfig::default(),
+            ProducerConfig::default(),
+            None,
+        ));
+        let producer_inner = MQProducerInnerImpl {
+            default_mqproducer_impl_inner: Some(producer.clone()),
+        };
+        assert!(producer.is_publish_topic_need_update(&topic));
+        assert!(
+            instance
+                .register_producer("route-refresh-producer", producer_inner)
+                .await
+        );
+
+        let consumer_group = CheetahString::from_static_str("route-refresh-consumer");
+        let mut consumer = ArcMut::new(DefaultMQPushConsumerImpl::new(
+            ClientConfig::default(),
+            ArcMut::new(ConsumerConfig {
+                consumer_group: consumer_group.clone(),
+                ..Default::default()
+            }),
+            None,
+        ));
+        consumer.rebalance_impl.put_subscription_data(
+            topic.clone(),
+            SubscriptionData {
+                topic: topic.clone(),
+                ..Default::default()
+            },
+        );
+        assert!(consumer.is_subscribe_topic_need_update(topic.as_str()).await);
+        assert!(
+            instance
+                .register_consumer(&consumer_group, MQConsumerInnerImpl::from_push(consumer.clone()))
+                .await
+        );
+
+        let mut broker_addrs = HashMap::new();
+        broker_addrs.insert(mix_all::MASTER_ID, CheetahString::from_static_str("127.0.0.1:10911"));
+        let mut route = TopicRouteData {
+            queue_datas: vec![QueueData {
+                broker_name: CheetahString::from_static_str("broker-a"),
+                read_queue_nums: 1,
+                write_queue_nums: 1,
+                perm: PermName::PERM_READ | PermName::PERM_WRITE,
+                ..Default::default()
+            }],
+            broker_datas: vec![BrokerData::new(
+                CheetahString::from_static_str("cluster-a"),
+                CheetahString::from_static_str("broker-a"),
+                broker_addrs,
+                None,
+            )],
+            ..Default::default()
+        };
+
+        let outcome = instance.apply_topic_route_data_if_fresh(&topic, &mut route, 0).await;
+
+        assert_eq!(outcome, TopicRouteApplyOutcome::Applied);
+        assert!(!producer.is_publish_topic_need_update(&topic));
+        assert!(!consumer.is_subscribe_topic_need_update(topic.as_str()).await);
+        assert_eq!(instance.topic_route_version(&topic), 1);
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -193,7 +193,15 @@ pub use crate::exception::RequestTimeoutException;
 #[doc(hidden)]
 pub use crate::factory::mq_client_instance::run_connection_event_listener_lifecycle_probe;
 #[doc(hidden)]
+pub use crate::factory::mq_client_instance::run_route_refresh_concurrent_stale_guard_probe;
+#[doc(hidden)]
+pub use crate::factory::mq_client_instance::run_route_refresh_shard_probe;
+#[doc(hidden)]
 pub use crate::factory::mq_client_instance::ConnectionEventListenerLifecycleProbe;
+#[doc(hidden)]
+pub use crate::factory::mq_client_instance::RouteRefreshConcurrentProbe;
+#[doc(hidden)]
+pub use crate::factory::mq_client_instance::RouteRefreshShardProbe;
 pub use crate::hook::consume_message_context::ConsumeMessageContext;
 pub use crate::hook::consume_message_hook::ConsumeMessageHook;
 pub use crate::hook::consume_message_hook::ConsumeMessageHookArc;

--- a/rocketmq-client/tests/rebalance_concurrent_safety_test.rs
+++ b/rocketmq-client/tests/rebalance_concurrent_safety_test.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
+use rocketmq_client_rust::run_route_refresh_concurrent_stale_guard_probe;
 use rocketmq_common::common::message::message_queue::MessageQueue;
 use rocketmq_remoting::protocol::heartbeat::subscription_data::SubscriptionData;
 use tokio::sync::RwLock;
@@ -504,6 +505,15 @@ async fn test_high_concurrency_stress() {
     println!("Error rate: {:.2}%", error_rate);
 
     assert!(error_rate < 1.0, "Error rate too high: {:.2}%", error_rate);
+}
+
+#[tokio::test]
+async fn test_route_refresh_stale_snapshot_does_not_overwrite_current_route() {
+    let probe = run_route_refresh_concurrent_stale_guard_probe().await;
+
+    assert!(probe.healthy, "{probe:?}");
+    assert!(probe.stale_skipped);
+    assert_eq!(probe.route_version, 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7628

### Brief Description

Optimizes client topic route refresh so scheduled refreshes process a bounded shard instead of every registered topic in one round. The route refresh path now tracks per-topic route snapshot versions, skips stale in-flight responses, records refresh counters and elapsed metrics, and keeps NameServer requests outside the `lock_namesrv` apply critical section. Route miss refreshes still refresh the requested topic immediately.

The namesrv refresh lifecycle benchmark now also records route refresh profiles for 10, 100, and 1000 topics. The 1000-topic profile selects 64 topics per scheduled round and reports a 93.6% peak topic-work reduction.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-client-rust --lib mq_client_instance` passed: 22 passed.
- `cargo test -p rocketmq-client-rust --test rebalance_concurrent_safety_test` passed: 7 passed.
- `cargo bench -p rocketmq-client-rust --bench namesrv_refresh_lifecycle_bench` passed. Latest samples: namesrv shutdown 153.51-156.17 us, route shard 10 topics 3.1571-3.4564 ms, 100 topics 3.0272-3.1056 ms, 1000 topics 3.1404-3.2310 ms.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route refreshes now run in smaller batches across topics, helping spread work more evenly during periodic updates.
  * Added stronger protection against stale route data so the latest route information is less likely to be overwritten.
  * Route refresh tracking now includes more detailed progress and outcome metrics.

* **Bug Fixes**
  * Improved handling of route updates for producer and consumer views to keep client-side routing data more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->