### PR TITLE
[ISSUE #7638]✨Complete Linux storage lifecycle capability plumbing

### DIFF
--- a/rocketmq-store/src/base/memory_lock_manager.rs
+++ b/rocketmq-store/src/base/memory_lock_manager.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
@@ -23,16 +24,32 @@ use crate::utils::ffi::mlock;
 #[derive(Debug)]
 pub struct MemoryLockManager {
     warn_only: bool,
+    budget_bytes: AtomicU64,
+    lock_attempts: AtomicUsize,
     locked_buffers: AtomicUsize,
     lock_failed_buffers: AtomicUsize,
+    lock_skipped_buffers: AtomicUsize,
+    locked_bytes: AtomicU64,
+    lock_failed_bytes: AtomicU64,
+    lock_skipped_bytes: AtomicU64,
 }
 
 impl MemoryLockManager {
     pub fn warn_only() -> Self {
+        Self::warn_only_with_budget(0)
+    }
+
+    pub fn warn_only_with_budget(budget_bytes: u64) -> Self {
         Self {
             warn_only: true,
+            budget_bytes: AtomicU64::new(budget_bytes),
+            lock_attempts: AtomicUsize::new(0),
             locked_buffers: AtomicUsize::new(0),
             lock_failed_buffers: AtomicUsize::new(0),
+            lock_skipped_buffers: AtomicUsize::new(0),
+            locked_bytes: AtomicU64::new(0),
+            lock_failed_bytes: AtomicU64::new(0),
+            lock_skipped_bytes: AtomicU64::new(0),
         }
     }
 
@@ -44,13 +61,40 @@ impl MemoryLockManager {
     where
         F: FnMut(*const u8, usize) -> RocketMQResult<()>,
     {
+        self.lock_attempts.fetch_add(1, Ordering::Relaxed);
+        let len_bytes = len as u64;
+        if !self.reserve_lock_budget(len_bytes) {
+            self.lock_skipped_buffers.fetch_add(1, Ordering::Relaxed);
+            self.lock_skipped_bytes.fetch_add(len_bytes, Ordering::Relaxed);
+            if self.warn_only {
+                warn!(
+                    "Skipped memory lock of {} bytes because lock budget {} bytes is exhausted",
+                    len_bytes,
+                    self.budget_bytes.load(Ordering::Relaxed)
+                );
+                return Ok(());
+            }
+            return Err(rocketmq_error::RocketMQError::StorageLockFailed {
+                path: format!(
+                    "memory lock budget exhausted: requested={} budget={}",
+                    len_bytes,
+                    self.budget_bytes.load(Ordering::Relaxed)
+                ),
+            });
+        }
+
         match locker(addr, len) {
             Ok(()) => {
                 self.locked_buffers.fetch_add(1, Ordering::Relaxed);
+                if self.budget_bytes.load(Ordering::Relaxed) == 0 {
+                    self.locked_bytes.fetch_add(len_bytes, Ordering::Relaxed);
+                }
                 Ok(())
             }
             Err(error) => {
+                self.release_reserved_budget(len_bytes);
                 self.lock_failed_buffers.fetch_add(1, Ordering::Relaxed);
+                self.lock_failed_bytes.fetch_add(len_bytes, Ordering::Relaxed);
                 if self.warn_only {
                     warn!(
                         "Failed to lock memory buffer of {} bytes, continuing without mlock: {}",
@@ -64,12 +108,61 @@ impl MemoryLockManager {
         }
     }
 
+    fn reserve_lock_budget(&self, len: u64) -> bool {
+        let budget = self.budget_bytes.load(Ordering::Relaxed);
+        if budget == 0 {
+            return true;
+        }
+        let mut current = self.locked_bytes.load(Ordering::Acquire);
+        loop {
+            let Some(next) = current.checked_add(len) else {
+                return false;
+            };
+            if next > budget {
+                return false;
+            }
+            match self
+                .locked_bytes
+                .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => return true,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn release_reserved_budget(&self, len: u64) {
+        if self.budget_bytes.load(Ordering::Relaxed) != 0 {
+            self.locked_bytes.fetch_sub(len, Ordering::AcqRel);
+        }
+    }
+
+    pub fn lock_attempt_count(&self) -> usize {
+        self.lock_attempts.load(Ordering::Relaxed)
+    }
+
     pub fn locked_buffer_count(&self) -> usize {
         self.locked_buffers.load(Ordering::Relaxed)
     }
 
     pub fn lock_failed_buffer_count(&self) -> usize {
         self.lock_failed_buffers.load(Ordering::Relaxed)
+    }
+
+    pub fn lock_skipped_buffer_count(&self) -> usize {
+        self.lock_skipped_buffers.load(Ordering::Relaxed)
+    }
+
+    pub fn locked_bytes(&self) -> u64 {
+        self.locked_bytes.load(Ordering::Relaxed)
+    }
+
+    pub fn lock_failed_bytes(&self) -> u64 {
+        self.lock_failed_bytes.load(Ordering::Relaxed)
+    }
+
+    pub fn lock_skipped_bytes(&self) -> u64 {
+        self.lock_skipped_bytes.load(Ordering::Relaxed)
     }
 }
 
@@ -98,5 +191,24 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(manager.locked_buffer_count(), 0);
         assert_eq!(manager.lock_failed_buffer_count(), 1);
+    }
+
+    #[test]
+    fn warn_only_manager_skips_lock_when_budget_is_exhausted() {
+        let manager = MemoryLockManager::warn_only_with_budget(4096);
+        let mut called = false;
+
+        let result = manager.lock_buffer_with(std::ptr::null(), 8192, |_, _| {
+            called = true;
+            Ok(())
+        });
+
+        assert!(result.is_ok());
+        assert!(!called);
+        assert_eq!(manager.lock_attempt_count(), 1);
+        assert_eq!(manager.locked_buffer_count(), 0);
+        assert_eq!(manager.lock_skipped_buffer_count(), 1);
+        assert_eq!(manager.lock_skipped_bytes(), 8192);
+        assert_eq!(manager.locked_bytes(), 0);
     }
 }

--- a/rocketmq-store/src/base/transient_store_pool.rs
+++ b/rocketmq-store/src/base/transient_store_pool.rs
@@ -94,8 +94,28 @@ impl TransientStorePool {
         self.memory_lock_manager.locked_buffer_count()
     }
 
+    pub fn lock_attempt_count(&self) -> usize {
+        self.memory_lock_manager.lock_attempt_count()
+    }
+
     pub fn lock_failed_buffer_count(&self) -> usize {
         self.memory_lock_manager.lock_failed_buffer_count()
+    }
+
+    pub fn lock_skipped_buffer_count(&self) -> usize {
+        self.memory_lock_manager.lock_skipped_buffer_count()
+    }
+
+    pub fn locked_bytes(&self) -> u64 {
+        self.memory_lock_manager.locked_bytes()
+    }
+
+    pub fn lock_failed_bytes(&self) -> u64 {
+        self.memory_lock_manager.lock_failed_bytes()
+    }
+
+    pub fn lock_skipped_bytes(&self) -> u64 {
+        self.memory_lock_manager.lock_skipped_bytes()
     }
 
     pub fn is_real_commit(&self) -> bool {

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -26,6 +26,7 @@ mod kv;
 pub mod log_file;
 pub(crate) mod message_encoder;
 pub mod message_store;
+pub mod platform;
 pub mod pop;
 pub mod queue;
 #[cfg(feature = "rocksdb_store")]

--- a/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/default_mapped_file_impl.rs
@@ -55,6 +55,8 @@ use crate::config::flush_disk_type::FlushDiskType;
 use crate::log_file::mapped_file::reference_resource::ReferenceResource;
 use crate::log_file::mapped_file::reference_resource_counter::ReferenceResourceCounter;
 use crate::log_file::mapped_file::MappedFile;
+use crate::platform::preallocate_file;
+use crate::platform::FilePreallocateOutcome;
 use crate::utils::ffi::get_page_size;
 use crate::utils::ffi::madvise;
 #[cfg(target_os = "linux")]
@@ -146,6 +148,7 @@ impl DefaultMappedFile {
         ensure_dir_ok(dir);
 
         let file_from_offset = Self::try_parse_file_from_offset(&path_buf)?;
+        let existing_len = fs::metadata(&path_buf).map(|metadata| metadata.len()).unwrap_or(0);
         let file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -153,6 +156,19 @@ impl DefaultMappedFile {
             .truncate(false)
             .open(&path_buf)?;
         file.set_len(file_size)?;
+        if existing_len < file_size {
+            match preallocate_file(&file, file_size) {
+                FilePreallocateOutcome::Allocated => {}
+                FilePreallocateOutcome::Unsupported { errno } => debug!(
+                    "File preallocation is unsupported for mapped file {} and will be skipped, errno={}",
+                    file_name, errno
+                ),
+                FilePreallocateOutcome::Failed { errno } => warn!(
+                    "File preallocation failed for mapped file {} and will continue with set_len, errno={}",
+                    file_name, errno
+                ),
+            }
+        }
 
         let mmap = unsafe { MmapMut::map_mut(&file)? };
         Ok(Self {

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -1866,6 +1866,19 @@ impl MessageStore for LocalFileMessageStore {
             }
         }
 
+        let storage_capability = crate::platform::current_store_platform_capability();
+        info!(
+            "Linux storage capability snapshot: os={} page_size={} memory_lock_limit_bytes={} \
+             file_preallocate_supported={}",
+            storage_capability.os_name,
+            storage_capability.page_size,
+            storage_capability
+                .memory_lock_limit_bytes
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".to_string()),
+            storage_capability.file_preallocate_supported
+        );
+
         if self.is_transient_store_pool_enable() {
             match self.transient_store_pool.init() {
                 Ok(_) => {}
@@ -2550,6 +2563,61 @@ impl MessageStore for LocalFileMessageStore {
             "ioUringBackendStatus".to_string(),
             crate::log_file::mapped_file::io_uring_backend_status()
                 .as_str()
+                .to_string(),
+        );
+        let storage_capability = crate::platform::current_store_platform_capability();
+        result.insert("linuxStorageOs".to_string(), storage_capability.os_name.to_string());
+        result.insert(
+            "linuxStoragePageSize".to_string(),
+            storage_capability.page_size.to_string(),
+        );
+        result.insert(
+            "linuxStorageMemoryLockLimitBytes".to_string(),
+            storage_capability
+                .memory_lock_limit_bytes
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".to_string()),
+        );
+        result.insert(
+            "linuxStorageFilePreallocateSupported".to_string(),
+            storage_capability.file_preallocate_supported.to_string(),
+        );
+        result.insert(
+            "transientStorePoolLockedBuffers".to_string(),
+            self.transient_store_pool.locked_buffer_count().to_string(),
+        );
+        result.insert(
+            "transientStorePoolLockAttempts".to_string(),
+            self.transient_store_pool.lock_attempt_count().to_string(),
+        );
+        result.insert(
+            "transientStorePoolLockFailedBuffers".to_string(),
+            self.transient_store_pool.lock_failed_buffer_count().to_string(),
+        );
+        result.insert(
+            "transientStorePoolLockSkippedBuffers".to_string(),
+            self.transient_store_pool.lock_skipped_buffer_count().to_string(),
+        );
+        result.insert(
+            "transientStorePoolLockedBytes".to_string(),
+            self.transient_store_pool.locked_bytes().to_string(),
+        );
+        result.insert(
+            "transientStorePoolLockFailedBytes".to_string(),
+            self.transient_store_pool.lock_failed_bytes().to_string(),
+        );
+        result.insert(
+            "transientStorePoolLockSkippedBytes".to_string(),
+            self.transient_store_pool.lock_skipped_bytes().to_string(),
+        );
+        result.insert(
+            "warmMappedFileEnable".to_string(),
+            self.message_store_config.warm_mapped_file_enable.to_string(),
+        );
+        result.insert(
+            "flushLeastPagesWhenWarmMappedFile".to_string(),
+            self.message_store_config
+                .flush_least_pages_when_warm_mapped_file
                 .to_string(),
         );
 
@@ -5319,6 +5387,24 @@ mod tests {
         assert_eq!(runtime_info["storeType"], "RocksDB");
         assert_eq!(runtime_info["rocksdbCqDoubleWriteEnable"], "true");
         assert_eq!(runtime_info["rocksdbCompatibilityMode"], "local_file_compat");
+    }
+
+    #[test]
+    fn runtime_info_reports_linux_storage_lifecycle_fields() {
+        let temp_dir = tempdir().unwrap();
+        let store = new_configured_test_store(&temp_dir, MessageStoreConfig::default());
+
+        let runtime_info = store.get_runtime_info();
+
+        assert!(runtime_info.contains_key("linuxStorageOs"));
+        assert!(runtime_info.contains_key("linuxStoragePageSize"));
+        assert!(runtime_info.contains_key("linuxStorageMemoryLockLimitBytes"));
+        assert_eq!(runtime_info["transientStorePoolLockAttempts"], "0");
+        assert_eq!(runtime_info["transientStorePoolLockedBuffers"], "0");
+        assert_eq!(runtime_info["transientStorePoolLockFailedBuffers"], "0");
+        assert_eq!(runtime_info["transientStorePoolLockSkippedBuffers"], "0");
+        assert_eq!(runtime_info["transientStorePoolLockedBytes"], "0");
+        assert_eq!(runtime_info["warmMappedFileEnable"], "false");
     }
 
     #[tokio::test]

--- a/rocketmq-store/src/platform.rs
+++ b/rocketmq-store/src/platform.rs
@@ -1,0 +1,112 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+
+use crate::utils::ffi::get_page_size;
+
+pub const PREALLOCATE_UNSUPPORTED_ERRNO: i32 = 95;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorePlatformCapability {
+    pub os_name: &'static str,
+    pub page_size: usize,
+    pub memory_lock_limit_bytes: Option<u64>,
+    pub file_preallocate_supported: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilePreallocateOutcome {
+    Allocated,
+    Unsupported { errno: i32 },
+    Failed { errno: i32 },
+}
+
+impl FilePreallocateOutcome {
+    pub fn is_degraded(self) -> bool {
+        matches!(self, Self::Unsupported { .. })
+    }
+}
+
+pub fn current_store_platform_capability() -> StorePlatformCapability {
+    StorePlatformCapability {
+        os_name: std::env::consts::OS,
+        page_size: get_page_size().max(1),
+        memory_lock_limit_bytes: memory_lock_limit_bytes(),
+        file_preallocate_supported: cfg!(target_os = "linux"),
+    }
+}
+
+pub fn classify_file_preallocate_result(result: i32, errno: i32) -> FilePreallocateOutcome {
+    if result == 0 {
+        FilePreallocateOutcome::Allocated
+    } else if is_unsupported_preallocate_errno(errno) {
+        FilePreallocateOutcome::Unsupported { errno }
+    } else {
+        FilePreallocateOutcome::Failed { errno }
+    }
+}
+
+pub fn preallocate_file(file: &File, len: u64) -> FilePreallocateOutcome {
+    if len == 0 {
+        return FilePreallocateOutcome::Allocated;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::fd::AsRawFd;
+
+        if len > i64::MAX as u64 {
+            return FilePreallocateOutcome::Failed { errno: libc::EINVAL };
+        }
+
+        let result = unsafe { libc::fallocate(file.as_raw_fd(), 0, 0, len as libc::off_t) };
+        let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+        classify_file_preallocate_result(result, errno)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = file;
+        FilePreallocateOutcome::Unsupported {
+            errno: PREALLOCATE_UNSUPPORTED_ERRNO,
+        }
+    }
+}
+
+fn is_unsupported_preallocate_errno(errno: i32) -> bool {
+    errno == PREALLOCATE_UNSUPPORTED_ERRNO || errno == libc::ENOSYS || errno == libc::EINVAL
+}
+
+#[cfg(unix)]
+fn memory_lock_limit_bytes() -> Option<u64> {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    let result = unsafe { libc::getrlimit(libc::RLIMIT_MEMLOCK, &mut limit) };
+    if result != 0 {
+        return None;
+    }
+    if limit.rlim_cur == libc::RLIM_INFINITY {
+        Some(u64::MAX)
+    } else {
+        Some(limit.rlim_cur)
+    }
+}
+
+#[cfg(not(unix))]
+fn memory_lock_limit_bytes() -> Option<u64> {
+    Some(0)
+}

--- a/rocketmq-store/tests/store_lifecycle_capability.rs
+++ b/rocketmq-store/tests/store_lifecycle_capability.rs
@@ -1,0 +1,40 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_store::platform::classify_file_preallocate_result;
+use rocketmq_store::platform::current_store_platform_capability;
+use rocketmq_store::platform::FilePreallocateOutcome;
+use rocketmq_store::platform::PREALLOCATE_UNSUPPORTED_ERRNO;
+
+#[test]
+fn platform_capability_snapshot_reports_page_size_and_lock_limit() {
+    let capability = current_store_platform_capability();
+
+    assert!(!capability.os_name.is_empty());
+    assert!(capability.page_size > 0);
+    assert!(capability.memory_lock_limit_bytes.is_some());
+}
+
+#[test]
+fn unsupported_preallocation_errno_is_reported_as_degraded() {
+    let outcome = classify_file_preallocate_result(-1, PREALLOCATE_UNSUPPORTED_ERRNO);
+
+    assert_eq!(
+        outcome,
+        FilePreallocateOutcome::Unsupported {
+            errno: PREALLOCATE_UNSUPPORTED_ERRNO
+        }
+    );
+    assert!(outcome.is_degraded());
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7638

### Brief Description

- Add a store platform capability snapshot with page size, memory-lock limit, and Linux file preallocation support visibility.
- Add a safe file preallocation wrapper and invoke it for newly expanded mapped files while preserving the existing `set_len` fallback path.
- Extend transient-store-pool memory locking with budget-aware attempt, skipped, failure, and byte counters.
- Expose Linux storage lifecycle and warmup fields through store runtime info, and log the capability snapshot during store init.
- This PR does not submit `docs/` and does not claim a throughput or latency improvement; later transfer-engine performance PRs will include before/after benchmark data.

### How Did You Test This Change?

- `cargo fmt --all --check` passed.
- `cargo test -p rocketmq-store --test store_lifecycle_capability` passed: 2 passed.
- `cargo test -p rocketmq-store --lib` passed: 497 passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added store platform capability reporting, including OS, page size, memory lock limit, and file preallocation support.
  * Exposed additional store metrics for memory lock attempts, successes, skips, and byte counts.
  * Expanded runtime info to include Linux storage capability details and warm-mapped-file settings.

* **Bug Fixes**
  * Improved mapped-file creation with file preallocation when supported, while continuing safely when it is not.
  * Added clearer handling for memory-lock budgeting and skipped lock attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->