### PR TITLE
[ISSUE #7664]✨Add HA transfer observability metrics

### DIFF
--- a/rocketmq-observability/src/metrics/catalog.rs
+++ b/rocketmq-observability/src/metrics/catalog.rs
@@ -111,6 +111,8 @@ const REMOTING_RPC_LABELS: &[&str] = &[
 ];
 const STORE_STORAGE_LABELS: &[&str] = &[labels::STORAGE_TYPE, labels::STORAGE_MEDIUM];
 const STORE_TOPIC_LABELS: &[&str] = &[labels::STORAGE_TYPE, labels::STORAGE_MEDIUM, labels::TOPIC];
+const STORE_TRANSFER_ENGINE_LABELS: &[&str] = &[labels::ENGINE];
+const STORE_TRANSFER_FALLBACK_LABELS: &[&str] = &[labels::FROM, labels::TO, labels::REASON];
 const TIMER_BOUND_LABELS: &[&str] = &[
     labels::STORAGE_TYPE,
     labels::STORAGE_MEDIUM,
@@ -402,6 +404,48 @@ pub const JAVA_METRICS: &[MetricDescriptor] = &[
         kind: MetricKind::Histogram,
         unit: "seconds",
         labels: STORE_TOPIC_LABELS,
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_LINUX_SENDFILE_BYTES_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "By",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_TRANSFER_BATCH_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{batch}",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_TRANSFER_BYTES_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "By",
+        labels: &[],
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_TRANSFER_ENGINE_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{transfer}",
+        labels: STORE_TRANSFER_ENGINE_LABELS,
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_TRANSFER_FALLBACK_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{fallback}",
+        labels: STORE_TRANSFER_FALLBACK_LABELS,
+        source: MetricSource::Store,
+    },
+    MetricDescriptor {
+        name: metrics::STORE_TRANSFER_PARTIAL_WRITE_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{write}",
+        labels: &[],
         source: MetricSource::Store,
     },
     MetricDescriptor {
@@ -737,6 +781,12 @@ mod tests {
         "rocketmq_storage_flush_behind_bytes",
         "rocketmq_storage_message_reserve_time",
         "rocketmq_storage_size",
+        "rocketmq_store_linux_sendfile_bytes_total",
+        "rocketmq_store_transfer_batch_total",
+        "rocketmq_store_transfer_bytes_total",
+        "rocketmq_store_transfer_engine_total",
+        "rocketmq_store_transfer_fallback_total",
+        "rocketmq_store_transfer_partial_write_total",
         "rocketmq_throughput_in_total",
         "rocketmq_throughput_out_total",
         "rocketmq_tiered_store_api_latency",
@@ -817,5 +867,36 @@ mod tests {
             .expect("delay message latency descriptor");
         assert_eq!(delay_message_latency.unit, "seconds");
         assert_eq!(delay_message_latency.labels, STORE_TOPIC_LABELS);
+
+        let transfer_batch = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_TRANSFER_BATCH_TOTAL)
+            .expect("transfer batch descriptor");
+        assert_eq!(transfer_batch.kind, MetricKind::Counter);
+        assert_eq!(transfer_batch.unit, "{batch}");
+        assert_eq!(transfer_batch.source, MetricSource::Store);
+        assert!(transfer_batch.labels.is_empty());
+
+        let transfer_engine = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_TRANSFER_ENGINE_TOTAL)
+            .expect("transfer engine descriptor");
+        assert_eq!(transfer_engine.kind, MetricKind::Counter);
+        assert_eq!(transfer_engine.labels, &[labels::ENGINE]);
+
+        let transfer_fallback = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_TRANSFER_FALLBACK_TOTAL)
+            .expect("transfer fallback descriptor");
+        assert_eq!(transfer_fallback.kind, MetricKind::Counter);
+        assert_eq!(transfer_fallback.labels, &[labels::FROM, labels::TO, labels::REASON]);
+
+        let linux_sendfile_bytes = JAVA_METRICS
+            .iter()
+            .find(|descriptor| descriptor.name == metrics::STORE_LINUX_SENDFILE_BYTES_TOTAL)
+            .expect("linux sendfile bytes descriptor");
+        assert_eq!(linux_sendfile_bytes.kind, MetricKind::Counter);
+        assert_eq!(linux_sendfile_bytes.unit, "By");
+        assert_eq!(linux_sendfile_bytes.source, MetricSource::Store);
     }
 }

--- a/rocketmq-observability/src/metrics/store.rs
+++ b/rocketmq-observability/src/metrics/store.rs
@@ -21,6 +21,12 @@ pub use crate::semantic::metrics::STORE_APPEND_LATENCY;
 pub use crate::semantic::metrics::STORE_DISK_USAGE;
 pub use crate::semantic::metrics::STORE_DISPATCH_LATENCY;
 pub use crate::semantic::metrics::STORE_FLUSH_LATENCY;
+pub use crate::semantic::metrics::STORE_LINUX_SENDFILE_BYTES_TOTAL;
+pub use crate::semantic::metrics::STORE_TRANSFER_BATCH_TOTAL;
+pub use crate::semantic::metrics::STORE_TRANSFER_BYTES_TOTAL;
+pub use crate::semantic::metrics::STORE_TRANSFER_ENGINE_TOTAL;
+pub use crate::semantic::metrics::STORE_TRANSFER_FALLBACK_TOTAL;
+pub use crate::semantic::metrics::STORE_TRANSFER_PARTIAL_WRITE_TOTAL;
 
 #[cfg(feature = "otel-metrics")]
 use std::sync::OnceLock;
@@ -118,6 +124,66 @@ pub fn record_delay_message_latency_from_timestamps(deliver_time_ms: i64, born_t
     }
 }
 
+pub fn record_transfer_batch(count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_transfer_batch_total(count, &[]);
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = count;
+}
+
+pub fn record_transfer_bytes(bytes: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_transfer_bytes_total(bytes, &[]);
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = bytes;
+}
+
+pub fn record_transfer_engine(engine: &str, count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_transfer_engine_total(count, &transfer_engine_attributes(engine));
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = (engine, count);
+}
+
+pub fn record_transfer_fallback(from: &str, to: &str, reason: &str, count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_transfer_fallback_total(count, &transfer_fallback_attributes(from, to, reason));
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = (from, to, reason, count);
+}
+
+pub fn record_transfer_partial_write(count: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_transfer_partial_write_total(count, &[]);
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = count;
+}
+
+pub fn record_linux_sendfile_bytes(bytes: u64) {
+    #[cfg(feature = "otel-metrics")]
+    if let Some(metrics) = STORE_METRICS.get() {
+        metrics.record_linux_sendfile_bytes_total(bytes, &[]);
+    }
+
+    #[cfg(not(feature = "otel-metrics"))]
+    let _ = bytes;
+}
+
 #[cfg(not(feature = "otel-metrics"))]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StoreMetrics;
@@ -142,6 +208,24 @@ impl StoreMetrics {
 
     #[inline]
     pub fn record_delay_message_latency(&self, _latency_seconds: u64) {}
+
+    #[inline]
+    pub fn record_transfer_batch_total(&self, _count: u64) {}
+
+    #[inline]
+    pub fn record_transfer_bytes_total(&self, _bytes: u64) {}
+
+    #[inline]
+    pub fn record_transfer_engine_total(&self, _count: u64) {}
+
+    #[inline]
+    pub fn record_transfer_fallback_total(&self, _count: u64) {}
+
+    #[inline]
+    pub fn record_transfer_partial_write_total(&self, _count: u64) {}
+
+    #[inline]
+    pub fn record_linux_sendfile_bytes_total(&self, _bytes: u64) {}
 }
 
 #[cfg(feature = "otel-metrics")]
@@ -152,6 +236,12 @@ pub struct StoreMetrics {
     dispatch_latency: opentelemetry::metrics::Histogram<u64>,
     disk_usage: opentelemetry::metrics::Gauge<u64>,
     delay_message_latency: opentelemetry::metrics::Histogram<u64>,
+    transfer_batch_total: opentelemetry::metrics::Counter<u64>,
+    transfer_bytes_total: opentelemetry::metrics::Counter<u64>,
+    transfer_engine_total: opentelemetry::metrics::Counter<u64>,
+    transfer_fallback_total: opentelemetry::metrics::Counter<u64>,
+    transfer_partial_write_total: opentelemetry::metrics::Counter<u64>,
+    linux_sendfile_bytes_total: opentelemetry::metrics::Counter<u64>,
 }
 
 #[cfg(feature = "otel-metrics")]
@@ -187,12 +277,54 @@ impl StoreMetrics {
             .with_unit("seconds")
             .build();
 
+        let transfer_batch_total = meter
+            .u64_counter(STORE_TRANSFER_BATCH_TOTAL)
+            .with_description("Total number of HA transfer batches")
+            .with_unit("{batch}")
+            .build();
+
+        let transfer_bytes_total = meter
+            .u64_counter(STORE_TRANSFER_BYTES_TOTAL)
+            .with_description("Total HA transfer bytes")
+            .with_unit("By")
+            .build();
+
+        let transfer_engine_total = meter
+            .u64_counter(STORE_TRANSFER_ENGINE_TOTAL)
+            .with_description("Total HA transfer engine selections")
+            .with_unit("{transfer}")
+            .build();
+
+        let transfer_fallback_total = meter
+            .u64_counter(STORE_TRANSFER_FALLBACK_TOTAL)
+            .with_description("Total HA transfer engine fallbacks")
+            .with_unit("{fallback}")
+            .build();
+
+        let transfer_partial_write_total = meter
+            .u64_counter(STORE_TRANSFER_PARTIAL_WRITE_TOTAL)
+            .with_description("Total HA transfer partial writes")
+            .with_unit("{write}")
+            .build();
+
+        let linux_sendfile_bytes_total = meter
+            .u64_counter(STORE_LINUX_SENDFILE_BYTES_TOTAL)
+            .with_description("Total Linux sendfile bytes used by HA transfer")
+            .with_unit("By")
+            .build();
+
         Self {
             append_latency,
             flush_latency,
             dispatch_latency,
             disk_usage,
             delay_message_latency,
+            transfer_batch_total,
+            transfer_bytes_total,
+            transfer_engine_total,
+            transfer_fallback_total,
+            transfer_partial_write_total,
+            linux_sendfile_bytes_total,
         }
     }
 
@@ -277,6 +409,36 @@ impl StoreMetrics {
     pub fn record_delay_message_latency(&self, latency_seconds: u64, attributes: &[opentelemetry::KeyValue]) {
         self.delay_message_latency.record(latency_seconds, attributes);
     }
+
+    #[inline]
+    pub fn record_transfer_batch_total(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.transfer_batch_total.add(count, attributes);
+    }
+
+    #[inline]
+    pub fn record_transfer_bytes_total(&self, bytes: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.transfer_bytes_total.add(bytes, attributes);
+    }
+
+    #[inline]
+    pub fn record_transfer_engine_total(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.transfer_engine_total.add(count, attributes);
+    }
+
+    #[inline]
+    pub fn record_transfer_fallback_total(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.transfer_fallback_total.add(count, attributes);
+    }
+
+    #[inline]
+    pub fn record_transfer_partial_write_total(&self, count: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.transfer_partial_write_total.add(count, attributes);
+    }
+
+    #[inline]
+    pub fn record_linux_sendfile_bytes_total(&self, bytes: u64, attributes: &[opentelemetry::KeyValue]) {
+        self.linux_sendfile_bytes_total.add(bytes, attributes);
+    }
 }
 
 #[cfg(feature = "otel-metrics")]
@@ -295,6 +457,23 @@ fn delay_message_latency_attributes(topic: &str) -> Vec<opentelemetry::KeyValue>
         topic.to_owned(),
     ));
     attrs
+}
+
+#[cfg(feature = "otel-metrics")]
+fn transfer_engine_attributes(engine: &str) -> [opentelemetry::KeyValue; 1] {
+    [opentelemetry::KeyValue::new(
+        crate::semantic::labels::ENGINE,
+        engine.to_owned(),
+    )]
+}
+
+#[cfg(feature = "otel-metrics")]
+fn transfer_fallback_attributes(from: &str, to: &str, reason: &str) -> [opentelemetry::KeyValue; 3] {
+    [
+        opentelemetry::KeyValue::new(crate::semantic::labels::FROM, from.to_owned()),
+        opentelemetry::KeyValue::new(crate::semantic::labels::TO, to.to_owned()),
+        opentelemetry::KeyValue::new(crate::semantic::labels::REASON, reason.to_owned()),
+    ]
 }
 
 #[cfg(all(test, feature = "otel-metrics"))]
@@ -316,6 +495,12 @@ mod tests {
         metrics.record_dispatch_latency(9, &attrs);
         metrics.record_disk_usage(1024, &attrs);
         metrics.record_delay_message_latency(30, &attrs);
+        metrics.record_transfer_batch_total(1, &[]);
+        metrics.record_transfer_bytes_total(1024, &[]);
+        metrics.record_transfer_engine_total(1, &transfer_engine_attributes("sendfile"));
+        metrics.record_transfer_fallback_total(1, &transfer_fallback_attributes("io_uring", "vectored", "unsupported"));
+        metrics.record_transfer_partial_write_total(2, &[]);
+        metrics.record_linux_sendfile_bytes_total(512, &[]);
         record_delay_message_latency(30);
     }
 
@@ -356,5 +541,15 @@ mod helper_tests {
     #[test]
     fn delay_message_latency_from_timestamps_records_positive_latency() {
         record_delay_message_latency_from_timestamps(2_000, 1_000, Some("topic-a"));
+    }
+
+    #[test]
+    fn ha_transfer_recorders_are_safe_without_explicit_meter() {
+        record_transfer_batch(1);
+        record_transfer_bytes(1024);
+        record_transfer_engine("sendfile", 1);
+        record_transfer_fallback("io_uring", "vectored", "unsupported", 1);
+        record_transfer_partial_write(2);
+        record_linux_sendfile_bytes(512);
     }
 }

--- a/rocketmq-observability/src/semantic.rs
+++ b/rocketmq-observability/src/semantic.rs
@@ -50,6 +50,12 @@ pub mod metrics {
     pub const STORE_FLUSH_LATENCY: &str = "rocketmq_store_flush_latency";
     pub const STORE_DISPATCH_LATENCY: &str = "rocketmq_store_dispatch_latency";
     pub const STORE_DISK_USAGE: &str = "rocketmq_store_disk_usage";
+    pub const STORE_LINUX_SENDFILE_BYTES_TOTAL: &str = "rocketmq_store_linux_sendfile_bytes_total";
+    pub const STORE_TRANSFER_BATCH_TOTAL: &str = "rocketmq_store_transfer_batch_total";
+    pub const STORE_TRANSFER_BYTES_TOTAL: &str = "rocketmq_store_transfer_bytes_total";
+    pub const STORE_TRANSFER_ENGINE_TOTAL: &str = "rocketmq_store_transfer_engine_total";
+    pub const STORE_TRANSFER_FALLBACK_TOTAL: &str = "rocketmq_store_transfer_fallback_total";
+    pub const STORE_TRANSFER_PARTIAL_WRITE_TOTAL: &str = "rocketmq_store_transfer_partial_write_total";
     pub const STORAGE_SIZE: &str = "rocketmq_storage_size";
     pub const STORAGE_FLUSH_BEHIND_BYTES: &str = "rocketmq_storage_flush_behind_bytes";
     pub const STORAGE_DISPATCH_BEHIND_BYTES: &str = "rocketmq_storage_dispatch_behind_bytes";
@@ -144,6 +150,10 @@ pub mod labels {
     pub const STORAGE_TYPE: &str = "storage_type";
     pub const STORAGE_MEDIUM: &str = "storage_medium";
     pub const TYPE: &str = "type";
+    pub const ENGINE: &str = "engine";
+    pub const FROM: &str = "from";
+    pub const TO: &str = "to";
+    pub const REASON: &str = "reason";
     pub const TIMER_BOUND_SECONDS: &str = "timer_bound_s";
     pub const OPERATION: &str = "operation";
     pub const SUCCESS: &str = "success";


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #7664

### Brief Description

Add HA transfer observability metric support in `rocketmq-observability`:

- Define semantic metric names for HA transfer batches, bytes, engine usage, fallback counts, partial writes, and Linux sendfile bytes.
- Register the new store counters in the metric catalog with engine and fallback label sets.
- Add store recorder helpers and OpenTelemetry counter instruments while keeping no-OTEL builds as safe no-ops.

This change only adds observability contract and recorder plumbing. It does not claim throughput, latency, CPU, syscall, or memory optimization, so no before/after performance comparison is applicable.

### How Did You Test This Change?

- `cargo test -p rocketmq-observability metrics::catalog::tests::java_metric_catalog_has_required_label_sets` passed.
- `cargo test -p rocketmq-observability metrics::store::helper_tests::ha_transfer_recorders_are_safe_without_explicit_meter` passed.
- `cargo test -p rocketmq-observability --features otel-metrics metrics::store::tests::store_metrics_constructs_and_records` passed.
- `cargo test -p rocketmq-observability` passed.
- `cargo test -p rocketmq-observability --features otel-metrics` passed.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
