### PR TITLE
[ISSUE #7640]✨Introduce commitlog transfer planner abstraction

### DIFF
--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -57,6 +57,9 @@ use crate::ha::ha_connection::HAConnectionId;
 use crate::ha::ha_connection_state::HAConnectionState;
 use crate::ha::ha_service::HAService;
 use crate::ha::HAConnectionError;
+use crate::transfer::batch::TransferPlan;
+use crate::transfer::planner::TransferPlanInput;
+use crate::transfer::planner::TransferPlanner;
 
 /// Transfer Header buffer size. Schema: physic offset and body size.
 /// Format: [physicOffset (8bytes)][bodySize (4bytes)]
@@ -769,47 +772,80 @@ impl WriteSocketService {
         }
 
         let next_offset = self.next_transfer_from_where.load(Ordering::Relaxed);
-        if let Some(select_result) = self
+        let max_commit_log_offset = self
             .ha_service
             .get_default_message_store()
-            .get_commit_log_data(next_offset)
-        {
-            let mut size = select_result.size as usize;
-            let max_batch_size = effective_ha_transfer_batch_size(self.message_store_config.ha_transfer_batch_size);
-
-            if size > max_batch_size {
-                size = max_batch_size;
-            }
-
-            let can_transfer_max_bytes = self.flow_monitor.can_transfer_max_byte_num();
-            if size > can_transfer_max_bytes as usize {
-                let current_time = current_millis();
-                let last_print = self.last_print_timestamp.load(Ordering::Relaxed);
-
-                if current_time - last_print > 1000 {
-                    warn!(
-                        "Trigger HA flow control, max transfer speed {:.2}KB/s, current speed: {:.2}KB/s",
-                        self.flow_monitor.max_transfer_byte_in_second() as f64 / 1024.0,
-                        self.flow_monitor.get_transferred_byte_in_second() as f64 / 1024.0
-                    );
-                    self.last_print_timestamp.store(current_time, Ordering::Relaxed);
-                }
-                size = can_transfer_max_bytes as usize;
-            }
-
-            let this_offset = next_offset;
-            self.next_transfer_from_where
-                .store(next_offset + size as i64, Ordering::Relaxed);
-
-            self.send_data(this_offset, select_result.get_bytes(), size).await?;
-        } else {
+            .get_commit_log()
+            .get_max_offset();
+        if next_offset >= max_commit_log_offset {
             if let Some(connection) = self.connection.upgrade() {
                 self.ha_service.handle_connection_caught_up(connection.as_ref());
             }
-            //self.ha_service.wait_for_running(100).await;
+            return Ok(());
+        }
+
+        let configured_max_batch_size =
+            effective_ha_transfer_batch_size(self.message_store_config.ha_transfer_batch_size);
+        let can_transfer_max_bytes = self.flow_monitor.can_transfer_max_byte_num() as usize;
+        self.maybe_log_flow_control(
+            next_offset,
+            max_commit_log_offset,
+            configured_max_batch_size,
+            can_transfer_max_bytes,
+        );
+
+        let plan = TransferPlanner::plan(
+            TransferPlanInput {
+                requested_offset: slave_request_offset,
+                next_transfer_offset: next_offset,
+                max_commit_log_offset,
+                configured_max_batch_bytes: self.message_store_config.ha_transfer_batch_size,
+                flow_control_available_bytes: can_transfer_max_bytes,
+                mapped_file_size: self.message_store_config.mapped_file_size_commit_log,
+                allow_cross_file_batch: false,
+                heartbeat_due: false,
+            },
+            |offset, max_bytes, allow_cross_file| {
+                self.ha_service
+                    .get_default_message_store()
+                    .get_commit_log()
+                    .select_segments(offset, max_bytes, allow_cross_file)
+            },
+        )?;
+
+        if let TransferPlan::Data(batch) = plan {
+            self.next_transfer_from_where
+                .store(batch.next_offset, Ordering::Relaxed);
+            self.send_data(batch.start_offset, batch.body_bytes(), batch.total_body_len)
+                .await?;
         }
 
         Ok(())
+    }
+
+    fn maybe_log_flow_control(
+        &self,
+        next_offset: i64,
+        max_commit_log_offset: i64,
+        configured_max_batch_size: usize,
+        can_transfer_max_bytes: usize,
+    ) {
+        let available = (max_commit_log_offset - next_offset).max(0) as usize;
+        let planned_without_flow = configured_max_batch_size.min(available);
+        if planned_without_flow <= can_transfer_max_bytes {
+            return;
+        }
+
+        let current_time = current_millis();
+        let last_print = self.last_print_timestamp.load(Ordering::Relaxed);
+        if current_time - last_print > 1000 {
+            warn!(
+                "Trigger HA flow control, max transfer speed {:.2}KB/s, current speed: {:.2}KB/s",
+                self.flow_monitor.max_transfer_byte_in_second() as f64 / 1024.0,
+                self.flow_monitor.get_transferred_byte_in_second() as f64 / 1024.0
+            );
+            self.last_print_timestamp.store(current_time, Ordering::Relaxed);
+        }
     }
 
     async fn send_heartbeat(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -40,6 +40,7 @@ pub mod store_path_config_helper;
 #[cfg(feature = "tieredstore")]
 pub mod tieredstore;
 pub mod timer;
+pub mod transfer;
 pub mod utils;
 
 #[doc(hidden)]

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -88,6 +88,9 @@ use crate::message_store::local_file_message_store::LocalFileMessageStore;
 use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
 use crate::queue::local_file_consume_queue_store::ConsumeQueueStore;
 use crate::store_error::StoreError;
+use crate::transfer::error::TransferError;
+use crate::transfer::error::TransferResult;
+use crate::transfer::segment::SegmentLease;
 use crate::utils::ffi::madvise;
 use crate::utils::ffi::MADV_NORMAL;
 use crate::utils::ffi::MADV_RANDOM;
@@ -1774,6 +1777,42 @@ impl CommitLog {
         Some(results)
     }
 
+    pub fn select_segments(
+        &self,
+        offset: i64,
+        max_bytes: usize,
+        allow_cross_file: bool,
+    ) -> TransferResult<Vec<SegmentLease>> {
+        if offset < 0 {
+            return Err(TransferError::InvalidInput(format!(
+                "offset must be non-negative: {offset}"
+            )));
+        }
+        if max_bytes == 0 {
+            return Ok(Vec::new());
+        }
+        let mapped_file_size = self.message_store_config.mapped_file_size_commit_log;
+        if mapped_file_size == 0 {
+            return Err(TransferError::InvalidInput(
+                "mapped_file_size_commit_log must be greater than zero".to_string(),
+            ));
+        }
+
+        let mut max_bytes = max_bytes.min(i32::MAX as usize);
+        if !allow_cross_file {
+            let position_in_file = offset.rem_euclid(mapped_file_size as i64) as usize;
+            max_bytes = max_bytes.min(mapped_file_size.saturating_sub(position_in_file));
+        }
+
+        let Some(results) = self.get_bulk_data(offset, max_bytes as i32) else {
+            return Ok(Vec::new());
+        };
+        Ok(results
+            .into_iter()
+            .filter_map(|result| SegmentLease::from_select_result(result.start_offset as i64, result))
+            .collect())
+    }
+
     pub fn get_data_with_option(
         &self,
         offset: i64,
@@ -2661,6 +2700,51 @@ mod tests {
             })
             .collect();
         assert_eq!(combined, b"CDEFghij");
+
+        let _ = fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn select_segments_caps_single_file_selection_at_mapped_file_boundary() {
+        let temp_root =
+            std::env::temp_dir().join(format!("rocketmq-rust-commitlog-select-segments-{}", current_millis()));
+        let mut store = new_test_message_store_with_config(
+            &temp_root,
+            MessageStoreConfig {
+                mapped_file_size_commit_log: 16,
+                ..MessageStoreConfig::default()
+            },
+            BrokerRole::SyncMaster,
+            false,
+        );
+        store.init().await.expect("init message store");
+
+        let first = *b"0123456789ABCDEF";
+        let second = *b"ghijklmnopqrstuv";
+        assert!(store
+            .get_commit_log_mut()
+            .append_data(0, &first, 0, first.len() as i32)
+            .await
+            .expect("append first chunk"));
+        assert!(store
+            .get_commit_log_mut()
+            .append_data(first.len() as i64, &second, 0, second.len() as i32)
+            .await
+            .expect("append second chunk"));
+
+        let segments = store
+            .get_commit_log()
+            .select_segments(12, 8, false)
+            .expect("single-file transfer segments");
+
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].segment().global_offset, 12);
+        assert_eq!(segments[0].segment().position_in_file, 12);
+        assert_eq!(segments[0].len(), 4);
+        assert_eq!(
+            segments[0].as_bytes().expect("segment bytes"),
+            Bytes::from_static(b"CDEF")
+        );
 
         let _ = fs::remove_dir_all(temp_root);
     }

--- a/rocketmq-store/src/transfer/batch.rs
+++ b/rocketmq-store/src/transfer/batch.rs
@@ -1,0 +1,66 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+
+use crate::transfer::segment::SegmentLease;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferKind {
+    Heartbeat,
+    Data,
+}
+
+pub struct TransferBatch {
+    pub frame_header: Bytes,
+    pub segments: Vec<SegmentLease>,
+    pub total_body_len: usize,
+    pub start_offset: i64,
+    pub next_offset: i64,
+    pub kind: TransferKind,
+}
+
+impl TransferBatch {
+    pub fn data(start_offset: i64, segments: Vec<SegmentLease>) -> Self {
+        let total_body_len = segments.iter().map(SegmentLease::len).sum::<usize>();
+        Self {
+            frame_header: Bytes::new(),
+            segments,
+            total_body_len,
+            start_offset,
+            next_offset: start_offset + total_body_len as i64,
+            kind: TransferKind::Data,
+        }
+    }
+
+    pub fn body_bytes(&self) -> Option<Bytes> {
+        match self.segments.as_slice() {
+            [segment] => segment.as_bytes(),
+            [] => Some(Bytes::new()),
+            segments => {
+                let mut bytes = Vec::with_capacity(self.total_body_len);
+                for segment in segments {
+                    bytes.extend_from_slice(segment.as_bytes()?.as_ref());
+                }
+                Some(Bytes::from(bytes))
+            }
+        }
+    }
+}
+
+pub enum TransferPlan {
+    NoData,
+    Heartbeat { next_offset: i64 },
+    Data(TransferBatch),
+}

--- a/rocketmq-store/src/transfer/error.rs
+++ b/rocketmq-store/src/transfer/error.rs
@@ -1,0 +1,23 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub type TransferResult<T> = Result<T, TransferError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransferError {
+    #[error("invalid transfer input: {0}")]
+    InvalidInput(String),
+    #[error("commitlog segment selection failed: {0}")]
+    SegmentSelection(String),
+}

--- a/rocketmq-store/src/transfer/mod.rs
+++ b/rocketmq-store/src/transfer/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod batch;
+pub mod error;
+pub mod planner;
+pub mod segment;

--- a/rocketmq-store/src/transfer/planner.rs
+++ b/rocketmq-store/src/transfer/planner.rs
@@ -1,0 +1,114 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::transfer::batch::TransferBatch;
+use crate::transfer::batch::TransferPlan;
+use crate::transfer::error::TransferError;
+use crate::transfer::error::TransferResult;
+use crate::transfer::segment::SegmentLease;
+
+pub const DEFAULT_TRANSFER_BATCH_SIZE: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+pub struct TransferPlanInput {
+    pub requested_offset: i64,
+    pub next_transfer_offset: i64,
+    pub max_commit_log_offset: i64,
+    pub configured_max_batch_bytes: usize,
+    pub flow_control_available_bytes: usize,
+    pub mapped_file_size: usize,
+    pub allow_cross_file_batch: bool,
+    pub heartbeat_due: bool,
+}
+
+pub struct TransferPlanner;
+
+impl TransferPlanner {
+    pub fn plan<F>(input: TransferPlanInput, select_segments: F) -> TransferResult<TransferPlan>
+    where
+        F: FnOnce(i64, usize, bool) -> TransferResult<Vec<SegmentLease>>,
+    {
+        if input.mapped_file_size == 0 {
+            return Err(TransferError::InvalidInput(
+                "mapped_file_size must be greater than zero".to_string(),
+            ));
+        }
+
+        let next_offset = Self::resolve_next_offset(input);
+        if next_offset < 0 {
+            return Ok(TransferPlan::NoData);
+        }
+        if next_offset >= input.max_commit_log_offset {
+            return Ok(Self::no_data_or_heartbeat(input.heartbeat_due, next_offset));
+        }
+
+        let max_body_bytes = Self::max_body_bytes(input, next_offset);
+        if max_body_bytes == 0 {
+            return Ok(TransferPlan::NoData);
+        }
+
+        let segments = select_segments(next_offset, max_body_bytes, input.allow_cross_file_batch)?;
+        if segments.is_empty() {
+            return Ok(Self::no_data_or_heartbeat(input.heartbeat_due, next_offset));
+        }
+
+        let total_body_len = segments.iter().map(SegmentLease::len).sum::<usize>();
+        if total_body_len == 0 {
+            return Ok(TransferPlan::NoData);
+        }
+        if total_body_len > max_body_bytes {
+            return Err(TransferError::SegmentSelection(format!(
+                "selected {} bytes exceeds planned max {} bytes",
+                total_body_len, max_body_bytes
+            )));
+        }
+
+        Ok(TransferPlan::Data(TransferBatch::data(next_offset, segments)))
+    }
+
+    fn resolve_next_offset(input: TransferPlanInput) -> i64 {
+        if input.next_transfer_offset != -1 {
+            return input.next_transfer_offset;
+        }
+        if input.requested_offset == 0 {
+            input.max_commit_log_offset - (input.max_commit_log_offset % input.mapped_file_size as i64)
+        } else {
+            input.requested_offset
+        }
+    }
+
+    fn max_body_bytes(input: TransferPlanInput, next_offset: i64) -> usize {
+        let configured = if input.configured_max_batch_bytes == 0 {
+            DEFAULT_TRANSFER_BATCH_SIZE
+        } else {
+            input.configured_max_batch_bytes
+        };
+        let available = (input.max_commit_log_offset - next_offset).max(0) as usize;
+        let mut max_body_bytes = configured.min(input.flow_control_available_bytes).min(available);
+        if !input.allow_cross_file_batch {
+            let position_in_file = next_offset.rem_euclid(input.mapped_file_size as i64) as usize;
+            let remaining_in_file = input.mapped_file_size.saturating_sub(position_in_file);
+            max_body_bytes = max_body_bytes.min(remaining_in_file);
+        }
+        max_body_bytes
+    }
+
+    fn no_data_or_heartbeat(heartbeat_due: bool, next_offset: i64) -> TransferPlan {
+        if heartbeat_due {
+            TransferPlan::Heartbeat { next_offset }
+        } else {
+            TransferPlan::NoData
+        }
+    }
+}

--- a/rocketmq-store/src/transfer/segment.rs
+++ b/rocketmq-store/src/transfer/segment.rs
@@ -1,0 +1,161 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use crate::base::select_result::SelectMappedBufferCacheState;
+use crate::base::select_result::SelectMappedBufferResult;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
+use crate::log_file::mapped_file::MappedFile;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferCacheState {
+    Unknown,
+    Hot,
+    Cold,
+}
+
+impl From<SelectMappedBufferCacheState> for TransferCacheState {
+    fn from(value: SelectMappedBufferCacheState) -> Self {
+        match value {
+            SelectMappedBufferCacheState::Unknown => Self::Unknown,
+            SelectMappedBufferCacheState::Hot => Self::Hot,
+            SelectMappedBufferCacheState::Cold => Self::Cold,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum SegmentSource {
+    Mmap { mapped_file: Arc<DefaultMappedFile> },
+    FileRange { file: Arc<File> },
+    Bytes,
+}
+
+#[derive(Clone)]
+pub struct CommitLogSegment {
+    pub global_offset: i64,
+    pub file_offset: u64,
+    pub position_in_file: u64,
+    pub len: usize,
+    pub source: SegmentSource,
+    pub cache_state: TransferCacheState,
+}
+
+#[derive(Clone)]
+pub struct FileRange {
+    pub file: Arc<File>,
+    pub position: u64,
+    pub len: usize,
+}
+
+pub struct SegmentLease {
+    segment: CommitLogSegment,
+    bytes: Option<Bytes>,
+}
+
+impl SegmentLease {
+    pub fn new(segment: CommitLogSegment, bytes: Option<Bytes>) -> Self {
+        Self { segment, bytes }
+    }
+
+    pub fn from_bytes(
+        global_offset: i64,
+        position_in_file: u64,
+        bytes: Bytes,
+        cache_state: TransferCacheState,
+    ) -> Self {
+        let len = bytes.len();
+        let file_offset = global_offset.saturating_sub(position_in_file as i64) as u64;
+        Self {
+            segment: CommitLogSegment {
+                global_offset,
+                file_offset,
+                position_in_file,
+                len,
+                source: SegmentSource::Bytes,
+                cache_state,
+            },
+            bytes: Some(bytes),
+        }
+    }
+
+    pub fn from_select_result(global_offset: i64, mut result: SelectMappedBufferResult) -> Option<Self> {
+        if result.size <= 0 {
+            return None;
+        }
+        let len = result.size as usize;
+        let bytes = result.bytes.take();
+        let mapped_file = result.mapped_file.take();
+        let position_in_file = result.file_offset;
+        let file_offset = mapped_file
+            .as_ref()
+            .map(|mapped_file| mapped_file.get_file_from_offset())
+            .unwrap_or_else(|| global_offset.saturating_sub(position_in_file as i64) as u64);
+        let source = match mapped_file {
+            Some(mapped_file) => SegmentSource::Mmap { mapped_file },
+            None => SegmentSource::Bytes,
+        };
+
+        Some(Self {
+            segment: CommitLogSegment {
+                global_offset,
+                file_offset,
+                position_in_file,
+                len,
+                source,
+                cache_state: result.cache_state.into(),
+            },
+            bytes,
+        })
+    }
+
+    pub fn segment(&self) -> &CommitLogSegment {
+        &self.segment
+    }
+
+    pub fn as_bytes(&self) -> Option<Bytes> {
+        self.bytes.clone()
+    }
+
+    pub fn as_file_range(&self) -> Option<FileRange> {
+        match &self.segment.source {
+            SegmentSource::FileRange { file } => Some(FileRange {
+                file: file.clone(),
+                position: self.segment.position_in_file,
+                len: self.segment.len,
+            }),
+            _ => None,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.segment.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.segment.len == 0
+    }
+}
+
+impl Drop for SegmentLease {
+    fn drop(&mut self) {
+        if let SegmentSource::Mmap { mapped_file } = &self.segment.source {
+            mapped_file.release();
+        }
+    }
+}

--- a/rocketmq-store/tests/transfer_planner.rs
+++ b/rocketmq-store/tests/transfer_planner.rs
@@ -1,0 +1,112 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use rocketmq_store::transfer::batch::TransferPlan;
+use rocketmq_store::transfer::planner::TransferPlanInput;
+use rocketmq_store::transfer::planner::TransferPlanner;
+use rocketmq_store::transfer::planner::DEFAULT_TRANSFER_BATCH_SIZE;
+use rocketmq_store::transfer::segment::SegmentLease;
+use rocketmq_store::transfer::segment::TransferCacheState;
+
+#[test]
+fn zero_configured_batch_size_uses_default_without_zero_data_frame() {
+    let input = TransferPlanInput {
+        requested_offset: 0,
+        next_transfer_offset: 0,
+        max_commit_log_offset: (DEFAULT_TRANSFER_BATCH_SIZE * 2) as i64,
+        configured_max_batch_bytes: 0,
+        flow_control_available_bytes: usize::MAX,
+        mapped_file_size: 1024 * 1024 * 1024,
+        allow_cross_file_batch: false,
+        heartbeat_due: false,
+    };
+
+    let plan = TransferPlanner::plan(input, |offset, max_bytes, allow_cross_file| {
+        assert_eq!(offset, 0);
+        assert_eq!(max_bytes, DEFAULT_TRANSFER_BATCH_SIZE);
+        assert!(!allow_cross_file);
+        Ok(vec![SegmentLease::from_bytes(
+            0,
+            0,
+            Bytes::from(vec![1; DEFAULT_TRANSFER_BATCH_SIZE]),
+            TransferCacheState::Hot,
+        )])
+    })
+    .expect("planner should build data plan");
+
+    let TransferPlan::Data(batch) = plan else {
+        panic!("expected data batch");
+    };
+    assert_eq!(batch.total_body_len, DEFAULT_TRANSFER_BATCH_SIZE);
+    assert_eq!(batch.next_offset, DEFAULT_TRANSFER_BATCH_SIZE as i64);
+    assert!(!batch.segments.is_empty());
+}
+
+#[test]
+fn flow_control_zero_returns_no_data_without_selecting_segments() {
+    let input = TransferPlanInput {
+        requested_offset: 0,
+        next_transfer_offset: 0,
+        max_commit_log_offset: 4096,
+        configured_max_batch_bytes: 4096,
+        flow_control_available_bytes: 0,
+        mapped_file_size: 1024 * 1024 * 1024,
+        allow_cross_file_batch: false,
+        heartbeat_due: false,
+    };
+    let mut selector_called = false;
+
+    let plan = TransferPlanner::plan(input, |_, _, _| {
+        selector_called = true;
+        Ok(Vec::new())
+    })
+    .expect("flow control should not be an error");
+
+    assert!(matches!(plan, TransferPlan::NoData));
+    assert!(!selector_called);
+}
+
+#[test]
+fn single_file_plan_caps_batch_at_mapped_file_boundary() {
+    let input = TransferPlanInput {
+        requested_offset: 900,
+        next_transfer_offset: 900,
+        max_commit_log_offset: 4096,
+        configured_max_batch_bytes: 512,
+        flow_control_available_bytes: 512,
+        mapped_file_size: 1024,
+        allow_cross_file_batch: false,
+        heartbeat_due: false,
+    };
+
+    let plan = TransferPlanner::plan(input, |offset, max_bytes, allow_cross_file| {
+        assert_eq!(offset, 900);
+        assert_eq!(max_bytes, 124);
+        assert!(!allow_cross_file);
+        Ok(vec![SegmentLease::from_bytes(
+            900,
+            900,
+            Bytes::from(vec![7; 124]),
+            TransferCacheState::Cold,
+        )])
+    })
+    .expect("planner should cap at file boundary");
+
+    let TransferPlan::Data(batch) = plan else {
+        panic!("expected data batch");
+    };
+    assert_eq!(batch.total_body_len, 124);
+    assert_eq!(batch.next_offset, 1024);
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7640

### Brief Description

- Add `rocketmq-store::transfer` modules for transfer errors, commitlog segments, segment leases, transfer batches, and transfer planning.
- Add `CommitLog::select_segments` to expose single-file transfer segment selection while preserving existing `SelectMappedBufferResult` consumers.
- Route HA master data selection through `TransferPlanner` while keeping the existing bytes-based HA frame format and send path.
- Cover default batch-size fallback, flow-control no-data behavior, file-boundary capping, and commitlog segment selection with tests.
- This PR does not claim a performance improvement; later vectored/sendfile transfer-engine PRs will include before/after benchmark data.

### How Did You Test This Change?

- `cargo fmt --all --check` passed.
- `cargo test -p rocketmq-store --test transfer_planner` passed: 3 passed.
- `cargo test -p rocketmq-store --lib` passed: 498 passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a smarter transfer planning flow for log replication, including batch sizing, boundary-aware segment selection, and heartbeat/no-data handling.
  * Added support for selecting commit log segments and representing transfer batches and segment leases.

* **Bug Fixes**
  * Improved handling when replication is already caught up.
  * Prevented transfers from crossing mapped-file boundaries when batching is restricted.
  * Tightened flow-control behavior so no-data cases are handled cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->