### PR TITLE
[ISSUE #7648]🐛Fix Windows platform libc errno reference

### DIFF
--- a/rocketmq-store/src/platform.rs
+++ b/rocketmq-store/src/platform.rs
@@ -85,8 +85,14 @@ pub fn preallocate_file(file: &File, len: u64) -> FilePreallocateOutcome {
     }
 }
 
+#[cfg(unix)]
 fn is_unsupported_preallocate_errno(errno: i32) -> bool {
     errno == PREALLOCATE_UNSUPPORTED_ERRNO || errno == libc::ENOSYS || errno == libc::EINVAL
+}
+
+#[cfg(not(unix))]
+fn is_unsupported_preallocate_errno(errno: i32) -> bool {
+    errno == PREALLOCATE_UNSUPPORTED_ERRNO
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7648

### Brief Description

- Split `is_unsupported_preallocate_errno` into Unix and non-Unix implementations.
- Keep Linux/Unix `libc::ENOSYS` and `libc::EINVAL` handling for `fallocate` errno classification.
- Avoid compiling `libc` references on Windows, where `rocketmq-store` only declares `libc` as a Unix target dependency.

This is a Windows CI/build portability fix only. It does not claim throughput, latency, CPU, syscall, memory-use, or production performance improvement.

### How Did You Test This Change?

- RED: a minimal `rustc --target x86_64-pc-windows-msvc` compile check that includes `rocketmq-store/src/platform.rs` failed with unresolved `libc` references at `rocketmq-store/src/platform.rs:89` before the fix.
- `cargo fmt --all --check` passed.
- The same minimal `rustc --target x86_64-pc-windows-msvc` compile check for `rocketmq-store/src/platform.rs` passed after the fix.
- `cargo clippy -p rocketmq-store --features rocksdb_store --all-targets -- -D warnings` passed on Linux.
- `cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_foundation_tests` passed: 82 passed, 0 failed.
- `cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_store_semantics_tests` passed: 5 passed, 0 failed.
- `cargo test -p rocketmq-store --lib` passed: 500 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform-specific handling for storage preallocation errors, so unsupported cases are now detected more accurately across different operating systems.
  * Adjusted behavior on non-Unix systems to avoid treating additional error codes as unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->