### PR TITLE
[ISSUE #7644]🚀Add Linux HA sendfile transfer engine

### DIFF
--- a/rocketmq-store/src/ha/transfer_engine.rs
+++ b/rocketmq-store/src/ha/transfer_engine.rs
@@ -22,12 +22,14 @@ use crate::transfer::error::TransferError;
 use crate::transfer::error::TransferResult;
 
 pub mod bytes;
+pub mod sendfile;
 pub mod vectored;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransferEngineKind {
     Bytes,
     Vectored,
+    Sendfile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,6 +51,9 @@ pub struct TransferStats {
     pub body_bytes: usize,
     pub frame_count: usize,
     pub write_call_count: usize,
+    pub sendfile_call_count: usize,
+    pub sendfile_bytes: usize,
+    pub fallback_bytes: usize,
     pub partial_write_count: usize,
 }
 
@@ -81,7 +86,9 @@ impl<W> HaTransferEngine<W> {
     pub fn from_selection(writer: W, engine: TransferEngineKind) -> Self {
         match engine {
             TransferEngineKind::Bytes => Self::Bytes(BytesTransferEngine::new(writer)),
-            TransferEngineKind::Vectored => Self::Vectored(VectoredTransferEngine::new(writer)),
+            TransferEngineKind::Vectored | TransferEngineKind::Sendfile => {
+                Self::Vectored(VectoredTransferEngine::new(writer))
+            }
         }
     }
 

--- a/rocketmq-store/src/ha/transfer_engine/bytes.rs
+++ b/rocketmq-store/src/ha/transfer_engine/bytes.rs
@@ -62,12 +62,15 @@ where
             body_bytes: batch.total_body_len,
             frame_count: 1,
             write_call_count,
+            sendfile_call_count: 0,
+            sendfile_bytes: 0,
+            fallback_bytes: 0,
             partial_write_count: write_call_count.saturating_sub(expected_write_calls),
         })
     }
 }
 
-async fn write_all_counted<W>(writer: &mut W, mut bytes: &[u8]) -> TransferResult<(usize, usize)>
+pub(crate) async fn write_all_counted<W>(writer: &mut W, mut bytes: &[u8]) -> TransferResult<(usize, usize)>
 where
     W: AsyncWrite + Unpin,
 {

--- a/rocketmq-store/src/ha/transfer_engine/sendfile.rs
+++ b/rocketmq-store/src/ha/transfer_engine/sendfile.rs
@@ -1,0 +1,193 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(unix)]
+use std::io;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::fd::RawFd;
+
+#[cfg(unix)]
+use tokio::io::AsyncWrite;
+#[cfg(unix)]
+use tokio::io::AsyncWriteExt;
+
+#[cfg(unix)]
+use crate::ha::transfer_engine::bytes::write_all_counted;
+#[cfg(unix)]
+use crate::ha::transfer_engine::vectored::VectoredTransferEngine;
+#[cfg(unix)]
+use crate::ha::transfer_engine::write_zero_error;
+#[cfg(unix)]
+use crate::ha::transfer_engine::TransferEngineKind;
+#[cfg(unix)]
+use crate::ha::transfer_engine::TransferStats;
+#[cfg(unix)]
+use crate::transfer::batch::TransferBatch;
+#[cfg(unix)]
+use crate::transfer::error::TransferError;
+#[cfg(unix)]
+use crate::transfer::error::TransferResult;
+#[cfg(unix)]
+use crate::transfer::segment::FileRange;
+
+#[cfg(unix)]
+pub trait SendfileOperation {
+    fn sendfile(&mut self, out_fd: RawFd, in_fd: RawFd, offset: u64, len: usize) -> io::Result<usize>;
+}
+
+#[cfg(unix)]
+#[derive(Debug, Default)]
+pub struct LinuxSendfileOperation;
+
+#[cfg(all(unix, target_os = "linux"))]
+impl SendfileOperation for LinuxSendfileOperation {
+    fn sendfile(&mut self, out_fd: RawFd, in_fd: RawFd, offset: u64, len: usize) -> io::Result<usize> {
+        let mut raw_offset = libc::off_t::try_from(offset).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("sendfile offset exceeds libc::off_t: {offset}"),
+            )
+        })?;
+        let written = unsafe { libc::sendfile(out_fd, in_fd, &mut raw_offset, len) };
+        if written < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(written as usize)
+        }
+    }
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+impl SendfileOperation for LinuxSendfileOperation {
+    fn sendfile(&mut self, _out_fd: RawFd, _in_fd: RawFd, _offset: u64, _len: usize) -> io::Result<usize> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "sendfile transfer is only enabled on Linux",
+        ))
+    }
+}
+
+#[cfg(unix)]
+pub struct SendfileTransferEngine<W, O = LinuxSendfileOperation> {
+    writer: W,
+    operation: O,
+}
+
+#[cfg(unix)]
+impl<W> SendfileTransferEngine<W, LinuxSendfileOperation> {
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer,
+            operation: LinuxSendfileOperation,
+        }
+    }
+}
+
+#[cfg(unix)]
+impl<W, O> SendfileTransferEngine<W, O> {
+    pub fn with_operation(writer: W, operation: O) -> Self {
+        Self { writer, operation }
+    }
+
+    pub fn into_parts(self) -> (W, O) {
+        (self.writer, self.operation)
+    }
+}
+
+#[cfg(unix)]
+impl<W, O> SendfileTransferEngine<W, O>
+where
+    W: AsyncWrite + AsRawFd + Unpin,
+    O: SendfileOperation,
+{
+    pub async fn send_batch(&mut self, batch: &TransferBatch) -> TransferResult<TransferStats> {
+        let Some(file_ranges) = batch_file_ranges(batch) else {
+            let mut fallback = VectoredTransferEngine::new(&mut self.writer);
+            let mut stats = fallback.send_batch(batch).await?;
+            stats.fallback_bytes = stats.body_bytes;
+            return Ok(stats);
+        };
+
+        let expected_header_calls = usize::from(!batch.frame_header.is_empty());
+        let (header_written, header_calls) = write_all_counted(&mut self.writer, &batch.frame_header).await?;
+        let mut bytes_written = header_written;
+        let mut sendfile_bytes = 0;
+        let mut sendfile_call_count = 0;
+        let mut partial_write_count = header_calls.saturating_sub(expected_header_calls);
+        let out_fd = self.writer.as_raw_fd();
+
+        for range in file_ranges {
+            let in_fd = range.file.as_raw_fd();
+            let mut position = range.position;
+            let mut remaining = range.len;
+            while remaining > 0 {
+                let written = match self.operation.sendfile(out_fd, in_fd, position, remaining) {
+                    Ok(0) => return Err(write_zero_error()),
+                    Ok(written) => written,
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(error) => return Err(TransferError::Io(error)),
+                };
+
+                sendfile_call_count += 1;
+                bytes_written += written;
+                sendfile_bytes += written;
+                if written < remaining {
+                    partial_write_count += 1;
+                }
+                position += written as u64;
+                remaining -= written;
+            }
+        }
+
+        self.writer.flush().await?;
+
+        Ok(TransferStats {
+            engine: TransferEngineKind::Sendfile,
+            bytes_written,
+            body_bytes: batch.total_body_len,
+            frame_count: 1,
+            write_call_count: header_calls,
+            sendfile_call_count,
+            sendfile_bytes,
+            fallback_bytes: 0,
+            partial_write_count,
+        })
+    }
+}
+
+#[cfg(unix)]
+fn batch_file_ranges(batch: &TransferBatch) -> Option<Vec<FileRange>> {
+    let mut remaining = batch.total_body_len;
+    if remaining == 0 {
+        return Some(Vec::new());
+    }
+
+    let mut ranges = Vec::with_capacity(batch.segments.len());
+    for segment in &batch.segments {
+        let mut range = segment.as_file_range()?;
+        let len = range.len.min(remaining);
+        if len > 0 {
+            range.len = len;
+            ranges.push(range);
+            remaining -= len;
+        }
+        if remaining == 0 {
+            break;
+        }
+    }
+
+    (remaining == 0).then_some(ranges)
+}

--- a/rocketmq-store/src/ha/transfer_engine/vectored.rs
+++ b/rocketmq-store/src/ha/transfer_engine/vectored.rs
@@ -75,6 +75,9 @@ where
             body_bytes: batch.total_body_len,
             frame_count: 1,
             write_call_count,
+            sendfile_call_count: 0,
+            sendfile_bytes: 0,
+            fallback_bytes: 0,
             partial_write_count,
         })
     }

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -2745,6 +2745,9 @@ mod tests {
             segments[0].as_bytes().expect("segment bytes"),
             Bytes::from_static(b"CDEF")
         );
+        let file_range = segments[0].as_file_range().expect("file range");
+        assert_eq!(file_range.position, 12);
+        assert_eq!(file_range.len, 4);
 
         let _ = fs::remove_dir_all(temp_root);
     }

--- a/rocketmq-store/src/transfer/segment.rs
+++ b/rocketmq-store/src/transfer/segment.rs
@@ -41,8 +41,13 @@ impl From<SelectMappedBufferCacheState> for TransferCacheState {
 
 #[derive(Clone)]
 pub enum SegmentSource {
-    Mmap { mapped_file: Arc<DefaultMappedFile> },
-    FileRange { file: Arc<File> },
+    Mmap {
+        mapped_file: Arc<DefaultMappedFile>,
+    },
+    FileRange {
+        file: Arc<File>,
+        mapped_file: Option<Arc<DefaultMappedFile>>,
+    },
     Bytes,
 }
 
@@ -94,6 +99,30 @@ impl SegmentLease {
         }
     }
 
+    pub fn from_file_range(
+        global_offset: i64,
+        file_offset: u64,
+        position_in_file: u64,
+        len: usize,
+        file: Arc<File>,
+        cache_state: TransferCacheState,
+    ) -> Self {
+        Self {
+            segment: CommitLogSegment {
+                global_offset,
+                file_offset,
+                position_in_file,
+                len,
+                source: SegmentSource::FileRange {
+                    file,
+                    mapped_file: None,
+                },
+                cache_state,
+            },
+            bytes: None,
+        }
+    }
+
     pub fn from_select_result(global_offset: i64, mut result: SelectMappedBufferResult) -> Option<Self> {
         if result.size <= 0 {
             return None;
@@ -107,7 +136,13 @@ impl SegmentLease {
             .map(|mapped_file| mapped_file.get_file_from_offset())
             .unwrap_or_else(|| global_offset.saturating_sub(position_in_file as i64) as u64);
         let source = match mapped_file {
-            Some(mapped_file) => SegmentSource::Mmap { mapped_file },
+            Some(mapped_file) => match mapped_file.get_file().try_clone() {
+                Ok(file) => SegmentSource::FileRange {
+                    file: Arc::new(file),
+                    mapped_file: Some(mapped_file),
+                },
+                Err(_) => SegmentSource::Mmap { mapped_file },
+            },
             None => SegmentSource::Bytes,
         };
 
@@ -134,7 +169,7 @@ impl SegmentLease {
 
     pub fn as_file_range(&self) -> Option<FileRange> {
         match &self.segment.source {
-            SegmentSource::FileRange { file } => Some(FileRange {
+            SegmentSource::FileRange { file, .. } => Some(FileRange {
                 file: file.clone(),
                 position: self.segment.position_in_file,
                 len: self.segment.len,
@@ -154,8 +189,13 @@ impl SegmentLease {
 
 impl Drop for SegmentLease {
     fn drop(&mut self) {
-        if let SegmentSource::Mmap { mapped_file } = &self.segment.source {
-            mapped_file.release();
+        match &self.segment.source {
+            SegmentSource::Mmap { mapped_file }
+            | SegmentSource::FileRange {
+                mapped_file: Some(mapped_file),
+                ..
+            } => mapped_file.release(),
+            SegmentSource::FileRange { mapped_file: None, .. } | SegmentSource::Bytes => {}
         }
     }
 }

--- a/rocketmq-store/tests/ha_sendfile_transfer_engine.rs
+++ b/rocketmq-store/tests/ha_sendfile_transfer_engine.rs
@@ -1,0 +1,263 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(unix)]
+
+use std::fs::File;
+use std::io;
+use std::io::IoSlice;
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::os::fd::RawFd;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+use rocketmq_store::ha::transfer_engine::sendfile::SendfileOperation;
+use rocketmq_store::ha::transfer_engine::sendfile::SendfileTransferEngine;
+use rocketmq_store::ha::transfer_engine::vectored::VectoredTransferEngine;
+use rocketmq_store::ha::transfer_engine::TransferEngineKind;
+use rocketmq_store::transfer::batch::TransferBatch;
+use rocketmq_store::transfer::batch::TransferKind;
+use rocketmq_store::transfer::segment::SegmentLease;
+use rocketmq_store::transfer::segment::TransferCacheState;
+use tempfile::NamedTempFile;
+use tokio::io::AsyncWrite;
+
+#[test]
+fn segment_lease_from_file_range_exposes_file_position_and_len() {
+    let file = Arc::new(temp_file_with_bytes(b"0123456789abcdef"));
+    let lease = SegmentLease::from_file_range(4096, 4096, 5, 7, file.clone(), TransferCacheState::Hot);
+
+    let range = lease.as_file_range().expect("file range");
+
+    assert_eq!(range.file.as_raw_fd(), file.as_raw_fd());
+    assert_eq!(range.position, 5);
+    assert_eq!(range.len, 7);
+    assert_eq!(lease.len(), 7);
+}
+
+#[tokio::test]
+async fn sendfile_transfer_engine_writes_header_then_sendfile_ranges() {
+    let file = Arc::new(temp_file_with_bytes(b"0123456789abcdef"));
+    let header = transfer_header(4096, 10);
+    let batch = TransferBatch {
+        frame_header: header.clone(),
+        segments: vec![SegmentLease::from_file_range(
+            4096,
+            4096,
+            3,
+            10,
+            file,
+            TransferCacheState::Hot,
+        )],
+        total_body_len: 10,
+        start_offset: 4096,
+        next_offset: 4106,
+        kind: TransferKind::Data,
+    };
+    let mut engine = SendfileTransferEngine::with_operation(RecordingWriter::default(), RecordingSendfile::new(4));
+
+    let stats = engine.send_batch(&batch).await.expect("sendfile transfer");
+
+    let (writer, operation) = engine.into_parts();
+    assert_eq!(writer.written, header);
+    assert_eq!(operation.calls.len(), 3);
+    assert_eq!(operation.calls[0].offset, 3);
+    assert_eq!(operation.calls[0].len, 10);
+    assert_eq!(operation.calls[1].offset, 7);
+    assert_eq!(operation.calls[1].len, 6);
+    assert_eq!(operation.calls[2].offset, 11);
+    assert_eq!(operation.calls[2].len, 2);
+    assert_eq!(stats.engine, TransferEngineKind::Sendfile);
+    assert_eq!(stats.bytes_written, header.len() + 10);
+    assert_eq!(stats.body_bytes, 10);
+    assert_eq!(stats.write_call_count, 1);
+    assert_eq!(stats.sendfile_call_count, 3);
+    assert_eq!(stats.sendfile_bytes, 10);
+    assert_eq!(stats.fallback_bytes, 0);
+    assert_eq!(stats.partial_write_count, 2);
+}
+
+#[tokio::test]
+async fn sendfile_transfer_engine_falls_back_to_vectored_for_byte_segments() {
+    let header = transfer_header(8192, 4);
+    let body = Bytes::from_static(b"body");
+    let batch = TransferBatch {
+        frame_header: header.clone(),
+        segments: vec![SegmentLease::from_bytes(8192, 0, body.clone(), TransferCacheState::Hot)],
+        total_body_len: body.len(),
+        start_offset: 8192,
+        next_offset: 8196,
+        kind: TransferKind::Data,
+    };
+    let mut engine =
+        SendfileTransferEngine::with_operation(RecordingWriter::default(), RecordingSendfile::new(usize::MAX));
+
+    let stats = engine.send_batch(&batch).await.expect("fallback transfer");
+
+    let (writer, operation) = engine.into_parts();
+    let mut expected = header.to_vec();
+    expected.extend_from_slice(&body);
+    assert_eq!(writer.written, expected);
+    assert!(operation.calls.is_empty());
+    assert_eq!(stats.engine, TransferEngineKind::Vectored);
+    assert_eq!(stats.sendfile_bytes, 0);
+    assert_eq!(stats.fallback_bytes, body.len());
+}
+
+#[tokio::test]
+async fn sendfile_transfer_engine_records_syscall_proxy_against_vectored_baseline() {
+    let body = Bytes::from(vec![7; 64 * 1024]);
+    let header = transfer_header(16384, body.len());
+    let vectored_batch = TransferBatch {
+        frame_header: header.clone(),
+        segments: vec![SegmentLease::from_bytes(
+            16384,
+            0,
+            body.clone(),
+            TransferCacheState::Hot,
+        )],
+        total_body_len: body.len(),
+        start_offset: 16384,
+        next_offset: 16384 + body.len() as i64,
+        kind: TransferKind::Data,
+    };
+    let mut vectored_engine = VectoredTransferEngine::new(RecordingWriter::default());
+
+    let vectored_stats = vectored_engine
+        .send_batch(&vectored_batch)
+        .await
+        .expect("vectored baseline transfer");
+
+    let file = Arc::new(temp_file_with_bytes(&body));
+    let sendfile_batch = TransferBatch {
+        frame_header: header,
+        segments: vec![SegmentLease::from_file_range(
+            16384,
+            16384,
+            0,
+            body.len(),
+            file,
+            TransferCacheState::Hot,
+        )],
+        total_body_len: body.len(),
+        start_offset: 16384,
+        next_offset: 16384 + body.len() as i64,
+        kind: TransferKind::Data,
+    };
+    let mut sendfile_engine =
+        SendfileTransferEngine::with_operation(RecordingWriter::default(), RecordingSendfile::new(usize::MAX));
+
+    let sendfile_stats = sendfile_engine
+        .send_batch(&sendfile_batch)
+        .await
+        .expect("sendfile transfer");
+
+    assert_eq!(vectored_stats.bytes_written, sendfile_stats.bytes_written);
+    assert_eq!(vectored_stats.write_call_count, 1);
+    assert_eq!(vectored_stats.sendfile_call_count, 0);
+    assert_eq!(sendfile_stats.write_call_count, 1);
+    assert_eq!(sendfile_stats.sendfile_call_count, 1);
+    assert_eq!(sendfile_stats.sendfile_bytes, body.len());
+    assert_eq!(sendfile_stats.fallback_bytes, 0);
+}
+
+fn temp_file_with_bytes(bytes: &[u8]) -> File {
+    let mut temp = NamedTempFile::new().expect("temp file");
+    temp.write_all(bytes).expect("write temp file");
+    temp.reopen().expect("reopen temp file")
+}
+
+fn transfer_header(offset: i64, body_size: usize) -> Bytes {
+    let mut header = BytesMut::with_capacity(12);
+    header.put_i64(offset);
+    header.put_i32(i32::try_from(body_size).expect("body size fits i32"));
+    header.freeze()
+}
+
+#[derive(Default)]
+struct RecordingWriter {
+    written: Vec<u8>,
+    vectored_calls: usize,
+}
+
+impl AsRawFd for RecordingWriter {
+    fn as_raw_fd(&self) -> RawFd {
+        77
+    }
+}
+
+impl AsyncWrite for RecordingWriter {
+    fn poll_write(mut self: Pin<&mut Self>, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        self.written.extend_from_slice(buf);
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.vectored_calls += 1;
+        let written = bufs.iter().map(|buf| buf.len()).sum::<usize>();
+        for buf in bufs {
+            self.written.extend_from_slice(buf);
+        }
+        Poll::Ready(Ok(written))
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[derive(Debug)]
+struct SendfileCall {
+    offset: u64,
+    len: usize,
+}
+
+struct RecordingSendfile {
+    max_chunk: usize,
+    calls: Vec<SendfileCall>,
+}
+
+impl RecordingSendfile {
+    fn new(max_chunk: usize) -> Self {
+        Self {
+            max_chunk: max_chunk.max(1),
+            calls: Vec::new(),
+        }
+    }
+}
+
+impl SendfileOperation for RecordingSendfile {
+    fn sendfile(&mut self, _out_fd: RawFd, _in_fd: RawFd, offset: u64, len: usize) -> io::Result<usize> {
+        self.calls.push(SendfileCall { offset, len });
+        Ok(len.min(self.max_chunk))
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7644

### Brief Description

Adds the Linux HA sendfile transfer engine boundary for commitlog replication:

- Extends `SegmentLease` so mapped commitlog selections can expose `FileRange` while keeping bytes fallback and mapped-file release semantics.
- Adds `SendfileTransferEngine` with an injectable `SendfileOperation` boundary and Linux `libc::sendfile` implementation.
- Sends HA headers through the normal async writer and sends eligible file-range bodies through sendfile.
- Falls back to `VectoredTransferEngine` before writing any header when the batch is not fully file-backed.
- Extends transfer stats with sendfile call count, sendfile bytes, fallback bytes, and partial-write count.
- Adds focused tests for file-range metadata, partial sendfile loops, fallback, and byte-count equivalence with the vectored baseline.

Performance-related data included in this PR:

- Unit-level syscall-proxy comparison from `sendfile_transfer_engine_records_syscall_proxy_against_vectored_baseline` with the same HA frame shape: 12-byte header + 64 KiB body.
- Vectored baseline: `bytes_written = 65548`, `write_call_count = 1`, `sendfile_call_count = 0`, `sendfile_bytes = 0`.
- Sendfile path: `bytes_written = 65548`, header `write_call_count = 1`, `sendfile_call_count = 1`, `sendfile_bytes = 65536`, `fallback_bytes = 0`.
- Partial-write test data: 10-byte file range with max 4 bytes per sendfile call produced `sendfile_call_count = 3`, `sendfile_bytes = 10`, and `partial_write_count = 2`.
- Fallback test data: byte-backed batch selected vectored fallback with `sendfile_bytes = 0` and `fallback_bytes = 4`.
- This PR does not claim throughput, latency, CPU, or production syscall improvement. Full HA replication benchmarks are still required before enabling sendfile as a production default or making performance claims.

### How Did You Test This Change?

- RED: `cargo test -p rocketmq-store --test ha_sendfile_transfer_engine` failed before implementation because `rocketmq_store::ha::transfer_engine::sendfile` did not exist.
- `cargo fmt --all --check` passed.
- `cargo test -p rocketmq-store --test ha_sendfile_transfer_engine` passed: 4 passed.
- `cargo test -p rocketmq-store --test ha_transfer_engine` passed: 4 passed.
- `cargo test -p rocketmq-store --test transfer_planner` passed: 3 passed.
- `cargo test -p rocketmq-store --lib` passed: 498 passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new transfer path that can use operating-system file transfer support for eligible data, with automatic fallback when needed.
  * Improved transfer reporting to include more detailed counts for file-based and fallback activity.

* **Bug Fixes**
  * Preserved correct file-range handling at mapped-file boundaries.
  * Added coverage to verify file-backed and byte-backed transfers behave consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->