### PR TITLE
[ISSUE #7632]✨Add client performance gates

### DIFF
--- a/scripts/client-perf-baseline.ps1
+++ b/scripts/client-perf-baseline.ps1
@@ -1,0 +1,461 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("baseline", "current", "prototype")]
+    [string]$Mode = "current",
+    [string]$OutputDirectory = "target/client-perf",
+    [string]$OutputFile = "",
+    [string]$MarkdownFile = "",
+    [string[]]$Bench = @(),
+    [switch]$Quick,
+    [switch]$CompileOnly,
+    [switch]$SkipBenchmarkRun,
+    [string]$CriterionArgs = ""
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
+    $PSNativeCommandUseErrorActionPreference = $false
+}
+
+$workspaceRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$outputRoot = Join-Path $workspaceRoot $OutputDirectory
+$logRoot = Join-Path $outputRoot "logs"
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+
+if ([string]::IsNullOrWhiteSpace($OutputFile)) {
+    $OutputFile = Join-Path $outputRoot "$Mode-$timestamp.json"
+}
+elseif (-not [System.IO.Path]::IsPathRooted($OutputFile)) {
+    $OutputFile = Join-Path $workspaceRoot $OutputFile
+}
+
+if ([string]::IsNullOrWhiteSpace($MarkdownFile)) {
+    $MarkdownFile = [System.IO.Path]::ChangeExtension($OutputFile, ".md")
+}
+elseif (-not [System.IO.Path]::IsPathRooted($MarkdownFile)) {
+    $MarkdownFile = Join-Path $workspaceRoot $MarkdownFile
+}
+
+New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
+New-Item -ItemType Directory -Force -Path $logRoot | Out-Null
+
+function Get-GitValue {
+    param([Parameter(Mandatory = $true)][string]$Arguments)
+
+    $output = & git -C $workspaceRoot $Arguments.Split(" ") 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return ""
+    }
+    return ($output -join "`n").Trim()
+}
+
+function Get-CommandOutput {
+    param(
+        [Parameter(Mandatory = $true)][string]$FileName,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $output = & $FileName @Arguments 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return ""
+    }
+    return ($output -join "`n").Trim()
+}
+
+function Split-CommandArguments {
+    param([string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return @()
+    }
+
+    return @(
+        [regex]::Matches($Value, '("[^"]*"|''[^'']*''|\S+)') |
+            ForEach-Object {
+                $item = $_.Value
+                if (($item.StartsWith('"') -and $item.EndsWith('"')) -or
+                    ($item.StartsWith("'") -and $item.EndsWith("'"))) {
+                    $item.Substring(1, $item.Length - 2)
+                }
+                else {
+                    $item
+                }
+            }
+    )
+}
+
+function Join-NativeArguments {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    return (($Arguments | ForEach-Object {
+            if ($_ -match '\s') {
+                '"' + $_.Replace('"', '\"') + '"'
+            }
+            else {
+                $_
+            }
+        }) -join " ")
+}
+
+function Format-CommandLine {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    return "cargo " + (Join-NativeArguments -Arguments $Arguments)
+}
+
+function Invoke-CargoProcess {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = "cargo"
+    $startInfo.Arguments = Join-NativeArguments -Arguments $Arguments
+    $startInfo.WorkingDirectory = $workspaceRoot
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.CreateNoWindow = $true
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $startInfo
+    [void]$process.Start()
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+
+    $combined = @()
+    if (-not [string]::IsNullOrWhiteSpace($stdout)) {
+        $combined += $stdout.TrimEnd()
+    }
+    if (-not [string]::IsNullOrWhiteSpace($stderr)) {
+        $combined += $stderr.TrimEnd()
+    }
+
+    return [ordered]@{
+        exit_code = $process.ExitCode
+        output = ($combined -join "`n")
+    }
+}
+
+function Get-RelativePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$BasePath,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $baseFullPath = (Resolve-Path $BasePath).Path.TrimEnd('\', '/')
+    $pathFullPath = (Resolve-Path $Path).Path
+    $baseUri = [Uri]($baseFullPath + [System.IO.Path]::DirectorySeparatorChar)
+    $pathUri = [Uri]$pathFullPath
+    return [Uri]::UnescapeDataString($baseUri.MakeRelativeUri($pathUri).ToString()).Replace('\', '/')
+}
+
+function Get-BenchmarkField {
+    param(
+        [Parameter(Mandatory = $true)]$Benchmark,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    $value = $Benchmark
+    while ($value -is [System.Array] -and $value.Count -eq 1) {
+        $value = $value[0]
+    }
+
+    if ($value -is [hashtable]) {
+        return $value[$Name]
+    }
+
+    if ($value -is [string] -and $value.Contains("|")) {
+        $parts = $value.Split("|", 4)
+        $indexByName = @{
+            Name = 0
+            Package = 1
+            Bench = 2
+            Purpose = 3
+        }
+        if ($indexByName.ContainsKey($Name) -and $parts.Count -gt $indexByName[$Name]) {
+            return $parts[$indexByName[$Name]]
+        }
+    }
+
+    if ($value.PSObject.Properties.Name -contains $Name) {
+        return $value.PSObject.Properties[$Name].Value
+    }
+
+    $typeName = if ($null -eq $value) { "<null>" } else { $value.GetType().FullName }
+    $propertyNames = if ($null -eq $value) { "" } else { ($value.PSObject.Properties.Name -join ",") }
+    throw "Benchmark entry is missing field '$Name'. Type=$typeName Properties=$propertyNames"
+}
+
+function Invoke-BenchmarkCommand {
+    param(
+        [Parameter(Mandatory = $true)]$Benchmark,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $name = Get-BenchmarkField -Benchmark $Benchmark -Name "Name"
+    $logPath = Join-Path $logRoot "$name-$timestamp.txt"
+    $commandLine = Format-CommandLine -Arguments $Arguments
+    $startedAt = Get-Date
+    $exitCode = 0
+    $status = "passed"
+
+    Write-Host "==> $name"
+    Write-Host "    $commandLine"
+
+    if ($SkipBenchmarkRun) {
+        "Skipped benchmark command: $commandLine" | Set-Content -Encoding utf8 -Path $logPath
+        $status = "skipped"
+    }
+    else {
+        $processResult = Invoke-CargoProcess -Arguments $Arguments
+        $exitCode = [int]$processResult.exit_code
+        $processResult.output | Tee-Object -FilePath $logPath | Out-Host
+        if ($exitCode -ne 0) {
+            $status = "failed"
+        }
+    }
+
+    $endedAt = Get-Date
+    $durationMs = [math]::Round(($endedAt - $startedAt).TotalMilliseconds, 2)
+    $result = [ordered]@{
+        name = $name
+        package = Get-BenchmarkField -Benchmark $Benchmark -Name "Package"
+        bench = Get-BenchmarkField -Benchmark $Benchmark -Name "Bench"
+        purpose = Get-BenchmarkField -Benchmark $Benchmark -Name "Purpose"
+        command = $commandLine
+        log = (Get-RelativePath -BasePath $workspaceRoot -Path $logPath)
+        started_at = $startedAt.ToUniversalTime().ToString("o")
+        duration_ms = $durationMs
+        exit_code = $exitCode
+        status = $status
+    }
+
+    if ($exitCode -ne 0) {
+        throw "$name failed with exit code $exitCode. See $logPath"
+    }
+
+    return $result
+}
+
+function Get-CriterionEstimates {
+    param([Parameter(Mandatory = $true)][datetime]$Since)
+
+    $criterionRoot = Join-Path $workspaceRoot "target/criterion"
+    if (-not (Test-Path $criterionRoot)) {
+        return @()
+    }
+
+    $results = @()
+    $threshold = $Since.AddSeconds(-5)
+    $estimateFiles = Get-ChildItem -Path $criterionRoot -Recurse -Filter "estimates.json" |
+        Where-Object { $_.FullName -match "[\\/]+new[\\/]+estimates\.json$" -and $_.LastWriteTime -ge $threshold } |
+        Sort-Object FullName
+
+    foreach ($file in $estimateFiles) {
+        $json = Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+        $scenarioDir = $file.Directory.Parent.FullName
+        $id = Get-RelativePath -BasePath $criterionRoot -Path $scenarioDir
+        $results += [ordered]@{
+            id = $id
+            unit = "ns"
+            source = Get-RelativePath -BasePath $workspaceRoot -Path $file.FullName
+            mean_point_estimate = [double]$json.mean.point_estimate
+            mean_lower_bound = [double]$json.mean.confidence_interval.lower_bound
+            mean_upper_bound = [double]$json.mean.confidence_interval.upper_bound
+            median_point_estimate = [double]$json.median.point_estimate
+            median_lower_bound = [double]$json.median.confidence_interval.lower_bound
+            median_upper_bound = [double]$json.median.confidence_interval.upper_bound
+            slope_point_estimate = [double]$json.slope.point_estimate
+        }
+    }
+
+    return $results
+}
+
+function Get-PrototypeArtifacts {
+    param([Parameter(Mandatory = $true)][datetime]$Since)
+
+    $artifactRoot = Join-Path $workspaceRoot "target/runtime-baseline/prototype"
+    if (-not (Test-Path $artifactRoot)) {
+        return @()
+    }
+
+    $threshold = $Since.AddSeconds(-5)
+    $artifacts = @()
+    $artifactFiles = Get-ChildItem -Path $artifactRoot -Filter "*.json" |
+        Where-Object { $_.LastWriteTime -ge $threshold } |
+        Sort-Object FullName
+
+    foreach ($file in $artifactFiles) {
+        $json = Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+        $metrics = if ($json.PSObject.Properties.Name -contains "metrics") { $json.metrics } else { $json }
+        $artifacts += [ordered]@{
+            path = Get-RelativePath -BasePath $workspaceRoot -Path $file.FullName
+            scenario = if ($json.PSObject.Properties.Name -contains "scenario") { $json.scenario } else { [System.IO.Path]::GetFileNameWithoutExtension($file.Name) }
+            source = if ($json.PSObject.Properties.Name -contains "source") { $json.source } else { "benchmark-artifact" }
+            metrics = $metrics
+        }
+    }
+
+    return $artifacts
+}
+
+$coreBenches = @(
+    "client-hot-path|rocketmq-client-rust|client_hot_path_benchmark|producer route lookup, queue select, batch encode, lite-pull clone"
+    "client-send-pipeline|rocketmq-client-rust|client_send_pipeline_benchmark|message construction, request construction, callback dispatch, async retry"
+    "client-consume-pipeline|rocketmq-client-rust|client_consume_pipeline_benchmark|ProcessQueue put/take/remove/max-span hot paths"
+    "produce-accumulator|rocketmq-client-rust|produce_accumulator_benchmark|batch accumulation throughput and capacity reservation"
+    "produce-accumulator-guard|rocketmq-client-rust|produce_accumulator_guard_lifecycle_bench|batch guard lifecycle and shutdown cost"
+    "client-runtime-spawn|rocketmq-client-rust|client_runtime_spawn_benchmark|fallback runtime task spawn lifecycle"
+    "client-pull-scheduler|rocketmq-client-rust|client_pull_scheduler_benchmark|delayed pull scheduler queue behavior"
+    "pull-message-service|rocketmq-client-rust|pull_message_service_lifecycle_bench|pull service task lifecycle"
+    "trace-worker|rocketmq-client-rust|trace_worker_lifecycle_bench|trace queue depth and event-driven flush"
+    "request-future-holder|rocketmq-client-rust|request_future_holder_lifecycle_bench|request-reply deadline scanning"
+    "namesrv-refresh|rocketmq-client-rust|namesrv_refresh_lifecycle_bench|topic route refresh sharding"
+    "connection-event-listener|rocketmq-client-rust|connection_event_listener_lifecycle_bench|heartbeat failure broker route index"
+)
+
+$requestedBenches = @(
+    $Bench |
+        ForEach-Object { ([string]$_).Split(",", [System.StringSplitOptions]::RemoveEmptyEntries) } |
+        ForEach-Object { ([string]$_).Trim() } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+)
+
+$selectedBenches = $coreBenches
+if ($requestedBenches.Count -gt 0) {
+    $knownNames = @($coreBenches | ForEach-Object { Get-BenchmarkField -Benchmark $_ -Name "Name" })
+    $knownBenchTargets = @($coreBenches | ForEach-Object { Get-BenchmarkField -Benchmark $_ -Name "Bench" })
+    $unknown = @($requestedBenches | Where-Object { $knownNames -notcontains $_ -and $knownBenchTargets -notcontains $_ })
+    if ($unknown.Count -gt 0) {
+        throw "Unknown client benchmark selector(s): $($unknown -join ', '). Known names: $($knownNames -join ', ')"
+    }
+
+    $selectedBenches = @()
+    foreach ($coreBench in $coreBenches) {
+        $coreName = Get-BenchmarkField -Benchmark $coreBench -Name "Name"
+        $coreBenchTarget = Get-BenchmarkField -Benchmark $coreBench -Name "Bench"
+        if ($requestedBenches -contains $coreName -or $requestedBenches -contains $coreBenchTarget) {
+            $selectedBenches += $coreBench
+        }
+    }
+}
+
+$effectiveCriterionArgs = $CriterionArgs
+if ($Quick -and [string]::IsNullOrWhiteSpace($effectiveCriterionArgs)) {
+    $effectiveCriterionArgs = "--sample-size 10 --warm-up-time 1 --measurement-time 1 --noplot"
+}
+
+$runStartedAt = Get-Date
+$commands = @()
+Push-Location $workspaceRoot
+try {
+    foreach ($bench in $selectedBenches) {
+        $arguments = @(
+            "bench",
+            "-p",
+            (Get-BenchmarkField -Benchmark $bench -Name "Package"),
+            "--bench",
+            (Get-BenchmarkField -Benchmark $bench -Name "Bench")
+        )
+        if ($CompileOnly) {
+            $arguments += "--no-run"
+        }
+        elseif (-not [string]::IsNullOrWhiteSpace($effectiveCriterionArgs)) {
+            $arguments += "--"
+            $arguments += Split-CommandArguments -Value $effectiveCriterionArgs
+        }
+
+        $commands += Invoke-BenchmarkCommand -Benchmark $bench -Arguments $arguments
+    }
+}
+finally {
+    Pop-Location
+}
+
+$criterionResults = if ($CompileOnly -or $SkipBenchmarkRun) { @() } else { Get-CriterionEstimates -Since $runStartedAt }
+$artifactResults = if ($CompileOnly -or $SkipBenchmarkRun) { @() } else { Get-PrototypeArtifacts -Since $runStartedAt }
+
+$payload = [ordered]@{
+    schema_version = 1
+    source = "scripts/client-perf-baseline.ps1"
+    mode = $Mode
+    generated_at = (Get-Date).ToUniversalTime().ToString("o")
+    output_directory = $OutputDirectory.Replace('\', '/')
+    git = [ordered]@{
+        branch = Get-GitValue -Arguments "rev-parse --abbrev-ref HEAD"
+        commit = Get-GitValue -Arguments "rev-parse HEAD"
+        short_commit = Get-GitValue -Arguments "rev-parse --short HEAD"
+    }
+    environment = [ordered]@{
+        os = [System.Runtime.InteropServices.RuntimeInformation]::OSDescription
+        architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+        processor_count = [Environment]::ProcessorCount
+        powershell = $PSVersionTable.PSVersion.ToString()
+        rustc = Get-CommandOutput -FileName "rustc" -Arguments @("--version")
+        cargo = Get-CommandOutput -FileName "cargo" -Arguments @("--version")
+    }
+    options = [ordered]@{
+        quick = [bool]$Quick
+        compile_only = [bool]$CompileOnly
+        skip_benchmark_run = [bool]$SkipBenchmarkRun
+        criterion_args = $effectiveCriterionArgs
+    }
+    thresholds = [ordered]@{
+        default_max_regression_percent = 5.0
+        lower_is_better_unit = "ns"
+        lifecycle_failure_metric_patterns = @("healthy=false", "leak", "still_running", "timed_out", "failed", "failure")
+    }
+    selected_benches = @($selectedBenches | ForEach-Object {
+            [ordered]@{
+                name = Get-BenchmarkField -Benchmark $_ -Name "Name"
+                package = Get-BenchmarkField -Benchmark $_ -Name "Package"
+                bench = Get-BenchmarkField -Benchmark $_ -Name "Bench"
+                purpose = Get-BenchmarkField -Benchmark $_ -Name "Purpose"
+            }
+        })
+    commands = $commands
+    criterion_results = $criterionResults
+    artifact_results = $artifactResults
+}
+
+$payload | ConvertTo-Json -Depth 24 | Out-File -Encoding utf8 -FilePath $OutputFile
+
+$markdown = @(
+    "# Client Performance $Mode Report",
+    "",
+    "- Generated at: $($payload.generated_at)",
+    "- Branch: $($payload.git.branch)",
+    "- Commit: $($payload.git.short_commit)",
+    "- OS: $($payload.environment.os)",
+    "- Processor count: $($payload.environment.processor_count)",
+    "- Criterion results: $(@($criterionResults).Count)",
+    "- Runtime artifact results: $(@($artifactResults).Count)",
+    "",
+    "## Commands",
+    "",
+    "| Benchmark | Status | Duration ms | Log |",
+    "|---|---:|---:|---|"
+)
+
+foreach ($command in $commands) {
+    $markdown += "| $($command.name) | $($command.status) | $($command.duration_ms) | `$($command.log)` |"
+}
+
+$markdown += @(
+    "",
+    "## Gate",
+    "",
+    "Compare this report with:",
+    "",
+    '```powershell',
+    ".\scripts\client-perf-compare.ps1 -Baseline target\client-perf\baseline.json -Current target\client-perf\current.json",
+    '```'
+)
+
+$markdown | Set-Content -Encoding utf8 -Path $MarkdownFile
+
+Write-Host "Client performance JSON report: $OutputFile"
+Write-Host "Client performance Markdown report: $MarkdownFile"

--- a/scripts/client-perf-compare.ps1
+++ b/scripts/client-perf-compare.ps1
@@ -1,0 +1,301 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Baseline,
+    [Parameter(Mandatory = $true)]
+    [string]$Current,
+    [double]$MaxRegressionPercent = 5.0,
+    [string]$OutputFile = "",
+    [string]$MarkdownFile = "",
+    [switch]$WarnOnlyMissing
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$workspaceRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+function Resolve-RepoPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+    return Join-Path $workspaceRoot $Path
+}
+
+function Read-Report {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $resolved = Resolve-RepoPath -Path $Path
+    if (-not (Test-Path $resolved)) {
+        throw "Performance report does not exist: $Path"
+    }
+    return Get-Content -Path $resolved -Raw | ConvertFrom-Json
+}
+
+function ConvertTo-ResultMap {
+    param([AllowNull()]$Results)
+
+    $map = @{}
+    if ($null -eq $Results) {
+        return $map
+    }
+
+    foreach ($result in @($Results)) {
+        if ($null -eq $result) {
+            continue
+        }
+        $idProperty = $result.PSObject.Properties["id"]
+        if ($null -ne $idProperty -and
+            $null -ne $idProperty.Value -and
+            -not [string]::IsNullOrWhiteSpace([string]$idProperty.Value)) {
+            $map[[string]$idProperty.Value] = $result
+        }
+    }
+    return $map
+}
+
+function Get-MetricPairs {
+    param(
+        [string]$Prefix,
+        [AllowNull()]$Value
+    )
+
+    $pairs = @()
+    if ($null -eq $Value) {
+        return $pairs
+    }
+
+    if ($Value -is [System.Array]) {
+        for ($index = 0; $index -lt $Value.Count; $index++) {
+            $name = if ([string]::IsNullOrWhiteSpace($Prefix)) { "[$index]" } else { "$Prefix[$index]" }
+            $pairs += Get-MetricPairs -Prefix $name -Value $Value[$index]
+        }
+        return $pairs
+    }
+
+    if ($Value -is [hashtable]) {
+        foreach ($key in $Value.Keys) {
+            $name = if ([string]::IsNullOrWhiteSpace($Prefix)) { [string]$key } else { "$Prefix.$key" }
+            $pairs += Get-MetricPairs -Prefix $name -Value $Value[$key]
+        }
+        return $pairs
+    }
+
+    if ($Value -is [pscustomobject]) {
+        foreach ($property in $Value.PSObject.Properties) {
+            $name = if ([string]::IsNullOrWhiteSpace($Prefix)) { $property.Name } else { "$Prefix.$($property.Name)" }
+            $pairs += Get-MetricPairs -Prefix $name -Value $property.Value
+        }
+        return $pairs
+    }
+
+    return @([ordered]@{ name = $Prefix; value = $Value })
+}
+
+function Try-GetDouble {
+    param(
+        [AllowNull()]$Value,
+        [ref]$Number
+    )
+
+    if ($null -eq $Value) {
+        return $false
+    }
+    return [double]::TryParse(
+        [string]$Value,
+        [System.Globalization.NumberStyles]::Float,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        $Number
+    )
+}
+
+function Test-FailureMetric {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [AllowNull()]$Value
+    )
+
+    if ($Name -match "(^|[.])healthy$" -and $Value -is [bool] -and -not $Value) {
+        return "healthy=false"
+    }
+
+    $number = 0.0
+    if (Try-GetDouble -Value $Value -Number ([ref]$number)) {
+        if ($number -gt 0 -and $Name -match "(leak|leaked|still_running|timed_out|failed|failure)") {
+            return "$Name=$number"
+        }
+    }
+
+    return ""
+}
+
+$baselineReport = Read-Report -Path $Baseline
+$currentReport = Read-Report -Path $Current
+
+$baselineMap = ConvertTo-ResultMap -Results $baselineReport.criterion_results
+$currentMap = ConvertTo-ResultMap -Results $currentReport.criterion_results
+
+$comparisons = @()
+$failures = @()
+$warnings = @()
+
+foreach ($id in ($baselineMap.Keys | Sort-Object)) {
+    if (-not $currentMap.ContainsKey($id)) {
+        $message = "Missing current Criterion result for $id"
+        if ($WarnOnlyMissing) {
+            $warnings += $message
+        }
+        else {
+            $failures += $message
+        }
+        continue
+    }
+
+    $baselineValue = [double]$baselineMap[$id].mean_point_estimate
+    $currentValue = [double]$currentMap[$id].mean_point_estimate
+    if ($baselineValue -le 0) {
+        $warnings += "Skipping $id because baseline mean is not positive: $baselineValue"
+        continue
+    }
+
+    $changePercent = (($currentValue - $baselineValue) / $baselineValue) * 100.0
+    $status = if ($changePercent -gt $MaxRegressionPercent) { "fail" } elseif ($changePercent -lt 0) { "improved" } else { "pass" }
+
+    if ($status -eq "fail") {
+        $failures += ("Criterion regression for {0}: {1:N2}% > {2:N2}%" -f $id, $changePercent, $MaxRegressionPercent)
+    }
+
+    $comparisons += [ordered]@{
+        id = $id
+        unit = "ns"
+        baseline_mean = $baselineValue
+        current_mean = $currentValue
+        change_percent = [math]::Round($changePercent, 4)
+        status = $status
+    }
+}
+
+foreach ($id in ($currentMap.Keys | Sort-Object)) {
+    if (-not $baselineMap.ContainsKey($id)) {
+        $warnings += "New current Criterion result without baseline: $id"
+    }
+}
+
+$artifactChecks = @()
+foreach ($artifact in @($currentReport.artifact_results)) {
+    if ($null -eq $artifact) {
+        continue
+    }
+    $pathProperty = $artifact.PSObject.Properties["path"]
+    $artifactPath = if ($null -ne $pathProperty -and $null -ne $pathProperty.Value) { [string]$pathProperty.Value } else { "artifact" }
+    $metricsProperty = $artifact.PSObject.Properties["metrics"]
+    $metricsValue = if ($null -ne $metricsProperty) { $metricsProperty.Value } else { $null }
+    foreach ($metric in Get-MetricPairs -Prefix "" -Value $metricsValue) {
+        $failureReason = Test-FailureMetric -Name $metric.name -Value $metric.value
+        if (-not [string]::IsNullOrWhiteSpace($failureReason)) {
+            $message = "$artifactPath reports $failureReason"
+            $failures += $message
+            $artifactChecks += [ordered]@{
+                artifact = $artifactPath
+                metric = $metric.name
+                value = $metric.value
+                status = "fail"
+                reason = $failureReason
+            }
+        }
+    }
+}
+
+if (@($comparisons).Count -eq 0) {
+    $warnings += "No matching Criterion results were compared."
+}
+
+$status = if (@($failures).Count -gt 0) { "fail" } else { "pass" }
+
+if ([string]::IsNullOrWhiteSpace($OutputFile)) {
+    $outputRoot = Join-Path $workspaceRoot "target/client-perf"
+    New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
+    $OutputFile = Join-Path $outputRoot "compare-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+}
+elseif (-not [System.IO.Path]::IsPathRooted($OutputFile)) {
+    $OutputFile = Join-Path $workspaceRoot $OutputFile
+}
+
+if ([string]::IsNullOrWhiteSpace($MarkdownFile)) {
+    $MarkdownFile = [System.IO.Path]::ChangeExtension($OutputFile, ".md")
+}
+elseif (-not [System.IO.Path]::IsPathRooted($MarkdownFile)) {
+    $MarkdownFile = Join-Path $workspaceRoot $MarkdownFile
+}
+
+$result = [ordered]@{
+    schema_version = 1
+    source = "scripts/client-perf-compare.ps1"
+    generated_at = (Get-Date).ToUniversalTime().ToString("o")
+    status = $status
+    max_regression_percent = $MaxRegressionPercent
+    baseline = [ordered]@{
+        path = $Baseline
+        commit = $baselineReport.git.short_commit
+        generated_at = $baselineReport.generated_at
+    }
+    current = [ordered]@{
+        path = $Current
+        commit = $currentReport.git.short_commit
+        generated_at = $currentReport.generated_at
+    }
+    compared_criterion_count = @($comparisons).Count
+    failures = $failures
+    warnings = $warnings
+    comparisons = $comparisons
+    artifact_checks = $artifactChecks
+}
+
+$result | ConvertTo-Json -Depth 24 | Out-File -Encoding utf8 -FilePath $OutputFile
+
+$markdown = @(
+    "# Client Performance Compare",
+    "",
+    "- Status: $status",
+    "- Max regression: $MaxRegressionPercent%",
+    "- Baseline: `$Baseline` ($($result.baseline.commit))",
+    "- Current: `$Current` ($($result.current.commit))",
+    "- Compared Criterion results: $(@($comparisons).Count)",
+    "- Failures: $(@($failures).Count)",
+    "- Warnings: $(@($warnings).Count)",
+    "",
+    "## Criterion",
+    "",
+    "| Benchmark | Change % | Status | Baseline ns | Current ns |",
+    "|---|---:|---|---:|---:|"
+)
+
+foreach ($comparison in $comparisons) {
+    $markdown += "| $($comparison.id) | $($comparison.change_percent) | $($comparison.status) | $($comparison.baseline_mean) | $($comparison.current_mean) |"
+}
+
+if (@($failures).Count -gt 0) {
+    $markdown += @("", "## Failures", "")
+    foreach ($failure in $failures) {
+        $markdown += "- $failure"
+    }
+}
+
+if (@($warnings).Count -gt 0) {
+    $markdown += @("", "## Warnings", "")
+    foreach ($warning in $warnings) {
+        $markdown += "- $warning"
+    }
+}
+
+$markdown | Set-Content -Encoding utf8 -Path $MarkdownFile
+
+Write-Host "Client performance compare JSON report: $OutputFile"
+Write-Host "Client performance compare Markdown report: $MarkdownFile"
+Write-Host "Client performance compare status: $status"
+
+if ($status -ne "pass") {
+    exit 1
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7632

### Brief Description

Adds repeatable client performance regression tooling under `scripts/`:

- `scripts/client-perf-baseline.ps1` runs the core broker-free client benchmark set, records command metadata, environment details, Criterion estimates, and lifecycle JSON artifacts, then writes JSON and Markdown reports under `target/client-perf`.
- `scripts/client-perf-compare.ps1` compares two generated reports, fails on configurable Criterion mean regressions, and flags lifecycle hard-failure metrics such as `healthy=false`, leak, still-running, timed-out, failed, and failure counters.

The scripts keep performance CI optional/manual so normal PR validation is not lengthened by long Criterion benchmark runs.

### How Did You Test This Change?

- PowerShell AST parse check passed for both scripts.
- `./scripts/client-perf-baseline.ps1 -Mode baseline -Bench client_runtime_spawn_benchmark -SkipBenchmarkRun -OutputFile target/client-perf/baseline-dryrun.json` passed.
- `./scripts/client-perf-compare.ps1 -Baseline target/client-perf/baseline-dryrun.json -Current target/client-perf/baseline-dryrun.json -OutputFile target/client-perf/compare-dryrun.json` passed.
- Synthetic compare regression sample returned exit code 1 as expected.
- `./scripts/client-perf-baseline.ps1 -Mode current -Bench client_runtime_spawn_benchmark -CompileOnly -OutputFile target/client-perf/current-compileonly.json` passed.
- `./scripts/client-perf-baseline.ps1 -Mode current -Bench client_runtime_spawn_benchmark -Quick -OutputFile target/client-perf/current-quick.json` passed and collected 2 Criterion results plus 1 runtime artifact.
- `./scripts/client-perf-compare.ps1 -Baseline target/client-perf/current-quick.json -Current target/client-perf/current-quick.json -OutputFile target/client-perf/compare-quick-self.json` passed.
- `cargo fmt --all` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client performance benchmarking support with JSON and Markdown report generation.
  * Added a comparison tool for baseline vs. current benchmark reports, including pass/fail regression checks and optional Markdown summaries.
  * Reports now include run metadata, environment details, benchmark results, and artifact checks for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->