### PR TITLE
[ISSUE #7662]✨Add HA transfer metrics aggregation

### DIFF
--- a/rocketmq-store/src/ha.rs
+++ b/rocketmq-store/src/ha.rs
@@ -28,6 +28,7 @@ pub mod ha_connection_state_notification_request;
 mod ha_connection_state_notification_service;
 pub mod ha_service;
 pub mod transfer_engine;
+pub mod transfer_metrics;
 pub(crate) mod wait_notify_object;
 
 /// Error types

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -56,6 +56,7 @@ use crate::ha::ha_connection_state::HAConnectionState;
 use crate::ha::ha_service::HAService;
 use crate::ha::transfer_engine::select_transfer_engine;
 use crate::ha::transfer_engine::HaTransferEngine;
+use crate::ha::transfer_engine::TransferEngineKind;
 use crate::ha::transfer_engine::TransferEnginePreference;
 use crate::ha::HAConnectionError;
 use crate::transfer::batch::TransferBatch;
@@ -648,12 +649,16 @@ impl WriteSocketService {
         next_transfer_from_where: Arc<AtomicI64>,
     ) -> Result<Self, HAConnectionError> {
         let enable_controller_mode = message_store_config.enable_controller_mode;
-        let selection = select_transfer_engine(TransferEnginePreference::Vectored, writer.is_write_vectored());
+        let preference = TransferEnginePreference::Vectored;
+        let selection = select_transfer_engine(preference, writer.is_write_vectored());
         if let Some(reason) = selection.fallback_reason {
             info!(
                 "HA transfer engine fallback to {:?} for slave[{}]: {}",
                 selection.engine, client_address, reason
             );
+            ha_service
+                .ha_transfer_metrics()
+                .record_fallback(TransferEngineKind::Vectored, selection.engine, reason);
         } else {
             info!(
                 "HA transfer engine selected {:?} for slave[{}]",
@@ -880,6 +885,7 @@ impl WriteSocketService {
         let stats = self.writer.send_batch(&batch).await?;
 
         self.last_write_timestamp.store(current_millis(), Ordering::Relaxed);
+        self.ha_service.ha_transfer_metrics().record_transfer(&stats);
         self.flow_monitor.add_byte_count_transferred(stats.bytes_written as i64);
         self.last_write_over.store(true, Ordering::Relaxed);
 
@@ -900,6 +906,7 @@ impl WriteSocketService {
         let stats = self.writer.send_batch(&batch).await?;
 
         self.last_write_timestamp.store(current_millis(), Ordering::Relaxed);
+        self.ha_service.ha_transfer_metrics().record_transfer(&stats);
         self.flow_monitor.add_byte_count_transferred(stats.bytes_written as i64);
         self.last_write_over.store(true, Ordering::Relaxed);
 

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -55,6 +55,7 @@ use crate::ha::ha_connection::HAConnectionId;
 use crate::ha::ha_connection_state_notification_request::HAConnectionStateNotificationRequest;
 use crate::ha::ha_connection_state_notification_service::HAConnectionStateNotificationService;
 use crate::ha::ha_service::HAService;
+use crate::ha::transfer_metrics::HaTransferMetrics;
 use crate::log_file::group_commit_request::GroupCommitRequest;
 use crate::message_store::local_file_message_store::LocalFileMessageStore;
 use crate::store_error::HAError;
@@ -81,6 +82,7 @@ pub struct DefaultHAService {
     ha_client: Option<GeneralHAClient>,
     ha_connection_state_notification_service: Option<HAConnectionStateNotificationService>,
     auto_switch_service: Option<WeakArcMut<AutoSwitchHAService>>,
+    ha_transfer_metrics: Arc<HaTransferMetrics>,
 }
 
 impl DefaultHAService {
@@ -96,11 +98,16 @@ impl DefaultHAService {
             ha_client: None,
             ha_connection_state_notification_service: None,
             auto_switch_service: None,
+            ha_transfer_metrics: Arc::new(HaTransferMetrics::default()),
         }
     }
 
     pub fn get_default_message_store(&self) -> &LocalFileMessageStore {
         self.default_message_store.as_ref()
+    }
+
+    pub fn ha_transfer_metrics(&self) -> Arc<HaTransferMetrics> {
+        self.ha_transfer_metrics.clone()
     }
 
     pub(crate) fn ensure_ha_client(&mut self) -> HAResult<bool> {
@@ -691,6 +698,23 @@ mod tests {
         let error = service.start().await.expect_err("start should fail before init");
 
         assert!(matches!(error, HAError::Service(message) if message.contains("AcceptSocketService")));
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[test]
+    fn default_ha_service_exposes_shared_transfer_metrics() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-default-ha-metrics-{}", current_millis()));
+        let store = new_test_message_store(&temp_root, false);
+        let service = DefaultHAService::new(store);
+        let metrics = service.ha_transfer_metrics();
+
+        metrics.record_fallback(
+            crate::ha::transfer_engine::TransferEngineKind::IoUring,
+            crate::ha::transfer_engine::TransferEngineKind::Vectored,
+            "io_uring unavailable",
+        );
+
+        assert_eq!(service.ha_transfer_metrics().snapshot().fallback_total, 1);
         let _ = std::fs::remove_dir_all(temp_root);
     }
 

--- a/rocketmq-store/src/ha/transfer_engine.rs
+++ b/rocketmq-store/src/ha/transfer_engine.rs
@@ -25,7 +25,7 @@ pub mod bytes;
 pub mod sendfile;
 pub mod vectored;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransferEngineKind {
     Bytes,
     Vectored,

--- a/rocketmq-store/src/ha/transfer_metrics.rs
+++ b/rocketmq-store/src/ha/transfer_metrics.rs
@@ -1,0 +1,147 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Mutex;
+
+use crate::ha::transfer_engine::TransferEngineKind;
+use crate::ha::transfer_engine::TransferStats;
+
+#[derive(Debug, Default)]
+pub struct HaTransferMetrics {
+    batch_total: AtomicU64,
+    bytes_total: AtomicU64,
+    body_bytes_total: AtomicU64,
+    write_call_total: AtomicU64,
+    sendfile_call_total: AtomicU64,
+    sendfile_bytes_total: AtomicU64,
+    fallback_bytes_total: AtomicU64,
+    partial_write_total: AtomicU64,
+    bytes_engine_total: AtomicU64,
+    vectored_engine_total: AtomicU64,
+    sendfile_engine_total: AtomicU64,
+    io_uring_engine_total: AtomicU64,
+    fallback_total: AtomicU64,
+    fallbacks: Mutex<BTreeMap<TransferFallbackKey, u64>>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TransferEngineTotals {
+    pub bytes: u64,
+    pub vectored: u64,
+    pub sendfile: u64,
+    pub io_uring: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HaTransferMetricsSnapshot {
+    pub batch_total: u64,
+    pub bytes_total: u64,
+    pub body_bytes_total: u64,
+    pub write_call_total: u64,
+    pub sendfile_call_total: u64,
+    pub sendfile_bytes_total: u64,
+    pub fallback_bytes_total: u64,
+    pub partial_write_total: u64,
+    pub engine_totals: TransferEngineTotals,
+    pub fallback_total: u64,
+    pub fallbacks: Vec<TransferFallbackSnapshot>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransferFallbackSnapshot {
+    pub from: TransferEngineKind,
+    pub to: TransferEngineKind,
+    pub reason: &'static str,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct TransferFallbackKey {
+    from: TransferEngineKind,
+    to: TransferEngineKind,
+    reason: &'static str,
+}
+
+impl HaTransferMetrics {
+    pub fn record_transfer(&self, stats: &TransferStats) {
+        self.batch_total.fetch_add(stats.frame_count as u64, Ordering::Relaxed);
+        self.bytes_total
+            .fetch_add(stats.bytes_written as u64, Ordering::Relaxed);
+        self.body_bytes_total
+            .fetch_add(stats.body_bytes as u64, Ordering::Relaxed);
+        self.write_call_total
+            .fetch_add(stats.write_call_count as u64, Ordering::Relaxed);
+        self.sendfile_call_total
+            .fetch_add(stats.sendfile_call_count as u64, Ordering::Relaxed);
+        self.sendfile_bytes_total
+            .fetch_add(stats.sendfile_bytes as u64, Ordering::Relaxed);
+        self.fallback_bytes_total
+            .fetch_add(stats.fallback_bytes as u64, Ordering::Relaxed);
+        self.partial_write_total
+            .fetch_add(stats.partial_write_count as u64, Ordering::Relaxed);
+
+        match stats.engine {
+            TransferEngineKind::Bytes => &self.bytes_engine_total,
+            TransferEngineKind::Vectored => &self.vectored_engine_total,
+            TransferEngineKind::Sendfile => &self.sendfile_engine_total,
+            TransferEngineKind::IoUring => &self.io_uring_engine_total,
+        }
+        .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_fallback(&self, from: TransferEngineKind, to: TransferEngineKind, reason: &'static str) {
+        self.fallback_total.fetch_add(1, Ordering::Relaxed);
+
+        let key = TransferFallbackKey { from, to, reason };
+        let mut fallbacks = self.fallbacks.lock().expect("lock HA transfer fallback metrics");
+        *fallbacks.entry(key).or_insert(0) += 1;
+    }
+
+    pub fn snapshot(&self) -> HaTransferMetricsSnapshot {
+        let fallbacks = self
+            .fallbacks
+            .lock()
+            .expect("lock HA transfer fallback metrics")
+            .iter()
+            .map(|(key, count)| TransferFallbackSnapshot {
+                from: key.from,
+                to: key.to,
+                reason: key.reason,
+                count: *count,
+            })
+            .collect();
+
+        HaTransferMetricsSnapshot {
+            batch_total: self.batch_total.load(Ordering::Relaxed),
+            bytes_total: self.bytes_total.load(Ordering::Relaxed),
+            body_bytes_total: self.body_bytes_total.load(Ordering::Relaxed),
+            write_call_total: self.write_call_total.load(Ordering::Relaxed),
+            sendfile_call_total: self.sendfile_call_total.load(Ordering::Relaxed),
+            sendfile_bytes_total: self.sendfile_bytes_total.load(Ordering::Relaxed),
+            fallback_bytes_total: self.fallback_bytes_total.load(Ordering::Relaxed),
+            partial_write_total: self.partial_write_total.load(Ordering::Relaxed),
+            engine_totals: TransferEngineTotals {
+                bytes: self.bytes_engine_total.load(Ordering::Relaxed),
+                vectored: self.vectored_engine_total.load(Ordering::Relaxed),
+                sendfile: self.sendfile_engine_total.load(Ordering::Relaxed),
+                io_uring: self.io_uring_engine_total.load(Ordering::Relaxed),
+            },
+            fallback_total: self.fallback_total.load(Ordering::Relaxed),
+            fallbacks,
+        }
+    }
+}

--- a/rocketmq-store/tests/ha_transfer_metrics.rs
+++ b/rocketmq-store/tests/ha_transfer_metrics.rs
@@ -1,0 +1,84 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_store::ha::transfer_engine::TransferEngineKind;
+use rocketmq_store::ha::transfer_engine::TransferStats;
+use rocketmq_store::ha::transfer_metrics::HaTransferMetrics;
+use rocketmq_store::ha::transfer_metrics::TransferFallbackSnapshot;
+
+#[test]
+fn ha_transfer_metrics_records_transfer_stats_by_engine() {
+    let metrics = HaTransferMetrics::default();
+    metrics.record_transfer(&TransferStats {
+        engine: TransferEngineKind::Vectored,
+        bytes_written: 128,
+        body_bytes: 116,
+        frame_count: 1,
+        write_call_count: 2,
+        sendfile_call_count: 0,
+        sendfile_bytes: 0,
+        fallback_bytes: 0,
+        partial_write_count: 1,
+    });
+    metrics.record_transfer(&TransferStats {
+        engine: TransferEngineKind::Sendfile,
+        bytes_written: 256,
+        body_bytes: 244,
+        frame_count: 1,
+        write_call_count: 1,
+        sendfile_call_count: 3,
+        sendfile_bytes: 244,
+        fallback_bytes: 0,
+        partial_write_count: 2,
+    });
+
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.batch_total, 2);
+    assert_eq!(snapshot.bytes_total, 384);
+    assert_eq!(snapshot.body_bytes_total, 360);
+    assert_eq!(snapshot.write_call_total, 3);
+    assert_eq!(snapshot.sendfile_call_total, 3);
+    assert_eq!(snapshot.sendfile_bytes_total, 244);
+    assert_eq!(snapshot.partial_write_total, 3);
+    assert_eq!(snapshot.engine_totals.vectored, 1);
+    assert_eq!(snapshot.engine_totals.sendfile, 1);
+}
+
+#[test]
+fn ha_transfer_metrics_records_fallback_labels() {
+    let metrics = HaTransferMetrics::default();
+
+    metrics.record_fallback(
+        TransferEngineKind::IoUring,
+        TransferEngineKind::Vectored,
+        "io_uring unavailable",
+    );
+    metrics.record_fallback(
+        TransferEngineKind::IoUring,
+        TransferEngineKind::Vectored,
+        "io_uring unavailable",
+    );
+
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.fallback_total, 2);
+    assert_eq!(
+        snapshot.fallbacks,
+        vec![TransferFallbackSnapshot {
+            from: TransferEngineKind::IoUring,
+            to: TransferEngineKind::Vectored,
+            reason: "io_uring unavailable",
+            count: 2,
+        }]
+    );
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7662

### Brief Description

Adds a HA transfer metrics aggregation boundary in `rocketmq-store`. The new collector records totals from `TransferStats`, including batch count, transferred bytes, body bytes, write calls, sendfile calls, sendfile bytes, fallback bytes, partial writes, and per-engine usage.

It also records fallback labels with from engine, to engine, and reason, and `DefaultHAService` now owns the shared collector. `WriteSocketService` records selection fallback once during writer setup and records transfer stats after successful heartbeat/data sends.

This is observability plumbing only. No throughput, latency, CPU, syscall, or memory improvement is claimed.

### How Did You Test This Change?

- `cargo test -p rocketmq-store --test ha_transfer_metrics` (RED before implementation: missing `transfer_metrics` module; passed after implementation)
- `cargo test -p rocketmq-store --lib ha::default_ha_service::tests::default_ha_service_exposes_shared_transfer_metrics` (RED before implementation: missing `ha_transfer_metrics` method; passed after implementation)
- `cargo test -p rocketmq-store --test ha_transfer_engine` (7 passed)
- `cargo test -p rocketmq-store --lib` (514 passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added high-availability transfer metrics, improving visibility into transfer activity, fallback behavior, and engine usage.
  * Enhanced HA transfer handling to consistently track transfer statistics during data and heartbeat sends.

* **Tests**
  * Added coverage for transfer metric aggregation and fallback tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->