### PR TITLE
[ISSUE #7654]🚀Add io_uring runtime capability probe

### DIFF
--- a/rocketmq-store/src/log_file/mapped_file/io_uring_impl.rs
+++ b/rocketmq-store/src/log_file/mapped_file/io_uring_impl.rs
@@ -14,6 +14,12 @@
 
 use std::io;
 
+pub const MIN_IO_URING_KERNEL_VERSION: LinuxKernelVersion = LinuxKernelVersion {
+    major: 5,
+    minor: 1,
+    patch: 0,
+};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IoUringBackendStatus {
     Available,
@@ -37,6 +43,129 @@ impl IoUringBackendStatus {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LinuxKernelVersion {
+    pub major: u16,
+    pub minor: u16,
+    pub patch: u16,
+}
+
+impl LinuxKernelVersion {
+    pub fn parse_release(release: &str) -> Option<Self> {
+        let mut parts = release.split('.');
+        let major = parse_numeric_component(parts.next()?)?;
+        let minor = parse_numeric_component(parts.next().unwrap_or("0"))?;
+        let patch = parse_numeric_component(parts.next().unwrap_or("0"))?;
+
+        Some(Self { major, minor, patch })
+    }
+
+    #[inline]
+    pub fn supports_io_uring(self) -> bool {
+        self >= MIN_IO_URING_KERNEL_VERSION
+    }
+
+    #[inline]
+    pub fn supports_send_zc(self) -> bool {
+        self >= LinuxKernelVersion {
+            major: 6,
+            minor: 0,
+            patch: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct IoUringOpcodeSupport {
+    pub read: bool,
+    pub write: bool,
+    pub fsync: bool,
+    pub registered_files: bool,
+    pub fixed_buffers: bool,
+    pub send_zc: bool,
+}
+
+impl IoUringOpcodeSupport {
+    pub fn from_kernel_version(version: Option<LinuxKernelVersion>) -> Self {
+        let Some(version) = version else {
+            return Self::default();
+        };
+
+        if !version.supports_io_uring() {
+            return Self::default();
+        }
+
+        Self {
+            read: true,
+            write: true,
+            fsync: true,
+            registered_files: true,
+            fixed_buffers: true,
+            send_zc: version.supports_send_zc(),
+        }
+    }
+
+    #[inline]
+    pub fn required_supported(self) -> bool {
+        self.read && self.write && self.fsync
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IoUringFallbackReason {
+    FeatureDisabled,
+    UnsupportedPlatform,
+    KernelTooOld {
+        required: LinuxKernelVersion,
+        actual: Option<LinuxKernelVersion>,
+    },
+    MissingRequiredOpcodes,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IoUringRuntimeCapability {
+    pub backend_status: IoUringBackendStatus,
+    pub kernel_version: Option<LinuxKernelVersion>,
+    pub opcode_support: IoUringOpcodeSupport,
+    pub fallback_reason: Option<IoUringFallbackReason>,
+    pub experimental: bool,
+}
+
+impl IoUringRuntimeCapability {
+    pub fn classify(
+        backend_status: IoUringBackendStatus,
+        kernel_version: Option<LinuxKernelVersion>,
+        opcode_support: IoUringOpcodeSupport,
+    ) -> Self {
+        let fallback_reason = match backend_status {
+            IoUringBackendStatus::FeatureDisabled => Some(IoUringFallbackReason::FeatureDisabled),
+            IoUringBackendStatus::UnsupportedPlatform => Some(IoUringFallbackReason::UnsupportedPlatform),
+            IoUringBackendStatus::Available => match kernel_version {
+                Some(version) if version.supports_io_uring() => {
+                    (!opcode_support.required_supported()).then_some(IoUringFallbackReason::MissingRequiredOpcodes)
+                }
+                actual => Some(IoUringFallbackReason::KernelTooOld {
+                    required: MIN_IO_URING_KERNEL_VERSION,
+                    actual,
+                }),
+            },
+        };
+
+        Self {
+            backend_status,
+            kernel_version,
+            opcode_support,
+            fallback_reason,
+            experimental: true,
+        }
+    }
+
+    #[inline]
+    pub fn basic_path_available(self) -> bool {
+        self.fallback_reason.is_none()
+    }
+}
+
 #[inline]
 pub fn io_uring_backend_status() -> IoUringBackendStatus {
     if !cfg!(target_os = "linux") {
@@ -46,6 +175,14 @@ pub fn io_uring_backend_status() -> IoUringBackendStatus {
     } else {
         IoUringBackendStatus::Available
     }
+}
+
+pub fn probe_io_uring_runtime_capability() -> IoUringRuntimeCapability {
+    let backend_status = io_uring_backend_status();
+    let kernel_version = current_linux_kernel_version();
+    let opcode_support = IoUringOpcodeSupport::from_kernel_version(kernel_version);
+
+    IoUringRuntimeCapability::classify(backend_status, kernel_version, opcode_support)
 }
 
 #[inline]
@@ -60,6 +197,25 @@ pub fn ensure_io_uring_backend_available() -> io::Result<()> {
             io::ErrorKind::Unsupported,
             "io_uring mapped-file backend requires Linux",
         )),
+    }
+}
+
+fn parse_numeric_component(component: &str) -> Option<u16> {
+    let digits: String = component.chars().take_while(|ch| ch.is_ascii_digit()).collect();
+    (!digits.is_empty()).then(|| digits.parse().ok()).flatten()
+}
+
+fn current_linux_kernel_version() -> Option<LinuxKernelVersion> {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .ok()
+            .and_then(|release| LinuxKernelVersion::parse_release(release.trim()))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
     }
 }
 
@@ -88,5 +244,138 @@ mod tests {
             IoUringBackendStatus::UnsupportedPlatform.as_str(),
             "unsupported_platform"
         );
+    }
+
+    #[test]
+    fn linux_kernel_version_parses_common_release_strings() {
+        assert_eq!(
+            LinuxKernelVersion::parse_release("5.15.0-105-generic"),
+            Some(LinuxKernelVersion {
+                major: 5,
+                minor: 15,
+                patch: 0,
+            })
+        );
+        assert_eq!(
+            LinuxKernelVersion::parse_release("6.8.12"),
+            Some(LinuxKernelVersion {
+                major: 6,
+                minor: 8,
+                patch: 12,
+            })
+        );
+        assert_eq!(LinuxKernelVersion::parse_release("not-a-kernel"), None);
+    }
+
+    #[test]
+    fn runtime_capability_requires_feature_platform_kernel_and_basic_opcodes() {
+        let support = IoUringOpcodeSupport {
+            read: true,
+            write: true,
+            fsync: true,
+            ..IoUringOpcodeSupport::default()
+        };
+
+        let capability = IoUringRuntimeCapability::classify(
+            IoUringBackendStatus::Available,
+            Some(LinuxKernelVersion {
+                major: 5,
+                minor: 1,
+                patch: 0,
+            }),
+            support,
+        );
+
+        assert!(capability.basic_path_available());
+        assert_eq!(capability.fallback_reason, None);
+
+        let missing_opcode = IoUringRuntimeCapability::classify(
+            IoUringBackendStatus::Available,
+            Some(LinuxKernelVersion {
+                major: 6,
+                minor: 1,
+                patch: 0,
+            }),
+            IoUringOpcodeSupport {
+                read: true,
+                write: true,
+                fsync: false,
+                ..IoUringOpcodeSupport::default()
+            },
+        );
+
+        assert!(!missing_opcode.basic_path_available());
+        assert_eq!(
+            missing_opcode.fallback_reason,
+            Some(IoUringFallbackReason::MissingRequiredOpcodes)
+        );
+
+        let old_kernel = IoUringRuntimeCapability::classify(
+            IoUringBackendStatus::Available,
+            Some(LinuxKernelVersion {
+                major: 5,
+                minor: 0,
+                patch: 21,
+            }),
+            support,
+        );
+
+        assert!(!old_kernel.basic_path_available());
+        assert_eq!(
+            old_kernel.fallback_reason,
+            Some(IoUringFallbackReason::KernelTooOld {
+                required: LinuxKernelVersion {
+                    major: 5,
+                    minor: 1,
+                    patch: 0,
+                },
+                actual: Some(LinuxKernelVersion {
+                    major: 5,
+                    minor: 0,
+                    patch: 21,
+                }),
+            })
+        );
+    }
+
+    #[test]
+    fn opcode_support_is_classified_from_kernel_capability_level() {
+        let linux_5_1 = IoUringOpcodeSupport::from_kernel_version(Some(LinuxKernelVersion {
+            major: 5,
+            minor: 1,
+            patch: 0,
+        }));
+        assert!(linux_5_1.required_supported());
+        assert!(linux_5_1.registered_files);
+        assert!(linux_5_1.fixed_buffers);
+        assert!(!linux_5_1.send_zc);
+
+        let linux_6_0 = IoUringOpcodeSupport::from_kernel_version(Some(LinuxKernelVersion {
+            major: 6,
+            minor: 0,
+            patch: 0,
+        }));
+        assert!(linux_6_0.required_supported());
+        assert!(linux_6_0.send_zc);
+    }
+
+    #[test]
+    fn runtime_probe_reports_backend_gate_and_experimental_status() {
+        let capability = probe_io_uring_runtime_capability();
+
+        assert_eq!(capability.backend_status, io_uring_backend_status());
+        assert!(capability.experimental);
+
+        if !cfg!(target_os = "linux") {
+            assert_eq!(
+                capability.fallback_reason,
+                Some(IoUringFallbackReason::UnsupportedPlatform)
+            );
+            assert_eq!(capability.kernel_version, None);
+        } else if !cfg!(feature = "io_uring") {
+            assert_eq!(capability.fallback_reason, Some(IoUringFallbackReason::FeatureDisabled));
+        } else {
+            assert!(capability.kernel_version.is_some());
+        }
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7654

### Brief Description

Adds a runtime capability probe for the experimental `io_uring` storage path. The probe records backend gate status, parsed Linux kernel version, required basic opcode support, optional registered-file/fixed-buffer/send-zc capability flags, and a structured fallback reason.

The `io_uring` path remains experimental and disabled by default. This PR adds capability gating only and does not claim throughput, latency, CPU, syscall, or memory improvements.

### How Did You Test This Change?

- RED: `cargo test -p rocketmq-store --lib log_file::mapped_file::io_uring_impl::tests::linux_kernel_version_parses_common_release_strings` failed before implementation because the runtime probe API did not exist.
- `cargo fmt --all`
- `cargo test -p rocketmq-store --lib log_file::mapped_file::io_uring_impl::tests`
- `cargo test -p rocketmq-store --lib log_file::mapped_file::io_uring_impl::tests --features io_uring`
- `if cargo tree -p rocketmq-store --no-default-features --features local_file_store -i tokio-uring >/tmp/rocketmq-store-tokio-uring-tree.txt 2>&1; then cat /tmp/rocketmq-store-tokio-uring-tree.txt; echo unexpected tokio-uring dependency with io_uring feature disabled; exit 1; else cat /tmp/rocketmq-store-tokio-uring-tree.txt; echo tokio-uring not present when io_uring feature is disabled; fi`
- `cargo tree -p rocketmq-store --features io_uring -i tokio-uring`
- `cargo test -p rocketmq-store --lib`
- `cargo test -p rocketmq-store --lib --features io_uring`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime checks for io_uring support so the app can better determine when the faster backend is available.
  * Improved detection of Linux kernel compatibility and required io_uring capabilities.

* **Bug Fixes**
  * Added clearer fallback handling when io_uring is unavailable, unsupported on the platform, or blocked by an older kernel.
  * Marked io_uring capability probing as experimental for safer rollout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->