### PR TITLE
[ISSUE #7658]🚀Add HA io_uring transfer fallback selection

### DIFF
--- a/rocketmq-store/src/ha/transfer_engine.rs
+++ b/rocketmq-store/src/ha/transfer_engine.rs
@@ -30,12 +30,20 @@ pub enum TransferEngineKind {
     Bytes,
     Vectored,
     Sendfile,
+    IoUring,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransferEnginePreference {
     Bytes,
     Vectored,
+    IoUring,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransferEngineAvailability {
+    pub vectored_write_available: bool,
+    pub io_uring_available: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,19 +69,51 @@ pub fn select_transfer_engine(
     preference: TransferEnginePreference,
     vectored_write_available: bool,
 ) -> TransferEngineSelection {
-    match (preference, vectored_write_available) {
-        (TransferEnginePreference::Bytes, _) => TransferEngineSelection {
+    select_transfer_engine_with_availability(
+        preference,
+        TransferEngineAvailability {
+            vectored_write_available,
+            io_uring_available: false,
+        },
+    )
+}
+
+pub fn select_transfer_engine_with_availability(
+    preference: TransferEnginePreference,
+    availability: TransferEngineAvailability,
+) -> TransferEngineSelection {
+    match preference {
+        TransferEnginePreference::Bytes => TransferEngineSelection {
             engine: TransferEngineKind::Bytes,
             fallback_reason: None,
         },
-        (TransferEnginePreference::Vectored, true) => TransferEngineSelection {
+        TransferEnginePreference::Vectored => select_vectored_transfer_engine(availability.vectored_write_available),
+        TransferEnginePreference::IoUring if availability.io_uring_available => TransferEngineSelection {
+            engine: TransferEngineKind::IoUring,
+            fallback_reason: None,
+        },
+        TransferEnginePreference::IoUring if availability.vectored_write_available => TransferEngineSelection {
+            engine: TransferEngineKind::Vectored,
+            fallback_reason: Some("io_uring unavailable"),
+        },
+        TransferEnginePreference::IoUring => TransferEngineSelection {
+            engine: TransferEngineKind::Bytes,
+            fallback_reason: Some("io_uring and vectored write unavailable"),
+        },
+    }
+}
+
+fn select_vectored_transfer_engine(vectored_write_available: bool) -> TransferEngineSelection {
+    if vectored_write_available {
+        TransferEngineSelection {
             engine: TransferEngineKind::Vectored,
             fallback_reason: None,
-        },
-        (TransferEnginePreference::Vectored, false) => TransferEngineSelection {
+        }
+    } else {
+        TransferEngineSelection {
             engine: TransferEngineKind::Bytes,
             fallback_reason: Some("vectored write unavailable"),
-        },
+        }
     }
 }
 
@@ -86,7 +126,7 @@ impl<W> HaTransferEngine<W> {
     pub fn from_selection(writer: W, engine: TransferEngineKind) -> Self {
         match engine {
             TransferEngineKind::Bytes => Self::Bytes(BytesTransferEngine::new(writer)),
-            TransferEngineKind::Vectored | TransferEngineKind::Sendfile => {
+            TransferEngineKind::Vectored | TransferEngineKind::Sendfile | TransferEngineKind::IoUring => {
                 Self::Vectored(VectoredTransferEngine::new(writer))
             }
         }

--- a/rocketmq-store/tests/ha_transfer_engine.rs
+++ b/rocketmq-store/tests/ha_transfer_engine.rs
@@ -23,7 +23,9 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use rocketmq_store::ha::transfer_engine::bytes::BytesTransferEngine;
 use rocketmq_store::ha::transfer_engine::select_transfer_engine;
+use rocketmq_store::ha::transfer_engine::select_transfer_engine_with_availability;
 use rocketmq_store::ha::transfer_engine::vectored::VectoredTransferEngine;
+use rocketmq_store::ha::transfer_engine::TransferEngineAvailability;
 use rocketmq_store::ha::transfer_engine::TransferEngineKind;
 use rocketmq_store::ha::transfer_engine::TransferEnginePreference;
 use rocketmq_store::transfer::batch::TransferBatch;
@@ -103,6 +105,51 @@ fn transfer_engine_selection_falls_back_to_bytes_when_vectored_is_unavailable() 
 
     assert_eq!(selection.engine, TransferEngineKind::Bytes);
     assert!(selection.fallback_reason.is_some());
+}
+
+#[test]
+fn io_uring_transfer_selection_uses_io_uring_when_available() {
+    let selection = select_transfer_engine_with_availability(
+        TransferEnginePreference::IoUring,
+        TransferEngineAvailability {
+            vectored_write_available: true,
+            io_uring_available: true,
+        },
+    );
+
+    assert_eq!(selection.engine, TransferEngineKind::IoUring);
+    assert_eq!(selection.fallback_reason, None);
+}
+
+#[test]
+fn io_uring_transfer_selection_falls_back_to_vectored_when_unavailable() {
+    let selection = select_transfer_engine_with_availability(
+        TransferEnginePreference::IoUring,
+        TransferEngineAvailability {
+            vectored_write_available: true,
+            io_uring_available: false,
+        },
+    );
+
+    assert_eq!(selection.engine, TransferEngineKind::Vectored);
+    assert_eq!(selection.fallback_reason, Some("io_uring unavailable"));
+}
+
+#[test]
+fn io_uring_transfer_selection_falls_back_to_bytes_when_vectored_is_unavailable() {
+    let selection = select_transfer_engine_with_availability(
+        TransferEnginePreference::IoUring,
+        TransferEngineAvailability {
+            vectored_write_available: false,
+            io_uring_available: false,
+        },
+    );
+
+    assert_eq!(selection.engine, TransferEngineKind::Bytes);
+    assert_eq!(
+        selection.fallback_reason,
+        Some("io_uring and vectored write unavailable")
+    );
 }
 
 fn transfer_header(offset: i64, body_size: usize) -> Bytes {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7658

### Brief Description

Adds an availability-aware HA transfer engine selector for the experimental `io_uring` preference. The existing selector API delegates with `io_uring` unavailable, so the current HA runtime selection remains on the existing vectored/bytes path.

The new selector can choose `IoUring` only when explicit availability says it is available; otherwise it falls back to vectored or bytes with a fallback reason. No throughput, latency, CPU, syscall, or memory improvement is claimed.

### How Did You Test This Change?

- `cargo test -p rocketmq-store --test ha_transfer_engine io_uring_transfer_selection_falls_back_to_vectored_when_unavailable` (RED before implementation: failed with unresolved imports and missing `IoUring` variants; passed after implementation)
- `cargo test -p rocketmq-store --test ha_transfer_engine` (7 passed)
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rocketmq-store --lib` (512 passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`