### PR TITLE
[ISSUE #7660]🚀Align io_uring flush benchmark semantics

### DIFF
--- a/rocketmq-store/benches/io_uring_performance.rs
+++ b/rocketmq-store/benches/io_uring_performance.rs
@@ -12,350 +12,90 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*
-//! Performance benchmarks for IoUringMappedFile vs DefaultMappedFile
+//! Flush benchmark entry point for the experimental `io_uring` storage path.
 //!
-//! Run with: cargo bench --bench io_uring_performance --features io_uring
-//!
-//! Expected improvements with io_uring:
-//! - Write throughput: +20-30%
-//! - Flush latency: -30-40%
-//! - CPU usage: -10-15%
+//! Run with:
+//! `cargo bench -p rocketmq-store --bench io_uring_performance --features io_uring`
 
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
-use std::sync::Arc;
+use std::hint::black_box;
 
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
 use cheetah_string::CheetahString;
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
 use criterion::criterion_group;
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
 use criterion::criterion_main;
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use criterion::BatchSize;
 use criterion::BenchmarkId;
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
 use criterion::Criterion;
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
 use criterion::Throughput;
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use rocketmq_store::bench_support::io_uring_flush_benchmark_cases;
+use rocketmq_store::bench_support::IoUringFlushBenchmarkPath;
+use rocketmq_store::bench_support::IoUringFlushBenchmarkWorkload;
+use rocketmq_store::bench_support::IO_URING_FLUSH_BENCHMARK_GROUP;
 use rocketmq_store::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
-use rocketmq_store::log_file::mapped_file::io_uring_impl::IoUringMappedFile;
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use rocketmq_store::log_file::mapped_file::io_uring_impl::probe_io_uring_runtime_capability;
 use rocketmq_store::log_file::mapped_file::MappedFile;
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
-use tokio::runtime::Runtime;
+use tempfile::TempDir;
 
-/// Benchmark: io_uring vs default write performance
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
-fn bench_write_comparison(c: &mut Criterion) {
-    let mut group = c.benchmark_group("write_comparison");
-    let rt = Runtime::new().unwrap();
+fn bench_flush_semantics(c: &mut Criterion) {
+    let capability = probe_io_uring_runtime_capability();
+    let mut group = c.benchmark_group(IO_URING_FLUSH_BENCHMARK_GROUP);
+    group.sample_size(10);
 
-    let sizes = [256, 1024, 4096, 16384]; // Different message sizes
-
-    for size in sizes {
-        group.throughput(Throughput::Bytes(size as u64));
-
-        // Benchmark io_uring
-        group.bench_with_input(BenchmarkId::new("io_uring", size), &size, |b, &size| {
-            b.iter(|| {
-                rt.block_on(async {
-                    let file = IoUringMappedFile::new(
-                        CheetahString::from(format!("/tmp/bench_io_uring_{}", size)),
-                        10 * 1024 * 1024, // 10MB
-                    )
-                    .await
-                    .unwrap();
-
-                    let data = vec![0x42; size];
-                    for i in 0..100 {
-                        let offset = (i * size) % (10 * 1024 * 1024 - size);
-                        std::hint::black_box(file.write_async(&data, offset).await.unwrap());
-                    }
-
-                    let _ = std::fs::remove_file(format!("/tmp/bench_io_uring_{}", size));
-                })
-            });
-        });
-
-        // Benchmark default
-        group.bench_with_input(BenchmarkId::new("default", size), &size, |b, &size| {
-            b.iter(|| {
-                let file = DefaultMappedFile::new(
-                    CheetahString::from(format!("/tmp/bench_default_{}", size)),
-                    10 * 1024 * 1024, // 10MB
-                    None,
-                )
-                .unwrap();
-
-                let data = vec![0x42; size];
-                for i in 0..100 {
-                    let offset = (i * size) % (10 * 1024 * 1024 - size);
-                    std::hint::black_box(file.append_message_offset_length(&data, 0, size));
-                }
-
-                let _ = std::fs::remove_file(format!("/tmp/bench_default_{}", size));
-            });
-        });
-    }
-
-    group.finish();
-}
-
-/// Benchmark: Flush performance comparison
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
-fn bench_flush_comparison(c: &mut Criterion) {
-    let mut group = c.benchmark_group("flush_comparison");
-    let rt = Runtime::new().unwrap();
-
-    // Benchmark io_uring async flush
-    group.bench_function("io_uring_flush", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let file = IoUringMappedFile::new(
-                    CheetahString::from("/tmp/bench_flush_io_uring"),
-                    1024 * 1024, // 1MB
-                )
-                .await
-                .unwrap();
-
-                // Write some data
-                let data = vec![0xAA; 4096];
-                for i in 0..10 {
-                    file.write_async(&data, i * data.len()).await.unwrap();
-                }
-                file.set_wrote_position((10 * data.len()) as i32);
-
-                // Flush
-                std::hint::black_box(file.flush_async().await.unwrap());
-
-                let _ = std::fs::remove_file("/tmp/bench_flush_io_uring");
-            })
-        });
-    });
-
-    // Benchmark default sync flush
-    group.bench_function("default_flush", |b| {
-        b.iter(|| {
-            let file = DefaultMappedFile::new(
-                CheetahString::from("/tmp/bench_flush_default"),
-                1024 * 1024, // 1MB
-                None,
-            )
-            .unwrap();
-
-            // Write some data
-            let data = vec![0xAA; 4096];
-            for i in 0..10 {
-                file.append_message_offset_length(&data, 0, data.len());
-            }
-
-            // Flush
-            std::hint::black_box(file.flush(0));
-
-            let _ = std::fs::remove_file("/tmp/bench_flush_default");
-        });
-    });
-
-    group.finish();
-}
-
-/// Benchmark: Concurrent write performance
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
-fn bench_concurrent_writes(c: &mut Criterion) {
-    let mut group = c.benchmark_group("concurrent_writes");
-    let rt = Runtime::new().unwrap();
-
-    let thread_counts = [1, 2, 4, 8];
-
-    for num_threads in thread_counts {
-        group.bench_with_input(
-            BenchmarkId::new("io_uring", num_threads),
-            &num_threads,
-            |b, &num_threads| {
-                b.iter(|| {
-                    rt.block_on(async move {
-                        let file = Arc::new(
-                            IoUringMappedFile::new(
-                                CheetahString::from(format!(
-                                    "/tmp/bench_concurrent_io_uring_{}",
-                                    num_threads
-                                )),
-                                50 * 1024 * 1024, // 50MB
-                            )
-                            .await
-                            .unwrap(),
+    for case in io_uring_flush_benchmark_cases() {
+        group.throughput(Throughput::Bytes(case.workload.total_bytes() as u64));
+        match case.path {
+            IoUringFlushBenchmarkPath::DefaultMappedFileBaseline => {
+                group.bench_with_input(
+                    BenchmarkId::new(case.path.as_str(), case.name),
+                    &case.workload,
+                    |b, &workload| {
+                        b.iter_batched(
+                            || prepare_default_flush_workload(workload),
+                            |(_temp_dir, file, data)| {
+                                let flushed_position = run_default_flush_workload(&file, &data, workload);
+                                black_box(flushed_position);
+                            },
+                            BatchSize::SmallInput,
                         );
-
-                        let mut handles = vec![];
-                        for task_id in 0..num_threads {
-                            let file_clone = Arc::clone(&file);
-                            let handle = tokio::spawn(async move {
-                                let data = vec![task_id as u8; 1024];
-                                for i in 0..100 {
-                                    let offset = (task_id * 100 + i) * data.len();
-                                    file_clone.write_async(&data, offset).await.unwrap();
-                                }
-                            });
-                            handles.push(handle);
-                        }
-
-                        for handle in handles {
-                            handle.await.unwrap();
-                        }
-
-                        let _ = std::fs::remove_file(format!(
-                            "/tmp/bench_concurrent_io_uring_{}",
-                            num_threads
-                        ));
-                    })
-                });
-            },
-        );
+                    },
+                );
+            }
+            IoUringFlushBenchmarkPath::IoUringExperimental => {
+                if capability.basic_path_available() {
+                    eprintln!(
+                        "skipping {}: concrete io_uring flush backend is not wired yet",
+                        case.name
+                    );
+                } else {
+                    eprintln!(
+                        "skipping {}: io_uring runtime capability fallback={:?}",
+                        case.name, capability.fallback_reason
+                    );
+                }
+            }
+        }
     }
 
     group.finish();
 }
 
-/// Benchmark: Large sequential write throughput
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
-fn bench_sequential_throughput(c: &mut Criterion) {
-    let mut group = c.benchmark_group("sequential_throughput");
-    let rt = Runtime::new().unwrap();
+fn prepare_default_flush_workload(workload: IoUringFlushBenchmarkWorkload) -> (TempDir, DefaultMappedFile, Vec<u8>) {
+    let temp_dir = TempDir::new().expect("create io_uring flush benchmark directory");
+    let file_path = temp_dir.path().join("00000000000000000000");
+    let file = DefaultMappedFile::new(
+        CheetahString::from_string(file_path.to_string_lossy().into_owned()),
+        workload.file_size as u64,
+    );
+    let data = vec![0xAA; workload.message_size];
 
-    group.throughput(Throughput::Bytes(10 * 1024 * 1024)); // 10MB
-
-    group.bench_function("io_uring_sequential", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let file = IoUringMappedFile::new(
-                    CheetahString::from("/tmp/bench_seq_io_uring"),
-                    20 * 1024 * 1024, // 20MB
-                )
-                .await
-                .unwrap();
-
-                let data = vec![0x55; 1024 * 1024]; // 1MB chunks
-                for i in 0..10 {
-                    std::hint::black_box(file.write_async(&data, i * data.len()).await.unwrap());
-                }
-
-                let _ = std::fs::remove_file("/tmp/bench_seq_io_uring");
-            })
-        });
-    });
-
-    group.bench_function("default_sequential", |b| {
-        b.iter(|| {
-            let file = DefaultMappedFile::new(
-                CheetahString::from("/tmp/bench_seq_default"),
-                20 * 1024 * 1024, // 20MB
-                None,
-            )
-            .unwrap();
-
-            let data = vec![0x55; 1024 * 1024]; // 1MB chunks
-            for i in 0..10 {
-                std::hint::black_box(file.append_message_offset_length(&data, 0, data.len()));
-            }
-
-            let _ = std::fs::remove_file("/tmp/bench_seq_default");
-        });
-    });
-
-    group.finish();
+    (temp_dir, file, data)
 }
 
-/// Benchmark: Read performance
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
-fn bench_read_performance(c: &mut Criterion) {
-    let mut group = c.benchmark_group("read_performance");
-    let rt = Runtime::new().unwrap();
-
-    // Setup: Create files with data
-    rt.block_on(async {
-        // io_uring file
-        let io_uring_file = IoUringMappedFile::new(
-            CheetahString::from("/tmp/bench_read_io_uring"),
-            10 * 1024 * 1024, // 10MB
-        )
-        .await
-        .unwrap();
-        let data = vec![0x77; 4096];
-        for i in 0..(10 * 1024 * 1024 / 4096) {
-            io_uring_file.write_async(&data, i * 4096).await.unwrap();
-        }
-
-        // default file
-        let default_file = DefaultMappedFile::new(
-            CheetahString::from("/tmp/bench_read_default"),
-            10 * 1024 * 1024, // 10MB
-            None,
-        )
-        .unwrap();
-        for i in 0..(10 * 1024 * 1024 / 4096) {
-            default_file.append_message_offset_length(&data, 0, data.len());
-        }
-    });
-
-    group.throughput(Throughput::Bytes(4096 * 100)); // 100 reads of 4KB
-
-    group.bench_function("io_uring_read", |b| {
-        b.iter(|| {
-            let file = rt.block_on(async {
-                IoUringMappedFile::new(
-                    CheetahString::from("/tmp/bench_read_io_uring"),
-                    10 * 1024 * 1024,
-                )
-                .await
-                .unwrap()
-            });
-
-            for i in 0..100 {
-                let offset = (i * 4096) % (10 * 1024 * 1024 - 4096);
-                std::hint::black_box(file.get_bytes(offset, 4096));
-            }
-        });
-    });
-
-    group.bench_function("default_read", |b| {
-        b.iter(|| {
-            let file = DefaultMappedFile::new(
-                CheetahString::from("/tmp/bench_read_default"),
-                10 * 1024 * 1024,
-                None,
-            )
-            .unwrap();
-
-            for i in 0..100 {
-                let offset = (i * 4096) % (10 * 1024 * 1024 - 4096);
-                std::hint::black_box(file.get_bytes(offset, 4096));
-            }
-        });
-    });
-
-    // Cleanup
-    let _ = std::fs::remove_file("/tmp/bench_read_io_uring");
-    let _ = std::fs::remove_file("/tmp/bench_read_default");
-
-    group.finish();
+fn run_default_flush_workload(file: &DefaultMappedFile, data: &[u8], workload: IoUringFlushBenchmarkWorkload) -> i32 {
+    for _ in 0..workload.message_count {
+        assert!(file.append_message_offset_length(data, 0, data.len()));
+    }
+    file.flush(workload.flush_least_pages)
 }
 
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
-criterion_group!(
-    benches,
-    bench_write_comparison,
-    bench_flush_comparison,
-    bench_concurrent_writes,
-    bench_sequential_throughput,
-    bench_read_performance
-);
-
-#[cfg(all(target_os = "linux", feature = "io_uring"))]
+criterion_group!(benches, bench_flush_semantics);
 criterion_main!(benches);
-*/
-fn main() {
-    // This benchmark requires Linux with io_uring feature enabled
-    println!("io_uring benchmarks require Linux and --features io_uring");
-}

--- a/rocketmq-store/src/lib.rs
+++ b/rocketmq-store/src/lib.rs
@@ -144,6 +144,67 @@ pub mod bench_support {
         pub healthy: bool,
     }
 
+    pub const IO_URING_FLUSH_BENCHMARK_GROUP: &str = "io_uring/flush_semantics";
+
+    pub const DEFAULT_IO_URING_FLUSH_BENCHMARK_WORKLOAD: IoUringFlushBenchmarkWorkload =
+        IoUringFlushBenchmarkWorkload {
+            file_size: 16 * 1024 * 1024,
+            message_size: 4 * 1024,
+            message_count: 64,
+            flush_least_pages: 0,
+        };
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+    pub enum IoUringFlushBenchmarkPath {
+        DefaultMappedFileBaseline,
+        IoUringExperimental,
+    }
+
+    impl IoUringFlushBenchmarkPath {
+        pub const fn as_str(self) -> &'static str {
+            match self {
+                Self::DefaultMappedFileBaseline => "default_mapped_file_baseline",
+                Self::IoUringExperimental => "io_uring_experimental",
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+    pub struct IoUringFlushBenchmarkWorkload {
+        pub file_size: usize,
+        pub message_size: usize,
+        pub message_count: usize,
+        pub flush_least_pages: i32,
+    }
+
+    impl IoUringFlushBenchmarkWorkload {
+        pub const fn total_bytes(self) -> usize {
+            self.message_size * self.message_count
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+    pub struct IoUringFlushBenchmarkCase {
+        pub name: &'static str,
+        pub path: IoUringFlushBenchmarkPath,
+        pub workload: IoUringFlushBenchmarkWorkload,
+    }
+
+    pub fn io_uring_flush_benchmark_cases() -> [IoUringFlushBenchmarkCase; 2] {
+        [
+            IoUringFlushBenchmarkCase {
+                name: "default_mapped_file_flush",
+                path: IoUringFlushBenchmarkPath::DefaultMappedFileBaseline,
+                workload: DEFAULT_IO_URING_FLUSH_BENCHMARK_WORKLOAD,
+            },
+            IoUringFlushBenchmarkCase {
+                name: "io_uring_experimental_flush",
+                path: IoUringFlushBenchmarkPath::IoUringExperimental,
+                workload: DEFAULT_IO_URING_FLUSH_BENCHMARK_WORKLOAD,
+            },
+        ]
+    }
+
     #[cfg(feature = "rocksdb_store")]
     #[derive(Debug, Clone, Serialize)]
     pub struct StoreRocksDbMaintenanceLifecycleProbe {
@@ -665,6 +726,36 @@ mod bench_support_tests {
         assert_eq!(probe.task_count_after_shutdown, 0, "{probe:?}");
         assert_eq!(probe.scheduled_overlaps, 0, "{probe:?}");
         assert_eq!(probe.scheduled_failures, 0, "{probe:?}");
+    }
+
+    #[test]
+    fn io_uring_flush_benchmark_cases_share_flush_manager_workload() {
+        use super::bench_support::IoUringFlushBenchmarkPath;
+
+        let cases = super::bench_support::io_uring_flush_benchmark_cases();
+        assert_eq!(
+            super::bench_support::IO_URING_FLUSH_BENCHMARK_GROUP,
+            "io_uring/flush_semantics"
+        );
+        assert_eq!(cases.len(), 2);
+
+        let baseline = cases
+            .iter()
+            .find(|case| case.path == IoUringFlushBenchmarkPath::DefaultMappedFileBaseline)
+            .expect("default mapped-file baseline case should exist");
+        let experimental = cases
+            .iter()
+            .find(|case| case.path == IoUringFlushBenchmarkPath::IoUringExperimental)
+            .expect("io_uring experimental case should exist");
+
+        assert_eq!(baseline.workload, experimental.workload);
+        assert_eq!(baseline.workload.flush_least_pages, 0);
+        assert_eq!(
+            baseline.workload.total_bytes(),
+            baseline.workload.message_size * baseline.workload.message_count
+        );
+        assert!(baseline.name.contains("default"));
+        assert!(experimental.name.contains("io_uring"));
     }
 
     #[cfg(feature = "rocksdb_store")]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7660

### Brief Description

Replaces the inactive `io_uring_performance` placeholder with a compile-checked Criterion flush benchmark entry. The benchmark now uses a shared workload description for the default mapped-file baseline and the experimental `io_uring` case, with the baseline executing the current append-then-`flush(0)` mapped-file semantics.

The experimental `io_uring` case is capability-gated and currently reports a skip reason until a concrete flush backend is wired. This PR removes unmeasured expected-improvement comments and does not claim throughput, latency, CPU, syscall, or memory improvements.

### How Did You Test This Change?

- `cargo test -p rocketmq-store --lib bench_support_tests::io_uring_flush_benchmark_cases_share_flush_manager_workload` (RED before implementation: missing benchmark workload API; passed after implementation)
- `cargo bench -p rocketmq-store --bench io_uring_performance --features io_uring --no-run`
- `cargo test -p rocketmq-store --lib` (513 passed)
- `cargo bench -p rocketmq-store --bench io_uring_performance --features io_uring -- --test` (smoke mode ran the default mapped-file baseline and reported the experimental `io_uring` flush backend skip reason)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

No before/after performance comparison is reported because this change adds the benchmark harness and makes no optimization claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated storage benchmarking to focus on flush behavior, with clearer coverage of both baseline and experimental I/O paths.
  * Added runtime checks so unsupported environments are skipped cleanly during benchmarking.
  * Standardized benchmark workload sizing for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->