### PR TITLE
[ISSUE #7634]✨Experiment with ProcessQueue contiguous storage

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl.rs
@@ -28,6 +28,7 @@ pub(crate) mod observability;
 pub mod pop_process_queue;
 pub(crate) mod pop_request;
 pub mod process_queue;
+pub(crate) mod process_queue_store;
 pub(crate) mod pull_api_wrapper;
 pub mod pull_message_service;
 pub mod pull_request;

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue.rs
@@ -34,6 +34,7 @@ use tokio::sync::RwLock;
 use tracing::info;
 
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
+use crate::consumer::consumer_impl::process_queue_store::ProcessQueueMessageStore;
 use crate::consumer::consumer_impl::PULL_MAX_IDLE_TIME;
 
 pub static REBALANCE_LOCK_MAX_LIVE_TIME: LazyLock<u64> = LazyLock::new(|| {
@@ -51,7 +52,7 @@ pub static REBALANCE_LOCK_INTERVAL: LazyLock<u64> = LazyLock::new(|| {
 });
 
 struct ProcessQueueStore {
-    msg_tree_map: BTreeMap<i64, ArcMut<MessageExt>>,
+    messages: ProcessQueueMessageStore,
     consuming_msg_orderly_tree_map: BTreeMap<i64, ArcMut<MessageExt>>,
     queue_offset_max: i64,
 }
@@ -59,7 +60,7 @@ struct ProcessQueueStore {
 impl ProcessQueueStore {
     fn new() -> Self {
         ProcessQueueStore {
-            msg_tree_map: BTreeMap::new(),
+            messages: ProcessQueueMessageStore::new(),
             consuming_msg_orderly_tree_map: BTreeMap::new(),
             queue_offset_max: 0,
         }
@@ -196,11 +197,11 @@ impl ProcessQueue {
             return;
         }
 
-        let loop_ = 16.min(self.store.read().await.msg_tree_map.len());
+        let loop_ = 16.min(self.store.read().await.messages.len());
         for _ in 0..loop_ {
             let msg = {
                 let store = self.store.read().await;
-                if let Some((_, value)) = store.msg_tree_map.first_key_value() {
+                if let Some((_, value)) = store.messages.first() {
                     let consume_start_time_stamp = MessageAccessor::get_consume_start_time_stamp(value.as_ref());
                     if let Some(ts_str) = consume_start_time_stamp {
                         if let Ok(ts) = ts_str.parse::<u64>() {
@@ -244,9 +245,9 @@ impl ProcessQueue {
             let should_remove = {
                 let store = self.store.read().await;
                 store
-                    .msg_tree_map
-                    .first_key_value()
-                    .is_some_and(|(offset, _)| queue_offset == *offset)
+                    .messages
+                    .first_offset()
+                    .is_some_and(|offset| queue_offset == offset)
             };
             if should_remove {
                 self.remove_message(&[msg]).await;
@@ -274,9 +275,10 @@ impl ProcessQueue {
         let mut inserted_max_offset = i64::MIN;
         {
             let mut store = self.store.write().await;
+            store.messages.reserve(messages.len());
             for message in messages {
                 let queue_offset = message.queue_offset;
-                if store.msg_tree_map.insert(queue_offset, message.clone()).is_none() {
+                if store.messages.insert(queue_offset, message.clone()).is_none() {
                     valid_msg_cnt += 1;
                     inserted_body_size += message.body().map_or(0, |body| body.len()) as u64;
                     inserted_min_offset = inserted_min_offset.min(queue_offset);
@@ -287,7 +289,7 @@ impl ProcessQueue {
                 }
             }
 
-            if !store.msg_tree_map.is_empty() && !self.consuming.load(Ordering::Acquire) {
+            if !store.messages.is_empty() && !self.consuming.load(Ordering::Acquire) {
                 dispatch_to_consume = true;
                 self.consuming.store(true, Ordering::Release);
             }
@@ -324,7 +326,7 @@ impl ProcessQueue {
 
         self.last_consume_timestamp.store(now, Ordering::Release);
 
-        if store.msg_tree_map.is_empty() {
+        if store.messages.is_empty() {
             return -1;
         }
 
@@ -337,7 +339,7 @@ impl ProcessQueue {
 
         for message in messages {
             let queue_offset = message.queue_offset;
-            if store.msg_tree_map.remove(&queue_offset).is_some() {
+            if store.messages.remove(&queue_offset).is_some() {
                 removed_cnt += 1;
                 removed_body_size += message.body().map_or(0, |body| body.len()) as u64;
                 if !snapshot_touched {
@@ -354,15 +356,15 @@ impl ProcessQueue {
             if prev == removed_cnt {
                 self.msg_size.store(0, Ordering::Release);
             }
-            if store.msg_tree_map.is_empty() {
+            if store.messages.is_empty() {
                 self.reset_offset_snapshot();
             } else if snapshot_touched {
                 self.refresh_offset_snapshot(&store);
             }
         }
 
-        if let Some((first_offset, _)) = store.msg_tree_map.first_key_value() {
-            result = *first_offset;
+        if let Some(first_offset) = store.messages.first_offset() {
+            result = first_offset;
         }
 
         result
@@ -371,7 +373,7 @@ impl ProcessQueue {
     pub(crate) async fn rollback(&self) {
         let mut store = self.store.write().await;
         let mut consuming = std::mem::take(&mut store.consuming_msg_orderly_tree_map);
-        store.msg_tree_map.append(&mut consuming);
+        store.messages.append_from_btree_map(&mut consuming);
         self.refresh_offset_snapshot(&store);
     }
 
@@ -403,7 +405,7 @@ impl ProcessQueue {
         let mut store = self.store.write().await;
         for message in messages {
             store.consuming_msg_orderly_tree_map.remove(&message.queue_offset);
-            store.msg_tree_map.insert(message.queue_offset, message.clone());
+            store.messages.insert(message.queue_offset, message.clone());
         }
         self.refresh_offset_snapshot(&store);
     }
@@ -416,7 +418,7 @@ impl ProcessQueue {
         self.last_consume_timestamp.store(now, Ordering::Release);
 
         for _ in 0..batch_size {
-            if let Some((offset, message)) = store.msg_tree_map.pop_first() {
+            if let Some((offset, message)) = store.messages.pop_first() {
                 store.consuming_msg_orderly_tree_map.insert(offset, message.clone());
                 messages.push(message);
             } else {
@@ -426,11 +428,11 @@ impl ProcessQueue {
 
         if messages.is_empty() {
             self.consuming.store(false, Ordering::Release);
-            if store.msg_tree_map.is_empty() {
+            if store.messages.is_empty() {
                 self.reset_offset_snapshot();
             }
-        } else if let Some((min_offset, _)) = store.msg_tree_map.first_key_value() {
-            self.min_offset_snapshot.store(*min_offset, Ordering::Release);
+        } else if let Some(min_offset) = store.messages.first_offset() {
+            self.min_offset_snapshot.store(min_offset, Ordering::Release);
         } else {
             self.reset_offset_snapshot();
         }
@@ -439,16 +441,12 @@ impl ProcessQueue {
     }
 
     pub(crate) async fn contains_message(&self, message_ext: &MessageExt) -> bool {
-        self.store
-            .read()
-            .await
-            .msg_tree_map
-            .contains_key(&message_ext.queue_offset)
+        self.store.read().await.messages.contains_key(&message_ext.queue_offset)
     }
 
     pub(crate) async fn clear(&self) {
         let mut store = self.store.write().await;
-        store.msg_tree_map.clear();
+        store.messages.clear();
         store.consuming_msg_orderly_tree_map.clear();
         store.queue_offset_max = 0;
         self.msg_count.store(0, Ordering::Release);
@@ -473,15 +471,12 @@ impl ProcessQueue {
     }
 
     fn refresh_offset_snapshot(&self, store: &ProcessQueueStore) {
-        match (
-            store.msg_tree_map.first_key_value(),
-            store.msg_tree_map.last_key_value(),
-        ) {
-            (Some((min_offset, _)), Some((max_offset, _))) => {
-                self.min_offset_snapshot.store(*min_offset, Ordering::Release);
-                self.max_offset_snapshot.store(*max_offset, Ordering::Release);
+        match store.messages.offset_span() {
+            Some((min_offset, max_offset)) => {
+                self.min_offset_snapshot.store(min_offset, Ordering::Release);
+                self.max_offset_snapshot.store(max_offset, Ordering::Release);
             }
-            _ => self.reset_offset_snapshot(),
+            None => self.reset_offset_snapshot(),
         }
     }
 
@@ -493,14 +488,12 @@ impl ProcessQueue {
     pub(crate) async fn fill_process_queue_info(&self, info: &mut ProcessQueueInfo) {
         let store = self.store.read().await;
 
-        if !store.msg_tree_map.is_empty() {
-            if let Some((min_offset, _)) = store.msg_tree_map.first_key_value() {
-                info.cached_msg_min_offset = *min_offset as u64;
+        if !store.messages.is_empty() {
+            if let Some((min_offset, max_offset)) = store.messages.offset_span() {
+                info.cached_msg_min_offset = min_offset as u64;
+                info.cached_msg_max_offset = max_offset as u64;
             }
-            if let Some((max_offset, _)) = store.msg_tree_map.last_key_value() {
-                info.cached_msg_max_offset = *max_offset as u64;
-            }
-            info.cached_msg_count = store.msg_tree_map.len() as u32;
+            info.cached_msg_count = store.messages.len() as u32;
         }
 
         info.cached_msg_size_in_mib = (self.msg_size.load(Ordering::Acquire) / (1024 * 1024)) as u32;
@@ -525,13 +518,7 @@ impl ProcessQueue {
     /// Returns `Some((min_offset, max_offset))` of the pending message tree, or `None` if empty.
     pub(crate) async fn get_offset_span(&self) -> Option<(i64, i64)> {
         let store = self.store.read().await;
-        match (
-            store.msg_tree_map.first_key_value(),
-            store.msg_tree_map.last_key_value(),
-        ) {
-            (Some((min, _)), Some((max, _))) => Some((*min, *max)),
-            _ => None,
-        }
+        store.messages.offset_span()
     }
 
     pub(crate) fn set_last_pull_timestamp(&self, last_pull_timestamp: u64) {
@@ -558,7 +545,7 @@ impl ProcessQueue {
         if self.msg_count.load(Ordering::Acquire) <= 0 {
             return false;
         }
-        !self.store.read().await.msg_tree_map.is_empty()
+        !self.store.read().await.messages.is_empty()
     }
 
     pub(crate) fn get_last_pull_timestamp(&self) -> u64 {
@@ -951,13 +938,13 @@ mod tests {
         let taken = pq.take_messages(5).await;
         assert_eq!(taken.len(), 5);
 
-        let msg_tree_map_len = pq.store.read().await.msg_tree_map.len();
-        assert_eq!(msg_tree_map_len, 5);
+        let pending_len = pq.store.read().await.messages.len();
+        assert_eq!(pending_len, 5);
 
         pq.rollback().await;
 
-        let msg_tree_map_len_after = pq.store.read().await.msg_tree_map.len();
-        assert_eq!(msg_tree_map_len_after, 10);
+        let pending_len_after = pq.store.read().await.messages.len();
+        assert_eq!(pending_len_after, 10);
 
         let consuming_map_len = pq.store.read().await.consuming_msg_orderly_tree_map.len();
         assert_eq!(consuming_map_len, 0);
@@ -1067,8 +1054,8 @@ mod tests {
         assert_eq!(pq.msg_count(), 0);
         assert_eq!(pq.msg_size(), 0);
 
-        let msg_tree_map_len = pq.store.read().await.msg_tree_map.len();
-        assert_eq!(msg_tree_map_len, 0);
+        let pending_len = pq.store.read().await.messages.len();
+        assert_eq!(pending_len, 0);
 
         let consuming_map_len = pq.store.read().await.consuming_msg_orderly_tree_map.len();
         assert_eq!(consuming_map_len, 0);
@@ -1124,6 +1111,49 @@ mod tests {
 
         pq.put_message(&inner_msgs).await;
         assert_eq!(pq.get_max_span().await, 10);
+    }
+
+    #[tokio::test]
+    async fn test_contiguous_offsets_use_vecdeque_store() {
+        let pq = ProcessQueue::new();
+        let msgs = create_test_messages(8);
+
+        pq.put_message(&msgs).await;
+
+        let store = pq.store.read().await;
+        assert_eq!(store.messages.storage_kind(), "contiguous");
+        assert_eq!(store.messages.len(), 8);
+        assert_eq!(store.messages.offset_span(), Some((0, 7)));
+    }
+
+    #[tokio::test]
+    async fn test_unordered_offsets_fallback_to_btree_store() {
+        let pq = ProcessQueue::new();
+        let msgs = create_test_messages_with_offsets(&[10, 5, 7]);
+
+        pq.put_message(&msgs).await;
+
+        let store = pq.store.read().await;
+        assert_eq!(store.messages.storage_kind(), "btree");
+        assert_eq!(store.messages.len(), 3);
+        assert_eq!(store.messages.offset_span(), Some((5, 10)));
+    }
+
+    #[tokio::test]
+    async fn test_middle_remove_downgrades_and_preserves_offsets() {
+        let pq = ProcessQueue::new();
+        let msgs = create_test_messages(5);
+
+        pq.put_message(&msgs).await;
+        pq.remove_message(&[msgs[2].clone()]).await;
+
+        assert_eq!(pq.msg_count(), 4);
+        assert_eq!(pq.get_max_span().await, 4);
+
+        let store = pq.store.read().await;
+        assert_eq!(store.messages.storage_kind(), "btree");
+        assert_eq!(store.messages.offset_span(), Some((0, 4)));
+        assert!(!store.messages.contains_key(&2));
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/consumer/consumer_impl/process_queue_store.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/process_queue_store.rs
@@ -1,0 +1,316 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::collections::VecDeque;
+
+use rocketmq_common::common::message::message_ext::MessageExt;
+use rocketmq_rust::ArcMut;
+
+pub(crate) struct ProcessQueueMessageStore {
+    inner: PendingMessageStore,
+}
+
+enum PendingMessageStore {
+    BTree(BTreeMap<i64, ArcMut<MessageExt>>),
+    Contiguous(ContiguousOffsetStore),
+}
+
+struct ContiguousOffsetStore {
+    base_offset: i64,
+    messages: VecDeque<ArcMut<MessageExt>>,
+}
+
+impl ProcessQueueMessageStore {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: PendingMessageStore::Contiguous(ContiguousOffsetStore::empty()),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match &self.inner {
+            PendingMessageStore::BTree(messages) => messages.len(),
+            PendingMessageStore::Contiguous(messages) => messages.len(),
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        if let PendingMessageStore::Contiguous(messages) = &mut self.inner {
+            messages.reserve(additional);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn storage_kind(&self) -> &'static str {
+        match &self.inner {
+            PendingMessageStore::BTree(_) => "btree",
+            PendingMessageStore::Contiguous(_) => "contiguous",
+        }
+    }
+
+    pub(crate) fn insert(&mut self, offset: i64, message: ArcMut<MessageExt>) -> Option<ArcMut<MessageExt>> {
+        match &mut self.inner {
+            PendingMessageStore::BTree(messages) => {
+                if messages.is_empty() {
+                    self.inner = PendingMessageStore::Contiguous(ContiguousOffsetStore::singleton(offset, message));
+                    None
+                } else if ContiguousOffsetStore::can_represent_insert_map(messages, offset) {
+                    let mut contiguous = ContiguousOffsetStore::from_btree_map(std::mem::take(messages));
+                    let previous = contiguous.insert_contiguous(offset, message);
+                    self.inner = PendingMessageStore::Contiguous(contiguous);
+                    previous
+                } else {
+                    messages.insert(offset, message)
+                }
+            }
+            PendingMessageStore::Contiguous(messages) => {
+                if messages.can_insert(offset) {
+                    messages.insert_contiguous(offset, message)
+                } else {
+                    let mut fallback = messages.to_btree_map();
+                    let previous = fallback.insert(offset, message);
+                    self.inner = PendingMessageStore::BTree(fallback);
+                    previous
+                }
+            }
+        }
+    }
+
+    pub(crate) fn remove(&mut self, offset: &i64) -> Option<ArcMut<MessageExt>> {
+        match &mut self.inner {
+            PendingMessageStore::BTree(messages) => messages.remove(offset),
+            PendingMessageStore::Contiguous(messages) => {
+                if !messages.contains_key(*offset) {
+                    None
+                } else if messages.can_remove_without_hole(*offset) {
+                    messages.remove_contiguous(*offset)
+                } else {
+                    let mut fallback = messages.to_btree_map();
+                    let previous = fallback.remove(offset);
+                    self.inner = PendingMessageStore::BTree(fallback);
+                    previous
+                }
+            }
+        }
+    }
+
+    pub(crate) fn pop_first(&mut self) -> Option<(i64, ArcMut<MessageExt>)> {
+        match &mut self.inner {
+            PendingMessageStore::BTree(messages) => messages.pop_first(),
+            PendingMessageStore::Contiguous(messages) => messages.pop_first(),
+        }
+    }
+
+    pub(crate) fn first(&self) -> Option<(i64, ArcMut<MessageExt>)> {
+        match &self.inner {
+            PendingMessageStore::BTree(messages) => messages
+                .first_key_value()
+                .map(|(offset, message)| (*offset, message.clone())),
+            PendingMessageStore::Contiguous(messages) => messages.first(),
+        }
+    }
+
+    pub(crate) fn first_offset(&self) -> Option<i64> {
+        self.first().map(|(offset, _)| offset)
+    }
+
+    pub(crate) fn offset_span(&self) -> Option<(i64, i64)> {
+        match &self.inner {
+            PendingMessageStore::BTree(messages) => match (messages.first_key_value(), messages.last_key_value()) {
+                (Some((min, _)), Some((max, _))) => Some((*min, *max)),
+                _ => None,
+            },
+            PendingMessageStore::Contiguous(messages) => messages.offset_span(),
+        }
+    }
+
+    pub(crate) fn contains_key(&self, offset: &i64) -> bool {
+        match &self.inner {
+            PendingMessageStore::BTree(messages) => messages.contains_key(offset),
+            PendingMessageStore::Contiguous(messages) => messages.contains_key(*offset),
+        }
+    }
+
+    pub(crate) fn append_from_btree_map(&mut self, messages: &mut BTreeMap<i64, ArcMut<MessageExt>>) {
+        let moved = std::mem::take(messages);
+        for (offset, message) in moved {
+            self.insert(offset, message);
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.inner = PendingMessageStore::Contiguous(ContiguousOffsetStore::empty());
+    }
+}
+
+impl ContiguousOffsetStore {
+    fn empty() -> Self {
+        Self {
+            base_offset: 0,
+            messages: VecDeque::new(),
+        }
+    }
+
+    fn singleton(offset: i64, message: ArcMut<MessageExt>) -> Self {
+        let mut messages = VecDeque::with_capacity(1);
+        messages.push_back(message);
+        Self {
+            base_offset: offset,
+            messages,
+        }
+    }
+
+    fn from_btree_map(messages: BTreeMap<i64, ArcMut<MessageExt>>) -> Self {
+        let base_offset = messages.first_key_value().map_or(0, |(offset, _)| *offset);
+        Self {
+            base_offset,
+            messages: messages.into_values().collect(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.messages.len()
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.messages.reserve(additional);
+    }
+
+    fn append_offset(&self) -> Option<i64> {
+        self.last_offset()?.checked_add(1)
+    }
+
+    fn last_offset(&self) -> Option<i64> {
+        if self.messages.is_empty() {
+            None
+        } else {
+            self.base_offset.checked_add(self.messages.len() as i64 - 1)
+        }
+    }
+
+    fn can_insert(&self, offset: i64) -> bool {
+        if self.messages.is_empty() {
+            return true;
+        }
+        self.contains_key(offset)
+            || self.append_offset() == Some(offset)
+            || self.base_offset.checked_sub(1) == Some(offset)
+    }
+
+    fn can_represent_insert_map(messages: &BTreeMap<i64, ArcMut<MessageExt>>, offset: i64) -> bool {
+        if messages.is_empty() {
+            return true;
+        }
+        let min = *messages.first_key_value().expect("non-empty map has first key").0;
+        let max = *messages.last_key_value().expect("non-empty map has last key").0;
+        let Some(width) = max.checked_sub(min).and_then(|delta| delta.checked_add(1)) else {
+            return false;
+        };
+        if width != messages.len() as i64 {
+            return false;
+        }
+        (min..=max).contains(&offset) || max.checked_add(1) == Some(offset) || min.checked_sub(1) == Some(offset)
+    }
+
+    fn insert_contiguous(&mut self, offset: i64, message: ArcMut<MessageExt>) -> Option<ArcMut<MessageExt>> {
+        if self.messages.is_empty() {
+            self.base_offset = offset;
+            self.messages.push_back(message);
+            return None;
+        }
+
+        if self.base_offset.checked_sub(1) == Some(offset) {
+            self.base_offset = offset;
+            self.messages.push_front(message);
+            return None;
+        }
+
+        if self.append_offset() == Some(offset) {
+            self.messages.push_back(message);
+            return None;
+        }
+
+        let index = offset
+            .checked_sub(self.base_offset)
+            .and_then(|distance| usize::try_from(distance).ok())
+            .expect("contiguous replacement offset is in range");
+        let previous = self.messages[index].clone();
+        self.messages[index] = message;
+        Some(previous)
+    }
+
+    fn can_remove_without_hole(&self, offset: i64) -> bool {
+        self.messages.is_empty() || offset == self.base_offset || Some(offset) == self.last_offset()
+    }
+
+    fn remove_contiguous(&mut self, offset: i64) -> Option<ArcMut<MessageExt>> {
+        if !self.contains_key(offset) {
+            return None;
+        }
+
+        if offset == self.base_offset {
+            let removed = self.messages.pop_front();
+            self.base_offset = self.base_offset.saturating_add(1);
+            return removed;
+        }
+
+        if Some(offset) == self.last_offset() {
+            return self.messages.pop_back();
+        }
+
+        None
+    }
+
+    fn pop_first(&mut self) -> Option<(i64, ArcMut<MessageExt>)> {
+        let offset = self.base_offset;
+        let message = self.messages.pop_front()?;
+        self.base_offset = self.base_offset.saturating_add(1);
+        Some((offset, message))
+    }
+
+    fn first(&self) -> Option<(i64, ArcMut<MessageExt>)> {
+        self.messages.front().map(|message| (self.base_offset, message.clone()))
+    }
+
+    fn offset_span(&self) -> Option<(i64, i64)> {
+        self.last_offset().map(|last| (self.base_offset, last))
+    }
+
+    fn contains_key(&self, offset: i64) -> bool {
+        offset
+            .checked_sub(self.base_offset)
+            .and_then(|distance| usize::try_from(distance).ok())
+            .is_some_and(|index| index < self.messages.len())
+    }
+
+    fn to_btree_map(&self) -> BTreeMap<i64, ArcMut<MessageExt>> {
+        self.messages
+            .iter()
+            .enumerate()
+            .map(|(index, message)| {
+                (
+                    self.base_offset
+                        .checked_add(index as i64)
+                        .expect("contiguous offset stays within i64 range"),
+                    message.clone(),
+                )
+            })
+            .collect()
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7634

### Brief Description

Adds an internal `ProcessQueueMessageStore` abstraction for pending consume messages. Dense queue offsets are stored in a `VecDeque`-backed contiguous store for cheaper front pop and edge removals, while unordered inserts and middle removals downgrade to the existing `BTreeMap` representation to preserve current semantics.

The `ProcessQueue` APIs continue to expose the same behavior for duplicate offsets, rollback/commit, offset span snapshots, temp-message checks, and process queue info. Focused tests cover contiguous storage, unordered fallback, and middle-remove fallback.

### How Did You Test This Change?

- `cargo fmt --all` passed.
- `cargo test -p rocketmq-client-rust --lib process_queue` passed: 38 passed.
- `cargo test -p rocketmq-client-rust consume_message_orderly` passed: 14 matching tests passed; filtered integration targets reported 0 matching tests.
- `cargo test -p rocketmq-client-rust --test broker_backed_smoke` passed: 17 passed. `ROCKETMQ_NAMESRV_ADDR` was not set, so broker-backed scenarios exercised the default skip harness rather than a live broker.
- `cargo bench -p rocketmq-client-rust --bench client_consume_pipeline_benchmark` passed. Final local Criterion run reported improvements for `process_queue_take/256`, `process_queue_remove/32`, `process_queue_remove/1024`, and `process_queue_max_span/256`; no significant change for most other probes; `process_queue_put/32` showed a small regression in that run.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of pending consumer messages for more efficient processing of ordered queues.
  * Added smarter storage management that adapts to message patterns automatically.

* **Bug Fixes**
  * Preserved message ordering and offset tracking when messages are added, removed, or retried.
  * Improved queue state reporting so pending-message counts and ranges stay accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->