### PR TITLE
[ISSUE #7650]🚀Complete HA ISR consistency semantics

### DIFF
--- a/rocketmq-store/src/ha/default_ha_client.rs
+++ b/rocketmq-store/src/ha/default_ha_client.rs
@@ -811,6 +811,7 @@ mod tests {
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
     use rocketmq_common::common::config::TopicConfig;
     use tempfile::tempdir;
+    use tokio::net::TcpListener;
 
     use super::*;
     use crate::config::message_store_config::MessageStoreConfig;
@@ -886,5 +887,58 @@ mod tests {
         ReaderTask::apply_master_confirm_offset(&store, header.confirm_offset);
 
         assert_eq!(store.get_confirm_offset(), 4);
+    }
+
+    #[tokio::test]
+    async fn reader_task_reports_master_slave_offsets_when_append_offset_mismatches() {
+        let temp_dir = tempdir().expect("temp dir");
+        let mut store = new_test_message_store(temp_dir.path());
+        store.init().await.expect("init message store");
+        store
+            .get_commit_log_mut()
+            .append_data(0, &[1, 2, 3, 4], 0, 4)
+            .await
+            .expect("append data");
+
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind loopback listener");
+        let client = TcpStream::connect(listener.local_addr().expect("listener addr"))
+            .await
+            .expect("connect loopback client");
+        let (server, _) = listener.accept().await.expect("accept loopback client");
+        let (reader_half, _) = server.into_split();
+        drop(client);
+
+        let (offset_tx, _offset_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (err_tx, _err_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut reader = ReaderTask {
+            reader: FramedRead::new(reader_half, BytesCodec::new()),
+            buf: BytesMut::from(
+                &encode_transfer_header(
+                    &mut BytesMut::with_capacity(CONTROLLER_TRANSFER_HEADER_SIZE),
+                    8,
+                    0,
+                    true,
+                    4,
+                )[..],
+            ),
+            dispatch_pos: 0,
+            offset_tx,
+            err_tx,
+            store: store.clone(),
+            flow_monitor: Arc::new(FlowMonitor::new(store.message_store_config())),
+            last_read_timestamp: Arc::new(AtomicU64::new(0)),
+            enable_controller_mode: true,
+        };
+
+        let error = reader
+            .dispatch_read()
+            .await
+            .expect_err("offset mismatch should stop dispatch");
+        let message = error.to_string();
+        assert!(message.contains("master pushed offset != slave max"));
+        assert!(message.contains("slave: 4"));
+        assert!(message.contains("master: 8"));
     }
 }

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -392,8 +392,12 @@ impl HAService for DefaultHAService {
         }
     }
 
-    fn in_sync_replicas_nums(&self, _master_put_where: i64) -> i32 {
-        1 + self.connection_count.load(Ordering::Relaxed) as i32
+    fn in_sync_replicas_nums(&self, master_put_where: i64) -> i32 {
+        1 + self
+            .try_snapshot_connections(master_put_where)
+            .into_iter()
+            .filter(|connection| connection.slave_ack_offset >= master_put_where)
+            .count() as i32
     }
 
     fn get_connection_count(&self) -> &AtomicU32 {
@@ -621,6 +625,7 @@ mod tests {
     use rocketmq_common::common::broker::broker_config::BrokerConfig;
     use rocketmq_common::common::config::TopicConfig;
     use rocketmq_common::TimeUtils::current_millis;
+    use tokio::io::AsyncWriteExt;
 
     use super::*;
     use crate::ha::auto_switch::auto_switch_ha_service::AutoSwitchHAService;
@@ -874,6 +879,50 @@ mod tests {
         service.remove_connection(connection.clone()).await;
 
         assert_eq!(auto_switch_service.get_local_sync_state_set(), HashSet::from([7_i64]));
+
+        connection.shutdown().await;
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn in_sync_replicas_count_requires_slave_ack_to_reach_master_offset() {
+        let temp_root = std::env::temp_dir().join(format!(
+            "rocketmq-rust-default-ha-in-sync-replicas-{}",
+            current_millis()
+        ));
+        let store = new_test_message_store(&temp_root, false);
+        let service = ArcMut::new(DefaultHAService::new(store));
+        let (server_stream, remote_addr, mut client) = new_server_stream().await;
+        let mut connection = AcceptSocketService::build_connection(
+            service.clone(),
+            service.get_default_message_store().message_store_config(),
+            server_stream,
+            remote_addr,
+            false,
+        )
+        .await
+        .expect("build default connection");
+        let connection_weak = ArcMut::downgrade(&connection);
+        connection.start(connection_weak).await.expect("start connection");
+        service.add_connection(connection.clone()).await;
+
+        client
+            .write_all(&64_i64.to_be_bytes())
+            .await
+            .expect("write slave ack offset");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if connection.get_slave_ack_offset() == 64 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("connection should observe slave ack offset");
+
+        assert_eq!(service.in_sync_replicas_nums(64), 2);
+        assert_eq!(service.in_sync_replicas_nums(65), 1);
 
         connection.shutdown().await;
         let _ = std::fs::remove_dir_all(temp_root);

--- a/rocketmq-store/src/ha/group_transfer_service.rs
+++ b/rocketmq-store/src/ha/group_transfer_service.rs
@@ -288,6 +288,29 @@ mod tests {
     }
 
     #[test]
+    fn all_ack_in_sync_state_set_requires_controller_members() {
+        let request_ack_nums = mix_all::ALL_ACK_IN_SYNC_STATE_SET;
+        let sync_state_set = HashSet::from([7_i64, 9_i64, 10_i64]);
+        let mut acked_replicas = vec![
+            HAAckedReplicaSnapshot {
+                slave_broker_id: Some(9),
+                slave_ack_offset: 128,
+            },
+            HAAckedReplicaSnapshot {
+                slave_broker_id: Some(10),
+                slave_ack_offset: 127,
+            },
+        ];
+
+        assert!(request_ack_nums < 0);
+        assert!(!has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 128));
+
+        acked_replicas[1].slave_ack_offset = 128;
+
+        assert!(has_required_sync_state_set_acks(&sync_state_set, &acked_replicas, 128));
+    }
+
+    #[test]
     fn sync_state_set_ack_ignores_non_members() {
         let sync_state_set = HashSet::from([7_i64, 9_i64]);
         let acked_replicas = vec![

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -2516,6 +2516,51 @@ mod tests {
         let _ = std::fs::remove_dir_all(temp_root);
     }
 
+    #[test]
+    fn auto_in_sync_replicas_clamps_required_acks_between_minimum_and_configured_value() {
+        let temp_root =
+            std::env::temp_dir().join(format!("rocketmq-rust-commitlog-auto-isr-acks-{}", current_millis()));
+        let store = new_test_message_store_with_config(
+            &temp_root,
+            MessageStoreConfig {
+                enable_auto_in_sync_replicas: true,
+                in_sync_replicas: 3,
+                min_in_sync_replicas: 2,
+                ..MessageStoreConfig::default()
+            },
+            BrokerRole::SyncMaster,
+            false,
+        );
+
+        assert_eq!(store.get_commit_log().calc_need_ack_nums(1), 2);
+        assert_eq!(store.get_commit_log().calc_need_ack_nums(2), 2);
+        assert_eq!(store.get_commit_log().calc_need_ack_nums(4), 3);
+
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[test]
+    fn configured_in_sync_replicas_takes_priority_when_auto_in_sync_replicas_is_disabled() {
+        let temp_root =
+            std::env::temp_dir().join(format!("rocketmq-rust-commitlog-fixed-isr-acks-{}", current_millis()));
+        let store = new_test_message_store_with_config(
+            &temp_root,
+            MessageStoreConfig {
+                enable_auto_in_sync_replicas: false,
+                in_sync_replicas: 3,
+                min_in_sync_replicas: 2,
+                ..MessageStoreConfig::default()
+            },
+            BrokerRole::SyncMaster,
+            false,
+        );
+
+        assert_eq!(store.get_commit_log().calc_need_ack_nums(1), 3);
+        assert_eq!(store.get_commit_log().calc_need_ack_nums(4), 3);
+
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
     #[tokio::test]
     async fn shutdown_flushes_pending_commitlog_data() {
         let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-commitlog-shutdown-{}", current_millis()));


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7650

### Brief Description

Completes the HA ISR consistency semantics for store replication by counting only replicas whose ACK offset reaches the master write offset, covering auto ISR ACK calculation priority, and making controller `ALL_ACK_IN_SYNC_STATE_SET` behavior explicit through tests.

This also adds coverage that slave append offset mismatches report both master and slave offsets before stopping dispatch. This PR makes correctness and compatibility changes only; it does not claim or measure performance improvements.

### How Did You Test This Change?

- `cargo fmt --all`
- `cargo test -p rocketmq-store --lib ha::default_ha_service::tests::in_sync_replicas_count_requires_slave_ack_to_reach_master_offset`
- `cargo test -p rocketmq-store --lib auto_in_sync_replicas_clamps_required_acks_between_minimum_and_configured_value`
- `cargo test -p rocketmq-store --lib configured_in_sync_replicas_takes_priority_when_auto_in_sync_replicas_is_disabled`
- `cargo test -p rocketmq-store --lib ha::default_ha_client::tests::reader_task_reports_master_slave_offsets_when_append_offset_mismatches`
- `cargo test -p rocketmq-store --lib ha::group_transfer_service::tests::all_ack_in_sync_state_set_requires_controller_members`
- `cargo test -p rocketmq-store --lib ha::auto_switch::auto_switch_ha_service::tests::maybe_shrink_sync_state_set_removes_stale_members`
- `cargo test -p rocketmq-store --lib ha::auto_switch::auto_switch_ha_service::tests::follower_rejects_stale_epoch`
- `cargo test -p rocketmq-store --lib ha::auto_switch::auto_switch_ha_service::tests::change_to_master_records_epoch_boundary_and_refreshes_confirm_offset`
- `cargo test -p rocketmq-store --lib ha::auto_switch::auto_switch_ha_service::tests::sync_controller_sync_state_set_updates_local_membership`
- `cargo test -p rocketmq-store --test ha_semantics_tests`
- `cargo test -p rocketmq-store --lib`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replica synchronization checks so only replicas that have actually caught up are counted as in-sync.
  * Fixed acknowledgment calculations to better respect configured limits when automatic sync-replica adjustment is enabled.
  * Strengthened error handling when a slave’s offset does not match the master’s expected position.
* **Tests**
  * Added coverage for replica-ack validation and sync-state behavior across several replication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->