### PR TITLE
[ISSUE #7642]🚀Add HA vectored transfer engine

### DIFF
--- a/rocketmq-store/src/ha.rs
+++ b/rocketmq-store/src/ha.rs
@@ -27,6 +27,7 @@ pub mod ha_connection_state;
 pub mod ha_connection_state_notification_request;
 mod ha_connection_state_notification_service;
 pub mod ha_service;
+pub mod transfer_engine;
 pub(crate) mod wait_notify_object;
 
 /// Error types

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -24,11 +24,11 @@ use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
-use futures_util::SinkExt;
 use futures_util::StreamExt;
 use rocketmq_common::TimeUtils::current_millis;
 use rocketmq_rust::ArcMut;
 use rocketmq_rust::WeakArcMut;
+use tokio::io::AsyncWrite;
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::net::tcp::OwnedWriteHalf;
 use tokio::net::TcpStream;
@@ -38,10 +38,8 @@ use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
 use tokio::time::timeout;
-use tokio_util::codec::BytesCodec;
 use tokio_util::codec::Decoder;
 use tokio_util::codec::FramedRead;
-use tokio_util::codec::FramedWrite;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -56,7 +54,12 @@ use crate::ha::ha_connection::HAConnection;
 use crate::ha::ha_connection::HAConnectionId;
 use crate::ha::ha_connection_state::HAConnectionState;
 use crate::ha::ha_service::HAService;
+use crate::ha::transfer_engine::select_transfer_engine;
+use crate::ha::transfer_engine::HaTransferEngine;
+use crate::ha::transfer_engine::TransferEnginePreference;
 use crate::ha::HAConnectionError;
+use crate::transfer::batch::TransferBatch;
+use crate::transfer::batch::TransferKind;
 use crate::transfer::batch::TransferPlan;
 use crate::transfer::planner::TransferPlanInput;
 use crate::transfer::planner::TransferPlanner;
@@ -215,7 +218,6 @@ impl DefaultHAConnection {
 
 impl HAConnection for DefaultHAConnection {
     async fn start(&mut self, conn: WeakArcMut<GeneralHAConnection>) -> Result<(), HAConnectionError> {
-        const CAPACITY: usize = 1024 * 8;
         self.change_current_state(HAConnectionState::Transfer).await;
 
         // Start flow monitor
@@ -233,7 +235,6 @@ impl HAConnection for DefaultHAConnection {
         let retained_stream = TcpStream::from_std(retained_std_stream).map_err(HAConnectionError::Io)?;
         let split_stream = TcpStream::from_std(std_stream).map_err(HAConnectionError::Io)?;
         self.socket_stream = Some(retained_stream);
-        // let framed = Framed::with_capacity(tcp_stream, BytesCodec::new(), CAPACITY);
         let (reader, write) = split_stream.into_split();
 
         // Create shutdown channel
@@ -267,7 +268,7 @@ impl HAConnection for DefaultHAConnection {
 
         // Create and start write service
         let write_service = WriteSocketService::new(
-            FramedWrite::new(write, BytesCodec::new()),
+            write,
             self.client_address.clone(),
             ArcMut::clone(&self.ha_service),
             Arc::clone(&self.current_state),
@@ -619,8 +620,7 @@ impl ReadSocketService {
 
 /// Write Socket Service
 pub struct WriteSocketService {
-    //writer: SplitSink<Framed<TcpStream, BytesCodec>, Bytes>,
-    writer: FramedWrite<OwnedWriteHalf, BytesCodec>,
+    writer: HaTransferEngine<OwnedWriteHalf>,
     client_address: String,
     ha_service: ArcMut<DefaultHAService>,
     current_state: Arc<RwLock<HAConnectionState>>,
@@ -637,8 +637,7 @@ pub struct WriteSocketService {
 
 impl WriteSocketService {
     pub async fn new(
-        // writer: SplitSink<Framed<TcpStream, BytesCodec>, Bytes>,
-        writer: FramedWrite<OwnedWriteHalf, BytesCodec>,
+        writer: OwnedWriteHalf,
         client_address: String,
         ha_service: ArcMut<DefaultHAService>,
         current_state: Arc<RwLock<HAConnectionState>>,
@@ -649,6 +648,19 @@ impl WriteSocketService {
         next_transfer_from_where: Arc<AtomicI64>,
     ) -> Result<Self, HAConnectionError> {
         let enable_controller_mode = message_store_config.enable_controller_mode;
+        let selection = select_transfer_engine(TransferEnginePreference::Vectored, writer.is_write_vectored());
+        if let Some(reason) = selection.fallback_reason {
+            info!(
+                "HA transfer engine fallback to {:?} for slave[{}]: {}",
+                selection.engine, client_address, reason
+            );
+        } else {
+            info!(
+                "HA transfer engine selected {:?} for slave[{}]",
+                selection.engine, client_address
+            );
+        }
+        let writer = HaTransferEngine::from_selection(writer, selection.engine);
         Ok(Self {
             writer,
             client_address,
@@ -816,8 +828,7 @@ impl WriteSocketService {
         if let TransferPlan::Data(batch) = plan {
             self.next_transfer_from_where
                 .store(batch.next_offset, Ordering::Relaxed);
-            self.send_data(batch.start_offset, batch.body_bytes(), batch.total_body_len)
-                .await?;
+            self.send_data(batch).await?;
         }
 
         Ok(())
@@ -851,49 +862,45 @@ impl WriteSocketService {
     async fn send_heartbeat(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let next_offset = self.next_transfer_from_where.load(Ordering::Relaxed);
         let confirm_offset = self.ha_service.get_default_message_store().get_confirm_offset();
-        let bytes = encode_transfer_header(
+        let frame_header = encode_transfer_header(
             &mut self.byte_buffer_header,
             next_offset,
             0,
             self.message_store_config.enable_controller_mode,
             confirm_offset,
         );
-        self.writer.send(bytes).await?;
+        let batch = TransferBatch {
+            frame_header,
+            segments: Vec::new(),
+            total_body_len: 0,
+            start_offset: next_offset,
+            next_offset,
+            kind: TransferKind::Heartbeat,
+        };
+        let stats = self.writer.send_batch(&batch).await?;
 
         self.last_write_timestamp.store(current_millis(), Ordering::Relaxed);
-        self.flow_monitor
-            .add_byte_count_transferred(transfer_header_size(self.message_store_config.enable_controller_mode) as i64);
+        self.flow_monitor.add_byte_count_transferred(stats.bytes_written as i64);
         self.last_write_over.store(true, Ordering::Relaxed);
 
         Ok(())
     }
 
-    async fn send_data(
-        &mut self,
-        offset: i64,
-        select_result: Option<Bytes>,
-        size: usize,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn send_data(&mut self, mut batch: TransferBatch) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let confirm_offset = self.ha_service.get_default_message_store().get_confirm_offset();
         let header_bytes = encode_transfer_header(
             &mut self.byte_buffer_header,
-            offset,
-            size,
+            batch.start_offset,
+            batch.total_body_len,
             self.message_store_config.enable_controller_mode,
             confirm_offset,
         );
+        batch.frame_header = header_bytes;
 
-        self.writer.send(header_bytes).await?;
-        if let Some(mut data) = select_result {
-            self.writer.send(data.split_to(size)).await?;
-        } else {
-            warn!("No data to send for offset {}", offset);
-        }
+        let stats = self.writer.send_batch(&batch).await?;
 
         self.last_write_timestamp.store(current_millis(), Ordering::Relaxed);
-        self.flow_monitor.add_byte_count_transferred(
-            (transfer_header_size(self.message_store_config.enable_controller_mode) + size) as i64,
-        );
+        self.flow_monitor.add_byte_count_transferred(stats.bytes_written as i64);
         self.last_write_over.store(true, Ordering::Relaxed);
 
         Ok(())

--- a/rocketmq-store/src/ha/transfer_engine.rs
+++ b/rocketmq-store/src/ha/transfer_engine.rs
@@ -1,0 +1,166 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ::bytes::Bytes;
+use tokio::io::AsyncWrite;
+
+use crate::ha::transfer_engine::bytes::BytesTransferEngine;
+use crate::ha::transfer_engine::vectored::VectoredTransferEngine;
+use crate::transfer::batch::TransferBatch;
+use crate::transfer::error::TransferError;
+use crate::transfer::error::TransferResult;
+
+pub mod bytes;
+pub mod vectored;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferEngineKind {
+    Bytes,
+    Vectored,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferEnginePreference {
+    Bytes,
+    Vectored,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransferEngineSelection {
+    pub engine: TransferEngineKind,
+    pub fallback_reason: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransferStats {
+    pub engine: TransferEngineKind,
+    pub bytes_written: usize,
+    pub body_bytes: usize,
+    pub frame_count: usize,
+    pub write_call_count: usize,
+    pub partial_write_count: usize,
+}
+
+pub fn select_transfer_engine(
+    preference: TransferEnginePreference,
+    vectored_write_available: bool,
+) -> TransferEngineSelection {
+    match (preference, vectored_write_available) {
+        (TransferEnginePreference::Bytes, _) => TransferEngineSelection {
+            engine: TransferEngineKind::Bytes,
+            fallback_reason: None,
+        },
+        (TransferEnginePreference::Vectored, true) => TransferEngineSelection {
+            engine: TransferEngineKind::Vectored,
+            fallback_reason: None,
+        },
+        (TransferEnginePreference::Vectored, false) => TransferEngineSelection {
+            engine: TransferEngineKind::Bytes,
+            fallback_reason: Some("vectored write unavailable"),
+        },
+    }
+}
+
+pub enum HaTransferEngine<W> {
+    Bytes(BytesTransferEngine<W>),
+    Vectored(VectoredTransferEngine<W>),
+}
+
+impl<W> HaTransferEngine<W> {
+    pub fn from_selection(writer: W, engine: TransferEngineKind) -> Self {
+        match engine {
+            TransferEngineKind::Bytes => Self::Bytes(BytesTransferEngine::new(writer)),
+            TransferEngineKind::Vectored => Self::Vectored(VectoredTransferEngine::new(writer)),
+        }
+    }
+
+    pub fn into_inner(self) -> W {
+        match self {
+            Self::Bytes(engine) => engine.into_inner(),
+            Self::Vectored(engine) => engine.into_inner(),
+        }
+    }
+
+    pub fn kind(&self) -> TransferEngineKind {
+        match self {
+            Self::Bytes(_) => TransferEngineKind::Bytes,
+            Self::Vectored(_) => TransferEngineKind::Vectored,
+        }
+    }
+}
+
+impl<W> HaTransferEngine<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    pub async fn send_batch(&mut self, batch: &TransferBatch) -> TransferResult<TransferStats> {
+        match self {
+            Self::Bytes(engine) => engine.send_batch(batch).await,
+            Self::Vectored(engine) => engine.send_batch(batch).await,
+        }
+    }
+}
+
+pub(crate) fn batch_body_bytes(batch: &TransferBatch) -> TransferResult<Bytes> {
+    let mut chunks = batch_body_chunks(batch)?;
+    match chunks.len() {
+        0 => Ok(Bytes::new()),
+        1 => Ok(chunks.remove(0)),
+        _ => {
+            let mut body = Vec::with_capacity(batch.total_body_len);
+            for chunk in chunks {
+                body.extend_from_slice(&chunk);
+            }
+            Ok(Bytes::from(body))
+        }
+    }
+}
+
+pub(crate) fn batch_body_chunks(batch: &TransferBatch) -> TransferResult<Vec<Bytes>> {
+    let mut remaining = batch.total_body_len;
+    if remaining == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut chunks = Vec::with_capacity(batch.segments.len());
+    for segment in &batch.segments {
+        let bytes = segment.as_bytes().ok_or(TransferError::UnsupportedSegmentSource(
+            "byte-backed segment required for bytes or vectored HA transfer",
+        ))?;
+        let len = bytes.len().min(remaining);
+        if len > 0 {
+            chunks.push(bytes.slice(..len));
+            remaining -= len;
+        }
+        if remaining == 0 {
+            break;
+        }
+    }
+
+    if remaining != 0 {
+        return Err(TransferError::InvalidInput(format!(
+            "transfer batch body underflow: expected {} bytes, missing {} bytes",
+            batch.total_body_len, remaining
+        )));
+    }
+
+    Ok(chunks)
+}
+
+pub(crate) fn write_zero_error() -> TransferError {
+    TransferError::Io(std::io::Error::new(
+        std::io::ErrorKind::WriteZero,
+        "transfer writer returned zero bytes",
+    ))
+}

--- a/rocketmq-store/src/ha/transfer_engine/bytes.rs
+++ b/rocketmq-store/src/ha/transfer_engine/bytes.rs
@@ -1,0 +1,88 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+
+use crate::ha::transfer_engine::batch_body_bytes;
+use crate::ha::transfer_engine::write_zero_error;
+use crate::ha::transfer_engine::TransferEngineKind;
+use crate::ha::transfer_engine::TransferStats;
+use crate::transfer::batch::TransferBatch;
+use crate::transfer::error::TransferResult;
+
+pub struct BytesTransferEngine<W> {
+    writer: W,
+}
+
+impl<W> BytesTransferEngine<W> {
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+}
+
+impl<W> BytesTransferEngine<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    pub async fn send_batch(&mut self, batch: &TransferBatch) -> TransferResult<TransferStats> {
+        let body = batch_body_bytes(batch)?;
+        let expected_write_calls = usize::from(!batch.frame_header.is_empty()) + usize::from(!body.is_empty());
+        let mut bytes_written = 0;
+        let mut write_call_count = 0;
+
+        let (header_written, header_calls) = write_all_counted(&mut self.writer, &batch.frame_header).await?;
+        bytes_written += header_written;
+        write_call_count += header_calls;
+
+        let (body_written, body_calls) = write_all_counted(&mut self.writer, &body).await?;
+        bytes_written += body_written;
+        write_call_count += body_calls;
+
+        self.writer.flush().await?;
+
+        Ok(TransferStats {
+            engine: TransferEngineKind::Bytes,
+            bytes_written,
+            body_bytes: batch.total_body_len,
+            frame_count: 1,
+            write_call_count,
+            partial_write_count: write_call_count.saturating_sub(expected_write_calls),
+        })
+    }
+}
+
+async fn write_all_counted<W>(writer: &mut W, mut bytes: &[u8]) -> TransferResult<(usize, usize)>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut bytes_written = 0;
+    let mut write_call_count = 0;
+
+    while !bytes.is_empty() {
+        let written = writer.write(bytes).await?;
+        if written == 0 {
+            return Err(write_zero_error());
+        }
+        bytes = &bytes[written..];
+        bytes_written += written;
+        write_call_count += 1;
+    }
+
+    Ok((bytes_written, write_call_count))
+}

--- a/rocketmq-store/src/ha/transfer_engine/vectored.rs
+++ b/rocketmq-store/src/ha/transfer_engine/vectored.rs
@@ -1,0 +1,118 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::IoSlice;
+
+use bytes::Bytes;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+
+use crate::ha::transfer_engine::batch_body_chunks;
+use crate::ha::transfer_engine::write_zero_error;
+use crate::ha::transfer_engine::TransferEngineKind;
+use crate::ha::transfer_engine::TransferStats;
+use crate::transfer::batch::TransferBatch;
+use crate::transfer::error::TransferResult;
+
+pub struct VectoredTransferEngine<W> {
+    writer: W,
+}
+
+impl<W> VectoredTransferEngine<W> {
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+}
+
+impl<W> VectoredTransferEngine<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    pub async fn send_batch(&mut self, batch: &TransferBatch) -> TransferResult<TransferStats> {
+        let chunks = transfer_chunks(batch)?;
+        let total_len = chunks.iter().map(Bytes::len).sum::<usize>();
+        let mut bytes_written = 0;
+        let mut write_call_count = 0;
+        let mut partial_write_count = 0;
+        let mut chunk_index = 0;
+        let mut chunk_offset = 0;
+
+        while chunk_index < chunks.len() {
+            let remaining_before_write = total_len - bytes_written;
+            let slices = io_slices(&chunks, chunk_index, chunk_offset);
+            let written = self.writer.write_vectored(&slices).await?;
+            if written == 0 {
+                return Err(write_zero_error());
+            }
+            write_call_count += 1;
+            bytes_written += written;
+            if written < remaining_before_write {
+                partial_write_count += 1;
+            }
+            advance_position(&chunks, &mut chunk_index, &mut chunk_offset, written);
+        }
+
+        self.writer.flush().await?;
+
+        Ok(TransferStats {
+            engine: TransferEngineKind::Vectored,
+            bytes_written,
+            body_bytes: batch.total_body_len,
+            frame_count: 1,
+            write_call_count,
+            partial_write_count,
+        })
+    }
+}
+
+fn transfer_chunks(batch: &TransferBatch) -> TransferResult<Vec<Bytes>> {
+    let body_chunks = batch_body_chunks(batch)?;
+    let mut chunks = Vec::with_capacity(1 + body_chunks.len());
+    if !batch.frame_header.is_empty() {
+        chunks.push(batch.frame_header.clone());
+    }
+    chunks.extend(body_chunks.into_iter().filter(|chunk| !chunk.is_empty()));
+    Ok(chunks)
+}
+
+fn io_slices(chunks: &[Bytes], chunk_index: usize, chunk_offset: usize) -> Vec<IoSlice<'_>> {
+    let mut slices = Vec::with_capacity(chunks.len() - chunk_index);
+    let first = &chunks[chunk_index][chunk_offset..];
+    if !first.is_empty() {
+        slices.push(IoSlice::new(first));
+    }
+    for chunk in &chunks[chunk_index + 1..] {
+        if !chunk.is_empty() {
+            slices.push(IoSlice::new(chunk));
+        }
+    }
+    slices
+}
+
+fn advance_position(chunks: &[Bytes], chunk_index: &mut usize, chunk_offset: &mut usize, mut written: usize) {
+    while written > 0 && *chunk_index < chunks.len() {
+        let remaining_in_chunk = chunks[*chunk_index].len() - *chunk_offset;
+        if written < remaining_in_chunk {
+            *chunk_offset += written;
+            return;
+        }
+        written -= remaining_in_chunk;
+        *chunk_index += 1;
+        *chunk_offset = 0;
+    }
+}

--- a/rocketmq-store/src/transfer/error.rs
+++ b/rocketmq-store/src/transfer/error.rs
@@ -20,4 +20,8 @@ pub enum TransferError {
     InvalidInput(String),
     #[error("commitlog segment selection failed: {0}")]
     SegmentSelection(String),
+    #[error("unsupported transfer segment source: {0}")]
+    UnsupportedSegmentSource(&'static str),
+    #[error("transfer I/O error: {0}")]
+    Io(#[from] std::io::Error),
 }

--- a/rocketmq-store/tests/ha_transfer_engine.rs
+++ b/rocketmq-store/tests/ha_transfer_engine.rs
@@ -1,0 +1,184 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::io::IoSlice;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use rocketmq_store::ha::transfer_engine::bytes::BytesTransferEngine;
+use rocketmq_store::ha::transfer_engine::select_transfer_engine;
+use rocketmq_store::ha::transfer_engine::vectored::VectoredTransferEngine;
+use rocketmq_store::ha::transfer_engine::TransferEngineKind;
+use rocketmq_store::ha::transfer_engine::TransferEnginePreference;
+use rocketmq_store::transfer::batch::TransferBatch;
+use rocketmq_store::transfer::batch::TransferKind;
+use rocketmq_store::transfer::segment::SegmentLease;
+use rocketmq_store::transfer::segment::TransferCacheState;
+use tokio::io::AsyncWrite;
+
+#[tokio::test]
+async fn bytes_transfer_engine_matches_existing_ha_frame_bytes() {
+    let header = transfer_header(128, 4);
+    let body = Bytes::from_static(b"data");
+    let batch = transfer_batch(header.clone(), body.clone());
+    let mut engine = BytesTransferEngine::new(ChunkedWriter::new(usize::MAX));
+
+    let stats = engine.send_batch(&batch).await.expect("bytes transfer");
+
+    let writer = engine.into_inner();
+    let mut expected = header.to_vec();
+    expected.extend_from_slice(&body);
+    assert_eq!(writer.written, expected);
+    assert_eq!(stats.engine, TransferEngineKind::Bytes);
+    assert_eq!(stats.bytes_written, expected.len());
+    assert_eq!(stats.body_bytes, body.len());
+    assert_eq!(stats.frame_count, 1);
+    assert_eq!(stats.write_call_count, 2);
+    assert_eq!(stats.partial_write_count, 0);
+    assert_eq!(writer.write_calls, 2);
+}
+
+#[tokio::test]
+async fn vectored_transfer_engine_handles_partial_writes_without_reordering_frame() {
+    let header = transfer_header(256, 8);
+    let body = Bytes::from_static(b"abcdefgh");
+    let batch = transfer_batch(header.clone(), body.clone());
+    let mut engine = VectoredTransferEngine::new(ChunkedWriter::new(5));
+
+    let stats = engine.send_batch(&batch).await.expect("vectored transfer");
+
+    let writer = engine.into_inner();
+    let mut expected = header.to_vec();
+    expected.extend_from_slice(&body);
+    assert_eq!(writer.written, expected);
+    assert!(writer.vectored_calls > 1);
+    assert_eq!(stats.engine, TransferEngineKind::Vectored);
+    assert_eq!(stats.bytes_written, expected.len());
+    assert_eq!(stats.body_bytes, body.len());
+    assert!(stats.partial_write_count > 0);
+}
+
+#[tokio::test]
+async fn vectored_transfer_engine_reduces_write_calls_for_complete_frame_writes() {
+    let body = Bytes::from(vec![7; 64 * 1024]);
+    let header = transfer_header(512, body.len());
+    let batch = transfer_batch(header, body);
+
+    let mut bytes_engine = BytesTransferEngine::new(ChunkedWriter::new(usize::MAX));
+    let bytes_stats = bytes_engine.send_batch(&batch).await.expect("bytes transfer");
+    let bytes_writer = bytes_engine.into_inner();
+
+    let mut vectored_engine = VectoredTransferEngine::new(ChunkedWriter::new(usize::MAX));
+    let vectored_stats = vectored_engine.send_batch(&batch).await.expect("vectored transfer");
+    let vectored_writer = vectored_engine.into_inner();
+
+    assert_eq!(bytes_stats.write_call_count, 2);
+    assert_eq!(bytes_writer.write_calls, 2);
+    assert_eq!(bytes_writer.vectored_calls, 0);
+    assert_eq!(vectored_stats.write_call_count, 1);
+    assert_eq!(vectored_writer.write_calls, 0);
+    assert_eq!(vectored_writer.vectored_calls, 1);
+    assert_eq!(bytes_writer.written, vectored_writer.written);
+}
+
+#[test]
+fn transfer_engine_selection_falls_back_to_bytes_when_vectored_is_unavailable() {
+    let selection = select_transfer_engine(TransferEnginePreference::Vectored, false);
+
+    assert_eq!(selection.engine, TransferEngineKind::Bytes);
+    assert!(selection.fallback_reason.is_some());
+}
+
+fn transfer_header(offset: i64, body_size: usize) -> Bytes {
+    let mut header = BytesMut::with_capacity(12);
+    header.put_i64(offset);
+    header.put_i32(i32::try_from(body_size).expect("body size fits i32"));
+    header.freeze()
+}
+
+fn transfer_batch(header: Bytes, body: Bytes) -> TransferBatch {
+    let total_body_len = body.len();
+    TransferBatch {
+        frame_header: header,
+        segments: vec![SegmentLease::from_bytes(128, 128, body, TransferCacheState::Hot)],
+        total_body_len,
+        start_offset: 128,
+        next_offset: 128 + total_body_len as i64,
+        kind: TransferKind::Data,
+    }
+}
+
+struct ChunkedWriter {
+    max_write: usize,
+    written: Vec<u8>,
+    write_calls: usize,
+    vectored_calls: usize,
+}
+
+impl ChunkedWriter {
+    fn new(max_write: usize) -> Self {
+        Self {
+            max_write: max_write.max(1),
+            written: Vec::new(),
+            write_calls: 0,
+            vectored_calls: 0,
+        }
+    }
+}
+
+impl AsyncWrite for ChunkedWriter {
+    fn poll_write(mut self: Pin<&mut Self>, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        self.write_calls += 1;
+        let len = buf.len().min(self.max_write);
+        self.written.extend_from_slice(&buf[..len]);
+        Poll::Ready(Ok(len))
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.vectored_calls += 1;
+        let mut remaining = self.max_write;
+        let mut written = 0;
+        for buf in bufs {
+            if remaining == 0 {
+                break;
+            }
+            let len = buf.len().min(remaining);
+            self.written.extend_from_slice(&buf[..len]);
+            remaining -= len;
+            written += len;
+        }
+        Poll::Ready(Ok(written))
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7642

### Brief Description

Adds the HA transfer engine layer for commitlog replication output:

- Adds `BytesTransferEngine` as the frame-compatible fallback writer.
- Adds `VectoredTransferEngine` using `write_vectored` with partial-write handling.
- Adds transfer engine selection that falls back to Bytes when vectored writes are unavailable.
- Routes `WriteSocketService` heartbeat and data sends through the engine abstraction while keeping the existing HA frame layout.
- Extends transfer errors for unsupported segment sources and transfer I/O failures.

Performance-related data included in this PR:

- Unit-level write-call comparison from `vectored_transfer_engine_reduces_write_calls_for_complete_frame_writes` using the same HA frame shape: 12-byte header + 64 KiB body.
- Bytes baseline: `write_call_count = 2`, output bytes match expected frame.
- Vectored path: `write_call_count = 1`, output bytes identical to the Bytes baseline.
- This is a deterministic write-call/syscall-proxy check only. This PR does not claim throughput, latency, CPU, or production syscall improvement; those require a follow-up benchmark report with before/after data.

### How Did You Test This Change?

- RED: `cargo test -p rocketmq-store --test ha_transfer_engine` failed before implementation because `rocketmq_store::ha::transfer_engine` did not exist.
- `cargo fmt --all --check` passed.
- `cargo test -p rocketmq-store --test ha_transfer_engine` passed: 4 passed.
- `cargo test -p rocketmq-store --test transfer_planner` passed: 3 passed.
- `cargo test -p rocketmq-store --lib` passed: 498 passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a more flexible high-availability transfer path, with automatic selection between standard and vectored sending.
  * Improved handling of batched data and heartbeat messages during replication/transfer.

* **Bug Fixes**
  * Better handles partial writes and write limits without reordering data.
  * Adds clearer error handling for unsupported transfer sources and I/O failures.
  * Improves transfer stats reporting, including bytes written and write-call counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->