### PR TITLE
[ISSUE #7652]🐛Fix remoting ingress coverage recursion limit

### DIFF
--- a/rocketmq-proxy/tests/remoting_ingress.rs
+++ b/rocketmq-proxy/tests/remoting_ingress.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::Mutex;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7652

### Brief Description

Adds the crate-level `#![recursion_limit = "256"]` attribute to `rocketmq-proxy/tests/remoting_ingress.rs` so the remoting ingress integration test crate can compile under nightly coverage instrumentation.

The failure is caused by rustc query depth overflow while computing the layout of the deep async/generic remoting server listener type in the test crate. This matches the existing proxy binary crate limit and does not change runtime behavior.

### How Did You Test This Change?

- Reproduced before the fix: `RUSTFLAGS="-C instrument-coverage --cfg=coverage --cfg=coverage_nightly" cargo +nightly test -p rocketmq-proxy --test remoting_ingress --all-features --no-run` failed with `queries overflow the depth limit`.
- `cargo fmt --all`
- `RUSTFLAGS="-C instrument-coverage --cfg=coverage --cfg=coverage_nightly" cargo +nightly test -p rocketmq-proxy --test remoting_ingress --all-features --no-run`
- `cargo test -p rocketmq-proxy --test remoting_ingress --all-features`
- `cargo fmt --all --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`