### PR TITLE
[ISSUE #7636]✨Fix HA batch size and storage lifecycle gaps

### DIFF
--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -62,7 +62,9 @@ use rocketmq_rust::ArcMut;
 use rocketmq_store::base::get_message_result::GetMessageResult;
 use rocketmq_store::base::message_status_enum::GetMessageStatus;
 use rocketmq_store::base::message_store::MessageStore;
+use rocketmq_store::base::select_result::SelectMappedBufferCacheState;
 use rocketmq_store::base::select_result::SelectMappedBufferResult;
+use rocketmq_store::base::select_result::SelectMappedBufferSourceKind;
 use rocketmq_store::filter::ArcMessageFilter;
 use rocketmq_store::pop::batch_ack_msg::BatchAckMsg;
 use rocketmq_store::pop::pop_check_point::PopCheckPoint;
@@ -1182,6 +1184,9 @@ where
                                 bytes: Some(encode),
                                 mapped_file: None,
                                 is_in_cache: true,
+                                source_kind: SelectMappedBufferSourceKind::Bytes,
+                                file_offset: 0,
+                                cache_state: SelectMappedBufferCacheState::Unknown,
                             };
                             get_message_result.add_message_inner(tmp_result);
                         }

--- a/rocketmq-store/src/base.rs
+++ b/rocketmq-store/src/base.rs
@@ -21,6 +21,7 @@ pub mod compaction_append_msg_callback;
 pub mod dispatch_request;
 pub mod flush_manager;
 pub mod get_message_result;
+pub mod memory_lock_manager;
 pub mod message_arriving_listener;
 pub mod message_encoder_pool;
 pub mod message_result;

--- a/rocketmq-store/src/base/memory_lock_manager.rs
+++ b/rocketmq-store/src/base/memory_lock_manager.rs
@@ -1,0 +1,102 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use rocketmq_error::RocketMQResult;
+use tracing::warn;
+
+use crate::utils::ffi::mlock;
+
+#[derive(Debug)]
+pub struct MemoryLockManager {
+    warn_only: bool,
+    locked_buffers: AtomicUsize,
+    lock_failed_buffers: AtomicUsize,
+}
+
+impl MemoryLockManager {
+    pub fn warn_only() -> Self {
+        Self {
+            warn_only: true,
+            locked_buffers: AtomicUsize::new(0),
+            lock_failed_buffers: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn lock_buffer(&self, addr: *const u8, len: usize) -> RocketMQResult<()> {
+        self.lock_buffer_with(addr, len, mlock)
+    }
+
+    pub(crate) fn lock_buffer_with<F>(&self, addr: *const u8, len: usize, mut locker: F) -> RocketMQResult<()>
+    where
+        F: FnMut(*const u8, usize) -> RocketMQResult<()>,
+    {
+        match locker(addr, len) {
+            Ok(()) => {
+                self.locked_buffers.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(error) => {
+                self.lock_failed_buffers.fetch_add(1, Ordering::Relaxed);
+                if self.warn_only {
+                    warn!(
+                        "Failed to lock memory buffer of {} bytes, continuing without mlock: {}",
+                        len, error
+                    );
+                    Ok(())
+                } else {
+                    Err(error)
+                }
+            }
+        }
+    }
+
+    pub fn locked_buffer_count(&self) -> usize {
+        self.locked_buffers.load(Ordering::Relaxed)
+    }
+
+    pub fn lock_failed_buffer_count(&self) -> usize {
+        self.lock_failed_buffers.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for MemoryLockManager {
+    fn default() -> Self {
+        Self::warn_only()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_error::RocketMQError;
+
+    use super::*;
+
+    #[test]
+    fn warn_only_manager_records_failure_without_returning_error() {
+        let manager = MemoryLockManager::warn_only();
+
+        let result = manager.lock_buffer_with(std::ptr::null(), 4096, |_, _| {
+            Err(RocketMQError::StorageLockFailed {
+                path: "test mlock failure".to_string(),
+            })
+        });
+
+        assert!(result.is_ok());
+        assert_eq!(manager.locked_buffer_count(), 0);
+        assert_eq!(manager.lock_failed_buffer_count(), 1);
+    }
+}

--- a/rocketmq-store/src/base/select_result.rs
+++ b/rocketmq-store/src/base/select_result.rs
@@ -19,6 +19,29 @@ use bytes::Bytes;
 use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::log_file::mapped_file::MappedFile;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectMappedBufferSourceKind {
+    MappedFile,
+    Bytes,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectMappedBufferCacheState {
+    Unknown,
+    Hot,
+    Cold,
+}
+
+impl SelectMappedBufferCacheState {
+    pub fn from_residency(is_in_cache: bool) -> Self {
+        if is_in_cache {
+            Self::Hot
+        } else {
+            Self::Cold
+        }
+    }
+}
+
 /// Represents the result of selecting a mapped buffer.
 pub struct SelectMappedBufferResult {
     /// The start offset.
@@ -30,6 +53,12 @@ pub struct SelectMappedBufferResult {
     pub mapped_file: Option<Arc<DefaultMappedFile>>,
     /// Whether the buffer is in cache.
     pub is_in_cache: bool,
+    /// Source kind used for observability and future transfer planning.
+    pub source_kind: SelectMappedBufferSourceKind,
+    /// Offset within the mapped file, when the result comes from a mapped file.
+    pub file_offset: u64,
+    /// Page-cache state observed when the result was selected.
+    pub cache_state: SelectMappedBufferCacheState,
 }
 
 impl Default for SelectMappedBufferResult {
@@ -40,6 +69,9 @@ impl Default for SelectMappedBufferResult {
             size: 0,
             mapped_file: None,
             is_in_cache: true,
+            source_kind: SelectMappedBufferSourceKind::Bytes,
+            file_offset: 0,
+            cache_state: SelectMappedBufferCacheState::Unknown,
         }
     }
 }

--- a/rocketmq-store/src/base/transient_store_pool.rs
+++ b/rocketmq-store/src/base/transient_store_pool.rs
@@ -19,7 +19,7 @@ use parking_lot::Mutex;
 use rocketmq_error::RocketMQResult;
 use tracing::warn;
 
-use crate::utils::ffi::mlock;
+use crate::base::memory_lock_manager::MemoryLockManager;
 use crate::utils::ffi::munlock;
 
 #[derive(Clone)]
@@ -28,6 +28,7 @@ pub struct TransientStorePool {
     file_size: usize,
     available_buffers: Arc<parking_lot::Mutex<VecDeque<Vec<u8>>>>,
     is_real_commit: Arc<parking_lot::Mutex<bool>>,
+    memory_lock_manager: Arc<MemoryLockManager>,
 }
 
 impl TransientStorePool {
@@ -39,14 +40,24 @@ impl TransientStorePool {
             file_size,
             available_buffers,
             is_real_commit,
+            memory_lock_manager: Arc::new(MemoryLockManager::warn_only()),
         }
     }
 
     pub fn init(&self) -> RocketMQResult<()> {
+        let memory_lock_manager = self.memory_lock_manager.clone();
+        self.init_with_locker(|addr, len| memory_lock_manager.lock_buffer(addr, len))
+    }
+
+    pub(crate) fn init_with_locker<F>(&self, mut locker: F) -> RocketMQResult<()>
+    where
+        F: FnMut(*const u8, usize) -> RocketMQResult<()>,
+    {
         let mut available_buffers = self.available_buffers.lock();
         for _ in 0..self.pool_size {
             let buffer = vec![0u8; self.file_size];
-            mlock(buffer.as_ptr(), self.file_size)?;
+            self.memory_lock_manager
+                .lock_buffer_with(buffer.as_ptr(), self.file_size, &mut locker)?;
             available_buffers.push_back(buffer);
         }
         Ok(())
@@ -79,6 +90,14 @@ impl TransientStorePool {
         available_buffers.len()
     }
 
+    pub fn locked_buffer_count(&self) -> usize {
+        self.memory_lock_manager.locked_buffer_count()
+    }
+
+    pub fn lock_failed_buffer_count(&self) -> usize {
+        self.memory_lock_manager.lock_failed_buffer_count()
+    }
+
     pub fn is_real_commit(&self) -> bool {
         let is_real_commit = self.is_real_commit.lock();
         *is_real_commit
@@ -87,5 +106,28 @@ impl TransientStorePool {
     pub fn set_real_commit(&self, real_commit: bool) {
         let mut is_real_commit = self.is_real_commit.lock();
         *is_real_commit = real_commit;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocketmq_error::RocketMQError;
+
+    use super::*;
+
+    #[test]
+    fn init_keeps_buffers_when_memory_lock_fails_warn_only() {
+        let pool = TransientStorePool::new(2, 4096);
+
+        let result = pool.init_with_locker(|_, _| {
+            Err(RocketMQError::StorageLockFailed {
+                path: "test mlock failure".to_string(),
+            })
+        });
+
+        assert!(result.is_ok());
+        assert_eq!(pool.available_buffer_nums(), 2);
+        assert_eq!(pool.locked_buffer_count(), 0);
+        assert_eq!(pool.lock_failed_buffer_count(), 2);
     }
 }

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -64,6 +64,7 @@ pub const TRANSFER_HEADER_SIZE: usize = 8 + 4;
 /// Controller transfer header extends the default header with confirm offset.
 /// Format: [physicOffset (8bytes)][bodySize (4bytes)][confirmOffset (8bytes)]
 pub(crate) const CONTROLLER_TRANSFER_HEADER_SIZE: usize = TRANSFER_HEADER_SIZE + 8;
+pub(crate) const DEFAULT_HA_TRANSFER_BATCH_SIZE: usize = 256 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TransferHeader {
@@ -94,6 +95,14 @@ pub(crate) fn encode_transfer_header(
         byte_buffer_header.put_i64(confirm_offset);
     }
     byte_buffer_header.split().freeze()
+}
+
+pub(crate) const fn effective_ha_transfer_batch_size(configured_batch_size: usize) -> usize {
+    if configured_batch_size == 0 {
+        DEFAULT_HA_TRANSFER_BATCH_SIZE
+    } else {
+        configured_batch_size
+    }
 }
 
 pub(crate) fn decode_transfer_header(
@@ -766,7 +775,7 @@ impl WriteSocketService {
             .get_commit_log_data(next_offset)
         {
             let mut size = select_result.size as usize;
-            let max_batch_size = self.message_store_config.ha_transfer_batch_size;
+            let max_batch_size = effective_ha_transfer_batch_size(self.message_store_config.ha_transfer_batch_size);
 
             if size > max_batch_size {
                 size = max_batch_size;
@@ -926,5 +935,18 @@ mod tests {
         assert_eq!(header.master_phy_offset, 128);
         assert_eq!(header.body_size, 64);
         assert_eq!(header.confirm_offset, Some(96));
+    }
+
+    #[test]
+    fn zero_configured_ha_transfer_batch_size_uses_safe_default() {
+        let effective = effective_ha_transfer_batch_size(0);
+
+        assert_eq!(effective, DEFAULT_HA_TRANSFER_BATCH_SIZE);
+        assert!(effective > 0);
+    }
+
+    #[test]
+    fn non_zero_configured_ha_transfer_batch_size_is_preserved() {
+        assert_eq!(effective_ha_transfer_batch_size(64 * 1024), 64 * 1024);
     }
 }

--- a/rocketmq-store/src/kv/compaction_store.rs
+++ b/rocketmq-store/src/kv/compaction_store.rs
@@ -22,7 +22,9 @@ use dashmap::DashMap;
 use crate::base::dispatch_request::DispatchRequest;
 use crate::base::get_message_result::GetMessageResult;
 use crate::base::message_status_enum::GetMessageStatus;
+use crate::base::select_result::SelectMappedBufferCacheState;
 use crate::base::select_result::SelectMappedBufferResult;
+use crate::base::select_result::SelectMappedBufferSourceKind;
 use crate::log_file::mapped_file::MappedFile;
 
 #[derive(Default)]
@@ -234,6 +236,9 @@ impl CompactionStore {
                     size: payload_size,
                     mapped_file: None,
                     is_in_cache: true,
+                    source_kind: SelectMappedBufferSourceKind::Bytes,
+                    file_offset: 0,
+                    cache_state: SelectMappedBufferCacheState::Unknown,
                 },
                 queue_offset as u64,
                 message.batch_num,

--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -47,7 +47,9 @@ use crate::base::compaction_append_msg_callback::CompactionAppendMsgCallback;
 use crate::base::message_result::AppendMessageResult;
 use crate::base::message_status_enum::AppendMessageStatus;
 use crate::base::put_message_context::PutMessageContext;
+use crate::base::select_result::SelectMappedBufferCacheState;
 use crate::base::select_result::SelectMappedBufferResult;
+use crate::base::select_result::SelectMappedBufferSourceKind;
 use crate::base::transient_store_pool::TransientStorePool;
 use crate::config::flush_disk_type::FlushDiskType;
 use crate::log_file::mapped_file::reference_resource::ReferenceResource;
@@ -652,6 +654,9 @@ impl MappedFile for DefaultMappedFile {
                     size,
                     bytes: Some(bytes),
                     is_in_cache,
+                    source_kind: SelectMappedBufferSourceKind::MappedFile,
+                    file_offset: pos as u64,
+                    cache_state: SelectMappedBufferCacheState::from_residency(is_in_cache),
                     mapped_file: None,
                 })
             } else {
@@ -1072,6 +1077,9 @@ impl MappedFile for DefaultMappedFile {
                 size,
                 bytes: Some(bytes),
                 is_in_cache,
+                source_kind: SelectMappedBufferSourceKind::MappedFile,
+                file_offset: pos as u64,
+                cache_state: SelectMappedBufferCacheState::from_residency(is_in_cache),
                 mapped_file: None,
             })
         } else {
@@ -1734,6 +1742,12 @@ mod tests {
         let metrics = mapped_file.get_metrics().unwrap();
         assert_eq!(metrics.cache_hits() + metrics.cache_misses(), 1);
         assert_eq!(result.is_in_cache, metrics.cache_hits() == 1);
+        assert_eq!(result.source_kind, SelectMappedBufferSourceKind::MappedFile);
+        assert_eq!(result.file_offset, 0);
+        assert_eq!(
+            result.cache_state,
+            SelectMappedBufferCacheState::from_residency(result.is_in_cache)
+        );
     }
 
     #[test]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -112,7 +112,11 @@ use crate::base::message_status_enum::GetMessageStatus;
 use crate::base::message_status_enum::PutMessageStatus;
 use crate::base::message_store::MessageStore;
 use crate::base::query_message_result::QueryMessageResult;
+#[cfg(feature = "tieredstore")]
+use crate::base::select_result::SelectMappedBufferCacheState;
 use crate::base::select_result::SelectMappedBufferResult;
+#[cfg(feature = "tieredstore")]
+use crate::base::select_result::SelectMappedBufferSourceKind;
 use crate::base::store_checkpoint::StoreCheckpoint;
 use crate::base::store_stats_service::StoreStatsService;
 use crate::base::transient_store_pool::TransientStorePool;
@@ -638,6 +642,9 @@ impl LocalFileMessageStore {
             bytes: Some(message),
             mapped_file: None,
             is_in_cache: false,
+            source_kind: SelectMappedBufferSourceKind::Bytes,
+            file_offset: 0,
+            cache_state: SelectMappedBufferCacheState::Unknown,
         }
     }
 
@@ -3056,7 +3063,7 @@ impl MessageStore for LocalFileMessageStore {
     }
 
     fn unlock_mapped_file<MF: MappedFile>(&self, unlock_mapped_file: &MF) {
-        warn!("unlock_mapped_file: not implemented");
+        unlock_mapped_file.munlock();
     }
 
     fn get_queue_store(&self) -> &dyn Any {
@@ -4567,6 +4574,7 @@ mod tests {
     use crate::hook::put_message_hook::PutMessageHook;
     use crate::hook::send_message_back_hook::SendMessageBackHook;
     use crate::kv::compaction_service::CompactionService;
+    use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
     use crate::message_encoder::message_ext_encoder::MessageExtEncoder;
     use crate::queue::consume_queue::ConsumeQueueTrait;
     use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
@@ -4627,6 +4635,19 @@ mod tests {
         let store = new_configured_test_store(&temp_dir, MessageStoreConfig::default());
 
         assert!(store.commit_log.has_allocate_mapped_file_service());
+    }
+
+    #[test]
+    fn unlock_mapped_file_is_safe_for_unlocked_and_repeated_calls() {
+        let store_dir = tempdir().unwrap();
+        let mapped_file_dir = tempdir().unwrap();
+        let store = new_configured_test_store(&store_dir, MessageStoreConfig::default());
+        let mapped_file_path = mapped_file_dir.path().join("00000000000000000000");
+        let mapped_file =
+            DefaultMappedFile::new(CheetahString::from(mapped_file_path.to_string_lossy().as_ref()), 4096);
+
+        store.unlock_mapped_file(&mapped_file);
+        store.unlock_mapped_file(&mapped_file);
     }
 
     fn new_unwired_test_store(temp_dir: &tempfile::TempDir) -> ArcMut<LocalFileMessageStore> {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7636

### Brief Description

- Fix HA transfer batching so a zero `ha_transfer_batch_size` uses the RocketMQ default 256 KiB transfer size instead of producing zero-length batches.
- Add a warn-only memory lock manager for transient store pool buffers, with lock success/failure counters and lifecycle-safe buffer initialization when `mlock` fails.
- Propagate mapped-buffer source/cache metadata across store, compaction, tiered bytes, and pop re-encoded results, and delegate mapped-file unlock to `munlock`.

### How Did You Test This Change?

- `cargo fmt --all` completed successfully.
- `cargo test -p rocketmq-store --lib` passed: 495 passed.
- `cargo test -p rocketmq-broker --lib` passed: 477 passed, 1 ignored.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer handling for memory-mapped storage, including lock success/failure tracking and improved buffer management.
  * Added clearer metadata for returned message buffers so storage source and cache state can be identified.
  * Added a fallback transfer batch size for high-availability sync when no size is configured.

* **Bug Fixes**
  * Improved mapped-file unlock behavior.
  * Ensured buffer selection now records cache residency details and offsets consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->